### PR TITLE
Millisecond output optional in _cat/indices test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
@@ -42,9 +42,9 @@
                /^(
                   index1                                                    \s+
                   (\d+)                                                     \s+
-                  (\d\d\d\d\-\d\d\-\d\dT\d\d:\d\d:\d\d.\d\d\dZ) \s+
+                  (\d\d\d\d\-\d\d\-\d\dT\d\d:\d\d:\d\d(.\d\d\d)?Z) \s+
                   (\d+)                                                     \s+
-                  (\d\d\d\d\-\d\d\-\d\dT\d\d:\d\d:\d\d.\d\d\dZ) \s*
+                  (\d\d\d\d\-\d\d\-\d\dT\d\d:\d\d:\d\d(.\d\d\d)?Z) \s*
                 )
                 $/
   - do:


### PR DESCRIPTION
Today we assert that _cat/indices returns a string matching

    \d\d\d\d\-\d\d\-\d\dT\d\d:\d\d:\d\d.\d\d\d?Z

in the `creation.date.string` field. However, if the index was created exactly
on the second then the milliseconds part is omitted from the output. This updates
the test to allow for this case, and also to insist that the separator between the
seconds and the milliseconds fields is `.` and not an arbitrary character.