### PR TITLE
[Zen2] Add UnicastConfiguredHostsResolver

### DIFF
--- a/server/src/main/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolver.java
+++ b/server/src/main/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolver.java
@@ -74,6 +74,7 @@ public class UnicastConfiguredHostsResolver extends AbstractLifecycleComponent i
     protected void doClose() {
     }
 
+    @Override
     public void resolveConfiguredHosts(Consumer<List<TransportAddress>> consumer) {
         if (lifecycle.started() == false) {
             logger.debug("resolveConfiguredHosts: lifecycle is {}, not proceeding", lifecycle);

--- a/server/src/main/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolver.java
+++ b/server/src/main/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolver.java
@@ -71,7 +71,10 @@ public class UnicastConfiguredHostsResolver extends AbstractLifecycleComponent i
     }
 
     public void resolveConfiguredHosts(Consumer<List<TransportAddress>> consumer) {
-        assert lifecycle.started() : lifecycle;
+        if (lifecycle.started() == false) {
+            logger.debug("resolveConfiguredHosts: lifecycle is {}, not proceeding", lifecycle);
+            return;
+        }
 
         if (resolveInProgress.compareAndSet(false, true)) {
             transportService.getThreadPool().generic().execute(new AbstractRunnable() {

--- a/server/src/main/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolver.java
+++ b/server/src/main/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolver.java
@@ -85,6 +85,11 @@ public class UnicastConfiguredHostsResolver extends AbstractLifecycleComponent i
 
                 @Override
                 protected void doRun() {
+                    if (lifecycle.started() == false) {
+                        logger.debug("resolveConfiguredHosts.doRun: lifecycle is {}, not proceeding", lifecycle);
+                        return;
+                    }
+
                     List<TransportAddress> providedAddresses
                         = hostsProvider.buildDynamicHosts((hosts, limitPortCounts)
                         -> UnicastZenPing.resolveHostsLists(executorService.get(), logger, hosts, limitPortCounts,

--- a/server/src/main/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolver.java
+++ b/server/src/main/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolver.java
@@ -77,6 +77,7 @@ public class UnicastConfiguredHostsResolver extends AbstractLifecycleComponent i
             transportService.getThreadPool().generic().execute(new AbstractRunnable() {
                 @Override
                 public void onFailure(Exception e) {
+                    logger.debug("failure when resolving unicast hosts list", e);
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolver.java
+++ b/server/src/main/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolver.java
@@ -92,7 +92,6 @@ public class UnicastConfiguredHostsResolver extends AbstractLifecycleComponent i
 
                 @Override
                 public void onAfter() {
-                    super.onAfter();
                     resolveInProgress.set(false);
                 }
 

--- a/server/src/test/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolverTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.discovery;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -32,11 +31,9 @@ import org.junit.Before;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.mockito.Mockito.mock;

--- a/server/src/test/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolverTests.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.discovery;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UnicastConfiguredHostsResolverTests extends ESTestCase {
+
+    private List<TransportAddress> transportAddresses;
+    private UnicastConfiguredHostsResolver unicastConfiguredHostsResolver;
+    private ThreadPool threadPool;
+
+    @Before
+    public void startResolver() {
+        final Settings settings = Settings.builder().put(NODE_NAME_SETTING.getKey(), "node").build();
+        threadPool = new ThreadPool(settings);
+        transportAddresses = new ArrayList<>();
+
+        TransportService transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+
+        unicastConfiguredHostsResolver = new UnicastConfiguredHostsResolver(
+            settings, transportService, hostsResolver -> transportAddresses, () -> {
+            final ThreadFactory threadFactory = EsExecutors.daemonThreadFactory("thread-factory-name");
+            return EsExecutors.newScaling("executor-name",
+                0, 10, 60, TimeUnit.SECONDS, threadFactory, threadPool.getThreadContext());
+        });
+
+        unicastConfiguredHostsResolver.start();
+    }
+
+    @After
+    public void stopResolver() {
+        unicastConfiguredHostsResolver.stop();
+        threadPool.shutdown();
+    }
+
+    public void testResolvesAddressesInBackgroundAndIgnoresConcurrentCalls() throws Exception {
+        final AtomicReference<List<TransportAddress>> resolvedAddressesRef = new AtomicReference<>();
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(1);
+
+        final int addressCount = randomIntBetween(0, 5);
+        for (int i = 0; i < addressCount; i++) {
+            transportAddresses.add(buildNewFakeTransportAddress());
+        }
+
+        unicastConfiguredHostsResolver.resolveConfiguredHosts(resolvedAddresses -> {
+            try {
+                assertTrue(startLatch.await(1, TimeUnit.SECONDS));
+            } catch (InterruptedException e) {
+                throw new AssertionError(e);
+            }
+            resolvedAddressesRef.set(resolvedAddresses);
+            endLatch.countDown();
+        });
+
+        unicastConfiguredHostsResolver.resolveConfiguredHosts(resolvedAddresses -> {
+            throw new AssertionError("unexpected concurrent resolution");
+        });
+
+        assertThat(resolvedAddressesRef.get(), nullValue());
+        startLatch.countDown();
+        assertTrue(endLatch.await(1, TimeUnit.SECONDS));
+        assertThat(resolvedAddressesRef.get(), equalTo(transportAddresses));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolverTests.java
@@ -79,7 +79,7 @@ public class UnicastConfiguredHostsResolverTests extends ESTestCase {
 
         unicastConfiguredHostsResolver.resolveConfiguredHosts(resolvedAddresses -> {
             try {
-                assertTrue(startLatch.await(1, TimeUnit.SECONDS));
+                assertTrue(startLatch.await(30, TimeUnit.SECONDS));
             } catch (InterruptedException e) {
                 throw new AssertionError(e);
             }
@@ -93,7 +93,7 @@ public class UnicastConfiguredHostsResolverTests extends ESTestCase {
 
         assertThat(resolvedAddressesRef.get(), nullValue());
         startLatch.countDown();
-        assertTrue(endLatch.await(1, TimeUnit.SECONDS));
+        assertTrue(endLatch.await(30, TimeUnit.SECONDS));
         assertThat(resolvedAddressesRef.get(), equalTo(transportAddresses));
     }
 }

--- a/server/src/test/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolverTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.junit.After;
@@ -49,15 +50,14 @@ public class UnicastConfiguredHostsResolverTests extends ESTestCase {
 
     @Before
     public void startResolver() {
-        final Settings settings = Settings.builder().put(NODE_NAME_SETTING.getKey(), "node").build();
-        threadPool = new ThreadPool(settings);
+        threadPool = new TestThreadPool("node");
         transportAddresses = new ArrayList<>();
 
         TransportService transportService = mock(TransportService.class);
         when(transportService.getThreadPool()).thenReturn(threadPool);
 
         unicastConfiguredHostsResolver
-            = new UnicastConfiguredHostsResolver(settings, transportService, hostsResolver -> transportAddresses);
+            = new UnicastConfiguredHostsResolver(Settings.EMPTY, transportService, hostsResolver -> transportAddresses);
         unicastConfiguredHostsResolver.start();
     }
 

--- a/server/src/test/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/UnicastConfiguredHostsResolverTests.java
@@ -56,13 +56,8 @@ public class UnicastConfiguredHostsResolverTests extends ESTestCase {
         TransportService transportService = mock(TransportService.class);
         when(transportService.getThreadPool()).thenReturn(threadPool);
 
-        unicastConfiguredHostsResolver = new UnicastConfiguredHostsResolver(
-            settings, transportService, hostsResolver -> transportAddresses, () -> {
-            final ThreadFactory threadFactory = EsExecutors.daemonThreadFactory("thread-factory-name");
-            return EsExecutors.newScaling("executor-name",
-                0, 10, 60, TimeUnit.SECONDS, threadFactory, threadPool.getThreadContext());
-        });
-
+        unicastConfiguredHostsResolver
+            = new UnicastConfiguredHostsResolver(settings, transportService, hostsResolver -> transportAddresses);
         unicastConfiguredHostsResolver.start();
     }
 


### PR DESCRIPTION
The `PeerFinder`, introduced in #32246, obtains the collection of seed
addresses configured by the user from a `ConfiguredHostsResolver`. In reality
this collection comes from the `UnicastHostsProvider` via a slightly
complicated threading model that performs the resolution of hostnames to
addresses using a dedicated `ExecutorService`. This commit introduces an
adapter to allow the `PeerFinder` to obtain its seed addresses in this manner.