### PR TITLE
Make index.lifecycle.name setting internal

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleSettings.java
@@ -30,7 +30,7 @@ public class LifecycleSettings {
     public static final Setting<TimeValue> LIFECYCLE_POLL_INTERVAL_SETTING = Setting.positiveTimeSetting(LIFECYCLE_POLL_INTERVAL,
         TimeValue.timeValueSeconds(3), Setting.Property.Dynamic, Setting.Property.NodeScope);
     public static final Setting<String> LIFECYCLE_NAME_SETTING = Setting.simpleString(LIFECYCLE_NAME,
-        Setting.Property.Dynamic, Setting.Property.IndexScope);
+        Setting.Property.Dynamic, Setting.Property.IndexScope, Setting.Property.InternalIndex);
     public static final Setting<String> LIFECYCLE_PHASE_SETTING = Setting.simpleString(LIFECYCLE_PHASE,
         Setting.Property.Dynamic, Setting.Property.IndexScope, Setting.Property.InternalIndex);
     public static final Setting<String> LIFECYCLE_ACTION_SETTING = Setting.simpleString(LIFECYCLE_ACTION,

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/index_lifecycle/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/index_lifecycle/10_basic.yml
@@ -205,34 +205,6 @@ setup:
   - match: { my_timeseries_lifecycle.phases.delete.after: "30s" }
 
   - do:
-      acknowlege: true
-      xpack.index_lifecycle.put_lifecycle:
-        lifecycle: "blah_lifecycle"
-        body: |
-           {
-             "policy": {
-               "type": "timeseries",
-               "phases": {
-                 "warm": {
-                   "after": "1s",
-                   "actions": {
-                     "forcemerge": {
-                       "max_num_segments": 1
-                     }
-                   }
-                 },
-                 "delete": {
-                   "after": "3s",
-                   "actions": {
-                     "delete": {}
-                   }
-                 }
-               }
-             }
-           }
-
-
-  - do:
       indices.create:
         index: my_timeseries_index
         body:
@@ -247,9 +219,8 @@ setup:
   - match: { error.root_cause.0.reason: "Cannot delete policy [my_timeseries_lifecycle]. It is being used by at least one index [my_timeseries_index]" }
 
   - do:
-      xpack.index_lifecycle.set_policy:
+      xpack.index_lifecycle.remove_policy:
         index: my_timeseries_index
-        new_policy: "blah_lifecycle"
 
   - do:
       acknowledge: true

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/index_lifecycle/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/index_lifecycle/10_basic.yml
@@ -205,6 +205,34 @@ setup:
   - match: { my_timeseries_lifecycle.phases.delete.after: "30s" }
 
   - do:
+      acknowlege: true
+      xpack.index_lifecycle.put_lifecycle:
+        lifecycle: "blah_lifecycle"
+        body: |
+           {
+             "policy": {
+               "type": "timeseries",
+               "phases": {
+                 "warm": {
+                   "after": "1s",
+                   "actions": {
+                     "forcemerge": {
+                       "max_num_segments": 1
+                     }
+                   }
+                 },
+                 "delete": {
+                   "after": "3s",
+                   "actions": {
+                     "delete": {}
+                   }
+                 }
+               }
+             }
+           }
+
+
+  - do:
       indices.create:
         index: my_timeseries_index
         body:
@@ -219,10 +247,9 @@ setup:
   - match: { error.root_cause.0.reason: "Cannot delete policy [my_timeseries_lifecycle]. It is being used by at least one index [my_timeseries_index]" }
 
   - do:
-      indices.put_settings:
+      xpack.index_lifecycle.set_policy:
         index: my_timeseries_index
-        body:
-          index.lifecycle.name: ""
+        new_policy: "blah_lifecycle"
 
   - do:
       acknowledge: true


### PR DESCRIPTION
This commit makes the `index.lifecycle.name` setting internal an index, this
means that the policy can only be set on the index creation, or with the
specialized `RestSetIndexLifecyclePolicy` action.

Relates to #29823

@colings86 I'm not 100% sure we should do as-is. You currently can't remove a policy from the index, unlike a setting (which you could set to `null` to remove it) we don't currently have a way to do that, in order to delete a policy then you have to create a dummy policy and update the index to use it. Maybe someone can explain more of the background for why we originally wanted this to be an internal setting?

I think we should either add an API to remove the lifecycle policy from an index, or keep this as a dynamic setting, what do you think?