### PR TITLE
Enable FIPS JVM in CI

### DIFF
--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -7,5 +7,6 @@
 
 ES_RUNTIME_JAVA:
   - java8
+  - java8fips
   - java10
   - java11


### PR DESCRIPTION
Now that #31666 and #31989 are merged we can run our tests in
fips JVM. This commit enables us to run tests on a Java 8
JVM using BouncyCastleFIPS as a Security Provider.

