### PR TITLE
[Rollup] Remove builders from HistoGroupConfig

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/GroupConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/GroupConfig.java
@@ -44,18 +44,18 @@ public class GroupConfig implements Writeable, ToXContentObject {
     private static final ParseField TERMS = new ParseField("terms");
 
     private final DateHistoGroupConfig dateHisto;
-    private final HistoGroupConfig histo;
+    private final HistogramGroupConfig histo;
     private final TermsGroupConfig terms;
 
     public static final ObjectParser<GroupConfig.Builder, Void> PARSER = new ObjectParser<>(NAME, GroupConfig.Builder::new);
 
     static {
         PARSER.declareObject(GroupConfig.Builder::setDateHisto, (p,c) -> DateHistoGroupConfig.PARSER.apply(p,c).build(), DATE_HISTO);
-        PARSER.declareObject(GroupConfig.Builder::setHisto, (p,c) -> HistoGroupConfig.PARSER.apply(p,c).build(), HISTO);
+        PARSER.declareObject(GroupConfig.Builder::setHisto, (p,c) -> HistogramGroupConfig.fromXContent(p), HISTO);
         PARSER.declareObject(GroupConfig.Builder::setTerms, (p,c) -> TermsGroupConfig.fromXContent(p), TERMS);
     }
 
-    private GroupConfig(DateHistoGroupConfig dateHisto, @Nullable HistoGroupConfig histo, @Nullable TermsGroupConfig terms) {
+    private GroupConfig(DateHistoGroupConfig dateHisto, @Nullable HistogramGroupConfig histo, @Nullable TermsGroupConfig terms) {
         this.dateHisto = Objects.requireNonNull(dateHisto, "A date_histogram group is mandatory");
         this.histo = histo;
         this.terms = terms;
@@ -63,7 +63,7 @@ public class GroupConfig implements Writeable, ToXContentObject {
 
     GroupConfig(StreamInput in) throws IOException {
         dateHisto = new DateHistoGroupConfig(in);
-        histo = in.readOptionalWriteable(HistoGroupConfig::new);
+        histo = in.readOptionalWriteable(HistogramGroupConfig::new);
         terms = in.readOptionalWriteable(TermsGroupConfig::new);
     }
 
@@ -71,7 +71,7 @@ public class GroupConfig implements Writeable, ToXContentObject {
         return dateHisto;
     }
 
-    public HistoGroupConfig getHisto() {
+    public HistogramGroupConfig getHisto() {
         return histo;
     }
 
@@ -83,7 +83,7 @@ public class GroupConfig implements Writeable, ToXContentObject {
         Set<String> fields = new HashSet<>();
         fields.add(dateHisto.getField());
         if (histo != null) {
-            fields.addAll(histo.getAllFields());
+            fields.addAll(asList(histo.getFields()));
         }
         if (terms != null) {
             fields.addAll(asList(terms.getFields()));
@@ -109,9 +109,7 @@ public class GroupConfig implements Writeable, ToXContentObject {
         dateHisto.toXContent(builder, params);
         builder.endObject();
         if (histo != null) {
-            builder.startObject(HISTO.getPreferredName());
-            histo.toXContent(builder, params);
-            builder.endObject();
+            builder.field(HISTO.getPreferredName(), histo);
         }
         if (terms != null) {
             builder.field(TERMS.getPreferredName(), terms);
@@ -156,7 +154,7 @@ public class GroupConfig implements Writeable, ToXContentObject {
 
     public static class Builder {
         private DateHistoGroupConfig dateHisto;
-        private HistoGroupConfig histo;
+        private HistogramGroupConfig histo;
         private TermsGroupConfig terms;
 
         public DateHistoGroupConfig getDateHisto() {
@@ -168,11 +166,11 @@ public class GroupConfig implements Writeable, ToXContentObject {
             return this;
         }
 
-        public HistoGroupConfig getHisto() {
+        public HistogramGroupConfig getHisto() {
             return histo;
         }
 
-        public GroupConfig.Builder setHisto(HistoGroupConfig histo) {
+        public GroupConfig.Builder setHisto(HistogramGroupConfig histo) {
             this.histo = histo;
             return this;
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/ConfigTestHelpers.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/ConfigTestHelpers.java
@@ -5,12 +5,13 @@
  */
 package org.elasticsearch.xpack.core.rollup;
 
+import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.rollup.job.DateHistoGroupConfig;
 import org.elasticsearch.xpack.core.rollup.job.GroupConfig;
-import org.elasticsearch.xpack.core.rollup.job.HistoGroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.HistogramGroupConfig;
 import org.elasticsearch.xpack.core.rollup.job.MetricConfig;
 import org.elasticsearch.xpack.core.rollup.job.RollupJobConfig;
 import org.elasticsearch.xpack.core.rollup.job.TermsGroupConfig;
@@ -50,7 +51,7 @@ public class ConfigTestHelpers {
         GroupConfig.Builder groupBuilder = new GroupConfig.Builder();
         groupBuilder.setDateHisto(getDateHisto().build());
         if (ESTestCase.randomBoolean()) {
-            groupBuilder.setHisto(getHisto().build());
+            groupBuilder.setHisto(randomHistogramGroupConfig(ESTestCase.random()));
         }
         if (ESTestCase.randomBoolean()) {
             groupBuilder.setTerms(randomTermsGroupConfig(ESTestCase.random()));
@@ -102,13 +103,6 @@ public class ConfigTestHelpers {
         return dateHistoBuilder;
     }
 
-    public static HistoGroupConfig.Builder getHisto() {
-        HistoGroupConfig.Builder histoBuilder = new HistoGroupConfig.Builder();
-        histoBuilder.setInterval(ESTestCase.randomIntBetween(1,10000));
-        histoBuilder.setFields(getFields());
-        return histoBuilder;
-    }
-
     public static  List<String> getFields() {
         return IntStream.range(0, ESTestCase.randomIntBetween(1, 10))
                 .mapToObj(n -> ESTestCase.randomAlphaOfLengthBetween(5, 10))
@@ -123,6 +117,10 @@ public class ConfigTestHelpers {
                 " " + (ESTestCase.randomBoolean() ? "*" : String.valueOf(ESTestCase.randomIntBetween(1, 12)))      + //month
                 " ?"                                                                         + //day of week
                 " " + (ESTestCase.randomBoolean() ? "*" : String.valueOf(ESTestCase.randomIntBetween(1970, 2199)));  //year
+    }
+
+    public static HistogramGroupConfig randomHistogramGroupConfig(final Random random) {
+        return new HistogramGroupConfig(randomInterval(random), randomFields(random));
     }
 
     public static TermsGroupConfig randomTermsGroupConfig(final Random random) {
@@ -140,5 +138,9 @@ public class ConfigTestHelpers {
 
     private static String randomField(final Random random) {
         return randomAsciiAlphanumOfLengthBetween(random, 5, 10);
+    }
+
+    private static long randomInterval(final Random random) {
+        return RandomNumbers.randomLongBetween(random, 0L, Long.MAX_VALUE);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/ConfigTestHelpers.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/ConfigTestHelpers.java
@@ -141,6 +141,6 @@ public class ConfigTestHelpers {
     }
 
     private static long randomInterval(final Random random) {
-        return RandomNumbers.randomLongBetween(random, 0L, Long.MAX_VALUE);
+        return RandomNumbers.randomLongBetween(random, 1L, Long.MAX_VALUE);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/job/HistogramGroupConfigSerializingTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/job/HistogramGroupConfigSerializingTests.java
@@ -10,7 +10,6 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractSerializingTestCase;
-import org.elasticsearch.xpack.core.rollup.ConfigTestHelpers;
 import org.elasticsearch.xpack.core.rollup.RollupField;
 
 import java.io.IOException;
@@ -18,34 +17,33 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.core.rollup.ConfigTestHelpers.randomHistogramGroupConfig;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class HistoGroupConfigSerializingTests extends AbstractSerializingTestCase<HistoGroupConfig> {
+public class HistogramGroupConfigSerializingTests extends AbstractSerializingTestCase<HistogramGroupConfig> {
+
     @Override
-    protected HistoGroupConfig doParseInstance(XContentParser parser) throws IOException {
-        return HistoGroupConfig.PARSER.apply(parser, null).build();
+    protected HistogramGroupConfig doParseInstance(XContentParser parser) throws IOException {
+        return HistogramGroupConfig.fromXContent(parser);
     }
 
     @Override
-    protected Writeable.Reader<HistoGroupConfig> instanceReader() {
-        return HistoGroupConfig::new;
+    protected Writeable.Reader<HistogramGroupConfig> instanceReader() {
+        return HistogramGroupConfig::new;
     }
 
     @Override
-    protected HistoGroupConfig createTestInstance() {
-        return ConfigTestHelpers.getHisto().build();
+    protected HistogramGroupConfig createTestInstance() {
+        return randomHistogramGroupConfig(random());
     }
 
     public void testValidateNoMapping() throws IOException {
         ActionRequestValidationException e = new ActionRequestValidationException();
         Map<String, Map<String, FieldCapabilities>> responseMap = new HashMap<>();
 
-        HistoGroupConfig config = new HistoGroupConfig.Builder()
-                .setFields(Collections.singletonList("my_field"))
-                .setInterval(123)
-                .build();
+        HistogramGroupConfig config = new HistogramGroupConfig(132, "my_field");
         config.validateMappings(responseMap, e);
         assertThat(e.validationErrors().get(0), equalTo("Could not find a [numeric] field with name [my_field] in any of the " +
                 "indices matching the index pattern."));
@@ -60,10 +58,7 @@ public class HistoGroupConfigSerializingTests extends AbstractSerializingTestCas
         FieldCapabilities fieldCaps = mock(FieldCapabilities.class);
         responseMap.put("some_other_field", Collections.singletonMap("long", fieldCaps));
 
-        HistoGroupConfig config = new HistoGroupConfig.Builder()
-                .setFields(Collections.singletonList("my_field"))
-                .setInterval(123)
-                .build();
+        HistogramGroupConfig config = new HistogramGroupConfig(132, "my_field");
         config.validateMappings(responseMap, e);
         assertThat(e.validationErrors().get(0), equalTo("Could not find a [numeric] field with name [my_field] in any of the " +
                 "indices matching the index pattern."));
@@ -78,10 +73,7 @@ public class HistoGroupConfigSerializingTests extends AbstractSerializingTestCas
         FieldCapabilities fieldCaps = mock(FieldCapabilities.class);
         responseMap.put("my_field", Collections.singletonMap("keyword", fieldCaps));
 
-        HistoGroupConfig config = new HistoGroupConfig.Builder()
-                .setFields(Collections.singletonList("my_field"))
-                .setInterval(123)
-                .build();
+        HistogramGroupConfig config = new HistogramGroupConfig(132, "my_field");
         config.validateMappings(responseMap, e);
         assertThat(e.validationErrors().get(0), equalTo("The field referenced by a histo group must be a [numeric] type, but " +
                 "found [keyword] for field [my_field]"));
@@ -97,10 +89,7 @@ public class HistoGroupConfigSerializingTests extends AbstractSerializingTestCas
         when(fieldCaps.isAggregatable()).thenReturn(false);
         responseMap.put("my_field", Collections.singletonMap("long", fieldCaps));
 
-        HistoGroupConfig config = new HistoGroupConfig.Builder()
-                .setFields(Collections.singletonList("my_field"))
-                .setInterval(123)
-                .build();
+        HistogramGroupConfig config = new HistogramGroupConfig(132, "my_field");
         config.validateMappings(responseMap, e);
         assertThat(e.validationErrors().get(0), equalTo("The field [my_field] must be aggregatable across all indices, but is not."));
     }
@@ -115,10 +104,7 @@ public class HistoGroupConfigSerializingTests extends AbstractSerializingTestCas
         String mappingType = randomFrom(RollupField.NUMERIC_FIELD_MAPPER_TYPES);
         responseMap.put("my_field", Collections.singletonMap(mappingType, fieldCaps));
 
-        HistoGroupConfig config = new HistoGroupConfig.Builder()
-                .setFields(Collections.singletonList("my_field"))
-                .setInterval(123)
-                .build();
+        HistogramGroupConfig config = new HistogramGroupConfig(132, "my_field");
         config.validateMappings(responseMap, e);
         assertThat(e.validationErrors().size(), equalTo(0));
     }

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupJobIdentifierUtilTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupJobIdentifierUtilTests.java
@@ -19,7 +19,7 @@ import org.elasticsearch.xpack.core.rollup.ConfigTestHelpers;
 import org.elasticsearch.xpack.core.rollup.action.RollupJobCaps;
 import org.elasticsearch.xpack.core.rollup.job.DateHistoGroupConfig;
 import org.elasticsearch.xpack.core.rollup.job.GroupConfig;
-import org.elasticsearch.xpack.core.rollup.job.HistoGroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.HistogramGroupConfig;
 import org.elasticsearch.xpack.core.rollup.job.MetricConfig;
 import org.elasticsearch.xpack.core.rollup.job.RollupJobConfig;
 import org.elasticsearch.xpack.core.rollup.job.TermsGroupConfig;
@@ -267,7 +267,7 @@ public class RollupJobIdentifierUtilTests extends ESTestCase {
         RollupJobConfig.Builder job2 = ConfigTestHelpers.getRollupJob("foo2").setRollupIndex(job.getRollupIndex());
         GroupConfig.Builder group2 = ConfigTestHelpers.getGroupConfig();
         group2.setDateHisto(new DateHistoGroupConfig.Builder().setField("foo").setInterval(new DateHistogramInterval("1h")).build())
-                .setHisto(ConfigTestHelpers.getHisto().setInterval(100).setFields(Collections.singletonList("bar")).build())
+                .setHisto(new HistogramGroupConfig(100L, "bar"))
                 .setTerms(null);
         job2.setGroupConfig(group2.build());
         RollupJobCaps cap2 = new RollupJobCaps(job2.build());
@@ -329,10 +329,7 @@ public class RollupJobIdentifierUtilTests extends ESTestCase {
                                 .setField("foo") // <-- NOTE same name but wrong type
                                 .setTimeZone(DateTimeZone.UTC)
                                 .build())
-                        .setHisto(new HistoGroupConfig.Builder()
-                                .setFields(Collections.singletonList("baz")) // <-- NOTE right type but wrong name
-                                .setInterval(1L)
-                                .build())
+                        .setHisto(new HistogramGroupConfig(1L, "baz")) // <-- NOTE right type but wrong name
                         .build())
                 .setMetricsConfig(Arrays.asList(new MetricConfig.Builder()
                                 .setField("max_field")
@@ -443,10 +440,7 @@ public class RollupJobIdentifierUtilTests extends ESTestCase {
                                 .setField("bar")
                                 .setTimeZone(DateTimeZone.UTC)
                                 .build())
-                        .setHisto(new HistoGroupConfig.Builder()
-                                .setFields(Collections.singletonList("baz")) // <-- NOTE note different field from one used in query
-                                .setInterval(1L)
-                                .build())
+                        .setHisto(new HistogramGroupConfig(1L, "baz")) // <-- NOTE right type but wrong name
                         .build())
                 .setMetricsConfig(Arrays.asList(new MetricConfig.Builder()
                                 .setField("max_field")
@@ -476,10 +470,7 @@ public class RollupJobIdentifierUtilTests extends ESTestCase {
                                 .setField("foo")
                                 .setTimeZone(DateTimeZone.UTC)
                                 .build())
-                        .setHisto(new HistoGroupConfig.Builder()
-                                .setFields(Collections.singletonList("bar"))
-                                .setInterval(100L) // <--- interval in job is much higher than agg interval above
-                                .build())
+                        .setHisto(new HistogramGroupConfig(1L, "baz")) // <-- NOTE right type but wrong name
                         .build())
                 .build();
         Set<RollupJobCaps> caps = singletonSet(new RollupJobCaps(job));

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/SearchActionTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/SearchActionTests.java
@@ -71,6 +71,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.xpack.core.rollup.ConfigTestHelpers.randomHistogramGroupConfig;
 import static org.elasticsearch.xpack.core.rollup.RollupField.COUNT_FIELD;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -502,7 +503,7 @@ public class SearchActionTests extends ESTestCase {
         RollupJobConfig.Builder job2 = ConfigTestHelpers.getRollupJob("foo2").setRollupIndex(job.getRollupIndex());
         GroupConfig.Builder group2 = ConfigTestHelpers.getGroupConfig();
         group2.setDateHisto(group.getDateHisto())
-                .setHisto(ConfigTestHelpers.getHisto().build())
+                .setHisto(randomHistogramGroupConfig(random()))
                 .setTerms(null);
         job2.setGroupConfig(group2.build());
         RollupJobCaps cap2 = new RollupJobCaps(job2.build());

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/config/ConfigTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/config/ConfigTests.java
@@ -202,7 +202,7 @@ public class ConfigTests extends ESTestCase {
     }
 
     public void testEmptyHistoField() {
-        Exception e = expectThrows(IllegalArgumentException.class, () -> new HistogramGroupConfig(1L, null));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> new HistogramGroupConfig(1L, (String[]) null));
         assertThat(e.getMessage(), equalTo("Fields must have at least one value"));
 
         e = expectThrows(IllegalArgumentException.class, () -> new HistogramGroupConfig(1L, new String[0]));

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/config/ConfigTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/config/ConfigTests.java
@@ -202,14 +202,18 @@ public class ConfigTests extends ESTestCase {
     }
 
     public void testEmptyHistoField() {
-        final String[] fields = randomBoolean() ? new String[0] : null;
-        Exception e = expectThrows(IllegalArgumentException.class, () -> new HistogramGroupConfig(1L, fields));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> new HistogramGroupConfig(1L, null));
+        assertThat(e.getMessage(), equalTo("Fields must have at least one value"));
+
+        e = expectThrows(IllegalArgumentException.class, () -> new HistogramGroupConfig(1L, new String[0]));
         assertThat(e.getMessage(), equalTo("Fields must have at least one value"));
     }
 
     public void testBadHistoIntervals() {
-        final long interval = randomBoolean() ? 0L : -1L;
-        Exception e = expectThrows(IllegalArgumentException.class, () -> new HistogramGroupConfig(interval, "foo", "bar"));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> new HistogramGroupConfig(0L, "foo", "bar"));
+        assertThat(e.getMessage(), equalTo("Interval must be a positive long"));
+
+        e = expectThrows(IllegalArgumentException.class, () -> new HistogramGroupConfig(-1L, "foo", "bar"));
         assertThat(e.getMessage(), equalTo("Interval must be a positive long"));
     }
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/IndexerUtilsTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/IndexerUtilsTests.java
@@ -52,6 +52,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.core.rollup.ConfigTestHelpers.randomHistogramGroupConfig;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -354,7 +355,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
         });
 
         GroupConfig.Builder groupConfig = ConfigTestHelpers.getGroupConfig();
-        groupConfig.setHisto(ConfigTestHelpers.getHisto().setFields(Collections.singletonList("abc")).build());
+        groupConfig.setHisto(randomHistogramGroupConfig(random()));
 
         List<IndexRequest> docs = IndexerUtils.processBuckets(composite, "foo", new RollupJobStats(), groupConfig.build(), "foo");
         assertThat(docs.size(), equalTo(1));
@@ -383,7 +384,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
         });
 
         GroupConfig.Builder groupConfig = ConfigTestHelpers.getGroupConfig();
-        groupConfig.setHisto(ConfigTestHelpers.getHisto().setFields(Collections.singletonList("abc")).build());
+        groupConfig.setHisto(randomHistogramGroupConfig(random()));
 
         List<IndexRequest> docs = IndexerUtils.processBuckets(composite, "foo", new RollupJobStats(), groupConfig.build(), "foo");
         assertThat(docs.size(), equalTo(1));

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/IndexerUtilsTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/IndexerUtilsTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xpack.core.rollup.ConfigTestHelpers;
 import org.elasticsearch.xpack.core.rollup.RollupField;
 import org.elasticsearch.xpack.core.rollup.job.DateHistoGroupConfig;
 import org.elasticsearch.xpack.core.rollup.job.GroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.HistogramGroupConfig;
 import org.elasticsearch.xpack.core.rollup.job.MetricConfig;
 import org.elasticsearch.xpack.core.rollup.job.RollupJobStats;
 import org.elasticsearch.xpack.core.rollup.job.TermsGroupConfig;
@@ -354,8 +355,10 @@ public class IndexerUtilsTests extends AggregatorTestCase {
             return foos;
         });
 
+        // The content of the config don't actually matter for this test
+        // because the test is just looking at agg keys
         GroupConfig.Builder groupConfig = ConfigTestHelpers.getGroupConfig();
-        groupConfig.setHisto(randomHistogramGroupConfig(random()));
+        groupConfig.setHisto(new HistogramGroupConfig(123L, "abc"));
 
         List<IndexRequest> docs = IndexerUtils.processBuckets(composite, "foo", new RollupJobStats(), groupConfig.build(), "foo");
         assertThat(docs.size(), equalTo(1));


### PR DESCRIPTION
Same motivation as #32507 but for the `HistoGroupConfig` configuration object.

Related to #29827