### PR TITLE
Adds ckb to the list of unsupported languages

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
@@ -70,6 +70,7 @@ public abstract class KerberosTestCase extends ESTestCase {
         unsupportedLocaleLanguages.add("uz");
         unsupportedLocaleLanguages.add("fa");
         unsupportedLocaleLanguages.add("ks");
+        unsupportedLocaleLanguages.add("ckb");
     }
 
     @BeforeClass


### PR DESCRIPTION
Adds ckb ( locale ckb-IQ ) to the list of unsupported languages for Kerberos tests. 
Reproduction line for when the issue manifested : 

```
./gradlew :x-pack:plugin:security:test -Dtests.seed=3F588AADB5767BE1 -Dtests.class=org.elasticsearch.xpack.security.authc.kerberos.KerberosTicketValidatorTests -Dtests.method="testWhenKeyTabWithInvalidContentFailsValidation" -Dtests.security.manager=true -Dtests.locale=ckb-IQ -Dtests.timezone=America/Guatemala
```