### PR TITLE
Fix thirdPartyAudit issues in FIPS JVMs

### DIFF
--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -83,7 +83,6 @@ thirdPartyAudit.excludes = [
         'io.netty.internal.tcnative.SSLContext',
 
         // from io.netty.handler.ssl.util.BouncyCastleSelfSignedCertGenerator (netty)
-        'org.bouncycastle.asn1.x500.X500Name',
         'org.bouncycastle.cert.X509v3CertificateBuilder',
         'org.bouncycastle.cert.jcajce.JcaX509CertificateConverter',
         'org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder',
@@ -164,3 +163,8 @@ thirdPartyAudit.excludes = [
         'org.conscrypt.Conscrypt$Engines',
         'org.conscrypt.HandshakeListener'
 ]
+// BouncyCastleFIPS provides this class, so the exclusion is invalid when running CI in
+// a FIPS JVM with BouncyCastleFIPS Provider
+if (inFipsJvm == false) {
+    thirdPartyAudit.excludes.add('org.bouncycastle.asn1.x500.X500Name')
+}

--- a/plugins/ingest-attachment/build.gradle
+++ b/plugins/ingest-attachment/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.BuildPlugin
+
 /*
  * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
@@ -82,6 +84,15 @@ dependencies {
 // TODO: stop using LanguageIdentifier...
 compileJava.options.compilerArgs << "-Xlint:-deprecation"
 
+// Do not attempt to run any of this project's tasks in a BC FIPS JVM as
+// ingest-attachment plugin depends on (non FIPS) BC
+if (inFipsJvm) {
+  tasks.all { task ->
+    if (task.hasProperty('enabled')) {
+      task.enabled = false
+    }
+  }
+}
 
 dependencyLicenses {
   mapping from: /apache-mime4j-.*/, to: 'apache-mime4j'


### PR DESCRIPTION
* Ingest attachment plugin can't be used in FIPS JVM (when
  BouncyCastle is the FIPS Security Provider) as it depends on
  BouncyCastle(non-FIPS). This commit attempts to mute the
  gradle project when running on a FIPS JVM in CI.
* transport-netty4 needs not
  exclude org.bouncycastle.asn1.x500.X500Name from thirdParty check
  in a FIPS JVM (with BC FIPS Security Provider) as the class is
  provided by BC FIPS jar.

Resolves #32388