### PR TITLE
[TEST] Select free port for Minio

### DIFF
--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -132,7 +132,7 @@ if (!s3TemporaryAccessKey && !s3TemporarySecretKey && !s3TemporaryBucket && !s3T
 final String minioVersion = 'RELEASE.2018-06-22T23-48-46Z'
 final String minioBinDir = "${buildDir}/minio/bin"
 final String minioDataDir = "${buildDir}/minio/data"
-final String minioAddress = "127.0.0.1:60920"
+final String minioAddress = "127.0.0.1"
 
 final String minioDistribution
 final String minioCheckSum
@@ -187,15 +187,30 @@ if (useFixture && minioDistribution) {
     dependsOn installMinio
 
     ext.minioPid = 0L
+    ext.minioPort = 0
 
     doLast {
+      // get free port
+      for (int port = 60920; port < 60940; port++) {
+        try {
+          javax.net.ServerSocketFactory.getDefault().createServerSocket(port, 1, InetAddress.getByName(minioAddress)).close()
+          minioPort = port
+          break
+        } catch (Exception e) {
+          logger.error("Failed to determine free port " + port + " for Minio process", e)
+        }
+      }
+      if (minioPort == 0) {
+        throw new GradleException("Could not find a free port for Minio")
+      }
+
       new File("${minioDataDir}/${s3PermanentBucket}").mkdirs()
       // we skip these tests on Windows so we do no need to worry about compatibility here
       final ProcessBuilder minio = new ProcessBuilder(
               "${minioBinDir}/${minioFileName}",
               "server",
               "--address",
-              minioAddress,
+              minioAddress + ":" + minioPort,
               minioDataDir)
       minio.environment().put('MINIO_ACCESS_KEY', s3PermanentAccessKey)
       minio.environment().put('MINIO_SECRET_KEY', s3PermanentSecretKey)
@@ -227,6 +242,7 @@ if (useFixture && minioDistribution) {
             final int index = line.lastIndexOf(":")
             assert index >= 0
             httpPort = Integer.parseInt(line.substring(index + 1))
+            assert httpPort == minioPort : "Port mismatch, expected ${minioPort} but was ${httpPort}"
 
             final File script = new File(project.buildDir, "minio/minio.killer.sh")
             script.setText(
@@ -269,10 +285,15 @@ if (useFixture && minioDistribution) {
   project.afterEvaluate {
     ClusterConfiguration cluster = project.extensions.getByName('integTestMinioCluster') as ClusterConfiguration
     cluster.dependsOn(project.bundlePlugin)
+    cluster.dependsOn(startMinio) // otherwise we don't know the Minio port
     cluster.keystoreSetting 's3.client.integration_test_permanent.access_key', s3PermanentAccessKey
     cluster.keystoreSetting 's3.client.integration_test_permanent.secret_key', s3PermanentSecretKey
 
-    cluster.setting 's3.client.integration_test_permanent.endpoint', "http://${minioAddress}"
+    Closure<String> minioAddressAndPort = {
+      assert startMinio.minioPort > 0
+      return 'http://' + minioAddress + ':' + startMinio.minioPort
+    }
+    cluster.setting 's3.client.integration_test_permanent.endpoint', "${ -> minioAddressAndPort.call()}"
 
     Task restIntegTestTask = project.tasks.getByName('integTestMinio')
     restIntegTestTask.clusterConfig.plugin(project.path)

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -196,8 +196,8 @@ if (useFixture && minioDistribution) {
           javax.net.ServerSocketFactory.getDefault().createServerSocket(port, 1, InetAddress.getByName(minioAddress)).close()
           minioPort = port
           break
-        } catch (Exception e) {
-          logger.error("Failed to determine free port " + port + " for Minio process", e)
+        } catch (BindException e) {
+          logger.info("Port " + port + " for Minio process is already taken", e)
         }
       }
       if (minioPort == 0) {


### PR DESCRIPTION
Minio does not support dynamic ports. The workaround here is to scan for a free port first. This is not foolproof, but as we don't expect too many of these builds to run at once on the same machine, this should do the trick.

Closes #32701 and #32208