### PR TITLE
Docs: Allow snippets to have line continuation

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/SnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/SnippetsTask.groovy
@@ -284,6 +284,10 @@ public class SnippetsTask extends DefaultTask {
                     contents.append(line).append('\n')
                     return
                 }
+                // Allow line extensions for console snippets within lists
+                if (snippet != null && line.trim() == '+') {
+                    return
+                }
                 // Just finished
                 emit()
             }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/SnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/SnippetsTask.groovy
@@ -284,7 +284,7 @@ public class SnippetsTask extends DefaultTask {
                     contents.append(line).append('\n')
                     return
                 }
-                // Allow line extensions for console snippets within lists
+                // Allow line continuations for console snippets within lists
                 if (snippet != null && line.trim() == '+') {
                     return
                 }


### PR DESCRIPTION
Currently, snippets in lists cannot be rendered correctly as a console command because the console command requires a line continuation '+'.  This allows snippets to have a line continuation between the snippet and the ```// CONSOLE```.

Example:
```
* List Item:
+
[source,js]
----
curl <something>
----
+
// CONSOLE
```