### PR TITLE
[Rollup] Move getMetadata() methods out of configuration objects

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/DateHistogramGroupConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/DateHistogramGroupConfig.java
@@ -211,10 +211,6 @@ public class DateHistogramGroupConfig implements Writeable, ToXContentObject {
         return map;
     }
 
-    public Map<String, Object> getMetadata() {
-        return Collections.singletonMap(RollupField.formatMetaField(RollupField.INTERVAL), interval.toString());
-    }
-
     public void validateMappings(Map<String, Map<String, FieldCapabilities>> fieldCapsResponse,
                                                              ActionRequestValidationException validationException) {
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/HistogramGroupConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/HistogramGroupConfig.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
@@ -115,8 +116,8 @@ public class HistogramGroupConfig implements Writeable, ToXContentObject {
         return map;
     }
 
-    public Map<String, Object> getMetadata() {
-        return Collections.singletonMap(RollupField.formatMetaField(RollupField.INTERVAL), interval);
+    public Set<String> getAllFields() {
+        return Arrays.stream(fields).collect(Collectors.toSet());
     }
 
     public void validateMappings(Map<String, Map<String, FieldCapabilities>> fieldCapsResponse,

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.rollup.job;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.rollup.ConfigTestHelpers;
+import org.elasticsearch.xpack.core.rollup.job.DateHistogramGroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.GroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.HistogramGroupConfig;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class RollupIndexerTests extends ESTestCase {
+
+    public void testCreateMetadataNoGroupConfig() {
+        final Map<String, Object> metadata = RollupIndexer.createMetadata(null);
+        assertNotNull(metadata);
+        assertTrue(metadata.isEmpty());
+    }
+
+    public void testCreateMetadataWithDateHistogramGroupConfigOnly() {
+        final DateHistogramGroupConfig dateHistogram = ConfigTestHelpers.randomDateHistogramGroupConfig(random());
+        final GroupConfig groupConfig = new GroupConfig(dateHistogram);
+
+        final Map<String, Object> metadata = RollupIndexer.createMetadata(groupConfig);
+        assertEquals(1, metadata.size());
+        assertTrue(metadata.containsKey("_rollup.interval"));
+        Object value = metadata.get("_rollup.interval");
+        assertThat(value, equalTo(dateHistogram.getInterval().toString()));
+    }
+
+    public void testCreateMetadata() {
+        final DateHistogramGroupConfig dateHistogram = ConfigTestHelpers.randomDateHistogramGroupConfig(random());
+        final HistogramGroupConfig histogram = ConfigTestHelpers.randomHistogramGroupConfig(random());
+        final GroupConfig groupConfig = new GroupConfig(dateHistogram, histogram, null);
+
+        final Map<String, Object> metadata = RollupIndexer.createMetadata(groupConfig);
+        assertEquals(1, metadata.size());
+        assertTrue(metadata.containsKey("_rollup.interval"));
+        Object value = metadata.get("_rollup.interval");
+        assertThat(value, equalTo(histogram.getInterval()));
+    }
+}
+


### PR DESCRIPTION
This pull request removes the `getMetadata()` methods from the `DateHistoGroupConfig` and `HistoGroupConfig` objects. This way the configuration objects do not rely on `RollupField.formatMetaField()` anymore and do not expose a `getMetadata()` method that is tighlty coupled to the rollup indexer.