### PR TITLE
add start trial API to HLRC

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseClient.java
@@ -31,6 +31,8 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.protocol.xpack.license.GetLicenseRequest;
 import org.elasticsearch.protocol.xpack.license.GetLicenseResponse;
+import org.elasticsearch.protocol.xpack.license.PostStartTrialRequest;
+import org.elasticsearch.protocol.xpack.license.PostStartTrialResponse;
 import org.elasticsearch.protocol.xpack.license.PutLicenseRequest;
 import org.elasticsearch.protocol.xpack.license.PutLicenseResponse;
 
@@ -131,5 +133,26 @@ public class LicenseClient {
                 return Strings.toString(builder);
             }
         }
+    }
+
+    public PostStartTrialResponse postStartTrial(PostStartTrialRequest request, RequestOptions options) throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(
+            request,
+            RequestConverters::postStartTrial,
+            options,
+            PostStartTrialResponse::fromXContent,
+            emptySet()
+        );
+    }
+
+    public void postStartTrialAsync(PostStartTrialRequest request, RequestOptions opts, ActionListener<PostStartTrialResponse> listener) {
+        restHighLevelClient.performRequestAsyncAndParseEntity(
+            request,
+            RequestConverters::postStartTrial,
+            opts,
+            PostStartTrialResponse::fromXContent,
+            listener,
+            emptySet()
+        );
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseClient.java
@@ -42,6 +42,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 
 /**
  * A wrapper for the {@link RestHighLevelClient} that provides methods for
@@ -100,6 +101,28 @@ public class LicenseClient {
             response -> new GetLicenseResponse(convertResponseToJson(response)), listener, emptySet());
     }
 
+    /**
+     * Enables and starts a trial license for the cluster.
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @return the response
+     * @throws IOException in case there is a problem sending the request or parsing back the response
+     */
+    public PostStartTrialResponse postStartTrial(PostStartTrialRequest request, RequestOptions options) throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(request, RequestConverters::postStartTrial, options,
+            PostStartTrialResponse::fromXContent, singleton(403)
+        );
+    }
+
+    /**
+     * Asynchronously enabled and starts a trial license for the cluster.
+     * @param opts the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @param listener the listener to be notified upon request completion
+     */
+    public void postStartTrialAsync(PostStartTrialRequest request, RequestOptions opts, ActionListener<PostStartTrialResponse> listener) {
+        restHighLevelClient.performRequestAsyncAndParseEntity(request, RequestConverters::postStartTrial, opts,
+            PostStartTrialResponse::fromXContent, listener, singleton(403)
+        );
+    }
 
     /**
      * Converts an entire response into a json sting
@@ -133,26 +156,5 @@ public class LicenseClient {
                 return Strings.toString(builder);
             }
         }
-    }
-
-    public PostStartTrialResponse postStartTrial(PostStartTrialRequest request, RequestOptions options) throws IOException {
-        return restHighLevelClient.performRequestAndParseEntity(
-            request,
-            RequestConverters::postStartTrial,
-            options,
-            PostStartTrialResponse::fromXContent,
-            emptySet()
-        );
-    }
-
-    public void postStartTrialAsync(PostStartTrialRequest request, RequestOptions opts, ActionListener<PostStartTrialResponse> listener) {
-        restHighLevelClient.performRequestAsyncAndParseEntity(
-            request,
-            RequestConverters::postStartTrial,
-            opts,
-            PostStartTrialResponse::fromXContent,
-            listener,
-            emptySet()
-        );
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -110,6 +110,7 @@ import org.elasticsearch.protocol.xpack.XPackInfoRequest;
 import org.elasticsearch.protocol.xpack.XPackUsageRequest;
 import org.elasticsearch.protocol.xpack.license.GetLicenseRequest;
 import org.elasticsearch.protocol.xpack.license.PutLicenseRequest;
+import org.elasticsearch.protocol.xpack.license.PostStartTrialRequest;
 import org.elasticsearch.protocol.xpack.ml.PutJobRequest;
 import org.elasticsearch.protocol.xpack.watcher.DeleteWatchRequest;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchRequest;
@@ -1186,6 +1187,24 @@ final class RequestConverters {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
         Params parameters = new Params(request);
         parameters.withLocal(getLicenseRequest.local());
+        return request;
+    }
+
+    static Request postStartTrial(PostStartTrialRequest postStartTrialRequest) {
+        Request request = new Request(HttpPost.METHOD_NAME, new EndpointBuilder()
+            .addPathPartAsIs("_xpack")
+            .addPathPartAsIs("license")
+            .addPathPartAsIs("start_trial")
+            .build());
+
+        Params parameters = new Params(request);
+        parameters.withMasterTimeout(postStartTrialRequest.masterNodeTimeout());
+        if (postStartTrialRequest.isAcknowledged()) {
+            parameters.putParam("acknowledge", "true");
+        }
+        if (postStartTrialRequest.getType() != null) {
+            parameters.putParam("type", postStartTrialRequest.getType());
+        }
         return request;
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -126,6 +126,7 @@ import org.elasticsearch.index.rankeval.RankEvalSpec;
 import org.elasticsearch.index.rankeval.RatedRequest;
 import org.elasticsearch.index.rankeval.RestRankEvalAction;
 import org.elasticsearch.protocol.xpack.XPackInfoRequest;
+import org.elasticsearch.protocol.xpack.license.PostStartTrialRequest;
 import org.elasticsearch.protocol.xpack.watcher.DeleteWatchRequest;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchRequest;
 import org.elasticsearch.repositories.fs.FsRepository;
@@ -2590,6 +2591,27 @@ public class RequestConvertersTests extends ESTestCase {
         assertEquals(HttpDelete.METHOD_NAME, request.getMethod());
         assertEquals("/_xpack/watcher/watch/" + watchId, request.getEndpoint());
         assertThat(request.getEntity(), nullValue());
+    }
+
+    public void testPostStartTrial() {
+        PostStartTrialRequest postStartTrialRequest = new PostStartTrialRequest();
+
+        final boolean acknowledged = randomBoolean();
+        postStartTrialRequest.acknowledge(acknowledged);
+
+        final String type = randomBoolean()
+            ? null
+            : randomAlphaOfLength(10);
+        postStartTrialRequest.setType(type);
+
+        Request request = RequestConverters.postStartTrial(postStartTrialRequest);
+        if (acknowledged) {
+            assertEquals(Boolean.toString(acknowledged), request.getParameters().get("acknowledge"));
+        }
+
+        if (type != null) {
+            assertEquals(type, request.getParameters().get("type"));
+        }
     }
 
     /**

--- a/docs/java-rest/high-level/licensing/post-start-trial.asciidoc
+++ b/docs/java-rest/high-level/licensing/post-start-trial.asciidoc
@@ -1,0 +1,59 @@
+[[java-rest-high-post-start-trial]]
+=== Post Start Trial
+
+[[java-rest-high-post-start-license-execution]]
+==== Execution
+
+This API creates and enables a trial license using the `postStartTrial()`
+method.
+
+["source","java",subs="attributes,callouts,macros"]
+---------------------------------------------------
+include-tagged::{doc_tests}/LicensingDocumentationIT.java[post-start-trial-execute]
+---------------------------------------------------
+
+[[java-rest-high-post-start-license-response]]
+==== Response
+
+The returned `PostStartTrialResponse` returns a field indicating whether the
+trial was started. If it was started, the response returns a the type of
+license started. If it was not started, it returns an error message describing
+why.
+
+Acknowledgement messages may also be returned if this API was called without
+the `acknowledge` flag set to `true`.  In this case you need to display the
+messages to the end user and if they agree, resubmit the license with the
+`acknowledge` flag set to `true`. Please note that the request will still
+return a 200 return code even if requires an acknowledgement. So, it is
+necessary to check the `acknowledged` flag.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/LicensingDocumentationIT.java[post-start-trial-response]
+--------------------------------------------------
+
+[[java-rest-high-post-start-trial-async]]
+
+==== Asynchronous execution
+
+This request can be executed asynchronously:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/LicensingDocumentationIT.java[post-start-trial-execute-async]
+--------------------------------------------------
+
+The asynchronous method does not block and returns immediately. Once it is
+completed the `ActionListener` is called back using the `onResponse` method
+if the execution successfully completed or using the `onFailure` method if
+it failed.
+
+A typical listener for `PostStartTrialResponse` looks like:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/LicensingDocumentationIT.java[post-start-trial-execute-listener]
+--------------------------------------------------
+<1> Called when the execution is successfully completed. The response is
+provided as an argument
+<2> Called in case of failure. The raised exception is provided as an argument

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -194,9 +194,11 @@ The Java High Level REST Client supports the following Licensing APIs:
 
 * <<java-rest-high-put-license>>
 * <<java-rest-high-get-license>>
+* <<java-rest-high-post-start-trial>>
 
 include::licensing/put-license.asciidoc[]
 include::licensing/get-license.asciidoc[]
+include::licensing/post-start-trial.asciidoc[]
 
 == Watcher APIs
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
@@ -29,6 +29,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse;
 import org.elasticsearch.protocol.xpack.license.LicensesStatus;
+import org.elasticsearch.protocol.xpack.license.PostStartTrialRequest;
 import org.elasticsearch.protocol.xpack.license.PutLicenseResponse;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.XPackPlugin;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensingClient.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensingClient.java
@@ -8,6 +8,7 @@ package org.elasticsearch.license;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.protocol.xpack.license.GetLicenseRequest;
+import org.elasticsearch.protocol.xpack.license.PostStartTrialRequest;
 import org.elasticsearch.protocol.xpack.license.PutLicenseResponse;
 
 public class LicensingClient {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartTrialRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartTrialRequestBuilder.java
@@ -7,6 +7,7 @@ package org.elasticsearch.license;
 
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.protocol.xpack.license.PostStartTrialRequest;
 
 class PostStartTrialRequestBuilder extends ActionRequestBuilder<PostStartTrialRequest, PostStartTrialResponse> {
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartTrialLicense.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartTrialLicense.java
@@ -33,6 +33,7 @@ public class RestPostStartTrialLicense extends XPackRestHandler {
         PostStartTrialRequest startTrialRequest = new PostStartTrialRequest();
         startTrialRequest.setType(request.param("type", "trial"));
         startTrialRequest.acknowledge(request.paramAsBoolean("acknowledge", false));
+        startTrialRequest.masterNodeTimeout(request.paramAsTime("master_timeout", startTrialRequest.masterNodeTimeout()));
         return channel -> client.licensing().postStartTrial(startTrialRequest,
                 new RestBuilderListener<PostStartTrialResponse>(channel) {
                     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartTrialLicense.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartTrialLicense.java
@@ -7,6 +7,7 @@ package org.elasticsearch.license;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.protocol.xpack.license.PostStartTrialRequest;
 import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartTrialClusterTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartTrialClusterTask.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.protocol.xpack.license.PostStartTrialRequest;
 import org.elasticsearch.xpack.core.XPackPlugin;
 
 import java.time.Clock;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportPostStartTrialAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportPostStartTrialAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.protocol.xpack.license.PostStartTrialRequest;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 

--- a/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/license/PostStartTrialRequest.java
+++ b/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/license/PostStartTrialRequest.java
@@ -1,9 +1,23 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-package org.elasticsearch.license;
+
+package org.elasticsearch.protocol.xpack.license;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;

--- a/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/license/PostStartTrialResponse.java
+++ b/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/license/PostStartTrialResponse.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.protocol.xpack.license;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParseException;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.protocol.xpack.common.ProtocolUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class PostStartTrialResponse extends AcknowledgedResponse {
+
+    private static final ParseField TRIAL_WAS_STARTED_FIELD = new ParseField("trial_was_started");
+    private static final ParseField TYPE_FIELD = new ParseField("type");
+    private static final ParseField ERROR_MESSAGE_FIELD = new ParseField("error_message");
+    private static final ParseField ACKNOWLEDGE_DETAILS_FIELD = new ParseField("acknowledge");
+    private static final ParseField ACKNOWLEDGE_HEADER_FIELD = new ParseField("message");
+
+    private static final ConstructingObjectParser<PostStartTrialResponse, Void> PARSER = new ConstructingObjectParser<>(
+        "post_start_trial_response",
+        true,
+        (arguments, aVoid) -> {
+            boolean acknowledged = (boolean) arguments[0];
+            boolean trialWasStarted = (boolean) arguments[1];
+            String type = (String) arguments[2];
+            String errorMessage = (String) arguments[3];
+            @SuppressWarnings("unchecked")
+            Tuple<String, Map<String, String[]>> acknowledgeDetails = (Tuple<String, Map<String, String[]>>) arguments[4];
+
+            if (trialWasStarted) {
+                return new PostStartTrialResponse(acknowledged, type);
+            } else {
+                return new PostStartTrialResponse(acknowledged, errorMessage, acknowledgeDetails.v1(), acknowledgeDetails.v2());
+            }
+        }
+    );
+
+    static {
+        declareAcknowledgedField(PARSER);
+        PARSER.declareBoolean(constructorArg(), TRIAL_WAS_STARTED_FIELD);
+        PARSER.declareString(optionalConstructorArg(), TYPE_FIELD);
+        PARSER.declareString(optionalConstructorArg(), ERROR_MESSAGE_FIELD);
+        PARSER.declareObject(optionalConstructorArg(), (parser, v) -> {
+            Map<String, String[]> acknowledgeMessages = new HashMap<>();
+            String message = null;
+            XContentParser.Token token;
+            String currentFieldName = null;
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    currentFieldName = parser.currentName();
+                } else {
+                    if (currentFieldName == null) {
+                        throw new XContentParseException(parser.getTokenLocation(), "expected message header or acknowledgement");
+                    }
+                    if ("message".equals(currentFieldName)) {
+                        if (token != XContentParser.Token.VALUE_STRING) {
+                            throw new XContentParseException(parser.getTokenLocation(), "unexpected message header type");
+                        }
+                        message = parser.text();
+                    } else {
+                        if (token != XContentParser.Token.START_ARRAY) {
+                            throw new XContentParseException(parser.getTokenLocation(), "unexpected acknowledgement type");
+                        }
+                        List<String> acknowledgeMessagesList = new ArrayList<>();
+                        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                            if (token != XContentParser.Token.VALUE_STRING) {
+                                throw new XContentParseException(parser.getTokenLocation(), "unexpected acknowledgement text");
+                            }
+                            acknowledgeMessagesList.add(parser.text());
+                        }
+                        acknowledgeMessages.put(currentFieldName, acknowledgeMessagesList.toArray(new String[0]));
+                    }
+                }
+            }
+            return new Tuple<>(message, acknowledgeMessages);
+        }, ACKNOWLEDGE_DETAILS_FIELD);
+    }
+
+    private boolean trialWasStarted;
+    private String type;
+    private String errorMessage;
+    private String acknowledgeMessage;
+    private Map<String, String[]> acknowledgeMessages;
+
+    public PostStartTrialResponse() {}
+
+    public PostStartTrialResponse(boolean acknowledged, String type) {
+        this(acknowledged, true, type, null, null, Collections.emptyMap());
+
+        Objects.requireNonNull(type);
+    }
+
+    public PostStartTrialResponse(boolean acknowledged,
+                                  String errorMessage,
+                                  String acknowledgeMessage,
+                                  Map<String, String[]> acknowledgeMessages) {
+        this(acknowledged, false, null, errorMessage, acknowledgeMessage, acknowledgeMessages);
+
+        Objects.requireNonNull(errorMessage);
+        Objects.requireNonNull(acknowledgeMessage);
+        Objects.requireNonNull(acknowledgeMessages);
+    }
+
+    // todo dont use this
+    public PostStartTrialResponse(boolean acknowledged,
+                                  boolean trialWasStarted,
+                                  String type,
+                                  String errorMessage,
+                                  String acknowledgeMessage,
+                                  Map<String, String[]> acknowledgeMessages) {
+
+        super(acknowledged);
+        this.trialWasStarted = trialWasStarted;
+        this.type = type;
+        this.errorMessage = errorMessage;
+        this.acknowledgeMessage = acknowledgeMessage;
+        this.acknowledgeMessages = acknowledgeMessages;
+    }
+
+    public boolean isTrialWasStarted() {
+        return trialWasStarted;
+    }
+
+    public void setTrialWasStarted(boolean trialWasStarted) {
+        this.trialWasStarted = trialWasStarted;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getAcknowledgeMessage() {
+        return acknowledgeMessage;
+    }
+
+    public void setAcknowledgeMessage(String acknowledgeMessage) {
+        this.acknowledgeMessage = acknowledgeMessage;
+    }
+
+    public Map<String, String[]> getAcknowledgeMessages() {
+        return acknowledgeMessages;
+    }
+
+    public void setAcknowledgeMessages(Map<String, String[]> acknowledgeMessages) {
+        this.acknowledgeMessage = acknowledgeMessage;
+    }
+
+    @Override
+    protected void addCustomFields(XContentBuilder builder, Params params) throws IOException {
+        builder.field(TRIAL_WAS_STARTED_FIELD.getPreferredName(), trialWasStarted);
+        if (trialWasStarted) {
+            builder.field(TYPE_FIELD.getPreferredName(), type);
+        } else {
+            builder.field(ERROR_MESSAGE_FIELD.getPreferredName(), errorMessage);
+        }
+
+        if (acknowledgeMessages.isEmpty() == false) {
+            builder.startObject(ACKNOWLEDGE_DETAILS_FIELD.getPreferredName());
+            builder.field(ACKNOWLEDGE_HEADER_FIELD.getPreferredName(), acknowledgeMessage);
+            for (Map.Entry<String, String[]> entry : acknowledgeMessages.entrySet()) {
+                builder.startArray(entry.getKey());
+                for (String message : entry.getValue()) {
+                    builder.value(message);
+                }
+                builder.endArray();
+            }
+            builder.endObject();
+        }
+    }
+
+    public static PostStartTrialResponse fromXContent(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null) {
+            return false;
+        }
+
+        if (getClass() != other.getClass()) {
+            return false;
+        }
+
+        if (super.equals(other) == false) {
+            return false;
+        }
+
+        PostStartTrialResponse otherResponse = (PostStartTrialResponse) other;
+
+        return Objects.equals(acknowledged, otherResponse.acknowledged)
+            && Objects.equals(trialWasStarted, otherResponse.trialWasStarted)
+            && Objects.equals(type, otherResponse.type)
+            && Objects.equals(acknowledgeMessage, otherResponse.acknowledgeMessage)
+            && ProtocolUtils.equals(acknowledgeMessages, otherResponse.acknowledgeMessages);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            super.hashCode(),
+            acknowledged,
+            trialWasStarted,
+            type,
+            acknowledgeMessage,
+            ProtocolUtils.hashCode(acknowledgeMessages)
+        );
+    }
+
+}

--- a/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/license/PostStartTrialResponse.java
+++ b/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/license/PostStartTrialResponse.java
@@ -132,8 +132,7 @@ public class PostStartTrialResponse extends AcknowledgedResponse {
         Objects.requireNonNull(acknowledgeMessages);
     }
 
-    // todo dont use this
-    public PostStartTrialResponse(boolean acknowledged,
+    private PostStartTrialResponse(boolean acknowledged,
                                   boolean trialWasStarted,
                                   String type,
                                   String errorMessage,
@@ -152,40 +151,20 @@ public class PostStartTrialResponse extends AcknowledgedResponse {
         return trialWasStarted;
     }
 
-    public void setTrialWasStarted(boolean trialWasStarted) {
-        this.trialWasStarted = trialWasStarted;
-    }
-
     public String getType() {
         return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
     }
 
     public String getErrorMessage() {
         return errorMessage;
     }
 
-    public void setErrorMessage(String errorMessage) {
-        this.errorMessage = errorMessage;
-    }
-
     public String getAcknowledgeMessage() {
         return acknowledgeMessage;
     }
 
-    public void setAcknowledgeMessage(String acknowledgeMessage) {
-        this.acknowledgeMessage = acknowledgeMessage;
-    }
-
     public Map<String, String[]> getAcknowledgeMessages() {
         return acknowledgeMessages;
-    }
-
-    public void setAcknowledgeMessages(Map<String, String[]> acknowledgeMessages) {
-        this.acknowledgeMessage = acknowledgeMessage;
     }
 
     @Override

--- a/x-pack/protocol/src/test/java/org/elasticsearch/protocol/xpack/license/PostStartTrialResponseTests.java
+++ b/x-pack/protocol/src/test/java/org/elasticsearch/protocol/xpack/license/PostStartTrialResponseTests.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.protocol.xpack.license;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractXContentTestCase;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+
+public class PostStartTrialResponseTests extends AbstractXContentTestCase<PostStartTrialResponse> {
+
+    @Override
+    protected PostStartTrialResponse createTestInstance() {
+        final boolean acknowledged = randomBoolean();
+
+        final boolean successfulStartedTrial = randomBoolean();
+
+        if (successfulStartedTrial) {
+            final String licenseType = randomAlphaOfLengthBetween(3, 20);
+            return new PostStartTrialResponse(acknowledged, licenseType);
+        } else {
+            final String errorMessage = randomAlphaOfLengthBetween(3, 20);
+            final String acknowledgeHeader = randomAlphaOfLengthBetween(3, 20);
+            final Map<String, String[]> acknowledgeMessages = randomAckMessages();
+            return new PostStartTrialResponse(acknowledged, errorMessage, acknowledgeHeader, acknowledgeMessages);
+        }
+    }
+
+    private static Map<String, String[]> randomAckMessages() {
+        int nFeatures = randomIntBetween(1, 5);
+
+        Map<String, String[]> ackMessages = new HashMap<>();
+
+        for (int i = 0; i < nFeatures; i++) {
+            String feature = randomAlphaOfLengthBetween(9, 15);
+            int nMessages = randomIntBetween(1, 5);
+            String[] messages = new String[nMessages];
+            for (int j = 0; j < nMessages; j++) {
+                messages[j] = randomAlphaOfLengthBetween(10, 30);
+            }
+            ackMessages.put(feature, messages);
+        }
+
+        return ackMessages;
+    }
+
+    @Override
+    protected PostStartTrialResponse doParseInstance(XContentParser parser) throws IOException {
+        return PostStartTrialResponse.fromXContent(parser);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return true;
+    }
+
+    @Override
+    protected Predicate<String> getRandomFieldsExcludeFilter() {
+        return p -> p.equals("acknowledge");
+    }
+}


### PR DESCRIPTION
This is kind of a WIP because I'm not sure about some of the approach I took here, but wanted to get some general feedback

The [existing PostStartTrialResponse class](https://github.com/elastic/elasticsearch/blob/38ec0ff6ca483132c54f7dcc0f680de999a3cead/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartTrialResponse.java) has an internal structure that's a little different than [its xcontent representation](https://github.com/elastic/elasticsearch/blob/38ec0ff6ca483132c54f7dcc0f680de999a3cead/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartTrialLicense.java#L38) because it stuffs some of its state into a status enum. Although I think I have a better idea now how to handle that inside the class now, so its xcontent generation can probably be moved inside the class. It also is missing the license type field which I think can be added to it [here](https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartTrialClusterTask.java#L49) from the request