### PR TITLE
[DOCS] Removes alternative docker pull example

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -34,12 +34,11 @@ endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-Docker images can be retrieved with the following commands:
+For example, Docker images can be retrieved with the following command:
 
 ["source","sh",subs="attributes"]
 --------------------------------------------
 docker pull {docker-repo}:{version}
-docker pull {docker-repo}-oss:{version}
 --------------------------------------------
 
 endif::[]

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -8,17 +8,12 @@ A list of all published Docker images and tags can be found in
 https://www.docker.elastic.co[www.docker.elastic.co]. The source code can be found
 on https://github.com/elastic/elasticsearch-docker/tree/{branch}[GitHub].
 
-==== Image types
-
 These images are free to use under the Elastic license. They contain open source 
 and free commercial features and access to paid commercial features.  
 {xpack-ref}/license-management.html[Start a 30-day trial] to try out all of the 
 paid commercial features. See the 
 https://www.elastic.co/subscriptions[Subscriptions] page for information about 
 Elastic license levels.
-
-Alternatively, you can download `-oss` images, which contain only features that 
-are available under the Apache 2.0 license.
 
 ==== Pulling the image
 
@@ -40,6 +35,10 @@ For example, Docker images can be retrieved with the following command:
 --------------------------------------------
 docker pull {docker-repo}:{version}
 --------------------------------------------
+
+Alternatively, you can download other Docker images that contain only features 
+that are available under the Apache 2.0 license. See 
+https://www.docker.elastic.co[www.docker.elastic.co]. 
 
 endif::[]
 

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -29,7 +29,7 @@ endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-For example, Docker images can be retrieved with the following command:
+For example, the Docker image can be retrieved with the following command:
 
 ["source","sh",subs="attributes"]
 --------------------------------------------

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -37,7 +37,7 @@ docker pull {docker-repo}:{version}
 --------------------------------------------
 
 Alternatively, you can download other Docker images that contain only features 
-that are available under the Apache 2.0 license. See 
+that are available under the Apache 2.0 license from 
 https://www.docker.elastic.co[www.docker.elastic.co]. 
 
 endif::[]


### PR DESCRIPTION
This PR removes the alternative "docker pull" command so that the instructions are focused on the default path.

cc'ing @jarpy, who added this information in https://github.com/elastic/elasticsearch/pull/27166

Related to https://github.com/elastic/kibana/pull/20624 and https://github.com/elastic/logstash/pull/9831