### PR TITLE
[Kerberos] Avoid vagrant update on precommit

### DIFF
--- a/x-pack/qa/kerberos-tests/build.gradle
+++ b/x-pack/qa/kerberos-tests/build.gradle
@@ -121,7 +121,7 @@ integTestRunner {
 if (project.rootProject.vagrantSupported == false) {
     integTest.enabled = false
 } else {
-    project.sourceSets.test.output.dir(generatedResources, builtBy: copyKeytabToGeneratedResources)
+    project.sourceSets.test.output.dir(generatedResources)
     integTestCluster.dependsOn krb5AddPrincipals, krb5kdcFixture, copyKeytabToGeneratedResources
     integTest.finalizedBy project(':test:fixtures:krb5kdc-fixture').halt
 }


### PR DESCRIPTION
This commit avoids dependency during compile on copy keytab to
be present in the generated sources so precommit does not
stall for updating vagrant box.

Closes#32387