### PR TITLE
Move icu4j and super-csv version numbers to versions file

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -6,6 +6,8 @@ spatial4j         = 0.7
 jts               = 1.15.0
 jackson           = 2.8.11
 snakeyaml         = 1.17
+icu4j             = 62.1
+supercsv          = 2.4.0
 # when updating log4j, please update also docs/java-api/index.asciidoc
 log4j             = 2.11.1
 slf4j             = 1.6.2

--- a/plugins/analysis-icu/build.gradle
+++ b/plugins/analysis-icu/build.gradle
@@ -30,7 +30,7 @@ forbiddenApis {
 
 dependencies {
   compile "org.apache.lucene:lucene-analyzers-icu:${versions.lucene}"
-  compile 'com.ibm.icu:icu4j:62.1'
+  compile "com.ibm.icu:icu4j:${versions.icu4j}"
 }
 
 dependencyLicenses {

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 
     // ml deps
     compile project(':libs:grok')
-    compile 'net.sf.supercsv:super-csv:2.4.0'
+    compile "net.sf.supercsv:super-csv:${versions.supercsv}"
     nativeBundle "org.elasticsearch.ml:ml-cpp:${project.version}@zip"
     testCompile 'org.ini4j:ini4j:0.5.2'
 }


### PR DESCRIPTION
The upcoming ML log structure finder functionality will use these
libraries, and it makes sense to use the same versions that are
being used elsewhere in Elasticsearch.  This is especially true
with icu4j, which is pretty big.