### PR TITLE
Docs: add security delete role to api call table

### DIFF
--- a/x-pack/docs/en/rest-api/security/roles.asciidoc
+++ b/x-pack/docs/en/rest-api/security/roles.asciidoc
@@ -11,6 +11,8 @@ realm.
 
 `GET /_xpack/security/role/<name>` +
 
+`DELETE /_xpack/security/role/<name>` +
+
 `POST /_xpack/security/role/<name>/_clear_cache` +
 
 `POST /_xpack/security/role/<name>` +


### PR DESCRIPTION
DELETE was missing from the top table.