### PR TITLE
Revert translog changes introduced for CCR

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -588,7 +588,7 @@ public abstract class Engine implements Closeable {
      * Creates a new translog snapshot from this engine for reading translog operations whose seq# in the provided range.
      * The caller has to close the returned snapshot after finishing the reading.
      */
-    public abstract Translog.Snapshot newTranslogSnapshotBetween(long minSeqNo, long maxSeqNo) throws IOException;
+    public abstract Translog.Snapshot newSnapshotFromMinSeqNo(long minSeqNo) throws IOException;
 
     public abstract TranslogStats getTranslogStats();
 

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1605,7 +1605,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      */
     public Translog.Snapshot newTranslogSnapshotFromMinSeqNo(long minSeqNo) throws IOException {
         // TODO: Remove this method after primary-replica resync use soft-deletes
-        return getEngine().newTranslogSnapshotBetween(minSeqNo, Long.MAX_VALUE);
+        return getEngine().newSnapshotFromMinSeqNo(minSeqNo);
     }
 
     /**


### PR DESCRIPTION
We introduced these changes in #26708 because for CCR.
However, CCR now uses Lucene instead of translog.

This commit reverts these changes so that we can
minimize differences between the ccr and the master branch.
