### PR TITLE
Add new permission for JDK11 to load JAAS libraries

### DIFF
--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -1,4 +1,4 @@
-1/*
+/*
  * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright
@@ -212,25 +212,6 @@ RestIntegTestTask integTestSecure = project.tasks.create('integTestSecure', Rest
 // Create a Integration Test suite just for HA related security based tests
 RestIntegTestTask integTestSecureHa = project.tasks.create('integTestSecureHa', RestIntegTestTask.class) {
   description = "Runs rest tests against an elasticsearch cluster with HDFS configured with HA Namenode and secured by MIT Kerberos."
-}
-
-if (rootProject.ext.compilerJavaVersion.isJava11()) {
-  // TODO remove when: https://github.com/elastic/elasticsearch/issues/31498
-  integTestRunner {
-    systemProperty 'tests.rest.blacklist', [
-            'hdfs_repository/30_snapshot/take snapshot',
-            'hdfs_repository/40_restore/Create a snapshot and then restore it',
-            'hdfs_repository/20_repository_verify/HDFS Repository Verify',
-            'hdfs_repository/30_snapshot_get/Get a snapshot',
-            'hdfs_repository/20_repository_create/HDFS Repository Creation',
-            'hdfs_repository/20_repository_delete/HDFS Delete Repository',
-            'hdfs_repository/30_snapshot_readonly/Get a snapshot - readonly',
-    ].join(',')
-  }
-}
-if (rootProject.ext.runtimeJavaVersion.isJava11() || rootProject.ext.compilerJavaVersion.isJava11()) {
-  // TODO remove when: https://github.com/elastic/elasticsearch/issues/31498
-  integTestHa.enabled = false
 }
 
 // Determine HDFS Fixture compatibility for the current build environment.

--- a/plugins/repository-hdfs/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/repository-hdfs/src/main/plugin-metadata/plugin-security.policy
@@ -61,6 +61,7 @@ grant {
 
   // Hadoop depends on OS level user information for simple authentication
   // Unix: UnixLoginModule: com.sun.security.auth.module.UnixSystem.UnixSystem init
+  permission java.lang.RuntimePermission "loadLibrary.jaas";
   permission java.lang.RuntimePermission "loadLibrary.jaas_unix";
   // Windows: NTLoginModule: com.sun.security.auth.module.NTSystem.loadNative
   permission java.lang.RuntimePermission "loadLibrary.jaas_nt";


### PR DESCRIPTION
Hadoop's security model uses the OS level authentication modules to collect information about the current user. In JDK 11, the UnixLoginModule makes use of a new permission to determine if the executing code is allowed to load the libraries required to pull the user information from the OS. This PR adds that permission and re-enables the tests that were previously failing when testing against JDK 11.

Fixes #31498. Tagging this as Core/Build for issue parity.