### PR TITLE
SCRIPTING: Support BucketAggScript return null

### DIFF
--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
@@ -147,7 +147,7 @@ public class ExpressionScriptEngine extends AbstractComponent implements ScriptE
             }
             return new BucketAggregationScript(parameters) {
                 @Override
-                public double execute() {
+                public Double execute() {
                     getParams().forEach((name, value) -> {
                         ReplaceableConstDoubleValues placeholder = functionValuesMap.get(name);
                         if (placeholder == null) {

--- a/server/src/main/java/org/elasticsearch/script/BucketAggregationScript.java
+++ b/server/src/main/java/org/elasticsearch/script/BucketAggregationScript.java
@@ -46,7 +46,7 @@ public abstract class BucketAggregationScript {
         return params;
     }
 
-    public abstract double execute();
+    public abstract Double execute();
 
     public interface Factory {
         BucketAggregationScript newInstance(Map<String, Object> params);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketscript/BucketScriptPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketscript/BucketScriptPipelineAggregator.java
@@ -110,13 +110,17 @@ public class BucketScriptPipelineAggregator extends PipelineAggregator {
             if (skipBucket) {
                 newBuckets.add(bucket);
             } else {
-                double returned = factory.newInstance(vars).execute();
-                final List<InternalAggregation> aggs = StreamSupport.stream(bucket.getAggregations().spliterator(), false).map(
+                Double returned = factory.newInstance(vars).execute();
+                if (returned == null) {
+                    newBuckets.add(bucket);
+                } else {
+                    final List<InternalAggregation> aggs = StreamSupport.stream(bucket.getAggregations().spliterator(), false).map(
                         (p) -> (InternalAggregation) p).collect(Collectors.toList());
-                aggs.add(new InternalSimpleValue(name(), returned, formatter, new ArrayList<>(), metaData()));
-                InternalMultiBucketAggregation.InternalBucket newBucket = originalAgg.createBucket(new InternalAggregations(aggs),
+                    aggs.add(new InternalSimpleValue(name(), returned, formatter, new ArrayList<>(), metaData()));
+                    InternalMultiBucketAggregation.InternalBucket newBucket = originalAgg.createBucket(new InternalAggregations(aggs),
                         bucket);
-                newBuckets.add(newBucket);
+                    newBuckets.add(newBucket);
+                }
             }
         }
         return originalAgg.create(newBuckets);

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -111,8 +111,13 @@ public class MockScriptEngine implements ScriptEngine {
         } else if (context.instanceClazz.equals(BucketAggregationScript.class)) {
             BucketAggregationScript.Factory factory = parameters -> new BucketAggregationScript(parameters) {
                 @Override
-                public double execute() {
-                    return ((Number) script.apply(getParams())).doubleValue();
+                public Double execute() {
+                    Object ret = script.apply(getParams());
+                    if (ret == null) {
+                        return null;
+                    } else {
+                        return ((Number) ret).doubleValue();
+                    }
                 }
             };
             return context.factoryClazz.cast(factory);


### PR DESCRIPTION
* As explained in #32790, `BucketAggregationScript` must support `null` as a return value
* Closes #32790