### PR TITLE
Remove _xpack from CCR APIs

### DIFF
--- a/x-pack/plugin/ccr/qa/multi-cluster-with-security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster-with-security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
@@ -76,7 +76,7 @@ public class FollowIndexSecurityIT extends ESRestTestCase {
             createAndFollowIndex("leader_cluster:" + allowedIndex, allowedIndex);
             assertBusy(() -> verifyDocuments(client(), allowedIndex, numDocs));
             assertThat(countCcrNodeTasks(), equalTo(1));
-            assertOK(client().performRequest(new Request("POST", "/" + allowedIndex + "/_xpack/ccr/_unfollow")));
+            assertOK(client().performRequest(new Request("POST", "/" + allowedIndex + "/_ccr/unfollow")));
             // Make sure that there are no other ccr relates operations running:
             assertBusy(() -> {
                 Map<String, Object> clusterState = toMap(adminClient().performRequest(new Request("GET", "/_cluster/state")));
@@ -87,7 +87,7 @@ public class FollowIndexSecurityIT extends ESRestTestCase {
 
             followIndex("leader_cluster:" + allowedIndex, allowedIndex);
             assertThat(countCcrNodeTasks(), equalTo(1));
-            assertOK(client().performRequest(new Request("POST", "/" + allowedIndex + "/_xpack/ccr/_unfollow")));
+            assertOK(client().performRequest(new Request("POST", "/" + allowedIndex + "/_ccr/unfollow")));
             // Make sure that there are no other ccr relates operations running:
             assertBusy(() -> {
                 Map<String, Object> clusterState = toMap(adminClient().performRequest(new Request("GET", "/_cluster/state")));
@@ -144,13 +144,13 @@ public class FollowIndexSecurityIT extends ESRestTestCase {
     }
 
     private static void followIndex(String leaderIndex, String followIndex) throws IOException {
-        final Request request = new Request("POST", "/" + followIndex + "/_xpack/ccr/_follow");
+        final Request request = new Request("POST", "/" + followIndex + "/_ccr/follow");
         request.setJsonEntity("{\"leader_index\": \"" + leaderIndex + "\", \"idle_shard_retry_delay\": \"10ms\"}");
         assertOK(client().performRequest(request));
     }
 
     private static void createAndFollowIndex(String leaderIndex, String followIndex) throws IOException {
-        final Request request = new Request("POST", "/" + followIndex + "/_xpack/ccr/_create_and_follow");
+        final Request request = new Request("POST", "/" + followIndex + "/_ccr/create_and_follow");
         request.setJsonEntity("{\"leader_index\": \"" + leaderIndex + "\", \"idle_shard_retry_delay\": \"10ms\"}");
         assertOK(client().performRequest(request));
     }

--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexIT.java
@@ -94,19 +94,19 @@ public class FollowIndexIT extends ESRestTestCase {
     }
 
     private static void followIndex(String leaderIndex, String followIndex) throws IOException {
-        final Request request = new Request("POST", "/" + followIndex + "/_xpack/ccr/_follow");
+        final Request request = new Request("POST", "/" + followIndex + "/_ccr/follow");
         request.setJsonEntity("{\"leader_index\": \"" + leaderIndex + "\", \"idle_shard_retry_delay\": \"10ms\"}");
         assertOK(client().performRequest(request));
     }
 
     private static void createAndFollowIndex(String leaderIndex, String followIndex) throws IOException {
-        final Request request = new Request("POST", "/" + followIndex + "/_xpack/ccr/_create_and_follow");
+        final Request request = new Request("POST", "/" + followIndex + "/_ccr/create_and_follow");
         request.setJsonEntity("{\"leader_index\": \"" + leaderIndex + "\", \"idle_shard_retry_delay\": \"10ms\"}");
         assertOK(client().performRequest(request));
     }
 
     private static void unfollowIndex(String followIndex) throws IOException {
-        assertOK(client().performRequest(new Request("POST", "/" + followIndex + "/_xpack/ccr/_unfollow")));
+        assertOK(client().performRequest(new Request("POST", "/" + followIndex + "/_ccr/unfollow")));
     }
 
     private static void verifyDocuments(String index, int expectedNumDocs) throws IOException {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestCreateAndFollowIndexAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestCreateAndFollowIndexAction.java
@@ -21,12 +21,12 @@ public class RestCreateAndFollowIndexAction extends BaseRestHandler {
 
     public RestCreateAndFollowIndexAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.POST, "/{index}/_xpack/ccr/_create_and_follow", this);
+        controller.registerHandler(RestRequest.Method.POST, "/{index}/_ccr/create_and_follow", this);
     }
 
     @Override
     public String getName() {
-        return "xpack_ccr_create_and_follow_index_action";
+        return "ccr_create_and_follow_index_action";
     }
 
     @Override

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestFollowIndexAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestFollowIndexAction.java
@@ -22,12 +22,12 @@ public class RestFollowIndexAction extends BaseRestHandler {
 
     public RestFollowIndexAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.POST, "/{index}/_xpack/ccr/_follow", this);
+        controller.registerHandler(RestRequest.Method.POST, "/{index}/_ccr/follow", this);
     }
 
     @Override
     public String getName() {
-        return "xpack_ccr_follow_index_action";
+        return "ccr_follow_index_action";
     }
 
     @Override

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestUnfollowIndexAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestUnfollowIndexAction.java
@@ -21,12 +21,12 @@ public class RestUnfollowIndexAction extends BaseRestHandler {
 
     public RestUnfollowIndexAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.POST, "/{index}/_xpack/ccr/_unfollow", this);
+        controller.registerHandler(RestRequest.Method.POST, "/{index}/_ccr/unfollow", this);
     }
 
     @Override
     public String getName() {
-        return "xpack_ccr_unfollow_index_action";
+        return "ccr_unfollow_index_action";
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.create_and_follow_index.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.create_and_follow_index.json
@@ -1,15 +1,15 @@
 {
-  "xpack.ccr.follow_index": {
+  "ccr.create_and_follow_index": {
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current",
     "methods": [ "POST" ],
     "url": {
-      "path": "/{index}/_xpack/ccr/_follow",
-      "paths": [ "/{index}/_xpack/ccr/_follow" ],
+      "path": "/{index}/_ccr/create_and_follow",
+      "paths": [ "/{index}/_ccr/create_and_follow" ],
       "parts": {
         "index": {
           "type": "string",
           "required": true,
-          "description": "The name of the follower index."
+          "description": "The name of the follower index"
         }
       }
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow_index.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow_index.json
@@ -1,15 +1,15 @@
 {
-  "xpack.ccr.create_and_follow_index": {
+  "ccr.follow_index": {
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current",
     "methods": [ "POST" ],
     "url": {
-      "path": "/{index}/_xpack/ccr/_create_and_follow",
-      "paths": [ "/{index}/_xpack/ccr/_create_and_follow" ],
+      "path": "/{index}/_ccr/follow",
+      "paths": [ "/{index}/_ccr/follow" ],
       "parts": {
         "index": {
           "type": "string",
           "required": true,
-          "description": "The name of the follower index"
+          "description": "The name of the follower index."
         }
       }
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.unfollow_index.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.unfollow_index.json
@@ -1,10 +1,10 @@
 {
-  "xpack.ccr.unfollow_index": {
+  "ccr.unfollow_index": {
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current",
     "methods": [ "POST" ],
     "url": {
-      "path": "/{index}/_xpack/ccr/_unfollow",
-      "paths": [ "/{index}/_xpack/ccr/_unfollow" ],
+      "path": "/{index}/_ccr/unfollow",
+      "paths": [ "/{index}/_ccr/unfollow" ],
       "parts": {
         "index": {
           "type": "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ccr/follow_and_unfollow.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ccr/follow_and_unfollow.yml
@@ -16,7 +16,7 @@
   - is_true: acknowledged
 
   - do:
-      xpack.ccr.create_and_follow_index:
+      ccr.create_and_follow_index:
         index: bar
         body:
           leader_index: foo
@@ -25,18 +25,18 @@
   - is_true: index_following_started
 
   - do:
-      xpack.ccr.unfollow_index:
+      ccr.unfollow_index:
         index: bar
   - is_true: acknowledged
 
   - do:
-      xpack.ccr.follow_index:
+      ccr.follow_index:
         index: bar
         body:
           leader_index: foo
   - is_true: acknowledged
 
   - do:
-      xpack.ccr.unfollow_index:
+      ccr.unfollow_index:
         index: bar
   - is_true: acknowledged


### PR DESCRIPTION
For a new feature like CCR we will go without this extra layer of indirection. This commit replaces all /_xpack/ccr/_(\S+) endpoints by /_ccr/$1 endpoints.
