### PR TITLE
[Docs] Add reason to use Settings API over config file

### DIFF
--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -108,9 +108,11 @@ The order of precedence for cluster settings is:
 2. persistent cluster settings
 3. settings in the `elasticsearch.yml` configuration file.
 
-It's best to use the `elasticsearch.yml` file only
-for local configurations, and set all cluster-wide settings with the
-`settings` API.
+It's best to set all cluster-wide settings with the `settings` API and use the
+`elasticsearch.yml` file only for local configurations. This way you can be sure that
+the setting is the same on all nodes. If, on the other hand, you define different
+settings on different nodes by accident using the configuration file, it is very
+difficult to notice these discrepancies.
 
 You can find the list of settings that you can dynamically update in <<modules,Modules>>.
 


### PR DESCRIPTION
Extending the warning to prefer the `setttings` API over changes in the
configuration file by giving reasons why this might be dangerous.