### PR TITLE
INGEST: Fix Deprecation Warning in Script Proc.

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
@@ -361,7 +361,7 @@ public final class ConfigurationUtils {
             return readProcessor(processorFactories, type, (Map<String, Object>) config);
         } else if (config instanceof String && "script".equals(type)) {
             Map<String, Object> normalizedScript = new HashMap<>(1);
-            normalizedScript.put(ScriptType.INLINE.getName(), config);
+            normalizedScript.put(ScriptType.INLINE.getParseField().getPreferredName(), config);
             return readProcessor(processorFactories, type, normalizedScript);
         } else {
             throw newConfigurationException(type, null, null,


### PR DESCRIPTION
* Using short script form normalized to a map that used 'inline' instead of 'source' so a short form processor definition like:

```
{
 "script": "ctx.foo= 'bar'"
}
```

would always warn about the following deprecation:

```
 #! Deprecation: Deprecated field [inline] used, expected [source] 
```