### PR TITLE
Ensure KeyStoreWrapper decryption exceptions are handled

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
@@ -359,7 +359,7 @@ public class KeyStoreWrapper implements SecureSettings {
             if (input.read() != -1) {
                 throw new SecurityException("Keystore has been corrupted or tampered with");
             }
-        } catch (EOFException e) {
+        } catch (IOException e) {
             throw new SecurityException("Keystore has been corrupted or tampered with", e);
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
@@ -32,7 +32,6 @@ import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.plugins.ReloadablePlugin;
 import org.elasticsearch.test.ESIntegTestCase;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;

--- a/server/src/test/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
@@ -205,14 +205,7 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
                             assertThat(nodesMap.size(), equalTo(cluster().size()));
                             for (final NodesReloadSecureSettingsResponse.NodeResponse nodeResponse : nodesReloadResponse.getNodes()) {
                                 assertThat(nodeResponse.reloadException(), notNullValue());
-                                // Running in a JVM with a BouncyCastle FIPS Security Provider, decrypting the Keystore with the wrong
-                                // password returns a SecurityException if the DataInputStream can't be fully consumed
-                                if (inFipsJvm()) {
                                     assertThat(nodeResponse.reloadException(), instanceOf(SecurityException.class));
-                                } else {
-                                    assertThat(nodeResponse.reloadException(), instanceOf(IOException.class));
-                                }
-
                             }
                         } catch (final AssertionError e) {
                             reloadSettingsError.set(e);

--- a/server/src/test/java/org/elasticsearch/common/settings/KeyStoreWrapperTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/KeyStoreWrapperTests.java
@@ -99,6 +99,16 @@ public class KeyStoreWrapperTests extends ESTestCase {
         assertTrue(keystore.getSettingNames().contains(KeyStoreWrapper.SEED_SETTING.getKey()));
     }
 
+    public void testDecryptKeyStoreWithWrongPassword() throws Exception {
+        KeyStoreWrapper keystore = KeyStoreWrapper.create();
+        keystore.save(env.configFile(), new char[0]);
+        final KeyStoreWrapper loadedkeystore = KeyStoreWrapper.load(env.configFile());
+        final Exception exception = expectThrows(Exception.class,
+            () -> loadedkeystore.decrypt(new char[]{'i', 'n', 'v', 'a', 'l', 'i', 'd'}));
+        exception.printStackTrace();
+        assertThat(exception.getMessage(), containsString("Keystore has been corrupted or tampered with"));
+    }
+
     public void testCannotReadStringFromClosedKeystore() throws Exception {
         KeyStoreWrapper keystore = KeyStoreWrapper.create();
         assertThat(keystore.getSettingNames(), Matchers.hasItem(KeyStoreWrapper.SEED_SETTING.getKey()));

--- a/server/src/test/java/org/elasticsearch/common/settings/KeyStoreWrapperTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/KeyStoreWrapperTests.java
@@ -103,9 +103,8 @@ public class KeyStoreWrapperTests extends ESTestCase {
         KeyStoreWrapper keystore = KeyStoreWrapper.create();
         keystore.save(env.configFile(), new char[0]);
         final KeyStoreWrapper loadedkeystore = KeyStoreWrapper.load(env.configFile());
-        final Exception exception = expectThrows(Exception.class,
+        final SecurityException exception = expectThrows(SecurityException.class,
             () -> loadedkeystore.decrypt(new char[]{'i', 'n', 'v', 'a', 'l', 'i', 'd'}));
-        exception.printStackTrace();
         assertThat(exception.getMessage(), containsString("Keystore has been corrupted or tampered with"));
     }
 


### PR DESCRIPTION
This commit ensures that all possible Exceptions in
KeyStoreWrapper#decrypt() are handled. More specifically, in the
case that a wrong password is used for secure settings, calling `readX`
on the DataInputStream that wraps the CipherInputStream can throw an
IOException. It also adds a test for loading a KeyStoreWrapper with
a wrong password.