### PR TITLE
Switch monitoring to new style Requests

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/VersionHttpResource.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/VersionHttpResource.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.Version;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.logging.Loggers;
@@ -16,7 +17,6 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -26,11 +26,6 @@ import java.util.Objects;
 public class VersionHttpResource extends HttpResource {
 
     private static final Logger logger = Loggers.getLogger(VersionHttpResource.class);
-
-    /**
-     * The parameters to pass with every version request to limit the output to just the version number.
-     */
-    public static final Map<String, String> PARAMETERS = Collections.singletonMap("filter_path", "version.number");
 
     /**
      * The minimum supported version of Elasticsearch.
@@ -59,7 +54,9 @@ public class VersionHttpResource extends HttpResource {
         logger.trace("checking [{}] to ensure that it supports the minimum version [{}]", resourceOwnerName, minimumVersion);
 
         try {
-            return validateVersion(client.performRequest("GET", "/", PARAMETERS));
+            Request request = new Request("GET", "/");
+            request.addParameter("filter_path", "version.number");
+            return validateVersion(client.performRequest(request));
         } catch (IOException | RuntimeException e) {
             logger.error(
                     (Supplier<?>)() ->

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/VersionHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/VersionHttpResourceTests.java
@@ -6,8 +6,9 @@
 package org.elasticsearch.xpack.monitoring.exporter.http;
 
 import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
+import org.apache.http.nio.entity.NStringEntity;
 import org.elasticsearch.Version;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.test.ESTestCase;
@@ -73,8 +74,9 @@ public class VersionHttpResourceTests extends ESTestCase {
     }
 
     public void testDoCheckAndPublishFailedWithIOException() throws IOException {
-        // request fails for some reason
-        when(client.performRequest("GET", "/", VersionHttpResource.PARAMETERS)).thenThrow(new IOException("expected"));
+        Request request = new Request("GET", "/");
+        request.addParameter("filter_path", "version.number");
+        when(client.performRequest(request)).thenThrow(new IOException("expected"));
 
         final VersionHttpResource resource = new VersionHttpResource(owner, Version.CURRENT);
 
@@ -82,12 +84,14 @@ public class VersionHttpResourceTests extends ESTestCase {
     }
 
     private Response responseForJSON(final String json) throws IOException {
-        final StringEntity entity = new StringEntity(json, ContentType.APPLICATION_JSON);
+        final NStringEntity entity = new NStringEntity(json, ContentType.APPLICATION_JSON);
 
         final Response response = mock(Response.class);
         when(response.getEntity()).thenReturn(entity);
 
-        when(client.performRequest("GET", "/", VersionHttpResource.PARAMETERS)).thenReturn(response);
+        Request request = new Request("GET", "/");
+        request.addParameter("filter_path", "version.number");
+        when(client.performRequest(request)).thenReturn(response);
 
         return response;
     }


### PR DESCRIPTION
In #29623 we added `Request` object flavored requests to the low level
REST client and in #30315 we deprecated the old `performRequest`s. This
changes all calls in the `x-pack/plugin/monitoring` project to use the new
versions.
