### PR TITLE
Make get all app privs requires "*" permission

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetPrivilegesRequest.java
@@ -50,7 +50,7 @@ public final class GetPrivilegesRequest extends ActionRequest implements Applica
 
     @Override
     public Collection<String> getApplicationNames() {
-        return Collections.singleton(application);
+        return application == null ? Collections.emptySet() : Collections.singleton(application);
     }
 
     public void privileges(String... privileges) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ConditionalClusterPrivileges.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ConditionalClusterPrivileges.java
@@ -135,7 +135,9 @@ public final class ConditionalClusterPrivileges {
             this.requestPredicate = request -> {
                 if (request instanceof ApplicationPrivilegesRequest) {
                     final ApplicationPrivilegesRequest privRequest = (ApplicationPrivilegesRequest) request;
-                    return privRequest.getApplicationNames().stream().allMatch(application -> applicationPredicate.test(application));
+                    final Collection<String> requestApplicationNames = privRequest.getApplicationNames();
+                    return requestApplicationNames.isEmpty() ? this.applicationNames.contains("*")
+                        : requestApplicationNames.stream().allMatch(application -> applicationPredicate.test(application));
                 }
                 return false;
             };

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageApplicationPrivilegesTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageApplicationPrivilegesTests.java
@@ -50,6 +50,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class ManageApplicationPrivilegesTests extends ESTestCase {
 
@@ -140,6 +141,19 @@ public class ManageApplicationPrivilegesTests extends ESTestCase {
         assertThat(cloudAndSwiftypePredicate, not(predicateMatches(putKibana)));
     }
 
+    public void testSecurityForGetAllApplicationPrivileges() {
+        final GetPrivilegesRequest getAll = new GetPrivilegesRequest();
+        getAll.application(null);
+        getAll.privileges(new String[0]);
+
+        assertThat(getAll.validate(), nullValue());
+
+        final ManageApplicationPrivileges kibanaOnly = new ManageApplicationPrivileges(Sets.newHashSet("kibana-*"));
+        final ManageApplicationPrivileges allApps = new ManageApplicationPrivileges(Sets.newHashSet("*"));
+
+        assertThat(kibanaOnly.getRequestPredicate(), not(predicateMatches(getAll)));
+        assertThat(allApps.getRequestPredicate(), predicateMatches(getAll));
+    }
 
     private ManageApplicationPrivileges clone(ManageApplicationPrivileges original) {
         return new ManageApplicationPrivileges(new LinkedHashSet<>(original.getApplicationNames()));


### PR DESCRIPTION
The default behaviour for "GetPrivileges" is to get all application
privileges. This should only be allowed if the user has access to
the "*" application.
