### PR TITLE
Core: Minor size reduction for AbstractComponent

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/component/AbstractComponent.java
+++ b/server/src/main/java/org/elasticsearch/common/component/AbstractComponent.java
@@ -34,13 +34,7 @@ public abstract class AbstractComponent {
     protected final Settings settings;
 
     public AbstractComponent(Settings settings) {
-        this.logger = Loggers.getLogger(getClass(), settings);
-        this.deprecationLogger = new DeprecationLogger(logger);
-        this.settings = settings;
-    }
-
-    public AbstractComponent(Settings settings, Class<?> customClass) {
-        this.logger = LogManager.getLogger(customClass);
+        this.logger = LogManager.getLogger(getClass());
         this.deprecationLogger = new DeprecationLogger(logger);
         this.settings = settings;
     }

--- a/server/src/main/java/org/elasticsearch/common/component/AbstractComponent.java
+++ b/server/src/main/java/org/elasticsearch/common/component/AbstractComponent.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
 

--- a/server/src/main/java/org/elasticsearch/common/component/AbstractComponent.java
+++ b/server/src/main/java/org/elasticsearch/common/component/AbstractComponent.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
 

--- a/server/src/main/java/org/elasticsearch/common/component/AbstractLifecycleComponent.java
+++ b/server/src/main/java/org/elasticsearch/common/component/AbstractLifecycleComponent.java
@@ -35,10 +35,6 @@ public abstract class AbstractLifecycleComponent extends AbstractComponent imple
         super(settings);
     }
 
-    protected AbstractLifecycleComponent(Settings settings, Class<?> customClass) {
-        super(settings, customClass);
-    }
-
     @Override
     public Lifecycle.State lifecycleState() {
         return this.lifecycle.state();

--- a/server/src/main/java/org/elasticsearch/common/logging/ESLoggerFactory.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ESLoggerFactory.java
@@ -38,9 +38,13 @@ public final class ESLoggerFactory {
 
     public static Logger getLogger(String prefix, Class<?> clazz) {
         /*
-         * Do not use LogManager#getLogger(Class) as this now uses Class#getCanonicalName under the hood; as this returns null for local and
-         * anonymous classes, any place we create, for example, an abstract component defined as an anonymous class (e.g., in tests) will
-         * result in a logger with a null name which will blow up in a lookup inside of Log4j.
+         * At one point we didn't use LogManager.getLogger(clazz) because
+         * of a bug in log4j that has since been fixed:
+         * https://github.com/apache/logging-log4j2/commit/ae33698a1846a5e10684ec3e52a99223f06047af
+         *
+         * For now we continue to use LogManager.getLogger(clazz.getName())
+         * because we expect to eventually migrate away from needing this
+         * method entirely.
          */
         return getLogger(prefix, LogManager.getLogger(clazz.getName()));
     }

--- a/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
@@ -118,13 +118,13 @@ public class ClusterApplierServiceTests extends ESTestCase {
         mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                         "test1",
-                        clusterApplierService.getClass().getName(),
+                        clusterApplierService.getClass().getCanonicalName(),
                         Level.DEBUG,
                         "*processing [test1]: took [1s] no change in cluster state"));
         mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                         "test2",
-                        clusterApplierService.getClass().getName(),
+                        clusterApplierService.getClass().getCanonicalName(),
                         Level.TRACE,
                         "*failed to execute cluster state applier in [2s]*"));
 
@@ -192,19 +192,19 @@ public class ClusterApplierServiceTests extends ESTestCase {
         mockAppender.addExpectation(
                 new MockLogAppender.UnseenEventExpectation(
                         "test1 shouldn't see because setting is too low",
-                        clusterApplierService.getClass().getName(),
+                        clusterApplierService.getClass().getCanonicalName(),
                         Level.WARN,
                         "*cluster state applier task [test1] took [*] above the warn threshold of *"));
         mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                         "test2",
-                        clusterApplierService.getClass().getName(),
+                        clusterApplierService.getClass().getCanonicalName(),
                         Level.WARN,
                         "*cluster state applier task [test2] took [32s] above the warn threshold of *"));
         mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                         "test4",
-                        clusterApplierService.getClass().getName(),
+                        clusterApplierService.getClass().getCanonicalName(),
                         Level.WARN,
                         "*cluster state applier task [test3] took [34s] above the warn threshold of *"));
 

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -309,19 +309,19 @@ public class MasterServiceTests extends ESTestCase {
         mockAppender.addExpectation(
             new MockLogAppender.SeenEventExpectation(
                 "test1",
-                masterService.getClass().getName(),
+                masterService.getClass().getCanonicalName(),
                 Level.DEBUG,
                 "*processing [test1]: took [1s] no change in cluster state"));
         mockAppender.addExpectation(
             new MockLogAppender.SeenEventExpectation(
                 "test2",
-                masterService.getClass().getName(),
+                masterService.getClass().getCanonicalName(),
                 Level.TRACE,
                 "*failed to execute cluster state update in [2s]*"));
         mockAppender.addExpectation(
             new MockLogAppender.SeenEventExpectation(
                 "test3",
-                masterService.getClass().getName(),
+                masterService.getClass().getCanonicalName(),
                 Level.DEBUG,
                 "*processing [test3]: took [3s] done publishing updated cluster state (version: *, uuid: *)"));
 
@@ -650,25 +650,25 @@ public class MasterServiceTests extends ESTestCase {
         mockAppender.addExpectation(
             new MockLogAppender.UnseenEventExpectation(
                 "test1 shouldn't see because setting is too low",
-                masterService.getClass().getName(),
+                masterService.getClass().getCanonicalName(),
                 Level.WARN,
                 "*cluster state update task [test1] took [*] above the warn threshold of *"));
         mockAppender.addExpectation(
             new MockLogAppender.SeenEventExpectation(
                 "test2",
-                masterService.getClass().getName(),
+                masterService.getClass().getCanonicalName(),
                 Level.WARN,
                 "*cluster state update task [test2] took [32s] above the warn threshold of *"));
         mockAppender.addExpectation(
             new MockLogAppender.SeenEventExpectation(
                 "test3",
-                masterService.getClass().getName(),
+                masterService.getClass().getCanonicalName(),
                 Level.WARN,
                 "*cluster state update task [test3] took [33s] above the warn threshold of *"));
         mockAppender.addExpectation(
             new MockLogAppender.SeenEventExpectation(
                 "test4",
-                masterService.getClass().getName(),
+                masterService.getClass().getCanonicalName(),
                 Level.WARN,
                 "*cluster state update task [test4] took [34s] above the warn threshold of *"));
 


### PR DESCRIPTION
This removes a constructor from `AbstractComponent` and
`AbstractLifecycleComponent` that we weren't using and it switches the
logger creation away from one of the `Settings` flavored methods which
are no longer needed.
