### PR TITLE
Correcting http methods

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -779,7 +779,7 @@ Here is the same exact search above using the alternative request body method:
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": { "match_all": {} },
   "sort": [
@@ -844,7 +844,7 @@ Going back to our last example, we executed this query:
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": { "match_all": {} }
 }
@@ -860,7 +860,7 @@ influence the search results. In the example in the section above we passed in
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": { "match_all": {} },
   "size": 1
@@ -875,7 +875,7 @@ This example does a `match_all` and returns documents 10 through 19:
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": { "match_all": {} },
   "from": 10,
@@ -891,7 +891,7 @@ This example does a `match_all` and sorts the results by account balance in desc
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": { "match_all": {} },
   "sort": { "balance": { "order": "desc" } }
@@ -908,7 +908,7 @@ This example shows how to return two fields, `account_number` and `balance` (ins
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": { "match_all": {} },
   "_source": ["account_number", "balance"]
@@ -927,7 +927,7 @@ This example returns the account numbered 20:
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": { "match": { "account_number": 20 } }
 }
@@ -939,7 +939,7 @@ This example returns all accounts containing the term "mill" in the address:
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": { "match": { "address": "mill" } }
 }
@@ -951,7 +951,7 @@ This example returns all accounts containing the term "mill" or "lane" in the ad
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": { "match": { "address": "mill lane" } }
 }
@@ -963,7 +963,7 @@ This example is a variant of `match` (`match_phrase`) that returns all accounts 
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": { "match_phrase": { "address": "mill lane" } }
 }
@@ -977,7 +977,7 @@ This example composes two `match` queries and returns all accounts containing "m
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": {
     "bool": {
@@ -998,7 +998,7 @@ In contrast, this example composes two `match` queries and returns all accounts 
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": {
     "bool": {
@@ -1019,7 +1019,7 @@ This example composes two `match` queries and returns all accounts that contain 
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": {
     "bool": {
@@ -1042,7 +1042,7 @@ This example returns all accounts of anybody who is 40 years old but doesn't liv
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": {
     "bool": {
@@ -1071,7 +1071,7 @@ This example uses a bool query to return all accounts with balances between 2000
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": {
     "bool": {
@@ -1103,7 +1103,7 @@ To start with, this example groups all the accounts by state, and then returns t
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "size": 0,
   "aggs": {
@@ -1193,7 +1193,7 @@ Building on the previous aggregation, this example calculates the average accoun
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "size": 0,
   "aggs": {
@@ -1221,7 +1221,7 @@ Building on the previous aggregation, let's now sort on the average balance in d
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "size": 0,
   "aggs": {
@@ -1250,7 +1250,7 @@ This example demonstrates how we can group by age brackets (ages 20-29, 30-39, a
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "size": 0,
   "aggs": {


### PR DESCRIPTION
### Correcting http methods
Correcting documentation as GET petitions don't have a body so the query petition method should be a POST. The code for CURL works because the argument "-d" sends a POST request.


### Example of CURL command:

```
curl -X GET "localhost:9200/bank/_search" -H 'Content-Type: application/json' -d'
{
  "query": { "match_all": {} },
  "sort": [
    { "account_number": "asc" }
  ]
}
'
```

###  From CURL manpage:

-d, --data <data>

_(HTTP) Sends the specified data in a POST request to the HTTP server, in the same way that a browser does when a user has filled in an HTML form and presses the submit button. This will cause curl to pass the data to the server using the content-type application/x-www-form-urlencoded. Compare to -F, --form._