### PR TITLE
Unmute WildFly tests in FIPS JVM

### DIFF
--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -84,7 +84,7 @@ task deploy(type: Copy) {
 }
 
 task writeElasticsearchProperties {
-    onlyIf { !Os.isFamily(Os.FAMILY_WINDOWS) && !inFipsJvm }
+    onlyIf { !Os.isFamily(Os.FAMILY_WINDOWS) }
     dependsOn 'integTestCluster#wait', deploy
     doLast {
         final File elasticsearchProperties = file("${wildflyInstall}/standalone/configuration/elasticsearch.properties")
@@ -178,7 +178,7 @@ task stopWildfly(type: LoggedExec) {
     commandLine "${wildflyInstall}/bin/jboss-cli.sh", "--controller=localhost:${-> managementPort}", "--connect", "command=shutdown"
 }
 
-if (!Os.isFamily(Os.FAMILY_WINDOWS) && !inFipsJvm) {
+if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
     integTestRunner.dependsOn(configureTransportClient)
     final TaskExecutionAdapter logDumpListener = new TaskExecutionAdapter() {
         @Override

--- a/qa/wildfly/src/test/java/org/elasticsearch/wildfly/WildflyIT.java
+++ b/qa/wildfly/src/test/java/org/elasticsearch/wildfly/WildflyIT.java
@@ -28,6 +28,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.TestRuleLimitSysouts;
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterModule;
@@ -50,6 +51,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
+@TestRuleLimitSysouts.Limit(bytes = 14000)
 public class WildflyIT extends LuceneTestCase {
 
     public void testTransportClient() throws URISyntaxException, IOException {


### PR DESCRIPTION
WildflyIT test fails in a FIPS JVM due to the amount of output in stderr. The excessive stderr output is due to https://bugs.openjdk.java.net/browse/JDK-8202893 and is not an indication of a failure that should be tracked. 
This commit adjusts the limit to something more lenient that would allow the test to succeed. 
Reverts #32543