### PR TITLE
[ML] Exploratory changes for moving Job configuration from the clusterstate

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -62,6 +62,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
 
     // Used for QueryPage
     public static final ParseField RESULTS_FIELD = new ParseField("datafeeds");
+    public static String TYPE = "datafeed";
 
     /**
      * The field name used to specify document counts in Elasticsearch

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
@@ -53,19 +53,19 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
      * Serialisation names
      */
     public static final ParseField ANALYSIS_CONFIG = new ParseField("analysis_config");
-    private static final ParseField BUCKET_SPAN = new ParseField("bucket_span");
-    private static final ParseField CATEGORIZATION_FIELD_NAME = new ParseField("categorization_field_name");
-    static final ParseField CATEGORIZATION_FILTERS = new ParseField("categorization_filters");
-    private static final ParseField CATEGORIZATION_ANALYZER = CategorizationAnalyzerConfig.CATEGORIZATION_ANALYZER;
-    private static final ParseField LATENCY = new ParseField("latency");
-    private static final ParseField SUMMARY_COUNT_FIELD_NAME = new ParseField("summary_count_field_name");
-    private static final ParseField DETECTORS = new ParseField("detectors");
-    private static final ParseField INFLUENCERS = new ParseField("influencers");
-    private static final ParseField OVERLAPPING_BUCKETS = new ParseField("overlapping_buckets");
-    private static final ParseField RESULT_FINALIZATION_WINDOW = new ParseField("result_finalization_window");
-    private static final ParseField MULTIVARIATE_BY_FIELDS = new ParseField("multivariate_by_fields");
-    private static final ParseField MULTIPLE_BUCKET_SPANS = new ParseField("multiple_bucket_spans");
-    private static final ParseField USER_PER_PARTITION_NORMALIZATION = new ParseField("use_per_partition_normalization");
+    public static final ParseField BUCKET_SPAN = new ParseField("bucket_span");
+    public static final ParseField CATEGORIZATION_FIELD_NAME = new ParseField("categorization_field_name");
+    public static final ParseField CATEGORIZATION_FILTERS = new ParseField("categorization_filters");
+    public static final ParseField CATEGORIZATION_ANALYZER = CategorizationAnalyzerConfig.CATEGORIZATION_ANALYZER;
+    public static final ParseField LATENCY = new ParseField("latency");
+    public static final ParseField SUMMARY_COUNT_FIELD_NAME = new ParseField("summary_count_field_name");
+    public static final ParseField DETECTORS = new ParseField("detectors");
+    public static final ParseField INFLUENCERS = new ParseField("influencers");
+    public static final ParseField OVERLAPPING_BUCKETS = new ParseField("overlapping_buckets");
+    public static final ParseField RESULT_FINALIZATION_WINDOW = new ParseField("result_finalization_window");
+    public static final ParseField MULTIVARIATE_BY_FIELDS = new ParseField("multivariate_by_fields");
+    public static final ParseField MULTIPLE_BUCKET_SPANS = new ParseField("multiple_bucket_spans");
+    public static final ParseField USE_PER_PARTITION_NORMALIZATION = new ParseField("use_per_partition_normalization");
 
     public static final String ML_CATEGORY_FIELD = "mlcategory";
     public static final Set<String> AUTO_CREATED_FIELDS = new HashSet<>(Collections.singletonList(ML_CATEGORY_FIELD));
@@ -102,7 +102,7 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
         parser.declareStringArray((builder, values) -> builder.setMultipleBucketSpans(
             values.stream().map(v -> TimeValue.parseTimeValue(v, MULTIPLE_BUCKET_SPANS.getPreferredName()))
                 .collect(Collectors.toList())), MULTIPLE_BUCKET_SPANS);
-        parser.declareBoolean(Builder::setUsePerPartitionNormalization, USER_PER_PARTITION_NORMALIZATION);
+        parser.declareBoolean(Builder::setUsePerPartitionNormalization, USE_PER_PARTITION_NORMALIZATION);
 
         return parser;
     }
@@ -418,7 +418,7 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
                     multipleBucketSpans.stream().map(TimeValue::getStringRep).collect(Collectors.toList()));
         }
         if (usePerPartitionNormalization) {
-            builder.field(USER_PER_PARTITION_NORMALIZATION.getPreferredName(), usePerPartitionNormalization);
+            builder.field(USE_PER_PARTITION_NORMALIZATION.getPreferredName(), usePerPartitionNormalization);
         }
         builder.endObject();
         return builder;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/DataDescription.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/DataDescription.java
@@ -77,12 +77,12 @@ public class DataDescription implements ToXContentObject, Writeable {
         }
     }
 
-    private static final ParseField DATA_DESCRIPTION_FIELD = new ParseField("data_description");
-    private static final ParseField FORMAT_FIELD = new ParseField("format");
-    private static final ParseField TIME_FIELD_NAME_FIELD = new ParseField("time_field");
-    private static final ParseField TIME_FORMAT_FIELD = new ParseField("time_format");
-    private static final ParseField FIELD_DELIMITER_FIELD = new ParseField("field_delimiter");
-    private static final ParseField QUOTE_CHARACTER_FIELD = new ParseField("quote_character");
+    public static final ParseField DATA_DESCRIPTION_FIELD = new ParseField("data_description");
+    public static final ParseField FORMAT_FIELD = new ParseField("format");
+    public static final ParseField TIME_FIELD_NAME_FIELD = new ParseField("time_field");
+    public static final ParseField TIME_FORMAT_FIELD = new ParseField("time_format");
+    public static final ParseField FIELD_DELIMITER_FIELD = new ParseField("field_delimiter");
+    public static final ParseField QUOTE_CHARACTER_FIELD = new ParseField("quote_character");
 
     /**
      * Special time format string for epoch times (seconds)

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -672,6 +672,10 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         return compatibleTypes;
     }
 
+    public static String documentId(String jobId) {
+        return "config-" + jobId;
+    }
+
     public static class Builder implements Writeable, ToXContentObject {
 
         private String id;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/ModelPlotConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/ModelPlotConfig.java
@@ -18,8 +18,8 @@ import java.util.Objects;
 
 public class ModelPlotConfig implements ToXContentObject, Writeable {
 
-    private static final ParseField TYPE_FIELD = new ParseField("model_plot_config");
-    private static final ParseField ENABLED_FIELD = new ParseField("enabled");
+    public static final ParseField TYPE_FIELD = new ParseField("model_plot_config");
+    public static final ParseField ENABLED_FIELD = new ParseField("enabled");
     public static final ParseField TERMS_FIELD = new ParseField("terms");
 
     // These parsers follow the pattern that metadata is parsed leniently (to allow for enhancements), whilst config is parsed strictly

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
@@ -56,4 +56,14 @@ public final class AnomalyDetectorsIndex {
     public static String jobStateIndexName() {
         return AnomalyDetectorsIndexFields.STATE_INDEX_NAME;
     }
+
+    /**
+     * The name of the index where job and datafeed configuration
+     * is stored
+     * @return The index name
+     */
+    public static String jobConfigIndexName() {
+        return AnomalyDetectorsIndexFields.JOB_CONFIG_INDEX;
+    }
+
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndexFields.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndexFields.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.core.ml.job.persistence;
 
 public final class AnomalyDetectorsIndexFields {
 
+    public static final String JOB_CONFIG_INDEX = ".ml-config";
     public static final String RESULTS_INDEX_PREFIX = ".ml-anomalies-";
     public static final String STATE_INDEX_NAME = ".ml-state";
     public static final String RESULTS_INDEX_DEFAULT = "shared";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -183,7 +183,7 @@ public class ElasticsearchMappings {
                         .startObject(Detector.EXCLUDE_FREQUENT_FIELD.getPreferredName())
                             .field(TYPE, KEYWORD)
                         .endObject()
-                        .startObject(Detector.RULES_FIELD.getPreferredName())
+                        .startObject(Detector.CUSTOM_RULES_FIELD.getPreferredName())
                             .field(TYPE, NESTED) // TODO
                         .endObject()
                         .startObject(Detector.DETECTOR_INDEX.getPreferredName())

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -7,10 +7,14 @@ package org.elasticsearch.xpack.core.ml.job.persistence;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.core.ml.calendars.Calendar;
-import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
+import org.elasticsearch.xpack.core.ml.datafeed.ChunkingConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisLimits;
+import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.config.ModelPlotConfig;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
@@ -97,17 +101,258 @@ public class ElasticsearchMappings {
     private ElasticsearchMappings() {
     }
 
-    public static XContentBuilder jobConfigMapping() throws IOException {
+    public static XContentBuilder configMapping() throws IOException {
         XContentBuilder builder = jsonBuilder();
         builder.startObject();
-            builder.startObject(TYPE);
-            ElasticsearchMappings.addDefaultMapping(builder);
-                builder.startObject(ElasticsearchMappings.PROPERTIES)
+        builder.startObject(DOC_TYPE);
+        addMetaInformation(builder);
+        addDefaultMapping(builder);
+        builder.startObject(PROPERTIES);
 
+        addJobConfigFields(builder);
+        addDatafeedConfigFields(builder);
+
+        builder.endObject()
+               .endObject()
+               .endObject();
+        return builder;
+    }
+
+    public static void addJobConfigFields(XContentBuilder builder) throws IOException {
+
+        builder.startObject("config_type")
+            .field(TYPE, KEYWORD)
+        .endObject()
+        .startObject(Job.ID.getPreferredName())
+            .field(TYPE, KEYWORD)
+        .endObject()
+        .startObject(Job.JOB_TYPE.getPreferredName())
+            .field(TYPE, KEYWORD)
+        .endObject()
+        .startObject(Job.JOB_VERSION.getPreferredName())
+            .field(TYPE, KEYWORD)
+        .endObject()
+        .startObject(Job.GROUPS.getPreferredName())
+            .field(TYPE, KEYWORD)
+        .endObject()
+        .startObject(Job.ANALYSIS_CONFIG.getPreferredName())
+            .field(TYPE, NESTED)
+            .startObject(PROPERTIES)
+                .startObject(AnalysisConfig.BUCKET_SPAN.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(AnalysisConfig.CATEGORIZATION_FIELD_NAME.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(AnalysisConfig.CATEGORIZATION_FILTERS.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(AnalysisConfig.CATEGORIZATION_ANALYZER.getPreferredName())
+                    .field(TYPE, NESTED) //  TODO
+                .endObject()
+                .startObject(AnalysisConfig.LATENCY.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(AnalysisConfig.SUMMARY_COUNT_FIELD_NAME.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(AnalysisConfig.DETECTORS.getPreferredName())
+                    .field(TYPE, NESTED)
+                    .startObject(PROPERTIES)
+                        .startObject(Detector.DETECTOR_DESCRIPTION_FIELD.getPreferredName())
+                            .field(TYPE, TEXT)
+                        .endObject()
+                        .startObject(Detector.FUNCTION_FIELD.getPreferredName())
+                            .field(TYPE, KEYWORD)
+                        .endObject()
+                        .startObject(Detector.FIELD_NAME_FIELD.getPreferredName())
+                            .field(TYPE, KEYWORD)
+                        .endObject()
+                        .startObject(Detector.BY_FIELD_NAME_FIELD.getPreferredName())
+                            .field(TYPE, KEYWORD)
+                        .endObject()
+                        .startObject(Detector.OVER_FIELD_NAME_FIELD.getPreferredName())
+                            .field(TYPE, KEYWORD)
+                        .endObject()
+                        .startObject(Detector.PARTITION_FIELD_NAME_FIELD.getPreferredName())
+                            .field(TYPE, KEYWORD)
+                        .endObject()
+                        .startObject(Detector.USE_NULL_FIELD.getPreferredName())
+                            .field(TYPE, BOOLEAN)
+                        .endObject()
+                        .startObject(Detector.EXCLUDE_FREQUENT_FIELD.getPreferredName())
+                            .field(TYPE, KEYWORD)
+                        .endObject()
+                        .startObject(Detector.RULES_FIELD.getPreferredName())
+                            .field(TYPE, NESTED) // TODO
+                        .endObject()
+                        .startObject(Detector.DETECTOR_INDEX.getPreferredName())
+                            .field(TYPE, LONG)
+                        .endObject()
+                    .endObject()
+                .endObject()
+
+                .startObject(AnalysisConfig.INFLUENCERS.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(AnalysisConfig.OVERLAPPING_BUCKETS.getPreferredName())
+                    .field(TYPE, BOOLEAN)
+                .endObject()
+                .startObject(AnalysisConfig.RESULT_FINALIZATION_WINDOW.getPreferredName())
+                    .field(TYPE, LONG)   // TODO This should be made a time value
+                .endObject()
+                .startObject(AnalysisConfig.MULTIVARIATE_BY_FIELDS.getPreferredName())
+                    .field(TYPE, BOOLEAN)
+                .endObject()
+                .startObject(AnalysisConfig.MULTIPLE_BUCKET_SPANS.getPreferredName())
+                  .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(AnalysisConfig.USE_PER_PARTITION_NORMALIZATION.getPreferredName())
+                    .field(TYPE, BOOLEAN)
                 .endObject()
             .endObject()
+        .endObject()
+
+        .startObject(Job.ANALYSIS_LIMITS.getPreferredName())
+            .field(TYPE, NESTED)
+            .startObject(PROPERTIES)
+                .startObject(AnalysisLimits.MODEL_MEMORY_LIMIT.getPreferredName())
+                    .field(TYPE, KEYWORD)  // TODO Should be a ByteSizeValue
+                .endObject()
+                .startObject(AnalysisLimits.CATEGORIZATION_EXAMPLES_LIMIT.getPreferredName())
+                    .field(TYPE, LONG)
+                .endObject()
+            .endObject()
+        .endObject()
+
+        .startObject(Job.CREATE_TIME.getPreferredName())
+            .field(TYPE, DATE)
+        .endObject()
+
+        .startObject(Job.CUSTOM_SETTINGS.getPreferredName())
+            .field(TYPE, NESTED)
+        .endObject()
+
+        .startObject(Job.DATA_DESCRIPTION.getPreferredName())
+            .field(TYPE, NESTED)
+            .startObject(PROPERTIES)
+                .startObject(DataDescription.FORMAT_FIELD.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(DataDescription.TIME_FIELD_NAME_FIELD.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(DataDescription.TIME_FORMAT_FIELD.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(DataDescription.FIELD_DELIMITER_FIELD.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(DataDescription.QUOTE_CHARACTER_FIELD.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+            .endObject()
+        .endObject()
+
+        .startObject(Job.DESCRIPTION.getPreferredName())
+            .field(TYPE, TEXT)
+        .endObject()
+        .startObject(Job.FINISHED_TIME.getPreferredName())
+            .field(TYPE, DATE)
+        .endObject()
+        .startObject(Job.LAST_DATA_TIME.getPreferredName())
+            .field(TYPE, DATE)
+        .endObject()
+        .startObject(Job.ESTABLISHED_MODEL_MEMORY.getPreferredName())
+            .field(TYPE, LONG) // TODO should be ByteSizeValue
+        .endObject()
+
+        .startObject(Job.MODEL_PLOT_CONFIG.getPreferredName())
+            .field(TYPE, NESTED)
+            .startObject(PROPERTIES)
+                .startObject(ModelPlotConfig.ENABLED_FIELD.getPreferredName())
+                    .field(TYPE, BOOLEAN)
+                .endObject()
+                .startObject(ModelPlotConfig.TERMS_FIELD.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+            .endObject()
+        .endObject()
+
+        .startObject(Job.RENORMALIZATION_WINDOW_DAYS.getPreferredName())
+            .field(TYPE, LONG) // TODO should be TimeValue
+        .endObject()
+        .startObject(Job.BACKGROUND_PERSIST_INTERVAL.getPreferredName())
+            .field(TYPE, KEYWORD)
+        .endObject()
+        .startObject(Job.MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName())
+            .field(TYPE, LONG) // TODO should be TimeValue
+        .endObject()
+        .startObject(Job.RESULTS_RETENTION_DAYS.getPreferredName())
+            .field(TYPE, LONG)  // TODO should be TimeValue
+        .endObject()
+        .startObject(Job.MODEL_SNAPSHOT_ID.getPreferredName())
+            .field(TYPE, KEYWORD)
+        .endObject()
+        .startObject(Job.MODEL_SNAPSHOT_MIN_VERSION.getPreferredName())
+            .field(TYPE, KEYWORD)
+        .endObject()
+        .startObject(Job.RESULTS_INDEX_NAME.getPreferredName())
+            .field(TYPE, KEYWORD)
+        .endObject()
+        .startObject(Job.DELETED.getPreferredName())
+            .field(TYPE, BOOLEAN)
         .endObject();
-        return builder;
+    }
+
+    public static void addDatafeedConfigFields(XContentBuilder builder) throws IOException {
+        builder.startObject(DatafeedConfig.ID.getPreferredName())
+            .field(TYPE, KEYWORD)
+        .endObject()
+        .startObject(DatafeedConfig.QUERY_DELAY.getPreferredName())
+            .field(TYPE, KEYWORD)
+        .endObject()
+        .startObject(DatafeedConfig.FREQUENCY.getPreferredName())
+            .field(TYPE, KEYWORD)
+        .endObject()
+        .startObject(DatafeedConfig.INDICES.getPreferredName())
+            .field(TYPE, KEYWORD)
+        .endObject()
+        .startObject(DatafeedConfig.TYPES.getPreferredName())
+            .field(TYPE, KEYWORD)
+        .endObject()
+
+        .startObject(DatafeedConfig.QUERY.getPreferredName())
+            .field(TYPE, NESTED) // TODO
+        .endObject()
+
+        .startObject(DatafeedConfig.SCROLL_SIZE.getPreferredName())
+            .field(TYPE, LONG)
+        .endObject()
+
+        .startObject(DatafeedConfig.AGGREGATIONS.getPreferredName())
+            .field(TYPE, NESTED) // TODO
+        .endObject()
+
+        .startObject(DatafeedConfig.SCRIPT_FIELDS.getPreferredName())
+            .field(TYPE, NESTED) // TODO
+        .endObject()
+
+        .startObject(DatafeedConfig.CHUNKING_CONFIG.getPreferredName())
+            .field(TYPE, NESTED)
+            .startObject(PROPERTIES)
+                .startObject(ChunkingConfig.MODE_FIELD.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(ChunkingConfig.TIME_SPAN_FIELD.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+            .endObject()
+        .endObject()
+
+        .startObject(DatafeedConfig.HEADERS.getPreferredName())
+            .field(TYPE, LONG)
+        .endObject();
     }
 
     /**
@@ -144,11 +389,11 @@ public class ElasticsearchMappings {
                .endObject();
     }
 
-    public static XContentBuilder docMapping() throws IOException {
-        return docMapping(Collections.emptyList());
+    public static XContentBuilder resultsMapping() throws IOException {
+        return resultsMapping(Collections.emptyList());
     }
 
-    public static XContentBuilder docMapping(Collection<String> extraTermFields) throws IOException {
+    public static XContentBuilder resultsMapping(Collection<String> extraTermFields) throws IOException {
         XContentBuilder builder = jsonBuilder();
         builder.startObject();
         builder.startObject(DOC_TYPE);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -7,6 +7,8 @@ package org.elasticsearch.xpack.core.ml.job.persistence;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.ml.calendars.Calendar;
+import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
 import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
@@ -93,6 +95,19 @@ public class ElasticsearchMappings {
     static final String RAW = "raw";
 
     private ElasticsearchMappings() {
+    }
+
+    public static XContentBuilder jobConfigMapping() throws IOException {
+        XContentBuilder builder = jsonBuilder();
+        builder.startObject();
+            builder.startObject(TYPE);
+            ElasticsearchMappings.addDefaultMapping(builder);
+                builder.startObject(ElasticsearchMappings.PROPERTIES)
+
+                .endObject()
+            .endObject()
+        .endObject();
+        return builder;
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
@@ -5,8 +5,14 @@
  */
 package org.elasticsearch.xpack.core.ml.job.results;
 
+import org.elasticsearch.xpack.core.ml.datafeed.ChunkingConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisLimits;
+import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.config.ModelPlotConfig;
 import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
@@ -36,7 +42,7 @@ public final class ReservedFieldNames {
      * 2.x requires mappings for given fields be consistent across all types
      * in a given index.)
      */
-    private static final String[] RESERVED_FIELD_NAME_ARRAY = {
+    private static final String[] RESERVED_RESULT_FIELD_NAME_ARRAY = {
             ElasticsearchMappings.ALL_FIELD_VALUES,
 
             Job.ID.getPreferredName(),
@@ -164,6 +170,89 @@ public final class ReservedFieldNames {
     };
 
     /**
+     * This array should be updated to contain all the field names that appear
+     * in any documents we store in our config index.
+     */
+    private static final String[] RESERVED_CONFIG_FIELD_NAME_ARRAY = {
+            Job.ID.getPreferredName(),
+            Job.JOB_TYPE.getPreferredName(),
+            Job.JOB_VERSION.getPreferredName(),
+            Job.GROUPS.getPreferredName(),
+            Job.ANALYSIS_CONFIG.getPreferredName(),
+            Job.ANALYSIS_LIMITS.getPreferredName(),
+            Job.CREATE_TIME.getPreferredName(),
+            Job.CUSTOM_SETTINGS.getPreferredName(),
+            Job.DATA_DESCRIPTION.getPreferredName(),
+            Job.DESCRIPTION.getPreferredName(),
+            Job.FINISHED_TIME.getPreferredName(),
+            Job.LAST_DATA_TIME.getPreferredName(),
+            Job.ESTABLISHED_MODEL_MEMORY.getPreferredName(),
+            Job.MODEL_PLOT_CONFIG.getPreferredName(),
+            Job.RENORMALIZATION_WINDOW_DAYS.getPreferredName(),
+            Job.BACKGROUND_PERSIST_INTERVAL.getPreferredName(),
+            Job.MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName(),
+            Job.RESULTS_RETENTION_DAYS.getPreferredName(),
+            Job.MODEL_SNAPSHOT_ID.getPreferredName(),
+            Job.MODEL_SNAPSHOT_MIN_VERSION.getPreferredName(),
+            Job.RESULTS_INDEX_NAME.getPreferredName(),
+            Job.DELETED.getPreferredName(),
+
+            AnalysisConfig.BUCKET_SPAN.getPreferredName(),
+            AnalysisConfig.CATEGORIZATION_FIELD_NAME.getPreferredName(),
+            AnalysisConfig.CATEGORIZATION_FILTERS.getPreferredName(),
+            AnalysisConfig.CATEGORIZATION_ANALYZER.getPreferredName(),
+            AnalysisConfig.LATENCY.getPreferredName(),
+            AnalysisConfig.SUMMARY_COUNT_FIELD_NAME.getPreferredName(),
+            AnalysisConfig.DETECTORS.getPreferredName(),
+            AnalysisConfig.INFLUENCERS.getPreferredName(),
+            AnalysisConfig.OVERLAPPING_BUCKETS.getPreferredName(),
+            AnalysisConfig.RESULT_FINALIZATION_WINDOW.getPreferredName(),
+            AnalysisConfig.MULTIVARIATE_BY_FIELDS.getPreferredName(),
+            AnalysisConfig.MULTIPLE_BUCKET_SPANS.getPreferredName(),
+            AnalysisConfig.USE_PER_PARTITION_NORMALIZATION.getPreferredName(),
+
+            AnalysisLimits.MODEL_MEMORY_LIMIT.getPreferredName(),
+            AnalysisLimits.CATEGORIZATION_EXAMPLES_LIMIT.getPreferredName(),
+
+            Detector.DETECTOR_DESCRIPTION_FIELD.getPreferredName(),
+            Detector.FUNCTION_FIELD.getPreferredName(),
+            Detector.FIELD_NAME_FIELD.getPreferredName(),
+            Detector.BY_FIELD_NAME_FIELD.getPreferredName(),
+            Detector.OVER_FIELD_NAME_FIELD.getPreferredName(),
+            Detector.PARTITION_FIELD_NAME_FIELD.getPreferredName(),
+            Detector.USE_NULL_FIELD.getPreferredName(),
+            Detector.EXCLUDE_FREQUENT_FIELD.getPreferredName(),
+            Detector.RULES_FIELD.getPreferredName(),
+            Detector.DETECTOR_INDEX.getPreferredName(),
+
+            DataDescription.FORMAT_FIELD.getPreferredName(),
+            DataDescription.TIME_FIELD_NAME_FIELD.getPreferredName(),
+            DataDescription.TIME_FORMAT_FIELD.getPreferredName(),
+            DataDescription.FIELD_DELIMITER_FIELD.getPreferredName(),
+            DataDescription.QUOTE_CHARACTER_FIELD.getPreferredName(),
+
+            ModelPlotConfig.ENABLED_FIELD.getPreferredName(),
+            ModelPlotConfig.TERMS_FIELD.getPreferredName(),
+
+            DatafeedConfig.ID.getPreferredName(),
+            DatafeedConfig.QUERY_DELAY.getPreferredName(),
+            DatafeedConfig.FREQUENCY.getPreferredName(),
+            DatafeedConfig.INDICES.getPreferredName(),
+            DatafeedConfig.TYPES.getPreferredName(),
+            DatafeedConfig.QUERY.getPreferredName(),
+            DatafeedConfig.SCROLL_SIZE.getPreferredName(),
+            DatafeedConfig.AGGREGATIONS.getPreferredName(),
+            DatafeedConfig.SCRIPT_FIELDS.getPreferredName(),
+            DatafeedConfig.CHUNKING_CONFIG.getPreferredName(),
+            DatafeedConfig.HEADERS.getPreferredName(),
+
+            ChunkingConfig.MODE_FIELD.getPreferredName(),
+            ChunkingConfig.TIME_SPAN_FIELD.getPreferredName(),
+
+            "config_type"
+    };
+
+    /**
      * Test if fieldName is one of the reserved names or if it contains dots then
      * that the segment before the first dot is not a reserved name. A fieldName
      * containing dots represents nested fields in which case we only care about
@@ -175,14 +264,19 @@ public final class ReservedFieldNames {
      */
     public static boolean isValidFieldName(String fieldName) {
         String[] segments = DOT_PATTERN.split(fieldName);
-        return !RESERVED_FIELD_NAMES.contains(segments[0]);
+        return !RESERVED_RESULT_FIELD_NAMES.contains(segments[0]);
     }
 
     /**
      * A set of all reserved field names in our results.  Fields from the raw
      * data with these names are not added to any result.
      */
-    public static final Set<String> RESERVED_FIELD_NAMES = new HashSet<>(Arrays.asList(RESERVED_FIELD_NAME_ARRAY));
+    public static final Set<String> RESERVED_RESULT_FIELD_NAMES = new HashSet<>(Arrays.asList(RESERVED_RESULT_FIELD_NAME_ARRAY));
+
+    /**
+     * A set of all reserved field names in our config.
+     */
+    public static final Set<String> RESERVED_CONFIG_FIELD_NAMES = new HashSet<>(Arrays.asList(RESERVED_CONFIG_FIELD_NAME_ARRAY));
 
     private ReservedFieldNames() {
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
@@ -222,7 +222,7 @@ public final class ReservedFieldNames {
             Detector.PARTITION_FIELD_NAME_FIELD.getPreferredName(),
             Detector.USE_NULL_FIELD.getPreferredName(),
             Detector.EXCLUDE_FREQUENT_FIELD.getPreferredName(),
-            Detector.RULES_FIELD.getPreferredName(),
+            Detector.CUSTOM_RULES_FIELD.getPreferredName(),
             Detector.DETECTOR_INDEX.getPreferredName(),
 
             DataDescription.FORMAT_FIELD.getPreferredName(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -629,7 +629,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 logger.warn("Error loading the template for the " + MlMetaIndex.INDEX_NAME + " index", e);
             }
 
-            try (XContentBuilder configMapping = ElasticsearchMappings.jobConfigMapping()) {
+            try (XContentBuilder configMapping = ElasticsearchMappings.configMapping()) {
                 IndexTemplateMetaData configTemplate = IndexTemplateMetaData.builder(AnomalyDetectorsIndex.jobConfigIndexName())
                         .patterns(Collections.singletonList(AnomalyDetectorsIndex.jobConfigIndexName()))
                         .settings(Settings.builder()
@@ -661,7 +661,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 logger.error("Error loading the template for the " + AnomalyDetectorsIndex.jobStateIndexName() + " index", e);
             }
 
-            try (XContentBuilder docMapping = ElasticsearchMappings.docMapping()) {
+            try (XContentBuilder docMapping = ElasticsearchMappings.resultsMapping()) {
                 IndexTemplateMetaData jobResultsTemplate = IndexTemplateMetaData.builder(AnomalyDetectorsIndex.jobResultsIndexPrefix())
                         .patterns(Collections.singletonList(AnomalyDetectorsIndex.jobResultsIndexPrefix() + "*"))
                         .settings(Settings.builder()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -629,6 +629,23 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 logger.warn("Error loading the template for the " + MlMetaIndex.INDEX_NAME + " index", e);
             }
 
+            try (XContentBuilder configMapping = ElasticsearchMappings.jobConfigMapping()) {
+                IndexTemplateMetaData configTemplate = IndexTemplateMetaData.builder(AnomalyDetectorsIndex.jobConfigIndexName())
+                        .patterns(Collections.singletonList(AnomalyDetectorsIndex.jobConfigIndexName()))
+                        .settings(Settings.builder()
+                                // Our indexes are small and one shard puts the
+                                // least possible burden on Elasticsearch
+                                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                                .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
+                                .put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), delayedNodeTimeOutSetting))
+                        .version(Version.CURRENT.id)
+                        .putMapping(ElasticsearchMappings.DOC_TYPE, Strings.toString(configMapping))
+                        .build();
+                templates.put(AnomalyDetectorsIndex.jobConfigIndexName(), configTemplate);
+            } catch (IOException e) {
+                logger.warn("Error loading the template for the " + AnomalyDetectorsIndex.jobConfigIndexName() + " index", e);
+            }
+
             try (XContentBuilder stateMapping = ElasticsearchMappings.stateMapping()) {
                 IndexTemplateMetaData stateTemplate = IndexTemplateMetaData.builder(AnomalyDetectorsIndex.jobStateIndexName())
                         .patterns(Collections.singletonList(AnomalyDetectorsIndex.jobStateIndexName()))

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteModelSnapshotAction.java
@@ -66,7 +66,7 @@ public class TransportDeleteModelSnapshotAction extends HandledTransportAction<D
                     ModelSnapshot deleteCandidate = deleteCandidates.get(0);
 
                     // Verify the snapshot is not being used
-                    jobManager.getJobOrThrowIfUnknown(request.getJobId(), ActionListener.wrap(
+                    jobManager.getJob(request.getJobId(), ActionListener.wrap(
                             job -> {
                                 String currentModelInUse = job.getModelSnapshotId();
                                 if (currentModelInUse != null && currentModelInUse.equals(request.getSnapshotId())) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteModelSnapshotAction.java
@@ -11,13 +11,11 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.DeleteModelSnapshotAction;
-import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.job.persistence.JobDataDeleter;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
@@ -32,18 +30,18 @@ public class TransportDeleteModelSnapshotAction extends HandledTransportAction<D
         DeleteModelSnapshotAction.Response> {
 
     private final Client client;
+    private final JobManager jobManager;
     private final JobProvider jobProvider;
-    private final ClusterService clusterService;
     private final Auditor auditor;
 
     @Inject
     public TransportDeleteModelSnapshotAction(Settings settings, TransportService transportService, ActionFilters actionFilters,
-                                              JobProvider jobProvider, ClusterService clusterService, Client client, Auditor auditor) {
+                                              JobManager jobManager, JobProvider jobProvider, Client client, Auditor auditor) {
         super(settings, DeleteModelSnapshotAction.NAME, transportService, actionFilters,
               DeleteModelSnapshotAction.Request::new);
         this.client = client;
+        this.jobManager = jobManager;
         this.jobProvider = jobProvider;
-        this.clusterService = clusterService;
         this.auditor = auditor;
     }
 
@@ -68,32 +66,39 @@ public class TransportDeleteModelSnapshotAction extends HandledTransportAction<D
                     ModelSnapshot deleteCandidate = deleteCandidates.get(0);
 
                     // Verify the snapshot is not being used
-                    Job job = JobManager.getJobOrThrowIfUnknown(request.getJobId(), clusterService.state());
-                    String currentModelInUse = job.getModelSnapshotId();
-                    if (currentModelInUse != null && currentModelInUse.equals(request.getSnapshotId())) {
-                        throw new IllegalArgumentException(Messages.getMessage(Messages.REST_CANNOT_DELETE_HIGHEST_PRIORITY,
-                                request.getSnapshotId(), request.getJobId()));
-                    }
+                    jobManager.getJobOrThrowIfUnknown(request.getJobId(), ActionListener.wrap(
+                            job -> {
+                                String currentModelInUse = job.getModelSnapshotId();
+                                if (currentModelInUse != null && currentModelInUse.equals(request.getSnapshotId())) {
+                                    listener.onFailure(
+                                            new IllegalArgumentException(Messages.getMessage(Messages.REST_CANNOT_DELETE_HIGHEST_PRIORITY,
+                                            request.getSnapshotId(), request.getJobId())));
+                                    return;
+                                }
 
-                    // Delete the snapshot and any associated state files
-                    JobDataDeleter deleter = new JobDataDeleter(client, request.getJobId());
-                    deleter.deleteModelSnapshots(Collections.singletonList(deleteCandidate), new ActionListener<BulkResponse>() {
-                        @Override
-                        public void onResponse(BulkResponse bulkResponse) {
-                            String msg = Messages.getMessage(Messages.JOB_AUDIT_SNAPSHOT_DELETED, deleteCandidate.getSnapshotId(),
-                                    deleteCandidate.getDescription());
-                            auditor.info(request.getJobId(), msg);
-                            logger.debug("[{}] {}", request.getJobId(), msg);
-                            // We don't care about the bulk response, just that it succeeded
-                            listener.onResponse(new DeleteModelSnapshotAction.Response(true));
-                        }
+                                // Delete the snapshot and any associated state files
+                                JobDataDeleter deleter = new JobDataDeleter(client, request.getJobId());
+                                deleter.deleteModelSnapshots(Collections.singletonList(deleteCandidate),
+                                        new ActionListener<BulkResponse>() {
+                                    @Override
+                                    public void onResponse(BulkResponse bulkResponse) {
+                                        String msg = Messages.getMessage(Messages.JOB_AUDIT_SNAPSHOT_DELETED,
+                                                deleteCandidate.getSnapshotId(), deleteCandidate.getDescription());
+                                        auditor.info(request.getJobId(), msg);
+                                        logger.debug("[{}] {}", request.getJobId(), msg);
+                                        // We don't care about the bulk response, just that it succeeded
+                                        listener.onResponse(new DeleteModelSnapshotAction.Response(true));
+                                    }
 
-                        @Override
-                        public void onFailure(Exception e) {
-                            listener.onFailure(e);
-                        }
-                    });
+                                    @Override
+                                    public void onFailure(Exception e) {
+                                        listener.onFailure(e);
+                                    }
+                                });
 
+                            },
+                            listener::onFailure
+                    ));
                 }, listener::onFailure);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportForecastJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportForecastJobAction.java
@@ -9,7 +9,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -41,14 +40,16 @@ public class TransportForecastJobAction extends TransportJobTaskAction<ForecastJ
     private static final ByteSizeValue FORECAST_LOCAL_STORAGE_LIMIT = new ByteSizeValue(500, ByteSizeUnit.MB);
 
     private final JobProvider jobProvider;
+    private final JobManager jobManager;
     @Inject
     public TransportForecastJobAction(Settings settings, TransportService transportService,
-                                      ClusterService clusterService, ActionFilters actionFilters,
+                                      ClusterService clusterService, ActionFilters actionFilters, JobManager jobManager,
                                       JobProvider jobProvider, AutodetectProcessManager processManager) {
         super(settings, ForecastJobAction.NAME, clusterService, transportService, actionFilters,
             ForecastJobAction.Request::new, ForecastJobAction.Response::new,
                 ThreadPool.Names.SAME, processManager);
         this.jobProvider = jobProvider;
+        this.jobManager = jobManager;
         // ThreadPool.Names.SAME, because operations is executed by autodetect worker thread
     }
 
@@ -62,57 +63,61 @@ public class TransportForecastJobAction extends TransportJobTaskAction<ForecastJ
     @Override
     protected void taskOperation(ForecastJobAction.Request request, TransportOpenJobAction.JobTask task,
                                  ActionListener<ForecastJobAction.Response> listener) {
-        ClusterState state = clusterService.state();
-        Job job = JobManager.getJobOrThrowIfUnknown(task.getJobId(), state);
-        validate(job, request);
+        jobManager.getJobOrThrowIfUnknown(task.getJobId(), ActionListener.wrap(
+                job -> {
+                    validate(job, request);
 
-        ForecastParams.Builder paramsBuilder = ForecastParams.builder();
+                    ForecastParams.Builder paramsBuilder = ForecastParams.builder();
 
-        if (request.getDuration() != null) {
-            paramsBuilder.duration(request.getDuration());
-        }
-
-        if (request.getExpiresIn() != null) {
-            paramsBuilder.expiresIn(request.getExpiresIn());
-        }
-
-        // tmp storage might be null, we do not log here, because it might not be
-        // required
-        Path tmpStorage = processManager.tryGetTmpStorage(task, FORECAST_LOCAL_STORAGE_LIMIT);
-        if (tmpStorage != null) {
-            paramsBuilder.tmpStorage(tmpStorage.toString());
-        }
-
-        ForecastParams params = paramsBuilder.build();
-        processManager.forecastJob(task, params, e -> {
-            if (e == null) {
-                Consumer<ForecastRequestStats> forecastRequestStatsHandler = forecastRequestStats -> {
-                    if (forecastRequestStats == null) {
-                        // paranoia case, it should not happen that we do not retrieve a result
-                        listener.onFailure(new ElasticsearchException(
-                                "Cannot run forecast: internal error, please check the logs"));
-                    } else if (forecastRequestStats.getStatus() == ForecastRequestStats.ForecastRequestStatus.FAILED) {
-                        List<String> messages = forecastRequestStats.getMessages();
-                        if (messages.size() > 0) {
-                            listener.onFailure(ExceptionsHelper.badRequestException("Cannot run forecast: "
-                                    + messages.get(0)));
-                        } else {
-                            // paranoia case, it should not be possible to have an empty message list
-                            listener.onFailure(
-                                    new ElasticsearchException(
-                                            "Cannot run forecast: internal error, please check the logs"));
-                        }
-                    } else {
-                        listener.onResponse(new ForecastJobAction.Response(true, params.getForecastId()));
+                    if (request.getDuration() != null) {
+                        paramsBuilder.duration(request.getDuration());
                     }
-                };
 
-                jobProvider.getForecastRequestStats(request.getJobId(), params.getForecastId(),
-                        forecastRequestStatsHandler, listener::onFailure);
-            } else {
-                listener.onFailure(e);
-            }
-        });
+                    if (request.getExpiresIn() != null) {
+                        paramsBuilder.expiresIn(request.getExpiresIn());
+                    }
+
+                    // tmp storage might be null, we do not log here, because it might not be
+                    // required
+                    Path tmpStorage = processManager.tryGetTmpStorage(task, FORECAST_LOCAL_STORAGE_LIMIT);
+                    if (tmpStorage != null) {
+                        paramsBuilder.tmpStorage(tmpStorage.toString());
+                    }
+
+                    ForecastParams params = paramsBuilder.build();
+                    processManager.forecastJob(task, params, e -> {
+                        if (e == null) {
+                            Consumer<ForecastRequestStats> forecastRequestStatsHandler = forecastRequestStats -> {
+                                if (forecastRequestStats == null) {
+                                    // paranoia case, it should not happen that we do not retrieve a result
+                                    listener.onFailure(new ElasticsearchException(
+                                            "Cannot run forecast: internal error, please check the logs"));
+                                } else if (forecastRequestStats.getStatus() == ForecastRequestStats.ForecastRequestStatus.FAILED) {
+                                    List<String> messages = forecastRequestStats.getMessages();
+                                    if (messages.size() > 0) {
+                                        listener.onFailure(ExceptionsHelper.badRequestException("Cannot run forecast: "
+                                                + messages.get(0)));
+                                    } else {
+                                        // paranoia case, it should not be possible to have an empty message list
+                                        listener.onFailure(
+                                                new ElasticsearchException(
+                                                        "Cannot run forecast: internal error, please check the logs"));
+                                    }
+                                } else {
+                                    listener.onResponse(new ForecastJobAction.Response(true, params.getForecastId()));
+                                }
+                            };
+
+                            jobProvider.getForecastRequestStats(request.getJobId(), params.getForecastId(),
+                                    forecastRequestStatsHandler, listener::onFailure);
+                        } else {
+                            listener.onFailure(e);
+                        }
+                    });
+                },
+                listener::onFailure
+        ));
+
     }
 
     static void validate(Job job, ForecastJobAction.Request request) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportForecastJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportForecastJobAction.java
@@ -63,7 +63,7 @@ public class TransportForecastJobAction extends TransportJobTaskAction<ForecastJ
     @Override
     protected void taskOperation(ForecastJobAction.Request request, TransportOpenJobAction.JobTask task,
                                  ActionListener<ForecastJobAction.Response> listener) {
-        jobManager.getJobOrThrowIfUnknown(task.getJobId(), ActionListener.wrap(
+        jobManager.getJob(task.getJobId(), ActionListener.wrap(
                 job -> {
                     validate(job, request);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetBucketsAction.java
@@ -38,28 +38,34 @@ public class TransportGetBucketsAction extends HandledTransportAction<GetBuckets
 
     @Override
     protected void doExecute(Task task, GetBucketsAction.Request request, ActionListener<GetBucketsAction.Response> listener) {
-        jobManager.getJobOrThrowIfUnknown(request.getJobId());
+        jobManager.getJobOrThrowIfUnknown(request.getJobId(), ActionListener.wrap(
+                job -> {
+                    BucketsQueryBuilder query =
+                            new BucketsQueryBuilder().expand(request.isExpand())
+                                    .includeInterim(request.isExcludeInterim() == false)
+                                    .start(request.getStart())
+                                    .end(request.getEnd())
+                                    .anomalyScoreThreshold(request.getAnomalyScore())
+                                    .sortField(request.getSort())
+                                    .sortDescending(request.isDescending());
 
-        BucketsQueryBuilder query =
-                new BucketsQueryBuilder().expand(request.isExpand())
-                        .includeInterim(request.isExcludeInterim() == false)
-                        .start(request.getStart())
-                        .end(request.getEnd())
-                        .anomalyScoreThreshold(request.getAnomalyScore())
-                        .sortField(request.getSort())
-                        .sortDescending(request.isDescending());
+                    if (request.getPageParams() != null) {
+                        query.from(request.getPageParams().getFrom())
+                                .size(request.getPageParams().getSize());
+                    }
+                    if (request.getTimestamp() != null) {
+                        query.timestamp(request.getTimestamp());
+                    } else {
+                        query.start(request.getStart());
+                        query.end(request.getEnd());
+                    }
+                    jobProvider.buckets(request.getJobId(), query, q ->
+                            listener.onResponse(new GetBucketsAction.Response(q)), listener::onFailure, client);
 
-        if (request.getPageParams() != null) {
-            query.from(request.getPageParams().getFrom())
-                    .size(request.getPageParams().getSize());
-        }
-        if (request.getTimestamp() != null) {
-            query.timestamp(request.getTimestamp());
-        } else {
-            query.start(request.getStart());
-            query.end(request.getEnd());
-        }
-        jobProvider.buckets(request.getJobId(), query, q ->
-                listener.onResponse(new GetBucketsAction.Response(q)), listener::onFailure, client);
+                },
+                listener::onFailure
+
+        ));
+
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetBucketsAction.java
@@ -38,7 +38,7 @@ public class TransportGetBucketsAction extends HandledTransportAction<GetBuckets
 
     @Override
     protected void doExecute(Task task, GetBucketsAction.Request request, ActionListener<GetBucketsAction.Response> listener) {
-        jobManager.getJobOrThrowIfUnknown(request.getJobId(), ActionListener.wrap(
+        jobManager.getJob(request.getJobId(), ActionListener.wrap(
                 job -> {
                     BucketsQueryBuilder query =
                             new BucketsQueryBuilder().expand(request.isExpand())
@@ -64,8 +64,6 @@ public class TransportGetBucketsAction extends HandledTransportAction<GetBuckets
 
                 },
                 listener::onFailure
-
         ));
-
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCategoriesAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCategoriesAction.java
@@ -37,7 +37,7 @@ public class TransportGetCategoriesAction extends HandledTransportAction<GetCate
 
     @Override
     protected void doExecute(Task task, GetCategoriesAction.Request request, ActionListener<GetCategoriesAction.Response> listener) {
-        jobManager.getJobOrThrowIfUnknown(request.getJobId(), ActionListener.wrap(
+        jobManager.getJob(request.getJobId(), ActionListener.wrap(
                 job -> {
                     Integer from = request.getPageParams() != null ? request.getPageParams().getFrom() : null;
                     Integer size = request.getPageParams() != null ? request.getPageParams().getSize() : null;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCategoriesAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCategoriesAction.java
@@ -37,11 +37,14 @@ public class TransportGetCategoriesAction extends HandledTransportAction<GetCate
 
     @Override
     protected void doExecute(Task task, GetCategoriesAction.Request request, ActionListener<GetCategoriesAction.Response> listener) {
-        jobManager.getJobOrThrowIfUnknown(request.getJobId());
-
-        Integer from = request.getPageParams() != null ? request.getPageParams().getFrom() : null;
-        Integer size = request.getPageParams() != null ? request.getPageParams().getSize() : null;
-        jobProvider.categoryDefinitions(request.getJobId(), request.getCategoryId(), true, from, size,
-                r -> listener.onResponse(new GetCategoriesAction.Response(r)), listener::onFailure, client);
+        jobManager.getJobOrThrowIfUnknown(request.getJobId(), ActionListener.wrap(
+                job -> {
+                    Integer from = request.getPageParams() != null ? request.getPageParams().getFrom() : null;
+                    Integer size = request.getPageParams() != null ? request.getPageParams().getSize() : null;
+                    jobProvider.categoryDefinitions(request.getJobId(), request.getCategoryId(), true, from, size,
+                            r -> listener.onResponse(new GetCategoriesAction.Response(r)), listener::onFailure, client);
+                },
+                listener::onFailure
+        ));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetInfluencersAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetInfluencersAction.java
@@ -38,18 +38,21 @@ public class TransportGetInfluencersAction extends HandledTransportAction<GetInf
 
     @Override
     protected void doExecute(Task task, GetInfluencersAction.Request request, ActionListener<GetInfluencersAction.Response> listener) {
-        jobManager.getJobOrThrowIfUnknown(request.getJobId());
-
-        InfluencersQueryBuilder.InfluencersQuery query = new InfluencersQueryBuilder()
-                .includeInterim(request.isExcludeInterim() == false)
-                .start(request.getStart())
-                .end(request.getEnd())
-                .from(request.getPageParams().getFrom())
-                .size(request.getPageParams().getSize())
-                .influencerScoreThreshold(request.getInfluencerScore())
-                .sortField(request.getSort())
-                .sortDescending(request.isDescending()).build();
-        jobProvider.influencers(request.getJobId(), query,
-                page -> listener.onResponse(new GetInfluencersAction.Response(page)), listener::onFailure, client);
+        jobManager.getJobOrThrowIfUnknown(request.getJobId(), ActionListener.wrap(
+                job -> {
+                    InfluencersQueryBuilder.InfluencersQuery query = new InfluencersQueryBuilder()
+                            .includeInterim(request.isExcludeInterim() == false)
+                            .start(request.getStart())
+                            .end(request.getEnd())
+                            .from(request.getPageParams().getFrom())
+                            .size(request.getPageParams().getSize())
+                            .influencerScoreThreshold(request.getInfluencerScore())
+                            .sortField(request.getSort())
+                            .sortDescending(request.isDescending()).build();
+                    jobProvider.influencers(request.getJobId(), query,
+                            page -> listener.onResponse(new GetInfluencersAction.Response(page)), listener::onFailure, client);
+                },
+                listener::onFailure)
+        );
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetInfluencersAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetInfluencersAction.java
@@ -38,7 +38,7 @@ public class TransportGetInfluencersAction extends HandledTransportAction<GetInf
 
     @Override
     protected void doExecute(Task task, GetInfluencersAction.Request request, ActionListener<GetInfluencersAction.Response> listener) {
-        jobManager.getJobOrThrowIfUnknown(request.getJobId(), ActionListener.wrap(
+        jobManager.getJob(request.getJobId(), ActionListener.wrap(
                 job -> {
                     InfluencersQueryBuilder.InfluencersQuery query = new InfluencersQueryBuilder()
                             .includeInterim(request.isExcludeInterim() == false)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsAction.java
@@ -50,8 +50,10 @@ public class TransportGetJobsAction extends TransportMasterNodeReadAction<GetJob
     protected void masterOperation(GetJobsAction.Request request, ClusterState state, ActionListener<GetJobsAction.Response> listener)
             throws Exception {
         logger.debug("Get job '{}'", request.getJobId());
-        QueryPage<Job> jobs = jobManager.expandJobs(request.getJobId(), request.allowNoJobs(), state);
-        listener.onResponse(new GetJobsAction.Response(jobs));
+        jobManager.expandJobs(request.getJobId(), request.allowNoJobs(), state, ActionListener.wrap(
+                jobs -> listener.onResponse(new GetJobsAction.Response(jobs)),
+                listener::onFailure
+        ));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
@@ -43,7 +43,7 @@ public class TransportGetModelSnapshotsAction extends HandledTransportAction<Get
                 request.getJobId(), request.getSnapshotId(), request.getPageParams().getFrom(), request.getPageParams().getSize(),
                 request.getStart(), request.getEnd(), request.getSort(), request.getDescOrder());
 
-        jobManager.getJobOrThrowIfUnknown(request.getJobId(), ActionListener.wrap(
+        jobManager.getJob(request.getJobId(), ActionListener.wrap(
                 job -> {
                     jobProvider.modelSnapshots(request.getJobId(), request.getPageParams().getFrom(), request.getPageParams().getSize(),
                             request.getStart(), request.getEnd(), request.getSort(), request.getDescOrder(), request.getSnapshotId(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
@@ -43,13 +43,16 @@ public class TransportGetModelSnapshotsAction extends HandledTransportAction<Get
                 request.getJobId(), request.getSnapshotId(), request.getPageParams().getFrom(), request.getPageParams().getSize(),
                 request.getStart(), request.getEnd(), request.getSort(), request.getDescOrder());
 
-        jobManager.getJobOrThrowIfUnknown(request.getJobId());
-
-        jobProvider.modelSnapshots(request.getJobId(), request.getPageParams().getFrom(), request.getPageParams().getSize(),
-                request.getStart(), request.getEnd(), request.getSort(), request.getDescOrder(), request.getSnapshotId(),
-                page -> {
-                    listener.onResponse(new GetModelSnapshotsAction.Response(clearQuantiles(page)));
-                }, listener::onFailure);
+        jobManager.getJobOrThrowIfUnknown(request.getJobId(), ActionListener.wrap(
+                job -> {
+                    jobProvider.modelSnapshots(request.getJobId(), request.getPageParams().getFrom(), request.getPageParams().getSize(),
+                            request.getStart(), request.getEnd(), request.getSort(), request.getDescOrder(), request.getSnapshotId(),
+                            page -> {
+                                listener.onResponse(new GetModelSnapshotsAction.Response(clearQuantiles(page)));
+                            }, listener::onFailure);
+                },
+                listener::onFailure
+        ));
     }
 
     public static QueryPage<ModelSnapshot> clearQuantiles(QueryPage<ModelSnapshot> page) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetRecordsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetRecordsAction.java
@@ -39,18 +39,21 @@ public class TransportGetRecordsAction extends HandledTransportAction<GetRecords
     @Override
     protected void doExecute(Task task, GetRecordsAction.Request request, ActionListener<GetRecordsAction.Response> listener) {
 
-        jobManager.getJobOrThrowIfUnknown(request.getJobId());
-
-        RecordsQueryBuilder query = new RecordsQueryBuilder()
-                .includeInterim(request.isExcludeInterim() == false)
-                .epochStart(request.getStart())
-                .epochEnd(request.getEnd())
-                .from(request.getPageParams().getFrom())
-                .size(request.getPageParams().getSize())
-                .recordScore(request.getRecordScoreFilter())
-                .sortField(request.getSort())
-                .sortDescending(request.isDescending());
-        jobProvider.records(request.getJobId(), query, page ->
-                        listener.onResponse(new GetRecordsAction.Response(page)), listener::onFailure, client);
+        jobManager.getJobOrThrowIfUnknown(request.getJobId(), ActionListener.wrap(
+                job -> {
+                    RecordsQueryBuilder query = new RecordsQueryBuilder()
+                            .includeInterim(request.isExcludeInterim() == false)
+                            .epochStart(request.getStart())
+                            .epochEnd(request.getEnd())
+                            .from(request.getPageParams().getFrom())
+                            .size(request.getPageParams().getSize())
+                            .recordScore(request.getRecordScoreFilter())
+                            .sortField(request.getSort())
+                            .sortDescending(request.isDescending());
+                    jobProvider.records(request.getJobId(), query, page ->
+                            listener.onResponse(new GetRecordsAction.Response(page)), listener::onFailure, client);
+                },
+                listener::onFailure
+        ));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetRecordsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetRecordsAction.java
@@ -39,7 +39,7 @@ public class TransportGetRecordsAction extends HandledTransportAction<GetRecords
     @Override
     protected void doExecute(Task task, GetRecordsAction.Request request, ActionListener<GetRecordsAction.Response> listener) {
 
-        jobManager.getJobOrThrowIfUnknown(request.getJobId(), ActionListener.wrap(
+        jobManager.getJob(request.getJobId(), ActionListener.wrap(
                 job -> {
                     RecordsQueryBuilder query = new RecordsQueryBuilder()
                             .includeInterim(request.isExcludeInterim() == false)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportJobTaskAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportJobTaskAction.java
@@ -52,8 +52,6 @@ public abstract class TransportJobTaskAction<Request extends JobTaskRequest<Requ
         String jobId = request.getJobId();
         // We need to check whether there is at least an assigned task here, otherwise we cannot redirect to the
         // node running the job task.
-        ClusterState state = clusterService.state();
-        JobManager.getJobOrThrowIfUnknown(jobId, state);
         PersistentTasksCustomMetaData tasks = clusterService.state().getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
         PersistentTasksCustomMetaData.PersistentTask<?> jobTask = MlTasks.getJobTask(jobId, tasks);
         if (jobTask == null || jobTask.isAssigned() == false) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -534,7 +534,7 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
             );
 
             // Step 1. Try adding results doc mapping
-            addDocMappingIfMissing(AnomalyDetectorsIndex.jobResultsAliasedName(jobParams.getJobId()), ElasticsearchMappings::docMapping,
+            addDocMappingIfMissing(AnomalyDetectorsIndex.jobResultsAliasedName(jobParams.getJobId()), ElasticsearchMappings::resultsMapping,
                     state, resultsPutMappingHandler);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
@@ -17,8 +17,10 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.action.RevertModelSnapshotAction;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
@@ -69,7 +71,8 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
         logger.debug("Received request to revert to snapshot id '{}' for job '{}', deleting intervening results: {}",
                 request.getSnapshotId(), request.getJobId(), request.getDeleteInterveningResults());
 
-        JobState jobState = jobManager.getJobState(request.getJobId());
+        PersistentTasksCustomMetaData tasks = clusterService.state().getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
+        JobState jobState = MlMetadata.getJobState(request.getJobId(), tasks);
         if (jobState.equals(JobState.CLOSED) == false) {
             throw ExceptionsHelper.conflictStatusException(Messages.getMessage(Messages.REST_JOB_NOT_CLOSED_REVERT));
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.RevertModelSnapshotAction;
-import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.job.persistence.JobDataDeleter;
@@ -70,8 +69,7 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
         logger.debug("Received request to revert to snapshot id '{}' for job '{}', deleting intervening results: {}",
                 request.getSnapshotId(), request.getJobId(), request.getDeleteInterveningResults());
 
-        Job job = JobManager.getJobOrThrowIfUnknown(request.getJobId(), clusterService.state());
-        JobState jobState = jobManager.getJobState(job.getId());
+        JobState jobState = jobManager.getJobState(request.getJobId());
         if (jobState.equals(JobState.CLOSED) == false) {
             throw ExceptionsHelper.conflictStatusException(Messages.getMessage(Messages.REST_JOB_NOT_CLOSED_REVERT));
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -216,19 +216,18 @@ public class JobManager extends AbstractComponent {
             @Override
             public void onResponse(Boolean indicesCreated) {
 
-                clusterService.submitStateUpdateTask("put-job-" + job.getId(),
-                        new AckedClusterStateUpdateTask<PutJobAction.Response>(request, actionListener) {
-                            @Override
-                            protected PutJobAction.Response newResponse(boolean acknowledged) {
-                                auditor.info(job.getId(), Messages.getMessage(Messages.JOB_AUDIT_CREATED));
-                                return new PutJobAction.Response(job);
-                            }
+                jobProvider.indexJob(job, new ActionListener<IndexResponse>() {
+                    @Override
+                    public void onResponse(IndexResponse indexResponse) {
+                        auditor.info(job.getId(), Messages.getMessage(Messages.JOB_AUDIT_CREATED));
+                        actionListener.onResponse(new PutJobAction.Response(job));
+                    }
 
-                            @Override
-                            public ClusterState execute(ClusterState currentState) {
-                                return updateClusterState(job, false, currentState);
-                            }
-                        });
+                    @Override
+                    public void onFailure(Exception e) {
+                        actionListener.onFailure(e);
+                    }
+                });
             }
 
             @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobProvider.java
@@ -12,7 +12,6 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
@@ -53,7 +52,6 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -194,7 +192,7 @@ public class JobProvider {
                 .execute(new ActionListener<DeleteResponse>() {
                     @Override
                     public void onResponse(DeleteResponse deleteResponse) {
-                        deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND
+                        actionListener.onResponse(new DeleteJobAction.Response());
                     }
 
                     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobProvider.java
@@ -179,7 +179,7 @@ public class JobProvider {
         try (InputStream stream = source.streamInput();
              XContentParser parser = XContentFactory.xContent(XContentType.JSON)
                      .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
-            return Job.CONFIG_PARSER.apply(parser, null);
+            return Job.STRICT_PARSER.apply(parser, null);
         } catch (IOException e) {
             LOGGER.error(new ElasticsearchParseException("failed to parse " + getResponse.getType(), e));
             return null;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobProvider.java
@@ -396,7 +396,7 @@ public class JobProvider {
 
     private void updateIndexMappingWithTermFields(String indexName, Collection<String> termFields, ActionListener<Boolean> listener) {
         // Put the whole "doc" mapping, not just the term fields, otherwise we'll wipe the _meta section of the mapping
-        try (XContentBuilder termFieldsMapping = ElasticsearchMappings.docMapping(termFields)) {
+        try (XContentBuilder termFieldsMapping = ElasticsearchMappings.resultsMapping(termFields)) {
             final PutMappingRequest request = client.admin().indices().preparePutMapping(indexName).setType(ElasticsearchMappings.DOC_TYPE)
                     .setSource(termFieldsMapping).request();
             executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, request, new ActionListener<PutMappingResponse>() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -359,10 +359,20 @@ public class AutodetectProcessManager extends AbstractComponent {
                     updateProcessMessage.setFilter(filter);
 
                     if (updateParams.isUpdateScheduledEvents()) {
-                        Job job = jobManager.getJobOrThrowIfUnknown(jobTask.getJobId());
-                        DataCounts dataCounts = getStatistics(jobTask).get().v1();
-                        ScheduledEventsQueryBuilder query = new ScheduledEventsQueryBuilder().start(job.earliestValidTimestamp(dataCounts));
-                        jobProvider.scheduledEventsForJob(jobTask.getJobId(), job.getGroups(), query, eventsListener);
+                        jobManager.getJobOrThrowIfUnknown(jobTask.getJobId(), new ActionListener<Job>() {
+                            @Override
+                            public void onResponse(Job job) {
+                                DataCounts dataCounts = getStatistics(jobTask).get().v1();
+                                ScheduledEventsQueryBuilder query = new ScheduledEventsQueryBuilder().start(job.earliestValidTimestamp(dataCounts));
+                                jobProvider.scheduledEventsForJob(jobTask.getJobId(), job.getGroups(), query, eventsListener);
+                            }
+
+                            @Override
+                            public void onFailure(Exception e) {
+                                handler.accept(e);
+                            }
+                        });
+
                     } else {
                         eventsListener.onResponse(null);
                     }
@@ -393,69 +403,69 @@ public class AutodetectProcessManager extends AbstractComponent {
 
     public void openJob(JobTask jobTask, Consumer<Exception> handler) {
         String jobId = jobTask.getJobId();
-        Job job = jobManager.getJobOrThrowIfUnknown(jobId);
-
-        if (job.getJobVersion() == null) {
-            handler.accept(ExceptionsHelper.badRequestException("Cannot open job [" + jobId
-                    + "] because jobs created prior to version 5.5 are not supported"));
-            return;
-        }
-
         logger.info("Opening job [{}]", jobId);
-        processByAllocation.putIfAbsent(jobTask.getAllocationId(), new ProcessContext(jobTask));
-        jobProvider.getAutodetectParams(job, params -> {
-            // We need to fork, otherwise we restore model state from a network thread (several GET api calls):
-            threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(new AbstractRunnable() {
-                @Override
-                public void onFailure(Exception e) {
-                    handler.accept(e);
-                }
 
-                @Override
-                protected void doRun() throws Exception {
-                    ProcessContext processContext = processByAllocation.get(jobTask.getAllocationId());
-                    if (processContext == null) {
-                        logger.debug("Aborted opening job [{}] as it has been closed", jobId);
-                        return;
-                    }
-                    if (processContext.getState() !=  ProcessContext.ProcessStateName.NOT_RUNNING) {
-                        logger.debug("Cannot open job [{}] when its state is [{}]", jobId, processContext.getState().getClass().getName());
-                        return;
-                    }
+        jobManager.getJobOrThrowIfUnknown(jobId, ActionListener.wrap(
+                job -> {
+                    processByAllocation.putIfAbsent(jobTask.getAllocationId(), new ProcessContext(jobTask));
+                    jobProvider.getAutodetectParams(job, params -> {
+                        // We need to fork, otherwise we restore model state from a network thread (several GET api calls):
+                        threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(new AbstractRunnable() {
+                            @Override
+                            public void onFailure(Exception e) {
+                                handler.accept(e);
+                            }
 
-                    try {
-                        createProcessAndSetRunning(processContext, params, handler);
-                        processContext.getAutodetectCommunicator().init(params.modelSnapshot());
-                        setJobState(jobTask, JobState.OPENED);
-                    } catch (Exception e1) {
-                        // No need to log here as the persistent task framework will log it
-                        try {
-                            // Don't leave a partially initialised process hanging around
-                            processContext.newKillBuilder()
-                                    .setAwaitCompletion(false)
-                                    .setFinish(false)
-                                    .kill();
-                            processByAllocation.remove(jobTask.getAllocationId());
-                        } finally {
-                            setJobState(jobTask, JobState.FAILED, e2 -> handler.accept(e1));
-                        }
-                    }
-                }
-            });
-        }, e1 -> {
-            logger.warn("Failed to gather information required to open job [" + jobId + "]", e1);
-            setJobState(jobTask, JobState.FAILED, e2 -> handler.accept(e1));
-        });
+                            @Override
+                            protected void doRun() {
+                                ProcessContext processContext = processByAllocation.get(jobTask.getAllocationId());
+                                if (processContext == null) {
+                                    logger.debug("Aborted opening job [{}] as it has been closed", jobId);
+                                    return;
+                                }
+                                if (processContext.getState() !=  ProcessContext.ProcessStateName.NOT_RUNNING) {
+                                    logger.debug("Cannot open job [{}] when its state is [{}]",
+                                            jobId, processContext.getState().getClass().getName());
+                                    return;
+                                }
+
+                                try {
+                                    createProcessAndSetRunning(processContext, job, params, handler);
+                                    processContext.getAutodetectCommunicator().init(params.modelSnapshot());
+                                    setJobState(jobTask, JobState.OPENED);
+                                } catch (Exception e1) {
+                                    // No need to log here as the persistent task framework will log it
+                                    try {
+                                        // Don't leave a partially initialised process hanging around
+                                        processContext.newKillBuilder()
+                                                .setAwaitCompletion(false)
+                                                .setFinish(false)
+                                                .kill();
+                                        processByAllocation.remove(jobTask.getAllocationId());
+                                    } finally {
+                                        setJobState(jobTask, JobState.FAILED, e2 -> handler.accept(e1));
+                                    }
+                                }
+                            }
+                        });
+                    }, e1 -> {
+                        logger.warn("Failed to gather information required to open job [" + jobId + "]", e1);
+                        setJobState(jobTask, JobState.FAILED, e2 -> handler.accept(e1));
+                    });
+                },
+                handler
+        ));
+
     }
 
-    private void createProcessAndSetRunning(ProcessContext processContext, AutodetectParams params, Consumer<Exception> handler) {
+    private void createProcessAndSetRunning(ProcessContext processContext, Job job, AutodetectParams params, Consumer<Exception> handler) {
         // At this point we lock the process context until the process has been started.
         // The reason behind this is to ensure closing the job does not happen before
         // the process is started as that can result to the job getting seemingly closed
         // but the actual process is hanging alive.
         processContext.tryLock();
         try {
-            AutodetectCommunicator communicator = create(processContext.getJobTask(), params, handler);
+            AutodetectCommunicator communicator = create(processContext.getJobTask(), job, params, handler);
             processContext.setRunning(communicator);
         } finally {
             // Now that the process is running and we have updated its state we can unlock.
@@ -465,7 +475,7 @@ public class AutodetectProcessManager extends AbstractComponent {
         }
     }
 
-    AutodetectCommunicator create(JobTask jobTask, AutodetectParams autodetectParams, Consumer<Exception> handler) {
+    AutodetectCommunicator create(JobTask jobTask, Job job, AutodetectParams autodetectParams, Consumer<Exception> handler) {
         // Closing jobs can still be using some or all threads in MachineLearning.AUTODETECT_THREAD_POOL_NAME
         // that an open job uses, so include them too when considering if enough threads are available.
         int currentRunningJobs = processByAllocation.size();
@@ -490,7 +500,6 @@ public class AutodetectProcessManager extends AbstractComponent {
             }
         }
 
-        Job job = jobManager.getJobOrThrowIfUnknown(jobId);
         // A TP with no queue, so that we fail immediately if there are no threads available
         ExecutorService autoDetectExecutorService = threadPool.executor(MachineLearning.AUTODETECT_THREAD_POOL_NAME);
         DataCountsReporter dataCountsReporter = new DataCountsReporter(settings, job, autodetectParams.dataCounts(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -359,7 +359,7 @@ public class AutodetectProcessManager extends AbstractComponent {
                     updateProcessMessage.setFilter(filter);
 
                     if (updateParams.isUpdateScheduledEvents()) {
-                        jobManager.getJobOrThrowIfUnknown(jobTask.getJobId(), new ActionListener<Job>() {
+                        jobManager.getJob(jobTask.getJobId(), new ActionListener<Job>() {
                             @Override
                             public void onResponse(Job job) {
                                 DataCounts dataCounts = getStatistics(jobTask).get().v1();
@@ -405,7 +405,7 @@ public class AutodetectProcessManager extends AbstractComponent {
         String jobId = jobTask.getJobId();
         logger.info("Opening job [{}]", jobId);
 
-        jobManager.getJobOrThrowIfUnknown(jobId, ActionListener.wrap(
+        jobManager.getJob(jobId, ActionListener.wrap(
                 job -> {
                     processByAllocation.putIfAbsent(jobTask.getAllocationId(), new ProcessContext(jobTask));
                     jobProvider.getAutodetectParams(job, params -> {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/license/MachineLearningLicensingTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/license/MachineLearningLicensingTests.java
@@ -53,7 +53,7 @@ public class MachineLearningLicensingTests extends BaseMlIntegTestCase {
         ensureYellow();
     }
 
-    public void testMachineLearningPutJobActionRestricted() throws Exception {
+    public void testMachineLearningPutJobActionRestricted() {
         String jobId = "testmachinelearningputjobactionrestricted";
         // Pick a license that does not allow machine learning
         License.OperationMode mode = randomInvalidLicenseType();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlSingleNodeTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlSingleNodeTestCase.java
@@ -5,10 +5,17 @@
  */
 package org.elasticsearch.xpack.ml;
 
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.license.LicenseService;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
+
+import java.util.Collection;
 
 /**
  * An extention to {@link ESSingleNodeTestCase} that adds node settings specifically needed for ML test cases.
@@ -16,12 +23,31 @@ import org.elasticsearch.xpack.core.ml.MachineLearningField;
 public abstract class MlSingleNodeTestCase extends ESSingleNodeTestCase {
 
     @Override
-    protected Settings nodeSettings() {
+    protected Settings nodeSettings()  {
         Settings.Builder newSettings = Settings.builder();
+        newSettings.put(super.nodeSettings());
         // Disable native ML autodetect_process as the c++ controller won't be available
         newSettings.put(MachineLearningField.AUTODETECT_PROCESS.getKey(), false);
+        newSettings.put(MachineLearningField.MAX_MODEL_MEMORY_LIMIT.getKey(), new ByteSizeValue(1024));
         newSettings.put(LicenseService.SELF_GENERATED_LICENSE_TYPE.getKey(), "trial");
+        // Disable security otherwise delete-by-query action fails to get authorized
+        newSettings.put(XPackSettings.SECURITY_ENABLED.getKey(), false);
+        newSettings.put(XPackSettings.MONITORING_ENABLED.getKey(), false);
+        newSettings.put(XPackSettings.WATCHER_ENABLED.getKey(), false);
         return newSettings.build();
     }
 
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(LocalStateMachineLearning.class, ReindexPlugin.class);
+    }
+
+    protected void waitForMlTemplates() throws Exception {
+        // block until the templates are installed
+        assertBusy(() -> {
+            ClusterState state = client().admin().cluster().prepareState().get().getState();
+            assertTrue("Timed out waiting for the ML templates to be installed",
+                    MachineLearning.allTemplatesInstalled(state));
+        });
+    }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobManagerIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobManagerIT.java
@@ -238,6 +238,14 @@ public class JobManagerIT extends MlSingleNodeTestCase {
         assertThat(result.results().get(0).getId(), equalTo("0"));
         assertThat(result.results().get(1).getId(), equalTo("1"));
         assertThat(result.results().get(2).getId(), equalTo("2"));
+
+        blockingCall(actionListener -> jobManager.getAllJobs(actionListener),
+                expandedJobsHolder, exceptionHolder);
+        result = expandedJobsHolder.get();
+        assertThat(result.count(), equalTo(3L));
+        assertThat(result.results().get(0).getId(), equalTo("0"));
+        assertThat(result.results().get(1).getId(), equalTo("1"));
+        assertThat(result.results().get(2).getId(), equalTo("2"));
     }
 
     private Job.Builder createJob(String jobId) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobManagerIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobManagerIT.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.analysis.AnalysisRegistry;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.xpack.core.ml.MLMetadataField;
+import org.elasticsearch.xpack.core.ml.MachineLearningField;
+import org.elasticsearch.xpack.core.ml.MlMetadata;
+import org.elasticsearch.xpack.core.ml.action.DeleteJobAction;
+import org.elasticsearch.xpack.core.ml.action.PutJobAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateJobAction;
+import org.elasticsearch.xpack.core.ml.action.util.QueryPage;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
+import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
+import org.elasticsearch.xpack.core.ml.job.config.Detector;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.config.JobUpdate;
+import org.elasticsearch.xpack.core.ml.job.persistence.JobStorageDeletionTask;
+import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
+import org.elasticsearch.xpack.ml.job.JobManager;
+import org.elasticsearch.xpack.ml.job.UpdateJobProcessNotifier;
+import org.elasticsearch.xpack.ml.job.categorization.CategorizationAnalyzerTests;
+import org.elasticsearch.xpack.ml.job.persistence.JobProvider;
+import org.elasticsearch.xpack.ml.notifications.Auditor;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JobManagerIT extends MlSingleNodeTestCase {
+
+    private JobManager jobManager;
+    private AnalysisRegistry analysisRegistry;
+
+    @Before
+    public void createComponents() throws Exception {
+        JobProvider jobProvider = new JobProvider(client(), Settings.EMPTY);
+        Auditor auditor = new Auditor(client(), "test_node");
+
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterSettings clusterSettings = new ClusterSettings(this.nodeSettings(),
+                Collections.singleton(MachineLearningField.MAX_MODEL_MEMORY_LIMIT));
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        UpdateJobProcessNotifier updateJobProcessNotifier = mock(UpdateJobProcessNotifier.class);
+
+        jobManager = new JobManager(node().getEnvironment(), Settings.EMPTY, jobProvider, clusterService, auditor,
+                this.client(), updateJobProcessNotifier);
+        analysisRegistry = CategorizationAnalyzerTests.buildTestAnalysisRegistry(node().getEnvironment());
+        waitForMlTemplates();
+    }
+
+    public void testGetMissingJob() throws InterruptedException {
+        AtomicReference<Job> jobHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+
+        blockingCall(actionListener -> jobManager.getJob("missing", actionListener), jobHolder, exceptionHolder);
+
+        assertNull(jobHolder.get());
+        assertNotNull(exceptionHolder.get());
+        assertThat(exceptionHolder.get(), instanceOf(ResourceNotFoundException.class));
+    }
+
+    public void testPutJob_setsCreateTime() throws InterruptedException {
+        final String jobId = "is-create-time-set";
+        AtomicReference<PutJobAction.Response> responseHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+
+        PutJobAction.Request putJobRequest = new PutJobAction.Request(createJob(jobId));
+        blockingCall(actionListener -> {
+                    try {
+                        jobManager.putJob(putJobRequest, analysisRegistry, createEmptyClusterState(), actionListener);
+                    } catch (IOException e) {
+                        exceptionHolder.set(e);
+                    }
+                },
+                responseHolder, exceptionHolder);
+
+        assertNull(exceptionHolder.get());
+        assertNotNull(responseHolder.get());
+
+        Job createdJob = responseHolder.get().getResponse();
+        assertNotNull(createdJob.getCreateTime());
+        Date now = new Date();
+        // job create time should be within the last second
+        assertThat(now.getTime(), greaterThanOrEqualTo(createdJob.getCreateTime().getTime()));
+        assertThat(now.getTime() - 1000, lessThanOrEqualTo(createdJob.getCreateTime().getTime()));
+
+        // Need to set the create time for the job objects to be equal
+        Job expectedJob = putJobRequest.getJobBuilder().build(createdJob.getCreateTime());
+        assertEquals(expectedJob, createdJob);
+
+        // Check we can't create another job with the same Id
+        // TODO For now this only works if we add the job to the cluster state
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder();
+        mlMetadata.putJob(putJobRequest.getJobBuilder().build(), false);
+        ClusterState clusterStateWithJob = ClusterState.builder(new ClusterName("_name"))
+                .metaData(MetaData.builder()
+                        .putCustom(MLMetadataField.TYPE, mlMetadata.build()))
+                .build();
+
+        responseHolder.set(null);
+        blockingCall(actionListener -> {
+                    try {
+                        jobManager.putJob(putJobRequest, analysisRegistry, clusterStateWithJob, actionListener);
+                    } catch (IOException e) {
+                        exceptionHolder.set(e);
+                    }
+                },
+                responseHolder, exceptionHolder);
+
+        assertNull(responseHolder.get());
+        assertThat(exceptionHolder.get(), instanceOf(ResourceAlreadyExistsException.class));
+    }
+
+    public void testCrud() throws InterruptedException {
+        final String jobId = "crud-job";
+
+        AtomicReference<PutJobAction.Response> putJobResponseHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+
+        // Create job
+        PutJobAction.Request putJobRequest = new PutJobAction.Request(createJob(jobId));
+        blockingCall(actionListener -> {
+                    try {
+                        jobManager.putJob(putJobRequest, analysisRegistry, createEmptyClusterState(), actionListener);
+                    } catch (IOException e) {
+                        exceptionHolder.set(e);
+                    }
+                },
+                putJobResponseHolder, exceptionHolder);
+
+        assertNull(exceptionHolder.get());
+        assertNotNull(putJobResponseHolder.get());
+
+        // Read Job
+        AtomicReference<Job> getJobResponseHolder = new AtomicReference<>();
+        blockingCall(actionListener -> jobManager.getJob(jobId, actionListener), getJobResponseHolder, exceptionHolder);
+        assertNull(exceptionHolder.get());
+
+        // Need to set the create time for the job objects to be equal
+        Job expectedJob = putJobRequest.getJobBuilder().build(getJobResponseHolder.get().getCreateTime());
+        assertEquals(expectedJob, getJobResponseHolder.get());
+
+        // Update Job
+        putJobResponseHolder.set(null);
+        JobUpdate jobUpdate = new JobUpdate.Builder(jobId).setDescription("This job has been updated").build();
+        UpdateJobAction.Request updateJobRequest = new UpdateJobAction.Request(jobId, jobUpdate);
+        blockingCall(actionListener -> jobManager.updateJob(updateJobRequest, actionListener),
+                putJobResponseHolder, exceptionHolder);
+        assertNull(exceptionHolder.get());
+        assertEquals("This job has been updated", putJobResponseHolder.get().getResponse().getDescription());
+
+        // Delete Job
+        AtomicReference<DeleteJobAction.Response> deleteJobResponseHolder = new AtomicReference<>();
+        JobStorageDeletionTask deletionTask = new JobStorageDeletionTask(1L, "deletion-task", "deletion-action", "deletion-task",
+                TaskId.EMPTY_TASK_ID, Collections.emptyMap());
+        DeleteJobAction.Request deleteJobRequest = new DeleteJobAction.Request(jobId);
+        blockingCall(actionListener -> jobManager.deleteJob(deleteJobRequest, deletionTask, actionListener),
+                deleteJobResponseHolder, exceptionHolder);
+        assertNull(exceptionHolder.get());
+        assertTrue(deleteJobResponseHolder.get().isAcknowledged());
+
+        // Read deleted job
+        getJobResponseHolder.set(null);
+        blockingCall(actionListener -> jobManager.getJob(jobId, actionListener), getJobResponseHolder, exceptionHolder);
+        assertNull(getJobResponseHolder.get());
+        assertThat(exceptionHolder.get(), instanceOf(ResourceNotFoundException.class));
+    }
+
+    public void testExpandJobs_givenAll() throws InterruptedException {
+        List<Job.Builder> jobs = new ArrayList<>();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder();
+        Date createTime = new Date();
+        for (int i = 0; i < 3; i++) {
+            Job.Builder builder = createJob(Integer.toString(i));
+            jobs.add(builder);
+            mlMetadata.putJob(builder.build(createTime), false);
+            // createTime must be set for mlMetadata.putJob
+            // and unset for jobManager.putJob
+            builder.setCreateTime(null);
+        }
+        // TODO For now this only works if we add the job to the cluster state
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
+                .metaData(MetaData.builder().putCustom(MLMetadataField.TYPE, mlMetadata.build())).build();
+
+
+        AtomicReference<PutJobAction.Response> putJobResponseHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+
+        // Create the jobs
+        for (Job.Builder jobBuilder : jobs) {
+            PutJobAction.Request putJobRequest = new PutJobAction.Request(jobBuilder);
+            blockingCall(actionListener -> {
+                        try {
+                            jobManager.putJob(putJobRequest, analysisRegistry, createEmptyClusterState(), actionListener);
+                        } catch (IOException e) {
+                            exceptionHolder.set(e);
+                        }
+                    },
+                    putJobResponseHolder, exceptionHolder);
+
+            assertNull(exceptionHolder.get());
+        }
+
+        AtomicReference<QueryPage<Job>> expandedJobsHolder = new AtomicReference<>();
+        blockingCall(actionListener -> jobManager.expandJobs("_all", true, clusterState, actionListener),
+                expandedJobsHolder, exceptionHolder);
+
+        QueryPage<Job> result = expandedJobsHolder.get();
+        assertThat(result.count(), equalTo(3L));
+        assertThat(result.results().get(0).getId(), equalTo("0"));
+        assertThat(result.results().get(1).getId(), equalTo("1"));
+        assertThat(result.results().get(2).getId(), equalTo("2"));
+    }
+
+    private Job.Builder createJob(String jobId) {
+        Detector.Builder d1 = new Detector.Builder("info_content", "domain");
+        d1.setOverFieldName("client");
+        AnalysisConfig.Builder ac = new AnalysisConfig.Builder(Collections.singletonList(d1.build()));
+
+        Job.Builder builder = new Job.Builder();
+        builder.setId(jobId);
+        builder.setAnalysisConfig(ac);
+        builder.setDataDescription(new DataDescription.Builder());
+        return builder;
+    }
+
+    private ClusterState createEmptyClusterState() {
+        ClusterState.Builder builder = ClusterState.builder(new ClusterName("_name"));
+        builder.metaData(MetaData.builder());
+        return builder.build();
+    }
+
+    private <T> void blockingCall(Consumer<ActionListener<T>> function, AtomicReference<T> response, AtomicReference<Exception> error)
+            throws InterruptedException {
+
+        CountDownLatch latch = new CountDownLatch(1);
+        ActionListener<T> listener = ActionListener.wrap(
+                r -> {
+                    response.set(r);
+                    latch.countDown();
+                },
+                e -> {
+                    error.set(e);
+                    latch.countDown();
+                }
+        );
+
+        function.accept(listener);
+        latch.await();
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobProviderIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobProviderIT.java
@@ -76,36 +76,12 @@ public class JobProviderIT extends MlSingleNodeTestCase {
 
     private JobProvider jobProvider;
 
-    @Override
-    protected Settings nodeSettings()  {
-        Settings.Builder newSettings = Settings.builder();
-        newSettings.put(super.nodeSettings());
-        newSettings.put(XPackSettings.SECURITY_ENABLED.getKey(), false);
-        newSettings.put(XPackSettings.MONITORING_ENABLED.getKey(), false);
-        newSettings.put(XPackSettings.WATCHER_ENABLED.getKey(), false);
-        return newSettings.build();
-    }
-
-    @Override
-    protected Collection<Class<? extends Plugin>> getPlugins() {
-        return pluginList(LocalStateMachineLearning.class);
-    }
-
     @Before
     public void createComponents() throws Exception {
         Settings.Builder builder = Settings.builder()
                 .put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueSeconds(1));
         jobProvider = new JobProvider(client(), builder.build());
         waitForMlTemplates();
-    }
-
-    private void waitForMlTemplates() throws Exception {
-        // block until the templates are installed
-        assertBusy(() -> {
-            ClusterState state = client().admin().cluster().prepareState().get().getState();
-            assertTrue("Timed out waiting for the ML templates to be installed",
-                    MachineLearning.allTemplatesInstalled(state));
-        });
     }
 
     public void testGetCalandarByJobId() throws Exception {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml.job;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterName;
@@ -33,8 +34,11 @@ import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
 import org.elasticsearch.xpack.core.ml.job.config.RuleScope;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
+import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.ml.job.categorization.CategorizationAnalyzerTests;
 import org.elasticsearch.xpack.ml.job.persistence.JobProvider;
+import org.elasticsearch.xpack.ml.job.persistence.MockClientBuilder;
 import org.elasticsearch.xpack.ml.job.process.autodetect.UpdateParams;
 import org.elasticsearch.xpack.ml.notifications.Auditor;
 import org.junit.Before;
@@ -47,12 +51,17 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+<<<<<<< HEAD
 import java.util.TreeSet;
+=======
+import java.util.concurrent.atomic.AtomicBoolean;
+>>>>>>> Add JobManager integration test
 
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
 import static org.elasticsearch.xpack.ml.action.TransportOpenJobActionTests.addJobTask;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.Matchers.any;
@@ -66,7 +75,6 @@ public class JobManagerTests extends ESTestCase {
 
     private Environment environment;
     private AnalysisRegistry analysisRegistry;
-    private Client client;
     private ClusterService clusterService;
     private JobProvider jobProvider;
     private Auditor auditor;
@@ -77,102 +85,15 @@ public class JobManagerTests extends ESTestCase {
         Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir()).build();
         environment = TestEnvironment.newEnvironment(settings);
         analysisRegistry = CategorizationAnalyzerTests.buildTestAnalysisRegistry(environment);
-        client = mock(Client.class);
         clusterService = mock(ClusterService.class);
         jobProvider = mock(JobProvider.class);
         auditor = mock(Auditor.class);
         updateJobProcessNotifier = mock(UpdateJobProcessNotifier.class);
     }
 
-//    public void testGetJobOrThrowIfUnknown_GivenUnknownJob() {
-//        ClusterState cs = createClusterState();
-//        ESTestCase.expectThrows(ResourceNotFoundException.class, () -> JobManager.getJobOrThrowIfUnknown("foo", cs));
-//    }
-//
-//    public void testGetJobOrThrowIfUnknown_GivenKnownJob() {
-//        Job job = buildJobBuilder("foo").build();
-//        MlMetadata mlMetadata = new MlMetadata.Builder().putJob(job, false).build();
-//        ClusterState cs = ClusterState.builder(new ClusterName("_name"))
-//                .metaData(MetaData.builder().putCustom(MLMetadataField.TYPE, mlMetadata)).build();
-//
-//        assertEquals(job, JobManager.getJobOrThrowIfUnknown("foo", cs));
-//    }
-
-    public void testExpandJobs_GivenAll() {
-        MlMetadata.Builder mlMetadata = new MlMetadata.Builder();
-        for (int i = 0; i < 3; i++) {
-            mlMetadata.putJob(buildJobBuilder(Integer.toString(i)).build(), false);
-        }
-        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
-                .metaData(MetaData.builder().putCustom(MlMetadata.TYPE, mlMetadata.build())).build();
-
-        JobManager jobManager = createJobManager();
-        QueryPage<Job> result = jobManager.expandJobs("_all", true, clusterState);
-
-        assertThat(result.count(), equalTo(3L));
-        assertThat(result.results().get(0).getId(), equalTo("0"));
-        assertThat(result.results().get(1).getId(), equalTo("1"));
-        assertThat(result.results().get(2).getId(), equalTo("2"));
-    }
-
-    @SuppressWarnings("unchecked")
-    public void testPutJob_AddsCreateTime() throws IOException {
-        JobManager jobManager = createJobManager();
-        PutJobAction.Request putJobRequest = new PutJobAction.Request(createJob());
-
-        doAnswer(invocation -> {
-            AckedClusterStateUpdateTask<Boolean> task = (AckedClusterStateUpdateTask<Boolean>) invocation.getArguments()[1];
-            task.onAllNodesAcked(null);
-            return null;
-        }).when(clusterService).submitStateUpdateTask(Matchers.eq("put-job-foo"), any(AckedClusterStateUpdateTask.class));
-
-        ArgumentCaptor<Job> requestCaptor = ArgumentCaptor.forClass(Job.class);
-        doAnswer(invocation -> {
-            ActionListener<Boolean> listener = (ActionListener<Boolean>) invocation.getArguments()[2];
-            listener.onResponse(true);
-            return null;
-        }).when(jobProvider).createJobResultIndex(requestCaptor.capture(), any(ClusterState.class), any(ActionListener.class));
-
-        ClusterState clusterState = createClusterState();
-
-        jobManager.putJob(putJobRequest, analysisRegistry, clusterState, new ActionListener<PutJobAction.Response>() {
-            @Override
-            public void onResponse(PutJobAction.Response response) {
-                Job job = requestCaptor.getValue();
-                assertNotNull(job.getCreateTime());
-                Date now = new Date();
-                // job create time should be within the last second
-                assertThat(now.getTime(), greaterThanOrEqualTo(job.getCreateTime().getTime()));
-                assertThat(now.getTime() - 1000, lessThanOrEqualTo(job.getCreateTime().getTime()));
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                fail(e.toString());
-            }
-        });
-    }
-
-    public void testPutJob_ThrowsIfJobExists() throws IOException {
-        JobManager jobManager = createJobManager();
-        PutJobAction.Request putJobRequest = new PutJobAction.Request(createJob());
-
-        MlMetadata.Builder mlMetadata = new MlMetadata.Builder();
-        mlMetadata.putJob(buildJobBuilder("foo").build(), false);
-        ClusterState clusterState = ClusterState.builder(new ClusterName("name"))
-                .metaData(MetaData.builder().putCustom(MlMetadata.TYPE, mlMetadata.build())).build();
-
-        jobManager.putJob(putJobRequest, analysisRegistry, clusterState, new ActionListener<PutJobAction.Response>() {
-            @Override
-            public void onResponse(PutJobAction.Response response) {
-                fail("should have got an error");
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                assertTrue(e instanceof ResourceAlreadyExistsException);
-            }
-        });
+    private MockClientBuilder mockClient() {
+        MockClientBuilder clientBuilder = new MockClientBuilder("cluster-test");
+        return clientBuilder;
     }
 
     public void testNotifyFilterChangedGivenNoop() {
@@ -387,20 +308,9 @@ public class JobManagerTests extends ESTestCase {
         assertThat(capturedUpdateParams.get(1).getJobId(), equalTo(job2.getId()));
         assertThat(capturedUpdateParams.get(1).isUpdateScheduledEvents(), is(true));
     }
+*/
 
-    private Job.Builder createJob() {
-        Detector.Builder d1 = new Detector.Builder("info_content", "domain");
-        d1.setOverFieldName("client");
-        AnalysisConfig.Builder ac = new AnalysisConfig.Builder(Collections.singletonList(d1.build()));
-
-        Job.Builder builder = new Job.Builder();
-        builder.setId("foo");
-        builder.setAnalysisConfig(ac);
-        builder.setDataDescription(new DataDescription.Builder());
-        return builder;
-    }
-
-    private JobManager createJobManager() {
+    private JobManager createJobManager(Client client) {
         ClusterSettings clusterSettings = new ClusterSettings(environment.settings(),
                 Collections.singleton(MachineLearningField.MAX_MODEL_MEMORY_LIMIT));
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
@@ -84,19 +84,19 @@ public class JobManagerTests extends ESTestCase {
         updateJobProcessNotifier = mock(UpdateJobProcessNotifier.class);
     }
 
-    public void testGetJobOrThrowIfUnknown_GivenUnknownJob() {
-        ClusterState cs = createClusterState();
-        ESTestCase.expectThrows(ResourceNotFoundException.class, () -> JobManager.getJobOrThrowIfUnknown("foo", cs));
-    }
-
-    public void testGetJobOrThrowIfUnknown_GivenKnownJob() {
-        Job job = buildJobBuilder("foo").build();
-        MlMetadata mlMetadata = new MlMetadata.Builder().putJob(job, false).build();
-        ClusterState cs = ClusterState.builder(new ClusterName("_name"))
-                .metaData(MetaData.builder().putCustom(MlMetadata.TYPE, mlMetadata)).build();
-
-        assertEquals(job, JobManager.getJobOrThrowIfUnknown("foo", cs));
-    }
+//    public void testGetJobOrThrowIfUnknown_GivenUnknownJob() {
+//        ClusterState cs = createClusterState();
+//        ESTestCase.expectThrows(ResourceNotFoundException.class, () -> JobManager.getJobOrThrowIfUnknown("foo", cs));
+//    }
+//
+//    public void testGetJobOrThrowIfUnknown_GivenKnownJob() {
+//        Job job = buildJobBuilder("foo").build();
+//        MlMetadata mlMetadata = new MlMetadata.Builder().putJob(job, false).build();
+//        ClusterState cs = ClusterState.builder(new ClusterName("_name"))
+//                .metaData(MetaData.builder().putCustom(MLMetadataField.TYPE, mlMetadata)).build();
+//
+//        assertEquals(job, JobManager.getJobOrThrowIfUnknown("foo", cs));
+//    }
 
     public void testExpandJobs_GivenAll() {
         MlMetadata.Builder mlMetadata = new MlMetadata.Builder();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockClientBuilder.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockClientBuilder.java
@@ -33,6 +33,7 @@ import org.elasticsearch.action.get.GetRequestBuilder;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequestBuilder;
@@ -42,20 +43,30 @@ import org.elasticsearch.client.AdminClient;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.MlMetaIndex;
 import org.elasticsearch.xpack.core.ml.action.DeleteJobAction;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -251,6 +262,46 @@ public class MockClientBuilder {
         when(builder.addSort(any(String.class), any(SortOrder.class))).thenReturn(builder);
         when(builder.get()).thenReturn(response);
         when(client.prepareSearch(eq(index))).thenReturn(builder);
+        return this;
+    }
+
+    /**
+     * Creates a {@link SearchResponse} with a {@link SearchHit} for each element of {@code docs}
+     * @param indexName Index being searched
+     * @param docs Returned in the SearchResponse
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    public MockClientBuilder prepareSearch(String indexName, List<BytesReference> docs) {
+        SearchRequestBuilder builder = mock(SearchRequestBuilder.class);
+        when(builder.setIndicesOptions(any())).thenReturn(builder);
+        when(builder.setQuery(any())).thenReturn(builder);
+        when(builder.setSource(any())).thenReturn(builder);
+        SearchRequest request = new SearchRequest(indexName);
+        when(builder.request()).thenReturn(request);
+
+        when(client.prepareSearch(eq(indexName))).thenReturn(builder);
+
+        SearchHit hits [] = new SearchHit[docs.size()];
+        for (int i=0; i<docs.size(); i++) {
+            SearchHit hit = new SearchHit(10);
+            hit.sourceRef(docs.get(i));
+            hits[i] = hit;
+        }
+
+        SearchResponse response = mock(SearchResponse.class);
+        SearchHits searchHits = new SearchHits(hits, hits.length, 0.0f);
+        when(response.getHits()).thenReturn(searchHits);
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocationOnMock) {
+                ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) invocationOnMock.getArguments()[1];
+                listener.onResponse(response);
+                return null;
+            }
+        }).when(client).search(eq(request), any());
+
         return this;
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
@@ -67,7 +67,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -132,7 +131,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
             ActionListener<Job> listener = (ActionListener<Job>) invocationOnMock.getArguments()[1];
             listener.onResponse(createJobDetails("foo"));
             return null;
-        }).when(jobManager).getJobOrThrowIfUnknown(eq("foo"), any());
+        }).when(jobManager).getJob(eq("foo"), any());
 
 
         doAnswer(invocationOnMock -> {
@@ -182,7 +181,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
             ActionListener<Job> listener = (ActionListener<Job>) invocationOnMock.getArguments()[1];
             listener.onResponse(createJobDetails("foo"));
             return null;
-        }).when(jobManager).getJobOrThrowIfUnknown(eq("foo"), any());
+        }).when(jobManager).getJob(eq("foo"), any());
         AutodetectProcessManager manager = createManager(communicator, client);
 
         JobTask jobTask = mock(JobTask.class);
@@ -202,7 +201,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
                 ActionListener<Job> listener = (ActionListener<Job>) invocationOnMock.getArguments()[1];
                 listener.onResponse(createJobDetails(jobId));
                 return null;
-            }).when(jobManager).getJobOrThrowIfUnknown(eq(jobId), any());
+            }).when(jobManager).getJob(eq(jobId), any());
         }
 
         Client client = mock(Client.class);
@@ -578,7 +577,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
             ActionListener<Job> listener = (ActionListener<Job>) invocationOnMock.getArguments()[1];
             listener.onResponse(job);
             return null;
-        }).when(jobManager).getJobOrThrowIfUnknown(eq("my_id"), any());
+        }).when(jobManager).getJob(eq("my_id"), any());
 
         AutodetectProcess autodetectProcess = mock(AutodetectProcess.class);
         AutodetectProcessFactory autodetectProcessFactory =
@@ -657,7 +656,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
             ActionListener<Job> listener = (ActionListener<Job>) invocationOnMock.getArguments()[1];
             listener.onResponse(createJobDetails(jobId));
             return null;
-        }).when(jobManager).getJobOrThrowIfUnknown(eq(jobId), any());
+        }).when(jobManager).getJob(eq(jobId), any());
 
         AutodetectProcess autodetectProcess = mock(AutodetectProcess.class);
         AutodetectProcessFactory autodetectProcessFactory =

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
@@ -126,7 +126,15 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         normalizerFactory = mock(NormalizerFactory.class);
         auditor = mock(Auditor.class);
 
-        when(jobManager.getJobOrThrowIfUnknown("foo")).thenReturn(createJobDetails("foo"));
+
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<Job> listener = (ActionListener<Job>) invocationOnMock.getArguments()[1];
+            listener.onResponse(createJobDetails("foo"));
+            return null;
+        }).when(jobManager).getJobOrThrowIfUnknown(eq("foo"), any());
+
+
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
             Consumer<AutodetectParams> handler = (Consumer<AutodetectParams>) invocationOnMock.getArguments()[1];
@@ -166,32 +174,15 @@ public class AutodetectProcessManagerTests extends ESTestCase {
                 + "See the breaking changes documentation for the next major version.");
     }
 
-    public void testOpenJob_withoutVersion() {
-        Client client = mock(Client.class);
-        AutodetectCommunicator communicator = mock(AutodetectCommunicator.class);
-        Job.Builder jobBuilder = new Job.Builder(createJobDetails("no_version"));
-        jobBuilder.setJobVersion(null);
-        Job job = jobBuilder.build();
-        assertThat(job.getJobVersion(), is(nullValue()));
-
-        when(jobManager.getJobOrThrowIfUnknown(job.getId())).thenReturn(job);
-        AutodetectProcessManager manager = createManager(communicator, client);
-
-        JobTask jobTask = mock(JobTask.class);
-        when(jobTask.getJobId()).thenReturn(job.getId());
-
-        AtomicReference<Exception> errorHolder = new AtomicReference<>();
-        manager.openJob(jobTask, errorHolder::set);
-
-        Exception error = errorHolder.get();
-        assertThat(error, is(notNullValue()));
-        assertThat(error.getMessage(), equalTo("Cannot open job [no_version] because jobs created prior to version 5.5 are not supported"));
-    }
-
     public void testOpenJob() {
         Client client = mock(Client.class);
         AutodetectCommunicator communicator = mock(AutodetectCommunicator.class);
-        when(jobManager.getJobOrThrowIfUnknown("foo")).thenReturn(createJobDetails("foo"));
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<Job> listener = (ActionListener<Job>) invocationOnMock.getArguments()[1];
+            listener.onResponse(createJobDetails("foo"));
+            return null;
+        }).when(jobManager).getJobOrThrowIfUnknown(eq("foo"), any());
         AutodetectProcessManager manager = createManager(communicator, client);
 
         JobTask jobTask = mock(JobTask.class);
@@ -205,10 +196,14 @@ public class AutodetectProcessManagerTests extends ESTestCase {
 
     @SuppressWarnings("unchecked")
     public void testOpenJob_exceedMaxNumJobs() {
-        when(jobManager.getJobOrThrowIfUnknown("foo")).thenReturn(createJobDetails("foo"));
-        when(jobManager.getJobOrThrowIfUnknown("bar")).thenReturn(createJobDetails("bar"));
-        when(jobManager.getJobOrThrowIfUnknown("baz")).thenReturn(createJobDetails("baz"));
-        when(jobManager.getJobOrThrowIfUnknown("foobar")).thenReturn(createJobDetails("foobar"));
+        for (String jobId : new String [] {"foo", "bar", "baz", "foobar"}) {
+            doAnswer(invocationOnMock -> {
+                @SuppressWarnings("unchecked")
+                ActionListener<Job> listener = (ActionListener<Job>) invocationOnMock.getArguments()[1];
+                listener.onResponse(createJobDetails(jobId));
+                return null;
+            }).when(jobManager).getJobOrThrowIfUnknown(eq(jobId), any());
+        }
 
         Client client = mock(Client.class);
         ThreadPool threadPool = mock(ThreadPool.class);
@@ -577,7 +572,14 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         doThrow(new EsRejectedExecutionException("")).when(executorService).submit(any(Runnable.class));
         when(threadPool.executor(anyString())).thenReturn(executorService);
         when(threadPool.scheduleWithFixedDelay(any(), any(), any())).thenReturn(mock(ThreadPool.Cancellable.class));
-        when(jobManager.getJobOrThrowIfUnknown("my_id")).thenReturn(createJobDetails("my_id"));
+        Job job = createJobDetails("my_id");
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<Job> listener = (ActionListener<Job>) invocationOnMock.getArguments()[1];
+            listener.onResponse(job);
+            return null;
+        }).when(jobManager).getJobOrThrowIfUnknown(eq("my_id"), any());
+
         AutodetectProcess autodetectProcess = mock(AutodetectProcess.class);
         AutodetectProcessFactory autodetectProcessFactory =
                 (j, autodetectParams, e, onProcessCrash) -> autodetectProcess;
@@ -588,7 +590,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("my_id");
         expectThrows(EsRejectedExecutionException.class,
-                () -> manager.create(jobTask, buildAutodetectParams(), e -> {}));
+                () -> manager.create(jobTask, job, buildAutodetectParams(), e -> {}));
         verify(autodetectProcess, times(1)).close();
     }
 
@@ -598,7 +600,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
 
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
-        manager.create(jobTask, buildAutodetectParams(), e -> {});
+        manager.create(jobTask, createJobDetails("foo"), buildAutodetectParams(), e -> {});
 
         String expectedNotification = "Loading model snapshot [N/A], job latest_record_timestamp [N/A]";
         verify(auditor).info("foo", expectedNotification);
@@ -614,7 +616,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
 
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
-        manager.create(jobTask, buildAutodetectParams(), e -> {});
+        manager.create(jobTask, createJobDetails("foo"), buildAutodetectParams(), e -> {});
 
         String expectedNotification = "Loading model snapshot [snapshot-1] with " +
                 "latest_record_timestamp [1970-01-01T00:00:00.000Z], " +
@@ -633,7 +635,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
 
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
-        manager.create(jobTask, buildAutodetectParams(), e -> {});
+        manager.create(jobTask, createJobDetails("foo"), buildAutodetectParams(), e -> {});
 
         String expectedNotification = "Loading model snapshot [N/A], " +
                 "job latest_record_timestamp [1970-01-01T00:00:00.000Z]";
@@ -650,7 +652,13 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         ExecutorService executorService = mock(ExecutorService.class);
         when(threadPool.executor(anyString())).thenReturn(executorService);
         when(threadPool.scheduleWithFixedDelay(any(), any(), any())).thenReturn(mock(ThreadPool.Cancellable.class));
-        when(jobManager.getJobOrThrowIfUnknown(jobId)).thenReturn(createJobDetails(jobId));
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<Job> listener = (ActionListener<Job>) invocationOnMock.getArguments()[1];
+            listener.onResponse(createJobDetails(jobId));
+            return null;
+        }).when(jobManager).getJobOrThrowIfUnknown(eq(jobId), any());
+
         AutodetectProcess autodetectProcess = mock(AutodetectProcess.class);
         AutodetectProcessFactory autodetectProcessFactory =
                 (j, autodetectParams, e, onProcessCrash) -> autodetectProcess;
@@ -684,7 +692,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
                 autodetectProcessFactory, normalizerFactory,
                 new NamedXContentRegistry(Collections.emptyList()), auditor);
         manager = spy(manager);
-        doReturn(communicator).when(manager).create(any(), eq(buildAutodetectParams()), any());
+        doReturn(communicator).when(manager).create(any(), any(), eq(buildAutodetectParams()), any());
         return manager;
     }
 


### PR DESCRIPTION
Adds the index `.ml-config` (name TBD) and mappings for the job and datafeed configurations.
CRUD methods for jobs stored in the index and changes the actions to use those methods.

This is a large amount of code but requires further work to open a job as the task executor still expects the config to be in the cluster state. 

This change isn't supposed to be committed as is, consider it an exploration of the required changes I hope to commit smaller PRs in the future