### PR TITLE
Copy missing segment attributes in getSegmentInfo

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -800,6 +800,8 @@ public abstract class Engine implements Closeable {
                     } catch (IOException e) {
                         logger.trace(() -> new ParameterizedMessage("failed to get size for [{}]", info.info.name), e);
                     }
+                    segment.segmentSort = info.info.getIndexSort();
+                    segment.attributes = info.info.getAttributes();
                     segments.put(info.info.name, segment);
                 } else {
                     segment.committed = true;


### PR DESCRIPTION
The index sort and the attributes map of a segment are not copied
on committed segments that are not loaded by the internal or external searcher.