### PR TITLE
Update IndexShardSnapshotStatus when an exception is encountered

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStage.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStage.java
@@ -41,7 +41,11 @@ public enum SnapshotIndexShardStage {
     /**
      * Snapshot failed
      */
-    FAILURE((byte)4, true);
+    FAILURE((byte)4, true),
+    /**
+     * Snapshot aborted
+     */
+    ABORTED((byte)5, false);
 
     private byte value;
 
@@ -88,6 +92,8 @@ public enum SnapshotIndexShardStage {
                 return DONE;
             case 4:
                 return FAILURE;
+            case 5:
+                return ABORTED;
             default:
                 throw new IllegalArgumentException("No snapshot shard stage for value [" + value + "]");
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStatus.java
@@ -81,6 +81,9 @@ public class SnapshotIndexShardStatus extends BroadcastShardResponse implements 
             case FAILURE:
                 stage = SnapshotIndexShardStage.FAILURE;
                 break;
+            case ABORTED:
+                stage = SnapshotIndexShardStage.ABORTED;
+                break;
             default:
                 throw new IllegalArgumentException("Unknown stage type " + indexShardStatus.getStage());
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotShardsStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotShardsStats.java
@@ -41,6 +41,7 @@ public class SnapshotShardsStats implements ToXContentObject {
     private int finalizingShards;
     private int doneShards;
     private int failedShards;
+    private int abortedShards;
     private int totalShards;
 
     SnapshotShardsStats(Collection<SnapshotIndexShardStatus> shards) {
@@ -61,6 +62,9 @@ public class SnapshotShardsStats implements ToXContentObject {
                     break;
                 case FAILURE:
                     failedShards++;
+                    break;
+                case ABORTED:
+                    abortedShards++;
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown stage type " + shard.getStage());
@@ -114,6 +118,13 @@ public class SnapshotShardsStats implements ToXContentObject {
     }
 
     /**
+     * Number of shards with the snapshot in the aborted stage
+     */
+    public int getAbortedShards() {
+        return abortedShards;
+    }
+
+    /**
      * Total number of shards
      */
     public int getTotalShards() {
@@ -127,6 +138,7 @@ public class SnapshotShardsStats implements ToXContentObject {
         static final String FINALIZING = "finalizing";
         static final String DONE = "done";
         static final String FAILED = "failed";
+        static final String ABORTED = "aborted";
         static final String TOTAL = "total";
     }
 
@@ -139,6 +151,7 @@ public class SnapshotShardsStats implements ToXContentObject {
             builder.field(Fields.FINALIZING, getFinalizingShards());
             builder.field(Fields.DONE, getDoneShards());
             builder.field(Fields.FAILED, getFailedShards());
+            builder.field(Fields.ABORTED, getAbortedShards());
             builder.field(Fields.TOTAL, getTotalShards());
         }
         builder.endObject();

--- a/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
@@ -139,6 +139,10 @@ public class IndexShardSnapshotStatus {
         return stage.get() == Stage.ABORTED;
     }
 
+    public boolean isFailed() {
+        return stage.get() == Stage.FAILURE;
+    }
+
     /**
      * Increments number of processed files
      */

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -41,6 +41,7 @@ import org.elasticsearch.cluster.SnapshotsInProgress.State;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Priority;
@@ -52,6 +53,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.SnapshotFailedEngineException;
 import org.elasticsearch.index.shard.IndexEventListener;
@@ -294,6 +296,14 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                                     logger.debug("[{}] trying to cancel snapshot on the shard [{}] that has already failed, " +
                                         "updating status on the master", entry.snapshot(), shard.key);
                                     notifyFailedSnapshotShard(entry.snapshot(), shard.key, localNodeId, lastSnapshotStatus.getFailure());
+                                } else if (stage == Stage.ABORTED) {
+                                    final IndexRoutingTable indexRoutingTable = event.state().getRoutingTable().index(shard.key.getIndexName());
+                                    final String shardCurrentNodeId = indexRoutingTable.getShards().get(shard.key.getId()).primaryShard().currentNodeId();
+                                    if (!shard.value.nodeId().equals(shardCurrentNodeId)) {
+                                        // Shard's snapshot node id and current primary node id are different, most likely no thread is working on it
+                                        final String failure_message = "Shard's snapshot state node and current primary node are different";
+                                        notifyFailedSnapshotShard(entry.snapshot(), shard.key, localNodeId, failure_message);
+                                    }
                                 }
                             }
                         }
@@ -325,16 +335,22 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
 
                 for (final Map.Entry<ShardId, IndexShardSnapshotStatus> shardEntry : entry.getValue().entrySet()) {
                     final ShardId shardId = shardEntry.getKey();
-                    final IndexShard indexShard = indicesService.indexServiceSafe(shardId.getIndex()).getShardOrNull(shardId.id());
-                    final IndexId indexId = indicesMap.get(shardId.getIndexName());
-                    assert indexId != null;
                     executor.execute(new AbstractRunnable() {
 
                         final SetOnce<Exception> failure = new SetOnce<>();
 
                         @Override
                         public void doRun() {
-                            snapshot(indexShard, snapshot, indexId, shardEntry.getValue());
+                            try {
+                                final IndexShard indexShard = indicesService.indexServiceSafe(shardId.getIndex()).getShardOrNull(shardId.id());
+                                final IndexId indexId = indicesMap.get(shardId.getIndexName());
+                                assert indexId != null;
+                                snapshot(indexShard, snapshot, indexId, shardEntry.getValue());
+                            } catch(IndexNotFoundException e) {
+                                final String failure = "IndexNotFoundException while fetching index";
+                                shardEntry.getValue().moveToFailed(System.currentTimeMillis(), failure);
+                                throw e;
+                            }
                         }
 
                         @Override
@@ -352,7 +368,12 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                         public void onAfter() {
                             final Exception exception = failure.get();
                             if (exception != null) {
-                                notifyFailedSnapshotShard(snapshot, shardId, localNodeId, ExceptionsHelper.detailedMessage(exception));
+                                final String failure = ExceptionsHelper.detailedMessage(exception);
+                                if (!shardEntry.getValue().isFailed()) {
+                                    // The status is not yet moved to failed, move it before notifying the master
+                                    shardEntry.getValue().moveToFailed(System.currentTimeMillis(), failure);
+                                }
+                                notifyFailedSnapshotShard(snapshot, shardId, localNodeId, failure);
                             } else {
                                 notifySuccessfulSnapshotShard(snapshot, shardId, localNodeId);
                             }
@@ -372,16 +393,22 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
     private void snapshot(final IndexShard indexShard, final Snapshot snapshot, final IndexId indexId, final IndexShardSnapshotStatus snapshotStatus) {
         final ShardId shardId = indexShard.shardId();
         if (indexShard.routingEntry().primary() == false) {
+            final String failure = "Snapshot should be performed only on primary";
+            snapshotStatus.moveToFailed(System.currentTimeMillis(), failure);
             throw new IndexShardSnapshotFailedException(shardId, "snapshot should be performed only on primary");
         }
         if (indexShard.routingEntry().relocating()) {
             // do not snapshot when in the process of relocation of primaries so we won't get conflicts
+            final String failure = "Cannot snapshot while relocating";
+            snapshotStatus.moveToFailed(System.currentTimeMillis(), failure);
             throw new IndexShardSnapshotFailedException(shardId, "cannot snapshot while relocating");
         }
 
         final IndexShardState indexShardState = indexShard.state();
         if (indexShardState == IndexShardState.CREATED || indexShardState == IndexShardState.RECOVERING) {
             // shard has just been created, or still recovering
+            final String failure = "Shard didn't fully recover yet";
+            snapshotStatus.moveToFailed(System.currentTimeMillis(), failure);
             throw new IndexShardSnapshotFailedException(shardId, "shard didn't fully recover yet");
         }
 
@@ -395,9 +422,11 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                     logger.debug("snapshot ({}) completed to {} with {}", snapshot, repository, lastSnapshotStatus);
                 }
             }
-        } catch (SnapshotFailedEngineException | IndexShardSnapshotFailedException e) {
+        } catch (IndexShardSnapshotFailedException e) {
+            // Shard status already moved to failed by BlobStoreRepository, throw the exception
             throw e;
         } catch (Exception e) {
+            snapshotStatus.moveToFailed(System.currentTimeMillis(), ExceptionsHelper.detailedMessage(e));
             throw new IndexShardSnapshotFailedException(shardId, "Failed to snapshot", e);
         }
     }


### PR DESCRIPTION
### Background
We have identified an issue in latest elastic search snapshot code where the snapshot is stuck (making no progress and not get deleted) when one or more shards’ (whose snapshot state is in INIT/STARTED state) are not worked on by the node it is assigned to. This could happen when primary node is different (changed after the snapshot is started) from the node (old primary) to which the shard is marked to be snapshot-ed.

### When does it happen
When one of the data nodes having primary shards is restarted (process restart) while the snapshot is running and joins back the cluster within 30 seconds. The node upon restart fails to process the cluster update (due to a race condition between the snapshot service and indices service) and all the shards for which the node was primary (before restart) and in INIT or STARTED state (snapshot state) will be stuck in that state forever.
 
The shards get stuck as the indices services throws a IndexNotFoundException as it hasn't processed the cluster update yet. And if one of the shards (say x out of y shards that need to snapshot-ed) receives the IndexNotFoundException, SnapshotShardsService fails to queue the snapshot thread for that shard as well for all the following shards (y - x) + 1. The master will keep on waiting for the shard to go to logical end state (DONE or FAILED) and report it back to the master. But since the snapshot thread didn't start for the shard, it will never report back the state and thus snapshot stuck indefinitely.

When a delete call is invoked on the snapshot which is stuck, all the shards which is in INIT or STARTED state will be marked as ABORTED expecting the BlobStoreRepository to throw an exception and move the shard to logically end state FAILED. But since no thread is working on these shards, it will remain as ABORTED and new subsequent delete call will be queued resulting in increase in number of tasks.

### Proposed Fix
1) When IndexNotFoundException is received by the SnapshotShardsService, catch the exception and immediately mark the snapshot shard state to FAILED. After marking it as FAILED, it can still go ahead and process the rest of the shards which will eventually make the snapshot to go into PARTIAL state instead of stuck forever.

2) When a snapshot delete call is made for a snapshot which is in progress (or stuck), SnaphotShardsService iterate through the shards of the snapshot and marks them as DONE or FAILED if it is complete or error-ed respectively. For the shards which are in INIT or STARTED state, it is marked as ABORTED expecting the thread which is uploading the data to detect the ABORTED state and throw an error, thus going to a logical FAILED state. But, since there are no threads working on these shards (lost during restart), the state remains the same forever. To fix that, while marking the shard status as ABORTED we can do an additional check to see if the shard’s current primary is different than the node to which the shard is marked to be snapshot-ed. If they are different, we can fail the shard immediately thus making all shards to reach a logical state (either DONE or FAILED) which in turn result in successful deletion of the problematic snapshot.

3) Adding ABORTED state in SnapshotIndexShardStage, SnapshotIndexShardStatus and SnapshotShardsStats where it is missing.

### Steps to reproduce (100% success)
* Create a multi node cluster (say with 3 data nodes).
* Using load generator, create multiple indices (say 500 indices) each with 1 replica and 3 shards
* After the data is loaded, register a repo (my-repo) and initiate a snapshot.
* Restart the elastic search process in one of the data nodes.
* [Verify] The new process will fail to update the snapshot state from cluster state.
* The snapshot goes to stuck state and can’t be deleted.

### Related Issues
* https://github.com/elastic/elasticsearch/issues/31624
* https://github.com/elastic/elasticsearch/issues/29118