### PR TITLE
handle AsyncAfterWriteAction failure on primary in the same way as failures on replicas 

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -97,32 +97,30 @@ public class ReplicationOperation<
 
             @Override
             public void onFailure(Exception e) {
-                final ShardRouting shardRouting = primary.routingEntry();
-                final ShardId shardId = shardRouting.shardId();
-                final String currentNodeId = primary.routingEntry().currentNodeId();
-                final RestStatus restStatus = ExceptionsHelper.status(e);
-
-                shardReplicaFailures.add(new ReplicationResponse.ShardInfo.Failure(
-                    shardId, currentNodeId, e, restStatus, true));
-
-                final ReplicationResponse.ShardInfo.Failure[] failuresArray;
-                if (shardReplicaFailures.isEmpty()) {
-                    failuresArray = ReplicationResponse.EMPTY;
-                } else {
-                    failuresArray = new ReplicationResponse.ShardInfo.Failure[shardReplicaFailures.size()];
-                    shardReplicaFailures.toArray(failuresArray);
-                }
-
                 // as primary failed
                 final int successfulShardsCount = successfulShards.decrementAndGet();
 
+                // be tolerant to this failure if there are some success
                 if (successfulShardsCount > 0) {
+                    final ShardRouting shardRouting = primary.routingEntry();
+                    final ShardId shardId = shardRouting.shardId();
+                    final String currentNodeId = primary.routingEntry().currentNodeId();
+                    final RestStatus restStatus = ExceptionsHelper.status(e);
+
+                    shardReplicaFailures.add(new ReplicationResponse.ShardInfo.Failure(
+                        shardId, currentNodeId, e, restStatus, true));
+
+                    final ReplicationResponse.ShardInfo.Failure[] failuresArray =
+                        new ReplicationResponse.ShardInfo.Failure[shardReplicaFailures.size()];
+                    shardReplicaFailures.toArray(failuresArray);
+
                     primaryResult.setShardInfo(new ReplicationResponse.ShardInfo(
                             totalShards.get(),
                             successfulShardsCount,
                             failuresArray
                         )
                     );
+
                     resultListener.onResponse(primaryResult);
                 } else {
                     listener.onFailure(e);

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -165,6 +165,7 @@ public abstract class TransportWriteAction<
         protected void respondIfPossible() {
             if (finishedAsyncActions && listener != null) {
                 Exception ex = asyncActionFailure;
+                asyncActionFailure = null;
                 if (ex == null) {
                     super.respond(listener);
                 } else {

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -154,7 +154,7 @@ public abstract class TransportWriteAction<
         }
 
         @Override
-        public synchronized void respond(ActionListener<Response> listener) {
+        public synchronized void respond(ActionListener listener) {
             this.listener = listener;
             respondIfPossible();
         }

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -505,10 +505,10 @@ public class TransportReplicationActionTests extends ESTestCase {
         }
         action.new AsyncPrimaryAction(request, primaryShard.allocationId().getId(), primaryTerm, createTransportChannel(listener), task) {
             @Override
-            protected ReplicationOperation<Request, Request, TransportReplicationAction.PrimaryResult<Request, TestResponse>>
+            protected ReplicationOperation<Request, Request, TransportReplicationAction.PrimaryResult<Request, TestResponse>, TestResponse>
             createReplicatedOperation(
                     Request request,
-                    ActionListener<TransportReplicationAction.PrimaryResult<Request, TestResponse>> actionListener,
+                    ActionListener<TestResponse> actionListener,
                     TransportReplicationAction<Request, Request, TestResponse>.PrimaryShardReference primaryShardReference) {
                 return new NoopReplicationOperation(request, actionListener) {
                     public void execute() throws Exception {
@@ -561,10 +561,10 @@ public class TransportReplicationActionTests extends ESTestCase {
         action.new AsyncPrimaryAction(request, primaryShard.allocationId().getRelocationId(), primaryTerm,
             createTransportChannel(listener), task) {
             @Override
-            protected ReplicationOperation<Request, Request, TransportReplicationAction.PrimaryResult<Request, TestResponse>>
+            protected ReplicationOperation<Request, Request, TransportReplicationAction.PrimaryResult<Request, TestResponse>, TestResponse>
             createReplicatedOperation(
                     Request request,
-                    ActionListener<TransportReplicationAction.PrimaryResult<Request, TestResponse>> actionListener,
+                    ActionListener<TestResponse> actionListener,
                     TransportReplicationAction<Request, Request, TestResponse>.PrimaryShardReference primaryShardReference) {
                 return new NoopReplicationOperation(request, actionListener) {
                     public void execute() throws Exception {
@@ -741,10 +741,10 @@ public class TransportReplicationActionTests extends ESTestCase {
         final boolean respondWithError = i == 3;
         action.new AsyncPrimaryAction(request, primaryShard.allocationId().getId(), primaryTerm, createTransportChannel(listener), task) {
             @Override
-            protected ReplicationOperation<Request, Request, TransportReplicationAction.PrimaryResult<Request, TestResponse>>
+            protected ReplicationOperation<Request, Request, TransportReplicationAction.PrimaryResult<Request, TestResponse>, TestResponse>
             createReplicatedOperation(
                     Request request,
-                    ActionListener<TransportReplicationAction.PrimaryResult<Request, TestResponse>> actionListener,
+                    ActionListener<TestResponse> actionListener,
                     TransportReplicationAction<Request, Request, TestResponse>.PrimaryShardReference primaryShardReference) {
                 assertIndexShardCounter(1);
                 if (throwExceptionOnCreation) {
@@ -1226,16 +1226,17 @@ public class TransportReplicationActionTests extends ESTestCase {
         return indexShard;
     }
 
-    class NoopReplicationOperation extends ReplicationOperation<Request, Request, TestAction.PrimaryResult<Request, TestResponse>> {
+    class NoopReplicationOperation extends ReplicationOperation<Request, Request,
+        TestAction.PrimaryResult<Request, TestResponse>, TestResponse> {
 
-        NoopReplicationOperation(Request request, ActionListener<TestAction.PrimaryResult<Request, TestResponse>> listener) {
+        NoopReplicationOperation(Request request, ActionListener<TestResponse> listener) {
             super(request, null, listener, null, TransportReplicationActionTests.this.logger, "noop");
         }
 
         @Override
         public void execute() throws Exception {
             // Using the diamond operator (<>) prevents Eclipse from being able to compile this code
-            this.resultListener.onResponse(new TransportReplicationAction.PrimaryResult<Request, TestResponse>(null, new TestResponse()));
+            this.resultListener.onResponse(new TransportReplicationAction.PrimaryResult<>(null, new TestResponse()));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/replication/AsyncAfterWriteActionIT.java
+++ b/server/src/test/java/org/elasticsearch/index/replication/AsyncAfterWriteActionIT.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.replication;
+
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.MockEngineFactoryPlugin;
+import org.elasticsearch.index.engine.EngineFactory;
+import org.elasticsearch.index.engine.InternalEngine;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.plugins.EnginePlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.AfterClass;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.index.IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class AsyncAfterWriteActionIT extends ESIntegTestCase {
+
+    private static Supplier<IOException> exceptionSupplier = null;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getMockPlugins() {
+        final List<Class<? extends Plugin>> plugins = new ArrayList<>(super.getMockPlugins());
+        plugins.remove(MockEngineFactoryPlugin.class);
+        plugins.add(IOExceptionMockedEngineFactoryPlugin.class);
+        return plugins;
+    }
+
+    @AfterClass
+    public static void cleanUp() {
+        exceptionSupplier = null;
+    }
+
+    public void testFailTranslogSyncOnPrimary() {
+        final String index = "index1";
+        final int nodes = randomIntBetween(2, 10);
+
+        internalCluster().startNodes(nodes);
+
+        assertAcked(prepareCreate(index,
+            Settings.builder()
+            .put(SETTING_NUMBER_OF_SHARDS, 1)
+            .put(SETTING_NUMBER_OF_REPLICAS, nodes - 1)
+            // to prevent triggering sync on every request
+            .put(INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.ASYNC.name())));
+
+        ensureGreen(index);
+
+        {
+            // enforce index creation
+            BulkItemResponse[] itemResponses = doBulkItemResponse(index, 1);
+            assertThat(itemResponses.length, equalTo(1));
+            assertThat(String.valueOf(itemResponses[0].getFailure()),
+                itemResponses[0].isFailed(), equalTo(false));
+        }
+
+        final long primaryTerm = getPrimaryTerm(index);
+
+        // turn to sync after every request
+        internalCluster().coordOnlyNodeClient().admin().indices()
+            .updateSettings(
+                new UpdateSettingsRequest(index).settings(Settings.builder()
+                    .put(INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.REQUEST.name())))
+            .actionGet();
+
+        AtomicBoolean throwException = new AtomicBoolean(true);
+
+        exceptionSupplier = () -> {
+            if (throwException.compareAndSet(true, false)){
+                return new IOException("fake io exception");
+            }
+            return null;
+        };
+
+        final int extraDocs = randomIntBetween(1, 10);
+        BulkItemResponse[] itemResponses = doBulkItemResponse(index, extraDocs);
+
+        assertThat(itemResponses.length, equalTo(extraDocs));
+        for (BulkItemResponse itemResponse : itemResponses) {
+            assertThat("request has to perform successfully, " + itemResponse.getFailure(),
+                itemResponse.isFailed(), equalTo(false));
+        }
+        final long newPrimaryTerm = getPrimaryTerm(index);
+
+        assertThat("primaryTerm has to be changed due to error in ensureTranslogSynced",
+            newPrimaryTerm, equalTo(primaryTerm + 1));
+    }
+
+    private BulkItemResponse[] doBulkItemResponse(String index, int docs) {
+        BulkRequest bulkRequest = new BulkRequest();
+        for(int i = 0; i < docs; i++){
+            IndexRequest indexRequest = new IndexRequest(index, "type", Integer.toString(i));
+            indexRequest.source(Requests.INDEX_CONTENT_TYPE, "field1", "val" + i);
+            bulkRequest.add(indexRequest);
+        }
+
+        BulkResponse response = client().bulk(bulkRequest).actionGet();
+
+        return response.getItems();
+    }
+
+    private long getPrimaryTerm(String index) {
+        final ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
+        final IndexShardRoutingTable indexShardRoutingTable = clusterState.getRoutingTable().index(index).shard(0);
+        final ShardRouting shardRouting = indexShardRoutingTable.primaryShard();
+        final ShardId shardId = shardRouting.shardId();
+        final String primaryNodeId = shardRouting.currentNodeId();
+        final DiscoveryNode primaryDiscoveryNode = clusterState.getNodes().get(primaryNodeId);
+        final String primaryNodeName = primaryDiscoveryNode.getName();
+        final IndicesService indicesService = internalCluster().getInstance(IndicesService.class, primaryNodeName);
+        final IndexService indexService = indicesService.indexService(resolveIndex(index));
+        final IndexShard shard = indexService.getShard(shardId.id());
+
+        return shard.getPrimaryTerm();
+    }
+
+    public static class IOExceptionMockedEngineFactoryPlugin extends Plugin implements EnginePlugin {
+
+        @Override
+        public Optional<EngineFactory> getEngineFactory(final IndexSettings indexSettings) {
+            final EngineFactory factory = config -> new InternalEngine(config) {
+                @Override
+                public boolean ensureTranslogSynced(Stream<Translog.Location> locations) throws IOException {
+                    final IOException exception = exceptionSupplier != null
+                        ? exceptionSupplier.get() : null;
+                    if (exception != null) {
+                        failEngine("translog sync failed", exception);
+                        throw exception;
+                    }
+                    return super.ensureTranslogSynced(locations);
+                }
+            };
+
+            return Optional.of(factory);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -75,6 +75,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.CommitStats;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.EngineException;
 import org.elasticsearch.index.engine.EngineTestCase;
 import org.elasticsearch.index.engine.InternalEngine;
@@ -138,9 +139,11 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.LongFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
@@ -240,6 +243,67 @@ public class IndexShardTests extends IndexShardTestCase {
         assertThat("store index should be corrupted", Store.canOpenIndex(logger, shardPath.resolveIndex(), shard.shardId(),
             (shardId, lockTimeoutMS) -> new DummyShardLock(shardId)),
             equalTo(false));
+    }
+
+    public void testFailOnEnsureTranslogSynced() throws Exception {
+        final AtomicReference<Exception> consumedException = new AtomicReference<>();
+
+        // set up to have InternalEngine that fails on ensureTranslogSynced
+        final boolean primary = randomBoolean();
+        ShardRouting shardRouting = TestShardRouting.newShardRouting(new ShardId("index", "_na_", 0), randomAlphaOfLength(10),
+            primary,
+            ShardRoutingState.INITIALIZING,
+            primary ? RecoverySource.StoreRecoverySource.EMPTY_STORE_INSTANCE : RecoverySource.PeerRecoverySource.INSTANCE);
+
+        assert shardRouting.initializing() : shardRouting;
+        Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+            .build();
+        IndexMetaData.Builder indexMetaData = IndexMetaData.builder(shardRouting.getIndexName())
+            .settings(settings)
+            .primaryTerm(0, primaryTerm)
+            .putMapping("_doc", "{ \"properties\": {} }");
+
+        final AtomicInteger exceptionCount = new AtomicInteger();
+
+        final IOException ioException = new IOException("xxx");
+        final Function<ShardRouting, IOException> exceptionFunction = routing -> {
+            exceptionCount.incrementAndGet();
+            return ioException;
+        };
+        final IndexShard shard = newShard(shardRouting, indexMetaData.build(), null,
+            new InternalEngineFactory() {
+                @Override
+                public Engine newReadWriteEngine(EngineConfig config) {
+                    return new InternalEngine(config) {
+                        @Override
+                        public boolean ensureTranslogSynced(Stream<Translog.Location> locations) throws IOException {
+                            final IOException exception = exceptionFunction.apply(shardRouting);
+                            if (exception != null) {
+                                throw exception;
+                            }
+                            return super.ensureTranslogSynced(locations);
+                        }
+
+                    };
+                }
+            },
+            () -> { }, new IndexingOperationListener[0]);
+
+        if (primary) {
+            recoverShardFromStore(shard);
+        } else {
+            recoveryEmptyReplica(shard);
+        }
+
+        // do sync
+        shard.sync(new Translog.Location(1, 1, 100), consumedException::set);
+
+        // post action checks
+        assertThat(consumedException.get(), equalTo(ioException));
+
+        closeShards(shard);
     }
 
     ShardStateMetaData getShardStateMetadata(IndexShard shard) {

--- a/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -443,17 +443,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         public void execute() {
             try {
                 new ReplicationOperation<>(request, new PrimaryRef(),
-                    new ActionListener<PrimaryResult>() {
-                        @Override
-                        public void onResponse(PrimaryResult result) {
-                            result.respond(listener);
-                        }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            listener.onFailure(e);
-                        }
-                    }, new ReplicasRef(), logger, opType).execute();
+                    listener, new ReplicasRef(), logger, opType).execute();
             } catch (Exception e) {
                 listener.onFailure(e);
             }
@@ -578,7 +568,8 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
                 finalResponse.setShardInfo(shardInfo);
             }
 
-            public void respond(ActionListener<Response> listener) {
+            @Override
+            public void respond(ActionListener listener) {
                 listener.onResponse(finalResponse);
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -121,7 +121,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
     };
 
     protected ThreadPool threadPool;
-    private long primaryTerm;
+    protected long primaryTerm;
 
     @Override
     public void setUp() throws Exception {


### PR DESCRIPTION
handle AsyncAfterWriteAction failure on primary in the same way as failures on replicas 

Closes #31716, based on #31755