### PR TITLE
[DOCS] Rollup Caps API incorrectly mentions GET Jobs API

### DIFF
--- a/x-pack/docs/en/rest-api/rollup/rollup-caps.asciidoc
+++ b/x-pack/docs/en/rest-api/rollup/rollup-caps.asciidoc
@@ -33,7 +33,7 @@ live?
 
 ==== Request Body
 
-There is no request body for the Get Jobs API.
+There is no request body for the Get Rollup Caps API.
 
 ==== Authorization
 


### PR DESCRIPTION
Tiny change in rollup caps docs which refers to the wrong API