### PR TITLE
Adjust SSLDriver behavior for JDK11 changes

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/nio/SSLDriver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/nio/SSLDriver.java
@@ -435,16 +435,16 @@ public class SSLDriver implements AutoCloseable {
         }
 
         private void maybeFinishHandshake() {
-            // We only acknowledge that we are done handshaking if there are no bytes that need to be written
             if (engine.isOutboundDone() || engine.isInboundDone()) {
+                // If the engine is partially closed, immediate transition to close mode.
                 if (currentMode.isHandshake()) {
                     currentMode = new CloseMode(true);
                 } else {
                     String message = "Expected to be in handshaking mode. Instead in non-handshaking mode: " + currentMode;
                     throw new AssertionError(message);
                 }
-
             } else if (hasFlushPending() == false) {
+                // We only acknowledge that we are done handshaking if there are no bytes that need to be written
                 if (currentMode.isHandshake()) {
                     currentMode = new ApplicationMode();
                 } else {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/nio/SSLDriver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/nio/SSLDriver.java
@@ -352,8 +352,8 @@ public class SSLDriver implements AutoCloseable {
                         // If we need NEED_TASK we should run the tasks immediately
                         if (handshakeStatus != SSLEngineResult.HandshakeStatus.NEED_TASK) {
                             continueHandshaking = false;
-                            break;
                         }
+                        break;
                     case NEED_TASK:
                         runTasks();
                         handshakeStatus = engine.getHandshakeStatus();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/nio/SSLDriver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/nio/SSLDriver.java
@@ -349,8 +349,11 @@ public class SSLDriver implements AutoCloseable {
                         if (hasFlushPending() == false) {
                             handshakeStatus = wrap(EMPTY_BUFFER_ARRAY).getHandshakeStatus();
                         }
-                        continueHandshaking = false;
-                        break;
+                        // If we need NEED_TASK we should run the tasks immediately
+                        if (handshakeStatus != SSLEngineResult.HandshakeStatus.NEED_TASK) {
+                            continueHandshaking = false;
+                            break;
+                        }
                     case NEED_TASK:
                         runTasks();
                         handshakeStatus = engine.getHandshakeStatus();
@@ -433,7 +436,15 @@ public class SSLDriver implements AutoCloseable {
 
         private void maybeFinishHandshake() {
             // We only acknowledge that we are done handshaking if there are no bytes that need to be written
-            if (hasFlushPending() == false) {
+            if (engine.isOutboundDone() || engine.isInboundDone()) {
+                if (currentMode.isHandshake()) {
+                    currentMode = new CloseMode(true);
+                } else {
+                    String message = "Expected to be in handshaking mode. Instead in non-handshaking mode: " + currentMode;
+                    throw new AssertionError(message);
+                }
+
+            } else if (hasFlushPending() == false) {
                 if (currentMode.isHandshake()) {
                     currentMode = new ApplicationMode();
                 } else {
@@ -510,7 +521,7 @@ public class SSLDriver implements AutoCloseable {
             if (isHandshaking && engine.isInboundDone() == false) {
                 // If we attempt to close during a handshake either we are sending an alert and inbound
                 // should already be closed or we are sending a close_notify. If we send a close_notify
-                // the peer will send an handshake error alert. If we attempt to receive the handshake alert,
+                // the peer might send an handshake error alert. If we attempt to receive the handshake alert,
                 // the engine will throw an IllegalStateException as it is not in a proper state to receive
                 // handshake message. Closing inbound immediately after close_notify is the cleanest option.
                 needToReceiveClose = false;


### PR DESCRIPTION
This is related to #32122. A number of things changed related to adding
TLS 1.3 support in JDK11. Some exception messages and other SSLEngine
behavior changed. This commit fixes assertions on exception messages.
Additionally it identifies two bugs related to how the SSLDriver behaves
in regards to JDK11 changes. Finally, it mutes a tests until correct
behavior can be identified. There is another open issue for that muted
test (#32144).