### PR TITLE
[DOCS] Add missing link to get license API docs

### DIFF
--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -196,5 +196,7 @@ include::script/delete_script.asciidoc[]
 The Java High Level REST Client supports the following Licensing APIs:
 
 * <<java-rest-high-put-license>>
+* <<java-rest-high-get-license>>
 
 include::licensing/put-license.asciidoc[]
+include::licensing/get-license.asciidoc[]


### PR DESCRIPTION
Without the link, the page is effectively not reachable