### PR TITLE
Reject follow request if following setting not enabled on follower

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/FollowIndexAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/FollowIndexAction.java
@@ -487,7 +487,10 @@ public class FollowIndexAction extends Action<FollowIndexAction.Response> {
         if (leaderIndex.getState() != IndexMetaData.State.OPEN || followIndex.getState() != IndexMetaData.State.OPEN) {
             throw new IllegalArgumentException("leader and follow index must be open");
         }
-
+        if (CcrSettings.CCR_FOLLOWING_INDEX_SETTING.get(followIndex.getSettings()) == false) {
+            throw new IllegalArgumentException("the following index [" + request.followerIndex + "] is not ready " +
+                "to follow; the setting [" + CcrSettings.CCR_FOLLOWING_INDEX_SETTING.getKey() + "] must be enabled.");
+        }
         // Make a copy, remove settings that are allowed to be different and then compare if the settings are equal.
         Settings leaderSettings = filter(leaderIndex.getSettings());
         Settings followerSettings = filter(followIndex.getSettings());

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/ShardChangesIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/ShardChangesIT.java
@@ -60,10 +60,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, transportClientRatio = 0)
 public class ShardChangesIT extends ESIntegTestCase {
@@ -425,6 +422,32 @@ public class ShardChangesIT extends ESIntegTestCase {
         // Both indices do not exist.
         FollowIndexAction.Request followRequest3 = createFollowRequest("non-existent-leader", "non-existent-follower");
         expectThrows(IllegalArgumentException.class, () -> client().execute(FollowIndexAction.INSTANCE, followRequest3).actionGet());
+    }
+
+    public void testValidateFollowingIndexSettings() throws Exception {
+        assertAcked(client().admin().indices().prepareCreate("test-leader")
+            .setSettings(Settings.builder().put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)));
+        // TODO: indexing should be optional but the current mapping logic requires for now.
+        client().prepareIndex("test-leader", "doc", "id").setSource("{\"f\": \"v\"}", XContentType.JSON).get();
+        assertAcked(client().admin().indices().prepareCreate("test-follower").get());
+        IllegalArgumentException followError = expectThrows(IllegalArgumentException.class, () -> client().execute(
+            FollowIndexAction.INSTANCE, createFollowRequest("test-leader", "test-follower")).actionGet());
+        assertThat(followError.getMessage(), equalTo("the following index [test-follower] is not ready to follow;" +
+            " the setting [index.xpack.ccr.following_index] must be enabled."));
+        // updating the `following_index` with an open index must not be allowed.
+        IllegalArgumentException updateError = expectThrows(IllegalArgumentException.class, () -> {
+            client().admin().indices().prepareUpdateSettings("test-follower")
+                .setSettings(Settings.builder().put(CcrSettings.CCR_FOLLOWING_INDEX_SETTING.getKey(), true)).get();
+        });
+        assertThat(updateError.getMessage(), containsString("Can't update non dynamic settings " +
+            "[[index.xpack.ccr.following_index]] for open indices [[test-follower/"));
+        assertAcked(client().admin().indices().prepareClose("test-follower"));
+        assertAcked(client().admin().indices().prepareUpdateSettings("test-follower")
+            .setSettings(Settings.builder().put(CcrSettings.CCR_FOLLOWING_INDEX_SETTING.getKey(), true)));
+        assertAcked(client().admin().indices().prepareOpen("test-follower"));
+        assertAcked(client().execute(FollowIndexAction.INSTANCE,
+            createFollowRequest("test-leader", "test-follower")).actionGet());
+        unfollowIndex("test-follower");
     }
 
     public void testFollowIndex_lowMaxTranslogBytes() throws Exception {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/ShardChangesIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/ShardChangesIT.java
@@ -60,7 +60,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, transportClientRatio = 0)
 public class ShardChangesIT extends ESIntegTestCase {


### PR DESCRIPTION
Today we do not check if the `following_index` setting of the follower
is enabled or not when processing a follow-request. If that setting is
disabled, the follower will use the default engine, not the following
engine. This change checks and rejects such invalid follow requests.

Relates #30086