### PR TITLE
Add matched_fields to link for to matched_fields example

### DIFF
--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -261,7 +261,7 @@ type:: The highlighter to use: `unified`, `plain`, or `fvh`. Defaults to
 * <<set-highlighter-type, Set highlighter type>>
 * <<configure-tags, Configure highlighting tags>>
 * <<highlight-source, Highlight source>>
-* <<matched-fields, Combine matches on multiple fields>>
+* <<matched-fields, Combine matches on multiple fields using matched_fields>>
 * <<explicit-field-order, Explicitly order highlighted fields>>
 * <<control-highlighted-frags, Control highlighted fragments>>
 * <<highlight-postings-list, Highlight using the postings list>>


### PR DESCRIPTION
Hello, was reading through the docs on using `matched_fields` and couldn't find the link to the example that demonstrated how that worked.  This adds the text to the link so that if someone is searching for it in the page they will find the link.  Is how I use so hopefully would be useful to someone else, if not please feel free to close pr. 

Thanks!

