### PR TITLE
HLRC: Forbid all Elasticsearch logging infra

### DIFF
--- a/client/rest-high-level/src/main/resources/forbidden/rest-high-level-signatures.txt
+++ b/client/rest-high-level/src/main/resources/forbidden/rest-high-level-signatures.txt
@@ -20,5 +20,14 @@ org.apache.http.entity.ContentType#create(java.lang.String,java.lang.String)
 org.apache.http.entity.ContentType#create(java.lang.String,java.nio.charset.Charset)
 org.apache.http.entity.ContentType#create(java.lang.String,org.apache.http.NameValuePair[])
 
+@defaultMessage ES's logging infrastructure uses log4j2 which we don't want to force on high level rest client users
+org.elasticsearch.common.logging.DeprecationLogger
+org.elasticsearch.common.logging.ESLoggerFactory
+org.elasticsearch.common.logging.LogConfigurator
+org.elasticsearch.common.logging.LoggerMessageFormat
+org.elasticsearch.common.logging.Loggers
+org.elasticsearch.common.logging.NodeNamePatternConverter
+org.elasticsearch.common.logging.PrefixLogger
+
 @defaultMessage We can't rely on log4j2 being on the classpath so don't log deprecations!
 org.elasticsearch.common.xcontent.LoggingDeprecationHandler


### PR DESCRIPTION
All of the Elasticsearch logging infrastructure relies on log4j but we
don't want the high level rest client to rely on log4j2. All of its
logging goes through commons-logging because our dependencies drag in
commons logging already. Anyway, this bans direct use of Elasticsearch's
logging infrastructure in the high level REST client. It is still
possible to use it indirectly though and there isn't anything we can
really do about that until we split the high level rest client from
Elasticsearch's server jar.
