### PR TITLE
Fixed bolding in allow-origin

### DIFF
--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -73,7 +73,7 @@ are missing.
 allowed. If you prepend and append a `/` to the value, this will
 be treated as a regular expression, allowing you to support HTTP and HTTPs.
 for example using `/https?:\/\/localhost(:[0-9]+)?/` would return the
-request header appropriately in both cases. `*` is a valid value but is
+request header appropriately in both cases. * is a valid value but is
 considered a *security risk* as your Elasticsearch instance is open to cross origin
 requests from *anywhere*.
 


### PR DESCRIPTION
The wrong part of the sentence was made bold, and the asterisk was "hidden"
