### PR TITLE
Fix wrong NaN check in MovingFunctions#stdDev()

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/movfn/MovingFunctions.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/movfn/MovingFunctions.java
@@ -85,7 +85,7 @@ public class MovingFunctions {
      * The average is based on the count of non-null, non-NaN values.
      */
     public static double stdDev(double[] values, double avg) {
-        if (avg == Double.NaN) {
+        if (Double.isNaN(avg)) {
             return Double.NaN;
         } else {
             long count = 0;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/movfn/MovFnWhitelistedFunctionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/movfn/MovFnWhitelistedFunctionTests.java
@@ -313,6 +313,10 @@ public class MovFnWhitelistedFunctionTests extends ESTestCase {
         assertThat(actual, equalTo(Double.NaN));
     }
 
+    public void testStdDevNaNAvg() {
+        assertThat(MovingFunctions.stdDev(new double[] { 1.0, 2.0, 3.0 }, Double.NaN), equalTo(Double.NaN));
+    }
+
     public void testLinearMovAvg() {
 
         int numValues = randomIntBetween(1, 100);


### PR DESCRIPTION
The initial check will never be true, because of the special semantics of NaN,
where no value is equal to Nan, including NaN. Thus, x == Double.NaN always
evaluates to false. The method still works correct because later computations
will also return NaN if the avg argument is NaN, but the intended shortcut
doesn't work.