### PR TITLE
Painless: Fix Sanity Checks for Whitelist Loading

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookup.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookup.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.lookup;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.painless.spi.WhitelistClass;
 import org.elasticsearch.painless.spi.WhitelistConstructor;
@@ -29,6 +30,7 @@ import org.objectweb.asm.Type;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Modifier;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -36,6 +38,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.PrimitiveIterator;
+import java.util.Spliterator;
 import java.util.Stack;
 import java.util.regex.Pattern;
 
@@ -733,7 +737,7 @@ public final class PainlessLookup {
                     // TODO: and it was dependent on the order of the extends which
                     // TODO: which no longer exists since this is generated automatically
                     // sanity check, look for missing covariant/generic override
-                    /*if (owner.clazz.isInterface() && child.clazz == Object.class) {
+                    if (owner.clazz.isInterface() && method.owner.clazz == Object.class) {
                         // ok
                     } else if (child.clazz == Spliterator.OfPrimitive.class || child.clazz == PrimitiveIterator.class) {
                         // ok, we rely on generics erasure for these (its guaranteed in the javadocs though!!!!)
@@ -750,17 +754,17 @@ public final class PainlessLookup {
                                 arguments = new Class<?>[method.arguments.size() + 1];
                                 arguments[0] = method.owner.clazz;
                                 for (int i = 0; i < method.arguments.size(); i++) {
-                                    arguments[i + 1] = method.arguments.get(i).clazz;
+                                    arguments[i + 1] = defClassToObjectClass(method.arguments.get(i));
                                 }
                             } else {
                                 impl = owner.clazz;
                                 arguments = new Class<?>[method.arguments.size()];
                                 for (int i = 0; i < method.arguments.size(); i++) {
-                                    arguments[i] = method.arguments.get(i).clazz;
+                                    arguments[i] = defClassToObjectClass(method.arguments.get(i));
                                 }
                             }
                             java.lang.reflect.Method m = impl.getMethod(method.method.getName(), arguments);
-                            if (m.getReturnType() != method.rtn.clazz) {
+                            if (m.getReturnType() != defClassToObjectClass(method.rtn)) {
                                 throw new IllegalStateException("missing covariant override for: " + m + " in " + owner.name);
                             }
                             if (m.isBridge() && !Modifier.isVolatile(method.modifiers)) {
@@ -773,7 +777,7 @@ public final class PainlessLookup {
                         } catch (ReflectiveOperationException e) {
                             throw new AssertionError(e);
                         }
-                    }*/
+                    }
                     owner.methods.put(methodKey, method);
                 }
             }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookup.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookup.java
@@ -38,8 +38,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.PrimitiveIterator;
-import java.util.Spliterator;
 import java.util.Stack;
 import java.util.regex.Pattern;
 
@@ -739,8 +737,6 @@ public final class PainlessLookup {
                     // sanity check, look for missing covariant/generic override
                     if (owner.clazz.isInterface() && method.owner.clazz == Object.class) {
                         // ok
-                    } else if (child.clazz == Spliterator.OfPrimitive.class || child.clazz == PrimitiveIterator.class) {
-                        // ok, we rely on generics erasure for these (its guaranteed in the javadocs though!!!!)
                     } else if (Constants.JRE_IS_MINIMUM_JAVA9 && owner.clazz == LocalDate.class) {
                         // ok, java 9 added covariant override for LocalDate.getEra() to return IsoEra:
                         // https://bugs.openjdk.java.net/browse/JDK-8072746
@@ -771,7 +767,7 @@ public final class PainlessLookup {
                                 // its a bridge in the destination, but not in the source, but it might still be ok, check generics:
                                 java.lang.reflect.Method source = child.clazz.getMethod(method.method.getName(), arguments);
                                 if (!Arrays.equals(source.getGenericParameterTypes(), source.getParameterTypes())) {
-                                    throw new IllegalStateException("missing generic override for: " + m + " in " + owner.name);
+                                    throw new IllegalStateException("missing generic override for: " + method.method + " in " + owner.name);
                                 }
                             }
                         } catch (ReflectiveOperationException e) {

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/java.time.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/java.time.txt
@@ -569,6 +569,7 @@ class java.time.ZoneOffset {
   ZoneOffset ofHoursMinutes(int,int)
   ZoneOffset ofHoursMinutesSeconds(int,int,int)
   ZoneOffset ofTotalSeconds(int)
+  int compareTo(ZoneOffset)
 }
 
 #### Enums

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/java.util.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/java.util.txt
@@ -233,16 +233,19 @@ class java.util.PrimitiveIterator {
 class java.util.PrimitiveIterator$OfDouble {
   Double next()
   double nextDouble()
+  void forEachRemaining(Consumer)
 }
 
 class java.util.PrimitiveIterator$OfInt {
   Integer next()
   int nextInt()
+  void forEachRemaining(Consumer)
 }
 
 class java.util.PrimitiveIterator$OfLong {
   Long next()
   long nextLong()
+  void forEachRemaining(Consumer)
 }
 
 class java.util.Spliterator {
@@ -265,21 +268,27 @@ class java.util.Spliterator {
 }
 
 class java.util.Spliterator$OfPrimitive {
-  void forEachRemaining(def)
-  boolean tryAdvance(def)
   Spliterator.OfPrimitive trySplit()
+  void forEachRemaining(Consumer)
+  boolean tryAdvance(Consumer)
 }
 
 class java.util.Spliterator$OfDouble {
   Spliterator.OfDouble trySplit()
+  boolean tryAdvance(Consumer)
+  void forEachRemaining(Consumer)
 }
 
 class java.util.Spliterator$OfInt {
   Spliterator.OfInt trySplit()
+  boolean tryAdvance(Consumer)
+  void forEachRemaining(Consumer)
 }
 
 class java.util.Spliterator$OfLong {
   Spliterator.OfLong trySplit()
+  boolean tryAdvance(Consumer)
+  void forEachRemaining(Consumer)
 }
 
 class java.util.Queue {

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
@@ -124,6 +124,7 @@ class org.apache.lucene.util.BytesRef {
   int length
   boolean bytesEquals(BytesRef)
   String utf8ToString()
+  int compareTo(BytesRef)
 }
 
 class org.elasticsearch.index.mapper.IpFieldMapper$IpFieldType$IpScriptDocValues {


### PR DESCRIPTION
Reinstates sanity checks when copying methods from a child painless class to a parent painless class.  These checks will throw an exception when a there is a missing covariant override necessary in the whitelist.  Example: ZoneOffset - int compareTo(ZoneOffset) is now required whereas before an incorrect method int compareTo(Object) would be called instead of the appropriate bridge method.