### PR TITLE
Date: Add DateFormatters class that uses java.time

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/CompoundDateTimeFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/CompoundDateTimeFormatter.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.common.time;
 
-import org.elasticsearch.common.util.ArrayUtils;
-
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -34,16 +32,12 @@ public class CompoundDateTimeFormatter {
     final DateTimeFormatter printer;
     final DateTimeFormatter[] parsers;
 
-    CompoundDateTimeFormatter(DateTimeFormatter parserAndPrinter, DateTimeFormatter ... parsers) {
-        if (parserAndPrinter == null) {
-            throw new IllegalArgumentException("printer is required for compound date formatter");
-        }
-        this.printer = parserAndPrinter;
+    CompoundDateTimeFormatter(DateTimeFormatter ... parsers) {
         if (parsers.length == 0) {
-            this.parsers = new DateTimeFormatter[]{parserAndPrinter};
-        } else {
-            this.parsers = ArrayUtils.concat(new DateTimeFormatter[]{parserAndPrinter}, parsers, DateTimeFormatter.class);
+            throw new IllegalArgumentException("at least one date time formatter is required");
         }
+        this.printer = parsers[0];
+        this.parsers = parsers;
     }
 
     public TemporalAccessor parse(String input) {
@@ -65,13 +59,12 @@ public class CompoundDateTimeFormatter {
     }
 
     public CompoundDateTimeFormatter withZone(ZoneId zoneId) {
-        final DateTimeFormatter printerWithZone = printer.withZone(zoneId);
         final DateTimeFormatter[] parsersWithZone = new DateTimeFormatter[parsers.length];
         for (int i = 0; i < parsers.length; i++) {
             parsersWithZone[i] = parsers[i].withZone(zoneId);
         }
 
-        return new CompoundDateTimeFormatter(printerWithZone, parsersWithZone);
+        return new CompoundDateTimeFormatter(parsersWithZone);
     }
 
     public String format(TemporalAccessor accessor) {

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common.time;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+/**
+ * wrapper class around java.time.DateTimeFormatter that supports multiple formats for easier parsing
+ */
+public class DateFormatter {
+
+    private DateTimeFormatter printer;
+    private DateTimeFormatter[] parsers;
+
+    public DateFormatter(DateTimeFormatter printer, DateTimeFormatter ... parsers) {
+        this.printer = printer;
+        this.parsers = parsers;
+    }
+
+    public TemporalAccessor parse(String input) {
+        if (parsers.length > 0) {
+            for (int i = 0; i < parsers.length; i++) {
+                try {
+                    return parsers[i].parse(input);
+                } catch (DateTimeParseException e) {}
+            }
+        }
+
+        return printer.parse(input);
+    }
+
+    public DateFormatter withZone(ZoneId zoneId) {
+        printer = printer.withZone(zoneId);
+        for (int i = 0; i < parsers.length; i++) {
+            parsers[i] = parsers[i].withZone(zoneId);
+        }
+
+        return this;
+    }
+
+    public String format(TemporalAccessor accessor) {
+        return printer.format(accessor);
+    }
+
+    // for internal use only
+    private DateTimeFormatter[] all() {
+        return Stream.concat(Arrays.stream(new DateTimeFormatter[] { printer }), Arrays.stream(parsers)).toArray(DateTimeFormatter[]::new);
+    }
+
+    public static DateFormatter merge(DateFormatter ... dateFormatters) {
+        DateTimeFormatter[] parsers = Arrays.stream(dateFormatters).map(DateFormatter::all)
+            .flatMap(Arrays::stream).toArray(DateTimeFormatter[]::new);
+        return new DateFormatter(dateFormatters[0].printer, parsers);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -36,6 +36,9 @@ import java.time.temporal.IsoFields;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalAdjusters;
 import java.time.temporal.WeekFields;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
@@ -896,16 +899,23 @@ public class DateFormatters {
             if (formats.length == 1) {
                 return forPattern(formats[0], locale);
             } else {
-                CompoundDateTimeFormatter[] formatters = new CompoundDateTimeFormatter[formats.length];
+                Collection<DateTimeFormatter> parsers = new LinkedHashSet<>(formats.length);
+                DateTimeFormatter printerAndParser = null;
                 for (int i = 0; i < formats.length; i++) {
+                    CompoundDateTimeFormatter dateTimeFormatter = forPattern(formats[i], locale);
+
+                    if (i == 0) {
+                        printerAndParser = dateTimeFormatter.printer;
+                    }
+
                     try {
-                        formatters[i] = forPattern(formats[i], locale);
+                        parsers.addAll(Arrays.asList(dateTimeFormatter.parsers));
                     } catch (IllegalArgumentException e) {
                         throw new IllegalArgumentException("Invalid format: [" + input + "]: " + e.getMessage(), e);
                     }
                 }
 
-                return CompoundDateTimeFormatter.merge(formatters);
+                return new CompoundDateTimeFormatter(printerAndParser, parsers.toArray(new DateTimeFormatter[0]));
             }
         } else {
             try {

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -80,7 +80,7 @@ public class DateFormatters {
         .append(OPTIONAL_TIME_ZONE_FORMATTER)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter BASIC_TIME_NO_MILLIS = new DateFormatter(BASIC_TIME_NO_MILLIS_FORMATTER);
+    private static final CompoundDateTimeFormatter BASIC_TIME_NO_MILLIS = new CompoundDateTimeFormatter(BASIC_TIME_NO_MILLIS_FORMATTER);
 
     private static final DateTimeFormatter BASIC_TIME_FORMATTER = new DateTimeFormatterBuilder()
         .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
@@ -90,28 +90,28 @@ public class DateFormatters {
         .append(OPTIONAL_TIME_ZONE_FORMATTER)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter BASIC_TIME = new DateFormatter(BASIC_TIME_FORMATTER);
+    private static final CompoundDateTimeFormatter BASIC_TIME = new CompoundDateTimeFormatter(BASIC_TIME_FORMATTER);
 
     private static final DateTimeFormatter BASIC_T_TIME_FORMATTER = new DateTimeFormatterBuilder()
         .appendLiteral("T")
         .append(BASIC_TIME_FORMATTER)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter BASIC_T_TIME = new DateFormatter(BASIC_T_TIME_FORMATTER);
+    private static final CompoundDateTimeFormatter BASIC_T_TIME = new CompoundDateTimeFormatter(BASIC_T_TIME_FORMATTER);
 
-    private static final DateFormatter BASIC_T_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter BASIC_T_TIME_NO_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendLiteral("T")
         .append(BASIC_TIME_NO_MILLIS_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter BASIC_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter BASIC_DATE_TIME = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 4, SignStyle.NORMAL)
         .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NOT_NEGATIVE)
         .append(BASIC_T_TIME_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter BASIC_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter BASIC_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 4, SignStyle.NORMAL)
         .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NOT_NEGATIVE)
@@ -119,15 +119,15 @@ public class DateFormatters {
         .append(BASIC_TIME_NO_MILLIS_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter BASIC_ORDINAL_DATE = new DateFormatter(
+    private static final CompoundDateTimeFormatter BASIC_ORDINAL_DATE = new CompoundDateTimeFormatter(
         DateTimeFormatter.ofPattern("yyyyDDD", Locale.ROOT));
 
-    private static final DateFormatter BASIC_ORDINAL_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter BASIC_ORDINAL_DATE_TIME = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendPattern("yyyyDDD")
         .append(BASIC_T_TIME_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter BASIC_ORDINAL_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter BASIC_ORDINAL_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendPattern("yyyyDDD")
         .appendLiteral("T")
         .append(BASIC_TIME_NO_MILLIS_FORMATTER)
@@ -140,15 +140,15 @@ public class DateFormatters {
         .appendValue(ChronoField.DAY_OF_WEEK)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter BASIC_WEEK_DATE = new DateFormatter(BASIC_WEEK_DATE_FORMATTER);
+    private static final CompoundDateTimeFormatter BASIC_WEEK_DATE = new CompoundDateTimeFormatter(BASIC_WEEK_DATE_FORMATTER);
 
-    private static final DateFormatter BASIC_WEEK_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter BASIC_WEEK_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(BASIC_WEEK_DATE_FORMATTER)
         .appendLiteral("T")
         .append(BASIC_TIME_NO_MILLIS_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter BASIC_WEEK_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter BASIC_WEEK_DATE_TIME = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(BASIC_WEEK_DATE_FORMATTER)
         .append(BASIC_T_TIME_FORMATTER)
         .toFormatter(Locale.ROOT));
@@ -161,13 +161,13 @@ public class DateFormatters {
         .appendValue(DAY_OF_MONTH, 1, 2, SignStyle.NOT_NEGATIVE)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter DATE = new DateFormatter(DATE_FORMATTER);
+    private static final CompoundDateTimeFormatter DATE = new CompoundDateTimeFormatter(DATE_FORMATTER);
 
-    private static final DateFormatter HOUR = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter HOUR = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter DATE_HOUR = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter DATE_HOUR = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(DATE_FORMATTER)
         .appendLiteral("T")
         .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
@@ -179,7 +179,7 @@ public class DateFormatters {
         .appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NOT_NEGATIVE)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter HOUR_MINUTE = new DateFormatter(HOUR_MINUTE_FORMATTER);
+    private static final CompoundDateTimeFormatter HOUR_MINUTE = new CompoundDateTimeFormatter(HOUR_MINUTE_FORMATTER);
 
     private static final DateTimeFormatter DATE_TIME_PREFIX = new DateTimeFormatterBuilder()
         .append(DATE_FORMATTER)
@@ -237,10 +237,10 @@ public class DateFormatters {
         .optionalEnd()
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter DATE_TIME_NO_MILLIS = new DateFormatter(DATE_TIME_NO_MILLIS_FORMATTER, DATE_TIME_NO_MILLIS_1,
+    private static final CompoundDateTimeFormatter DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(DATE_TIME_NO_MILLIS_FORMATTER, DATE_TIME_NO_MILLIS_1,
         DATE_TIME_NO_MILLIS_2, DATE_TIME_NO_MILLIS_3, DATE_TIME_NO_MILLIS_4, DATE_TIME_NO_MILLIS_5, DATE_TIME_NO_MILLIS_6);
 
-    private static final DateFormatter DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter DATE_TIME = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(DATE_FORMATTER)
         .appendLiteral('T')
         .append(HOUR_MINUTE_FORMATTER)
@@ -252,7 +252,7 @@ public class DateFormatters {
         .append(OPTIONAL_TIME_ZONE_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter DATE_OPTIONAL_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter DATE_OPTIONAL_TIME = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(DATE_FORMATTER)
         .parseLenient()
         .optionalStart()
@@ -273,19 +273,19 @@ public class DateFormatters {
         .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter HOUR_MINUTE_SECOND = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter HOUR_MINUTE_SECOND = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(HOUR_MINUTE_FORMATTER)
         .appendLiteral(":")
         .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter DATE_HOUR_MINUTE_SECOND = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter DATE_HOUR_MINUTE_SECOND = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(DATE_FORMATTER)
         .appendLiteral("T")
         .append(HOUR_MINUTE_SECOND_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter DATE_HOUR_MINUTE = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter DATE_HOUR_MINUTE = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(DATE_FORMATTER)
         .appendLiteral("T")
         .append(HOUR_MINUTE_FORMATTER)
@@ -300,15 +300,15 @@ public class DateFormatters {
         .appendFraction(MILLI_OF_SECOND, 1, 3, true)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter HOUR_MINUTE_SECOND_MILLIS = new DateFormatter(HOUR_MINUTE_SECOND_MILLIS_FORMATTER);
+    private static final CompoundDateTimeFormatter HOUR_MINUTE_SECOND_MILLIS = new CompoundDateTimeFormatter(HOUR_MINUTE_SECOND_MILLIS_FORMATTER);
 
-    private static final DateFormatter DATE_HOUR_MINUTE_SECOND_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter DATE_HOUR_MINUTE_SECOND_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(DATE_FORMATTER)
         .appendLiteral("T")
         .append(HOUR_MINUTE_SECOND_MILLIS_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter DATE_HOUR_MINUTE_SECOND_FRACTION = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter DATE_HOUR_MINUTE_SECOND_FRACTION = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(DATE_FORMATTER)
         .appendLiteral("T")
         .append(HOUR_MINUTE_SECOND_MILLIS_FORMATTER)
@@ -320,16 +320,16 @@ public class DateFormatters {
         .appendValue(DAY_OF_YEAR, 1, 3, SignStyle.NOT_NEGATIVE)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter ORDINAL_DATE = new DateFormatter(ORDINAL_DATE_FORMATTER);
+    private static final CompoundDateTimeFormatter ORDINAL_DATE = new CompoundDateTimeFormatter(ORDINAL_DATE_FORMATTER);
 
-    private static final DateFormatter ORDINAL_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter ORDINAL_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(ORDINAL_DATE_FORMATTER)
         .appendLiteral('T')
         .append(HOUR_MINUTE_SECOND_FORMATTER)
         .append(OPTIONAL_TIME_ZONE_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter ORDINAL_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter ORDINAL_DATE_TIME = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(ORDINAL_DATE_FORMATTER)
         .appendLiteral('T')
         .append(HOUR_MINUTE_FORMATTER)
@@ -395,7 +395,7 @@ public class DateFormatters {
         .append(TIME_ZONE_FORMATTER_WITHOUT_COLON)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter T_TIME = new DateFormatter(
+    private static final CompoundDateTimeFormatter T_TIME = new CompoundDateTimeFormatter(
         new DateTimeFormatterBuilder().appendLiteral("T").append(TIME_FORMATTER_1).toFormatter(Locale.ROOT),
         new DateTimeFormatterBuilder().appendLiteral("T").append(TIME_FORMATTER_2).toFormatter(Locale.ROOT),
         new DateTimeFormatterBuilder().appendLiteral("T").append(TIME_FORMATTER_3).toFormatter(Locale.ROOT)
@@ -428,9 +428,9 @@ public class DateFormatters {
         .append(TIME_ZONE_FORMATTER_WITHOUT_COLON)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter TIME = new DateFormatter(TIME_ZONE_ID, TIME_ZONE_WITH_COLON, TIME_ZONE_WITHOUT_COLON);
+    private static final CompoundDateTimeFormatter TIME = new CompoundDateTimeFormatter(TIME_ZONE_ID, TIME_ZONE_WITH_COLON, TIME_ZONE_WITHOUT_COLON);
 
-    private static final DateFormatter TIME_NO_MILLIS = new DateFormatter(TIME_NO_MILLIS_FORMATTER_1, TIME_NO_MILLIS_FORMATTER_2,
+    private static final CompoundDateTimeFormatter TIME_NO_MILLIS = new CompoundDateTimeFormatter(TIME_NO_MILLIS_FORMATTER_1, TIME_NO_MILLIS_FORMATTER_2,
         TIME_NO_MILLIS_FORMATTER_3);
 
     private static final DateTimeFormatter T_TIME_NO_MILLIS_FORMATTER_1 = new DateTimeFormatterBuilder()
@@ -448,7 +448,7 @@ public class DateFormatters {
         .append(TIME_NO_MILLIS_FORMATTER_3)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter T_TIME_NO_MILLIS = new DateFormatter(T_TIME_NO_MILLIS_FORMATTER_1, T_TIME_NO_MILLIS_FORMATTER_2,
+    private static final CompoundDateTimeFormatter T_TIME_NO_MILLIS = new CompoundDateTimeFormatter(T_TIME_NO_MILLIS_FORMATTER_1, T_TIME_NO_MILLIS_FORMATTER_2,
         T_TIME_NO_MILLIS_FORMATTER_3);
 
     private static final DateTimeFormatter WEEK_DATE_FORMATTER = new DateTimeFormatterBuilder()
@@ -459,31 +459,31 @@ public class DateFormatters {
         .appendValue(DAY_OF_WEEK, 1)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter WEEK_DATE = new DateFormatter(WEEK_DATE_FORMATTER);
+    private static final CompoundDateTimeFormatter WEEK_DATE = new CompoundDateTimeFormatter(WEEK_DATE_FORMATTER);
 
-    private static final DateFormatter WEEK_DATE_TIME_NO_MILLIS = new DateFormatter(
+    private static final CompoundDateTimeFormatter WEEK_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(
         new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).append(T_TIME_NO_MILLIS_FORMATTER_1).toFormatter(Locale.ROOT),
         new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).append(T_TIME_NO_MILLIS_FORMATTER_2).toFormatter(Locale.ROOT),
         new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).append(T_TIME_NO_MILLIS_FORMATTER_3).toFormatter(Locale.ROOT)
         );
 
-    private static final DateFormatter WEEK_DATE_TIME = new DateFormatter(
+    private static final CompoundDateTimeFormatter WEEK_DATE_TIME = new CompoundDateTimeFormatter(
         new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).appendLiteral("T").append(TIME_FORMATTER_1).toFormatter(Locale.ROOT),
         new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).appendLiteral("T").append(TIME_FORMATTER_2).toFormatter(Locale.ROOT),
         new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).appendLiteral("T").append(TIME_FORMATTER_3).toFormatter(Locale.ROOT)
     );
 
-    private static final DateFormatter WEEK_YEAR = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter WEEK_YEAR = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(WeekFields.ISO.weekBasedYear())
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter WEEKYEAR_WEEK = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter WEEKYEAR_WEEK = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(WeekFields.ISO.weekBasedYear())
         .appendLiteral("-W")
         .appendValue(WeekFields.ISO.weekOfWeekBasedYear())
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter WEEKYEAR_WEEK_DAY = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter WEEKYEAR_WEEK_DAY = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(WeekFields.ISO.weekBasedYear())
         .appendLiteral("-W")
         .appendValue(WeekFields.ISO.weekOfWeekBasedYear())
@@ -491,17 +491,17 @@ public class DateFormatters {
         .appendValue(WeekFields.ISO.dayOfWeek())
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter YEAR = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter YEAR = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter YEAR_MONTH = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter YEAR_MONTH = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR)
         .appendLiteral("-")
         .appendValue(MONTH_OF_YEAR)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter YEAR_MONTH_DAY = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter YEAR_MONTH_DAY = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR)
         .appendLiteral("-")
         .appendValue(MONTH_OF_YEAR)
@@ -509,11 +509,11 @@ public class DateFormatters {
         .appendValue(DAY_OF_MONTH)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter EPOCH_SECOND = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter EPOCH_SECOND = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(ChronoField.INSTANT_SECONDS)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter EPOCH_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter EPOCH_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(ChronoField.INSTANT_SECONDS, 1, 19, SignStyle.NEVER)
         .appendValue(ChronoField.MILLI_OF_SECOND, 3)
         .toFormatter(Locale.ROOT));
@@ -526,25 +526,25 @@ public class DateFormatters {
         .appendValue(ChronoField.DAY_OF_WEEK)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter STRICT_BASIC_WEEK_DATE = new DateFormatter(STRICT_BASIC_WEEK_DATE_FORMATTER);
+    private static final CompoundDateTimeFormatter STRICT_BASIC_WEEK_DATE = new CompoundDateTimeFormatter(STRICT_BASIC_WEEK_DATE_FORMATTER);
 
-    private static final DateFormatter STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(STRICT_BASIC_WEEK_DATE_FORMATTER)
         .append(DateTimeFormatter.ofPattern("'T'HHmmssX", Locale.ROOT))
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter STRICT_BASIC_WEEK_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_BASIC_WEEK_DATE_TIME = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(STRICT_BASIC_WEEK_DATE_FORMATTER)
         .append(DateTimeFormatter.ofPattern("'T'HHmmss.SSSX", Locale.ROOT))
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter STRICT_DATE = new DateFormatter(
+    private static final CompoundDateTimeFormatter STRICT_DATE = new CompoundDateTimeFormatter(
         DateTimeFormatter.ISO_LOCAL_DATE.withResolverStyle(ResolverStyle.LENIENT));
 
-    private static final DateFormatter STRICT_DATE_HOUR = new DateFormatter(
+    private static final CompoundDateTimeFormatter STRICT_DATE_HOUR = new CompoundDateTimeFormatter(
         DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH", Locale.ROOT));
 
-    private static final DateFormatter STRICT_DATE_HOUR_MINUTE = new DateFormatter(
+    private static final CompoundDateTimeFormatter STRICT_DATE_HOUR_MINUTE = new CompoundDateTimeFormatter(
         DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm", Locale.ROOT));
 
     private static final DateTimeFormatter STRICT_YEAR_MONTH_DAY_FORMATTER = new DateTimeFormatterBuilder()
@@ -555,15 +555,15 @@ public class DateFormatters {
         .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NOT_NEGATIVE)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter STRICT_YEAR_MONTH_DAY = new DateFormatter(STRICT_YEAR_MONTH_DAY_FORMATTER);
+    private static final CompoundDateTimeFormatter STRICT_YEAR_MONTH_DAY = new CompoundDateTimeFormatter(STRICT_YEAR_MONTH_DAY_FORMATTER);
 
-    private static final DateFormatter STRICT_YEAR_MONTH = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_YEAR_MONTH = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
         .appendLiteral("-")
         .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter STRICT_YEAR = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_YEAR = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
         .toFormatter(Locale.ROOT));
 
@@ -575,9 +575,9 @@ public class DateFormatters {
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter STRICT_HOUR_MINUTE_SECOND = new DateFormatter(STRICT_HOUR_MINUTE_SECOND_FORMATTER);
+    private static final CompoundDateTimeFormatter STRICT_HOUR_MINUTE_SECOND = new CompoundDateTimeFormatter(STRICT_HOUR_MINUTE_SECOND_FORMATTER);
 
-    private static final DateFormatter STRICT_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_DATE_TIME = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
         .appendLiteral('T')
         .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
@@ -587,7 +587,7 @@ public class DateFormatters {
         .append(OPTIONAL_TIME_ZONE_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter STRICT_DATE_OPTIONAL_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_DATE_OPTIONAL_TIME = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
         .optionalStart()
         .appendLiteral('T')
@@ -599,7 +599,7 @@ public class DateFormatters {
         .optionalEnd()
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter STRICT_ORDINAL_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_ORDINAL_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
         .appendLiteral('-')
         .appendValue(DAY_OF_YEAR, 3, 3, SignStyle.NOT_NEGATIVE)
@@ -608,7 +608,7 @@ public class DateFormatters {
         .append(OPTIONAL_TIME_ZONE_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter STRICT_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
         .appendLiteral('T')
         .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
@@ -620,23 +620,23 @@ public class DateFormatters {
         .appendFraction(MILLI_OF_SECOND, 1, 3, true)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter STRICT_HOUR_MINUTE_SECOND_MILLIS = new DateFormatter(STRICT_HOUR_MINUTE_SECOND_MILLIS_FORMATTER);
+    private static final CompoundDateTimeFormatter STRICT_HOUR_MINUTE_SECOND_MILLIS = new CompoundDateTimeFormatter(STRICT_HOUR_MINUTE_SECOND_MILLIS_FORMATTER);
 
-    private static final DateFormatter STRICT_HOUR_MINUTE_SECOND_FRACTION = STRICT_HOUR_MINUTE_SECOND_MILLIS;
+    private static final CompoundDateTimeFormatter STRICT_HOUR_MINUTE_SECOND_FRACTION = STRICT_HOUR_MINUTE_SECOND_MILLIS;
 
-    private static final DateFormatter STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
         .appendLiteral("T")
         .append(STRICT_HOUR_MINUTE_SECOND_MILLIS_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS = STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION;
+    private static final CompoundDateTimeFormatter STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS = STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION;
 
-    private static final DateFormatter STRICT_HOUR = new DateFormatter(DateTimeFormatter.ofPattern("HH", Locale.ROOT));
+    private static final CompoundDateTimeFormatter STRICT_HOUR = new CompoundDateTimeFormatter(DateTimeFormatter.ofPattern("HH", Locale.ROOT));
 
-    private static final DateFormatter STRICT_HOUR_MINUTE = new DateFormatter(DateTimeFormatter.ofPattern("HH:mm", Locale.ROOT));
+    private static final CompoundDateTimeFormatter STRICT_HOUR_MINUTE = new CompoundDateTimeFormatter(DateTimeFormatter.ofPattern("HH:mm", Locale.ROOT));
 
-    private static final DateFormatter STRICT_ORDINAL_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_ORDINAL_DATE_TIME = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
         .appendLiteral('-')
         .appendValue(DAY_OF_YEAR, 3, 3, SignStyle.NOT_NEGATIVE)
@@ -660,14 +660,14 @@ public class DateFormatters {
         .append(TIME_ZONE_FORMATTER)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter STRICT_TIME = new DateFormatter(STRICT_TIME_FORMATTER);
+    private static final CompoundDateTimeFormatter STRICT_TIME = new CompoundDateTimeFormatter(STRICT_TIME_FORMATTER);
 
     private static final DateTimeFormatter STRICT_T_TIME_FORMATTER = new DateTimeFormatterBuilder()
         .appendLiteral("T")
         .append(STRICT_TIME_FORMATTER)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter STRICT_T_TIME = new DateFormatter(STRICT_T_TIME_FORMATTER);
+    private static final CompoundDateTimeFormatter STRICT_T_TIME = new CompoundDateTimeFormatter(STRICT_T_TIME_FORMATTER);
 
     private static final DateTimeFormatter STRICT_TIME_NO_MILLIS_FORMATTER = new DateTimeFormatterBuilder()
         .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
@@ -678,28 +678,28 @@ public class DateFormatters {
         .append(TIME_ZONE_FORMATTER)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter STRICT_TIME_NO_MILLIS = new DateFormatter(STRICT_TIME_NO_MILLIS_FORMATTER);
+    private static final CompoundDateTimeFormatter STRICT_TIME_NO_MILLIS = new CompoundDateTimeFormatter(STRICT_TIME_NO_MILLIS_FORMATTER);
 
     private static final DateTimeFormatter STRICT_T_TIME_NO_MILLIS_FORMATTER = new DateTimeFormatterBuilder()
         .appendLiteral("T")
         .append(STRICT_TIME_NO_MILLIS_FORMATTER)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter STRICT_T_TIME_NO_MILLIS = new DateFormatter(STRICT_T_TIME_NO_MILLIS_FORMATTER);
+    private static final CompoundDateTimeFormatter STRICT_T_TIME_NO_MILLIS = new CompoundDateTimeFormatter(STRICT_T_TIME_NO_MILLIS_FORMATTER);
 
-    private static final DateFormatter STRICT_WEEK_DATE = new DateFormatter(DateTimeFormatter.ISO_WEEK_DATE);
+    private static final CompoundDateTimeFormatter STRICT_WEEK_DATE = new CompoundDateTimeFormatter(DateTimeFormatter.ISO_WEEK_DATE);
 
-    private static final DateFormatter STRICT_WEEK_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_WEEK_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(DateTimeFormatter.ISO_WEEK_DATE)
         .append(STRICT_T_TIME_NO_MILLIS_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter STRICT_WEEK_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_WEEK_DATE_TIME = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(DateTimeFormatter.ISO_WEEK_DATE)
         .append(STRICT_T_TIME_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter STRICT_WEEKYEAR = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_WEEKYEAR = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(WeekFields.ISO.weekBasedYear(), 4, 10, SignStyle.EXCEEDS_PAD)
         .toFormatter(Locale.ROOT));
 
@@ -709,24 +709,24 @@ public class DateFormatters {
         .appendValue(WeekFields.ISO.weekOfWeekBasedYear(), 2, 2, SignStyle.NOT_NEGATIVE)
         .toFormatter(Locale.ROOT);
 
-    private static final DateFormatter STRICT_WEEKYEAR_WEEK = new DateFormatter(STRICT_WEEKYEAR_WEEK_FORMATTER);
+    private static final CompoundDateTimeFormatter STRICT_WEEKYEAR_WEEK = new CompoundDateTimeFormatter(STRICT_WEEKYEAR_WEEK_FORMATTER);
 
-    private static final DateFormatter STRICT_WEEKYEAR_WEEK_DAY = new DateFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_WEEKYEAR_WEEK_DAY = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(STRICT_WEEKYEAR_WEEK_FORMATTER)
         .appendLiteral("-")
         .appendValue(WeekFields.ISO.dayOfWeek())
         .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter BASIC_ISO_DATE = new DateFormatter(DateTimeFormatter.BASIC_ISO_DATE);
-    private static final DateFormatter ISO_ORDINAL_DATE = new DateFormatter(DateTimeFormatter.ISO_ORDINAL_DATE);
-    private static final DateFormatter STRICT_DATE_HOUR_MINUTE_SECOND =
-        new DateFormatter(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT));
+    private static final CompoundDateTimeFormatter BASIC_ISO_DATE = new CompoundDateTimeFormatter(DateTimeFormatter.BASIC_ISO_DATE);
+    private static final CompoundDateTimeFormatter ISO_ORDINAL_DATE = new CompoundDateTimeFormatter(DateTimeFormatter.ISO_ORDINAL_DATE);
+    private static final CompoundDateTimeFormatter STRICT_DATE_HOUR_MINUTE_SECOND =
+        new CompoundDateTimeFormatter(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT));
 
-    public static DateFormatter forPattern(String input) {
+    public static CompoundDateTimeFormatter forPattern(String input) {
         return forPattern(input, Locale.ROOT);
     }
 
-    public static DateFormatter forPattern(String input, Locale locale) {
+    public static CompoundDateTimeFormatter forPattern(String input, Locale locale) {
         if (Strings.hasLength(input)) {
             input = input.trim();
         }
@@ -896,7 +896,7 @@ public class DateFormatters {
             if (formats.length == 1) {
                 return forPattern(formats[0], locale);
             } else {
-                DateFormatter[] formatters = new DateFormatter[formats.length];
+                CompoundDateTimeFormatter[] formatters = new CompoundDateTimeFormatter[formats.length];
                 for (int i = 0; i < formats.length; i++) {
                     try {
                         formatters[i] = forPattern(formats[i], locale);
@@ -905,11 +905,11 @@ public class DateFormatters {
                     }
                 }
 
-                return DateFormatter.merge(formatters);
+                return CompoundDateTimeFormatter.merge(formatters);
             }
         } else {
             try {
-                return new DateFormatter(new DateTimeFormatterBuilder().appendPattern(input).toFormatter(locale));
+                return new CompoundDateTimeFormatter(new DateTimeFormatterBuilder().appendPattern(input).toFormatter(locale));
             } catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException("Invalid format: [" + input + "]: " + e.getMessage(), e);
             }

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -130,7 +130,8 @@ public class DateFormatters {
         .append(BASIC_T_TIME_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final CompoundDateTimeFormatter BASIC_ORDINAL_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter BASIC_ORDINAL_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(
+        new DateTimeFormatterBuilder()
         .appendPattern("yyyyDDD")
         .appendLiteral("T")
         .append(BASIC_TIME_NO_MILLIS_FORMATTER)
@@ -145,7 +146,8 @@ public class DateFormatters {
 
     private static final CompoundDateTimeFormatter BASIC_WEEK_DATE = new CompoundDateTimeFormatter(BASIC_WEEK_DATE_FORMATTER);
 
-    private static final CompoundDateTimeFormatter BASIC_WEEK_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter BASIC_WEEK_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(
+        new DateTimeFormatterBuilder()
         .append(BASIC_WEEK_DATE_FORMATTER)
         .appendLiteral("T")
         .append(BASIC_TIME_NO_MILLIS_FORMATTER)
@@ -240,8 +242,9 @@ public class DateFormatters {
         .optionalEnd()
         .toFormatter(Locale.ROOT);
 
-    private static final CompoundDateTimeFormatter DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(DATE_TIME_NO_MILLIS_FORMATTER, DATE_TIME_NO_MILLIS_1,
-        DATE_TIME_NO_MILLIS_2, DATE_TIME_NO_MILLIS_3, DATE_TIME_NO_MILLIS_4, DATE_TIME_NO_MILLIS_5, DATE_TIME_NO_MILLIS_6);
+    private static final CompoundDateTimeFormatter DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(DATE_TIME_NO_MILLIS_FORMATTER,
+        DATE_TIME_NO_MILLIS_1,  DATE_TIME_NO_MILLIS_2, DATE_TIME_NO_MILLIS_3, DATE_TIME_NO_MILLIS_4, DATE_TIME_NO_MILLIS_5,
+        DATE_TIME_NO_MILLIS_6);
 
     private static final CompoundDateTimeFormatter DATE_TIME = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(DATE_FORMATTER)
@@ -303,15 +306,18 @@ public class DateFormatters {
         .appendFraction(MILLI_OF_SECOND, 1, 3, true)
         .toFormatter(Locale.ROOT);
 
-    private static final CompoundDateTimeFormatter HOUR_MINUTE_SECOND_MILLIS = new CompoundDateTimeFormatter(HOUR_MINUTE_SECOND_MILLIS_FORMATTER);
+    private static final CompoundDateTimeFormatter HOUR_MINUTE_SECOND_MILLIS =
+        new CompoundDateTimeFormatter(HOUR_MINUTE_SECOND_MILLIS_FORMATTER);
 
-    private static final CompoundDateTimeFormatter DATE_HOUR_MINUTE_SECOND_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter DATE_HOUR_MINUTE_SECOND_MILLIS =
+        new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(DATE_FORMATTER)
         .appendLiteral("T")
         .append(HOUR_MINUTE_SECOND_MILLIS_FORMATTER)
         .toFormatter(Locale.ROOT));
 
-    private static final CompoundDateTimeFormatter DATE_HOUR_MINUTE_SECOND_FRACTION = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter DATE_HOUR_MINUTE_SECOND_FRACTION =
+        new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(DATE_FORMATTER)
         .appendLiteral("T")
         .append(HOUR_MINUTE_SECOND_MILLIS_FORMATTER)
@@ -325,7 +331,8 @@ public class DateFormatters {
 
     private static final CompoundDateTimeFormatter ORDINAL_DATE = new CompoundDateTimeFormatter(ORDINAL_DATE_FORMATTER);
 
-    private static final CompoundDateTimeFormatter ORDINAL_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter ORDINAL_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(
+        new DateTimeFormatterBuilder()
         .append(ORDINAL_DATE_FORMATTER)
         .appendLiteral('T')
         .append(HOUR_MINUTE_SECOND_FORMATTER)
@@ -431,10 +438,11 @@ public class DateFormatters {
         .append(TIME_ZONE_FORMATTER_WITHOUT_COLON)
         .toFormatter(Locale.ROOT);
 
-    private static final CompoundDateTimeFormatter TIME = new CompoundDateTimeFormatter(TIME_ZONE_ID, TIME_ZONE_WITH_COLON, TIME_ZONE_WITHOUT_COLON);
+    private static final CompoundDateTimeFormatter TIME = new CompoundDateTimeFormatter(TIME_ZONE_ID, TIME_ZONE_WITH_COLON,
+        TIME_ZONE_WITHOUT_COLON);
 
-    private static final CompoundDateTimeFormatter TIME_NO_MILLIS = new CompoundDateTimeFormatter(TIME_NO_MILLIS_FORMATTER_1, TIME_NO_MILLIS_FORMATTER_2,
-        TIME_NO_MILLIS_FORMATTER_3);
+    private static final CompoundDateTimeFormatter TIME_NO_MILLIS =
+        new CompoundDateTimeFormatter(TIME_NO_MILLIS_FORMATTER_1, TIME_NO_MILLIS_FORMATTER_2, TIME_NO_MILLIS_FORMATTER_3);
 
     private static final DateTimeFormatter T_TIME_NO_MILLIS_FORMATTER_1 = new DateTimeFormatterBuilder()
         .appendLiteral("T")
@@ -451,8 +459,8 @@ public class DateFormatters {
         .append(TIME_NO_MILLIS_FORMATTER_3)
         .toFormatter(Locale.ROOT);
 
-    private static final CompoundDateTimeFormatter T_TIME_NO_MILLIS = new CompoundDateTimeFormatter(T_TIME_NO_MILLIS_FORMATTER_1, T_TIME_NO_MILLIS_FORMATTER_2,
-        T_TIME_NO_MILLIS_FORMATTER_3);
+    private static final CompoundDateTimeFormatter T_TIME_NO_MILLIS =
+        new CompoundDateTimeFormatter(T_TIME_NO_MILLIS_FORMATTER_1, T_TIME_NO_MILLIS_FORMATTER_2, T_TIME_NO_MILLIS_FORMATTER_3);
 
     private static final DateTimeFormatter WEEK_DATE_FORMATTER = new DateTimeFormatterBuilder()
         .appendValue(IsoFields.WEEK_BASED_YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
@@ -531,12 +539,14 @@ public class DateFormatters {
 
     private static final CompoundDateTimeFormatter STRICT_BASIC_WEEK_DATE = new CompoundDateTimeFormatter(STRICT_BASIC_WEEK_DATE_FORMATTER);
 
-    private static final CompoundDateTimeFormatter STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(
+        new DateTimeFormatterBuilder()
         .append(STRICT_BASIC_WEEK_DATE_FORMATTER)
         .append(DateTimeFormatter.ofPattern("'T'HHmmssX", Locale.ROOT))
         .toFormatter(Locale.ROOT));
 
-    private static final CompoundDateTimeFormatter STRICT_BASIC_WEEK_DATE_TIME = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_BASIC_WEEK_DATE_TIME = new CompoundDateTimeFormatter(
+        new DateTimeFormatterBuilder()
         .append(STRICT_BASIC_WEEK_DATE_FORMATTER)
         .append(DateTimeFormatter.ofPattern("'T'HHmmss.SSSX", Locale.ROOT))
         .toFormatter(Locale.ROOT));
@@ -578,7 +588,8 @@ public class DateFormatters {
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
         .toFormatter(Locale.ROOT);
 
-    private static final CompoundDateTimeFormatter STRICT_HOUR_MINUTE_SECOND = new CompoundDateTimeFormatter(STRICT_HOUR_MINUTE_SECOND_FORMATTER);
+    private static final CompoundDateTimeFormatter STRICT_HOUR_MINUTE_SECOND =
+        new CompoundDateTimeFormatter(STRICT_HOUR_MINUTE_SECOND_FORMATTER);
 
     private static final CompoundDateTimeFormatter STRICT_DATE_TIME = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
@@ -602,7 +613,8 @@ public class DateFormatters {
         .optionalEnd()
         .toFormatter(Locale.ROOT));
 
-    private static final CompoundDateTimeFormatter STRICT_ORDINAL_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_ORDINAL_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(
+        new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
         .appendLiteral('-')
         .appendValue(DAY_OF_YEAR, 3, 3, SignStyle.NOT_NEGATIVE)
@@ -623,11 +635,13 @@ public class DateFormatters {
         .appendFraction(MILLI_OF_SECOND, 1, 3, true)
         .toFormatter(Locale.ROOT);
 
-    private static final CompoundDateTimeFormatter STRICT_HOUR_MINUTE_SECOND_MILLIS = new CompoundDateTimeFormatter(STRICT_HOUR_MINUTE_SECOND_MILLIS_FORMATTER);
+    private static final CompoundDateTimeFormatter STRICT_HOUR_MINUTE_SECOND_MILLIS =
+        new CompoundDateTimeFormatter(STRICT_HOUR_MINUTE_SECOND_MILLIS_FORMATTER);
 
     private static final CompoundDateTimeFormatter STRICT_HOUR_MINUTE_SECOND_FRACTION = STRICT_HOUR_MINUTE_SECOND_MILLIS;
 
-    private static final CompoundDateTimeFormatter STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION = new CompoundDateTimeFormatter(
+        new DateTimeFormatterBuilder()
         .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
         .appendLiteral("T")
         .append(STRICT_HOUR_MINUTE_SECOND_MILLIS_FORMATTER)
@@ -635,9 +649,11 @@ public class DateFormatters {
 
     private static final CompoundDateTimeFormatter STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS = STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION;
 
-    private static final CompoundDateTimeFormatter STRICT_HOUR = new CompoundDateTimeFormatter(DateTimeFormatter.ofPattern("HH", Locale.ROOT));
+    private static final CompoundDateTimeFormatter STRICT_HOUR =
+        new CompoundDateTimeFormatter(DateTimeFormatter.ofPattern("HH", Locale.ROOT));
 
-    private static final CompoundDateTimeFormatter STRICT_HOUR_MINUTE = new CompoundDateTimeFormatter(DateTimeFormatter.ofPattern("HH:mm", Locale.ROOT));
+    private static final CompoundDateTimeFormatter STRICT_HOUR_MINUTE =
+        new CompoundDateTimeFormatter(DateTimeFormatter.ofPattern("HH:mm", Locale.ROOT));
 
     private static final CompoundDateTimeFormatter STRICT_ORDINAL_DATE_TIME = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
@@ -688,11 +704,13 @@ public class DateFormatters {
         .append(STRICT_TIME_NO_MILLIS_FORMATTER)
         .toFormatter(Locale.ROOT);
 
-    private static final CompoundDateTimeFormatter STRICT_T_TIME_NO_MILLIS = new CompoundDateTimeFormatter(STRICT_T_TIME_NO_MILLIS_FORMATTER);
+    private static final CompoundDateTimeFormatter STRICT_T_TIME_NO_MILLIS =
+        new CompoundDateTimeFormatter(STRICT_T_TIME_NO_MILLIS_FORMATTER);
 
     private static final CompoundDateTimeFormatter STRICT_WEEK_DATE = new CompoundDateTimeFormatter(DateTimeFormatter.ISO_WEEK_DATE);
 
-    private static final CompoundDateTimeFormatter STRICT_WEEK_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(new DateTimeFormatterBuilder()
+    private static final CompoundDateTimeFormatter STRICT_WEEK_DATE_TIME_NO_MILLIS = new CompoundDateTimeFormatter(
+        new DateTimeFormatterBuilder()
         .append(DateTimeFormatter.ISO_WEEK_DATE)
         .append(STRICT_T_TIME_NO_MILLIS_FORMATTER)
         .toFormatter(Locale.ROOT));
@@ -926,7 +944,7 @@ public class DateFormatters {
         }
     }
 
-    public static final ZonedDateTime EPOCH_ZONED_DATE_TIME = Instant.EPOCH.atZone(ZoneOffset.UTC);
+    private static final ZonedDateTime EPOCH_ZONED_DATE_TIME = Instant.EPOCH.atZone(ZoneOffset.UTC);
 
     public static ZonedDateTime toZonedDateTime(TemporalAccessor accessor) {
         return toZonedDateTime(accessor, EPOCH_ZONED_DATE_TIME);

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -1,0 +1,1015 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.time;
+
+import org.elasticsearch.common.Strings;
+
+import java.time.DateTimeException;
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
+import java.time.format.SignStyle;
+import java.time.temporal.ChronoField;
+import java.time.temporal.IsoFields;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.DAY_OF_WEEK;
+import static java.time.temporal.ChronoField.DAY_OF_YEAR;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+
+public class DateFormatters {
+
+    private static final DateTimeFormatter TIME_ZONE_FORMATTER = new DateTimeFormatterBuilder()
+        .optionalStart().appendZoneId().optionalEnd()
+        .optionalStart().appendOffset("+HHmm", "Z").optionalEnd()
+        .optionalStart().appendOffset("+HH:mm", "Z").optionalEnd()
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter TIME_ZONE_FORMATTER_ZONE_ID = new DateTimeFormatterBuilder()
+        .appendZoneId()
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter TIME_ZONE_FORMATTER_WITHOUT_COLON = new DateTimeFormatterBuilder()
+        .appendOffset("+HHmm", "Z")
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter TIME_ZONE_FORMATTER_WITH_COLON = new DateTimeFormatterBuilder()
+        .appendOffset("+HH:mm", "Z")
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter OPTIONAL_TIME_ZONE_FORMATTER = new DateTimeFormatterBuilder()
+        .optionalStart()
+        .append(TIME_ZONE_FORMATTER)
+        .optionalEnd()
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter BASIC_TIME_NO_MILLIS_FORMATTER = new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
+        .append(OPTIONAL_TIME_ZONE_FORMATTER)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter BASIC_TIME_NO_MILLIS = new DateFormatter(BASIC_TIME_NO_MILLIS_FORMATTER);
+
+    private static final DateTimeFormatter BASIC_TIME_FORMATTER = new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendFraction(MILLI_OF_SECOND, 1, 3, true)
+        .append(OPTIONAL_TIME_ZONE_FORMATTER)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter BASIC_TIME = new DateFormatter(BASIC_TIME_FORMATTER);
+
+    private static final DateTimeFormatter BASIC_T_TIME_FORMATTER = new DateTimeFormatterBuilder()
+        .appendLiteral("T")
+        .append(BASIC_TIME_FORMATTER)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter BASIC_T_TIME = new DateFormatter(BASIC_T_TIME_FORMATTER);
+
+    private static final DateFormatter BASIC_T_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendLiteral("T")
+        .append(BASIC_TIME_NO_MILLIS_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter BASIC_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR, 4, 4, SignStyle.NORMAL)
+        .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NOT_NEGATIVE)
+        .append(BASIC_T_TIME_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter BASIC_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR, 4, 4, SignStyle.NORMAL)
+        .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral("T")
+        .append(BASIC_TIME_NO_MILLIS_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter BASIC_ORDINAL_DATE = new DateFormatter(
+        DateTimeFormatter.ofPattern("yyyyDDD", Locale.ROOT));
+
+    private static final DateFormatter BASIC_ORDINAL_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendPattern("yyyyDDD")
+        .append(BASIC_T_TIME_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter BASIC_ORDINAL_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendPattern("yyyyDDD")
+        .appendLiteral("T")
+        .append(BASIC_TIME_NO_MILLIS_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateTimeFormatter BASIC_WEEK_DATE_FORMATTER = new DateTimeFormatterBuilder()
+        .appendValue(IsoFields.WEEK_BASED_YEAR)
+        .appendLiteral("W")
+        .appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 1, 2, SignStyle.NEVER)
+        .appendValue(ChronoField.DAY_OF_WEEK)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter BASIC_WEEK_DATE = new DateFormatter(BASIC_WEEK_DATE_FORMATTER);
+
+    private static final DateFormatter BASIC_WEEK_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(BASIC_WEEK_DATE_FORMATTER)
+        .appendLiteral("T")
+        .append(BASIC_TIME_NO_MILLIS_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter BASIC_WEEK_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(BASIC_WEEK_DATE_FORMATTER)
+        .append(BASIC_T_TIME_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateTimeFormatter DATE_FORMATTER = new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR, 1, 4, SignStyle.NORMAL)
+        .appendLiteral('-')
+        .appendValue(MONTH_OF_YEAR, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral('-')
+        .appendValue(DAY_OF_MONTH, 1, 2, SignStyle.NOT_NEGATIVE)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter DATE = new DateFormatter(DATE_FORMATTER);
+
+    private static final DateFormatter HOUR = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter DATE_HOUR = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(DATE_FORMATTER)
+        .appendLiteral("T")
+        .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateTimeFormatter HOUR_MINUTE_FORMATTER = new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NOT_NEGATIVE)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter HOUR_MINUTE = new DateFormatter(HOUR_MINUTE_FORMATTER);
+
+    private static final DateTimeFormatter DATE_TIME_PREFIX = new DateTimeFormatterBuilder()
+        .append(DATE_FORMATTER)
+        .appendLiteral('T')
+        .append(HOUR_MINUTE_FORMATTER)
+        .optionalStart()
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .optionalEnd()
+        .toFormatter(Locale.ROOT);
+
+    // only the formatter, nothing optional here
+    private static final DateTimeFormatter DATE_TIME_NO_MILLIS_FORMATTER = new DateTimeFormatterBuilder()
+        .append(DATE_FORMATTER)
+        .appendLiteral('T')
+        .append(HOUR_MINUTE_FORMATTER)
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendZoneId()
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter DATE_TIME_NO_MILLIS_1 = new DateTimeFormatterBuilder()
+        .append(DATE_TIME_PREFIX)
+        .append(TIME_ZONE_FORMATTER_WITH_COLON)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter DATE_TIME_NO_MILLIS_2 = new DateTimeFormatterBuilder()
+        .append(DATE_TIME_PREFIX)
+        .append(TIME_ZONE_FORMATTER_WITHOUT_COLON)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter DATE_TIME_NO_MILLIS_3 = new DateTimeFormatterBuilder()
+        .append(DATE_TIME_PREFIX)
+        .append(TIME_ZONE_FORMATTER_ZONE_ID)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter DATE_TIME_NO_MILLIS_4 = new DateTimeFormatterBuilder()
+        .append(DATE_TIME_PREFIX)
+        .optionalStart()
+        .append(TIME_ZONE_FORMATTER_WITH_COLON)
+        .optionalEnd()
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter DATE_TIME_NO_MILLIS_5 = new DateTimeFormatterBuilder()
+        .append(DATE_TIME_PREFIX)
+        .optionalStart()
+        .append(TIME_ZONE_FORMATTER_WITHOUT_COLON)
+        .optionalEnd()
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter DATE_TIME_NO_MILLIS_6 = new DateTimeFormatterBuilder()
+        .append(DATE_TIME_PREFIX)
+        .optionalStart()
+        .append(TIME_ZONE_FORMATTER_ZONE_ID)
+        .optionalEnd()
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter DATE_TIME_NO_MILLIS = new DateFormatter(DATE_TIME_NO_MILLIS_FORMATTER, DATE_TIME_NO_MILLIS_1,
+        DATE_TIME_NO_MILLIS_2, DATE_TIME_NO_MILLIS_3, DATE_TIME_NO_MILLIS_4, DATE_TIME_NO_MILLIS_5, DATE_TIME_NO_MILLIS_6);
+
+    private static final DateFormatter DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(DATE_FORMATTER)
+        .appendLiteral('T')
+        .append(HOUR_MINUTE_FORMATTER)
+        .optionalStart()
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendFraction(MILLI_OF_SECOND, 1, 3, true)
+        .optionalEnd()
+        .append(OPTIONAL_TIME_ZONE_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter DATE_OPTIONAL_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(DATE_FORMATTER)
+        .parseLenient()
+        .optionalStart()
+        .appendLiteral('T')
+        .append(HOUR_MINUTE_FORMATTER)
+        .optionalStart()
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendFraction(MILLI_OF_SECOND, 1, 3, true)
+        .optionalEnd()
+        .append(OPTIONAL_TIME_ZONE_FORMATTER)
+        .optionalEnd()
+        .toFormatter(Locale.ROOT));
+
+    private static final DateTimeFormatter HOUR_MINUTE_SECOND_FORMATTER = new DateTimeFormatterBuilder()
+        .append(HOUR_MINUTE_FORMATTER)
+        .appendLiteral(":")
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter HOUR_MINUTE_SECOND = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(HOUR_MINUTE_FORMATTER)
+        .appendLiteral(":")
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter DATE_HOUR_MINUTE_SECOND = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(DATE_FORMATTER)
+        .appendLiteral("T")
+        .append(HOUR_MINUTE_SECOND_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter DATE_HOUR_MINUTE = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(DATE_FORMATTER)
+        .appendLiteral("T")
+        .append(HOUR_MINUTE_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateTimeFormatter HOUR_MINUTE_SECOND_MILLIS_FORMATTER = new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendFraction(MILLI_OF_SECOND, 1, 3, true)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter HOUR_MINUTE_SECOND_MILLIS = new DateFormatter(HOUR_MINUTE_SECOND_MILLIS_FORMATTER);
+
+    private static final DateFormatter DATE_HOUR_MINUTE_SECOND_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(DATE_FORMATTER)
+        .appendLiteral("T")
+        .append(HOUR_MINUTE_SECOND_MILLIS_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter DATE_HOUR_MINUTE_SECOND_FRACTION = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(DATE_FORMATTER)
+        .appendLiteral("T")
+        .append(HOUR_MINUTE_SECOND_MILLIS_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateTimeFormatter ORDINAL_DATE_FORMATTER = new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .appendLiteral('-')
+        .appendValue(DAY_OF_YEAR, 1, 3, SignStyle.NOT_NEGATIVE)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter ORDINAL_DATE = new DateFormatter(ORDINAL_DATE_FORMATTER);
+
+    private static final DateFormatter ORDINAL_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(ORDINAL_DATE_FORMATTER)
+        .appendLiteral('T')
+        .append(HOUR_MINUTE_SECOND_FORMATTER)
+        .append(OPTIONAL_TIME_ZONE_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter ORDINAL_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(ORDINAL_DATE_FORMATTER)
+        .appendLiteral('T')
+        .append(HOUR_MINUTE_FORMATTER)
+        .optionalStart()
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendFraction(MILLI_OF_SECOND, 1, 3, true)
+        .optionalEnd()
+        .append(TIME_ZONE_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateTimeFormatter TIME_FORMATTER_1 = new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendFraction(MILLI_OF_SECOND, 1, 3, true)
+        .append(TIME_ZONE_FORMATTER_ZONE_ID)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter TIME_FORMATTER_2 = new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendFraction(MILLI_OF_SECOND, 1, 3, true)
+        .append(TIME_ZONE_FORMATTER_WITH_COLON)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter TIME_FORMATTER_3 = new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendFraction(MILLI_OF_SECOND, 1, 3, true)
+        .append(TIME_ZONE_FORMATTER_WITHOUT_COLON)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter TIME_PREFIX = new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendFraction(MILLI_OF_SECOND, 1, 3, true)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter TIME_ZONE_ID = new DateTimeFormatterBuilder()
+        .append(TIME_PREFIX)
+        .append(TIME_ZONE_FORMATTER_ZONE_ID)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter TIME_ZONE_WITH_COLON = new DateTimeFormatterBuilder()
+        .append(TIME_PREFIX)
+        .append(TIME_ZONE_FORMATTER_WITH_COLON)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter TIME_ZONE_WITHOUT_COLON = new DateTimeFormatterBuilder()
+        .append(TIME_PREFIX)
+        .append(TIME_ZONE_FORMATTER_WITHOUT_COLON)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter T_TIME = new DateFormatter(
+        new DateTimeFormatterBuilder().appendLiteral("T").append(TIME_FORMATTER_1).toFormatter(Locale.ROOT),
+        new DateTimeFormatterBuilder().appendLiteral("T").append(TIME_FORMATTER_2).toFormatter(Locale.ROOT),
+        new DateTimeFormatterBuilder().appendLiteral("T").append(TIME_FORMATTER_3).toFormatter(Locale.ROOT)
+    );
+
+    private static final DateTimeFormatter TIME_NO_MILLIS_FORMATTER_1 = new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .append(TIME_ZONE_FORMATTER_ZONE_ID)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter TIME_NO_MILLIS_FORMATTER_2 = new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .append(TIME_ZONE_FORMATTER_WITH_COLON)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter TIME_NO_MILLIS_FORMATTER_3 = new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .append(TIME_ZONE_FORMATTER_WITHOUT_COLON)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter TIME = new DateFormatter(TIME_ZONE_ID, TIME_ZONE_WITH_COLON, TIME_ZONE_WITHOUT_COLON);
+
+    private static final DateFormatter TIME_NO_MILLIS = new DateFormatter(TIME_NO_MILLIS_FORMATTER_1, TIME_NO_MILLIS_FORMATTER_2,
+        TIME_NO_MILLIS_FORMATTER_3);
+
+    private static final DateTimeFormatter T_TIME_NO_MILLIS_FORMATTER_1 = new DateTimeFormatterBuilder()
+        .appendLiteral("T")
+        .append(TIME_NO_MILLIS_FORMATTER_1)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter T_TIME_NO_MILLIS_FORMATTER_2 = new DateTimeFormatterBuilder()
+        .appendLiteral("T")
+        .append(TIME_NO_MILLIS_FORMATTER_2)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter T_TIME_NO_MILLIS_FORMATTER_3 = new DateTimeFormatterBuilder()
+        .appendLiteral("T")
+        .append(TIME_NO_MILLIS_FORMATTER_3)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter T_TIME_NO_MILLIS = new DateFormatter(T_TIME_NO_MILLIS_FORMATTER_1, T_TIME_NO_MILLIS_FORMATTER_2,
+        T_TIME_NO_MILLIS_FORMATTER_3);
+
+    private static final DateTimeFormatter WEEK_DATE_FORMATTER = new DateTimeFormatterBuilder()
+        .appendValue(IsoFields.WEEK_BASED_YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .appendLiteral("-W")
+        .appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral('-')
+        .appendValue(DAY_OF_WEEK, 1)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter WEEK_DATE = new DateFormatter(WEEK_DATE_FORMATTER);
+
+    private static final DateFormatter WEEK_DATE_TIME_NO_MILLIS = new DateFormatter(
+        new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).append(T_TIME_NO_MILLIS_FORMATTER_1).toFormatter(Locale.ROOT),
+        new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).append(T_TIME_NO_MILLIS_FORMATTER_2).toFormatter(Locale.ROOT),
+        new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).append(T_TIME_NO_MILLIS_FORMATTER_3).toFormatter(Locale.ROOT)
+        );
+
+    private static final DateFormatter WEEK_DATE_TIME = new DateFormatter(
+        new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).appendLiteral("T").append(TIME_FORMATTER_1).toFormatter(Locale.ROOT),
+        new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).appendLiteral("T").append(TIME_FORMATTER_2).toFormatter(Locale.ROOT),
+        new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).appendLiteral("T").append(TIME_FORMATTER_3).toFormatter(Locale.ROOT)
+    );
+
+    private static final DateFormatter WEEK_YEAR = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(WeekFields.ISO.weekBasedYear())
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter WEEKYEAR_WEEK = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(WeekFields.ISO.weekBasedYear())
+        .appendLiteral("-W")
+        .appendValue(WeekFields.ISO.weekOfWeekBasedYear())
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter WEEKYEAR_WEEK_DAY = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(WeekFields.ISO.weekBasedYear())
+        .appendLiteral("-W")
+        .appendValue(WeekFields.ISO.weekOfWeekBasedYear())
+        .appendLiteral("-")
+        .appendValue(WeekFields.ISO.dayOfWeek())
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter YEAR = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter YEAR_MONTH = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR)
+        .appendLiteral("-")
+        .appendValue(MONTH_OF_YEAR)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter YEAR_MONTH_DAY = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR)
+        .appendLiteral("-")
+        .appendValue(MONTH_OF_YEAR)
+        .appendLiteral("-")
+        .appendValue(DAY_OF_MONTH)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter EPOCH_SECOND = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.INSTANT_SECONDS)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter EPOCH_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.INSTANT_SECONDS, 1, 19, SignStyle.NEVER)
+        .appendValue(ChronoField.MILLI_OF_SECOND, 3)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateTimeFormatter STRICT_BASIC_WEEK_DATE_FORMATTER = new DateTimeFormatterBuilder()
+        .parseStrict()
+        .appendValue(IsoFields.WEEK_BASED_YEAR, 4)
+        .appendLiteral("W")
+        .appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 1, 2, SignStyle.NEVER)
+        .appendValue(ChronoField.DAY_OF_WEEK)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter STRICT_BASIC_WEEK_DATE = new DateFormatter(STRICT_BASIC_WEEK_DATE_FORMATTER);
+
+    private static final DateFormatter STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(STRICT_BASIC_WEEK_DATE_FORMATTER)
+        .append(DateTimeFormatter.ofPattern("'T'HHmmssX", Locale.ROOT))
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter STRICT_BASIC_WEEK_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(STRICT_BASIC_WEEK_DATE_FORMATTER)
+        .append(DateTimeFormatter.ofPattern("'T'HHmmss.SSSX", Locale.ROOT))
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter STRICT_DATE = new DateFormatter(
+        DateTimeFormatter.ISO_LOCAL_DATE.withResolverStyle(ResolverStyle.LENIENT));
+
+    private static final DateFormatter STRICT_DATE_HOUR = new DateFormatter(
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH", Locale.ROOT));
+
+    private static final DateFormatter STRICT_DATE_HOUR_MINUTE = new DateFormatter(
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm", Locale.ROOT));
+
+    private static final DateTimeFormatter STRICT_YEAR_MONTH_DAY_FORMATTER = new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .appendLiteral("-")
+        .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral('-')
+        .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NOT_NEGATIVE)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter STRICT_YEAR_MONTH_DAY = new DateFormatter(STRICT_YEAR_MONTH_DAY_FORMATTER);
+
+    private static final DateFormatter STRICT_YEAR_MONTH = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .appendLiteral("-")
+        .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter STRICT_YEAR = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateTimeFormatter STRICT_HOUR_MINUTE_SECOND_FORMATTER = new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter STRICT_HOUR_MINUTE_SECOND = new DateFormatter(STRICT_HOUR_MINUTE_SECOND_FORMATTER);
+
+    private static final DateFormatter STRICT_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
+        .appendLiteral('T')
+        .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
+        .optionalStart()
+        .appendFraction(MILLI_OF_SECOND, 3, 3, true)
+        .optionalEnd()
+        .append(OPTIONAL_TIME_ZONE_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter STRICT_DATE_OPTIONAL_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
+        .optionalStart()
+        .appendLiteral('T')
+        .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
+        .optionalStart()
+        .appendFraction(MILLI_OF_SECOND, 3, 3, true)
+        .optionalEnd()
+        .append(OPTIONAL_TIME_ZONE_FORMATTER)
+        .optionalEnd()
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter STRICT_ORDINAL_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .appendLiteral('-')
+        .appendValue(DAY_OF_YEAR, 3, 3, SignStyle.NOT_NEGATIVE)
+        .appendLiteral('T')
+        .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
+        .append(OPTIONAL_TIME_ZONE_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter STRICT_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
+        .appendLiteral('T')
+        .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
+        .append(OPTIONAL_TIME_ZONE_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateTimeFormatter STRICT_HOUR_MINUTE_SECOND_MILLIS_FORMATTER = new DateTimeFormatterBuilder()
+        .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
+        .appendFraction(MILLI_OF_SECOND, 1, 3, true)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter STRICT_HOUR_MINUTE_SECOND_MILLIS = new DateFormatter(STRICT_HOUR_MINUTE_SECOND_MILLIS_FORMATTER);
+
+    private static final DateFormatter STRICT_HOUR_MINUTE_SECOND_FRACTION = STRICT_HOUR_MINUTE_SECOND_MILLIS;
+
+    private static final DateFormatter STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
+        .appendLiteral("T")
+        .append(STRICT_HOUR_MINUTE_SECOND_MILLIS_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS = STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION;
+
+    private static final DateFormatter STRICT_HOUR = new DateFormatter(DateTimeFormatter.ofPattern("HH", Locale.ROOT));
+
+    private static final DateFormatter STRICT_HOUR_MINUTE = new DateFormatter(DateTimeFormatter.ofPattern("HH:mm", Locale.ROOT));
+
+    private static final DateFormatter STRICT_ORDINAL_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .appendLiteral('-')
+        .appendValue(DAY_OF_YEAR, 3, 3, SignStyle.NOT_NEGATIVE)
+        .appendLiteral('T')
+        .appendPattern("HH:mm")
+        .optionalStart()
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendFraction(MILLI_OF_SECOND, 1, 3, true)
+        .optionalEnd()
+        .append(OPTIONAL_TIME_ZONE_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateTimeFormatter STRICT_TIME_FORMATTER = new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendFraction(MILLI_OF_SECOND, 1, 3, true)
+        .append(TIME_ZONE_FORMATTER)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter STRICT_TIME = new DateFormatter(STRICT_TIME_FORMATTER);
+
+    private static final DateTimeFormatter STRICT_T_TIME_FORMATTER = new DateTimeFormatterBuilder()
+        .appendLiteral("T")
+        .append(STRICT_TIME_FORMATTER)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter STRICT_T_TIME = new DateFormatter(STRICT_T_TIME_FORMATTER);
+
+    private static final DateTimeFormatter STRICT_TIME_NO_MILLIS_FORMATTER = new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
+        .append(TIME_ZONE_FORMATTER)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter STRICT_TIME_NO_MILLIS = new DateFormatter(STRICT_TIME_NO_MILLIS_FORMATTER);
+
+    private static final DateTimeFormatter STRICT_T_TIME_NO_MILLIS_FORMATTER = new DateTimeFormatterBuilder()
+        .appendLiteral("T")
+        .append(STRICT_TIME_NO_MILLIS_FORMATTER)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter STRICT_T_TIME_NO_MILLIS = new DateFormatter(STRICT_T_TIME_NO_MILLIS_FORMATTER);
+
+    private static final DateFormatter STRICT_WEEK_DATE = new DateFormatter(DateTimeFormatter.ISO_WEEK_DATE);
+
+    private static final DateFormatter STRICT_WEEK_DATE_TIME_NO_MILLIS = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(DateTimeFormatter.ISO_WEEK_DATE)
+        .append(STRICT_T_TIME_NO_MILLIS_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter STRICT_WEEK_DATE_TIME = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(DateTimeFormatter.ISO_WEEK_DATE)
+        .append(STRICT_T_TIME_FORMATTER)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter STRICT_WEEKYEAR = new DateFormatter(new DateTimeFormatterBuilder()
+        .appendValue(WeekFields.ISO.weekBasedYear(), 4, 10, SignStyle.EXCEEDS_PAD)
+        .toFormatter(Locale.ROOT));
+
+    private static final DateTimeFormatter STRICT_WEEKYEAR_WEEK_FORMATTER = new DateTimeFormatterBuilder()
+        .appendValue(WeekFields.ISO.weekBasedYear(), 4, 10, SignStyle.EXCEEDS_PAD)
+        .appendLiteral("-W")
+        .appendValue(WeekFields.ISO.weekOfWeekBasedYear(), 2, 2, SignStyle.NOT_NEGATIVE)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateFormatter STRICT_WEEKYEAR_WEEK = new DateFormatter(STRICT_WEEKYEAR_WEEK_FORMATTER);
+
+    private static final DateFormatter STRICT_WEEKYEAR_WEEK_DAY = new DateFormatter(new DateTimeFormatterBuilder()
+        .append(STRICT_WEEKYEAR_WEEK_FORMATTER)
+        .appendLiteral("-")
+        .appendValue(WeekFields.ISO.dayOfWeek())
+        .toFormatter(Locale.ROOT));
+
+    private static final DateFormatter BASIC_ISO_DATE = new DateFormatter(DateTimeFormatter.BASIC_ISO_DATE);
+    private static final DateFormatter ISO_ORDINAL_DATE = new DateFormatter(DateTimeFormatter.ISO_ORDINAL_DATE);
+    private static final DateFormatter STRICT_DATE_HOUR_MINUTE_SECOND =
+        new DateFormatter(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT));
+
+    public static DateFormatter forPattern(String input) {
+        return forPattern(input, Locale.ROOT);
+    }
+
+    public static DateFormatter forPattern(String input, Locale locale) {
+        if (Strings.hasLength(input)) {
+            input = input.trim();
+        }
+        if (input == null || input.length() == 0) {
+            throw new IllegalArgumentException("No date pattern provided");
+        }
+
+        if ("basicDate".equals(input) || "basic_date".equals(input)) {
+            return BASIC_ISO_DATE;
+        } else if ("basicDateTime".equals(input) || "basic_date_time".equals(input)) {
+            return BASIC_DATE_TIME;
+        } else if ("basicDateTimeNoMillis".equals(input) || "basic_date_time_no_millis".equals(input)) {
+            return BASIC_DATE_TIME_NO_MILLIS;
+        } else if ("basicOrdinalDate".equals(input) || "basic_ordinal_date".equals(input)) {
+            return BASIC_ORDINAL_DATE;
+        } else if ("basicOrdinalDateTime".equals(input) || "basic_ordinal_date_time".equals(input)) {
+            return BASIC_ORDINAL_DATE_TIME;
+        } else if ("basicOrdinalDateTimeNoMillis".equals(input) || "basic_ordinal_date_time_no_millis".equals(input)) {
+            return BASIC_ORDINAL_DATE_TIME_NO_MILLIS;
+        } else if ("basicTime".equals(input) || "basic_time".equals(input)) {
+            return BASIC_TIME;
+        } else if ("basicTimeNoMillis".equals(input) || "basic_time_no_millis".equals(input)) {
+            return BASIC_TIME_NO_MILLIS;
+        } else if ("basicTTime".equals(input) || "basic_t_time".equals(input)) {
+            return BASIC_T_TIME;
+        } else if ("basicTTimeNoMillis".equals(input) || "basic_t_time_no_millis".equals(input)) {
+            return BASIC_T_TIME_NO_MILLIS;
+        } else if ("basicWeekDate".equals(input) || "basic_week_date".equals(input)) {
+            return BASIC_WEEK_DATE;
+        } else if ("basicWeekDateTime".equals(input) || "basic_week_date_time".equals(input)) {
+            return BASIC_WEEK_DATE_TIME;
+        } else if ("basicWeekDateTimeNoMillis".equals(input) || "basic_week_date_time_no_millis".equals(input)) {
+            return BASIC_WEEK_DATE_TIME_NO_MILLIS;
+        } else if ("date".equals(input)) {
+            return DATE;
+        } else if ("dateHour".equals(input) || "date_hour".equals(input)) {
+            return DATE_HOUR;
+        } else if ("dateHourMinute".equals(input) || "date_hour_minute".equals(input)) {
+            return DATE_HOUR_MINUTE;
+        } else if ("dateHourMinuteSecond".equals(input) || "date_hour_minute_second".equals(input)) {
+            return DATE_HOUR_MINUTE_SECOND;
+        } else if ("dateHourMinuteSecondFraction".equals(input) || "date_hour_minute_second_fraction".equals(input)) {
+            return DATE_HOUR_MINUTE_SECOND_FRACTION;
+        } else if ("dateHourMinuteSecondMillis".equals(input) || "date_hour_minute_second_millis".equals(input)) {
+            return DATE_HOUR_MINUTE_SECOND_MILLIS;
+        } else if ("dateOptionalTime".equals(input) || "date_optional_time".equals(input)) {
+            return DATE_OPTIONAL_TIME;
+        } else if ("dateTime".equals(input) || "date_time".equals(input)) {
+            return DATE_TIME;
+        } else if ("dateTimeNoMillis".equals(input) || "date_time_no_millis".equals(input)) {
+            return DATE_TIME_NO_MILLIS;
+        } else if ("hour".equals(input)) {
+            return HOUR;
+        } else if ("hourMinute".equals(input) || "hour_minute".equals(input)) {
+            return HOUR_MINUTE;
+        } else if ("hourMinuteSecond".equals(input) || "hour_minute_second".equals(input)) {
+            return HOUR_MINUTE_SECOND;
+        } else if ("hourMinuteSecondFraction".equals(input) || "hour_minute_second_fraction".equals(input)) {
+            return HOUR_MINUTE_SECOND_MILLIS;
+        } else if ("hourMinuteSecondMillis".equals(input) || "hour_minute_second_millis".equals(input)) {
+            return HOUR_MINUTE_SECOND_MILLIS;
+        } else if ("ordinalDate".equals(input) || "ordinal_date".equals(input)) {
+            return ORDINAL_DATE;
+        } else if ("ordinalDateTime".equals(input) || "ordinal_date_time".equals(input)) {
+            return ORDINAL_DATE_TIME;
+        } else if ("ordinalDateTimeNoMillis".equals(input) || "ordinal_date_time_no_millis".equals(input)) {
+            return ORDINAL_DATE_TIME_NO_MILLIS;
+        } else if ("time".equals(input)) {
+            return TIME;
+        } else if ("timeNoMillis".equals(input) || "time_no_millis".equals(input)) {
+            return TIME_NO_MILLIS;
+        } else if ("tTime".equals(input) || "t_time".equals(input)) {
+            return T_TIME;
+        } else if ("tTimeNoMillis".equals(input) || "t_time_no_millis".equals(input)) {
+            return T_TIME_NO_MILLIS;
+        } else if ("weekDate".equals(input) || "week_date".equals(input)) {
+            return WEEK_DATE;
+        } else if ("weekDateTime".equals(input) || "week_date_time".equals(input)) {
+            return WEEK_DATE_TIME;
+        } else if ("weekDateTimeNoMillis".equals(input) || "week_date_time_no_millis".equals(input)) {
+            return WEEK_DATE_TIME_NO_MILLIS;
+        } else if ("weekyear".equals(input) || "week_year".equals(input)) {
+            return WEEK_YEAR;
+        } else if ("weekyearWeek".equals(input) || "weekyear_week".equals(input)) {
+            return WEEKYEAR_WEEK;
+        } else if ("weekyearWeekDay".equals(input) || "weekyear_week_day".equals(input)) {
+            return WEEKYEAR_WEEK_DAY;
+        } else if ("year".equals(input)) {
+            return YEAR;
+        } else if ("yearMonth".equals(input) || "year_month".equals(input)) {
+            return YEAR_MONTH;
+        } else if ("yearMonthDay".equals(input) || "year_month_day".equals(input)) {
+            return YEAR_MONTH_DAY;
+        } else if ("epoch_second".equals(input)) {
+            return EPOCH_SECOND;
+        } else if ("epoch_millis".equals(input)) {
+            return EPOCH_MILLIS;
+        // strict date formats here, must be at least 4 digits for year and two for months and two for day
+        } else if ("strictBasicWeekDate".equals(input) || "strict_basic_week_date".equals(input)) {
+            return STRICT_BASIC_WEEK_DATE;
+        } else if ("strictBasicWeekDateTime".equals(input) || "strict_basic_week_date_time".equals(input)) {
+            return STRICT_BASIC_WEEK_DATE_TIME;
+        } else if ("strictBasicWeekDateTimeNoMillis".equals(input) || "strict_basic_week_date_time_no_millis".equals(input)) {
+            return STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS;
+        } else if ("strictDate".equals(input) || "strict_date".equals(input)) {
+            return STRICT_DATE;
+        } else if ("strictDateHour".equals(input) || "strict_date_hour".equals(input)) {
+            return STRICT_DATE_HOUR;
+        } else if ("strictDateHourMinute".equals(input) || "strict_date_hour_minute".equals(input)) {
+            return STRICT_DATE_HOUR_MINUTE;
+        } else if ("strictDateHourMinuteSecond".equals(input) || "strict_date_hour_minute_second".equals(input)) {
+            return STRICT_DATE_HOUR_MINUTE_SECOND;
+        } else if ("strictDateHourMinuteSecondFraction".equals(input) || "strict_date_hour_minute_second_fraction".equals(input)) {
+            return STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION;
+        } else if ("strictDateHourMinuteSecondMillis".equals(input) || "strict_date_hour_minute_second_millis".equals(input)) {
+            return STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS;
+        } else if ("strictDateOptionalTime".equals(input) || "strict_date_optional_time".equals(input)) {
+            return STRICT_DATE_OPTIONAL_TIME;
+        } else if ("strictDateTime".equals(input) || "strict_date_time".equals(input)) {
+            return STRICT_DATE_TIME;
+        } else if ("strictDateTimeNoMillis".equals(input) || "strict_date_time_no_millis".equals(input)) {
+            return STRICT_DATE_TIME_NO_MILLIS;
+        } else if ("strictHour".equals(input) || "strict_hour".equals(input)) {
+            return STRICT_HOUR;
+        } else if ("strictHourMinute".equals(input) || "strict_hour_minute".equals(input)) {
+            return STRICT_HOUR_MINUTE;
+        } else if ("strictHourMinuteSecond".equals(input) || "strict_hour_minute_second".equals(input)) {
+            return STRICT_HOUR_MINUTE_SECOND;
+        } else if ("strictHourMinuteSecondFraction".equals(input) || "strict_hour_minute_second_fraction".equals(input)) {
+            return STRICT_HOUR_MINUTE_SECOND_FRACTION;
+        } else if ("strictHourMinuteSecondMillis".equals(input) || "strict_hour_minute_second_millis".equals(input)) {
+            return STRICT_HOUR_MINUTE_SECOND_MILLIS;
+        } else if ("strictOrdinalDate".equals(input) || "strict_ordinal_date".equals(input)) {
+            return ISO_ORDINAL_DATE;
+        } else if ("strictOrdinalDateTime".equals(input) || "strict_ordinal_date_time".equals(input)) {
+            return STRICT_ORDINAL_DATE_TIME;
+        } else if ("strictOrdinalDateTimeNoMillis".equals(input) || "strict_ordinal_date_time_no_millis".equals(input)) {
+            return STRICT_ORDINAL_DATE_TIME_NO_MILLIS;
+        } else if ("strictTime".equals(input) || "strict_time".equals(input)) {
+            return STRICT_TIME;
+        } else if ("strictTimeNoMillis".equals(input) || "strict_time_no_millis".equals(input)) {
+            return STRICT_TIME_NO_MILLIS;
+        } else if ("strictTTime".equals(input) || "strict_t_time".equals(input)) {
+            return STRICT_T_TIME;
+        } else if ("strictTTimeNoMillis".equals(input) || "strict_t_time_no_millis".equals(input)) {
+            return STRICT_T_TIME_NO_MILLIS;
+        } else if ("strictWeekDate".equals(input) || "strict_week_date".equals(input)) {
+            return STRICT_WEEK_DATE;
+        } else if ("strictWeekDateTime".equals(input) || "strict_week_date_time".equals(input)) {
+            return STRICT_WEEK_DATE_TIME;
+        } else if ("strictWeekDateTimeNoMillis".equals(input) || "strict_week_date_time_no_millis".equals(input)) {
+            return STRICT_WEEK_DATE_TIME_NO_MILLIS;
+        } else if ("strictWeekyear".equals(input) || "strict_weekyear".equals(input)) {
+            return STRICT_WEEKYEAR;
+        } else if ("strictWeekyearWeek".equals(input) || "strict_weekyear_week".equals(input)) {
+            return STRICT_WEEKYEAR_WEEK;
+        } else if ("strictWeekyearWeekDay".equals(input) || "strict_weekyear_week_day".equals(input)) {
+            return STRICT_WEEKYEAR_WEEK_DAY;
+        } else if ("strictYear".equals(input) || "strict_year".equals(input)) {
+            return STRICT_YEAR;
+        } else if ("strictYearMonth".equals(input) || "strict_year_month".equals(input)) {
+            return STRICT_YEAR_MONTH;
+        } else if ("strictYearMonthDay".equals(input) || "strict_year_month_day".equals(input)) {
+            return STRICT_YEAR_MONTH_DAY;
+        } else if (Strings.hasLength(input) && input.contains("||")) {
+            String[] formats = Strings.delimitedListToStringArray(input, "||");
+            if (formats.length == 1) {
+                return forPattern(formats[0], locale);
+            } else {
+                DateFormatter[] formatters = new DateFormatter[formats.length];
+                for (int i = 0; i < formats.length; i++) {
+                    try {
+                        formatters[i] = forPattern(formats[i], locale);
+                    } catch (IllegalArgumentException e) {
+                        throw new IllegalArgumentException("Invalid format: [" + input + "]: " + e.getMessage(), e);
+                    }
+                }
+
+                return DateFormatter.merge(formatters);
+            }
+        } else {
+            try {
+                return new DateFormatter(new DateTimeFormatterBuilder().appendPattern(input).toFormatter(locale));
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid format: [" + input + "]: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    public static final ZonedDateTime EPOCH_ZONED_DATE_TIME = Instant.EPOCH.atZone(ZoneOffset.UTC);
+
+    public static ZonedDateTime toZonedDateTime(TemporalAccessor accessor) {
+        return toZonedDateTime(accessor, EPOCH_ZONED_DATE_TIME);
+    }
+
+    public static ZonedDateTime toZonedDateTime(TemporalAccessor accessor, ZonedDateTime defaults) {
+        try {
+            return ZonedDateTime.from(accessor);
+        } catch (DateTimeException e ) {
+        }
+
+        ZonedDateTime result = defaults;
+
+        // special case epoch seconds
+        if (accessor.isSupported(ChronoField.INSTANT_SECONDS)) {
+            result = result.with(ChronoField.INSTANT_SECONDS, accessor.getLong(ChronoField.INSTANT_SECONDS));
+            if (accessor.isSupported(ChronoField.NANO_OF_SECOND)) {
+                result = result.with(ChronoField.NANO_OF_SECOND, accessor.getLong(ChronoField.NANO_OF_SECOND));
+            }
+            return result;
+        }
+
+        // try to set current year
+        if (accessor.isSupported(ChronoField.YEAR)) {
+            result = result.with(ChronoField.YEAR, accessor.getLong(ChronoField.YEAR));
+        } else if (accessor.isSupported(ChronoField.YEAR_OF_ERA)) {
+            result = result.with(ChronoField.YEAR_OF_ERA, accessor.getLong(ChronoField.YEAR_OF_ERA));
+        } else if (accessor.isSupported(WeekFields.ISO.weekBasedYear())) {
+            if (accessor.isSupported(WeekFields.ISO.weekOfWeekBasedYear())) {
+                return LocalDate.from(result)
+                    .with(WeekFields.ISO.weekBasedYear(), accessor.getLong(WeekFields.ISO.weekBasedYear()))
+                    .withDayOfMonth(1) // makes this compatible with joda
+                    .with(WeekFields.ISO.weekOfWeekBasedYear(), accessor.getLong(WeekFields.ISO.weekOfWeekBasedYear()))
+                    .atStartOfDay(ZoneOffset.UTC);
+            } else {
+                return LocalDate.from(result)
+                    .with(WeekFields.ISO.weekBasedYear(), accessor.getLong(WeekFields.ISO.weekBasedYear()))
+                    // this exists solely to be BWC compatible with joda
+//                    .with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY))
+                    .with(TemporalAdjusters.firstInMonth(DayOfWeek.MONDAY))
+                    .atStartOfDay(defaults.getZone());
+//                return result.withHour(0).withMinute(0).withSecond(0)
+//                    .with(WeekFields.ISO.weekBasedYear(), 0)
+//                    .with(WeekFields.ISO.weekBasedYear(), accessor.getLong(WeekFields.ISO.weekBasedYear()));
+//                return ((ZonedDateTime) tmp).with(WeekFields.ISO.weekOfWeekBasedYear(), 1);
+            }
+        } else if (accessor.isSupported(IsoFields.WEEK_BASED_YEAR)) {
+            // special case weekbased year
+            result = result.with(IsoFields.WEEK_BASED_YEAR, accessor.getLong(IsoFields.WEEK_BASED_YEAR));
+            if (accessor.isSupported(IsoFields.WEEK_OF_WEEK_BASED_YEAR)) {
+                result = result.with(IsoFields.WEEK_OF_WEEK_BASED_YEAR, accessor.getLong(IsoFields.WEEK_OF_WEEK_BASED_YEAR));
+            }
+            return result;
+        }
+
+        // month
+        if (accessor.isSupported(ChronoField.MONTH_OF_YEAR)) {
+            result = result.with(ChronoField.MONTH_OF_YEAR, accessor.getLong(ChronoField.MONTH_OF_YEAR));
+        }
+
+        // day of month
+        if (accessor.isSupported(ChronoField.DAY_OF_MONTH)) {
+            result = result.with(ChronoField.DAY_OF_MONTH, accessor.getLong(ChronoField.DAY_OF_MONTH));
+        }
+
+        // hour
+        if (accessor.isSupported(ChronoField.HOUR_OF_DAY)) {
+            result = result.with(ChronoField.HOUR_OF_DAY, accessor.getLong(ChronoField.HOUR_OF_DAY));
+        }
+
+        // minute
+        if (accessor.isSupported(ChronoField.MINUTE_OF_HOUR)) {
+            result = result.with(ChronoField.MINUTE_OF_HOUR, accessor.getLong(ChronoField.MINUTE_OF_HOUR));
+        }
+
+        // second
+        if (accessor.isSupported(ChronoField.SECOND_OF_MINUTE)) {
+            result = result.with(ChronoField.SECOND_OF_MINUTE, accessor.getLong(ChronoField.SECOND_OF_MINUTE));
+        }
+
+        if (accessor.isSupported(ChronoField.OFFSET_SECONDS)) {
+            result = result.withZoneSameLocal(ZoneOffset.ofTotalSeconds(accessor.get(ChronoField.OFFSET_SECONDS)));
+        }
+
+        // millis
+        if (accessor.isSupported(ChronoField.MILLI_OF_SECOND)) {
+            result = result.with(ChronoField.MILLI_OF_SECOND, accessor.getLong(ChronoField.MILLI_OF_SECOND));
+        }
+
+        if (accessor.isSupported(ChronoField.NANO_OF_SECOND)) {
+            result = result.with(ChronoField.NANO_OF_SECOND, accessor.getLong(ChronoField.NANO_OF_SECOND));
+        }
+
+        return result;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -918,14 +918,8 @@ public class DateFormatters {
                 return forPattern(formats[0], locale);
             } else {
                 Collection<DateTimeFormatter> parsers = new LinkedHashSet<>(formats.length);
-                DateTimeFormatter printerAndParser = null;
                 for (int i = 0; i < formats.length; i++) {
                     CompoundDateTimeFormatter dateTimeFormatter = forPattern(formats[i], locale);
-
-                    if (i == 0) {
-                        printerAndParser = dateTimeFormatter.printer;
-                    }
-
                     try {
                         parsers.addAll(Arrays.asList(dateTimeFormatter.parsers));
                     } catch (IllegalArgumentException e) {
@@ -933,7 +927,7 @@ public class DateFormatters {
                     }
                 }
 
-                return new CompoundDateTimeFormatter(printerAndParser, parsers.toArray(new DateTimeFormatter[0]));
+                return new CompoundDateTimeFormatter(parsers.toArray(new DateTimeFormatter[0]));
             }
         } else {
             try {

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -21,13 +21,15 @@ package org.elasticsearch.monitor.jvm;
 
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.joda.FormatDateTimeFormatter;
-import org.elasticsearch.common.joda.Joda;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.common.unit.TimeValue;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -41,7 +43,7 @@ public class HotThreads {
 
     private static final Object mutex = new Object();
 
-    private static final FormatDateTimeFormatter DATE_TIME_FORMATTER = Joda.forPattern("dateOptionalTime");
+    private static final DateFormatter DATE_TIME_FORMATTER = DateFormatters.forPattern("dateOptionalTime");
 
     private int busiestThreads = 3;
     private TimeValue interval = new TimeValue(500, TimeUnit.MILLISECONDS);
@@ -136,7 +138,7 @@ public class HotThreads {
 
         StringBuilder sb = new StringBuilder();
         sb.append("Hot threads at ");
-        sb.append(DATE_TIME_FORMATTER.printer().print(System.currentTimeMillis()));
+        sb.append(DATE_TIME_FORMATTER.format(LocalDateTime.now(Clock.systemUTC())));
         sb.append(", interval=");
         sb.append(interval);
         sb.append(", busiestThreads=");

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -21,7 +21,7 @@ package org.elasticsearch.monitor.jvm;
 
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.CompoundDateTimeFormatter;
 import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.common.unit.TimeValue;
 
@@ -43,7 +43,7 @@ public class HotThreads {
 
     private static final Object mutex = new Object();
 
-    private static final DateFormatter DATE_TIME_FORMATTER = DateFormatters.forPattern("dateOptionalTime");
+    private static final CompoundDateTimeFormatter DATE_TIME_FORMATTER = DateFormatters.forPattern("dateOptionalTime");
 
     private int busiestThreads = 3;
     private TimeValue interval = new TimeValue(500, TimeUnit.MILLISECONDS);

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.CompoundDateTimeFormatter;
 import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ObjectParser;
@@ -52,7 +52,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
 
     public static final String CONTEXT_MODE_PARAM = "context_mode";
     public static final String CONTEXT_MODE_SNAPSHOT = "SNAPSHOT";
-    private static final DateFormatter DATE_TIME_FORMATTER = DateFormatters.forPattern("strictDateOptionalTime");
+    private static final CompoundDateTimeFormatter DATE_TIME_FORMATTER = DateFormatters.forPattern("strictDateOptionalTime");
     private static final String SNAPSHOT = "snapshot";
     private static final String UUID = "uuid";
     private static final String INDICES = "indices";

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -27,8 +27,8 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.joda.FormatDateTimeFormatter;
-import org.elasticsearch.common.joda.Joda;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -37,6 +37,8 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -50,7 +52,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
 
     public static final String CONTEXT_MODE_PARAM = "context_mode";
     public static final String CONTEXT_MODE_SNAPSHOT = "SNAPSHOT";
-    private static final FormatDateTimeFormatter DATE_TIME_FORMATTER = Joda.forPattern("strictDateOptionalTime");
+    private static final DateFormatter DATE_TIME_FORMATTER = DateFormatters.forPattern("strictDateOptionalTime");
     private static final String SNAPSHOT = "snapshot";
     private static final String UUID = "uuid";
     private static final String INDICES = "indices";
@@ -530,11 +532,11 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             builder.field(REASON, reason);
         }
         if (verbose || startTime != 0) {
-            builder.field(START_TIME, DATE_TIME_FORMATTER.printer().print(startTime));
+            builder.field(START_TIME, DATE_TIME_FORMATTER.format(Instant.ofEpochMilli(startTime).atZone(ZoneOffset.UTC)));
             builder.field(START_TIME_IN_MILLIS, startTime);
         }
         if (verbose || endTime != 0) {
-            builder.field(END_TIME, DATE_TIME_FORMATTER.printer().print(endTime));
+            builder.field(END_TIME, DATE_TIME_FORMATTER.format(Instant.ofEpochMilli(endTime).atZone(ZoneOffset.UTC)));
             builder.field(END_TIME_IN_MILLIS, endTime);
             builder.humanReadableField(DURATION_IN_MILLIS, DURATION, new TimeValue(endTime - startTime));
         }

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.common.joda;
 
-import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.CompoundDateTimeFormatter;
 import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.test.ESTestCase;
 import org.joda.time.DateTime;
@@ -363,7 +363,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         FormatDateTimeFormatter jodaFormatter = Joda.forPattern(format);
         DateTime jodaDateTime = jodaFormatter.parser().parseDateTime(input);
 
-        DateFormatter javaTimeFormatter = DateFormatters.forPattern(format);
+        CompoundDateTimeFormatter javaTimeFormatter = DateFormatters.forPattern(format);
         TemporalAccessor javaTimeAccessor = javaTimeFormatter.parse(input);
         ZonedDateTime zonedDateTime = DateFormatters.toZonedDateTime(javaTimeAccessor);
 
@@ -385,7 +385,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
     }
 
     private void assertJavaTimeParseException(String input, String format, String expectedMessage) {
-        DateFormatter javaTimeFormatter = DateFormatters.forPattern(format);
+        CompoundDateTimeFormatter javaTimeFormatter = DateFormatters.forPattern(format);
         DateTimeParseException dateTimeParseException = expectThrows(DateTimeParseException.class, () -> javaTimeFormatter.parse(input));
         assertThat(dateTimeParseException.getMessage(), startsWith(expectedMessage));
     }

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -1,0 +1,392 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.joda;
+
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.DateFormatters;
+import org.elasticsearch.test.ESTestCase;
+import org.joda.time.DateTime;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
+import java.util.Locale;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+
+public class JavaJodaTimeDuellingTests extends ESTestCase {
+
+    public void testTimeZoneFormatting() {
+        assertSameDate("2001-01-01T00:00:00Z", "date_time_no_millis");
+        // the following fail under java 8 but work under java 10, needs investigation
+        assertSameDate("2001-01-01T00:00:00-0800", "date_time_no_millis");
+        assertSameDate("2001-01-01T00:00:00+1030", "date_time_no_millis");
+        assertSameDate("2001-01-01T00:00:00-08", "date_time_no_millis");
+        assertSameDate("2001-01-01T00:00:00+10:30", "date_time_no_millis");
+
+        // different timezone parsing styles require a different number of letters
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSSXXX", Locale.ROOT);
+        formatter.parse("20181126T121212.123Z");
+        formatter.parse("20181126T121212.123-08:30");
+
+        DateTimeFormatter formatter2 = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSSXXXX", Locale.ROOT);
+        formatter2.parse("20181126T121212.123+1030");
+        formatter2.parse("20181126T121212.123-0830");
+
+        // ... and can be combined, note that this is not an XOR, so one could append both timezones with this example
+        DateTimeFormatter formatter3 = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSS[XXXX][XXX]", Locale.ROOT);
+        formatter3.parse("20181126T121212.123Z");
+        formatter3.parse("20181126T121212.123-08:30");
+        formatter3.parse("20181126T121212.123+1030");
+        formatter3.parse("20181126T121212.123-0830");
+    }
+
+    public void testCustomTimeFormats() {
+        assertSameDate("2010 12 06 11:05:15", "yyyy dd MM HH:mm:ss");
+        assertSameDate("12/06", "dd/MM");
+        assertSameDate("Nov 24 01:29:01 -0800", "MMM dd HH:mm:ss Z");
+    }
+
+    public void testDuellingFormatsValidParsing() {
+        assertSameDate("1522332219", "epoch_second");
+        assertSameDate("1522332219321", "epoch_millis");
+
+        assertSameDate("20181126", "basic_date");
+        assertSameDate("20181126T121212.123Z", "basic_date_time");
+        assertSameDate("20181126T121212.123+10:00", "basic_date_time");
+        assertSameDate("20181126T121212.123-0800", "basic_date_time");
+
+        assertSameDate("20181126T121212Z", "basic_date_time_no_millis");
+        assertSameDate("2018363", "basic_ordinal_date");
+        assertSameDate("2018363T121212.123Z", "basic_ordinal_date_time");
+        assertSameDate("2018363T121212Z", "basic_ordinal_date_time_no_millis");
+        assertSameDate("121212.123Z", "basic_time");
+        assertSameDate("121212Z", "basic_time_no_millis");
+        assertSameDate("T121212.123Z", "basic_t_time");
+        assertSameDate("T121212Z", "basic_t_time_no_millis");
+        assertSameDate("2018W313", "basic_week_date");
+        assertSameDate("1W313", "basic_week_date");
+        assertSameDate("18W313", "basic_week_date");
+        assertSameDate("2018W313T121212.123Z", "basic_week_date_time");
+        assertSameDate("2018W313T121212Z", "basic_week_date_time_no_millis");
+
+        assertSameDate("2018-12-31", "date");
+        assertSameDate("18-5-6", "date");
+
+        assertSameDate("2018-12-31T12", "date_hour");
+        assertSameDate("2018-12-31T8", "date_hour");
+
+        assertSameDate("2018-12-31T12:12", "date_hour_minute");
+        assertSameDate("2018-12-31T8:3", "date_hour_minute");
+
+        assertSameDate("2018-12-31T12:12:12", "date_hour_minute_second");
+        assertSameDate("2018-12-31T12:12:1", "date_hour_minute_second");
+
+        assertSameDate("2018-12-31T12:12:12.123", "date_hour_minute_second_fraction");
+        assertSameDate("2018-12-31T12:12:12.123", "date_hour_minute_second_millis");
+        assertSameDate("2018-12-31T12:12:12.1", "date_hour_minute_second_millis");
+        assertSameDate("2018-12-31T12:12:12.1", "date_hour_minute_second_fraction");
+
+        assertSameDate("2018-12-31", "date_optional_time");
+        assertSameDate("2018-12-1", "date_optional_time");
+        assertSameDate("2018-12-31T10:15:30", "date_optional_time");
+        assertSameDate("2018-12-31T10:15:3", "date_optional_time");
+        assertSameDate("2018-12-31T10:5:30", "date_optional_time");
+        assertSameDate("2018-12-31T1:15:30", "date_optional_time");
+
+        assertSameDate("2018-12-31T10:15:30.123Z", "date_time");
+        assertSameDate("2018-12-31T10:15:30.11Z", "date_time");
+        assertSameDate("2018-12-31T10:15:3.123Z", "date_time");
+
+        assertSameDate("2018-12-31T10:15:30Z", "date_time_no_millis");
+        assertSameDate("2018-12-31T10:5:30Z", "date_time_no_millis");
+        assertSameDate("2018-12-31T10:15:3Z", "date_time_no_millis");
+        assertSameDate("2018-12-31T1:15:30Z", "date_time_no_millis");
+
+        assertSameDate("12", "hour");
+        assertSameDate("01", "hour");
+        assertSameDate("1", "hour");
+
+        assertSameDate("12:12", "hour_minute");
+        assertSameDate("12:01", "hour_minute");
+        assertSameDate("12:1", "hour_minute");
+
+        assertSameDate("12:12:12", "hour_minute_second");
+        assertSameDate("12:12:01", "hour_minute_second");
+        assertSameDate("12:12:1", "hour_minute_second");
+
+        assertSameDate("12:12:12.123", "hour_minute_second_fraction");
+        assertSameDate("12:12:12.1", "hour_minute_second_fraction");
+        assertParseException("12:12:12", "hour_minute_second_fraction");
+        assertSameDate("12:12:12.123", "hour_minute_second_millis");
+        assertSameDate("12:12:12.1", "hour_minute_second_millis");
+        assertParseException("12:12:12", "hour_minute_second_millis");
+
+        assertSameDate("2018-128", "ordinal_date");
+        assertSameDate("2018-1", "ordinal_date");
+
+        assertSameDate("2018-128T10:15:30.123Z", "ordinal_date_time");
+        assertSameDate("2018-1T10:15:30.123Z", "ordinal_date_time");
+
+        assertSameDate("2018-128T10:15:30Z", "ordinal_date_time_no_millis");
+        assertSameDate("2018-1T10:15:30Z", "ordinal_date_time_no_millis");
+
+        assertSameDate("10:15:30.123Z", "time");
+        assertSameDate("1:15:30.123Z", "time");
+        assertSameDate("10:1:30.123Z", "time");
+        assertSameDate("10:15:3.123Z", "time");
+        assertParseException("10:15:3.1", "time");
+        assertParseException("10:15:3Z", "time");
+
+        assertSameDate("10:15:30Z", "time_no_millis");
+        assertSameDate("01:15:30Z", "time_no_millis");
+        assertSameDate("1:15:30Z", "time_no_millis");
+        assertSameDate("10:5:30Z", "time_no_millis");
+        assertSameDate("10:15:3Z", "time_no_millis");
+        assertParseException("10:15:3", "time_no_millis");
+
+        assertSameDate("T10:15:30.123Z", "t_time");
+        assertSameDate("T1:15:30.123Z", "t_time");
+        assertSameDate("T10:1:30.123Z", "t_time");
+        assertSameDate("T10:15:3.123Z", "t_time");
+        assertParseException("T10:15:3.1", "t_time");
+        assertParseException("T10:15:3Z", "t_time");
+
+        assertSameDate("T10:15:30Z", "t_time_no_millis");
+        assertSameDate("T1:15:30Z", "t_time_no_millis");
+        assertSameDate("T10:1:30Z", "t_time_no_millis");
+        assertSameDate("T10:15:3Z", "t_time_no_millis");
+        assertParseException("T10:15:3", "t_time_no_millis");
+
+        assertSameDate("2012-W48-6", "week_date");
+        assertSameDate("2012-W01-6", "week_date");
+        assertSameDate("2012-W1-6", "week_date");
+        // joda comes up with a different exception message here, so we have to adapt
+        assertJodaParseException("2012-W1-8", "week_date",
+            "Cannot parse \"2012-W1-8\": Value 8 for dayOfWeek must be in the range [1,7]");
+        assertJavaTimeParseException("2012-W1-8", "week_date", "Text '2012-W1-8' could not be parsed");
+
+        assertSameDate("2012-W48-6T10:15:30.123Z", "week_date_time");
+        assertSameDate("2012-W1-6T10:15:30.123Z", "week_date_time");
+
+        assertSameDate("2012-W48-6T10:15:30Z", "week_date_time_no_millis");
+        assertSameDate("2012-W1-6T10:15:30Z", "week_date_time_no_millis");
+
+        assertSameDate("2012", "year");
+        assertSameDate("1", "year");
+        assertSameDate("-2000", "year");
+
+        assertSameDate("2012-12", "yearMonth");
+        assertSameDate("1-1", "yearMonth");
+
+        assertSameDate("2012-12-31", "yearMonthDay");
+        assertSameDate("1-12-31", "yearMonthDay");
+        assertSameDate("2012-1-31", "yearMonthDay");
+        assertSameDate("2012-12-1", "yearMonthDay");
+
+        assertSameDate("2018", "week_year");
+        assertSameDate("1", "week_year");
+        assertSameDate("2017", "week_year");
+
+        assertSameDate("2018-W29", "weekyear_week");
+        assertSameDate("2018-W1", "weekyear_week");
+
+        assertSameDate("2012-W31-5", "weekyear_week_day");
+        assertSameDate("2012-W1-1", "weekyear_week_day");
+    }
+
+    public void testDuelingStrictParsing() {
+        assertSameDate("2018W313", "strict_basic_week_date");
+        assertParseException("18W313", "strict_basic_week_date");
+        assertSameDate("2018W313T121212.123Z", "strict_basic_week_date_time");
+        assertParseException("2018W313T12128.123Z", "strict_basic_week_date_time");
+        assertParseException("2018W313T81212.123Z", "strict_basic_week_date_time");
+        assertParseException("2018W313T12812.123Z", "strict_basic_week_date_time");
+        assertParseException("2018W313T12812.1Z", "strict_basic_week_date_time");
+        assertSameDate("2018W313T121212Z", "strict_basic_week_date_time_no_millis");
+        assertParseException("2018W313T12128Z", "strict_basic_week_date_time_no_millis");
+        assertParseException("2018W313T81212Z", "strict_basic_week_date_time_no_millis");
+        assertParseException("2018W313T12812Z", "strict_basic_week_date_time_no_millis");
+        assertSameDate("2018-12-31", "strict_date");
+        assertParseException("2018-8-31", "strict_date");
+        assertSameDate("2018-12-31T12", "strict_date_hour");
+        assertParseException("2018-12-31T8", "strict_date_hour");
+        assertSameDate("2018-12-31T12:12", "strict_date_hour_minute");
+        assertParseException("2018-12-31T8:3", "strict_date_hour_minute");
+        assertSameDate("2018-12-31T12:12:12", "strict_date_hour_minute_second");
+        assertParseException("2018-12-31T12:12:1", "strict_date_hour_minute_second");
+        assertSameDate("2018-12-31T12:12:12.123", "strict_date_hour_minute_second_fraction");
+        assertSameDate("2018-12-31T12:12:12.123", "strict_date_hour_minute_second_millis");
+        assertSameDate("2018-12-31T12:12:12.1", "strict_date_hour_minute_second_millis");
+        assertSameDate("2018-12-31T12:12:12.1", "strict_date_hour_minute_second_fraction");
+        assertParseException("2018-12-31T12:12:12", "strict_date_hour_minute_second_millis");
+        assertParseException("2018-12-31T12:12:12", "strict_date_hour_minute_second_fraction");
+        assertSameDate("2018-12-31", "strict_date_optional_time");
+        assertParseException("2018-12-1", "strict_date_optional_time");
+        assertParseException("2018-1-31", "strict_date_optional_time");
+        assertSameDate("2018-12-31T10:15:30", "strict_date_optional_time");
+        assertParseException("2018-12-31T10:15:3", "strict_date_optional_time");
+        assertParseException("2018-12-31T10:5:30", "strict_date_optional_time");
+        assertParseException("2018-12-31T9:15:30", "strict_date_optional_time");
+        assertSameDate("2018-12-31T10:15:30.123Z", "strict_date_time");
+        assertSameDate("2018-12-31T10:15:30.11Z", "strict_date_time");
+        assertParseException("2018-12-31T10:15:3.123Z", "strict_date_time");
+        assertParseException("2018-12-31T10:5:30.123Z", "strict_date_time");
+        assertParseException("2018-12-31T1:15:30.123Z", "strict_date_time");
+        assertSameDate("2018-12-31T10:15:30Z", "strict_date_time_no_millis");
+        assertParseException("2018-12-31T10:5:30Z", "strict_date_time_no_millis");
+        assertParseException("2018-12-31T10:15:3Z", "strict_date_time_no_millis");
+        assertParseException("2018-12-31T1:15:30Z", "strict_date_time_no_millis");
+        assertSameDate("12", "strict_hour");
+        assertSameDate("01", "strict_hour");
+        assertParseException("1", "strict_hour");
+        assertSameDate("12:12", "strict_hour_minute");
+        assertSameDate("12:01", "strict_hour_minute");
+        assertParseException("12:1", "strict_hour_minute");
+        assertSameDate("12:12:12", "strict_hour_minute_second");
+        assertSameDate("12:12:01", "strict_hour_minute_second");
+        assertParseException("12:12:1", "strict_hour_minute_second");
+        assertSameDate("12:12:12.123", "strict_hour_minute_second_fraction");
+        assertSameDate("12:12:12.1", "strict_hour_minute_second_fraction");
+        assertParseException("12:12:12", "strict_hour_minute_second_fraction");
+        assertSameDate("12:12:12.123", "strict_hour_minute_second_millis");
+        assertSameDate("12:12:12.1", "strict_hour_minute_second_millis");
+        assertParseException("12:12:12", "strict_hour_minute_second_millis");
+        assertSameDate("2018-128", "strict_ordinal_date");
+        assertParseException("2018-1", "strict_ordinal_date");
+
+        assertSameDate("2018-128T10:15:30.123Z", "strict_ordinal_date_time");
+        assertParseException("2018-1T10:15:30.123Z", "strict_ordinal_date_time");
+
+        assertSameDate("2018-128T10:15:30Z", "strict_ordinal_date_time_no_millis");
+        assertParseException("2018-1T10:15:30Z", "strict_ordinal_date_time_no_millis");
+
+        assertSameDate("10:15:30.123Z", "strict_time");
+        assertParseException("1:15:30.123Z", "strict_time");
+        assertParseException("10:1:30.123Z", "strict_time");
+        assertParseException("10:15:3.123Z", "strict_time");
+        assertParseException("10:15:3.1", "strict_time");
+        assertParseException("10:15:3Z", "strict_time");
+
+        assertSameDate("10:15:30Z", "strict_time_no_millis");
+        assertSameDate("01:15:30Z", "strict_time_no_millis");
+        assertParseException("1:15:30Z", "strict_time_no_millis");
+        assertParseException("10:5:30Z", "strict_time_no_millis");
+        assertParseException("10:15:3Z", "strict_time_no_millis");
+        assertParseException("10:15:3", "strict_time_no_millis");
+
+        assertSameDate("T10:15:30.123Z", "strict_t_time");
+        assertParseException("T1:15:30.123Z", "strict_t_time");
+        assertParseException("T10:1:30.123Z", "strict_t_time");
+        assertParseException("T10:15:3.123Z", "strict_t_time");
+        assertParseException("T10:15:3.1", "strict_t_time");
+        assertParseException("T10:15:3Z", "strict_t_time");
+
+        assertSameDate("T10:15:30Z", "strict_t_time_no_millis");
+        assertParseException("T1:15:30Z", "strict_t_time_no_millis");
+        assertParseException("T10:1:30Z", "strict_t_time_no_millis");
+        assertParseException("T10:15:3Z", "strict_t_time_no_millis");
+        assertParseException("T10:15:3", "strict_t_time_no_millis");
+
+        assertSameDate("2012-W48-6", "strict_week_date");
+        assertSameDate("2012-W01-6", "strict_week_date");
+        assertParseException("2012-W1-6", "strict_week_date");
+        assertParseException("2012-W1-8", "strict_week_date");
+
+        assertSameDate("2012-W48-6", "strict_week_date");
+        assertSameDate("2012-W01-6", "strict_week_date");
+        assertParseException("2012-W1-6", "strict_week_date");
+        // joda comes up with a different exception message here, so we have to adapt
+        assertJodaParseException("2012-W01-8", "strict_week_date",
+            "Cannot parse \"2012-W01-8\": Value 8 for dayOfWeek must be in the range [1,7]");
+        assertJavaTimeParseException("2012-W01-8", "strict_week_date", "Text '2012-W01-8' could not be parsed");
+
+        assertSameDate("2012-W48-6T10:15:30.123Z", "strict_week_date_time");
+        assertParseException("2012-W1-6T10:15:30.123Z", "strict_week_date_time");
+
+        assertSameDate("2012-W48-6T10:15:30Z", "strict_week_date_time_no_millis");
+        assertParseException("2012-W1-6T10:15:30Z", "strict_week_date_time_no_millis");
+
+        assertSameDate("2012", "strict_year");
+        assertParseException("1", "strict_year");
+        assertSameDate("-2000", "strict_year");
+
+        assertSameDate("2012-12", "strict_year_month");
+        assertParseException("1-1", "strict_year_month");
+
+        assertSameDate("2012-12-31", "strict_year_month_day");
+        assertParseException("1-12-31", "strict_year_month_day");
+        assertParseException("2012-1-31", "strict_year_month_day");
+        assertParseException("2012-12-1", "strict_year_month_day");
+
+        assertSameDate("2018", "strict_weekyear");
+        assertParseException("1", "strict_weekyear");
+
+        assertSameDate("2018", "strict_weekyear");
+        assertSameDate("2017", "strict_weekyear");
+        assertParseException("1", "strict_weekyear");
+
+        assertSameDate("2018-W29", "strict_weekyear_week");
+        assertSameDate("2018-W01", "strict_weekyear_week");
+        assertParseException("2018-W1", "strict_weekyear_week");
+
+        assertSameDate("2012-W31-5", "strict_weekyear_week_day");
+        assertParseException("2012-W1-1", "strict_weekyear_week_day");
+    }
+
+    public void testSeveralTimeFormats() {
+        assertSameDate("2018-12-12", "year_month_day||ordinal_date");
+        assertSameDate("2018-128", "year_month_day||ordinal_date");
+    }
+
+    private void assertSameDate(String input, String format) {
+        FormatDateTimeFormatter jodaFormatter = Joda.forPattern(format);
+        DateTime jodaDateTime = jodaFormatter.parser().parseDateTime(input);
+
+        DateFormatter javaTimeFormatter = DateFormatters.forPattern(format);
+        TemporalAccessor javaTimeAccessor = javaTimeFormatter.parse(input);
+        ZonedDateTime zonedDateTime = DateFormatters.toZonedDateTime(javaTimeAccessor);
+
+        String msg = String.format(Locale.ROOT, "Input [%s] Format [%s] Joda [%s], Java [%s]", input, format, jodaDateTime,
+            DateTimeFormatter.ISO_INSTANT.format(zonedDateTime.toInstant()));
+
+        assertThat(msg, jodaDateTime.getMillis(), is(zonedDateTime.toInstant().toEpochMilli()));
+    }
+
+    private void assertParseException(String input, String format) {
+        assertJodaParseException(input, format, "Invalid format: \"" + input);
+        assertJavaTimeParseException(input, format, "Text '" + input + "' could not be parsed");
+    }
+
+    private void assertJodaParseException(String input, String format, String expectedMessage) {
+        FormatDateTimeFormatter jodaFormatter = Joda.forPattern(format);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> jodaFormatter.parser().parseDateTime(input));
+        assertThat(e.getMessage(), containsString(expectedMessage));
+    }
+
+    private void assertJavaTimeParseException(String input, String format, String expectedMessage) {
+        DateFormatter javaTimeFormatter = DateFormatters.forPattern(format);
+        DateTimeParseException dateTimeParseException = expectThrows(DateTimeParseException.class, () -> javaTimeFormatter.parse(input));
+        assertThat(dateTimeParseException.getMessage(), startsWith(expectedMessage));
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -124,6 +124,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -176,6 +177,7 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     private static final List<String> JODA_TIMEZONE_IDS;
     private static final List<String> JAVA_TIMEZONE_IDS;
+    private static final List<String> JAVA_ZONE_IDS;
 
     private static final AtomicInteger portGenerator = new AtomicInteger();
 
@@ -203,6 +205,10 @@ public abstract class ESTestCase extends LuceneTestCase {
         List<String> javaTZIds = Arrays.asList(TimeZone.getAvailableIDs());
         Collections.sort(javaTZIds);
         JAVA_TIMEZONE_IDS = Collections.unmodifiableList(javaTZIds);
+
+        List<String> javaZoneIds = new ArrayList<>(ZoneId.getAvailableZoneIds());
+        Collections.sort(javaZoneIds);
+        JAVA_ZONE_IDS = Collections.unmodifiableList(javaZoneIds);
     }
 
     protected final Logger logger = Loggers.getLogger(getClass());
@@ -701,10 +707,17 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     /**
-     * generate a random TimeZone from the ones available in java.time
+     * generate a random TimeZone from the ones available in java.util
      */
     public static TimeZone randomTimeZone() {
         return TimeZone.getTimeZone(randomFrom(JAVA_TIMEZONE_IDS));
+    }
+
+    /**
+     * generate a random TimeZone from the ones available in java.time
+     */
+    public static ZoneId randomZone() {
+        return ZoneId.of(randomFrom(JAVA_ZONE_IDS));
     }
 
     /**


### PR DESCRIPTION
A newly added class called DateFormatters now contains java.time based
builders for dates, which also intends to be fully backwards compatible,
when the name based date formatters are picked.

A duelling test class has been added that ensures the same dates when
parsing java or joda time formatted dates for the name based dates.

A first user of this class is the ingest module, which now uses
java.time under the hood instead of joda time.

Note, that java.time and joda time are not fully backwards compatible,
which also means that old formats will currently not work with this
setup.

Note: This is does not include the joda to java-time conversions in the ingest processors done in #30612, just adding the new class.