### PR TITLE
Switch low level rest tests to new style Requests

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderIntegTests.java
@@ -76,7 +76,7 @@ public class RestClientBuilderIntegTests extends RestClientTestCase {
         try {
             try (RestClient client = buildRestClient()) {
                 try {
-                    client.performRequest("GET", "/");
+                    client.performRequest(new Request("GET", "/"));
                     fail("connection should have been rejected due to SSL handshake");
                 } catch (Exception e) {
                     assertThat(e.getMessage(), containsString("General SSLEngine problem"));
@@ -85,7 +85,7 @@ public class RestClientBuilderIntegTests extends RestClientTestCase {
 
             SSLContext.setDefault(getSslContext());
             try (RestClient client = buildRestClient()) {
-                Response response = client.performRequest("GET", "/");
+                Response response = client.performRequest(new Request("GET", "/"));
                 assertEquals(200, response.getStatusLine().getStatusCode());
             }
         } finally {

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
@@ -256,35 +256,51 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
 
     public void testEncodeParams() throws IOException {
         {
-            Response response = restClient.performRequest("PUT", "/200", Collections.singletonMap("routing", "this/is/the/routing"));
+            Request request = new Request("PUT", "/200");
+            request.addParameter("routing", "this/is/the/routing");
+            Response response = restClient.performRequest(request);
             assertEquals(pathPrefix + "/200?routing=this%2Fis%2Fthe%2Frouting", response.getRequestLine().getUri());
         }
         {
-            Response response = restClient.performRequest("PUT", "/200", Collections.singletonMap("routing", "this|is|the|routing"));
+            Request request = new Request("PUT", "/200");
+            request.addParameter("routing", "this|is|the|routing");
+            Response response = restClient.performRequest(request);
             assertEquals(pathPrefix + "/200?routing=this%7Cis%7Cthe%7Crouting", response.getRequestLine().getUri());
         }
         {
-            Response response = restClient.performRequest("PUT", "/200", Collections.singletonMap("routing", "routing#1"));
+            Request request = new Request("PUT", "/200");
+            request.addParameter("routing", "routing#1");
+            Response response = restClient.performRequest(request);
             assertEquals(pathPrefix + "/200?routing=routing%231", response.getRequestLine().getUri());
         }
         {
-            Response response = restClient.performRequest("PUT", "/200", Collections.singletonMap("routing", "中文"));
+            Request request = new Request("PUT", "/200");
+            request.addParameter("routing", "中文");
+            Response response = restClient.performRequest(request);
             assertEquals(pathPrefix + "/200?routing=%E4%B8%AD%E6%96%87", response.getRequestLine().getUri());
         }
         {
-            Response response = restClient.performRequest("PUT", "/200", Collections.singletonMap("routing", "foo bar"));
+            Request request = new Request("PUT", "/200");
+            request.addParameter("routing", "foo bar");
+            Response response = restClient.performRequest(request);
             assertEquals(pathPrefix + "/200?routing=foo+bar", response.getRequestLine().getUri());
         }
         {
-            Response response = restClient.performRequest("PUT", "/200", Collections.singletonMap("routing", "foo+bar"));
+            Request request = new Request("PUT", "/200");
+            request.addParameter("routing", "foo+bar");
+            Response response = restClient.performRequest(request);
             assertEquals(pathPrefix + "/200?routing=foo%2Bbar", response.getRequestLine().getUri());
         }
         {
-            Response response = restClient.performRequest("PUT", "/200", Collections.singletonMap("routing", "foo/bar"));
+            Request request = new Request("PUT", "/200");
+            request.addParameter("routing", "foo/bar");
+            Response response = restClient.performRequest(request);
             assertEquals(pathPrefix + "/200?routing=foo%2Fbar", response.getRequestLine().getUri());
         }
         {
-            Response response = restClient.performRequest("PUT", "/200", Collections.singletonMap("routing", "foo^bar"));
+            Request request = new Request("PUT", "/200");
+            request.addParameter("routing", "foo^bar");
+            Response response = restClient.performRequest(request);
             assertEquals(pathPrefix + "/200?routing=foo%5Ebar", response.getRequestLine().getUri());
         }
     }
@@ -341,14 +357,14 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
     public void testUrlWithoutLeadingSlash() throws Exception {
         if (pathPrefix.length() == 0) {
             try {
-                restClient.performRequest("GET", "200");
+                restClient.performRequest(new Request("GET", "200"));
                 fail("request should have failed");
             } catch (ResponseException e) {
                 assertEquals(404, e.getResponse().getStatusLine().getStatusCode());
             }
         } else {
             {
-                Response response = restClient.performRequest("GET", "200");
+                Response response = restClient.performRequest(new Request("GET", "200"));
                 //a trailing slash gets automatically added if a pathPrefix is configured
                 assertEquals(200, response.getStatusLine().getStatusCode());
             }
@@ -357,7 +373,7 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
                 try (RestClient restClient = RestClient.builder(
                     new HttpHost(httpServer.getAddress().getHostString(), httpServer.getAddress().getPort()))
                     .setPathPrefix(pathPrefix.substring(1)).build()) {
-                    Response response = restClient.performRequest("GET", "200");
+                    Response response = restClient.performRequest(new Request("GET", "200"));
                     //a trailing slash gets automatically added if a pathPrefix is configured
                     assertEquals(200, response.getStatusLine().getStatusCode());
                 }

--- a/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
@@ -267,7 +267,7 @@ public class RestClientDocumentation {
         }
         {
             //tag::rest-client-response2
-            Response response = restClient.performRequest("GET", "/");
+            Response response = restClient.performRequest(new Request("GET", "/"));
             RequestLine requestLine = response.getRequestLine(); // <1>
             HttpHost host = response.getHost(); // <2>
             int statusCode = response.getStatusLine().getStatusCode(); // <3>


### PR DESCRIPTION
In #29623 we added `Request` object flavored requests to the low level
REST client and in #30315 we deprecated the old `performRequest`s. This
changes all calls in the `client/rest` project to use the new versions.
