### PR TITLE
QA: build improvements related to SQL projects

### DIFF
--- a/x-pack/build.gradle
+++ b/x-pack/build.gradle
@@ -45,6 +45,7 @@ subprojects {
   ext.projectSubstitutions += [ "org.elasticsearch.plugin:x-pack-ml:${version}": xpackModule('ml')]
   ext.projectSubstitutions += [ "org.elasticsearch.plugin:x-pack-monitoring:${version}": xpackModule('monitoring')]
   ext.projectSubstitutions += [ "org.elasticsearch.plugin:x-pack-security:${version}": xpackModule('security')]
+  ext.projectSubstitutions += [ "org.elasticsearch.plugin:x-pack-sql:${version}": xpackModule('sql')]
   ext.projectSubstitutions += [ "org.elasticsearch.plugin:x-pack-upgrade:${version}": xpackModule('upgrade')]
   ext.projectSubstitutions += [ "org.elasticsearch.plugin:x-pack-watcher:${version}": xpackModule('watcher')]
 }

--- a/x-pack/qa/sql/build.gradle
+++ b/x-pack/qa/sql/build.gradle
@@ -4,6 +4,7 @@ import org.elasticsearch.gradle.test.RunTask
 description = 'Integration tests for SQL'
 apply plugin: 'elasticsearch.build'
 archivesBaseName = 'qa-sql'
+group = "org.elasticsearch.x-pack.qa.sql"
 
 dependencies {
   compile "org.elasticsearch.test:framework:${version}"


### PR DESCRIPTION
Register SQL as an xpackModule
Specify group for SQL QA to disambiguate projects (otherwise due to an
old Gradle bug (https://github.com/gradle/gradle/issues/847) any
subprojects under SQL QA will not be able to refer to SQL xpackModule

Co-authored-by: Alpar Torok <torokalpar@gmail.com>