### PR TITLE
[ML] Mute test failing due to Java 11 date time format parsing bug

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/DataDescription.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/DataDescription.java
@@ -353,7 +353,8 @@ public class DataDescription implements ToXContentObject, Writeable {
                     try {
                         DateTimeFormatterTimestampConverter.ofPattern(format, ZoneOffset.UTC);
                     } catch (IllegalArgumentException e) {
-                        throw ExceptionsHelper.badRequestException(Messages.getMessage(Messages.JOB_CONFIG_INVALID_TIMEFORMAT, format));
+                        throw ExceptionsHelper.badRequestException(
+                                    Messages.getMessage(Messages.JOB_CONFIG_INVALID_TIMEFORMAT, format), e.getCause());
                     }
             }
             timeFormat = format;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/time/DateTimeFormatterTimestampConverter.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/time/DateTimeFormatterTimestampConverter.java
@@ -54,9 +54,9 @@ public class DateTimeFormatterTimestampConverter implements TimestampConverter {
                 .parseDefaulting(ChronoField.YEAR_OF_ERA, LocalDate.now(defaultTimezone).getYear())
                 .toFormatter();
 
-        String now = formatter.format(ZonedDateTime.ofInstant(Instant.ofEpochSecond(0), ZoneOffset.UTC));
+        String formattedTime = formatter.format(ZonedDateTime.ofInstant(Instant.ofEpochSecond(0), ZoneOffset.UTC));
         try {
-            TemporalAccessor parsed = formatter.parse(now);
+            TemporalAccessor parsed = formatter.parse(formattedTime);
             boolean hasTimeZone = parsed.isSupported(ChronoField.INSTANT_SECONDS);
             if (hasTimeZone) {
                 Instant.from(parsed);
@@ -67,7 +67,7 @@ public class DateTimeFormatterTimestampConverter implements TimestampConverter {
             return new DateTimeFormatterTimestampConverter(formatter, hasTimeZone, defaultTimezone);
         }
         catch (DateTimeException e) {
-            throw new IllegalArgumentException("Timestamp cannot be derived from pattern: " + pattern);
+            throw new IllegalArgumentException("Timestamp cannot be derived from pattern: " + pattern, e);
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/DataDescriptionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/DataDescriptionTests.java
@@ -53,7 +53,12 @@ public class DataDescriptionTests extends AbstractSerializingTestCase<DataDescri
         description.setTimeFormat("epoch");
         description.setTimeFormat("epoch_ms");
         description.setTimeFormat("yyyy-MM-dd HH");
-        description.setTimeFormat("yyyy.MM.dd G 'at' HH:mm:ss Z");
+    }
+
+    @AwaitsFix(bugUrl = "https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8206980")
+    public void testVerify_GivenValidFormat_Java11Bug() {
+        DataDescription.Builder description = new DataDescription.Builder();
+        description.setTimeFormat("yyyy.MM.dd G 'at' HH:mm:ss z");
     }
 
     public void testVerify_GivenInValidFormat() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/DataDescriptionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/DataDescriptionTests.java
@@ -17,6 +17,8 @@ import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription.DataFormat;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 
+import java.time.DateTimeException;
+
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -51,8 +53,7 @@ public class DataDescriptionTests extends AbstractSerializingTestCase<DataDescri
         description.setTimeFormat("epoch");
         description.setTimeFormat("epoch_ms");
         description.setTimeFormat("yyyy-MM-dd HH");
-        String goodFormat = "yyyy.MM.dd G 'at' HH:mm:ss z";
-        description.setTimeFormat(goodFormat);
+        description.setTimeFormat("yyyy.MM.dd G 'at' HH:mm:ss Z");
     }
 
     public void testVerify_GivenInValidFormat() {
@@ -68,6 +69,10 @@ public class DataDescriptionTests extends AbstractSerializingTestCase<DataDescri
         e = expectThrows(ElasticsearchException.class, () -> description.setTimeFormat("y-M-dd"));
         assertEquals(Messages.getMessage(Messages.JOB_CONFIG_INVALID_TIMEFORMAT, "y-M-dd"), e.getMessage());
         expectThrows(ElasticsearchException.class, () -> description.setTimeFormat("YYY-mm-UU hh:mm:ssY"));
+
+        Throwable cause = e.getCause();
+        assertNotNull(cause);
+        assertThat(cause, instanceOf(DateTimeException.class));
     }
 
     public void testTransform_GivenDelimitedAndEpoch() {


### PR DESCRIPTION
Follow on to #31817 

The `DataDescriptionTests` fail on Java 11 with the format string `yyyy.MM.dd G 'at' HH:mm:ss z` ~~due to a change in the validation, a capital `Z` should be used instead of lower case~~. The cause is a bug in Java 11 early access build https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8206980, the failing test is muted until that bug is resolved.

This change also returns the root cause `DateTimeException` in the error. 

Note setting the time stamp format string can only be done via the API and not in the UI. 

Reproduce command is:
```
./gradlew :x-pack:plugin:core:test   -Dtests.seed=C2598B6DFDB04B7B   -Dtests.class=org.elasticsearch.xpack.core.ml.job.config.DataDescriptionTests   -Dtests.method="testVerify_GivenValidFormat"   -Dtests.security.manager=true   -Dtests.locale=en-TZ   -Dtests.timezone=America/Port-au-Prince
```
