### PR TITLE
Add known issue with AVX-512 and JDK 10

### DIFF
--- a/docs/reference/release-notes/6.3.asciidoc
+++ b/docs/reference/release-notes/6.3.asciidoc
@@ -3,6 +3,52 @@
 
 Also see <<breaking-changes-6.3>>.
 
+[IMPORTANT]
+.Known issue with Elasticsearch 6.3.0 on JDK 10
+======================================================
+
+There appears to be a bug in JDK 10 impacting Elasticsearch 6.3.0 (note that the
+official Docker image is based on JDK 10). The issue appears to impact the C2
+compiler on hardware that supports
+https://en.wikipedia.org/wiki/AVX-512[AVX-512 instructions] (e.g., Skylake-X
+CPUs). The issue manifests as a segmentation fault in Java code executing
+`org.apache.lucene.util.MergedIterator#pullTop`:
+
+[source,txt]
+----
+#
+# A fatal error has been detected by the Java Runtime Environment:
+#
+#  SIGSEGV (0xb) at pc=0x00007fc7ebc050eb, pid=1, tid=151
+#
+# JRE version: OpenJDK Runtime Environment (10.0.1+10) (build 10.0.1+10)
+# Java VM: OpenJDK 64-Bit Server VM (10.0.1+10, mixed mode, tiered, compressed oops, concurrent mark sweep gc, linux-amd64)
+# Problematic frame:
+# J 14088 c2 org.apache.lucene.util.MergedIterator.pullTop()V (135 bytes) @ 0x00007fc7ebc050eb [0x00007fc7ebc041e0+0x0000000000000f0b]
+----
+
+or executing `org.apache.lucene.util.MergedIterator#pushTop`:
+
+[source,txt]
+----
+#
+# A fatal error has been detected by the Java Runtime Environment:
+#
+#  SIGSEGV (0xb) at pc=0x00007f8c43de5371, pid=1, tid=140
+#
+# JRE version: OpenJDK Runtime Environment (10.0.1+10) (build 10.0.1+10)
+# Java VM: OpenJDK 64-Bit Server VM (10.0.1+10, mixed mode, tiered, compressed oops, concurrent mark sweep gc, linux-amd64)
+# Problematic frame:
+# J 13039 c2 org.apache.lucene.util.MergedIterator.pushTop()V (92 bytes) @ 0x00007f8c43de5371 [0x00007f8c43de4c40+0x0000000000000731]
+----
+
+A workaround is to disable the C2 compiler from using AVX-512 instructions via
+the <<jvm-options,JVM option>> `-XX:UseAVX=2`. This issue has been taken
+upstream to the JDK maintainers and the workaround will be necessary until a
+version of the JDK that is not prone to this issue is released. For additional
+background, see {issue}31425[#31425].
+
++
 [[bug-6.3.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/6.3.asciidoc
+++ b/docs/reference/release-notes/6.3.asciidoc
@@ -8,7 +8,7 @@ Also see <<breaking-changes-6.3>>.
 ======================================================
 
 There appears to be a bug in JDK 10 impacting Elasticsearch 6.3.x (note that the
-official Docker image is based on JDK 10). The issue appears to impact the C2
+official Docker images are based on JDK 10). The issue appears to impact the C2
 compiler on hardware that supports
 https://en.wikipedia.org/wiki/AVX-512[AVX-512 instructions] (e.g., Skylake-X
 CPUs). The issue manifests as a segmentation fault in Java code executing

--- a/docs/reference/release-notes/6.3.asciidoc
+++ b/docs/reference/release-notes/6.3.asciidoc
@@ -4,10 +4,10 @@
 Also see <<breaking-changes-6.3>>.
 
 [IMPORTANT]
-.Known issue with Elasticsearch 6.3.0 on JDK 10
+.Known issue with Elasticsearch 6.3.x on JDK 10
 ======================================================
 
-There appears to be a bug in JDK 10 impacting Elasticsearch 6.3.0 (note that the
+There appears to be a bug in JDK 10 impacting Elasticsearch 6.3.x (note that the
 official Docker image is based on JDK 10). The issue appears to impact the C2
 compiler on hardware that supports
 https://en.wikipedia.org/wiki/AVX-512[AVX-512 instructions] (e.g., Skylake-X


### PR DESCRIPTION
It appears that there is a bug in the C2 compiler in JDK 10 that impacts hardware that supports AVX-512. This commit adds this as a known issue to the 6.3 release notes, and provides a workaround.

Relates #31425