### PR TITLE
Remove reference to non-existent store type

### DIFF
--- a/docs/reference/index-modules/store.asciidoc
+++ b/docs/reference/index-modules/store.asciidoc
@@ -67,11 +67,6 @@ process equal to the size of the file being mapped. Before using this
 class, be sure you have allowed plenty of
 <<vm-max-map-count,virtual address space>>.
 
-[[default_fs]]`default_fs` deprecated[5.0.0, The `default_fs` store type is deprecated - use `fs` instead]::
-
-The `default` type is deprecated and is aliased to `fs` for backward
-compatibility.
-
 === Pre-loading data into the file system cache
 
 NOTE: This is an expert setting, the details of which may change in the future.

--- a/docs/reference/setup/sysconfig/virtual-memory.asciidoc
+++ b/docs/reference/setup/sysconfig/virtual-memory.asciidoc
@@ -1,7 +1,7 @@
 [[vm-max-map-count]]
 === Virtual memory
 
-Elasticsearch uses a <<default_fs,`mmapfs`>> directory by
+Elasticsearch uses a <<mmapfs,`mmapfs`>> directory by
 default to store its indices.  The default operating system limits on mmap
 counts is likely to be too low, which may result in out of memory exceptions.
 


### PR DESCRIPTION
We removed the default_fs store type yet the docs still contain a reference to them. This commit addresses that by removing this reference, and changing a reference to this section of the docs to instead refer to mmapfs.
