### PR TITLE
Rename authorizing_realms to authorization_realms

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -415,9 +415,10 @@ public class XPackLicenseState {
     }
 
     /**
-     * @return whether "authorizing_realms" are allowed based on the license {@link OperationMode}
+     * @return whether "authorization_realms" are allowed based on the license {@link OperationMode}
+     * @see org.elasticsearch.xpack.core.security.authc.support.DelegatedAuthorizationSettings
      */
-    public boolean isAuthorizingRealmAllowed() {
+    public boolean isAuthorizationRealmAllowed() {
         final Status localStatus = status;
         return (localStatus.mode == OperationMode.PLATINUM || localStatus.mode == OperationMode.TRIAL)
             && localStatus.active;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/DelegatedAuthorizationSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/DelegatedAuthorizationSettings.java
@@ -18,7 +18,7 @@ import java.util.function.Function;
  */
 public class DelegatedAuthorizationSettings {
 
-    public static final Setting<List<String>> AUTHZ_REALMS = Setting.listSetting("authorizing_realms",
+    public static final Setting<List<String>> AUTHZ_REALMS = Setting.listSetting("authorization_realms",
         Collections.emptyList(), Function.identity(), Setting.Property.NodeScope);
 
     public static Collection<Setting<?>> getSettings() {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/DelegatedAuthorizationSupport.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/DelegatedAuthorizationSupport.java
@@ -25,7 +25,7 @@ import java.util.List;
 import static org.elasticsearch.common.Strings.collectionToDelimitedString;
 
 /**
- * Utility class for supporting "delegated authorization" (aka "authorizing_realms", aka "lookup realms").
+ * Utility class for supporting "delegated authorization" (aka "authorization_realms", aka "lookup realms").
  * A {@link Realm} may support delegating authorization to another realm. It does this by registering a
  * setting for {@link DelegatedAuthorizationSettings#AUTHZ_REALMS}, and constructing an instance of this
  * class. Then, after the realm has performed any authentication steps, if {@link #hasDelegation()} is
@@ -74,7 +74,7 @@ public class DelegatedAuthorizationSupport {
      * with a meaningful diagnostic message.
      */
     public void resolve(String username, ActionListener<AuthenticationResult> resultListener) {
-        if (licenseState.isAuthorizingRealmAllowed() == false) {
+        if (licenseState.isAuthorizationRealmAllowed() == false) {
             resultListener.onResponse(AuthenticationResult.unsuccessful(
                 DelegatedAuthorizationSettings.AUTHZ_REALMS.getKey() + " are not permitted",
                 LicenseUtils.newComplianceException(DelegatedAuthorizationSettings.AUTHZ_REALMS.getKey())

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
@@ -84,7 +84,7 @@ public class LdapRealmTests extends LdapTestCase {
         defaultGlobalSettings = Settings.builder().put("path.home", createTempDir()).build();
         sslService = new SSLService(defaultGlobalSettings, TestEnvironment.newEnvironment(defaultGlobalSettings));
         licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isAuthorizingRealmAllowed()).thenReturn(true);
+        when(licenseState.isAuthorizationRealmAllowed()).thenReturn(true);
     }
 
     @After

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/PkiRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/PkiRealmTests.java
@@ -70,7 +70,7 @@ public class PkiRealmTests extends ESTestCase {
                 .put("path.home", createTempDir())
                 .build();
         licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isAuthorizingRealmAllowed()).thenReturn(true);
+        when(licenseState.isAuthorizationRealmAllowed()).thenReturn(true);
     }
 
     public void testTokenSupport() {
@@ -350,7 +350,7 @@ public class PkiRealmTests extends ESTestCase {
         otherRealm.registerUser(lookupUser);
 
         final Settings realmSettings = Settings.builder()
-            .putList("authorizing_realms", "other_realm")
+            .putList("authorization_realms", "other_realm")
             .build();
         final UserRoleMapper roleMapper = buildRoleMapper(Collections.emptySet(), token.dn());
         final PkiRealm pkiRealm = buildRealm(roleMapper, realmSettings, otherRealm);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/DelegatedAuthorizationSupportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/DelegatedAuthorizationSupportTests.java
@@ -75,13 +75,13 @@ public class DelegatedAuthorizationSupportTests extends ESTestCase {
         final AuthenticationResult result = future.get();
         assertThat(result.getStatus(), equalTo(AuthenticationResult.Status.CONTINUE));
         assertThat(result.getUser(), nullValue());
-        assertThat(result.getMessage(), equalTo("No [authorizing_realms] have been configured"));
+        assertThat(result.getMessage(), equalTo("No [authorization_realms] have been configured"));
     }
 
     public void testMissingRealmInDelegationList() {
         final XPackLicenseState license = getLicenseState(true);
         final Settings settings = Settings.builder()
-            .putList("authorizing_realms", "no-such-realm")
+            .putList("authorization_realms", "no-such-realm")
             .build();
         final IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () ->
             new DelegatedAuthorizationSupport(realms, buildRealmConfig("r", settings), license)
@@ -93,7 +93,7 @@ public class DelegatedAuthorizationSupportTests extends ESTestCase {
         final XPackLicenseState license = getLicenseState(true);
         final List<MockLookupRealm> useRealms = shuffle(randomSubsetOf(randomIntBetween(1, realms.size()), realms));
         final Settings settings = Settings.builder()
-            .putList("authorizing_realms", useRealms.stream().map(Realm::name).collect(Collectors.toList()))
+            .putList("authorization_realms", useRealms.stream().map(Realm::name).collect(Collectors.toList()))
             .build();
         final User user = new User("my_user");
         randomFrom(useRealms).registerUser(user);
@@ -111,7 +111,7 @@ public class DelegatedAuthorizationSupportTests extends ESTestCase {
         final List<MockLookupRealm> useRealms = shuffle(randomSubsetOf(randomIntBetween(3, realms.size()), realms));
         final List<String> names = useRealms.stream().map(Realm::name).collect(Collectors.toList());
         final Settings settings = Settings.builder()
-            .putList("authorizing_realms", names)
+            .putList("authorization_realms", names)
             .build();
         final List<User> users = new ArrayList<>(names.size());
         final String username = randomAlphaOfLength(8);
@@ -135,7 +135,7 @@ public class DelegatedAuthorizationSupportTests extends ESTestCase {
         final XPackLicenseState license = getLicenseState(true);
         final List<MockLookupRealm> useRealms = shuffle(randomSubsetOf(randomIntBetween(1, realms.size()), realms));
         final Settings settings = Settings.builder()
-            .putList("authorizing_realms", useRealms.stream().map(Realm::name).collect(Collectors.toList()))
+            .putList("authorization_realms", useRealms.stream().map(Realm::name).collect(Collectors.toList()))
             .build();
         final DelegatedAuthorizationSupport das = new DelegatedAuthorizationSupport(realms, buildRealmConfig("r", settings), license);
         assertThat(das.hasDelegation(), equalTo(true));
@@ -151,7 +151,7 @@ public class DelegatedAuthorizationSupportTests extends ESTestCase {
     public void testLicenseRejection() throws Exception {
         final XPackLicenseState license = getLicenseState(false);
         final Settings settings = Settings.builder()
-            .putList("authorizing_realms", realms.get(0).name())
+            .putList("authorization_realms", realms.get(0).name())
             .build();
         final DelegatedAuthorizationSupport das = new DelegatedAuthorizationSupport(realms, buildRealmConfig("r", settings), license);
         assertThat(das.hasDelegation(), equalTo(true));
@@ -160,14 +160,14 @@ public class DelegatedAuthorizationSupportTests extends ESTestCase {
         final AuthenticationResult result = future.get();
         assertThat(result.getStatus(), equalTo(AuthenticationResult.Status.CONTINUE));
         assertThat(result.getUser(), nullValue());
-        assertThat(result.getMessage(), equalTo("authorizing_realms are not permitted"));
+        assertThat(result.getMessage(), equalTo("authorization_realms are not permitted"));
         assertThat(result.getException(), instanceOf(ElasticsearchSecurityException.class));
-        assertThat(result.getException().getMessage(), equalTo("current license is non-compliant for [authorizing_realms]"));
+        assertThat(result.getException().getMessage(), equalTo("current license is non-compliant for [authorization_realms]"));
     }
 
     private XPackLicenseState getLicenseState(boolean authzRealmsAllowed) {
         final XPackLicenseState license = mock(XPackLicenseState.class);
-        when(license.isAuthorizingRealmAllowed()).thenReturn(authzRealmsAllowed);
+        when(license.isAuthorizationRealmAllowed()).thenReturn(authzRealmsAllowed);
         return license;
     }
 }


### PR DESCRIPTION
The previous name incorrectly implies that the realms are actively
authorizing something, however the reality is that they are realms
that are consulted for the purposes of authorization.
