### PR TITLE
Switch high level rest tests to new style requests

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -612,7 +612,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         createIndex(index, Settings.EMPTY);
         closeIndex(index);
         ResponseException exception = expectThrows(ResponseException.class,
-                () -> client().performRequest(HttpGet.METHOD_NAME, index + "/_search"));
+                () -> client().performRequest(new Request(HttpGet.METHOD_NAME, index + "/_search")));
         assertThat(exception.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.BAD_REQUEST.getStatus()));
         assertThat(exception.getMessage().contains(index), equalTo(true));
 
@@ -621,7 +621,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
                 highLevelClient().indices()::openAsync);
         assertTrue(openIndexResponse.isAcknowledged());
 
-        Response response = client().performRequest(HttpGet.METHOD_NAME, index + "/_search");
+        Response response = client().performRequest(new Request(HttpGet.METHOD_NAME, index + "/_search"));
         assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
     }
 
@@ -650,7 +650,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
     public void testCloseExistingIndex() throws IOException {
         String index = "index";
         createIndex(index, Settings.EMPTY);
-        Response response = client().performRequest(HttpGet.METHOD_NAME, index + "/_search");
+        Response response = client().performRequest(new Request(HttpGet.METHOD_NAME, index + "/_search"));
         assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
 
         CloseIndexRequest closeIndexRequest = new CloseIndexRequest(index);
@@ -659,7 +659,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertTrue(closeIndexResponse.isAcknowledged());
 
         ResponseException exception = expectThrows(ResponseException.class,
-                () -> client().performRequest(HttpGet.METHOD_NAME, index + "/_search"));
+                () -> client().performRequest(new Request(HttpGet.METHOD_NAME, index + "/_search")));
         assertThat(exception.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.BAD_REQUEST.getStatus()));
         assertThat(exception.getMessage().contains(index), equalTo(true));
     }
@@ -817,7 +817,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertFalse(execute(getAliasesRequest, highLevelClient().indices()::existsAlias, highLevelClient().indices()::existsAliasAsync));
 
         createIndex("index", Settings.EMPTY);
-        client().performRequest(HttpPut.METHOD_NAME, "/index/_alias/alias");
+        client().performRequest(new Request(HttpPut.METHOD_NAME, "/index/_alias/alias"));
         assertTrue(execute(getAliasesRequest, highLevelClient().indices()::existsAlias, highLevelClient().indices()::existsAliasAsync));
 
         GetAliasesRequest getAliasesRequest2 = new GetAliasesRequest();
@@ -936,10 +936,10 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
     public void testGetAlias() throws IOException {
         {
             createIndex("index1", Settings.EMPTY);
-            client().performRequest(HttpPut.METHOD_NAME, "/index1/_alias/alias1");
+            client().performRequest(new Request(HttpPut.METHOD_NAME, "/index1/_alias/alias1"));
 
             createIndex("index2", Settings.EMPTY);
-            client().performRequest(HttpPut.METHOD_NAME, "/index2/_alias/alias2");
+            client().performRequest(new Request(HttpPut.METHOD_NAME, "/index2/_alias/alias2"));
 
             createIndex("index3", Settings.EMPTY);
         }
@@ -1075,7 +1075,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
             assertThat(getAliasesResponse.getError(), equalTo("alias [" + alias + "] missing"));
         }
         createIndex(index, Settings.EMPTY);
-        client().performRequest(HttpPut.METHOD_NAME, index + "/_alias/" + alias);
+        client().performRequest(new Request(HttpPut.METHOD_NAME, index + "/_alias/" + alias));
         {
             GetAliasesRequest getAliasesRequest = new GetAliasesRequest().indices(index, "non_existent_index");
             GetAliasesResponse getAliasesResponse = execute(getAliasesRequest, highLevelClient().indices()::getAlias,

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
@@ -39,7 +39,7 @@ public class PingAndInfoIT extends ESRestHighLevelClientTestCase {
     public void testInfo() throws IOException {
         MainResponse info = highLevelClient().info(RequestOptions.DEFAULT);
         // compare with what the low level client outputs
-        Map<String, Object> infoAsMap = entityAsMap(adminClient().performRequest(HttpGet.METHOD_NAME, "/"));
+        Map<String, Object> infoAsMap = entityAsMap(adminClient().performRequest(new Request(HttpGet.METHOD_NAME, "/")));
         assertEquals(infoAsMap.get("cluster_name"), info.getClusterName().value());
         assertEquals(infoAsMap.get("cluster_uuid"), info.getClusterUuid());
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.client.documentation;
 
-import org.apache.http.entity.ContentType;
-import org.apache.http.nio.entity.NStringEntity;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
@@ -66,7 +64,6 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -756,7 +753,9 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
     public void testGet() throws Exception {
         RestHighLevelClient client = highLevelClient();
         {
-            String mappings = "{\n" +
+            Request createIndex = new Request("PUT", "/posts");
+            createIndex.setJsonEntity(
+                    "{\n" +
                     "    \"mappings\" : {\n" +
                     "        \"doc\" : {\n" +
                     "            \"properties\" : {\n" +
@@ -767,10 +766,8 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
                     "            }\n" +
                     "        }\n" +
                     "    }\n" +
-                    "}";
-
-            NStringEntity entity = new NStringEntity(mappings, ContentType.APPLICATION_JSON);
-            Response response = client().performRequest("PUT", "/posts", Collections.emptyMap(), entity);
+                    "}");
+            Response response = client().performRequest(createIndex);
             assertEquals(200, response.getStatusLine().getStatusCode());
 
             IndexRequest indexRequest = new IndexRequest("posts", "doc", "1")
@@ -1071,21 +1068,21 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         RestHighLevelClient client = highLevelClient();
 
         {
-            String mappings = "{\n" +
-            "    \"mappings\" : {\n" +
-            "        \"type\" : {\n" +
-            "            \"properties\" : {\n" +
-            "                \"foo\" : {\n" +
-            "                    \"type\": \"text\",\n" +
-            "                    \"store\": true\n" +
-            "                }\n" +
-            "            }\n" +
-            "        }\n" +
-            "    }\n" +
-            "}";
-
-            NStringEntity entity = new NStringEntity(mappings, ContentType.APPLICATION_JSON);
-            Response response = client().performRequest("PUT", "/index", Collections.emptyMap(), entity);
+            Request createIndex = new Request("PUT", "/index");
+            createIndex.setJsonEntity(
+                    "{\n" +
+                    "    \"mappings\" : {\n" +
+                    "        \"type\" : {\n" +
+                    "            \"properties\" : {\n" +
+                    "                \"foo\" : {\n" +
+                    "                    \"type\": \"text\",\n" +
+                    "                    \"store\": true\n" +
+                    "                }\n" +
+                    "            }\n" +
+                    "        }\n" +
+                    "    }\n" +
+                    "}");
+            Response response = client().performRequest(createIndex);
             assertEquals(200, response.getStatusLine().getStatusCode());
         }
 


### PR DESCRIPTION
In #29623 we added `Request` object flavored requests to the low level
REST client and in #30315 we deprecated the old `performRequest`s. This
changes all calls in the `client/rest-high-level` project to use the new
versions.
