### PR TITLE
[Kerberos] Fix to audit log authc failed event once

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTicketValidator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTicketValidator.java
@@ -96,11 +96,11 @@ public class KerberosTicketValidator {
         } catch (PrivilegedActionException pve) {
             if (pve.getCause() instanceof LoginException) {
                 actionListener.onFailure((LoginException) pve.getCause());
-            }
-            if (pve.getCause() instanceof GSSException) {
+            } else if (pve.getCause() instanceof GSSException) {
                 actionListener.onFailure((GSSException) pve.getCause());
+            } else {
+                actionListener.onFailure(pve.getException());
             }
-            actionListener.onFailure(pve.getException());
         } finally {
             privilegedLogoutNoThrow(loginContext);
             privilegedDisposeNoThrow(gssContext);


### PR DESCRIPTION
The exception was being sent twice due to incorrect handling
of conditional statements causing multiple `authentication_failed`
events in audit logs.
