### PR TITLE
Mute bwc tests for old versions in FIPS JVMs

### DIFF
--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -129,8 +129,12 @@ subprojects {
       .file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')
     into outputDir
   }
-
-  for (Version version : bwcVersions.indexCompatible) {
+  List<Version> indexCompatibleVersions = bwcVersions.indexCompatible
+  // Versions before 6.4.0 cannot be run in a FIPS 140 JVM, so exclude them
+  if (inFipsJvm){
+    indexCompatibleVersions.removeAll { it.before("6.4.0")}
+  }
+  for (Version version : indexCompatibleVersions) {
     String baseName = "v${version}"
 
     Task oldClusterTest = tasks.create(name: "${baseName}#oldClusterTest", type: RestIntegTestTask) {
@@ -240,7 +244,12 @@ subprojects {
   // basic integ tests includes testing bwc against the most recent version
   task integTest {
     if (project.bwc_tests_enabled) {
-      for (final def version : bwcVersions.snapshotsIndexCompatible) {
+      List<Version> snapshotsIndexCompatibleVersions = bwcVersions.snapshotsWireCompatible
+      // Versions before 6.4.0 cannot be run in a FIPS 140 JVM, so exclude them
+      if (inFipsJvm){
+        snapshotsIndexCompatibleVersions.removeAll{ it.before("6.4.0")}
+      }
+      for (final def version : snapshotsIndexCompatibleVersions) {
         dependsOn "v${version}#bwcTest"
       }
     }

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -129,12 +129,7 @@ subprojects {
       .file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')
     into outputDir
   }
-  List<Version> indexCompatibleVersions = bwcVersions.indexCompatible
-  // Versions before 6.4.0 cannot be run in a FIPS 140 JVM, so exclude them
-  if (inFipsJvm){
-    indexCompatibleVersions.removeAll { it.before("6.4.0")}
-  }
-  for (Version version : indexCompatibleVersions) {
+  for (Version version : bwcVersions.getIndexCompatible(inFipsJvm)) {
     String baseName = "v${version}"
 
     Task oldClusterTest = tasks.create(name: "${baseName}#oldClusterTest", type: RestIntegTestTask) {
@@ -244,12 +239,7 @@ subprojects {
   // basic integ tests includes testing bwc against the most recent version
   task integTest {
     if (project.bwc_tests_enabled) {
-      List<Version> snapshotsIndexCompatibleVersions = bwcVersions.snapshotsWireCompatible
-      // Versions before 6.4.0 cannot be run in a FIPS 140 JVM, so exclude them
-      if (inFipsJvm){
-        snapshotsIndexCompatibleVersions.removeAll{ it.before("6.4.0")}
-      }
-      for (final def version : snapshotsIndexCompatibleVersions) {
+      for (final def version : bwcVersions.getSnapshotsWireCompatible(inFipsJvm)) {
         dependsOn "v${version}#bwcTest"
       }
     }

--- a/x-pack/qa/full-cluster-restart/with-system-key/build.gradle
+++ b/x-pack/qa/full-cluster-restart/with-system-key/build.gradle
@@ -1,8 +1,0 @@
-import org.elasticsearch.gradle.test.RestIntegTestTask
-
-// Skip test on FIPS FIXME https://github.com/elastic/elasticsearch/issues/32737
-if (project.inFipsJvm) {
-    tasks.withType(RestIntegTestTask) {
-        enabled = false
-    }
-}

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -111,12 +111,7 @@ subprojects {
             .file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')
     into outputDir
   }
-  List<Version> wireCompatibleVersions = bwcVersions.wireCompatible
-  // Versions before 6.4.0 cannot be run in a FIPS 140 JVM, so exclude them
-  if (inFipsJvm){
-    wireCompatibleVersions.removeAll{ it.before("6.4.0")}
-  }
-  for (Version version : wireCompatibleVersions) {
+  for (Version version : bwcVersions.getWireCompatible(inFipsJvm)) {
     String baseName = "v${version}"
 
     Task oldClusterTest = tasks.create(name: "${baseName}#oldClusterTest", type: RestIntegTestTask) {
@@ -280,12 +275,7 @@ subprojects {
   // basic integ tests includes testing bwc against the most recent version
   task integTest {
     if (project.bwc_tests_enabled) {
-      List<Version> snapshotsWireCompatibleVersions = bwcVersions.snapshotsWireCompatible
-      // Versions before 6.4.0 cannot be run in a FIPS 140 JVM, so exclude them
-      if (inFipsJvm){
-          snapshotsWireCompatibleVersions.removeAll{ it.before("6.4.0")}
-      }
-      for (final def version : snapshotsWireCompatibleVersions) {
+      for (final def version : bwcVersions.getSnapshotsWireCompatible(inFipsJvm)) {
         dependsOn "v${version}#bwcTest"
       }
     }

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -111,8 +111,12 @@ subprojects {
             .file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')
     into outputDir
   }
-
-  for (Version version : bwcVersions.wireCompatible) {
+  List<Version> wireCompatibleVersions = bwcVersions.wireCompatible
+  // Versions before 6.4.0 cannot be run in a FIPS 140 JVM, so exclude them
+  if (inFipsJvm){
+    wireCompatibleVersions.removeAll{ it.before("6.4.0")}
+  }
+  for (Version version : wireCompatibleVersions) {
     String baseName = "v${version}"
 
     Task oldClusterTest = tasks.create(name: "${baseName}#oldClusterTest", type: RestIntegTestTask) {
@@ -276,7 +280,12 @@ subprojects {
   // basic integ tests includes testing bwc against the most recent version
   task integTest {
     if (project.bwc_tests_enabled) {
-      for (final def version : bwcVersions.snapshotsWireCompatible) {
+      List<Version> snapshotsWireCompatibleVersions = bwcVersions.snapshotsWireCompatible
+      // Versions before 6.4.0 cannot be run in a FIPS 140 JVM, so exclude them
+      if (inFipsJvm){
+          snapshotsWireCompatibleVersions.removeAll{ it.before("6.4.0")}
+      }
+      for (final def version : snapshotsWireCompatibleVersions) {
         dependsOn "v${version}#bwcTest"
       }
     }

--- a/x-pack/qa/rolling-upgrade/with-system-key/build.gradle
+++ b/x-pack/qa/rolling-upgrade/with-system-key/build.gradle
@@ -1,10 +1,3 @@
 import org.elasticsearch.gradle.test.RestIntegTestTask
 
-// Skip test on FIPS FIXME https://github.com/elastic/elasticsearch/issues/32737
-if (project.inFipsJvm) {
-    tasks.withType(RestIntegTestTask) {
-        enabled = false
-    }
-}
-
 group = "${group}.x-pack.qa.rolling-upgrade.with-system-key"


### PR DESCRIPTION
Elasticsearch versions earlier than 6.4.0 cannot properly run in a
FIPS 140 JVM. This commit ensures that we do not try to run bwc
tests that entail spinning up < 6.4.0 nodes when CI is run in a FIPS
140 JVM.
It also reverts e497173 and e64bb48 as the workarounds inserted there
are no longer required.

Resolves #32737