### PR TITLE
Fix BwC Tests looking for UUID in Index Stats Pre 6.4

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -57,7 +57,6 @@ for (Version version : bwcVersions.wireCompatible) {
   tasks.getByName("${baseName}#mixedClusterTestRunner").configure {
     /* To support taking index snapshots, we have to set path.repo setting */
     systemProperty 'tests.path.repo', new File(buildDir, "cluster/shared/repo")
-    systemProperty 'tests.rest.blacklist', ['indices.stats/10_index/Index - all'].join(',')
   }
 }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/10_index.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/10_index.yml
@@ -41,6 +41,10 @@ setup:
 
 ---
 "Index - all":
+  - skip:
+      version: " - 6.3.99"
+      reason: "uuid is only available from 6.4.0 on"
+
   - do:
       indices.stats: { index: _all }
 


### PR DESCRIPTION
* UUID field was added for #31791 and only went into 6.4 and 7.0
* Fixes #32119