### PR TITLE
Adds concept of a safe action

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/AllocateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/AllocateAction.java
@@ -112,6 +112,10 @@ public class AllocateAction implements LifecycleAction {
         return builder;
     }
 
+    @Override
+    public boolean isSafeAction() {
+        return true;
+    }
 
     @Override
     public List<Step> toSteps(Client client, String phase, StepKey nextStepKey) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/DeleteAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/DeleteAction.java
@@ -52,6 +52,11 @@ public class DeleteAction implements LifecycleAction {
     }
 
     @Override
+    public boolean isSafeAction() {
+        return true;
+    }
+
+    @Override
     public List<Step> toSteps(Client client, String phase, Step.StepKey nextStepKey) {
         Step.StepKey deleteStepKey = new Step.StepKey(phase, NAME, DeleteStep.NAME);
         return Collections.singletonList(new DeleteStep(deleteStepKey, nextStepKey, client));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ForceMergeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ForceMergeAction.java
@@ -84,6 +84,11 @@ public class ForceMergeAction implements LifecycleAction {
     }
 
     @Override
+    public boolean isSafeAction() {
+        return true;
+    }
+
+    @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(MAX_NUM_SEGMENTS_FIELD.getPreferredName(), maxNumSegments);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleAction.java
@@ -28,4 +28,11 @@ public interface LifecycleAction extends ToXContentObject, NamedWriteable {
      * @return an ordered list of steps that represent the execution plan of the action
      */
     List<Step> toSteps(Client client, String phase, @Nullable Step.StepKey nextStepKey);
+
+    /**
+     * @return true if this action is considered safe. An action is not safe if
+     *         it will produce unwanted side effects or will get stuck when the
+     *         action configuration is changed while an index is in this action
+     */
+    boolean isSafeAction();
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicy.java
@@ -228,6 +228,9 @@ public class LifecyclePolicy extends AbstractDiffable<LifecyclePolicy>
     }
 
     public boolean isActionSafe(StepKey stepKey) {
+        if ("new".equals(stepKey.getPhase())) {
+            return true;
+        }
         Phase phase = phases.get(stepKey.getPhase());
         if (phase != null) {
             LifecycleAction action = phase.getActions().get(stepKey.getAction());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicy.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.xcontent.ObjectParser.ValueType;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -224,6 +225,21 @@ public class LifecyclePolicy extends AbstractDiffable<LifecyclePolicy>
         }
 
         return steps;
+    }
+
+    public boolean isActionSafe(StepKey stepKey) {
+        Phase phase = phases.get(stepKey.getPhase());
+        if (phase != null) {
+            LifecycleAction action = phase.getActions().get(stepKey.getAction());
+            if (action != null) {
+                return action.isSafeAction();
+            } else {
+                throw new IllegalArgumentException("Action [" + stepKey.getAction() + "] in phase [" + stepKey.getPhase()
+                        + "]  does not exist in policy [" + name + "]");
+            }
+        } else {
+            throw new IllegalArgumentException("Phase [" + stepKey.getPhase() + "]  does not exist in policy [" + name + "]");
+        }
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReadOnlyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReadOnlyAction.java
@@ -55,6 +55,11 @@ public class ReadOnlyAction implements LifecycleAction {
     }
 
     @Override
+    public boolean isSafeAction() {
+        return true;
+    }
+
+    @Override
     public List<Step> toSteps(Client client, String phase, Step.StepKey nextStepKey) {
         Step.StepKey key = new Step.StepKey(phase, NAME, NAME);
         Settings readOnlySettings = Settings.builder().put(IndexMetaData.SETTING_BLOCKS_WRITE, true).build();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAction.java
@@ -74,6 +74,11 @@ public class ReplicasAction implements LifecycleAction {
     }
 
     @Override
+    public boolean isSafeAction() {
+        return true;
+    }
+
+    @Override
     public List<Step> toSteps(Client client, String phase, Step.StepKey nextStepKey) {
         StepKey updateReplicasKey = new StepKey(phase, NAME, UpdateSettingsStep.NAME);
         StepKey enoughKey = new StepKey(phase, NAME, ReplicasAllocatedStep.NAME);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/RolloverAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/RolloverAction.java
@@ -126,6 +126,11 @@ public class RolloverAction implements LifecycleAction {
     }
 
     @Override
+    public boolean isSafeAction() {
+        return true;
+    }
+
+    @Override
     public List<Step> toSteps(Client client, String phase, Step.StepKey nextStepKey) {
         StepKey updateDateStepKey = new StepKey(phase, NAME, UpdateRolloverLifecycleDateStep.NAME);
         RolloverStep rolloverStep = new RolloverStep(new StepKey(phase, NAME, RolloverStep.NAME), updateDateStepKey, client,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ShrinkAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ShrinkAction.java
@@ -76,6 +76,11 @@ public class ShrinkAction implements LifecycleAction {
     }
 
     @Override
+    public boolean isSafeAction() {
+        return false;
+    }
+
+    @Override
     public List<Step> toSteps(Client client, String phase, Step.StepKey nextStepKey) {
         StepKey setSingleNodeKey = new StepKey(phase, NAME, SetSingleNodeAllocateStep.NAME);
         StepKey allocationRoutedKey = new StepKey(phase, NAME, AllocationRoutedStep.NAME);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/AbstractActionTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/AbstractActionTestCase.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.indexlifecycle;
+
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+public abstract class AbstractActionTestCase<T extends LifecycleAction> extends AbstractSerializingTestCase<T> {
+
+    public abstract void testToSteps();
+
+    protected boolean isSafeAction() {
+        return true;
+    }
+
+    public final void testIsSafeAction() {
+        LifecycleAction action = createTestInstance();
+        assertEquals(isSafeAction(), action.isSafeAction());
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/AllocateActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/AllocateActionTests.java
@@ -9,7 +9,6 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.util.Collections;
@@ -19,7 +18,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class AllocateActionTests extends AbstractSerializingTestCase<AllocateAction> {
+public class AllocateActionTests extends AbstractActionTestCase<AllocateAction> {
 
     @Override
     protected AllocateAction doParseInstance(XContentParser parser) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/DeleteActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/DeleteActionTests.java
@@ -7,13 +7,12 @@ package org.elasticsearch.xpack.core.indexlifecycle;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.io.IOException;
 import java.util.List;
 
-public class DeleteActionTests extends AbstractSerializingTestCase<DeleteAction> {
+public class DeleteActionTests extends AbstractActionTestCase<DeleteAction> {
 
     @Override
     protected DeleteAction doParseInstance(XContentParser parser) throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ForceMergeActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ForceMergeActionTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.io.IOException;
@@ -21,7 +20,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class ForceMergeActionTests extends AbstractSerializingTestCase<ForceMergeAction> {
+public class ForceMergeActionTests extends AbstractActionTestCase<ForceMergeAction> {
 
     @Override
     protected ForceMergeAction doParseInstance(XContentParser parser) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ReadOnlyActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ReadOnlyActionTests.java
@@ -8,14 +8,13 @@ package org.elasticsearch.xpack.core.indexlifecycle;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class ReadOnlyActionTests extends AbstractSerializingTestCase<ReadOnlyAction> {
+public class ReadOnlyActionTests extends AbstractActionTestCase<ReadOnlyAction> {
 
     @Override
     protected ReadOnlyAction doParseInstance(XContentParser parser) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasActionTests.java
@@ -8,13 +8,12 @@ package org.elasticsearch.xpack.core.indexlifecycle;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.io.IOException;
 import java.util.List;
 
-public class ReplicasActionTests extends AbstractSerializingTestCase<ReplicasAction> {
+public class ReplicasActionTests extends AbstractActionTestCase<ReplicasAction> {
 
     @Override
     protected ReplicasAction doParseInstance(XContentParser parser) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/RolloverActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/RolloverActionTests.java
@@ -10,13 +10,12 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.io.IOException;
 import java.util.List;
 
-public class RolloverActionTests extends AbstractSerializingTestCase<RolloverAction> {
+public class RolloverActionTests extends AbstractActionTestCase<RolloverAction> {
 
     @Override
     protected RolloverAction doParseInstance(XContentParser parser) throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ShrinkActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ShrinkActionTests.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.core.indexlifecycle;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.io.IOException;
@@ -15,7 +14,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class ShrinkActionTests extends AbstractSerializingTestCase<ShrinkAction> {
+public class ShrinkActionTests extends AbstractActionTestCase<ShrinkAction> {
 
     @Override
     protected ShrinkAction doParseInstance(XContentParser parser) throws IOException {
@@ -79,5 +78,10 @@ public class ShrinkActionTests extends AbstractSerializingTestCase<ShrinkAction>
         assertThat(steps.get(5).getKey(), equalTo(expectedSixthKey));
         assertThat(steps.get(5).getNextStepKey(), equalTo(nextStepKey));
         assertThat(((ShrunkenIndexCheckStep) steps.get(5)).getShrunkIndexPrefix(), equalTo(ShrinkAction.SHRUNKEN_INDEX_PREFIX));
+    }
+
+    @Override
+    protected boolean isSafeAction() {
+        return false;
     }
 }


### PR DESCRIPTION
A safe action is one that does not have unwanted side effects if the
configuration of the action is change in the policy while and index is
executing the action.

This commit formalises this concept with the only current unsafe action
being ShrinkAction. It also adds testing around this and add a method
to LifecyclePolicy which returns whether the action for the provided
StepKey is safe.

Also, makes IndexLifecycleRunners checks use the safe indications instead of
