### PR TITLE
[TEST] Allow tests to run in FIPS JVM

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactoryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactoryTests.java
@@ -93,10 +93,13 @@ public class SessionFactoryTests extends ESTestCase {
         options = SessionFactory.connectionOptions(realmConfig, sslService.apply(settings), logger);
         assertThat(options.getSSLSocketVerifier(), is(instanceOf(TrustAllSSLSocketVerifier.class)));
 
-        settings = Settings.builder().put("ssl.verification_mode", VerificationMode.NONE).build();
-        realmConfig = new RealmConfig(realmName, settings, environment.settings(), environment, threadContext);
-        options = SessionFactory.connectionOptions(realmConfig, sslService.apply(settings), logger);
-        assertThat(options.getSSLSocketVerifier(), is(instanceOf(TrustAllSSLSocketVerifier.class)));
+        // Can't run in FIPS with verification_mode none, disable this check instead of duplicating the test case
+        if (inFipsJvm() == false) {
+            settings = Settings.builder().put("ssl.verification_mode", VerificationMode.NONE).build();
+            realmConfig = new RealmConfig(realmName, settings, environment.settings(), environment, threadContext);
+            options = SessionFactory.connectionOptions(realmConfig, sslService.apply(settings), logger);
+            assertThat(options.getSSLSocketVerifier(), is(instanceOf(TrustAllSSLSocketVerifier.class)));
+        }
 
         settings = Settings.builder().put("ssl.verification_mode", VerificationMode.FULL).build();
         realmConfig = new RealmConfig(realmName, settings, environment.settings(), environment, threadContext);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SecurityNioHttpServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SecurityNioHttpServerTransportTests.java
@@ -49,11 +49,13 @@ public class SecurityNioHttpServerTransportTests extends ESTestCase {
 
     @Before
     public void createSSLService() {
-        Path testNodeStore = getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks");
+        Path testNodeKey = getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem");
+        Path testNodeCert = getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt");
         MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString("xpack.ssl.keystore.secure_password", "testnode");
+        secureSettings.setString("xpack.ssl.secure_key_passphrase", "testnode");
         Settings settings = Settings.builder()
-            .put("xpack.ssl.keystore.path", testNodeStore)
+            .put("xpack.ssl.key", testNodeKey)
+            .put("xpack.ssl.certificate", testNodeCert)
             .put("path.home", createTempDir())
             .setSecureSettings(secureSettings)
             .build();


### PR DESCRIPTION
* Change SecurityNioHttpServerTransportTests to use PEM key and
certificate files instead of a JKS keystore so that this tests
can also run in a FIPS 140 JVM ( These tests were not in master when
#31666 was merged ) 
* Do not attempt to run cases with ssl.verification_mode NONE in
SessionFactoryTests when run in a FIPS 140 JVM