### PR TITLE
Update RestClient.java

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -803,7 +803,11 @@ public class RestClient implements Closeable {
                     fullPath = pathPrefix + "/" + path;
                 }
             } else {
-                fullPath = path;
+                if (path.startsWith("/")) {
+                  fullPath = path;
+                } else {
+                  fullPath = "/" + path;
+                }
             }
 
             URIBuilder uriBuilder = new URIBuilder(fullPath);


### PR DESCRIPTION
This is a trivial change which ensures the user has a leading slash on the URI.

As currently written, the user can pass a request without a slash.  Without this, the request is not strictly valid according to the HTTP spec. Nonetheless, requests to ES still work, but requests via an AWS ELB/ALB fail.