### PR TITLE
Fix a test bug around nested aggregations and field aliases.

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
@@ -655,6 +655,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
 
     public void testFieldAlias() throws IOException {
         int numRootDocs = randomIntBetween(1, 20);
+        int expectedNestedDocs = 0;
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(
             NumberFieldMapper.NumberType.LONG);
@@ -665,6 +666,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 for (int i = 0; i < numRootDocs; i++) {
                     List<Document> documents = new ArrayList<>();
                     int numNestedDocs = randomIntBetween(0, 20);
+                    expectedNestedDocs += numNestedDocs;
                     generateDocuments(documents, numNestedDocs, i, NESTED_OBJECT, VALUE_FIELD_NAME);
 
                     Document document = new Document();
@@ -681,7 +683,6 @@ public class NestedAggregatorTests extends AggregatorTestCase {
             try (IndexReader indexReader = wrap(DirectoryReader.open(directory))) {
                 NestedAggregationBuilder agg = nested(NESTED_AGG, NESTED_OBJECT).subAggregation(
                     max(MAX_AGG_NAME).field(VALUE_FIELD_NAME));
-
                 NestedAggregationBuilder aliasAgg = nested(NESTED_AGG, NESTED_OBJECT).subAggregation(
                     max(MAX_AGG_NAME).field(VALUE_FIELD_NAME + "-alias"));
 
@@ -690,8 +691,8 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 Nested aliasNested = search(newSearcher(indexReader, false, true),
                     new MatchAllDocsQuery(), aliasAgg, fieldType);
 
-                assertTrue(nested.getDocCount() > 0);
                 assertEquals(nested, aliasNested);
+                assertEquals(expectedNestedDocs, nested.getDocCount());
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorTests.java
@@ -169,6 +169,7 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
 
     public void testFieldAlias() throws IOException {
         int numParentDocs = randomIntBetween(1, 20);
+        int expectedParentDocs = 0;
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(
             NumberFieldMapper.NumberType.LONG);
@@ -179,6 +180,10 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
                 for (int i = 0; i < numParentDocs; i++) {
                     List<Document> documents = new ArrayList<>();
                     int numNestedDocs = randomIntBetween(0, 20);
+                    if (numNestedDocs > 0) {
+                        expectedParentDocs++;
+                    }
+
                     for (int nested = 0; nested < numNestedDocs; nested++) {
                         Document document = new Document();
                         document.add(new Field(IdFieldMapper.NAME, Uid.encodeId(Integer.toString(i)),
@@ -203,7 +208,6 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
             }
 
             try (IndexReader indexReader = wrap(DirectoryReader.open(directory))) {
-
                 MaxAggregationBuilder maxAgg = max(MAX_AGG_NAME).field(VALUE_FIELD_NAME);
                 MaxAggregationBuilder aliasMaxAgg = max(MAX_AGG_NAME).field(VALUE_FIELD_NAME + "-alias");
 
@@ -220,8 +224,8 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
                 ReverseNested reverseNested = nested.getAggregations().get(REVERSE_AGG_NAME);
                 ReverseNested aliasReverseNested = aliasNested.getAggregations().get(REVERSE_AGG_NAME);
 
-                assertTrue(reverseNested.getDocCount() > 0);
                 assertEquals(reverseNested, aliasReverseNested);
+                assertEquals(expectedParentDocs, reverseNested.getDocCount());
             }
         }
     }


### PR DESCRIPTION
This issue affected both `NestedAggregatorTest` and `ReverseNestedAggregatorTest`.
