### PR TITLE
Change rest response of `IndicesStatsResponse` for red indices

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -159,13 +159,17 @@ public class IndicesStatsResponse extends BroadcastResponse {
 
         builder.startObject("_all");
 
-        builder.startObject("primaries");
-        getPrimaries().toXContent(builder, params);
-        builder.endObject();
+        if (primary != null) {
+            builder.startObject("primaries");
+            getPrimaries().toXContent(builder, params);
+            builder.endObject();
+        }
 
-        builder.startObject("total");
-        getTotal().toXContent(builder, params);
-        builder.endObject();
+        if (total != null) {
+            builder.startObject("total");
+            getTotal().toXContent(builder, params);
+            builder.endObject();
+        }
 
         builder.endObject();
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponseTests.java
@@ -19,10 +19,12 @@
 
 package org.elasticsearch.action.admin.indices.stats;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.ArrayList;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -30,6 +32,12 @@ import static org.hamcrest.object.HasToString.hasToString;
 
 
 public class IndicesStatsResponseTests extends ESTestCase {
+
+    public void testRedIndicesToXContent() {
+        IndicesStatsResponse response = new IndicesStatsResponse(new ShardStats[0], 10, 0, 0, new ArrayList<>());
+        String output = Strings.toString(response);
+        assertEquals("{\"_shards\":{\"total\":10,\"successful\":0,\"failed\":0},\"_all\":{},\"indices\":{}}", output);
+    }
 
     public void testInvalidLevel() {
         final IndicesStatsResponse response = new IndicesStatsResponse();


### PR DESCRIPTION
Not showing the `primaries` and `total` fields under `_all` in `IndicesStatsResponse` when indices are red (not allocated).

Relates to #27178