### PR TITLE
[Kerberos] Use canonical host name with SPNEGO test

### DIFF
--- a/x-pack/qa/kerberos-tests/build.gradle
+++ b/x-pack/qa/kerberos-tests/build.gradle
@@ -41,7 +41,7 @@ Object httpPrincipal = new Object() {
     @Override
     String toString() {
         InetAddress resolvedAddress = InetAddress.getByName('127.0.0.1')
-        return "HTTP/" + resolvedAddress.getHostName()
+        return "HTTP/" + resolvedAddress.getCanonicalHostName()
     }
 }
 

--- a/x-pack/qa/kerberos-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationIT.java
+++ b/x-pack/qa/kerberos-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationIT.java
@@ -112,7 +112,7 @@ public class KerberosAuthenticationIT extends ESRestTestCase {
     protected HttpHost buildHttpHost(String host, int port) {
         try {
             InetAddress inetAddress = InetAddress.getByName(host);
-            return super.buildHttpHost(inetAddress.getHostName(), port);
+            return super.buildHttpHost(inetAddress.getCanonicalHostName(), port);
         } catch (UnknownHostException e) {
             assumeNoException("failed to resolve host [" + host + "]", e);
         }

--- a/x-pack/qa/kerberos-tests/src/test/resources/plugin-security.policy
+++ b/x-pack/qa/kerberos-tests/src/test/resources/plugin-security.policy
@@ -1,4 +1,7 @@
 grant {
   permission javax.security.auth.AuthPermission "doAsPrivileged";
   permission javax.security.auth.kerberos.DelegationPermission "\"HTTP/localhost@BUILD.ELASTIC.CO\" \"krbtgt/BUILD.ELASTIC.CO@BUILD.ELASTIC.CO\"";
+  permission javax.security.auth.kerberos.DelegationPermission "\"HTTP/localhost.localdomain@BUILD.ELASTIC.CO\" \"krbtgt/BUILD.ELASTIC.CO@BUILD.ELASTIC.CO\"";
+  permission javax.security.auth.kerberos.DelegationPermission "\"HTTP/localhost4@BUILD.ELASTIC.CO\" \"krbtgt/BUILD.ELASTIC.CO@BUILD.ELASTIC.CO\"";
+  permission javax.security.auth.kerberos.DelegationPermission "\"HTTP/localhost4.localdomain4@BUILD.ELASTIC.CO\" \"krbtgt/BUILD.ELASTIC.CO@BUILD.ELASTIC.CO\"";
 };


### PR DESCRIPTION
The Apache Http components support for Spnego scheme
uses the canonical hostname by default.
On Centos, by default, there are other aliases like
`localhost.localdomain`, `localhost4`, `localhost4.localdomain4`.
This commit modifies where we resolve hostname to use 
`getCanonicalHostName` instead of `getHostName` and adds 
DelegationPermission to security policy
for the alternate aliases of localhost.

Closes#32498