### PR TITLE
Bump the 6.x branch to 6.5.0

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,4 +1,4 @@
-elasticsearch     = 6.4.0
+elasticsearch     = 6.5.0
 lucene            = 7.4.0
 
 # optional dependencies

--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -1,4 +1,4 @@
-:version:               6.4.0
+:version:               6.5.0
 :major-version:         6.x
 :lucene_version:        7.4.0
 :lucene_version_path:   7_4_0

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -174,8 +174,10 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_6_3_3 = new Version(V_6_3_3_ID, org.apache.lucene.util.Version.LUCENE_7_3_1);
     public static final int V_6_4_0_ID = 6040099;
     public static final Version V_6_4_0 = new Version(V_6_4_0_ID, org.apache.lucene.util.Version.LUCENE_7_4_0);
+    public static final int V_6_5_0_ID = 6050099;
+    public static final Version V_6_5_0 = new Version(V_6_5_0_ID, org.apache.lucene.util.Version.LUCENE_7_4_0);
 
-    public static final Version CURRENT = V_6_4_0;
+    public static final Version CURRENT = V_6_5_0;
 
     static {
         assert CURRENT.luceneVersion.equals(org.apache.lucene.util.Version.LATEST) : "Version must be upgraded to ["
@@ -188,6 +190,8 @@ public class Version implements Comparable<Version>, ToXContentFragment {
 
     public static Version fromId(int id) {
         switch (id) {
+            case V_6_5_0_ID:
+                return V_6_5_0;
             case V_6_4_0_ID:
                 return V_6_4_0;
             case V_6_3_3_ID:


### PR DESCRIPTION
This commit bumps the 6.x branch of elasticsearch to 6.5.0.
