### PR TITLE
Logging: Drop some of the logging constructors

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/Loggers.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/Loggers.java
@@ -58,7 +58,7 @@ public class Loggers {
      * Class.
      */
     public static Logger getLogger(String loggerName, Settings settings, ShardId shardId, String... prefixes) {
-        return getLogger(loggerName, settings,
+        return getLogger(loggerName,
             asArrayList(shardId.getIndexName(), Integer.toString(shardId.id()), prefixes).toArray(new String[0]));
     }
 
@@ -70,7 +70,7 @@ public class Loggers {
         return ESLoggerFactory.getLogger(formatPrefix(prefixes), clazz);
     }
 
-    public static Logger getLogger(String loggerName, Settings settings, String... prefixes) {
+    public static Logger getLogger(String loggerName, String... prefixes) {
         return ESLoggerFactory.getLogger(formatPrefix(prefixes), loggerName);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/IndexingSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexingSlowLog.java
@@ -89,7 +89,7 @@ public final class IndexingSlowLog implements IndexingOperationListener {
             }, Property.Dynamic, Property.IndexScope);
 
     IndexingSlowLog(IndexSettings indexSettings) {
-        this.indexLogger = Loggers.getLogger(INDEX_INDEXING_SLOWLOG_PREFIX + ".index", indexSettings.getSettings());
+        this.indexLogger = Loggers.getLogger(INDEX_INDEXING_SLOWLOG_PREFIX + ".index");
         this.index = indexSettings.getIndex();
 
         indexSettings.getScopedSettings().addSettingsUpdateConsumer(INDEX_INDEXING_SLOWLOG_REFORMAT_SETTING, this::setReformat);

--- a/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -82,8 +82,8 @@ public final class SearchSlowLog implements SearchOperationListener {
 
     public SearchSlowLog(IndexSettings indexSettings) {
 
-        this.queryLogger = Loggers.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".query", indexSettings.getSettings());
-        this.fetchLogger = Loggers.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".fetch", indexSettings.getSettings());
+        this.queryLogger = Loggers.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".query");
+        this.fetchLogger = Loggers.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".fetch");
 
         indexSettings.getScopedSettings().addSettingsUpdateConsumer(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING, this::setQueryWarnThreshold);
         this.queryWarnThreshold = indexSettings.getValue(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING).nanos();

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -312,7 +312,7 @@ public class Watcher extends Plugin implements ActionPlugin, ScriptPlugin, Reloa
         actionFactoryMap.put(EmailAction.TYPE, new EmailActionFactory(settings, emailService, templateEngine, emailAttachmentsParser));
         actionFactoryMap.put(WebhookAction.TYPE, new WebhookActionFactory(settings, httpClient, httpTemplateParser, templateEngine));
         actionFactoryMap.put(IndexAction.TYPE, new IndexActionFactory(settings, client));
-        actionFactoryMap.put(LoggingAction.TYPE, new LoggingActionFactory(settings, templateEngine));
+        actionFactoryMap.put(LoggingAction.TYPE, new LoggingActionFactory(templateEngine));
         actionFactoryMap.put(HipChatAction.TYPE, new HipChatActionFactory(settings, templateEngine, hipChatService));
         actionFactoryMap.put(JiraAction.TYPE, new JiraActionFactory(settings, templateEngine, jiraService));
         actionFactoryMap.put(SlackAction.TYPE, new SlackActionFactory(settings, templateEngine, slackService));

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/logging/ExecutableLoggingAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/logging/ExecutableLoggingAction.java
@@ -22,9 +22,9 @@ public class ExecutableLoggingAction extends ExecutableAction<LoggingAction> {
     private final Logger textLogger;
     private final TextTemplateEngine templateEngine;
 
-    public ExecutableLoggingAction(LoggingAction action, Logger logger, Settings settings, TextTemplateEngine templateEngine) {
+    public ExecutableLoggingAction(LoggingAction action, Logger logger, TextTemplateEngine templateEngine) {
         super(action, logger);
-        this.textLogger = action.category != null ? Loggers.getLogger(action.category, settings) : logger;
+        this.textLogger = action.category != null ? Loggers.getLogger(action.category) : logger;
         this.templateEngine = templateEngine;
     }
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/logging/LoggingActionFactory.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/logging/LoggingActionFactory.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.xpack.watcher.actions.logging;
 
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.watcher.actions.ActionFactory;
 import org.elasticsearch.xpack.watcher.common.text.TextTemplateEngine;
@@ -14,19 +13,16 @@ import org.elasticsearch.xpack.watcher.common.text.TextTemplateEngine;
 import java.io.IOException;
 
 public class LoggingActionFactory extends ActionFactory {
-
-    private final Settings settings;
     private final TextTemplateEngine templateEngine;
 
-    public LoggingActionFactory(Settings settings, TextTemplateEngine templateEngine) {
-        super(Loggers.getLogger(ExecutableLoggingAction.class, settings));
-        this.settings = settings;
+    public LoggingActionFactory(TextTemplateEngine templateEngine) {
+        super(Loggers.getLogger(ExecutableLoggingAction.class));
         this.templateEngine = templateEngine;
     }
 
     @Override
     public ExecutableLoggingAction parseExecutable(String watchId, String actionId, XContentParser parser) throws IOException {
         LoggingAction action = LoggingAction.parse(watchId, actionId, parser);
-        return new ExecutableLoggingAction(action, actionLogger, settings, templateEngine);
+        return new ExecutableLoggingAction(action, actionLogger, templateEngine);
     }
 }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/logging/LoggingActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/logging/LoggingActionTests.java
@@ -93,7 +93,7 @@ public class LoggingActionTests extends ESTestCase {
 
     public void testParser() throws Exception {
         Settings settings = Settings.EMPTY;
-        LoggingActionFactory parser = new LoggingActionFactory(settings, engine);
+        LoggingActionFactory parser = new LoggingActionFactory(engine);
 
         String text = randomAlphaOfLength(10);
         TextTemplate template = new TextTemplate(text);
@@ -126,14 +126,13 @@ public class LoggingActionTests extends ESTestCase {
     }
 
     public void testParserSelfGenerated() throws Exception {
-        Settings settings = Settings.EMPTY;
-        LoggingActionFactory parser = new LoggingActionFactory(settings, engine);
+        LoggingActionFactory parser = new LoggingActionFactory(engine);
 
         String text = randomAlphaOfLength(10);
         TextTemplate template = new TextTemplate(text);
         String category = randomAlphaOfLength(10);
         LoggingAction action = new LoggingAction(template, level, category);
-        ExecutableLoggingAction executable = new ExecutableLoggingAction(action, logger, settings, engine);
+        ExecutableLoggingAction executable = new ExecutableLoggingAction(action, logger, engine);
         XContentBuilder builder = jsonBuilder();
         executable.toXContent(builder, Attachment.XContent.EMPTY_PARAMS);
 
@@ -147,7 +146,7 @@ public class LoggingActionTests extends ESTestCase {
 
     public void testParserBuilder() throws Exception {
         Settings settings = Settings.EMPTY;
-        LoggingActionFactory parser = new LoggingActionFactory(settings, engine);
+        LoggingActionFactory parser = new LoggingActionFactory(engine);
 
         String text = randomAlphaOfLength(10);
         TextTemplate template = new TextTemplate(text);
@@ -173,7 +172,7 @@ public class LoggingActionTests extends ESTestCase {
 
     public void testParserFailure() throws Exception {
         Settings settings = Settings.EMPTY;
-        LoggingActionFactory parser = new LoggingActionFactory(settings, engine);
+        LoggingActionFactory parser = new LoggingActionFactory(engine);
 
         XContentBuilder builder = jsonBuilder()
                 .startObject().endObject();

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchTests.java
@@ -442,7 +442,7 @@ public class WatchTests extends ESTestCase {
     private WatchParser createWatchparser() throws Exception {
         LoggingAction loggingAction = new LoggingAction(new TextTemplate("foo"), null, null);
         List<ActionWrapper> actions = Collections.singletonList(new ActionWrapper("_logging_", randomThrottler(), null, null,
-                new ExecutableLoggingAction(loggingAction, logger, settings, new MockTextTemplateEngine())));
+                new ExecutableLoggingAction(loggingAction, logger, new MockTextTemplateEngine())));
 
         ScheduleRegistry scheduleRegistry = registry(new IntervalSchedule(new IntervalSchedule.Interval(1,
                 IntervalSchedule.Interval.Unit.SECONDS)));
@@ -627,7 +627,7 @@ public class WatchTests extends ESTestCase {
                             new HttpRequestTemplate.Parser(authRegistry), templateEngine));
                     break;
                 case LoggingAction.TYPE:
-                    parsers.put(LoggingAction.TYPE, new LoggingActionFactory(settings, new MockTextTemplateEngine()));
+                    parsers.put(LoggingAction.TYPE, new LoggingActionFactory(new MockTextTemplateEngine()));
                     break;
             }
         }


### PR DESCRIPTION
Now that we set the node name statically we don't need these logging
constructors.
