### PR TITLE
Tests: Fix XPack upgrade tests

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/XPackIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/XPackIT.java
@@ -84,7 +84,7 @@ public class XPackIT extends AbstractRollingTestCase {
         List<String> expectedTemplates = new ArrayList<>();
         // Watcher creates its templates as soon as the first watcher node connects
         expectedTemplates.add(".triggered_watches");
-        expectedTemplates.add(".watch-history-8");
+        expectedTemplates.add(".watch-history-9");
         expectedTemplates.add(".watches");
         if (masterIsNewVersion()) {
             // Everything else waits until the master is upgraded to create its templates


### PR DESCRIPTION
The tests refer to an older watch history template, that was
updated as part of b982e1aacedd353b6aa10eb0514e20000ba09091 (initial PR
was #31873)

Closes #32307