### PR TITLE
Update monitoring template version to 6040099

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringTemplateUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringTemplateUtils.java
@@ -28,7 +28,7 @@ public final class MonitoringTemplateUtils {
      * <p>
      * It may be possible for this to diverge between templates and pipelines, but for now they're the same.
      */
-    public static final int LAST_UPDATED_VERSION = Version.V_6_2_0.id;
+    public static final int LAST_UPDATED_VERSION = Version.V_6_4_0.id;
 
     /**
      * Current version of templates used in their name to differentiate from breaking changes (separate from product version).

--- a/x-pack/plugin/core/src/main/resources/monitoring-alerts.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-alerts.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-alerts-${monitoring.template.version}" ],
-  "version": 6020099,
+  "version": 6040099,
   "settings": {
     "index": {
       "number_of_shards": 1,

--- a/x-pack/plugin/core/src/main/resources/monitoring-beats.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-beats.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-beats-${monitoring.template.version}-*" ],
-  "version": 6020099,
+  "version": 6040099,
   "settings": {
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0,

--- a/x-pack/plugin/core/src/main/resources/monitoring-es.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-es.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-es-${monitoring.template.version}-*" ],
-  "version": 6020099,
+  "version": 6040099,
   "settings": {
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0,

--- a/x-pack/plugin/core/src/main/resources/monitoring-kibana.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-kibana.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-kibana-${monitoring.template.version}-*" ],
-  "version": 6020099,
+  "version": 6040099,
   "settings": {
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0,

--- a/x-pack/plugin/core/src/main/resources/monitoring-logstash.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-logstash.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-logstash-${monitoring.template.version}-*" ],
-  "version": 6020099,
+  "version": 6040099,
   "settings": {
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0,

--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_cluster_status.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_cluster_status.json
@@ -7,7 +7,7 @@
       "link": "elasticsearch/indices",
       "severity": 2100,
       "type": "monitoring",
-      "version_created": 6020099,
+      "version_created": 6040099,
       "watch": "${monitoring.watch.id}"
     }
   },

--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_nodes.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_nodes.json
@@ -7,7 +7,7 @@
       "link": "elasticsearch/nodes",
       "severity": 1999,
       "type": "monitoring",
-      "version_created": 6020099,
+      "version_created": 6040099,
       "watch": "${monitoring.watch.id}"
     }
   },

--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_version_mismatch.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_version_mismatch.json
@@ -7,7 +7,7 @@
       "link": "elasticsearch/nodes",
       "severity": 1000,
       "type": "monitoring",
-      "version_created": 6020099,
+      "version_created": 6040099,
       "watch": "${monitoring.watch.id}"
     }
   },

--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/kibana_version_mismatch.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/kibana_version_mismatch.json
@@ -7,7 +7,7 @@
       "link": "kibana/instances",
       "severity": 1000,
       "type": "monitoring",
-      "version_created": 6020099,
+      "version_created": 6040099,
       "watch": "${monitoring.watch.id}"
     }
   },

--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/logstash_version_mismatch.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/logstash_version_mismatch.json
@@ -7,7 +7,7 @@
       "link": "logstash/instances",
       "severity": 1000,
       "type": "monitoring",
-      "version_created": 6020099,
+      "version_created": 6040099,
       "watch": "${monitoring.watch.id}"
     }
   },

--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/xpack_license_expiration.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/xpack_license_expiration.json
@@ -8,7 +8,7 @@
       "alert_index": ".monitoring-alerts-6",
       "cluster_uuid": "${monitoring.watch.cluster_uuid}",
       "type": "monitoring",
-      "version_created": 6020099,
+      "version_created": 6040099,
       "watch": "${monitoring.watch.id}"
     }
   },


### PR DESCRIPTION
This ensures the new monitoring fields are available in 6.4 monitoring templates.
