### PR TITLE
INGEST: Clean up Java8 Stream Usage (#32059)

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessor.java
@@ -68,8 +68,7 @@ public final class GrokProcessor extends AbstractProcessor {
             throw new IllegalArgumentException("Provided Grok expressions do not match field value: [" + fieldValue + "]");
         }
 
-        matches.entrySet().stream()
-            .forEach((e) -> ingestDocument.setFieldValue(e.getKey(), e.getValue()));
+        matches.forEach(ingestDocument::setFieldValue);
 
         if (traceMatch) {
             if (matchPatterns.size() > 1) {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -531,8 +531,7 @@ public final class IngestDocument {
 
     private static void appendValues(List<Object> list, Object value) {
         if (value instanceof List) {
-            List<?> valueList = (List<?>) value;
-            valueList.stream().forEach(list::add);
+            list.addAll((List<?>) value);
         } else {
             list.add(value);
         }


### PR DESCRIPTION
* GrokProcessor: Rationalize the loop over the map to save allocations and indirection
* IngestDocument: Rationalize way we append to `List`

Backport of #32059 to `6.x`, PR is just here to run Jenkins.