### PR TITLE
Switch many non-x-pack, non-qa to new style requests

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/rest/Netty4BadRequestIT.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/rest/Netty4BadRequestIT.java
@@ -19,7 +19,8 @@
 
 package org.elasticsearch.rest;
 
-import org.apache.http.message.BasicHeader;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.settings.Setting;
@@ -43,7 +44,7 @@ import static org.hamcrest.Matchers.hasToString;
 public class Netty4BadRequestIT extends ESRestTestCase {
 
     public void testBadRequest() throws IOException {
-        final Response response = client().performRequest("GET", "/_nodes/settings", Collections.emptyMap());
+        final Response response = client().performRequest(new Request("GET", "/_nodes/settings"));
         final ObjectPath objectPath = ObjectPath.createFromResponse(response);
         final Map<String, Object> map = objectPath.evaluate("nodes");
         int maxMaxInitialLineLength = Integer.MIN_VALUE;
@@ -77,9 +78,9 @@ public class Netty4BadRequestIT extends ESRestTestCase {
     }
 
     public void testInvalidParameterValue() throws IOException {
-        final ResponseException e = expectThrows(
-                ResponseException.class,
-                () -> client().performRequest("GET", "/_cluster/settings", Collections.singletonMap("pretty", "neither-true-nor-false")));
+        final Request request = new Request("GET", "/_cluster/settings");
+        request.addParameter("pretty", "neither-true-nor-false");
+        final ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(request));
         final Response response = e.getResponse();
         assertThat(response.getStatusLine().getStatusCode(), equalTo(400));
         final ObjectPath objectPath = ObjectPath.createFromResponse(response);
@@ -89,9 +90,11 @@ public class Netty4BadRequestIT extends ESRestTestCase {
     }
 
     public void testInvalidHeaderValue() throws IOException {
-        final BasicHeader header = new BasicHeader("Content-Type", "\t");
-        final ResponseException e =
-                expectThrows(ResponseException.class, () -> client().performRequest("GET", "/_cluster/settings", header));
+        final Request request = new Request("GET", "/_cluster/settings");
+        final RequestOptions.Builder options = request.getOptions().toBuilder();
+        options.addHeader("Content-Type", "\t");
+        request.setOptions(options);
+        final ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(request));
         final Response response = e.getResponse();
         assertThat(response.getStatusLine().getStatusCode(), equalTo(400));
         final ObjectPath objectPath = ObjectPath.createFromResponse(response);

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
@@ -19,8 +19,7 @@
 
 package org.elasticsearch.rest;
 
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -57,8 +56,9 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
                 builder.field("test", "test");
             }
             builder.endObject();
-            client().performRequest("PUT", "/" + indexName + "/" + typeName + "/" + "1", emptyMap(),
-                new StringEntity(Strings.toString(builder), ContentType.APPLICATION_JSON));
+            Request request = new Request("PUT", "/" + indexName + "/" + typeName + "/" + "1");
+            request.setJsonEntity(Strings.toString(builder));
+            client().performRequest(request);
         }
     }
 
@@ -109,8 +109,9 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
             }
             builder.endObject();
 
-            client().performRequest("POST", "_aliases", emptyMap(), new StringEntity(Strings.toString(builder),
-                            ContentType.APPLICATION_JSON));
+            Request request = new Request("POST", "/_aliases");
+            request.setJsonEntity(Strings.toString(builder));
+            client().performRequest(request);
             headTestCase("/_alias/test_alias", emptyMap(), greaterThan(0));
             headTestCase("/test/_alias/test_alias", emptyMap(), greaterThan(0));
         }
@@ -135,8 +136,9 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
             }
             builder.endObject();
 
-            client().performRequest("PUT", "/_template/template", emptyMap(),
-                new StringEntity(Strings.toString(builder), ContentType.APPLICATION_JSON));
+            Request request = new Request("PUT", "/_template/template");
+            request.setJsonEntity(Strings.toString(builder));
+            client().performRequest(request);
             headTestCase("/_template/template", emptyMap(), greaterThan(0));
         }
     }
@@ -164,8 +166,10 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
                 builder.endObject();
             }
             builder.endObject();
-            client().performRequest("PUT", "/test-no-source", emptyMap(), new StringEntity(Strings.toString(builder),
-                            ContentType.APPLICATION_JSON));
+
+            Request request = new Request("PUT", "/test-no-source");
+            request.setJsonEntity(Strings.toString(builder));
+            client().performRequest(request);
             createTestDoc("test-no-source", "test-no-source");
             headTestCase("/test-no-source/test-no-source/1/_source", emptyMap(), NOT_FOUND.getStatus(), equalTo(0));
         }
@@ -190,7 +194,11 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
             final Map<String, String> params,
             final int expectedStatusCode,
             final Matcher<Integer> matcher) throws IOException {
-        Response response = client().performRequest("HEAD", url, params);
+        Request request = new Request("HEAD", url);
+        for (Map.Entry<String, String> param : params.entrySet()) {
+            request.addParameter(param.getKey(), param.getValue());
+        }
+        Response response = client().performRequest(request);
         assertEquals(expectedStatusCode, response.getStatusLine().getStatusCode());
         assertThat(Integer.valueOf(response.getHeader("Content-Length")), matcher);
         assertNull("HEAD requests shouldn't have a response body but " + url + " did", response.getEntity());

--- a/qa/verify-version-constants/src/test/java/org/elasticsearch/qa/verify_version_constants/VerifyVersionConstantsIT.java
+++ b/qa/verify-version-constants/src/test/java/org/elasticsearch/qa/verify_version_constants/VerifyVersionConstantsIT.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.qa.verify_version_constants;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.yaml.ObjectPath;
@@ -32,7 +33,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 public class VerifyVersionConstantsIT extends ESRestTestCase {
 
     public void testLuceneVersionConstant() throws IOException, ParseException {
-        final Response response = client().performRequest("GET", "/");
+        final Response response = client().performRequest(new Request("GET", "/"));
         assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
         final ObjectPath objectPath = ObjectPath.createFromResponse(response);
         final String elasticsearchVersionString = objectPath.evaluate("version.number").toString();


### PR DESCRIPTION
In #29623 we added `Request` object flavored requests to the low level
REST client and in #30315 we deprecated the old `performRequest`s. This
changes most of the calls not in X-Pack or `qa` to their new versions.
