### PR TITLE
Wrong discovery.type for azure in breaking changes

### DIFF
--- a/docs/reference/migration/migrate_6_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_6_0/settings.asciidoc
@@ -83,6 +83,6 @@ they are replaced with `script.allowed_types` and `script.allowed_contexts`.
 
 ==== Discovery Settings
 
-The `discovery.type` settings no longer supports the values `gce`, `aws` and `ec2`.
+The `discovery.type` settings no longer supports the values `gce`, `azure` and `ec2`.
 Integration with these platforms should be done by setting the `discovery.zen.hosts_provider` setting to
 one of those values.


### PR DESCRIPTION
Should be `azure` instead of `aws`.
