### PR TITLE
Bypass highlight query terms extraction on empty fields

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
@@ -76,6 +76,9 @@ public class UnifiedHighlighter implements Highlighter {
             fieldValues = fieldValues.stream()
                 .map((s) -> convertFieldValue(fieldType, s))
                 .collect(Collectors.toList());
+            if (fieldValues.size() == 0) {
+                return null;
+            }
             final IndexSearcher searcher = new IndexSearcher(hitContext.reader());
             final CustomUnifiedHighlighter highlighter;
             final String fieldValue = mergeFieldValues(fieldValues, MULTIVAL_SEP_CHAR);


### PR DESCRIPTION
Dealing with empty fields in the highlight phase can
slow down the query because the query terms extraction is done independently
on each field. This change shortcuts the highlighting performed by the unified highlighter
for fields that are not present in the document. In such cases there is nothing to higlight so
we don't need to visit the query to build the highligh builder.