### PR TITLE
[Rollup] Move toAggCap() methods out of rollup config objects

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/DateHistogramGroupConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/DateHistogramGroupConfig.java
@@ -29,7 +29,6 @@ import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -55,10 +54,10 @@ import static org.elasticsearch.common.xcontent.ObjectParser.ValueType;
 public class DateHistogramGroupConfig implements Writeable, ToXContentObject {
 
     static final String NAME = "date_histogram";
-    private static final String INTERVAL = "interval";
+    public static final String INTERVAL = "interval";
     private static final String FIELD = "field";
     public static final String TIME_ZONE = "time_zone";
-    private static final String DELAY = "delay";
+    public static final String DELAY = "delay";
     private static final String DEFAULT_TIMEZONE = "UTC";
     private static final ConstructingObjectParser<DateHistogramGroupConfig, Void> PARSER;
     static {
@@ -194,21 +193,6 @@ public class DateHistogramGroupConfig implements Writeable, ToXContentObject {
         vsBuilder.field(field);
         vsBuilder.timeZone(toDateTimeZone(timeZone));
         return Collections.singletonList(vsBuilder);
-    }
-
-    /**
-     * @return A map representing this config object as a RollupCaps aggregation object
-     */
-    public Map<String, Object> toAggCap() {
-        Map<String, Object> map = new HashMap<>(3);
-        map.put("agg", DateHistogramAggregationBuilder.NAME);
-        map.put(INTERVAL, interval.toString());
-        if (delay != null) {
-            map.put(DELAY, delay.toString());
-        }
-        map.put(TIME_ZONE, timeZone);
-
-        return map;
     }
 
     public void validateMappings(Map<String, Map<String, FieldCapabilities>> fieldCapsResponse,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/HistogramGroupConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/HistogramGroupConfig.java
@@ -24,11 +24,9 @@ import org.elasticsearch.xpack.core.rollup.RollupField;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
@@ -48,7 +46,7 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constru
 public class HistogramGroupConfig implements Writeable, ToXContentObject {
 
     static final String NAME = "histogram";
-    private static final String INTERVAL = "interval";
+    public static final String INTERVAL = "interval";
     private static final String FIELDS = "fields";
     private static final ConstructingObjectParser<HistogramGroupConfig, Void> PARSER;
     static {
@@ -104,20 +102,6 @@ public class HistogramGroupConfig implements Writeable, ToXContentObject {
             vsBuilder.missingBucket(true);
             return vsBuilder;
         }).collect(Collectors.toList());
-    }
-
-    /**
-     * @return A map representing this config object as a RollupCaps aggregation object
-     */
-    public Map<String, Object> toAggCap() {
-        Map<String, Object> map = new HashMap<>(2);
-        map.put("agg", HistogramAggregationBuilder.NAME);
-        map.put(INTERVAL, interval);
-        return map;
-    }
-
-    public Set<String> getAllFields() {
-        return Arrays.stream(fields).collect(Collectors.toSet());
     }
 
     public void validateMappings(Map<String, Map<String, FieldCapabilities>> fieldCapsResponse,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/MetricConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/MetricConfig.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 
@@ -150,13 +149,6 @@ public class MetricConfig implements Writeable, ToXContentObject {
             aggs.add(newBuilder);
         }
         return aggs;
-    }
-
-    /**
-     * @return A map representing this config object as a RollupCaps aggregation object
-     */
-    public List<Map<String, Object>> toAggCap() {
-        return metrics.stream().map(metric -> Collections.singletonMap("agg", (Object)metric)).collect(Collectors.toList());
     }
 
     public void validateMappings(Map<String, Map<String, FieldCapabilities>> fieldCapsResponse,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/TermsGroupConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/TermsGroupConfig.java
@@ -25,7 +25,6 @@ import org.elasticsearch.xpack.core.rollup.RollupField;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -92,15 +91,6 @@ public class TermsGroupConfig implements Writeable, ToXContentObject {
             vsBuilder.missingBucket(true);
             return vsBuilder;
         }).collect(Collectors.toList());
-    }
-
-    /**
-     * @return A map representing this config object as a RollupCaps aggregation object
-     */
-    public Map<String, Object> toAggCap() {
-        Map<String, Object> map = new HashMap<>(1);
-        map.put("agg", TermsAggregationBuilder.NAME);
-        return map;
     }
 
     public void validateMappings(Map<String, Map<String, FieldCapabilities>> fieldCapsResponse,


### PR DESCRIPTION
This pull request moves the `toAggCap()` methods out of the rollup configuration objects. These methods are used in the `RollupJobCaps` and can be computed there, simplifying the rollup configuration objects.