### PR TITLE
Painless: Fix Context Link

### DIFF
--- a/docs/painless/painless-contexts.asciidoc
+++ b/docs/painless/painless-contexts.asciidoc
@@ -1,7 +1,7 @@
 [[painless-contexts]]
 == Painless contexts
 
-:es_version: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:es_version: https://www.elastic.co/guide/en/elasticsearch/reference/current
 :xp_version: https://www.elastic.co/guide/en/x-pack/current
 
 A Painless script is evaluated within a context. Each context has values that


### PR DESCRIPTION
Currently, links were set to master, but should be set to current.