### PR TITLE
Switch x-pack/plugin to new style Requests

### DIFF
--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
@@ -9,6 +9,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.http.HttpStatus;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.settings.Settings;
@@ -128,18 +129,22 @@ public class XPackRestIT extends ESClientYamlSuiteTestCase {
                     () -> "Exception when waiting for [" + template + "] template to be created");
             }
 
-            boolean existsWatcherIndex = adminClient().performRequest("HEAD", ".watches").getStatusLine().getStatusCode() == 200;
+            boolean existsWatcherIndex = adminClient()
+                    .performRequest(new Request("HEAD", ".watches"))
+                    .getStatusLine().getStatusCode() == 200;
             if (existsWatcherIndex == false) {
                 return;
             }
-            Response response = adminClient().performRequest("GET", ".watches/_search", Collections.singletonMap("size", "1000"));
+            Request searchWatchesRequest = new Request("GET", ".watches/_search");
+            searchWatchesRequest.addParameter("size", "1000");
+            Response response = adminClient().performRequest(searchWatchesRequest);
             ObjectPath objectPathResponse = ObjectPath.createFromResponse(response);
             int totalHits = objectPathResponse.evaluate("hits.total");
             if (totalHits > 0) {
                 List<Map<String, Object>> hits = objectPathResponse.evaluate("hits.hits");
                 for (Map<String, Object> hit : hits) {
                     String id = (String) hit.get("_id");
-                    assertOK(adminClient().performRequest("DELETE", "_xpack/watcher/watch/" + id));
+                    adminClient().performRequest(new Request("DELETE", "_xpack/watcher/watch/" + id));
                 }
             }
         }


### PR DESCRIPTION
In #29623 we added `Request` object flavored requests to the low level
REST client and in #30315 we deprecated the old `performRequest`s. This
changes all calls in the `x-pack/plugin` project to use the new versions.
