### PR TITLE
Tests: Disable rolling upgrade tests with system key on fips JVM

### DIFF
--- a/x-pack/qa/rolling-upgrade/with-system-key/build.gradle
+++ b/x-pack/qa/rolling-upgrade/with-system-key/build.gradle
@@ -1,1 +1,10 @@
+import org.elasticsearch.gradle.test.RestIntegTestTask
+
+// Skip test on FIPS FIXME https://github.com/elastic/elasticsearch/issues/32737
+if (project.inFipsJvm) {
+    tasks.withType(RestIntegTestTask) {
+        enabled = false
+    }
+}
+
 group = "${group}.x-pack.qa.rolling-upgrade.with-system-key"


### PR DESCRIPTION
This disables the x-pack rolling upgrade tests using a fips JVM, as
there are problems creating the keystore.

Relates #32737
