### PR TITLE
Add document _count API support to Rest High Level Client. 

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -86,6 +86,7 @@ import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.client.count.CountRequest;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Priority;
@@ -636,6 +637,18 @@ final class RequestConverters {
         Params params = new Params(request);
         params.withIndicesOptions(getAliasesRequest.indicesOptions());
         params.withLocal(getAliasesRequest.local());
+        return request;
+    }
+
+    static Request count(CountRequest countRequest) throws IOException {
+        Request request = new Request(HttpPost.METHOD_NAME, endpoint(countRequest.indices(), countRequest.types(), "_count"));
+        Params params = new Params(request);
+        params.withRouting(countRequest.routing());
+        params.withPreference(countRequest.preference());
+        params.withIndicesOptions(countRequest.indicesOptions());
+        if (countRequest.source() != null) {
+            request.setEntity(createEntity(countRequest.source(), REQUEST_BODY_CONTENT_TYPE));
+        }
         return request;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -55,6 +55,8 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.client.count.CountRequest;
+import org.elasticsearch.client.count.CountResponse;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.ParseField;
@@ -435,6 +437,29 @@ public class RestHighLevelClient implements Closeable {
     }
 
     /**
+     * Executes a count request using the Count API
+     * @param countRequest the request
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @return the response
+     * @throws IOException in case there is a problem sending the request or parsing back the response
+     */
+    public final CountResponse count(CountRequest countRequest, RequestOptions options) throws IOException {
+        return performRequestAndParseEntity(countRequest, RequestConverters::count, options, CountResponse::fromXContent,
+        emptySet());
+    }
+
+    /**
+     * Asynchronously executes a count request using the Count API
+     * @param countRequest the request
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @param listener the listener to be notified upon request completion
+     */
+    public final void countAsync(CountRequest countRequest, RequestOptions options, ActionListener<CountResponse> listener) {
+        performRequestAsyncAndParseEntity(countRequest, RequestConverters::count,  options,CountResponse::fromXContent,
+            listener, emptySet());
+    }
+
+    /**
      * Updates a document using the Update API.
      * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html">Update API on elastic.co</a>
      * @param updateRequest the request
@@ -668,7 +693,7 @@ public class RestHighLevelClient implements Closeable {
                 emptySet());
     }
 
-        
+
     /**
      * Executes a request using the Multi Search Template API.
      *
@@ -678,9 +703,9 @@ public class RestHighLevelClient implements Closeable {
     public final MultiSearchTemplateResponse multiSearchTemplate(MultiSearchTemplateRequest multiSearchTemplateRequest,
             RequestOptions options) throws IOException {
         return performRequestAndParseEntity(multiSearchTemplateRequest, RequestConverters::multiSearchTemplate,
-                options, MultiSearchTemplateResponse::fromXContext, emptySet());        
-    }   
-    
+                options, MultiSearchTemplateResponse::fromXContext, emptySet());
+    }
+
     /**
      * Asynchronously executes a request using the Multi Search Template API
      *
@@ -692,7 +717,7 @@ public class RestHighLevelClient implements Closeable {
                                           ActionListener<MultiSearchTemplateResponse> listener) {
         performRequestAsyncAndParseEntity(multiSearchTemplateRequest, RequestConverters::multiSearchTemplate,
             options, MultiSearchTemplateResponse::fromXContext, listener, emptySet());
-    }    
+    }
 
     /**
      * Asynchronously executes a request using the Ranking Evaluation API.

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/count/CountRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/count/CountRequest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.count;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+import java.util.Objects;
+
+
+/**
+ * Encapsulates a request to _count API against one, several or all indices.
+ */
+public final class CountRequest extends ActionRequest implements IndicesRequest.Replaceable {
+
+    //As internally Elasticsearch uses search api to provide count api, CountRequest wraps SearchRequest and delegates appropriate methods.
+    private final SearchRequest searchRequest;
+
+    public CountRequest() {
+        this.searchRequest = new SearchRequest();
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return searchRequest.validate();
+    }
+
+    /**
+     * Constructs a new count request against the indices. No indices provided here means that count will execute on all indices.
+     */
+    public CountRequest(String... indices) {
+        this.searchRequest = new SearchRequest(indices);
+    }
+
+    /**
+     * Constructs a new search request against the provided indices with the given search source.
+     */
+    public CountRequest(String[] indices, SearchSourceBuilder source) {
+        this.searchRequest = new SearchRequest(indices, source);
+    }
+
+    /**
+     * Sets the indices the count will be executed on.
+     */
+    public CountRequest indices(String... indices) {
+        searchRequest.indices(indices);
+        return this;
+    }
+
+    /**
+     * The source of the count request.
+     */
+    public CountRequest source(SearchSourceBuilder sourceBuilder) {
+        searchRequest.source(sourceBuilder);
+        return this;
+    }
+
+    /**
+     * The document types to execute the count against. Defaults to be executed against all types.
+     *
+     * @deprecated Types are going away, prefer filtering on a type.
+     */
+    @Deprecated
+    public CountRequest types(String... types) {
+        searchRequest.types(types);
+        return this;
+    }
+
+    /**
+     * A comma separated list of routing values to control the shards the count will be executed on.
+     */
+    public CountRequest routing(String routing) {
+        searchRequest.routing(routing);
+        return this;
+    }
+
+    /**
+     * The routing values to control the count that the search will be executed on.
+     */
+    public CountRequest routing(String... routings) {
+        searchRequest.routing(routings);
+        return this;
+    }
+
+    /**
+     * Returns the indices options used to resolve indices. They tell for instance whether a single index is accepted, whether an empty
+     * array will be converted to _all, and how wildcards will be expanded if needed.
+     *
+     * @see org.elasticsearch.action.support.IndicesOptions
+     */
+    public CountRequest indicesOptions(IndicesOptions indicesOptions) {
+        searchRequest.indicesOptions(indicesOptions);
+        return this;
+    }
+
+    /**
+     * Sets the preference to execute the count. Defaults to randomize across shards. Can be set to {@code _local} to prefer local shards
+     * or a custom value, which guarantees that the same order will be used across different requests.
+     */
+    public CountRequest preference(String preference) {
+        searchRequest.preference(preference);
+        return this;
+    }
+
+    public IndicesOptions indicesOptions() {
+        return searchRequest.indicesOptions();
+    }
+
+    public String routing() {
+        return searchRequest.routing();
+    }
+
+    public String preference() {
+        return searchRequest.preference();
+    }
+
+    public SearchSourceBuilder source() {
+        return searchRequest.source();
+    }
+
+    public String[] indices() {
+        return searchRequest.indices();
+    }
+
+    public String[] types() {
+        return searchRequest.types();
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CountRequest that = (CountRequest) o;
+        return Objects.equals(searchRequest, that.searchRequest);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(searchRequest);
+    }
+
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/count/CountResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/count/CountResponse.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.count;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.StatusToXContentObject;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.action.RestActions;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+
+/**
+ * A response to _count API request.
+ */
+public final class CountResponse extends ActionResponse implements StatusToXContentObject {
+
+    private static final ParseField COUNT = new ParseField("count");
+    private static final ParseField TERMINATED_EARLY = new ParseField("terminated_early");
+    private static final ParseField SHARDS = new ParseField("_shards");
+
+    private final long count;
+    private final Boolean terminatedEarly;
+    private final ShardStats shardStats;
+
+    public CountResponse(long count, Boolean terminatedEarly, ShardStats shardStats) {
+        this.count = count;
+        this.terminatedEarly = terminatedEarly;
+        this.shardStats = shardStats;
+    }
+
+    /**
+     * Number of documents matching request.
+     */
+    public long getCount() {
+        return count;
+    }
+
+    /**
+     * The total number of shards the search was executed on.
+     */
+    public int getTotalShards() {
+        return shardStats.totalShards;
+    }
+
+    /**
+     * The successful number of shards the search was executed on.
+     */
+    public int getSuccessfulShards() {
+        return shardStats.successfulShards;
+    }
+
+    /**
+     * The number of shards skipped due to pre-filtering
+     */
+    public int getSkippedShards() {
+        return shardStats.skippedShards;
+    }
+
+    /**
+     * The failed number of shards the search was executed on.
+     */
+    public int getFailedShards() {
+        return shardStats.shardFailures.length;
+    }
+
+    /**
+     * The failures that occurred during the search.
+     */
+    public ShardSearchFailure[] getShardFailures() {
+        return shardStats.shardFailures;
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.status(shardStats.successfulShards, shardStats.totalShards, shardStats.shardFailures);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+
+    public static CountResponse fromXContent(XContentParser parser) throws IOException {
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+        parser.nextToken();
+        ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser::getTokenLocation);
+        String currentName = parser.currentName();
+        Boolean terminatedEarly = null;
+        long count = 0;
+        ShardStats shardStats = new ShardStats(-1, -1,0, ShardSearchFailure.EMPTY_ARRAY);
+
+        for (XContentParser.Token token = parser.nextToken(); token != XContentParser.Token.END_OBJECT; token = parser.nextToken()) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentName = parser.currentName();
+            } else if (token.isValue()) {
+                if (COUNT.match(currentName, parser.getDeprecationHandler())) {
+                    count = parser.longValue();
+                } else if (TERMINATED_EARLY.match(currentName, parser.getDeprecationHandler())) {
+                    terminatedEarly = parser.booleanValue();
+                } else {
+                    parser.skipChildren();
+                }
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                if (SHARDS.match(currentName, parser.getDeprecationHandler())) {
+                    shardStats = ShardStats.fromXContent(parser);
+                } else {
+                    parser.skipChildren();
+                }
+            }
+        }
+        return new CountResponse(count, terminatedEarly, shardStats);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(COUNT.getPreferredName(), count);
+        if (isTerminatedEarly() != null) {
+            builder.field(TERMINATED_EARLY.getPreferredName(), isTerminatedEarly());
+        }
+        shardStats.toXContent(builder, params);
+        builder.endObject();
+        return builder;
+    }
+
+    public Boolean isTerminatedEarly() {
+        return terminatedEarly;
+    }
+
+    /**
+     * Encapsulates _shards section of count api response.
+     */
+    public static final class ShardStats implements ToXContent {
+
+        public static final ParseField FAILED = new ParseField("failed");
+        public static final ParseField SKIPPED = new ParseField("skipped");
+        public static final ParseField TOTAL = new ParseField("total");
+        public static final ParseField SUCCESSFUL = new ParseField("successful");
+        public static final ParseField FAILURES = new ParseField("failures");
+
+        private final int successfulShards;
+        private final int totalShards;
+        private final int skippedShards;
+        private ShardSearchFailure[] shardFailures;
+
+        public ShardStats(int successfulShards, int totalShards, int skippedShards, ShardSearchFailure[] shardFailures) {
+            this.successfulShards = successfulShards;
+            this.totalShards = totalShards;
+            this.skippedShards = skippedShards;
+            this.shardFailures = shardFailures;
+        }
+
+        public static ShardStats fromXContent(XContentParser parser) throws IOException {
+            int successfulShards = -1;
+            int totalShards = -1;
+            int skippedShards = 0; //BWC @see org.elasticsearch.action.search.SearchResponse
+            List<ShardSearchFailure> failures = new ArrayList<>();
+            XContentParser.Token token;
+            String currentName = parser.currentName();
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    currentName = parser.currentName();
+                } else if (token.isValue()) {
+                    if (FAILED.match(currentName, parser.getDeprecationHandler())) {
+                        parser.intValue();
+                    } else if (SKIPPED.match(currentName, parser.getDeprecationHandler())) {
+                        skippedShards = parser.intValue();
+                    } else if (TOTAL.match(currentName, parser.getDeprecationHandler())) {
+                        totalShards = parser.intValue();
+                    } else if (SUCCESSFUL.match(currentName, parser.getDeprecationHandler())) {
+                        successfulShards = parser.intValue();
+                    } else {
+                        parser.skipChildren();
+                    }
+                } else if (token == XContentParser.Token.START_ARRAY) {
+                    if (FAILURES.match(currentName, parser.getDeprecationHandler())) {
+                        while ((parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                            failures.add(ShardSearchFailure.fromXContent(parser));
+                        }
+                    } else {
+                        parser.skipChildren();
+                    }
+                } else {
+                    parser.skipChildren();
+                }
+            }
+            return new ShardStats(successfulShards,totalShards,skippedShards,failures.toArray(new ShardSearchFailure[failures.size()]));
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            RestActions.buildBroadcastShardsHeader(builder, params, totalShards, successfulShards, skippedShards,
+                shardFailures.length, shardFailures);
+            return builder;
+        }
+    }
+
+
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CountIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CountIT.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.elasticsearch.client.count.CountRequest;
+import org.elasticsearch.client.count.CountResponse;
+import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class CountIT extends ESRestHighLevelClientTestCase {
+
+    @Before
+    public void indexDocuments() throws IOException {
+        StringEntity doc1 = new StringEntity("{\"type\":\"type1\", \"num\":10, \"num2\":50}", ContentType.APPLICATION_JSON);
+        client().performRequest(HttpPut.METHOD_NAME, "/index/type/1", Collections.emptyMap(), doc1);
+        StringEntity doc2 = new StringEntity("{\"type\":\"type1\", \"num\":20, \"num2\":40}", ContentType.APPLICATION_JSON);
+        client().performRequest(HttpPut.METHOD_NAME, "/index/type/2", Collections.emptyMap(), doc2);
+        StringEntity doc3 = new StringEntity("{\"type\":\"type1\", \"num\":50, \"num2\":35}", ContentType.APPLICATION_JSON);
+        client().performRequest(HttpPut.METHOD_NAME, "/index/type/3", Collections.emptyMap(), doc3);
+        StringEntity doc4 = new StringEntity("{\"type\":\"type2\", \"num\":100, \"num2\":10}", ContentType.APPLICATION_JSON);
+        client().performRequest(HttpPut.METHOD_NAME, "/index/type/4", Collections.emptyMap(), doc4);
+        StringEntity doc5 = new StringEntity("{\"type\":\"type2\", \"num\":100, \"num2\":10}", ContentType.APPLICATION_JSON);
+        client().performRequest(HttpPut.METHOD_NAME, "/index/type/5", Collections.emptyMap(), doc5);
+        client().performRequest(HttpPost.METHOD_NAME, "/index/_refresh");
+
+        StringEntity doc = new StringEntity("{\"field\":\"value1\", \"rating\": 7}", ContentType.APPLICATION_JSON);
+        client().performRequest(HttpPut.METHOD_NAME, "/index1/doc/1", Collections.emptyMap(), doc);
+        doc = new StringEntity("{\"field\":\"value2\"}", ContentType.APPLICATION_JSON);
+        client().performRequest(HttpPut.METHOD_NAME, "/index1/doc/2", Collections.emptyMap(), doc);
+
+        StringEntity doc2_1 = new StringEntity("{\"type\":\"type1\", \"num\":10, \"num2\":50}", ContentType.APPLICATION_JSON);
+        client().performRequest(HttpPut.METHOD_NAME, "/index2/type/1", Collections.emptyMap(), doc2_1);
+
+        client().performRequest(HttpPost.METHOD_NAME, "/index,index1,index2/_refresh");
+    }
+
+
+    public void testCountOneIndexNoQuery() throws IOException {
+        CountRequest countRequest = new CountRequest("index");
+        CountResponse countResponse = execute(countRequest, highLevelClient()::count, highLevelClient()::countAsync);
+        assertCountHeader(countResponse);
+        assertEquals(5, countResponse.getCount());
+    }
+
+    public void testCountMultipleIndicesNoQuery() throws IOException {
+        CountRequest countRequest = new CountRequest("index", "index1");
+        CountResponse countResponse = execute(countRequest, highLevelClient()::count, highLevelClient()::countAsync);
+        assertCountHeader(countResponse);
+        assertEquals(7, countResponse.getCount());
+    }
+
+    public void testCountAllIndicesNoQuery() throws IOException {
+        CountRequest countRequest = new CountRequest();
+        CountResponse countResponse = execute(countRequest, highLevelClient()::count, highLevelClient()::countAsync);
+        assertCountHeader(countResponse);
+        assertEquals(8, countResponse.getCount());
+    }
+
+    public void testCountOneIndexMatchQuery() throws IOException {
+        CountRequest countRequest = new CountRequest("index");
+        countRequest.source(new SearchSourceBuilder().query(new MatchQueryBuilder("num", 10)));
+        CountResponse countResponse = execute(countRequest, highLevelClient()::count, highLevelClient()::countAsync);
+        assertCountHeader(countResponse);
+        assertEquals(1, countResponse.getCount());
+    }
+
+    public void testCountMultipleIndicesMatchQueryUsingConstructor() throws IOException {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(new MatchQueryBuilder("num", 10));
+        CountRequest countRequest = new CountRequest(new String[]{"index","index2"},sourceBuilder);
+        CountResponse countResponse = execute(countRequest, highLevelClient()::count, highLevelClient()::countAsync);
+        assertCountHeader(countResponse);
+        assertEquals(2, countResponse.getCount());
+    }
+
+    public void testCountMultipleIndicesMatchQuery() throws IOException {
+        CountRequest countRequest = new CountRequest("index", "index2");
+        countRequest.source(new SearchSourceBuilder().query(new MatchQueryBuilder("num", 10)));
+        CountResponse countResponse = execute(countRequest, highLevelClient()::count, highLevelClient()::countAsync);
+        assertCountHeader(countResponse);
+        assertEquals(2, countResponse.getCount());
+    }
+
+    public void testCountAllIndicesMatchQuery() throws IOException {
+        CountRequest countRequest = new CountRequest();
+        countRequest.source(new SearchSourceBuilder().query(new MatchQueryBuilder("num", 10)));
+        CountResponse countResponse = execute(countRequest, highLevelClient()::count, highLevelClient()::countAsync);
+        assertCountHeader(countResponse);
+        assertEquals(2, countResponse.getCount());
+    }
+
+    private static void assertCountHeader(CountResponse countResponse) {
+        assertEquals(0, countResponse.getSkippedShards());
+        assertEquals(0, countResponse.getFailedShards());
+        assertThat(countResponse.getTotalShards(), greaterThan(0));
+        assertEquals(countResponse.getTotalShards(), countResponse.getSuccessfulShards());
+        assertEquals(0, countResponse.getShardFailures().length);
+    }
+
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CountRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CountRequestTests.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.count.CountRequest;
+import org.elasticsearch.common.util.ArrayUtils;
+import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
+
+//quite similar to SearchRequestTests as CountRequest wraps SearchRequest
+public class CountRequestTests extends ESTestCase {
+
+    public void testIllegalArguments() {
+        CountRequest countRequest = new CountRequest();
+        assertNotNull(countRequest.indices());
+        assertNotNull(countRequest.indicesOptions());
+        assertNotNull(countRequest.types());
+
+        NullPointerException e = expectThrows(NullPointerException.class, () -> countRequest.indices((String[]) null));
+        assertEquals("indices must not be null", e.getMessage());
+        e = expectThrows(NullPointerException.class, () -> countRequest.indices((String) null));
+        assertEquals("index must not be null", e.getMessage());
+
+        e = expectThrows(NullPointerException.class, () -> countRequest.indicesOptions(null));
+        assertEquals("indicesOptions must not be null", e.getMessage());
+
+        e = expectThrows(NullPointerException.class, () -> countRequest.types((String[]) null));
+        assertEquals("types must not be null", e.getMessage());
+        e = expectThrows(NullPointerException.class, () -> countRequest.types((String) null));
+        assertEquals("type must not be null", e.getMessage());
+
+        e = expectThrows(NullPointerException.class, () -> countRequest.source(null));
+        assertEquals("source must not be null", e.getMessage());
+
+    }
+
+    public void testEqualsAndHashcode() {
+        checkEqualsAndHashCode(createCountRequest(), CountRequestTests::copyRequest, this::mutate);
+    }
+
+    private CountRequest createCountRequest() {
+        CountRequest countRequest = new CountRequest("index");
+        countRequest.source(new SearchSourceBuilder().query(new MatchQueryBuilder("num", 10)));
+        return countRequest;
+    }
+
+    private CountRequest mutate(CountRequest countRequest) {
+        CountRequest mutation = copyRequest(countRequest);
+        List<Runnable> mutators = new ArrayList<>();
+        mutators.add(() -> mutation.indices(ArrayUtils.concat(countRequest.indices(), new String[]{randomAlphaOfLength(10)})));
+        mutators.add(() -> mutation.indicesOptions(randomValueOtherThan(countRequest.indicesOptions(),
+            () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()))));
+        mutators.add(() -> mutation.types(ArrayUtils.concat(countRequest.types(), new String[]{randomAlphaOfLength(10)})));
+        mutators.add(() -> mutation.preference(randomValueOtherThan(countRequest.preference(), () -> randomAlphaOfLengthBetween(3, 10))));
+        mutators.add(() -> mutation.routing(randomValueOtherThan(countRequest.routing(), () -> randomAlphaOfLengthBetween(3, 10))));
+        randomFrom(mutators).run();
+        return mutation;
+    }
+
+    private static CountRequest copyRequest(CountRequest countRequest) {
+        CountRequest result = new CountRequest();
+        result.indices(countRequest.indices());
+        result.indicesOptions(countRequest.indicesOptions());
+        result.types(countRequest.types());
+        result.preference(countRequest.preference());
+        result.routing(countRequest.routing());
+        if (countRequest.source() != null) {
+            result.source(countRequest.source());
+        }
+        return result;
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CountResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CountResponseTests.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.elasticsearch.action.OriginalIndices;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.client.count.CountResponse;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.search.SearchShardTarget;
+import org.elasticsearch.test.AbstractXContentTestCase;
+
+import java.io.IOException;
+
+public class CountResponseTests extends AbstractXContentTestCase<CountResponse> {
+
+    @Override
+    protected CountResponse createTestInstance() {
+        long count = 5;
+        Boolean terminatedEarly = randomBoolean() ? null : randomBoolean();
+        int totalShards = randomIntBetween(1, Integer.MAX_VALUE);
+        int successfulShards = randomIntBetween(0, totalShards);
+        int skippedShards = randomIntBetween(0, totalShards);
+        int numFailures = randomIntBetween(1, 5);
+        ShardSearchFailure[] failures = new ShardSearchFailure[numFailures];
+        for (int i = 0; i < failures.length; i++) {
+            failures[i] = createShardFailureTestItem();
+        }
+        CountResponse.ShardStats shardStats = new CountResponse.ShardStats(successfulShards, totalShards, skippedShards,
+            randomBoolean() ? ShardSearchFailure.EMPTY_ARRAY : failures);
+        return new CountResponse(count, terminatedEarly, shardStats);
+    }
+
+
+    @SuppressWarnings("Duplicates") //suppress warning, as original code is in server:test:SearchResponseTests, would need to add a testJar
+    // (similar as x-pack), or move test code from server to test framework
+    public static ShardSearchFailure createShardFailureTestItem() {
+        String randomMessage = randomAlphaOfLengthBetween(3, 20);
+        Exception ex = new ParsingException(0, 0, randomMessage , new IllegalArgumentException("some bad argument"));
+        SearchShardTarget searchShardTarget = null;
+        if (randomBoolean()) {
+            String nodeId = randomAlphaOfLengthBetween(5, 10);
+            String indexName = randomAlphaOfLengthBetween(5, 10);
+            searchShardTarget = new SearchShardTarget(nodeId,
+                new ShardId(new Index(indexName, IndexMetaData.INDEX_UUID_NA_VALUE), randomInt()), null, null);
+        }
+        return new ShardSearchFailure(ex, searchShardTarget);
+    }
+
+    @Override
+    protected CountResponse doParseInstance(XContentParser parser) throws IOException {
+        return CountResponse.fromXContent(parser);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return true;
+    }
+
+    @Override
+    protected boolean assertToXContentEquivalence() {
+        return false;
+    }
+
+    @Override
+    protected void assertEqualInstances(CountResponse expectedInstance, CountResponse newInstance) {
+        assertEquals(expectedInstance.getCount(), newInstance.getCount());
+        assertEquals(expectedInstance.status(), newInstance.status());
+        assertEquals(expectedInstance.isTerminatedEarly(), newInstance.isTerminatedEarly());
+        assertEquals(expectedInstance.getTotalShards(), newInstance.getTotalShards());
+        assertEquals(expectedInstance.getFailedShards(), newInstance.getFailedShards());
+        assertEquals(expectedInstance.getSkippedShards(), newInstance.getSkippedShards());
+        assertEquals(expectedInstance.getSuccessfulShards(), newInstance.getSuccessfulShards());
+        assertEquals(expectedInstance.getShardFailures().length, newInstance.getShardFailures().length);
+
+        ShardSearchFailure[] expectedFailures = expectedInstance.getShardFailures();
+        ShardSearchFailure[] newFailures = newInstance.getShardFailures();
+
+        for (int i = 0; i < newFailures.length; i++) {
+            ShardSearchFailure parsedFailure = newFailures[i];
+            ShardSearchFailure originalFailure = expectedFailures[i];
+            assertEquals(originalFailure.index(), parsedFailure.index());
+            assertEquals(originalFailure.shard(), parsedFailure.shard());
+            assertEquals(originalFailure.shardId(), parsedFailure.shardId());
+            String originalMsg = originalFailure.getCause().getMessage();
+            assertEquals(parsedFailure.getCause().getMessage(), "Elasticsearch exception [type=parsing_exception, reason=" +
+                originalMsg + "]");
+            String nestedMsg = originalFailure.getCause().getCause().getMessage();
+            assertEquals(parsedFailure.getCause().getCause().getMessage(),
+                "Elasticsearch exception [type=illegal_argument_exception, reason=" + nestedMsg + "]");
+        }
+    }
+
+
+    public void testToXContent() {
+        CountResponse response = new CountResponse(8, null, new CountResponse.ShardStats(1, 1, 0, ShardSearchFailure.EMPTY_ARRAY));
+        String expectedString = "{\"count\":8,\"_shards\":{\"total\":1,\"successful\":1,\"skipped\":0,\"failed\":0}}";
+        assertEquals(expectedString, Strings.toString(response));
+    }
+
+    public void testToXContentWithTerminatedEarly() {
+        CountResponse response = new CountResponse(8, true, new CountResponse.ShardStats(1, 1, 0, ShardSearchFailure.EMPTY_ARRAY));
+        String expectedString = "{\"count\":8,\"terminated_early\":true,\"_shards\":{\"total\":1,\"successful\":1,\"skipped\":0," +
+            "\"failed\":0}}";
+        assertEquals(expectedString, Strings.toString(response));
+    }
+
+    public void testToXContentWithTerminatedEarlyAndShardFailures() {
+        ShardSearchFailure failure = new ShardSearchFailure(new ParsingException(0, 0, "not looking well", null),
+            new SearchShardTarget("nodeId", new ShardId(new Index("indexName", "indexUuid"), 1), null, OriginalIndices.NONE));
+        CountResponse response = new CountResponse(8, true, new CountResponse.ShardStats(1, 2, 0, new ShardSearchFailure[]{failure}));
+        String expectedString =
+            "{\"count\":8," +
+                "\"terminated_early\":true," +
+                "\"_shards\":" +
+                "{\"total\":2," +
+                "\"successful\":1," +
+                "\"skipped\":0," +
+                "\"failed\":1," +
+                "\"failures\":" +
+                "[{\"shard\":1," +
+                "\"index\":\"indexName\"," +
+                "\"node\":\"nodeId\"," +
+                "\"reason\":{\"type\":\"parsing_exception\",\"reason\":\"not looking well\",\"line\":0,\"col\":0}}]" +
+                "}" +
+                "}";
+        assertEquals(expectedString, Strings.toString(response));
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CountDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CountDocumentationIT.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.documentation;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.LatchedActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.ESRestHighLevelClientTestCase;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.count.CountRequest;
+import org.elasticsearch.client.count.CountResponse;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This class is used to generate the Java Indices API documentation.
+ * You need to wrap your code between two tags like:
+ * // tag::example
+ * // end::example
+ *
+ * Where example is your tag name.
+ *
+ * Then in the documentation, you can extract what is between tag and end tags with
+ * ["source","java",subs="attributes,callouts,macros"]
+ * --------------------------------------------------
+ * include-tagged::{doc-tests}/CountDocumentationIT.java[example]
+ * --------------------------------------------------
+ *
+ * The column width of the code block is 84. If the code contains a line longer
+ * than 84, the line will be cut and a horizontal scroll bar will be displayed.
+ * (the code indentation of the tag is not included in the width)
+ */
+public class CountDocumentationIT extends ESRestHighLevelClientTestCase {
+
+    @SuppressWarnings({"unused", "unchecked"})
+    public void testCount() throws Exception {
+        indexCountTestData();
+        RestHighLevelClient client = highLevelClient();
+        {
+            // tag::count-request-basic
+            CountRequest countRequest = new CountRequest(); // <1>
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder(); // <2>
+            searchSourceBuilder.query(QueryBuilders.matchAllQuery()); // <3>
+            countRequest.source(searchSourceBuilder); // <4>
+            // end::count-request-basic
+        }
+        {
+            // tag::count-request-indices-types
+            CountRequest countRequest = new CountRequest("blog"); // <1>
+            countRequest.types("doc"); // <2>
+            // end::count-request-indices-types
+            // tag::count-request-routing
+            countRequest.routing("routing"); // <1>
+            // end::count-request-routing
+            // tag::count-request-indicesOptions
+            countRequest.indicesOptions(IndicesOptions.lenientExpandOpen()); // <1>
+            // end::count-request-indicesOptions
+            // tag::count-request-preference
+            countRequest.preference("_local"); // <1>
+            // end::count-request-preference
+            assertNotNull(client.count(countRequest, RequestOptions.DEFAULT));
+        }
+        {
+            // tag::count-source-basics
+            SearchSourceBuilder sourceBuilder = new SearchSourceBuilder(); // <1>
+            sourceBuilder.query(QueryBuilders.termQuery("user", "kimchy")); // <2>
+            // end::count-source-basics
+
+            // tag::count-source-setter
+            CountRequest countRequest = new CountRequest();
+            countRequest.indices("blog", "author");
+            countRequest.source(sourceBuilder);
+            // end::count-source-setter
+
+            // tag::count-execute
+            CountResponse countResponse = client.count(countRequest, RequestOptions.DEFAULT);
+            // end::count-execute
+
+            // tag::count-execute-listener
+            ActionListener<CountResponse> listener = new ActionListener<CountResponse>() {
+
+                @Override
+                public void onResponse(CountResponse countResponse) {
+                    // <1>
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    // <2>
+                }
+            };
+            // end::count-execute-listener
+
+            // Replace the empty listener by a blocking listener in test
+            final CountDownLatch latch = new CountDownLatch(1);
+            listener = new LatchedActionListener<>(listener, latch);
+
+            // tag::count-execute-async
+            client.countAsync(countRequest, RequestOptions.DEFAULT, listener); // <1>
+            // end::count-execute-async
+
+            assertTrue(latch.await(30L, TimeUnit.SECONDS));
+
+            // tag::count-response-1
+            long count = countResponse.getCount();
+            RestStatus status = countResponse.status();
+            Boolean terminatedEarly = countResponse.isTerminatedEarly();
+            // end::count-response-1
+
+            // tag::count-response-2
+            int totalShards = countResponse.getTotalShards();
+            int skippedShards = countResponse.getSkippedShards();
+            int successfulShards = countResponse.getSuccessfulShards();
+            int failedShards = countResponse.getFailedShards();
+            for (ShardSearchFailure failure : countResponse.getShardFailures()) {
+                // failures should be handled here
+            }
+            // end::count-response-2
+            assertNotNull(countResponse);
+            assertEquals(4, countResponse.getCount());
+        }
+    }
+
+    private static void indexCountTestData() throws IOException {
+        CreateIndexRequest authorsRequest = new CreateIndexRequest("author")
+            .mapping("doc", "user", "type=keyword,doc_values=false");
+        CreateIndexResponse authorsResponse = highLevelClient().indices().create(authorsRequest, RequestOptions.DEFAULT);
+        assertTrue(authorsResponse.isAcknowledged());
+
+        BulkRequest bulkRequest = new BulkRequest();
+        bulkRequest.add(new IndexRequest("blog", "doc", "1")
+                .source(XContentType.JSON, "title", "Doubling Down on Open?", "user",
+                    Collections.singletonList("kimchy"), "innerObject", Collections.singletonMap("key", "value")));
+        bulkRequest.add(new IndexRequest("blog", "doc", "2")
+                .source(XContentType.JSON, "title", "Swiftype Joins Forces with Elastic", "user",
+                        Arrays.asList("kimchy", "matt"), "innerObject", Collections.singletonMap("key", "value")));
+        bulkRequest.add(new IndexRequest("blog", "doc", "3")
+                .source(XContentType.JSON, "title", "On Net Neutrality", "user",
+                        Arrays.asList("tyler","kimchy"), "innerObject", Collections.singletonMap("key", "value")));
+
+        bulkRequest.add(new IndexRequest("author", "doc", "1")
+            .source(XContentType.JSON, "user", "kimchy"));
+
+
+        bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        BulkResponse bulkResponse = highLevelClient().bulk(bulkRequest, RequestOptions.DEFAULT);
+        assertSame(RestStatus.OK, bulkResponse.status());
+        assertFalse(bulkResponse.hasFailures());
+    }
+}

--- a/docs/java-rest/high-level/search/count.asciidoc
+++ b/docs/java-rest/high-level/search/count.asciidoc
@@ -1,0 +1,145 @@
+[[java-rest-high-count]]
+=== Count API
+
+[[java-rest-high-document-count-request]]
+==== Count Request
+
+The `CountRequest` is used to execute a query and get the number of matches for the query. The query to use in `CountRequest` can be
+set in similar way as query in `SearchRequest` using `SearchSourceBuilder`.
+
+In its most basic form, we can add a query to the request:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/CountDocumentationIT.java[count-request-basic]
+--------------------------------------------------
+
+<1> Creates the `CountRequest`. Without arguments this runs against all indices.
+<2> Most search parameters are added to the `SearchSourceBuilder`.
+<3> Add a `match_all` query to the `SearchSourceBuilder`.
+<4> Add the `SearchSourceBuilder` to the `CountRequest`.
+
+[[java-rest-high-count-request-optional]]
+===== Count Request optional arguments
+
+Let's first look at some of the optional arguments of a `CountRequest`:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/CountDocumentationIT.java[count-request-indices-types]
+--------------------------------------------------
+<1> Restricts the request to an index
+<2> Limits the request to a type
+
+There are a couple of other interesting optional parameters:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/CountDocumentationIT.java[count-request-routing]
+--------------------------------------------------
+<1> Set a routing parameter
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/CountDocumentationIT.java[count-request-indicesOptions]
+--------------------------------------------------
+<1> Setting `IndicesOptions` controls how unavailable indices are resolved and how wildcard expressions are expanded
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/CountDocumentationIT.java[count-request-preference]
+--------------------------------------------------
+<1> Use the preference parameter e.g. to execute the search to prefer local shards. The default is to randomize across shards.
+
+===== Using the SearchSourceBuilder in CountRequest
+
+Most options controlling the search behavior can be set on the `SearchSourceBuilder`,
+which contains more or less the equivalent of the options in the search request body of the Rest API.
+
+Here are a few examples of some common options:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/CountDocumentationIT.java[count-source-basics]
+--------------------------------------------------
+<1> Create a `SearchSourceBuilder` with default options.
+<2> Set the query. Can be any type of `QueryBuilder`
+
+After this, the `SearchSourceBuilder` only needs to be added to the
+`CountRequest`:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/CountDocumentationIT.java[count-source-setter]
+--------------------------------------------------
+
+Note subtle difference when using `SearchSourceBuilder` in `SearchRequest` and using `SearchSourceBuilder` in `CountRequest` - using
+`SearchSourceBuilder` in `SearchRequest` one can use `SearchSourceBuilder.size()` and `SearchSourceBuilder.from()` methods to set the
+number of search hits to return, and the starting index. In `CountRequest` we're interested in total number of matches and these methods
+have no meaning.
+
+The <<java-rest-high-query-builders, Building Queries>> page gives a list of all available search queries with
+their corresponding `QueryBuilder` objects and `QueryBuilders` helper methods.
+
+[[java-rest-high-document-count-sync]]
+==== Synchronous Execution
+
+When executing a `CountRequest` in the following manner, the client waits
+for the `CountResponse` to be returned before continuing with code execution:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/CountDocumentationIT.java[count-execute]
+--------------------------------------------------
+
+[[java-rest-high-document-count-async]]
+==== Asynchronous Execution
+
+Executing a `CountRequest` can also be done in an asynchronous fashion so that
+the client can return directly. Users need to specify how the response or
+potential failures will be handled by passing the request and a listeners to the
+asynchronous count method:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/CountDocumentationIT.java[count-execute-async]
+--------------------------------------------------
+<1> The `CountRequest` to execute and the `ActionListener` to use when
+the execution completes
+
+The asynchronous method does not block and returns immediately. Once it is
+completed the `ActionListener` is called back using the `onResponse` method
+if the execution successfully completed or using the `onFailure` method if
+it failed.
+
+A typical listener for `CountResponse` looks like:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/CountDocumentationIT.java[count-execute-listener]
+--------------------------------------------------
+<1> Called when the execution is successfully completed.
+<2> Called when the whole `CountRequest` fails.
+
+[[java-rest-high-count-response]]
+==== CountResponse
+
+The `CountResponse` that is returned by executing the count API call provides total count of hits and details about the count execution
+itself, like the HTTP status code, or whether the request terminated early:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/CountDocumentationIT.java[count-response-1]
+--------------------------------------------------
+
+Second, the response also provides information about the execution on the
+shard level by offering statistics about the total number of shards that were
+affected by the underlying search, and the successful vs. unsuccessful shards. Possible
+failures can also be handled by iterating over an array off
+`ShardSearchFailures` like in the following example:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/CountDocumentationIT.java[count-response-2]
+--------------------------------------------------
+

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -37,6 +37,7 @@ The Java High Level REST Client supports the following Search APIs:
 * <<java-rest-high-field-caps>>
 * <<java-rest-high-rank-eval>>
 * <<java-rest-high-explain>>
+* <<java-rest-high-count>>
 
 include::search/search.asciidoc[]
 include::search/scroll.asciidoc[]
@@ -46,6 +47,7 @@ include::search/multi-search-template.asciidoc[]
 include::search/field-caps.asciidoc[]
 include::search/rank-eval.asciidoc[]
 include::search/explain.asciidoc[]
+include::search/count.asciidoc[]
 
 == Miscellaneous APIs
 


### PR DESCRIPTION
At the moment there are no CountRequest and CountResponse classes, and RestCountAction will return SearchResponse with XContent generated dynamically (inline).
CountRequest and CountResponse are added to HL Rest Client.
CountRequest aggregates SearchRequest and exposes relevant methods to user of CountRequest, and delegates these to the counterparts in SearchRequest.
CountResponse, on the contrary has no relationship with SearchResponse, instead CountResponse will reuese relevant members (SearchShardFailures).
Relates to #27205 
@javanna 
