### PR TITLE
[test] package pre-install java check

### DIFF
--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
@@ -129,7 +129,7 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
         });
 
         Platforms.onLinux(() -> {
-            final String javaPath = sh.run("which java").stdout.trim();
+            final String javaPath = sh.run("command -v java").stdout.trim();
 
             try {
                 sh.run("chmod -x '" + javaPath + "'");


### PR DESCRIPTION
This recreates a test that was added to the bats packaging tests
in #31343 but didn't make it over to the java project during when the
linux package tests were ported in #31943

When packages are installed but can not locate the java executable, they
should fail with a descriptive message