### PR TITLE
TESTS: Explicitly Fail Http Client Timeouts

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
@@ -58,6 +58,7 @@ import java.util.concurrent.TimeUnit;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.junit.Assert.fail;
 
 /**
  * Tiny helper to send http requests over netty.
@@ -145,7 +146,9 @@ class Netty4HttpClient implements Closeable {
             for (HttpRequest request : requests) {
                 channelFuture.channel().writeAndFlush(request);
             }
-            latch.await(30, TimeUnit.SECONDS);
+            if (latch.await(30L, TimeUnit.SECONDS) == false) {
+                fail("Failed to get all expected responses.");
+            }
 
         } finally {
             if (channelFuture != null) {

--- a/plugins/transport-nio/src/test/java/org/elasticsearch/http/nio/NioHttpClient.java
+++ b/plugins/transport-nio/src/test/java/org/elasticsearch/http/nio/NioHttpClient.java
@@ -71,6 +71,7 @@ import java.util.function.Consumer;
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static org.elasticsearch.common.util.concurrent.EsExecutors.daemonThreadFactory;
+import static org.junit.Assert.fail;
 
 /**
  * Tiny helper to send http requests over nio.
@@ -136,7 +137,9 @@ class NioHttpClient implements Closeable {
             for (HttpRequest request : requests) {
                 nioSocketChannel.getContext().sendMessage(request, (v, e) -> {});
             }
-            latch.await(30, TimeUnit.SECONDS);
+            if (latch.await(30L, TimeUnit.SECONDS) == false) {
+                fail("Failed to get all expected responses.");
+            }
 
         } catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
* Don't quietly ignore timeouts when waiting for HTTP responses
* Fixes #32702