### PR TITLE
Rename "policy" to "global" in role definition

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptor.java
@@ -152,7 +152,7 @@ public class RoleDescriptor implements ToXContentObject {
         StringBuilder sb = new StringBuilder("Role[");
         sb.append("name=").append(name);
         sb.append(", cluster=[").append(Strings.arrayToCommaDelimitedString(clusterPrivileges));
-        sb.append("], policy=[").append(Strings.arrayToCommaDelimitedString(conditionalClusterPrivileges));
+        sb.append("], global=[").append(Strings.arrayToCommaDelimitedString(conditionalClusterPrivileges));
         sb.append("], indicesPrivileges=[");
         for (IndicesPrivileges group : indicesPrivileges) {
             sb.append(group.toString()).append(",");
@@ -216,7 +216,7 @@ public class RoleDescriptor implements ToXContentObject {
         builder.startObject();
         builder.array(Fields.CLUSTER.getPreferredName(), clusterPrivileges);
         if (conditionalClusterPrivileges.length != 0) {
-            builder.field(Fields.POLICY.getPreferredName());
+            builder.field(Fields.GLOBAL.getPreferredName());
             ConditionalClusterPrivileges.toXContent(builder, params, Arrays.asList(conditionalClusterPrivileges));
         }
         builder.array(Fields.INDICES.getPreferredName(), (Object[]) indicesPrivileges);
@@ -328,7 +328,7 @@ public class RoleDescriptor implements ToXContentObject {
             } else if (Fields.APPLICATIONS.match(currentFieldName, parser.getDeprecationHandler())
                     || Fields.APPLICATION.match(currentFieldName, parser.getDeprecationHandler())) {
                 applicationPrivileges = parseApplicationPrivileges(name, parser);
-            } else if (Fields.POLICY.match(currentFieldName, parser.getDeprecationHandler())) {
+            } else if (Fields.GLOBAL.match(currentFieldName, parser.getDeprecationHandler())) {
                 conditionalClusterPrivileges = ConditionalClusterPrivileges.parse(parser);
             } else if (Fields.METADATA.match(currentFieldName, parser.getDeprecationHandler())) {
                 if (token != XContentParser.Token.START_OBJECT) {
@@ -966,7 +966,7 @@ public class RoleDescriptor implements ToXContentObject {
 
     public interface Fields {
         ParseField CLUSTER = new ParseField("cluster");
-        ParseField POLICY = new ParseField("policy");
+        ParseField GLOBAL = new ParseField("global");
         ParseField INDEX = new ParseField("index");
         ParseField INDICES = new ParseField("indices");
         ParseField APPLICATIONS = new ParseField("applications");

--- a/x-pack/plugin/core/src/main/resources/security-index-template.json
+++ b/x-pack/plugin/core/src/main/resources/security-index-template.json
@@ -108,7 +108,7 @@
         "application" : {
           "type" : "keyword"
         },
-        "policy": {
+        "global": {
           "type": "object",
           "properties": {
             "application": {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -287,7 +287,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         verifyNoMoreInteractions(auditTrail);
     }
 
-    public void testAuthorizeUsingPolicyConditionals() {
+    public void testAuthorizeUsingConditionalPrivileges() {
         final DeletePrivilegesRequest request = new DeletePrivilegesRequest();
         final Authentication authentication = createAuthentication(new User("user1", "role1"));
 
@@ -306,7 +306,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         verifyNoMoreInteractions(auditTrail);
     }
 
-    public void testAuthorizationDeniedWhenPolicyConditionalsDoNotMatch() {
+    public void testAuthorizationDeniedWhenConditionalPrivilegesDoNotMatch() {
         final DeletePrivilegesRequest request = new DeletePrivilegesRequest();
         final Authentication authentication = createAuthentication(new User("user1", "role1"));
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RoleDescriptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RoleDescriptorTests.java
@@ -77,7 +77,7 @@ public class RoleDescriptorTests extends ESTestCase {
             conditionalClusterPrivileges, new String[] { "sudo" }, Collections.emptyMap(), Collections.emptyMap());
 
         assertThat(descriptor.toString(), is("Role[name=test, cluster=[all,none]" +
-                ", policy=[{APPLICATION:manage:applications=app01,app02}]" +
+                ", global=[{APPLICATION:manage:applications=app01,app02}]" +
                 ", indicesPrivileges=[IndicesPrivileges[indices=[i1,i2], privileges=[read]" +
                 ", field_security=[grant=[body,title], except=null], query={\"query\": {\"match_all\": {}}}],]" +
                 ", applicationPrivileges=[ApplicationResourcePrivileges[application=my_app, privileges=[read,write], resources=[*]],]" +
@@ -165,7 +165,7 @@ public class RoleDescriptorTests extends ESTestCase {
                 "     {\"resources\": [\"object-123\",\"object-456\"], \"privileges\":[\"read\", \"delete\"], \"application\":\"app1\"}," +
                 "     {\"resources\": [\"*\"], \"privileges\":[\"admin\"], \"application\":\"app2\" }" +
                 " ]," +
-                " \"policy\": { \"application\": { \"manage\": { \"applications\" : [ \"kibana\", \"logstash\" ] } } }" +
+                " \"global\": { \"application\": { \"manage\": { \"applications\" : [ \"kibana\", \"logstash\" ] } } }" +
                 "}";
         rd = RoleDescriptor.parse("test", new BytesArray(q), false, XContentType.JSON);
         assertThat(rd.getName(), equalTo("test"));

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/roles/40_global_privileges.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/roles/40_global_privileges.yml
@@ -12,7 +12,7 @@ setup:
         body:  >
             {
               "password": "s3krit",
-              "roles" : [ "with_policy" ]
+              "roles" : [ "with_global" ]
             }
 
 ---
@@ -23,7 +23,7 @@ teardown:
         ignore: 404
   - do:
       xpack.security.delete_role:
-        name: "with_policy"
+        name: "with_global"
         ignore: 404
 
 
@@ -31,10 +31,10 @@ teardown:
 "Test put role with conditional security privileges":
   - do:
       xpack.security.put_role:
-        name: "with_policy"
+        name: "with_global"
         body:  >
             {
-              "policy": {
+              "global": {
                 "application": {
                   "manage": {
                     "applications": [ "app1-*" , "app2-*" ]
@@ -46,6 +46,6 @@ teardown:
 
   - do:
       xpack.security.get_role:
-        name: "with_policy"
-  - match: { with_policy.policy.application.manage.applications.0:  "app1-*" }
-  - match: { with_policy.policy.application.manage.applications.1:  "app2-*" }
+        name: "with_global"
+  - match: { with_global.global.application.manage.applications.0:  "app1-*" }
+  - match: { with_global.global.application.manage.applications.1:  "app2-*" }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/40_condtional_cluster_priv.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/40_condtional_cluster_priv.yml
@@ -21,7 +21,7 @@ setup:
         name: "app_manage"
         body:  >
             {
-              "policy": {
+              "global": {
                 "application": {
                   "manage": {
                     "applications": [ "app" , "app-*" ]


### PR DESCRIPTION
The "global" field stores cluster privileges that have a richer
privilege model than the traditional "cluster" privileges.

This commit renames the JSON field (in the API and security index)
from "policy" to "global"
