### PR TITLE
Require that all app privileges have actions

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequest.java
@@ -50,6 +50,9 @@ public final class PutPrivilegesRequest extends ActionRequest implements Applica
             } catch (IllegalArgumentException e) {
                 validationException = addValidationError(e.getMessage(), validationException);
             }
+            if (privilege.getActions().isEmpty()) {
+                validationException = addValidationError("Application privileges must have at least one action", validationException);
+            }
             for (String action : privilege.getActions()) {
                 if (action.indexOf('/') == -1 && action.indexOf('*') == -1 && action.indexOf(':') == -1) {
                     validationException = addValidationError("action [" + action + "] must contain one of [ '/' , '*' , ':' ]",

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/ApplicationPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/ApplicationPermission.java
@@ -97,6 +97,7 @@ public final class ApplicationPermission {
 
         private boolean grants(ApplicationPrivilege other, Automaton resource) {
             return this.application.test(other.getApplication())
+                && Operations.isEmpty(privilege.getAutomaton()) == false
                 && Operations.subsetOf(other.getAutomaton(), privilege.getAutomaton())
                 && Operations.subsetOf(resource, this.resources);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilege.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 
 /**
  * An application privilege has an application name (e.g. {@code "my-app"}) that identifies an application (that exists
- * outside of elasticsearch), a privilege name (e.g. {@code "admin}) that is meaningful to that application, and zero or
+ * outside of elasticsearch), a privilege name (e.g. {@code "admin}) that is meaningful to that application, and one or
  * more "action patterns" (e.g {@code "admin/user/*", "admin/team/*"}).
  * Action patterns must contain at least one special character from ({@code /}, {@code :}, {@code *}) to distinguish them
  * from privilege names.

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequestTests.java
@@ -57,6 +57,10 @@ public class PutPrivilegesRequestTests extends ESTestCase {
         assertValidationFailure(request(spaceName), "Application privilege names must match");
         assertValidationFailure(request(numericName), "Application privilege names must match");
 
+        // no actions
+        final ApplicationPrivilegeDescriptor nothing = descriptor("*", "nothing");
+        assertValidationFailure(request(nothing), "Application privileges must have at least one action");
+
         // reserved metadata
         final ApplicationPrivilegeDescriptor reservedMetadata = new ApplicationPrivilegeDescriptor("app", "all",
             Collections.emptySet(), Collections.singletonMap("_notAllowed", true)

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/ApplicationPermissionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/ApplicationPermissionTests.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.core.security.authz.permission;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilege;
 import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilegeDescriptor;
 
@@ -20,7 +19,6 @@ import java.util.List;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.equalTo;
 
-@TestLogging("org.elasticsearch.xpack.core.security.authz.permission:TRACE")
 public class ApplicationPermissionTests extends ESTestCase {
 
     private List<ApplicationPrivilegeDescriptor> store = new ArrayList<>();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilegeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilegeTests.java
@@ -86,6 +86,20 @@ public class ApplicationPrivilegeTests extends ESTestCase {
         }
     }
 
+    public void testNonePrivilege() {
+        final ApplicationPrivilege none = ApplicationPrivilege.NONE.apply("super-mega-app");
+        CharacterRunAutomaton run = new CharacterRunAutomaton(none.getAutomaton());
+        for (int i = randomIntBetween(5, 10); i > 0; i--) {
+            final String action;
+            if (randomBoolean()) {
+                action = randomAlphaOfLengthBetween(3, 12);
+            } else {
+                action = randomAlphaOfLengthBetween(3, 6) + randomFrom(":", "/") + randomAlphaOfLengthBetween(3, 8);
+            }
+            assertFalse("NONE should not grant " + action, run.run(action));
+        }
+    }
+
     public void testGetPrivilegeByName() {
         final ApplicationPrivilegeDescriptor descriptor = descriptor("my-app", "read", "data:read/*", "action:login");
         final ApplicationPrivilegeDescriptor myWrite = descriptor("my-app", "write", "data:write/*", "action:login");


### PR DESCRIPTION
The javadoc and validation for ApplicationPrivileges supports the idea
that a privilege could have no actions. However, in that case every
privilege that had no actions grants every other action-less privilege
within the same action, including the NONE privilege.

This commit makes the following changes:
- It is not possible to PUT a privilege without any actions
- A permission with no actions, never grants another privilege even if
  that privilege is also a zero-action privilege (which, ideally would
  never exist, but can occur through missing privileges or index
  manipulation).