### PR TITLE
Release pipelined request in netty server tests

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerPipeliningTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerPipeliningTests.java
@@ -240,37 +240,43 @@ public class Netty4HttpServerPipeliningTests extends ESTestCase {
 
         @Override
         public void run() {
-            final String uri;
-            if (pipelinedRequest != null && pipelinedRequest.last() instanceof FullHttpRequest) {
-                uri = ((FullHttpRequest) pipelinedRequest.last()).uri();
-            } else {
-                uri = fullHttpRequest.uri();
-            }
-
-            final ByteBuf buffer = Unpooled.copiedBuffer(uri, StandardCharsets.UTF_8);
-
-            final DefaultFullHttpResponse httpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, buffer);
-            httpResponse.headers().add(HttpHeaderNames.CONTENT_LENGTH, buffer.readableBytes());
-
-            final boolean slow = uri.matches("/slow/\\d+");
-            if (slow) {
-                try {
-                    Thread.sleep(scaledRandomIntBetween(500, 1000));
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+            try {
+                final String uri;
+                if (pipelinedRequest != null && pipelinedRequest.last() instanceof FullHttpRequest) {
+                    uri = ((FullHttpRequest) pipelinedRequest.last()).uri();
+                } else {
+                    uri = fullHttpRequest.uri();
                 }
-            } else {
-                assert uri.matches("/\\d+");
-            }
 
-            final ChannelPromise promise = ctx.newPromise();
-            final Object msg;
-            if (pipelinedRequest != null) {
-                msg = pipelinedRequest.createHttpResponse(httpResponse, promise);
-            } else {
-                msg = httpResponse;
+                final ByteBuf buffer = Unpooled.copiedBuffer(uri, StandardCharsets.UTF_8);
+
+                final DefaultFullHttpResponse httpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, buffer);
+                httpResponse.headers().add(HttpHeaderNames.CONTENT_LENGTH, buffer.readableBytes());
+
+                final boolean slow = uri.matches("/slow/\\d+");
+                if (slow) {
+                    try {
+                        Thread.sleep(scaledRandomIntBetween(500, 1000));
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                } else {
+                    assert uri.matches("/\\d+");
+                }
+
+                final ChannelPromise promise = ctx.newPromise();
+                final Object msg;
+                if (pipelinedRequest != null) {
+                    msg = pipelinedRequest.createHttpResponse(httpResponse, promise);
+                } else {
+                    msg = httpResponse;
+                }
+                ctx.writeAndFlush(msg, promise);
+            } finally {
+                if (pipelinedRequest != null) {
+                    pipelinedRequest.release();
+                }
             }
-            ctx.writeAndFlush(msg, promise);
         }
 
     }

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerPipeliningTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerPipeliningTests.java
@@ -250,7 +250,7 @@ public class Netty4HttpServerPipeliningTests extends ESTestCase {
 
                 final ByteBuf buffer = Unpooled.copiedBuffer(uri, StandardCharsets.UTF_8);
 
-                final DefaultFullHttpResponse httpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, buffer);
+                final FullHttpResponse httpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, buffer);
                 httpResponse.headers().add(HttpHeaderNames.CONTENT_LENGTH, buffer.readableBytes());
 
                 final boolean slow = uri.matches("/slow/\\d+");


### PR DESCRIPTION
The Netty4HttpServerPipeliningTests adds a different request handler to
the netty pipeline. This request does not properly release pipelined
request. This means that when we enable leak detection, the test fails.
This commit properly releases the request.