### PR TITLE
Remove "best_compression" option from the ForceMergeAction

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/SegmentCountStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/SegmentCountStepTests.java
@@ -37,9 +37,8 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         Step.StepKey stepKey = randomStepKey();
         StepKey nextStepKey = randomStepKey();
         int maxNumSegments = randomIntBetween(1, 10);
-        boolean bestCompression = randomBoolean();
 
-        return new SegmentCountStep(stepKey, nextStepKey, null, maxNumSegments, bestCompression);
+        return new SegmentCountStep(stepKey, nextStepKey, null, maxNumSegments);
     }
 
     @Override
@@ -47,9 +46,8 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         StepKey key = instance.getKey();
         StepKey nextKey = instance.getNextStepKey();
         int maxNumSegments = instance.getMaxNumSegments();
-        boolean bestCompression = instance.isBestCompression();
 
-        switch (between(0, 3)) {
+        switch (between(0, 2)) {
             case 0:
                 key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
                 break;
@@ -59,20 +57,16 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
             case 2:
                 maxNumSegments += 1;
                 break;
-            case 3:
-                bestCompression = !bestCompression;
-                break;
             default:
                 throw new AssertionError("Illegal randomisation branch");
         }
 
-        return new SegmentCountStep(key, nextKey, null, maxNumSegments, bestCompression);
+        return new SegmentCountStep(key, nextKey, null, maxNumSegments);
     }
 
     @Override
     public SegmentCountStep copyInstance(SegmentCountStep instance) {
-        return new SegmentCountStep(instance.getKey(), instance.getNextStepKey(),
-            null, instance.getMaxNumSegments(), instance.isBestCompression());
+        return new SegmentCountStep(instance.getKey(), instance.getNextStepKey(), null, instance.getMaxNumSegments());
     }
 
     public void testIsConditionMet() {
@@ -103,7 +97,6 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
 
         Step.StepKey stepKey = randomStepKey();
         StepKey nextStepKey = randomStepKey();
-        boolean bestCompression = randomBoolean();
 
         Mockito.doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
@@ -115,7 +108,7 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         SetOnce<Boolean> conditionMetResult = new SetOnce<>();
         SetOnce<ToXContentObject> conditionInfo = new SetOnce<>();
 
-        SegmentCountStep step = new SegmentCountStep(stepKey, nextStepKey, client, maxNumSegments, bestCompression);
+        SegmentCountStep step = new SegmentCountStep(stepKey, nextStepKey, client, maxNumSegments);
         step.evaluateCondition(index, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject info) {
@@ -161,7 +154,6 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
 
         Step.StepKey stepKey = randomStepKey();
         StepKey nextStepKey = randomStepKey();
-        boolean bestCompression = randomBoolean();
 
         Mockito.doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
@@ -173,7 +165,7 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         SetOnce<Boolean> conditionMetResult = new SetOnce<>();
         SetOnce<ToXContentObject> conditionInfo = new SetOnce<>();
 
-        SegmentCountStep step = new SegmentCountStep(stepKey, nextStepKey, client, maxNumSegments, bestCompression);
+        SegmentCountStep step = new SegmentCountStep(stepKey, nextStepKey, client, maxNumSegments);
         step.evaluateCondition(index, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject info) {
@@ -203,7 +195,6 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         Step.StepKey stepKey = randomStepKey();
         StepKey nextStepKey = randomStepKey();
         int maxNumSegments = randomIntBetween(3, 10);
-        boolean bestCompression = randomBoolean();
 
         Mockito.doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
@@ -214,7 +205,7 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
 
         SetOnce<Boolean> exceptionThrown = new SetOnce<>();
 
-        SegmentCountStep step = new SegmentCountStep(stepKey, nextStepKey, client, maxNumSegments, bestCompression);
+        SegmentCountStep step = new SegmentCountStep(stepKey, nextStepKey, client, maxNumSegments);
         step.evaluateCondition(index, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject info) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/TimeseriesLifecycleTypeTests.java
@@ -28,10 +28,10 @@ import static org.elasticsearch.xpack.core.indexlifecycle.TimeseriesLifecycleTyp
 import static org.hamcrest.Matchers.equalTo;
 
 public class TimeseriesLifecycleTypeTests extends ESTestCase {
-    
+
     private static final AllocateAction TEST_ALLOCATE_ACTION = new AllocateAction(Collections.singletonMap("node", "node1"),null, null);
     private static final DeleteAction TEST_DELETE_ACTION = new DeleteAction();
-    private static final ForceMergeAction TEST_FORCE_MERGE_ACTION = new ForceMergeAction(1, true);
+    private static final ForceMergeAction TEST_FORCE_MERGE_ACTION = new ForceMergeAction(1);
     private static final ReplicasAction TEST_REPLICAS_ACTION = new ReplicasAction(1);
     private static final RolloverAction TEST_ROLLOVER_ACTION = new RolloverAction(new ByteSizeValue(1), null, null);
     private static final ShrinkAction TEST_SHRINK_ACTION = new ShrinkAction(1);

--- a/x-pack/plugin/index-lifecycle/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleInitialisationIT.java
+++ b/x-pack/plugin/index-lifecycle/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleInitialisationIT.java
@@ -97,7 +97,7 @@ public class IndexLifecycleInitialisationIT extends ESIntegTestCase {
             .put(SETTING_NUMBER_OF_REPLICAS, 0).put(LifecycleSettings.LIFECYCLE_NAME, "test").build();
         Map<String, Phase> phases = new HashMap<>();
 
-        Map<String, LifecycleAction> warmPhaseActions = Collections.singletonMap(ForceMergeAction.NAME, new ForceMergeAction(10000, false));
+        Map<String, LifecycleAction> warmPhaseActions = Collections.singletonMap(ForceMergeAction.NAME, new ForceMergeAction(10000));
         phases.put("warm", new Phase("warm", TimeValue.timeValueSeconds(2), warmPhaseActions));
 
         Map<String, LifecycleAction> deletePhaseActions = Collections.singletonMap(DeleteAction.NAME, new DeleteAction());

--- a/x-pack/plugin/index-lifecycle/src/test/java/org/elasticsearch/xpack/indexlifecycle/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/index-lifecycle/src/test/java/org/elasticsearch/xpack/indexlifecycle/TimeSeriesLifecycleActionsIT.java
@@ -110,7 +110,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         };
         assertThat(numSegments.get(), greaterThan(1));
 
-        createNewSingletonPolicy("warm", new ForceMergeAction(1, false));
+        createNewSingletonPolicy("warm", new ForceMergeAction(1));
         updateIndexSettings(index, Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy));
 
         assertBusy(() -> {


### PR DESCRIPTION
This option is only settable while the index is closed, and doesn't make sense
for a force merge.

Relates to #29823