### PR TITLE
Skips to next available action on missing step

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/AllocateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/AllocateAction.java
@@ -132,6 +132,13 @@ public class AllocateAction implements LifecycleAction {
     }
 
     @Override
+    public List<StepKey> toStepKeys(String phase) {
+        StepKey allocateKey = new StepKey(phase, NAME, NAME);
+        StepKey allocationRoutedKey = new StepKey(phase, NAME, AllocationRoutedStep.NAME);
+        return Arrays.asList(allocateKey, allocationRoutedKey);
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(include, exclude, require);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/DeleteAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/DeleteAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -60,6 +61,11 @@ public class DeleteAction implements LifecycleAction {
     public List<Step> toSteps(Client client, String phase, Step.StepKey nextStepKey) {
         Step.StepKey deleteStepKey = new Step.StepKey(phase, NAME, DeleteStep.NAME);
         return Collections.singletonList(new DeleteStep(deleteStepKey, nextStepKey, client));
+    }
+
+    @Override
+    public List<StepKey> toStepKeys(String phase) {
+        return Collections.singletonList(new Step.StepKey(phase, NAME, DeleteStep.NAME));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ForceMergeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ForceMergeAction.java
@@ -93,6 +93,17 @@ public class ForceMergeAction implements LifecycleAction {
     }
 
     @Override
+    public List<StepKey> toStepKeys(String phase) {
+        StepKey updateCompressionKey = new StepKey(phase, NAME, "best_compression");
+        StepKey forceMergeKey = new StepKey(phase, NAME, ForceMergeStep.NAME);
+        StepKey countKey = new StepKey(phase, NAME, SegmentCountStep.NAME);
+        if (bestCompression) {
+            return Arrays.asList(updateCompressionKey, forceMergeKey, countKey);
+        }
+        return Arrays.asList(forceMergeKey, countKey);
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(maxNumSegments);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ForceMergeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ForceMergeAction.java
@@ -84,7 +84,6 @@ public class ForceMergeAction implements LifecycleAction {
 
     @Override
     public List<Step> toSteps(Client client, String phase, Step.StepKey nextStepKey) {
-        StepKey updateCompressionKey = new StepKey(phase, NAME, "best_compression");
         StepKey forceMergeKey = new StepKey(phase, NAME, ForceMergeStep.NAME);
         StepKey countKey = new StepKey(phase, NAME, SegmentCountStep.NAME);
         ForceMergeStep forceMergeStep = new ForceMergeStep(forceMergeKey, countKey, client, maxNumSegments);
@@ -94,12 +93,8 @@ public class ForceMergeAction implements LifecycleAction {
 
     @Override
     public List<StepKey> toStepKeys(String phase) {
-        StepKey updateCompressionKey = new StepKey(phase, NAME, "best_compression");
         StepKey forceMergeKey = new StepKey(phase, NAME, ForceMergeStep.NAME);
         StepKey countKey = new StepKey(phase, NAME, SegmentCountStep.NAME);
-        if (bestCompression) {
-            return Arrays.asList(updateCompressionKey, forceMergeKey, countKey);
-        }
         return Arrays.asList(forceMergeKey, countKey);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleAction.java
@@ -9,6 +9,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.util.List;
 
@@ -28,6 +29,15 @@ public interface LifecycleAction extends ToXContentObject, NamedWriteable {
      * @return an ordered list of steps that represent the execution plan of the action
      */
     List<Step> toSteps(Client client, String phase, @Nullable Step.StepKey nextStepKey);
+
+    /**
+     * 
+     * @param phase
+     *            the name of the phase this action is being executed within
+     * @return the {@link StepKey}s for the steps which will be executed in this
+     *         action
+     */
+    List<StepKey> toStepKeys(String phase);
 
     /**
      * @return true if this action is considered safe. An action is not safe if

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicy.java
@@ -245,6 +245,74 @@ public class LifecyclePolicy extends AbstractDiffable<LifecyclePolicy>
         }
     }
 
+    public StepKey getNextValidStep(StepKey stepKey) {
+        Phase phase = phases.get(stepKey.getPhase());
+        if (phase == null) {
+            // Phase doesn't exist so find the after step for the previous
+            // available phase
+            return getStepBeforePhase(stepKey.getPhase());
+        } else {
+            // Phase exists so check if the action exists
+            LifecycleAction action = phase.getActions().get(stepKey.getAction());
+            if (action == null) {
+                // if action doesn't exist find the first step in the next
+                // available action
+                return getFirstStepInNextAction(stepKey.getAction(), phase);
+            } else {
+                // if the action exists check if the step itself exists
+                if (action.toStepKeys(phase.getName()).contains(stepKey)) {
+                    // stepKey is valid still so return it
+                    return stepKey;
+                } else {
+                    // stepKey no longer exists in the action so we need to move
+                    // to the first step in the next action since skipping steps
+                    // in an action is not safe
+                    return getFirstStepInNextAction(stepKey.getAction(), phase);
+                }
+            }
+        }
+    }
+    
+    private StepKey getNextAfterStep(String currentPhaseName) {
+        String nextPhaseName = type.getNextPhaseName(currentPhaseName, phases);
+        if (nextPhaseName == null) {
+            // We don't have a next phase after this one so the next step is the TerminalPolicyStep
+            return TerminalPolicyStep.KEY;
+        } else {
+            return new StepKey(currentPhaseName, PhaseAfterStep.NAME, PhaseAfterStep.NAME);
+        }
+    }
+
+    private StepKey getStepBeforePhase(String currentPhaseName) {
+        String nextPhaseName = type.getNextPhaseName(currentPhaseName, phases);
+        if (nextPhaseName == null) {
+            // We don't have a next phase after this one so the next step is the
+            // TerminalPolicyStep
+            return TerminalPolicyStep.KEY;
+        } else {
+            String prevPhaseName = type.getPreviousPhaseName(currentPhaseName, phases);
+            if (prevPhaseName == null) {
+                // no previous phase available so go to the
+                // InitializePolicyContextStep
+                return InitializePolicyContextStep.KEY;
+            }
+            return new StepKey(prevPhaseName, PhaseAfterStep.NAME, PhaseAfterStep.NAME);
+        }
+    }
+
+    private StepKey getFirstStepInNextAction(String currentActionName, Phase phase) {
+        String nextActionName = type.getNextActionName(currentActionName, phase);
+        if (nextActionName == null) {
+            // The current action is the last in this phase so we need to find
+            // the next after step
+            return getNextAfterStep(phase.getName());
+        } else {
+            LifecycleAction nextAction = phase.getActions().get(nextActionName);
+            // Return the first stepKey for nextAction
+            return nextAction.toStepKeys(phase.getName()).get(0);
+        }
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(name, phases);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicy.java
@@ -245,12 +245,18 @@ public class LifecyclePolicy extends AbstractDiffable<LifecyclePolicy>
         }
     }
 
+    /**
+     * Finds the next valid {@link StepKey} on or after the provided
+     * {@link StepKey}. If the provided {@link StepKey} is valid in this policy
+     * it will be returned. If its not valid the next available {@link StepKey}
+     * will be returned.
+     */
     public StepKey getNextValidStep(StepKey stepKey) {
         Phase phase = phases.get(stepKey.getPhase());
         if (phase == null) {
             // Phase doesn't exist so find the after step for the previous
             // available phase
-            return getStepBeforePhase(stepKey.getPhase());
+            return getAfterStepBeforePhase(stepKey.getPhase());
         } else {
             // Phase exists so check if the action exists
             LifecycleAction action = phase.getActions().get(stepKey.getAction());
@@ -276,14 +282,16 @@ public class LifecyclePolicy extends AbstractDiffable<LifecyclePolicy>
     private StepKey getNextAfterStep(String currentPhaseName) {
         String nextPhaseName = type.getNextPhaseName(currentPhaseName, phases);
         if (nextPhaseName == null) {
-            // We don't have a next phase after this one so the next step is the TerminalPolicyStep
+            // We don't have a next phase after this one so there is no after
+            // step to move to. Instead we need to go to the terminal step as
+            // there are no more steps we should execute
             return TerminalPolicyStep.KEY;
         } else {
             return new StepKey(currentPhaseName, PhaseAfterStep.NAME, PhaseAfterStep.NAME);
         }
     }
 
-    private StepKey getStepBeforePhase(String currentPhaseName) {
+    private StepKey getAfterStepBeforePhase(String currentPhaseName) {
         String nextPhaseName = type.getNextPhaseName(currentPhaseName, phases);
         if (nextPhaseName == null) {
             // We don't have a next phase after this one so the next step is the

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleType.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.core.indexlifecycle;
 
 import org.elasticsearch.common.io.stream.NamedWriteable;
 
+import java.security.Policy;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -18,7 +19,46 @@ public interface LifecycleType extends NamedWriteable {
      */
     List<Phase> getOrderedPhases(Map<String, Phase> phases);
 
+    /**
+     * Returns the next phase thats available after
+     * <code>currentPhaseName</code>. Note that <code>currentPhaseName</code>
+     * does not need to exist in <code>phases</code>.
+     * 
+     * If the current {@link Phase} is the last phase in the {@link Policy} this
+     * method will return <code>null</code>.
+     * 
+     * If the phase is not valid for the lifecycle type an
+     * {@link IllegalArgumentException} will be thrown.
+     */
+    String getNextPhaseName(String currentPhaseName, Map<String, Phase> phases);
+
+    /**
+     * Returns the previous phase thats available before
+     * <code>currentPhaseName</code>. Note that <code>currentPhaseName</code>
+     * does not need to exist in <code>phases</code>.
+     * 
+     * If the current {@link Phase} is the first phase in the {@link Policy}
+     * this method will return <code>null</code>.
+     * 
+     * If the phase is not valid for the lifecycle type an
+     * {@link IllegalArgumentException} will be thrown.
+     */
+    String getPreviousPhaseName(String currentPhaseName, Map<String, Phase> phases);
+
     List<LifecycleAction> getOrderedActions(Phase phase);
+
+    /**
+     * Returns the name of the next phase that is available in the phases after
+     * <code>currentActionName</code>. Note that <code>currentActionName</code>
+     * does not need to exist in the {@link Phase}.
+     * 
+     * If the current action is the last action in the phase this method will
+     * return <code>null</code>.
+     * 
+     * If the action is not valid for the phase an
+     * {@link IllegalArgumentException} will be thrown.
+     */
+    String getNextActionName(String currentActionName, Phase phase);
 
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReadOnlyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReadOnlyAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -64,6 +65,11 @@ public class ReadOnlyAction implements LifecycleAction {
         Step.StepKey key = new Step.StepKey(phase, NAME, NAME);
         Settings readOnlySettings = Settings.builder().put(IndexMetaData.SETTING_BLOCKS_WRITE, true).build();
         return Collections.singletonList(new UpdateSettingsStep(key, nextStepKey, client, readOnlySettings));
+    }
+    
+    @Override
+    public List<StepKey> toStepKeys(String phase) {
+        return Collections.singletonList(new Step.StepKey(phase, NAME, NAME));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAction.java
@@ -87,6 +87,13 @@ public class ReplicasAction implements LifecycleAction {
                 new ReplicasAllocatedStep(enoughKey, nextStepKey));
     }
 
+    @Override
+    public List<StepKey> toStepKeys(String phase) {
+        StepKey updateReplicasKey = new StepKey(phase, NAME, UpdateSettingsStep.NAME);
+        StepKey enoughKey = new StepKey(phase, NAME, ReplicasAllocatedStep.NAME);
+        return Arrays.asList(updateReplicasKey, enoughKey);
+    }
+
     public int getNumberOfReplicas() {
         return numberOfReplicas;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/RolloverAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/RolloverAction.java
@@ -140,6 +140,13 @@ public class RolloverAction implements LifecycleAction {
     }
 
     @Override
+    public List<StepKey> toStepKeys(String phase) {
+        StepKey rolloverStepKey = new StepKey(phase, NAME, RolloverStep.NAME);
+        StepKey updateDateStepKey = new StepKey(phase, NAME, UpdateRolloverLifecycleDateStep.NAME);
+        return Arrays.asList(rolloverStepKey, updateDateStepKey);
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(maxSize, maxAge, maxDocs);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ShrinkAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ShrinkAction.java
@@ -98,6 +98,17 @@ public class ShrinkAction implements LifecycleAction {
     }
 
     @Override
+    public List<StepKey> toStepKeys(String phase) {
+        StepKey setSingleNodeKey = new StepKey(phase, NAME, SetSingleNodeAllocateStep.NAME);
+        StepKey allocationRoutedKey = new StepKey(phase, NAME, AllocationRoutedStep.NAME);
+        StepKey shrinkKey = new StepKey(phase, NAME, ShrinkStep.NAME);
+        StepKey enoughShardsKey = new StepKey(phase, NAME, ShrunkShardsAllocatedStep.NAME);
+        StepKey aliasKey = new StepKey(phase, NAME, ShrinkSetAliasStep.NAME);
+        StepKey isShrunkIndexKey = new StepKey(phase, NAME, ShrunkenIndexCheckStep.NAME);
+        return Arrays.asList(setSingleNodeKey, allocationRoutedKey, shrinkKey, enoughShardsKey, aliasKey, isShrunkIndexKey);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/TimeseriesLifecycleType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/TimeseriesLifecycleType.java
@@ -79,6 +79,45 @@ public class TimeseriesLifecycleType implements LifecycleType {
         return orderedPhases;
     }
 
+    @Override
+    public String getNextPhaseName(String currentPhaseName, Map<String, Phase> phases) {
+        int index = VALID_PHASES.indexOf(currentPhaseName);
+        if (index < 0) {
+            throw new IllegalArgumentException("[" + currentPhaseName + "] is not a valid phase for lifecycle type [" + TYPE + "]");
+        } else {
+            // Find the next phase after `index` that exists in `phases` and return it
+            while (++index < VALID_PHASES.size()) {
+                String phaseName = VALID_PHASES.get(index);
+                if (phases.containsKey(phaseName)) {
+                    return phaseName;
+                }
+            }
+            // if we have exhausted VALID_PHASES and haven't found a matching
+            // phase in `phases` return null indicating there is no next phase
+            // available
+            return null;
+        }
+    }
+
+    public String getPreviousPhaseName(String currentPhaseName, Map<String, Phase> phases) {
+        int index = VALID_PHASES.indexOf(currentPhaseName);
+        if (index < 0) {
+            throw new IllegalArgumentException("[" + currentPhaseName + "] is not a valid phase for lifecycle type [" + TYPE + "]");
+        } else {
+            // Find the previous phase before `index` that exists in `phases` and return it
+            while (--index >=0) {
+                String phaseName = VALID_PHASES.get(index);
+                if (phases.containsKey(phaseName)) {
+                    return phaseName;
+                }
+            }
+            // if we have exhausted VALID_PHASES and haven't found a matching
+            // phase in `phases` return null indicating there is no previous phase
+            // available
+            return null;
+        }
+    }
+
     public List<LifecycleAction> getOrderedActions(Phase phase) {
         Map<String, LifecycleAction> actions = phase.getActions();
         switch (phase.getName()) {
@@ -96,6 +135,45 @@ public class TimeseriesLifecycleType implements LifecycleType {
                     .filter(Objects::nonNull).collect(Collectors.toList());
             default:
                 throw new IllegalArgumentException("lifecycle type[" + TYPE + "] does not support phase[" + phase.getName() + "]");
+        }
+    }
+    
+    @Override
+    public String getNextActionName(String currentActionName, Phase phase) {
+        List<String> orderedActionNames;
+        switch (phase.getName()) {
+        case "hot":
+            orderedActionNames = ORDERED_VALID_HOT_ACTIONS;
+            break;
+        case "warm":
+            orderedActionNames = ORDERED_VALID_WARM_ACTIONS;
+            break;
+        case "cold":
+            orderedActionNames = ORDERED_VALID_COLD_ACTIONS;
+            break;
+        case "delete":
+            orderedActionNames = ORDERED_VALID_DELETE_ACTIONS;
+            break;
+        default:
+            throw new IllegalArgumentException("lifecycle type[" + TYPE + "] does not support phase[" + phase.getName() + "]");
+        }
+
+        int index = orderedActionNames.indexOf(currentActionName);
+        if (index < 0) {
+            throw new IllegalArgumentException("[" + currentActionName + "] is not a valid action for phase [" + phase.getName()
+                    + "] in lifecycle type [" + TYPE + "]");
+        } else {
+            // Find the next action after `index` that exists in the phase and return it
+            while (++index < orderedActionNames.size()) {
+                String actionName = orderedActionNames.get(index);
+                if (phase.getActions().containsKey(actionName)) {
+                    return actionName;
+                }
+            }
+            // if we have exhausted `validActions` and haven't found a matching
+            // action in the Phase return null indicating there is no next
+            // action available
+            return null;
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/TimeseriesLifecycleType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/TimeseriesLifecycleType.java
@@ -82,7 +82,7 @@ public class TimeseriesLifecycleType implements LifecycleType {
     @Override
     public String getNextPhaseName(String currentPhaseName, Map<String, Phase> phases) {
         int index = VALID_PHASES.indexOf(currentPhaseName);
-        if (index < 0) {
+        if (index < 0 && "new".equals(currentPhaseName) == false) {
             throw new IllegalArgumentException("[" + currentPhaseName + "] is not a valid phase for lifecycle type [" + TYPE + "]");
         } else {
             // Find the next phase after `index` that exists in `phases` and return it
@@ -100,6 +100,9 @@ public class TimeseriesLifecycleType implements LifecycleType {
     }
 
     public String getPreviousPhaseName(String currentPhaseName, Map<String, Phase> phases) {
+        if ("new".equals(currentPhaseName)) {
+            return null;
+        }
         int index = VALID_PHASES.indexOf(currentPhaseName);
         if (index < 0) {
             throw new IllegalArgumentException("[" + currentPhaseName + "] is not a valid phase for lifecycle type [" + TYPE + "]");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/AbstractActionTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/AbstractActionTestCase.java
@@ -7,6 +7,10 @@
 package org.elasticsearch.xpack.core.indexlifecycle;
 
 import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public abstract class AbstractActionTestCase<T extends LifecycleAction> extends AbstractSerializingTestCase<T> {
 
@@ -19,5 +23,18 @@ public abstract class AbstractActionTestCase<T extends LifecycleAction> extends 
     public final void testIsSafeAction() {
         LifecycleAction action = createTestInstance();
         assertEquals(isSafeAction(), action.isSafeAction());
+    }
+
+    public void testToStepKeys() {
+        T action = createTestInstance();
+        String phase = randomAlphaOfLengthBetween(1, 10);
+        StepKey nextStepKey = new StepKey(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10),
+                randomAlphaOfLengthBetween(1, 10));
+        List<Step> steps = action.toSteps(null, phase, nextStepKey);
+        assertNotNull(steps);
+        List<StepKey> stepKeys = action.toStepKeys(phase);
+        assertNotNull(stepKeys);
+        List<StepKey> expectedStepKeys = steps.stream().map(Step::getKey).collect(Collectors.toList());
+        assertEquals(expectedStepKeys, stepKeys);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicyTests.java
@@ -355,7 +355,7 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
 
         private final String name;
 
-        public NamedMockAction(String name, List<Step> steps) {
+        NamedMockAction(String name, List<Step> steps) {
             super(steps, true);
             this.name = name;
         }
@@ -376,7 +376,7 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
         private final List<String> orderedPhaseNames;
         private final Map<String, List<String>> orderedActionNamesForPhases;
 
-        public ControllableLifecycleType(List<String> orderedPhases, Map<String, List<String>> orderedActionNamesForPhases) {
+        ControllableLifecycleType(List<String> orderedPhases, Map<String, List<String>> orderedActionNamesForPhases) {
             this.orderedPhaseNames = orderedPhases;
             this.orderedActionNamesForPhases = orderedActionNamesForPhases;
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicyTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -20,12 +21,15 @@ import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -211,5 +215,284 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
                 () -> policy.isActionSafe(new StepKey("first_phase", "non_existant_action", randomAlphaOfLength(10))));
         assertEquals("Action [non_existant_action] in phase [first_phase]  does not exist in policy [" + policy.getName() + "]",
                 exception.getMessage());
+
+        assertTrue(policy.isActionSafe(new StepKey("new", randomAlphaOfLength(10), randomAlphaOfLength(10))));
+    }
+
+    public void testGetNextValidStep() {
+        List<String> orderedPhases = Arrays.asList("phase_1", "phase_2", "phase_3", "phase_4", "phase_5");
+        Map<String, List<String>> orderedActionNamesForPhases = new HashMap<>();
+        List<String> actionNamesforPhase = new ArrayList<>();
+        actionNamesforPhase.add("action_1");
+        actionNamesforPhase.add("action_2");
+        actionNamesforPhase.add("action_3");
+        actionNamesforPhase.add("action_4");
+        orderedActionNamesForPhases.put("phase_1", actionNamesforPhase);
+        orderedActionNamesForPhases.put("phase_2", actionNamesforPhase);
+        orderedActionNamesForPhases.put("phase_3", actionNamesforPhase);
+        orderedActionNamesForPhases.put("phase_4", actionNamesforPhase);
+        orderedActionNamesForPhases.put("phase_5", actionNamesforPhase);
+        LifecycleType lifecycleType = new ControllableLifecycleType(orderedPhases, orderedActionNamesForPhases);
+
+        // create a policy which has only phases 1,2, and 4 and within them has
+        // actions 1 and 3 which both contain steps 1, 2, and 3.
+        Map<String, Phase> phases = new HashMap<>();
+        for (int p = 1; p <= 4; p++) {
+            if (p == 3) {
+                continue;
+            }
+            String phaseName = "phase_" + p;
+            Map<String, LifecycleAction> actions = new HashMap<>();
+
+            for (int a = 1; a <= 3; a++) {
+                if (a == 2) {
+                    continue;
+                }
+                String actionName = "action_" + a;
+                List<Step> steps = new ArrayList<>();
+                for (int s = 1; s <= 3; s++) {
+                    String stepName = "step_" + s;
+                    steps.add(new MockStep(new StepKey(phaseName, actionName, stepName), null));
+                }
+                NamedMockAction action = new NamedMockAction(actionName, steps);
+                actions.put(action.getWriteableName(), action);
+            }
+
+            Phase phase = new Phase(phaseName, TimeValue.ZERO, actions);
+            phases.put(phase.getName(), phase);
+        }
+        LifecyclePolicy policy = new LifecyclePolicy(lifecycleType, lifecycleName, phases);
+
+        // step still exists
+        StepKey currentStep = new StepKey(randomFrom("phase_1", "phase_2", "phase_4"), randomFrom("action_1", "action_3"),
+                randomFrom("step_1", "step_2", "step_3"));
+        StepKey nextStep = policy.getNextValidStep(currentStep);
+        assertNotNull(nextStep);
+        assertEquals(currentStep, nextStep);
+
+        // current action exists but step does not
+        currentStep = new StepKey("phase_1", "action_1", "step_missing");
+        nextStep = policy.getNextValidStep(currentStep);
+        assertNotNull(nextStep);
+        assertEquals(new StepKey("phase_1", "action_3", "step_1"), nextStep);
+
+        // current action exists but step does not and action is last in phase
+        currentStep = new StepKey("phase_1", "action_3", "step_missing");
+        nextStep = policy.getNextValidStep(currentStep);
+        assertNotNull(nextStep);
+        assertEquals(new StepKey("phase_1", PhaseAfterStep.NAME, PhaseAfterStep.NAME), nextStep);
+
+        // current action exists but step does not and action is last in the
+        // last phase
+        currentStep = new StepKey("phase_4", "action_3", "step_missing");
+        nextStep = policy.getNextValidStep(currentStep);
+        assertNotNull(nextStep);
+        assertEquals(TerminalPolicyStep.KEY, nextStep);
+
+        // current action no longer exists
+        currentStep = new StepKey("phase_1", "action_2", "step_2");
+        nextStep = policy.getNextValidStep(currentStep);
+        assertNotNull(nextStep);
+        assertEquals(new StepKey("phase_1", "action_3", "step_1"), nextStep);
+
+        // current action no longer exists and action was last in phase
+        currentStep = new StepKey("phase_1", "action_4", "step_2");
+        nextStep = policy.getNextValidStep(currentStep);
+        assertNotNull(nextStep);
+        assertEquals(new StepKey("phase_1", PhaseAfterStep.NAME, PhaseAfterStep.NAME), nextStep);
+
+        // current action no longer exists and action was last in the last phase
+        currentStep = new StepKey("phase_4", "action_4", "step_2");
+        nextStep = policy.getNextValidStep(currentStep);
+        assertNotNull(nextStep);
+        assertEquals(TerminalPolicyStep.KEY, nextStep);
+
+        // current phase no longer exists
+        currentStep = new StepKey("phase_3", "action_2", "step_2");
+        nextStep = policy.getNextValidStep(currentStep);
+        assertNotNull(nextStep);
+        assertEquals(new StepKey("phase_2", PhaseAfterStep.NAME, PhaseAfterStep.NAME), nextStep);
+
+        // current phase no longer exists and was last phase
+        currentStep = new StepKey("phase_5", "action_2", "step_2");
+        nextStep = policy.getNextValidStep(currentStep);
+        assertNotNull(nextStep);
+        assertEquals(TerminalPolicyStep.KEY, nextStep);
+
+        // create a new policy where only phase 2 exists and within it has
+        // actions 1 and 3 which both contain steps 1, 2, and 3.
+        phases = new HashMap<>();
+        String phaseName = "phase_2";
+        Map<String, LifecycleAction> actions = new HashMap<>();
+
+        for (int a = 1; a <= 3; a++) {
+            if (a == 2) {
+                continue;
+            }
+            String actionName = "action_" + a;
+            List<Step> steps = new ArrayList<>();
+            for (int s = 1; s <= 3; s++) {
+                String stepName = "step_" + s;
+                steps.add(new MockStep(new StepKey(phaseName, actionName, stepName), null));
+            }
+            NamedMockAction action = new NamedMockAction(actionName, steps);
+            actions.put(action.getWriteableName(), action);
+        }
+
+        Phase phase = new Phase(phaseName, TimeValue.ZERO, actions);
+        phases.put(phase.getName(), phase);
+        policy = new LifecyclePolicy(lifecycleType, lifecycleName, phases);
+
+        // current phase no longer exists and was first phase
+        currentStep = new StepKey("phase_1", "action_2", "step_2");
+        nextStep = policy.getNextValidStep(currentStep);
+        assertNotNull(nextStep);
+        assertEquals(InitializePolicyContextStep.KEY, nextStep);
+
+    }
+
+    private static class NamedMockAction extends MockAction {
+
+        private final String name;
+
+        public NamedMockAction(String name, List<Step> steps) {
+            super(steps, true);
+            this.name = name;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return name;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class ControllableLifecycleType implements LifecycleType {
+
+        private final List<String> orderedPhaseNames;
+        private final Map<String, List<String>> orderedActionNamesForPhases;
+
+        public ControllableLifecycleType(List<String> orderedPhases, Map<String, List<String>> orderedActionNamesForPhases) {
+            this.orderedPhaseNames = orderedPhases;
+            this.orderedActionNamesForPhases = orderedActionNamesForPhases;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return "controllable_lifecycle_type";
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+        }
+
+        @Override
+        public List<Phase> getOrderedPhases(Map<String, Phase> phases) {
+            return orderedPhaseNames.stream().map(n -> phases.get(n)).filter(Objects::nonNull).collect(Collectors.toList());
+        }
+
+        @Override
+        public String getNextPhaseName(String currentPhaseName, Map<String, Phase> phases) {
+            int index = orderedPhaseNames.indexOf(currentPhaseName);
+            if (index < 0) {
+                throw new IllegalArgumentException(
+                        "[" + currentPhaseName + "] is not a valid phase for lifecycle type [" + getWriteableName() + "]");
+            } else if (index == orderedPhaseNames.size() - 1) {
+                return null;
+            } else {
+             // Find the next phase after `index` that exists in `phases` and return it
+                while (++index < orderedPhaseNames.size()) {
+                    String phaseName = orderedPhaseNames.get(index);
+                    if (phases.containsKey(phaseName)) {
+                        return phaseName;
+                    }
+                }
+                // if we have exhausted VALID_PHASES and haven't found a matching
+                // phase in `phases` return null indicating there is no next phase
+                // available
+                return null;
+            }
+        }
+
+        @Override
+        public String getPreviousPhaseName(String currentPhaseName, Map<String, Phase> phases) {
+            int index = orderedPhaseNames.indexOf(currentPhaseName);
+            if (index < 0) {
+                throw new IllegalArgumentException(
+                        "[" + currentPhaseName + "] is not a valid phase for lifecycle type [" + getWriteableName() + "]");
+            } else if (index == orderedPhaseNames.size() - 1) {
+                return null;
+            } else {
+             // Find the previous phase before `index` that exists in `phases` and return it
+                while (--index >= 0) {
+                    String phaseName = orderedPhaseNames.get(index);
+                    if (phases.containsKey(phaseName)) {
+                        return phaseName;
+                    }
+                }
+                // if we have exhausted VALID_PHASES and haven't found a matching
+                // phase in `phases` return null indicating there is no next phase
+                // available
+                return null;
+            }
+        }
+
+        @Override
+        public List<LifecycleAction> getOrderedActions(Phase phase) {
+            List<String> orderedActionNames = orderedActionNamesForPhases.get(phase.getName());
+            if (orderedActionNames == null) {
+                throw new IllegalArgumentException(
+                        "[" + phase.getName() + "] is not a valid phase for lifecycle type [" + getWriteableName() + "]");
+            }
+
+            return orderedActionNames.stream().map(n -> phase.getActions().get(n)).filter(Objects::nonNull).collect(Collectors.toList());
+        }
+
+        @Override
+        public String getNextActionName(String currentActionName, Phase phase) {
+            List<String> orderedActionNames = orderedActionNamesForPhases.get(phase.getName());
+            if (orderedActionNames == null) {
+                throw new IllegalArgumentException(
+                        "[" + phase.getName() + "] is not a valid phase for lifecycle type [" + getWriteableName() + "]");
+            }
+
+            int index = orderedActionNames.indexOf(currentActionName);
+            if (index < 0) {
+                throw new IllegalArgumentException("[" + currentActionName + "] is not a valid action for phase [" + phase.getName()
+                        + "] in lifecycle type [" + getWriteableName() + "]");
+            } else {
+                // Find the next action after `index` that exists in the phase and return it
+                while (++index < orderedActionNames.size()) {
+                    String actionName = orderedActionNames.get(index);
+                    if (phase.getActions().containsKey(actionName)) {
+                        return actionName;
+                    }
+                }
+                // if we have exhausted `validActions` and haven't found a matching
+                // action in the Phase return null indicating there is no next
+                // action available
+                return null;
+            }
+        }
+
+        @Override
+        public void validate(Collection<Phase> phases) {
+            phases.forEach(phase -> {
+                if (orderedPhaseNames.contains(phase.getName()) == false) {
+                    throw new IllegalArgumentException("Timeseries lifecycle does not support phase [" + phase.getName() + "]");
+                }
+                List<String> allowedActions = orderedActionNamesForPhases.get(phase.getName());
+                phase.getActions().forEach((actionName, action) -> {
+                    if (allowedActions.contains(actionName) == false) {
+                        throw new IllegalArgumentException(
+                                "invalid action [" + actionName + "] " + "defined in phase [" + phase.getName() + "]");
+                    }
+                });
+            });
+        }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/MockAction.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/MockAction.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -72,6 +73,11 @@ public class MockAction implements LifecycleAction {
     @Override
     public List<Step> toSteps(Client client, String phase, Step.StepKey nextStepKey) {
         return new ArrayList<>(steps);
+    }
+
+    @Override
+    public List<StepKey> toStepKeys(String phase) {
+        return steps.stream().map(Step::getKey).collect(Collectors.toList());
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/TestLifecycleType.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/TestLifecycleType.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class TestLifecycleType implements LifecycleType {
     public static final TestLifecycleType INSTANCE = new TestLifecycleType();
@@ -41,7 +42,48 @@ public class TestLifecycleType implements LifecycleType {
     }
 
     @Override
+    public String getNextPhaseName(String currentPhaseName, Map<String, Phase> phases) {
+        List<String> orderedPhaseNames = getOrderedPhases(phases).stream().map(Phase::getName).collect(Collectors.toList());
+        int index = orderedPhaseNames.indexOf(currentPhaseName);
+        if (index < 0) {
+            throw new IllegalArgumentException("[" + currentPhaseName + "] is not a valid phase for lifecycle type [" + TYPE + "]");
+        } else if (index == orderedPhaseNames.size() - 1) {
+            return null;
+        } else {
+            return orderedPhaseNames.get(index + 1);
+        }
+    }
+
+    @Override
+    public String getPreviousPhaseName(String currentPhaseName, Map<String, Phase> phases) {
+        List<String> orderedPhaseNames = getOrderedPhases(phases).stream().map(Phase::getName).collect(Collectors.toList());
+        int index = orderedPhaseNames.indexOf(currentPhaseName);
+        if (index < 0) {
+            throw new IllegalArgumentException("[" + currentPhaseName + "] is not a valid phase for lifecycle type [" + TYPE + "]");
+        } else if (index == 0) {
+            return null;
+        } else {
+            return orderedPhaseNames.get(index - 1);
+        }
+    }
+
+    @Override
     public List<LifecycleAction> getOrderedActions(Phase phase) {
         return new ArrayList<>(phase.getActions().values());
+    }
+
+    @Override
+    public String getNextActionName(String currentActionName, Phase phase) {
+        List<String> orderedActionNames = getOrderedActions(phase).stream().map(LifecycleAction::getWriteableName)
+                .collect(Collectors.toList());
+        int index = orderedActionNames.indexOf(currentActionName);
+        if (index < 0) {
+            throw new IllegalArgumentException("[" + currentActionName + "] is not a valid action for phase [" + phase.getName()
+                    + "] in lifecycle type [" + TYPE + "]");
+        } else if (index == orderedActionNames.size() - 1) {
+            return null;
+        } else {
+            return orderedActionNames.get(index + 1);
+        }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/TimeseriesLifecycleTypeTests.java
@@ -9,10 +9,12 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -184,6 +186,280 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
         Phase deletePhase = new Phase("delete", TimeValue.ZERO, actions);
         List<LifecycleAction> orderedActions = TimeseriesLifecycleType.INSTANCE.getOrderedActions(deletePhase);
         assertTrue(isSorted(orderedActions, LifecycleAction::getWriteableName, ORDERED_VALID_DELETE_ACTIONS));
+    }
+
+    public void testGetNextPhaseName() {
+        assertNextPhaseName("hot", "warm", new String[] { "hot", "warm" });
+        assertNextPhaseName("hot", "warm", new String[] { "hot", "warm", "cold" });
+        assertNextPhaseName("hot", "warm", new String[] { "hot", "warm", "cold", "delete" });
+        assertNextPhaseName("hot", "warm", new String[] { "warm", "cold", "delete" });
+        assertNextPhaseName("hot", "warm", new String[] { "warm", "cold", "delete" });
+        assertNextPhaseName("hot", "warm", new String[] { "warm", "delete" });
+        assertNextPhaseName("hot", "cold", new String[] { "cold", "delete" });
+        assertNextPhaseName("hot", "cold", new String[] { "cold" });
+        assertNextPhaseName("hot", "delete", new String[] { "hot", "delete" });
+        assertNextPhaseName("hot", "delete", new String[] { "delete" });
+        assertNextPhaseName("hot", null, new String[] { "hot" });
+        assertNextPhaseName("hot", null, new String[] {});
+
+        assertNextPhaseName("warm", "cold", new String[] { "hot", "warm", "cold", "delete" });
+        assertNextPhaseName("warm", "cold", new String[] { "warm", "cold", "delete" });
+        assertNextPhaseName("warm", "cold", new String[] { "cold", "delete" });
+        assertNextPhaseName("warm", "cold", new String[] { "cold" });
+        assertNextPhaseName("warm", "delete", new String[] { "hot", "warm", "delete" });
+        assertNextPhaseName("warm", null, new String[] { "hot", "warm" });
+        assertNextPhaseName("warm", null, new String[] { "warm" });
+        assertNextPhaseName("warm", null, new String[] { "hot" });
+        assertNextPhaseName("warm", null, new String[] {});
+
+        assertNextPhaseName("cold", "delete", new String[] { "hot", "warm", "cold", "delete" });
+        assertNextPhaseName("cold", "delete", new String[] { "warm", "cold", "delete" });
+        assertNextPhaseName("cold", "delete", new String[] { "cold", "delete" });
+        assertNextPhaseName("cold", "delete", new String[] { "delete" });
+        assertNextPhaseName("cold", "delete", new String[] { "hot", "warm", "delete" });
+        assertNextPhaseName("cold", null, new String[] { "hot", "warm", "cold" });
+        assertNextPhaseName("cold", null, new String[] { "hot", "warm" });
+        assertNextPhaseName("cold", null, new String[] { "cold" });
+        assertNextPhaseName("cold", null, new String[] { "hot" });
+        assertNextPhaseName("cold", null, new String[] {});
+
+        assertNextPhaseName("delete", null, new String[] { "hot", "warm", "cold" });
+        assertNextPhaseName("delete", null, new String[] { "hot", "warm" });
+        assertNextPhaseName("delete", null, new String[] { "cold" });
+        assertNextPhaseName("delete", null, new String[] { "hot" });
+        assertNextPhaseName("delete", null, new String[] {});
+        assertNextPhaseName("delete", null, new String[] { "hot", "warm", "cold", "delete" });
+        assertNextPhaseName("delete", null, new String[] { "hot", "warm", "delete" });
+        assertNextPhaseName("delete", null, new String[] { "cold", "delete" });
+        assertNextPhaseName("delete", null, new String[] { "delete" });
+        assertNextPhaseName("delete", null, new String[] {});
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+                () -> TimeseriesLifecycleType.INSTANCE.getNextPhaseName("foo", Collections.emptyMap()));
+        assertEquals("[foo] is not a valid phase for lifecycle type [" + TimeseriesLifecycleType.TYPE + "]", exception.getMessage());
+        exception = expectThrows(IllegalArgumentException.class, () -> TimeseriesLifecycleType.INSTANCE
+                .getNextPhaseName("foo", Collections.singletonMap("foo", new Phase("foo", TimeValue.ZERO, Collections.emptyMap()))));
+        assertEquals("[foo] is not a valid phase for lifecycle type [" + TimeseriesLifecycleType.TYPE + "]", exception.getMessage());
+    }
+
+    public void testGetPreviousPhaseName() {
+        assertPreviousPhaseName("hot", null, new String[] { "hot", "warm" });
+        assertPreviousPhaseName("hot", null, new String[] { "hot", "warm", "cold" });
+        assertPreviousPhaseName("hot", null, new String[] { "hot", "warm", "cold", "delete" });
+        assertPreviousPhaseName("hot", null, new String[] { "warm", "cold", "delete" });
+        assertPreviousPhaseName("hot", null, new String[] { "warm", "delete" });
+        assertPreviousPhaseName("hot", null, new String[] { "cold", "delete" });
+        assertPreviousPhaseName("hot", null, new String[] { "cold" });
+        assertPreviousPhaseName("hot", null, new String[] { "hot", "delete" });
+        assertPreviousPhaseName("hot", null, new String[] { "delete" });
+        assertPreviousPhaseName("hot", null, new String[] { "hot" });
+        assertPreviousPhaseName("hot", null, new String[] {});
+
+        assertPreviousPhaseName("warm", "hot", new String[] { "hot", "warm", "cold", "delete" });
+        assertPreviousPhaseName("warm", null, new String[] { "warm", "cold", "delete" });
+        assertPreviousPhaseName("warm", "hot", new String[] { "hot", "cold", "delete" });
+        assertPreviousPhaseName("warm", null, new String[] { "cold", "delete" });
+        assertPreviousPhaseName("warm", "hot", new String[] { "hot", "delete" });
+        assertPreviousPhaseName("warm", null, new String[] { "delete" });
+        assertPreviousPhaseName("warm", "hot", new String[] { "hot" });
+        assertPreviousPhaseName("warm", null, new String[] {});
+
+        assertPreviousPhaseName("cold", "warm", new String[] { "hot", "warm", "cold", "delete" });
+        assertPreviousPhaseName("cold", "hot", new String[] { "hot", "cold", "delete" });
+        assertPreviousPhaseName("cold", "warm", new String[] { "warm", "cold", "delete" });
+        assertPreviousPhaseName("cold", null, new String[] { "cold", "delete" });
+        assertPreviousPhaseName("cold", "warm", new String[] { "hot", "warm", "delete" });
+        assertPreviousPhaseName("cold", "hot", new String[] { "hot", "delete" });
+        assertPreviousPhaseName("cold", "warm", new String[] { "warm", "delete" });
+        assertPreviousPhaseName("cold", null, new String[] { "delete" });
+        assertPreviousPhaseName("cold", "warm", new String[] { "hot", "warm" });
+        assertPreviousPhaseName("cold", "hot", new String[] { "hot" });
+        assertPreviousPhaseName("cold", "warm", new String[] { "warm" });
+        assertPreviousPhaseName("cold", null, new String[] {});
+
+        assertPreviousPhaseName("delete", "cold", new String[] { "hot", "warm", "cold", "delete" });
+        assertPreviousPhaseName("delete", "cold", new String[] { "warm", "cold", "delete" });
+        assertPreviousPhaseName("delete", "warm", new String[] { "hot", "warm", "delete" });
+        assertPreviousPhaseName("delete", "hot", new String[] { "hot", "delete" });
+        assertPreviousPhaseName("delete", "cold", new String[] { "cold", "delete" });
+        assertPreviousPhaseName("delete", null, new String[] { "delete" });
+        assertPreviousPhaseName("delete", "cold", new String[] { "hot", "warm", "cold" });
+        assertPreviousPhaseName("delete", "cold", new String[] { "warm", "cold" });
+        assertPreviousPhaseName("delete", "warm", new String[] { "hot", "warm" });
+        assertPreviousPhaseName("delete", "hot", new String[] { "hot" });
+        assertPreviousPhaseName("delete", "cold", new String[] { "cold" });
+        assertPreviousPhaseName("delete", null, new String[] {});
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+                () -> TimeseriesLifecycleType.INSTANCE.getPreviousPhaseName("foo", Collections.emptyMap()));
+        assertEquals("[foo] is not a valid phase for lifecycle type [" + TimeseriesLifecycleType.TYPE + "]", exception.getMessage());
+        exception = expectThrows(IllegalArgumentException.class, () -> TimeseriesLifecycleType.INSTANCE
+                .getPreviousPhaseName("foo", Collections.singletonMap("foo", new Phase("foo", TimeValue.ZERO, Collections.emptyMap()))));
+        assertEquals("[foo] is not a valid phase for lifecycle type [" + TimeseriesLifecycleType.TYPE + "]", exception.getMessage());
+    }
+
+    public void testGetNextActionName() {
+        // Hot Phase
+        assertNextActionName("hot", RolloverAction.NAME, null, new String[] {});
+        assertNextActionName("hot", RolloverAction.NAME, null, new String[] { RolloverAction.NAME });
+        assertInvalidAction("hot", "foo", new String[] { RolloverAction.NAME });
+        assertInvalidAction("hot", AllocateAction.NAME, new String[] { RolloverAction.NAME });
+        assertInvalidAction("hot", DeleteAction.NAME, new String[] { RolloverAction.NAME });
+        assertInvalidAction("hot", ForceMergeAction.NAME, new String[] { RolloverAction.NAME });
+        assertInvalidAction("hot", ReadOnlyAction.NAME, new String[] { RolloverAction.NAME });
+        assertInvalidAction("hot", ReplicasAction.NAME, new String[] { RolloverAction.NAME });
+        assertInvalidAction("hot", ShrinkAction.NAME, new String[] { RolloverAction.NAME });
+
+        // Warm Phase
+        assertNextActionName("warm", ReadOnlyAction.NAME, AllocateAction.NAME,
+                new String[] { ReadOnlyAction.NAME, AllocateAction.NAME, ReplicasAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", ReadOnlyAction.NAME, ReplicasAction.NAME,
+                new String[] { ReadOnlyAction.NAME, ReplicasAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", ReadOnlyAction.NAME, ShrinkAction.NAME,
+                new String[] { ReadOnlyAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", ReadOnlyAction.NAME, ForceMergeAction.NAME,
+                new String[] { ReadOnlyAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", ReadOnlyAction.NAME, null, new String[] { ReadOnlyAction.NAME });
+
+        assertNextActionName("warm", ReadOnlyAction.NAME, AllocateAction.NAME,
+                new String[] { AllocateAction.NAME, ReplicasAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", ReadOnlyAction.NAME, ReplicasAction.NAME,
+                new String[] { ReplicasAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", ReadOnlyAction.NAME, ShrinkAction.NAME, new String[] { ShrinkAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", ReadOnlyAction.NAME, ForceMergeAction.NAME, new String[] { ForceMergeAction.NAME });
+        assertNextActionName("warm", ReadOnlyAction.NAME, null, new String[] {});
+
+        assertNextActionName("warm", AllocateAction.NAME, ReplicasAction.NAME,
+                new String[] { ReadOnlyAction.NAME, AllocateAction.NAME, ReplicasAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", AllocateAction.NAME, ShrinkAction.NAME,
+                new String[] { ReadOnlyAction.NAME, AllocateAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", AllocateAction.NAME, ForceMergeAction.NAME,
+                new String[] { ReadOnlyAction.NAME, AllocateAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", AllocateAction.NAME, null, new String[] { ReadOnlyAction.NAME, AllocateAction.NAME });
+
+        assertNextActionName("warm", AllocateAction.NAME, ReplicasAction.NAME,
+                new String[] { ReplicasAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", AllocateAction.NAME, ShrinkAction.NAME, new String[] { ShrinkAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", AllocateAction.NAME, ForceMergeAction.NAME, new String[] { ForceMergeAction.NAME });
+        assertNextActionName("warm", AllocateAction.NAME, null, new String[] {});
+
+        assertNextActionName("warm", ReplicasAction.NAME, ShrinkAction.NAME,
+                new String[] { ReadOnlyAction.NAME, AllocateAction.NAME, ReplicasAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", ReplicasAction.NAME, ForceMergeAction.NAME,
+                new String[] { ReadOnlyAction.NAME, AllocateAction.NAME, ReplicasAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", ReplicasAction.NAME, null,
+                new String[] { ReadOnlyAction.NAME, AllocateAction.NAME, ReplicasAction.NAME });
+
+        assertNextActionName("warm", ReplicasAction.NAME, ShrinkAction.NAME, new String[] { ShrinkAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", ReplicasAction.NAME, ForceMergeAction.NAME, new String[] { ForceMergeAction.NAME });
+        assertNextActionName("warm", ReplicasAction.NAME, null, new String[] {});
+
+        assertNextActionName("warm", ShrinkAction.NAME, ForceMergeAction.NAME,
+                new String[] { ReadOnlyAction.NAME, AllocateAction.NAME, ReplicasAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME });
+        assertNextActionName("warm", ShrinkAction.NAME, null,
+                new String[] { ReadOnlyAction.NAME, AllocateAction.NAME, ReplicasAction.NAME, ShrinkAction.NAME });
+
+        assertNextActionName("warm", ShrinkAction.NAME, ForceMergeAction.NAME, new String[] { ForceMergeAction.NAME });
+        assertNextActionName("warm", ShrinkAction.NAME, null, new String[] {});
+
+        assertNextActionName("warm", ForceMergeAction.NAME, null,
+                new String[] { ReadOnlyAction.NAME, AllocateAction.NAME, ReplicasAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME });
+
+        assertNextActionName("warm", ForceMergeAction.NAME, null, new String[] {});
+
+        assertInvalidAction("warm", "foo", new String[] { RolloverAction.NAME });
+        assertInvalidAction("warm", DeleteAction.NAME,
+                new String[] { ReadOnlyAction.NAME, AllocateAction.NAME, ReplicasAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME });
+        assertInvalidAction("warm", RolloverAction.NAME,
+                new String[] { ReadOnlyAction.NAME, AllocateAction.NAME, ReplicasAction.NAME, ShrinkAction.NAME, ForceMergeAction.NAME });
+
+        // Cold Phase
+        assertNextActionName("cold", AllocateAction.NAME, ReplicasAction.NAME, new String[] { AllocateAction.NAME, ReplicasAction.NAME });
+        assertNextActionName("cold", AllocateAction.NAME, null, new String[] { AllocateAction.NAME });
+
+        assertNextActionName("cold", AllocateAction.NAME, ReplicasAction.NAME, new String[] { ReplicasAction.NAME });
+        assertNextActionName("cold", AllocateAction.NAME, null, new String[] {});
+
+        assertNextActionName("cold", ReplicasAction.NAME, null, new String[] { AllocateAction.NAME, ReplicasAction.NAME });
+        assertNextActionName("cold", AllocateAction.NAME, null, new String[] {});
+
+        assertInvalidAction("cold", "foo", new String[] { AllocateAction.NAME, ReplicasAction.NAME });
+        assertInvalidAction("cold", DeleteAction.NAME, new String[] { AllocateAction.NAME, ReplicasAction.NAME });
+        assertInvalidAction("cold", ForceMergeAction.NAME, new String[] { AllocateAction.NAME, ReplicasAction.NAME });
+        assertInvalidAction("cold", ReadOnlyAction.NAME, new String[] { AllocateAction.NAME, ReplicasAction.NAME });
+        assertInvalidAction("cold", RolloverAction.NAME, new String[] { AllocateAction.NAME, ReplicasAction.NAME });
+        assertInvalidAction("cold", ShrinkAction.NAME, new String[] { AllocateAction.NAME, ReplicasAction.NAME });
+
+        // Delete Phase
+        assertNextActionName("delete", DeleteAction.NAME, null, new String[] {});
+        assertNextActionName("delete", DeleteAction.NAME, null, new String[] { DeleteAction.NAME });
+        assertInvalidAction("delete", "foo", new String[] { DeleteAction.NAME });
+        assertInvalidAction("delete", AllocateAction.NAME, new String[] { DeleteAction.NAME });
+        assertInvalidAction("delete", ForceMergeAction.NAME, new String[] { DeleteAction.NAME });
+        assertInvalidAction("delete", ReadOnlyAction.NAME, new String[] { DeleteAction.NAME });
+        assertInvalidAction("delete", ReplicasAction.NAME, new String[] { DeleteAction.NAME });
+        assertInvalidAction("delete", RolloverAction.NAME, new String[] { DeleteAction.NAME });
+        assertInvalidAction("delete", ShrinkAction.NAME, new String[] { DeleteAction.NAME });
+
+        Phase phase = new Phase("foo", TimeValue.ZERO, Collections.emptyMap());
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+                () -> TimeseriesLifecycleType.INSTANCE.getNextActionName(ShrinkAction.NAME, phase));
+        assertEquals("lifecycle type[" + TimeseriesLifecycleType.TYPE + "] does not support phase[" + phase.getName() + "]",
+                exception.getMessage());
+    }
+
+    private void assertNextActionName(String phaseName, String currentAction, String expectedNextAction, String... availableActionNames) {
+        Map<String, LifecycleAction> availableActions = convertActionNamesToActions(availableActionNames);
+        Phase phase = new Phase(phaseName, TimeValue.ZERO, availableActions);
+        String nextAction = TimeseriesLifecycleType.INSTANCE.getNextActionName(currentAction, phase);
+        assertEquals(expectedNextAction, nextAction);
+    }
+
+    private void assertInvalidAction(String phaseName, String currentAction, String... availableActionNames) {
+        Map<String, LifecycleAction> availableActions = convertActionNamesToActions(availableActionNames);
+        Phase phase = new Phase(phaseName, TimeValue.ZERO, availableActions);
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+                () -> TimeseriesLifecycleType.INSTANCE.getNextActionName(currentAction, phase));
+        assertEquals("[" + currentAction + "] is not a valid action for phase [" + phaseName + "] in lifecycle type ["
+                + TimeseriesLifecycleType.TYPE + "]", exception.getMessage());
+    }
+
+    private ConcurrentMap<String, LifecycleAction> convertActionNamesToActions(String... availableActionNames) {
+        return Arrays.asList(availableActionNames).stream().map(n -> {
+            switch (n) {
+            case AllocateAction.NAME:
+                return new AllocateAction(Collections.singletonMap("foo", "bar"), Collections.emptyMap(), Collections.emptyMap());
+            case DeleteAction.NAME:
+                return new DeleteAction();
+            case ForceMergeAction.NAME:
+                return new ForceMergeAction(1, false);
+            case ReadOnlyAction.NAME:
+                return new ReadOnlyAction();
+            case ReplicasAction.NAME:
+                return new ReplicasAction(1);
+            case RolloverAction.NAME:
+                return new RolloverAction(ByteSizeValue.parseBytesSizeValue("0b", "test"), TimeValue.ZERO, 1L);
+            case ShrinkAction.NAME:
+                return new ShrinkAction(1);
+            }
+            return new DeleteAction();
+        }).collect(Collectors.toConcurrentMap(LifecycleAction::getWriteableName, Function.identity()));
+    }
+
+    private void assertNextPhaseName(String currentPhase, String expectedNextPhase, String... availablePhaseNames) {
+        Map<String, Phase> availablePhases = Arrays.asList(availablePhaseNames).stream()
+                .map(n -> new Phase(n, TimeValue.ZERO, Collections.emptyMap()))
+                .collect(Collectors.toMap(Phase::getName, Function.identity()));
+        String nextPhase = TimeseriesLifecycleType.INSTANCE.getNextPhaseName(currentPhase, availablePhases);
+        assertEquals(expectedNextPhase, nextPhase);
+    }
+
+    private void assertPreviousPhaseName(String currentPhase, String expectedNextPhase, String... availablePhaseNames) {
+        Map<String, Phase> availablePhases = Arrays.asList(availablePhaseNames).stream()
+                .map(n -> new Phase(n, TimeValue.ZERO, Collections.emptyMap()))
+                .collect(Collectors.toMap(Phase::getName, Function.identity()));
+        String nextPhase = TimeseriesLifecycleType.INSTANCE.getPreviousPhaseName(currentPhase, availablePhases);
+        assertEquals(expectedNextPhase, nextPhase);
     }
 
     /**

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/TimeseriesLifecycleTypeTests.java
@@ -432,7 +432,7 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
             case DeleteAction.NAME:
                 return new DeleteAction();
             case ForceMergeAction.NAME:
-                return new ForceMergeAction(1, false);
+                return new ForceMergeAction(1);
             case ReadOnlyAction.NAME:
                 return new ReadOnlyAction();
             case ReplicasAction.NAME:

--- a/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportPutLifecycleAction.java
+++ b/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportPutLifecycleAction.java
@@ -78,6 +78,7 @@ public class TransportPutLifecycleAction extends TransportMasterNodeAction<Reque
                             throw new ResourceAlreadyExistsException("Lifecycle policy already exists: {}",
                                     request.getPolicy().getName());
                         }
+                        // NORELEASE Check if current step exists in new policy and if not move to next available step
                         SortedMap<String, LifecyclePolicyMetadata> newPolicies = new TreeMap<>(currentMetadata.getPolicyMetadatas());
 
                         Map<String, String> filteredHeaders = threadPool.getThreadContext().getHeaders().entrySet().stream()

--- a/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportSetPolicyForIndexAction.java
+++ b/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportSetPolicyForIndexAction.java
@@ -79,7 +79,8 @@ public class TransportSetPolicyForIndexAction extends TransportMasterNodeAction<
                             throw new ResourceNotFoundException("Policy does not exist [{}]", newPolicyName);
                         }
 
-                        return IndexLifecycleRunner.setPolicyForIndexes(newPolicyName, indices, currentState, newPolicy, failedIndexes);
+                        return IndexLifecycleRunner.setPolicyForIndexes(newPolicyName, indices, currentState, newPolicy, failedIndexes,
+                                () -> System.currentTimeMillis());
                     }
 
                     @Override

--- a/x-pack/plugin/index-lifecycle/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/index-lifecycle/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunnerTests.java
@@ -846,8 +846,10 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         String indexName = randomAlphaOfLength(10);
         String oldPolicyName = "old_policy";
         String newPolicyName = "new_policy";
-        LifecyclePolicy newPolicy = new LifecyclePolicy(TestLifecycleType.INSTANCE, newPolicyName, Collections.emptyMap());
-        StepKey currentStep = new StepKey(randomAlphaOfLength(10), MockAction.NAME, randomAlphaOfLength(10));
+        String phaseName = randomAlphaOfLength(10);
+        StepKey currentStep = new StepKey(phaseName, MockAction.NAME, randomAlphaOfLength(10));
+        LifecyclePolicy newPolicy = createPolicy(oldPolicyName,
+                new StepKey(phaseName, MockAction.NAME, randomAlphaOfLength(9)), null);
         LifecyclePolicy oldPolicy = createPolicy(oldPolicyName, currentStep, null);
         Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, oldPolicyName)
                 .put(LifecycleSettings.LIFECYCLE_PHASE, currentStep.getPhase())
@@ -861,10 +863,10 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         List<String> failedIndexes = new ArrayList<>();
 
         ClusterState newClusterState = IndexLifecycleRunner.setPolicyForIndexes(newPolicyName, indices, clusterState, newPolicy,
-                failedIndexes);
+                failedIndexes, () -> now);
 
         assertTrue(failedIndexes.isEmpty());
-        assertClusterStateOnPolicy(clusterState, index, newPolicyName, currentStep, currentStep, newClusterState, now);
+        assertClusterStateOnPolicy(clusterState, index, newPolicyName, currentStep, TerminalPolicyStep.KEY, newClusterState, now);
     }
 
     public void testSetPolicyForIndexNoCurrentPolicy() {
@@ -880,13 +882,14 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         List<String> failedIndexes = new ArrayList<>();
 
         ClusterState newClusterState = IndexLifecycleRunner.setPolicyForIndexes(newPolicyName, indices, clusterState, newPolicy,
-                failedIndexes);
+                failedIndexes, () -> now);
 
         assertTrue(failedIndexes.isEmpty());
         assertClusterStateOnPolicy(clusterState, index, newPolicyName, currentStep, currentStep, newClusterState, now);
     }
 
     public void testSetPolicyForIndexIndexDoesntExist() {
+        long now = randomNonNegativeLong();
         String indexName = randomAlphaOfLength(10);
         String oldPolicyName = "old_policy";
         String newPolicyName = "new_policy";
@@ -905,7 +908,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         List<String> failedIndexes = new ArrayList<>();
 
         ClusterState newClusterState = IndexLifecycleRunner.setPolicyForIndexes(newPolicyName, indices, clusterState, newPolicy,
-                failedIndexes);
+                failedIndexes, () -> now);
 
         assertEquals(1, failedIndexes.size());
         assertEquals("doesnt_exist", failedIndexes.get(0));
@@ -913,6 +916,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
     }
 
     public void testSetPolicyForIndexIndexInUnsafe() {
+        long now = randomNonNegativeLong();
         String indexName = randomAlphaOfLength(10);
         String oldPolicyName = "old_policy";
         String newPolicyName = "new_policy";
@@ -931,7 +935,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         List<String> failedIndexes = new ArrayList<>();
 
         ClusterState newClusterState = IndexLifecycleRunner.setPolicyForIndexes(newPolicyName, indices, clusterState, newPolicy,
-                failedIndexes);
+                failedIndexes, () -> now);
 
         assertEquals(1, failedIndexes.size());
         assertEquals(index.getName(), failedIndexes.get(0));
@@ -958,13 +962,14 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         List<String> failedIndexes = new ArrayList<>();
 
         ClusterState newClusterState = IndexLifecycleRunner.setPolicyForIndexes(newPolicyName, indices, clusterState, newPolicy,
-                failedIndexes);
+                failedIndexes, () -> now);
 
         assertTrue(failedIndexes.isEmpty());
         assertClusterStateOnPolicy(clusterState, index, newPolicyName, currentStep, currentStep, newClusterState, now);
     }
 
     public void testSetPolicyForIndexIndexInUnsafeActionChanged() {
+        long now = randomNonNegativeLong();
         String indexName = randomAlphaOfLength(10);
         String oldPolicyName = "old_policy";
         String newPolicyName = "new_policy";
@@ -974,7 +979,10 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         // change the current action so its not equal to the old one by adding a step
         Map<String, Phase> phases = new HashMap<>();
         Map<String, LifecycleAction> actions = new HashMap<>();
-        MockAction unsafeAction = new MockAction(Collections.singletonList(new MockStep(currentStep, null)), false);
+        List<Step> steps = new ArrayList<>();
+        steps.add(new MockStep(currentStep, null));
+        steps.add(new MockStep(new StepKey(currentStep.getPhase(), currentStep.getAction(), randomAlphaOfLength(5)), null));
+        MockAction unsafeAction = new MockAction(steps, false);
         actions.put(unsafeAction.getWriteableName(), unsafeAction);
         Phase phase = new Phase(currentStep.getPhase(), TimeValue.timeValueMillis(0), actions);
         phases.put(phase.getName(), phase);
@@ -992,7 +1000,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         List<String> failedIndexes = new ArrayList<>();
 
         ClusterState newClusterState = IndexLifecycleRunner.setPolicyForIndexes(newPolicyName, indices, clusterState, newPolicy,
-                failedIndexes);
+                failedIndexes, () -> now);
 
         assertEquals(1, failedIndexes.size());
         assertEquals(index.getName(), failedIndexes.get(0));
@@ -1006,7 +1014,8 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
             assert unsafeStep == null
                     || safeStep.getPhase().equals(unsafeStep.getPhase()) == false : "safe and unsafe actions must be in different phases";
             Map<String, LifecycleAction> actions = new HashMap<>();
-            MockAction safeAction = new MockAction(Collections.emptyList(), true);
+            List<Step> steps = Collections.singletonList(new MockStep(safeStep, null));
+            MockAction safeAction = new MockAction(steps, true);
             actions.put(safeAction.getWriteableName(), safeAction);
             Phase phase = new Phase(safeStep.getPhase(), TimeValue.timeValueMillis(0), actions);
             phases.put(phase.getName(), phase);
@@ -1014,7 +1023,8 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         if (unsafeStep != null) {
             assert MockAction.NAME.equals(unsafeStep.getAction()) : "The unsafe action needs to be MockAction.NAME";
             Map<String, LifecycleAction> actions = new HashMap<>();
-            MockAction unsafeAction = new MockAction(Collections.emptyList(), false);
+            List<Step> steps = Collections.singletonList(new MockStep(unsafeStep, null));
+            MockAction unsafeAction = new MockAction(steps, false);
             actions.put(unsafeAction.getWriteableName(), unsafeAction);
             Phase phase = new Phase(unsafeStep.getPhase(), TimeValue.timeValueMillis(0), actions);
             phases.put(phase.getName(), phase);
@@ -1094,7 +1104,10 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         // change the current action so its not equal to the old one by adding a step
         Map<String, Phase> phases = new HashMap<>();
         Map<String, LifecycleAction> actions = new HashMap<>();
-        MockAction unsafeAction = new MockAction(Collections.singletonList(new MockStep(currentStep, null)), false);
+        List<Step> newSteps = new ArrayList<>();
+        newSteps.add(new MockStep(currentStep, null));
+        newSteps.add(new MockStep(new StepKey(currentStep.getPhase(), currentStep.getAction(), randomAlphaOfLength(5)), null));
+        MockAction unsafeAction = new MockAction(newSteps, false);
         actions.put(unsafeAction.getWriteableName(), unsafeAction);
         Phase phase = new Phase(currentStep.getPhase(), TimeValue.timeValueMillis(0), actions);
         phases.put(phase.getName(), phase);


### PR DESCRIPTION
if policy update on index means current step no longer exists

This change only updates the setPolicy for index to add this
functionality. The update policy API will be changed in a follow up PR.