### PR TITLE
Switch x-pack:plugin:core to new style Requests

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/StartBasicLicenseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/StartBasicLicenseTests.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.license;
 
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
@@ -67,12 +68,14 @@ public class StartBasicLicenseTests extends AbstractLicensesIntegrationTestCase 
         }
 
         RestClient restClient = getRestClient();
-        Response response = restClient.performRequest("GET", "/_xpack/license/basic_status");
+        Response response = restClient.performRequest(new Request("GET", "/_xpack/license/basic_status"));
         String body = Streams.copyToString(new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8));
         assertEquals(200, response.getStatusLine().getStatusCode());
         assertEquals("{\"eligible_to_start_basic\":true}", body);
 
-        Response response2 = restClient.performRequest("POST", "/_xpack/license/start_basic?acknowledge=true");
+        Request ackRequest = new Request("POST", "/_xpack/license/start_basic");
+        ackRequest.addParameter("acknowledge", "true");
+        Response response2 = restClient.performRequest(ackRequest);
         String body2 = Streams.copyToString(new InputStreamReader(response2.getEntity().getContent(), StandardCharsets.UTF_8));
         assertEquals(200, response2.getStatusLine().getStatusCode());
         assertTrue(body2.contains("\"acknowledged\":true"));
@@ -86,20 +89,19 @@ public class StartBasicLicenseTests extends AbstractLicensesIntegrationTestCase 
         long expirationMillis = licensingClient.prepareGetLicense().get().license().expiryDate();
         assertEquals(LicenseService.BASIC_SELF_GENERATED_LICENSE_EXPIRATION_MILLIS, expirationMillis);
 
-        Response response3 = restClient.performRequest("GET", "/_xpack/license");
+        Response response3 = restClient.performRequest(new Request("GET", "/_xpack/license"));
         String body3 = Streams.copyToString(new InputStreamReader(response3.getEntity().getContent(), StandardCharsets.UTF_8));
         assertTrue(body3.contains("\"type\" : \"basic\""));
         assertFalse(body3.contains("expiry_date"));
         assertFalse(body3.contains("expiry_date_in_millis"));
 
-
-        Response response4 = restClient.performRequest("GET", "/_xpack/license/basic_status");
+        Response response4 = restClient.performRequest(new Request("GET", "/_xpack/license/basic_status"));
         String body4 = Streams.copyToString(new InputStreamReader(response4.getEntity().getContent(), StandardCharsets.UTF_8));
         assertEquals(200, response3.getStatusLine().getStatusCode());
         assertEquals("{\"eligible_to_start_basic\":false}", body4);
 
         ResponseException ex = expectThrows(ResponseException.class,
-                () -> restClient.performRequest("POST", "/_xpack/license/start_basic"));
+                () -> restClient.performRequest(new Request("POST", "/_xpack/license/start_basic")));
         Response response5 = ex.getResponse();
         String body5 = Streams.copyToString(new InputStreamReader(response5.getEntity().getContent(), StandardCharsets.UTF_8));
         assertEquals(403, response5.getStatusLine().getStatusCode());
@@ -118,7 +120,7 @@ public class StartBasicLicenseTests extends AbstractLicensesIntegrationTestCase 
             assertEquals("trial", getLicenseResponse.license().type());
         });
 
-        Response response2 = getRestClient().performRequest("POST", "/_xpack/license/start_basic");
+        Response response2 = getRestClient().performRequest(new Request("POST", "/_xpack/license/start_basic"));
         String body2 = Streams.copyToString(new InputStreamReader(response2.getEntity().getContent(), StandardCharsets.UTF_8));
         assertEquals(200, response2.getStatusLine().getStatusCode());
         assertTrue(body2.contains("\"acknowledged\":false"));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/integration/MlRestTestStateCleaner.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/integration/MlRestTestStateCleaner.java
@@ -45,20 +45,11 @@ public class MlRestTestStateCleaner {
         }
 
         try {
-            int statusCode = adminClient.performRequest("POST", "/_xpack/ml/datafeeds/_all/_stop")
-                    .getStatusLine().getStatusCode();
-            if (statusCode != 200) {
-                logger.error("Got status code " + statusCode + " when stopping datafeeds");
-            }
+            adminClient.performRequest(new Request("POST", "/_xpack/ml/datafeeds/_all/_stop"));
         } catch (Exception e1) {
             logger.warn("failed to stop all datafeeds. Forcing stop", e1);
             try {
-                int statusCode = adminClient
-                        .performRequest("POST", "/_xpack/ml/datafeeds/_all/_stop?force=true")
-                        .getStatusLine().getStatusCode();
-                if (statusCode != 200) {
-                    logger.error("Got status code " + statusCode + " when stopping datafeeds");
-                }
+                adminClient.performRequest(new Request("POST", "/_xpack/ml/datafeeds/_all/_stop?force=true"));
             } catch (Exception e2) {
                 logger.warn("Force-closing all data feeds failed", e2);
             }
@@ -68,10 +59,7 @@ public class MlRestTestStateCleaner {
 
         for (Map<String, Object> datafeed : datafeeds) {
             String datafeedId = (String) datafeed.get("datafeed_id");
-            int statusCode = adminClient.performRequest("DELETE", "/_xpack/ml/datafeeds/" + datafeedId).getStatusLine().getStatusCode();
-            if (statusCode != 200) {
-                logger.error("Got status code " + statusCode + " when deleting datafeed " + datafeedId);
-            }
+            adminClient.performRequest(new Request("DELETE", "/_xpack/ml/datafeeds/" + datafeedId));
         }
     }
 
@@ -87,17 +75,11 @@ public class MlRestTestStateCleaner {
         }
 
         try {
-            int statusCode = adminClient
-                    .performRequest("POST", "/_xpack/ml/anomaly_detectors/_all/_close")
-                    .getStatusLine().getStatusCode();
-            if (statusCode != 200) {
-                logger.error("Got status code " + statusCode + " when closing all jobs");
-            }
+            adminClient.performRequest(new Request("POST", "/_xpack/ml/anomaly_detectors/_all/_close"));
         } catch (Exception e1) {
             logger.warn("failed to close all jobs. Forcing closed", e1);
             try {
-                adminClient.performRequest("POST",
-                        "/_xpack/ml/anomaly_detectors/_all/_close?force=true");
+                adminClient.performRequest(new Request("POST", "/_xpack/ml/anomaly_detectors/_all/_close?force=true"));
             } catch (Exception e2) {
                 logger.warn("Force-closing all jobs failed", e2);
             }
@@ -107,10 +89,7 @@ public class MlRestTestStateCleaner {
 
         for (Map<String, Object> jobConfig : jobConfigs) {
             String jobId = (String) jobConfig.get("job_id");
-            int statusCode = adminClient.performRequest("DELETE", "/_xpack/ml/anomaly_detectors/" + jobId).getStatusLine().getStatusCode();
-            if (statusCode != 200) {
-                logger.error("Got status code " + statusCode + " when deleting job " + jobId);
-            }
+            adminClient.performRequest(new Request("DELETE", "/_xpack/ml/anomaly_detectors/" + jobId));
         }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/RollupRestTestStateCleaner.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/RollupRestTestStateCleaner.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.core.rollup;
 
 import org.apache.http.HttpStatus;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -17,7 +18,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -35,8 +35,9 @@ public class RollupRestTestStateCleaner {
     private static void waitForPendingTasks(RestClient adminClient) throws Exception {
         ESTestCase.assertBusy(() -> {
             try {
-                Response response = adminClient.performRequest("GET", "/_cat/tasks",
-                        Collections.singletonMap("detailed", "true"));
+                Request request = new Request("GET", "/_cat/tasks");
+                request.addParameter("detailed", "true");
+                Response response = adminClient.performRequest(request);
                 if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
                     try (BufferedReader responseReader = new BufferedReader(
                             new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8))) {
@@ -63,7 +64,7 @@ public class RollupRestTestStateCleaner {
 
     @SuppressWarnings("unchecked")
     private static void deleteAllJobs(RestClient adminClient) throws Exception {
-        Response response = adminClient.performRequest("GET", "/_xpack/rollup/job/_all");
+        Response response = adminClient.performRequest(new Request("GET", "/_xpack/rollup/job/_all"));
         Map<String, Object> jobs = ESRestTestCase.entityAsMap(response);
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> jobConfigs =
@@ -76,7 +77,7 @@ public class RollupRestTestStateCleaner {
         for (Map<String, Object> jobConfig : jobConfigs) {
             String jobId = (String) ((Map<String, Object>) jobConfig.get("config")).get("id");
             try {
-                response = adminClient.performRequest("DELETE", "/_xpack/rollup/job/" + jobId);
+                response = adminClient.performRequest(new Request("DELETE", "/_xpack/rollup/job/" + jobId));
             } catch (Exception e) {
                 // ok
             }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestTestHelper.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestTestHelper.java
@@ -10,6 +10,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksAction;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
@@ -25,12 +26,10 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 
 public final class XPackRestTestHelper {
@@ -47,8 +46,9 @@ public final class XPackRestTestHelper {
         ESTestCase.awaitBusy(() -> {
             String response;
             try {
-                response = EntityUtils
-                        .toString(client.performRequest("GET", "/_cat/nodes", singletonMap("h", "master,version")).getEntity());
+                Request request = new Request("GET", "/_cat/nodes");
+                request.addParameter("h", "master,version");
+                response = EntityUtils.toString(client.performRequest(request).getEntity());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -67,7 +67,7 @@ public final class XPackRestTestHelper {
             ESTestCase.awaitBusy(() -> {
                 Map<?, ?> response;
                 try {
-                    String string = EntityUtils.toString(client.performRequest("GET", "/_template/" + template).getEntity());
+                    String string = EntityUtils.toString(client.performRequest(new Request("GET", "/_template/" + template)).getEntity());
                     response = XContentHelper.convertToMap(JsonXContent.jsonXContent, string, false);
                 } catch (ResponseException e) {
                     if (e.getResponse().getStatusLine().getStatusCode() == 404) {
@@ -89,8 +89,9 @@ public final class XPackRestTestHelper {
     public static void waitForPendingTasks(RestClient adminClient) throws Exception {
         ESTestCase.assertBusy(() -> {
             try {
-                Response response = adminClient.performRequest("GET", "/_cat/tasks",
-                        Collections.singletonMap("detailed", "true"));
+                Request request = new Request("GET", "/_cat/tasks");
+                request.addParameter("detailed", "true");
+                Response response = adminClient.performRequest(request);
                 // Check to see if there are tasks still active. We exclude the
                 // list tasks
                 // actions tasks form this otherwise we will always fail


### PR DESCRIPTION
In #29623 we added `Request` object flavored requests to the low level
REST client and in #30315 we deprecated the old `performRequest`s. This
changes all calls in the `x-pack:plugin:core` project to use the new versions.
