### PR TITLE
Fixes suggestion generics

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestion.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestion.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ContextParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.suggest.Suggest;
@@ -79,7 +80,7 @@ public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry>
         return suggestion;
     }
 
-    public static class Entry extends Suggestion.Entry<Suggestion.Entry.Option> {
+    public static class Entry extends Suggestion.Entry<PhraseSuggestion.Entry.Option> {
 
         protected double cutoffScore = Double.MIN_VALUE;
 
@@ -107,7 +108,7 @@ public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry>
         }
 
         @Override
-        protected void merge(Suggestion.Entry<Suggestion.Entry.Option> other) {
+        protected void merge(Suggestion.Entry<Option> other) {
             super.merge(other);
             // If the cluster contains both pre 0.90.4 and post 0.90.4 nodes then we'll see Suggestion.Entry
             // objects being merged with PhraseSuggestion.Entry objects.  We merge Suggestion.Entry objects
@@ -121,7 +122,7 @@ public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry>
         }
 
         @Override
-        public void addOption(Suggestion.Entry.Option option) {
+        public void addOption(Option option) {
             if (option.getScore() > this.cutoffScore) {
                 this.options.add(option);
             }
@@ -131,7 +132,8 @@ public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry>
 
         static {
             declareCommonFields(PARSER);
-            PARSER.declareObjectArray(Entry::addOptions, (p,c) -> Option.fromXContent(p), new ParseField(OPTIONS));
+            PARSER.declareObjectArray(Entry::addOptions, (ContextParser<Void, Option>) (p, c) -> Option.fromXContent(p),
+                    new ParseField(OPTIONS));
         }
 
         public static Entry fromXContent(XContentParser parser) {

--- a/server/src/test/java/org/elasticsearch/search/suggest/SuggestionEntryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/SuggestionEntryTests.java
@@ -129,7 +129,8 @@ public class SuggestionEntryTests extends ESTestCase {
     }
 
     public void testToXContent() throws IOException {
-        PhraseSuggestion.Entry.Option phraseOption = new PhraseSuggestion.Entry.Option(new Text("someText"), new Text("somethingHighlighted"),
+        PhraseSuggestion.Entry.Option phraseOption = new PhraseSuggestion.Entry.Option(new Text("someText"),
+                new Text("somethingHighlighted"),
             1.3f, true);
         PhraseSuggestion.Entry phraseEntry = new PhraseSuggestion.Entry(new Text("entryText"), 42, 313);
         phraseEntry.addOption(phraseOption);

--- a/server/src/test/java/org/elasticsearch/search/suggest/SuggestionEntryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/SuggestionEntryTests.java
@@ -129,11 +129,11 @@ public class SuggestionEntryTests extends ESTestCase {
     }
 
     public void testToXContent() throws IOException {
-        PhraseSuggestion.Entry.Option option = new PhraseSuggestion.Entry.Option(new Text("someText"), new Text("somethingHighlighted"),
+        PhraseSuggestion.Entry.Option phraseOption = new PhraseSuggestion.Entry.Option(new Text("someText"), new Text("somethingHighlighted"),
             1.3f, true);
-        PhraseSuggestion.Entry entry = new PhraseSuggestion.Entry(new Text("entryText"), 42, 313);
-        entry.addOption(option);
-        BytesReference xContent = toXContent(entry, XContentType.JSON, randomBoolean());
+        PhraseSuggestion.Entry phraseEntry = new PhraseSuggestion.Entry(new Text("entryText"), 42, 313);
+        phraseEntry.addOption(phraseOption);
+        BytesReference xContent = toXContent(phraseEntry, XContentType.JSON, randomBoolean());
         assertEquals(
                 "{\"text\":\"entryText\","
                 + "\"offset\":42,"
@@ -145,11 +145,10 @@ public class SuggestionEntryTests extends ESTestCase {
                     + "\"collate_match\":true}"
                 + "]}", xContent.utf8ToString());
 
-        org.elasticsearch.search.suggest.term.TermSuggestion.Entry.Option termOption =
-                new org.elasticsearch.search.suggest.term.TermSuggestion.Entry.Option(new Text("termSuggestOption"), 42, 3.13f);
-        entry = new PhraseSuggestion.Entry(new Text("entryText"), 42, 313);
-        entry.addOption(termOption);
-        xContent = toXContent(entry, XContentType.JSON, randomBoolean());
+        TermSuggestion.Entry.Option termOption = new TermSuggestion.Entry.Option(new Text("termSuggestOption"), 42, 3.13f);
+        TermSuggestion.Entry termEntry = new TermSuggestion.Entry(new Text("entryText"), 42, 313);
+        termEntry.addOption(termOption);
+        xContent = toXContent(termEntry, XContentType.JSON, randomBoolean());
         assertEquals(
                 "{\"text\":\"entryText\","
                 + "\"offset\":42,"
@@ -160,12 +159,11 @@ public class SuggestionEntryTests extends ESTestCase {
                     + "\"freq\":42}"
                 + "]}", xContent.utf8ToString());
 
-        org.elasticsearch.search.suggest.completion.CompletionSuggestion.Entry.Option completionOption =
-                new org.elasticsearch.search.suggest.completion.CompletionSuggestion.Entry.Option(-1, new Text("completionOption"),
+        CompletionSuggestion.Entry.Option completionOption = new CompletionSuggestion.Entry.Option(-1, new Text("completionOption"),
                         3.13f, Collections.singletonMap("key", Collections.singleton("value")));
-        entry = new PhraseSuggestion.Entry(new Text("entryText"), 42, 313);
-        entry.addOption(completionOption);
-        xContent = toXContent(entry, XContentType.JSON, randomBoolean());
+        CompletionSuggestion.Entry completionEntry = new CompletionSuggestion.Entry(new Text("entryText"), 42, 313);
+        completionEntry.addOption(completionOption);
+        xContent = toXContent(completionEntry, XContentType.JSON, randomBoolean());
         assertEquals(
                 "{\"text\":\"entryText\","
                 + "\"offset\":42,"

--- a/server/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
@@ -209,7 +209,8 @@ public class SuggestionTests extends ESTestCase {
                     + "}", xContent.utf8ToString());
         }
         {
-            Option option = new PhraseSuggestion.Entry.Option(new Text("someText"), new Text("somethingHighlighted"), 1.3f, true);
+            PhraseSuggestion.Entry.Option option = new PhraseSuggestion.Entry.Option(new Text("someText"), new Text("somethingHighlighted"),
+                    1.3f, true);
             PhraseSuggestion.Entry entry = new PhraseSuggestion.Entry(new Text("entryText"), 42, 313, 1.0);
             entry.addOption(option);
             PhraseSuggestion suggestion = new PhraseSuggestion("suggestionName", 5);


### PR DESCRIPTION
This solves a compile problem in Eclipse where Eclipse could not
resolve the generics for the options field in `PhraseSuggestion.Entry`.
But I think this is also a good change in general because
`PhraseSuggestion.Entry` is now declaring the specific `Option`
implementation it requires rather than `Suggest.Entry.Option` which is
more general and could lead to weird bugs. `CompletionSuggestion.Entry`
and `TermSuggestion.Entry` already declare the more specific class they
use so I think this was an oversight in `PhaseSuggestion.Entry`