### PR TITLE
Test: fix null failure in watcher test

### DIFF
--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessageTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessageTests.java
@@ -461,7 +461,6 @@ public class SlackMessageTests extends ESTestCase {
         assertThat(parsed, equalTo(template));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/31948")
     public void testTemplateRender() throws Exception {
         Settings settings = SlackMessageDefaultsTests.randomSettings();
         SlackMessageDefaults defaults = new SlackMessageDefaults(settings);
@@ -482,7 +481,7 @@ public class SlackMessageTests extends ESTestCase {
         if (randomBoolean()) {
             templateBuilder.setText(randomAlphaOfLength(10));
         }
-        if (randomBoolean()) {
+        if (templateBuilder.text == null || randomBoolean()) {
             int count = randomIntBetween(0, 3);
             for (int i = 0; i < count; i++) {
                 Attachment.Template.Builder attachmentBuilder = createRandomAttachmentTemplateBuilder();


### PR DESCRIPTION
A new commit was merged that does not allow a null attachement &&
text. This is valid for the slack API, as it does not allow this, but
our unit tests did. This commit fixes the broken unit test.

Closes #31948
