### PR TITLE
Rename "authorizing_realms" to "user_lookup.realms"

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -392,9 +392,10 @@ public class XPackLicenseState {
     }
 
     /**
-     * @return whether "authorizing_realms" are allowed based on the license {@link OperationMode}
+     * @return whether "lookup_realm" are allowed based on the license {@link OperationMode}
+     * @see org.elasticsearch.xpack.core.security.authc.support.DelegatedAuthorizationSettings
      */
-    public boolean isAuthorizingRealmAllowed() {
+    public boolean isLookupRealmAllowed() {
         final Status localStatus = status;
         return (localStatus.mode == OperationMode.PLATINUM || localStatus.mode == OperationMode.TRIAL)
             && localStatus.active;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/DelegatedAuthorizationSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/DelegatedAuthorizationSettings.java
@@ -18,10 +18,10 @@ import java.util.function.Function;
  */
 public class DelegatedAuthorizationSettings {
 
-    public static final Setting<List<String>> AUTHZ_REALMS = Setting.listSetting("authorizing_realms",
+    public static final Setting<List<String>> LOOKUP_REALMS = Setting.listSetting("user_lookup.realms",
         Collections.emptyList(), Function.identity(), Setting.Property.NodeScope);
 
     public static Collection<Setting<?>> getSettings() {
-        return Collections.singleton(AUTHZ_REALMS);
+        return Collections.singleton(LOOKUP_REALMS);
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
@@ -84,7 +84,7 @@ public class LdapRealmTests extends LdapTestCase {
         defaultGlobalSettings = Settings.builder().put("path.home", createTempDir()).build();
         sslService = new SSLService(defaultGlobalSettings, TestEnvironment.newEnvironment(defaultGlobalSettings));
         licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isAuthorizingRealmAllowed()).thenReturn(true);
+        when(licenseState.isLookupRealmAllowed()).thenReturn(true);
     }
 
     @After
@@ -238,7 +238,7 @@ public class LdapRealmTests extends LdapTestCase {
         String userTemplate = VALID_USER_TEMPLATE;
         final Settings.Builder builder = Settings.builder()
             .put(buildLdapSettings(ldapUrls(), userTemplate, groupSearchBase, LdapSearchScope.SUB_TREE))
-            .putList(DelegatedAuthorizationSettings.AUTHZ_REALMS.getKey(), "mock_lookup");
+            .putList(DelegatedAuthorizationSettings.LOOKUP_REALMS.getKey(), "mock_lookup");
 
         if (randomBoolean()) {
             // maybe disable caching

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/PkiRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/PkiRealmTests.java
@@ -70,7 +70,7 @@ public class PkiRealmTests extends ESTestCase {
                 .put("path.home", createTempDir())
                 .build();
         licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isAuthorizingRealmAllowed()).thenReturn(true);
+        when(licenseState.isLookupRealmAllowed()).thenReturn(true);
     }
 
     public void testTokenSupport() {
@@ -350,7 +350,7 @@ public class PkiRealmTests extends ESTestCase {
         otherRealm.registerUser(lookupUser);
 
         final Settings realmSettings = Settings.builder()
-            .putList("authorizing_realms", "other_realm")
+            .putList("user_lookup.realms", "other_realm")
             .build();
         final UserRoleMapper roleMapper = buildRoleMapper(Collections.emptySet(), token.dn());
         final PkiRealm pkiRealm = buildRealm(roleMapper, realmSettings, otherRealm);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/DelegatedAuthorizationSupportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/DelegatedAuthorizationSupportTests.java
@@ -75,13 +75,13 @@ public class DelegatedAuthorizationSupportTests extends ESTestCase {
         final AuthenticationResult result = future.get();
         assertThat(result.getStatus(), equalTo(AuthenticationResult.Status.CONTINUE));
         assertThat(result.getUser(), nullValue());
-        assertThat(result.getMessage(), equalTo("No [authorizing_realms] have been configured"));
+        assertThat(result.getMessage(), equalTo("No [user_lookup.realms] have been configured"));
     }
 
     public void testMissingRealmInDelegationList() {
         final XPackLicenseState license = getLicenseState(true);
         final Settings settings = Settings.builder()
-            .putList("authorizing_realms", "no-such-realm")
+            .putList("user_lookup.realms", "no-such-realm")
             .build();
         final IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () ->
             new DelegatedAuthorizationSupport(realms, buildRealmConfig("r", settings), license)
@@ -93,7 +93,7 @@ public class DelegatedAuthorizationSupportTests extends ESTestCase {
         final XPackLicenseState license = getLicenseState(true);
         final List<MockLookupRealm> useRealms = shuffle(randomSubsetOf(randomIntBetween(1, realms.size()), realms));
         final Settings settings = Settings.builder()
-            .putList("authorizing_realms", useRealms.stream().map(Realm::name).collect(Collectors.toList()))
+            .putList("user_lookup.realms", useRealms.stream().map(Realm::name).collect(Collectors.toList()))
             .build();
         final User user = new User("my_user");
         randomFrom(useRealms).registerUser(user);
@@ -111,7 +111,7 @@ public class DelegatedAuthorizationSupportTests extends ESTestCase {
         final List<MockLookupRealm> useRealms = shuffle(randomSubsetOf(randomIntBetween(3, realms.size()), realms));
         final List<String> names = useRealms.stream().map(Realm::name).collect(Collectors.toList());
         final Settings settings = Settings.builder()
-            .putList("authorizing_realms", names)
+            .putList("user_lookup.realms", names)
             .build();
         final List<User> users = new ArrayList<>(names.size());
         final String username = randomAlphaOfLength(8);
@@ -135,7 +135,7 @@ public class DelegatedAuthorizationSupportTests extends ESTestCase {
         final XPackLicenseState license = getLicenseState(true);
         final List<MockLookupRealm> useRealms = shuffle(randomSubsetOf(randomIntBetween(1, realms.size()), realms));
         final Settings settings = Settings.builder()
-            .putList("authorizing_realms", useRealms.stream().map(Realm::name).collect(Collectors.toList()))
+            .putList("user_lookup.realms", useRealms.stream().map(Realm::name).collect(Collectors.toList()))
             .build();
         final DelegatedAuthorizationSupport das = new DelegatedAuthorizationSupport(realms, buildRealmConfig("r", settings), license);
         assertThat(das.hasDelegation(), equalTo(true));
@@ -151,7 +151,7 @@ public class DelegatedAuthorizationSupportTests extends ESTestCase {
     public void testLicenseRejection() throws Exception {
         final XPackLicenseState license = getLicenseState(false);
         final Settings settings = Settings.builder()
-            .putList("authorizing_realms", realms.get(0).name())
+            .putList("user_lookup.realms", realms.get(0).name())
             .build();
         final DelegatedAuthorizationSupport das = new DelegatedAuthorizationSupport(realms, buildRealmConfig("r", settings), license);
         assertThat(das.hasDelegation(), equalTo(true));
@@ -160,14 +160,14 @@ public class DelegatedAuthorizationSupportTests extends ESTestCase {
         final AuthenticationResult result = future.get();
         assertThat(result.getStatus(), equalTo(AuthenticationResult.Status.CONTINUE));
         assertThat(result.getUser(), nullValue());
-        assertThat(result.getMessage(), equalTo("authorizing_realms are not permitted"));
+        assertThat(result.getMessage(), equalTo("user_lookup.realms are not permitted"));
         assertThat(result.getException(), instanceOf(ElasticsearchSecurityException.class));
-        assertThat(result.getException().getMessage(), equalTo("current license is non-compliant for [authorizing_realms]"));
+        assertThat(result.getException().getMessage(), equalTo("current license is non-compliant for [user_lookup.realms]"));
     }
 
     private XPackLicenseState getLicenseState(boolean authzRealmsAllowed) {
         final XPackLicenseState license = mock(XPackLicenseState.class);
-        when(license.isAuthorizingRealmAllowed()).thenReturn(authzRealmsAllowed);
+        when(license.isLookupRealmAllowed()).thenReturn(authzRealmsAllowed);
         return license;
     }
 }


### PR DESCRIPTION
Authorizing is a bit of a misleading term. While user_lookup isn't
100% obvious in its meaning, it can be documented and shouldn't create
any misconceptions.

_Note to reviewers: If you've got a better suggestion, speak up!_