### PR TITLE
S3 endpoint is not automatically guessed from bucket name

### DIFF
--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -79,9 +79,9 @@ are marked as `Secure`.
 
 `endpoint`::
 
-    The s3 service endpoint to connect to. This will be automatically
-    figured out by the s3 client based on the bucket location, but
-    can be specified explicitly. See http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region.
+    The s3 service endpoint to connect to. Mandatory if you are using another 
+    region than `us-east-1`.
+    See http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region.
 
 `protocol`::
 


### PR DESCRIPTION
We were saying that the S3 `endpoint` can be automatically guessed from the bucket name.

I don't think this can be true. The `endpoint` is needed on a client level whereas the bucket name is set on a repository level. This is confusing IMO as I believe the endpoint must be set if not using the default one (`us-east-1`).

For example, creating a bucket like:

```json
{
  "type": "s3",
  "settings": {
    "bucket": "foo.s3.cn-north-1.amazonaws.com.cn"
  }
}
```

Is failing with:

```json
{
  "error" : {
    "root_cause" : [
      {
        "type" : "repository_exception",
        "reason" : "[s3_repository] failed to create repository"
      }
    ],
    "type" : "repository_exception",
    "reason" : "[s3_repository] failed to create repository",
    "caused_by" : {
      "type" : "illegal_argument_exception",
      "reason" : "The bucket [foo.s3.cn-north-1.amazonaws.com.cn] does not exist. Please create it before  creating an s3 snapshot repository backed by it."
    }
  },
  "status" : 500
}
```

But if you set `s3.client.default.endpoint: s3.cn-north-1.amazonaws.com.cn` in `elasticsearch.yml`, this is working well with:

```json
{
  "type": "s3",
  "settings": {
    "bucket": "foo"
  }
}
```

See related discussion: https://discuss.elastic.co/t/cant-create-s3-repository-for-backup-in-aws-beijing-region/141584