### PR TITLE
HLRC: Refactor WatchStatus

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/ActionStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/ActionStatus.java
@@ -5,56 +5,54 @@
  */
 package org.elasticsearch.xpack.core.watcher.actions;
 
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ToXContentObject;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.protocol.xpack.watcher.status.ActionAckStatus;
+import org.elasticsearch.protocol.xpack.watcher.status.ActionStatusExecution;
+import org.elasticsearch.protocol.xpack.watcher.status.ActionStatusThrottle;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
-import java.io.IOException;
-import java.util.Locale;
 import java.util.Objects;
 
-import static org.elasticsearch.xpack.core.watcher.support.Exceptions.illegalArgument;
-import static org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils.dateTimeFormatter;
+public class ActionStatus {
 
-public class ActionStatus implements ToXContentObject {
-
-    private AckStatus ackStatus;
-    @Nullable private Execution lastExecution;
-    @Nullable private Execution lastSuccessfulExecution;
-    @Nullable private Throttle lastThrottle;
+    private ActionAckStatus ackStatus;
+    @Nullable private ActionStatusExecution lastExecution;
+    @Nullable private ActionStatusExecution lastSuccessfulExecution;
+    @Nullable private ActionStatusThrottle lastThrottle;
 
     public ActionStatus(DateTime now) {
-        this(new AckStatus(now, AckStatus.State.AWAITS_SUCCESSFUL_EXECUTION), null, null, null);
+        this(new ActionAckStatus(now, ActionAckStatus.State.AWAITS_SUCCESSFUL_EXECUTION),
+                null, null, null);
     }
 
-    public ActionStatus(AckStatus ackStatus, @Nullable Execution lastExecution, @Nullable Execution lastSuccessfulExecution,
-                        @Nullable Throttle lastThrottle) {
+    public ActionStatus(ActionAckStatus ackStatus, @Nullable ActionStatusExecution lastExecution,
+                        @Nullable ActionStatusExecution lastSuccessfulExecution, @Nullable ActionStatusThrottle lastThrottle) {
         this.ackStatus = ackStatus;
         this.lastExecution = lastExecution;
         this.lastSuccessfulExecution = lastSuccessfulExecution;
         this.lastThrottle = lastThrottle;
     }
 
-    public AckStatus ackStatus() {
+    public ActionStatus(org.elasticsearch.protocol.xpack.watcher.status.ActionStatus protocolStatus) {
+        this.ackStatus = protocolStatus.ackStatus();
+        this.lastExecution = protocolStatus.lastExecution();
+        this.lastSuccessfulExecution = protocolStatus.lastSuccessfulExecution();
+        this.lastThrottle = protocolStatus.lastThrottle();
+    }
+
+    public ActionAckStatus ackStatus() {
         return ackStatus;
     }
 
-    public Execution lastExecution() {
+    public ActionStatusExecution lastExecution() {
         return lastExecution;
     }
 
-    public Execution lastSuccessfulExecution() {
+    public ActionStatusExecution lastSuccessfulExecution() {
         return lastSuccessfulExecution;
     }
 
-    public Throttle lastThrottle() {
+    public ActionStatusThrottle lastThrottle() {
         return lastThrottle;
     }
 
@@ -81,423 +79,42 @@ public class ActionStatus implements ToXContentObject {
 
             case FAILURE:
                 String reason = result instanceof Action.Result.Failure ? ((Action.Result.Failure) result).reason() : "";
-                lastExecution = Execution.failure(timestamp, reason);
+                lastExecution = ActionStatusExecution.failure(timestamp, reason);
                 return;
 
             case THROTTLED:
                 reason = result instanceof Action.Result.Throttled ? ((Action.Result.Throttled) result).reason() : "";
-                lastThrottle = new Throttle(timestamp, reason);
+                lastThrottle = new ActionStatusThrottle(timestamp, reason);
                 return;
 
             case SUCCESS:
             case SIMULATED:
-                lastExecution = Execution.successful(timestamp);
+                lastExecution = ActionStatusExecution.successful(timestamp);
                 lastSuccessfulExecution = lastExecution;
-                if (ackStatus.state == AckStatus.State.AWAITS_SUCCESSFUL_EXECUTION) {
-                    ackStatus = new AckStatus(timestamp, AckStatus.State.ACKABLE);
+                if (ackStatus.state() == ActionAckStatus.State.AWAITS_SUCCESSFUL_EXECUTION) {
+                    ackStatus = new ActionAckStatus(timestamp, ActionAckStatus.State.ACKABLE);
                 }
         }
     }
 
     public boolean onAck(DateTime timestamp) {
-        if (ackStatus.state == AckStatus.State.ACKABLE) {
-            ackStatus = new AckStatus(timestamp, AckStatus.State.ACKED);
+        if (ackStatus.state() == ActionAckStatus.State.ACKABLE) {
+            ackStatus = new ActionAckStatus(timestamp, ActionAckStatus.State.ACKED);
             return true;
         }
         return false;
     }
 
     public boolean resetAckStatus(DateTime timestamp) {
-        if (ackStatus.state != AckStatus.State.AWAITS_SUCCESSFUL_EXECUTION) {
-            ackStatus = new AckStatus(timestamp, AckStatus.State.AWAITS_SUCCESSFUL_EXECUTION);
+        if (ackStatus.state() != ActionAckStatus.State.AWAITS_SUCCESSFUL_EXECUTION) {
+            ackStatus = new ActionAckStatus(timestamp, ActionAckStatus.State.AWAITS_SUCCESSFUL_EXECUTION);
             return true;
         }
         return false;
     }
 
-    public static void writeTo(ActionStatus status, StreamOutput out) throws IOException {
-        AckStatus.writeTo(status.ackStatus, out);
-        out.writeBoolean(status.lastExecution != null);
-        if (status.lastExecution != null) {
-            Execution.writeTo(status.lastExecution, out);
-        }
-        out.writeBoolean(status.lastSuccessfulExecution != null);
-        if (status.lastSuccessfulExecution != null) {
-            Execution.writeTo(status.lastSuccessfulExecution, out);
-        }
-        out.writeBoolean(status.lastThrottle != null);
-        if (status.lastThrottle != null) {
-            Throttle.writeTo(status.lastThrottle, out);
-        }
-    }
-
-    public static ActionStatus readFrom(StreamInput in) throws IOException {
-        AckStatus ackStatus = AckStatus.readFrom(in);
-        Execution lastExecution = in.readBoolean() ? Execution.readFrom(in) : null;
-        Execution lastSuccessfulExecution = in.readBoolean() ? Execution.readFrom(in) : null;
-        Throttle lastThrottle = in.readBoolean() ? Throttle.readFrom(in) : null;
-        return new ActionStatus(ackStatus, lastExecution, lastSuccessfulExecution, lastThrottle);
-    }
-
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
-        builder.field(Field.ACK_STATUS.getPreferredName(), ackStatus, params);
-        if (lastExecution != null) {
-            builder.field(Field.LAST_EXECUTION.getPreferredName(), lastExecution, params);
-        }
-        if (lastSuccessfulExecution != null) {
-            builder.field(Field.LAST_SUCCESSFUL_EXECUTION.getPreferredName(), lastSuccessfulExecution, params);
-        }
-        if (lastThrottle != null) {
-            builder.field(Field.LAST_THROTTLE.getPreferredName(), lastThrottle, params);
-        }
-        return builder.endObject();
-    }
-
-    public static ActionStatus parse(String watchId, String actionId, XContentParser parser) throws IOException {
-        AckStatus ackStatus = null;
-        Execution lastExecution = null;
-        Execution lastSuccessfulExecution = null;
-        Throttle lastThrottle = null;
-
-        String currentFieldName = null;
-        XContentParser.Token token;
-        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                currentFieldName = parser.currentName();
-            } else if (Field.ACK_STATUS.match(currentFieldName, parser.getDeprecationHandler())) {
-                ackStatus = AckStatus.parse(watchId, actionId, parser);
-            } else if (Field.LAST_EXECUTION.match(currentFieldName, parser.getDeprecationHandler())) {
-                lastExecution = Execution.parse(watchId, actionId, parser);
-            } else if (Field.LAST_SUCCESSFUL_EXECUTION.match(currentFieldName, parser.getDeprecationHandler())) {
-                lastSuccessfulExecution = Execution.parse(watchId, actionId, parser);
-            } else if (Field.LAST_THROTTLE.match(currentFieldName, parser.getDeprecationHandler())) {
-                lastThrottle = Throttle.parse(watchId, actionId, parser);
-            } else {
-                throw new ElasticsearchParseException("could not parse action status for [{}/{}]. unexpected field [{}]", watchId,
-                        actionId, currentFieldName);
-            }
-        }
-        if (ackStatus == null) {
-            throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field [{}]", watchId,
-                    actionId, Field.ACK_STATUS.getPreferredName());
-        }
-        return new ActionStatus(ackStatus, lastExecution, lastSuccessfulExecution, lastThrottle);
-    }
-
-    public static class AckStatus implements ToXContentObject {
-
-        public enum State {
-            AWAITS_SUCCESSFUL_EXECUTION((byte) 1),
-            ACKABLE((byte) 2),
-            ACKED((byte) 3);
-
-            private byte value;
-
-            State(byte value) {
-                this.value = value;
-            }
-
-            static State resolve(byte value) {
-                switch (value) {
-                    case 1 : return AWAITS_SUCCESSFUL_EXECUTION;
-                    case 2 : return ACKABLE;
-                    case 3 : return ACKED;
-                    default:
-                        throw illegalArgument("unknown action ack status state value [{}]", value);
-                }
-            }
-        }
-
-        private final DateTime timestamp;
-        private final State state;
-
-        public AckStatus(DateTime timestamp, State state) {
-            this.timestamp = timestamp.toDateTime(DateTimeZone.UTC);
-            this.state = state;
-        }
-
-        public DateTime timestamp() {
-            return timestamp;
-        }
-
-        public State state() {
-            return state;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            AckStatus ackStatus = (AckStatus) o;
-
-            return Objects.equals(timestamp, ackStatus.timestamp) &&  Objects.equals(state, ackStatus.state);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(timestamp, state);
-        }
-
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            return builder.startObject()
-                    .field(Field.TIMESTAMP.getPreferredName()).value(dateTimeFormatter.printer().print(timestamp))
-                    .field(Field.ACK_STATUS_STATE.getPreferredName(), state.name().toLowerCase(Locale.ROOT))
-                    .endObject();
-        }
-
-        public static AckStatus parse(String watchId, String actionId, XContentParser parser) throws IOException {
-            DateTime timestamp = null;
-            State state = null;
-
-            String currentFieldName = null;
-            XContentParser.Token token;
-            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                if (token == XContentParser.Token.FIELD_NAME) {
-                    currentFieldName = parser.currentName();
-                } else if (Field.TIMESTAMP.match(currentFieldName, parser.getDeprecationHandler())) {
-                    timestamp = dateTimeFormatter.parser().parseDateTime(parser.text());
-                } else if (Field.ACK_STATUS_STATE.match(currentFieldName, parser.getDeprecationHandler())) {
-                    state = State.valueOf(parser.text().toUpperCase(Locale.ROOT));
-                } else {
-                    throw new ElasticsearchParseException("could not parse action status for [{}/{}]. unexpected field [{}.{}]", watchId,
-                            actionId, Field.ACK_STATUS.getPreferredName(), currentFieldName);
-                }
-            }
-            if (timestamp == null) {
-                throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field [{}.{}]",
-                        watchId, actionId, Field.ACK_STATUS.getPreferredName(), Field.TIMESTAMP.getPreferredName());
-            }
-            if (state == null) {
-                throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field [{}.{}]",
-                        watchId, actionId, Field.ACK_STATUS.getPreferredName(), Field.ACK_STATUS_STATE.getPreferredName());
-            }
-            return new AckStatus(timestamp, state);
-        }
-
-        static void writeTo(AckStatus status, StreamOutput out) throws IOException {
-            out.writeLong(status.timestamp.getMillis());
-            out.writeByte(status.state.value);
-        }
-
-        static AckStatus readFrom(StreamInput in) throws IOException {
-            DateTime timestamp = new DateTime(in.readLong(), DateTimeZone.UTC);
-            State state = State.resolve(in.readByte());
-            return new AckStatus(timestamp, state);
-        }
-    }
-
-    public static class Execution implements ToXContentObject {
-
-        public static Execution successful(DateTime timestamp) {
-            return new Execution(timestamp, true, null);
-        }
-
-        public static Execution failure(DateTime timestamp, String reason) {
-            return new Execution(timestamp, false, reason);
-        }
-
-        private final DateTime timestamp;
-        private final boolean successful;
-        private final String reason;
-
-        private Execution(DateTime timestamp, boolean successful, String reason) {
-            this.timestamp = timestamp.toDateTime(DateTimeZone.UTC);
-            this.successful = successful;
-            this.reason = reason;
-        }
-
-        public DateTime timestamp() {
-            return timestamp;
-        }
-
-        public boolean successful() {
-            return successful;
-        }
-
-        public String reason() {
-            return reason;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            Execution execution = (Execution) o;
-
-            return Objects.equals(successful, execution.successful) &&
-                   Objects.equals(timestamp, execution.timestamp) &&
-                   Objects.equals(reason, execution.reason);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(timestamp, successful, reason);
-        }
-
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.startObject();
-            builder.field(Field.TIMESTAMP.getPreferredName()).value(dateTimeFormatter.printer().print(timestamp));
-            builder.field(Field.EXECUTION_SUCCESSFUL.getPreferredName(), successful);
-            if (reason != null) {
-                builder.field(Field.REASON.getPreferredName(), reason);
-            }
-            return builder.endObject();
-        }
-
-        public static Execution parse(String watchId, String actionId, XContentParser parser) throws IOException {
-            DateTime timestamp = null;
-            Boolean successful = null;
-            String reason = null;
-
-            String currentFieldName = null;
-            XContentParser.Token token;
-            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                if (token == XContentParser.Token.FIELD_NAME) {
-                    currentFieldName = parser.currentName();
-                } else if (Field.TIMESTAMP.match(currentFieldName, parser.getDeprecationHandler())) {
-                    timestamp = dateTimeFormatter.parser().parseDateTime(parser.text());
-                } else if (Field.EXECUTION_SUCCESSFUL.match(currentFieldName, parser.getDeprecationHandler())) {
-                    successful = parser.booleanValue();
-                } else if (Field.REASON.match(currentFieldName, parser.getDeprecationHandler())) {
-                    reason = parser.text();
-                } else {
-                    throw new ElasticsearchParseException("could not parse action status for [{}/{}]. unexpected field [{}.{}]", watchId,
-                            actionId, Field.LAST_EXECUTION.getPreferredName(), currentFieldName);
-                }
-            }
-            if (timestamp == null) {
-                throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field [{}.{}]",
-                        watchId, actionId, Field.LAST_EXECUTION.getPreferredName(), Field.TIMESTAMP.getPreferredName());
-            }
-            if (successful == null) {
-                throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field [{}.{}]",
-                        watchId, actionId, Field.LAST_EXECUTION.getPreferredName(), Field.EXECUTION_SUCCESSFUL.getPreferredName());
-            }
-            if (successful) {
-                return successful(timestamp);
-            }
-            if (reason == null) {
-                throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field for unsuccessful" +
-                        " execution [{}.{}]", watchId, actionId, Field.LAST_EXECUTION.getPreferredName(), Field.REASON.getPreferredName());
-            }
-            return failure(timestamp, reason);
-        }
-
-        public static void writeTo(Execution execution, StreamOutput out) throws IOException {
-            out.writeLong(execution.timestamp.getMillis());
-            out.writeBoolean(execution.successful);
-            if (!execution.successful) {
-                out.writeString(execution.reason);
-            }
-        }
-
-        public static Execution readFrom(StreamInput in) throws IOException {
-            DateTime timestamp = new DateTime(in.readLong(), DateTimeZone.UTC);
-            boolean successful = in.readBoolean();
-            if (successful) {
-                return successful(timestamp);
-            }
-            return failure(timestamp, in.readString());
-        }
-    }
-
-    public static class Throttle implements ToXContentObject {
-
-        private final DateTime timestamp;
-        private final String reason;
-
-        public Throttle(DateTime timestamp, String reason) {
-            this.timestamp = timestamp.toDateTime(DateTimeZone.UTC);
-            this.reason = reason;
-        }
-
-        public DateTime timestamp() {
-            return timestamp;
-        }
-
-        public String reason() {
-            return reason;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            Throttle throttle = (Throttle) o;
-            return Objects.equals(timestamp, throttle.timestamp) && Objects.equals(reason, throttle.reason);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(timestamp, reason);
-        }
-
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            return builder.startObject()
-                    .field(Field.TIMESTAMP.getPreferredName()).value(dateTimeFormatter.printer().print(timestamp))
-                    .field(Field.REASON.getPreferredName(), reason)
-                    .endObject();
-        }
-
-        public static Throttle parse(String watchId, String actionId, XContentParser parser) throws IOException {
-            DateTime timestamp = null;
-            String reason = null;
-
-            String currentFieldName = null;
-            XContentParser.Token token;
-            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                if (token == XContentParser.Token.FIELD_NAME) {
-                    currentFieldName = parser.currentName();
-                } else if (Field.TIMESTAMP.match(currentFieldName, parser.getDeprecationHandler())) {
-                    timestamp = dateTimeFormatter.parser().parseDateTime(parser.text());
-                } else if (Field.REASON.match(currentFieldName, parser.getDeprecationHandler())) {
-                    reason = parser.text();
-                } else {
-                    throw new ElasticsearchParseException("could not parse action status for [{}/{}]. unexpected field [{}.{}]", watchId,
-                            actionId, Field.LAST_THROTTLE.getPreferredName(), currentFieldName);
-                }
-            }
-            if (timestamp == null) {
-                throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field [{}.{}]",
-                        watchId, actionId, Field.LAST_THROTTLE.getPreferredName(), Field.TIMESTAMP.getPreferredName());
-            }
-            if (reason == null) {
-                throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field [{}.{}]",
-                        watchId, actionId, Field.LAST_THROTTLE.getPreferredName(), Field.REASON.getPreferredName());
-            }
-            return new Throttle(timestamp, reason);
-        }
-
-        static void writeTo(Throttle throttle, StreamOutput out) throws IOException {
-            out.writeLong(throttle.timestamp.getMillis());
-            out.writeString(throttle.reason);
-        }
-
-        static Throttle readFrom(StreamInput in) throws IOException {
-            DateTime timestamp = new DateTime(in.readLong(), DateTimeZone.UTC);
-            return new Throttle(timestamp, in.readString());
-        }
-    }
-
-    interface Field {
-        ParseField ACK_STATUS = new ParseField("ack");
-        ParseField ACK_STATUS_STATE = new ParseField("state");
-
-        ParseField LAST_EXECUTION = new ParseField("last_execution");
-        ParseField LAST_SUCCESSFUL_EXECUTION = new ParseField("last_successful_execution");
-        ParseField EXECUTION_SUCCESSFUL = new ParseField("successful");
-
-        ParseField LAST_THROTTLE = new ParseField("last_throttle");
-
-        ParseField TIMESTAMP = new ParseField("timestamp");
-        ParseField REASON = new ParseField("reason");
+    public org.elasticsearch.protocol.xpack.watcher.status.ActionStatus toProtocolStatus() {
+        return new org.elasticsearch.protocol.xpack.watcher.status.ActionStatus(ackStatus, lastExecution, lastSuccessfulExecution,
+                lastThrottle);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/ActionWrapper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/ActionWrapper.java
@@ -20,7 +20,7 @@ import org.elasticsearch.xpack.core.watcher.actions.throttler.ThrottlerField;
 import org.elasticsearch.xpack.core.watcher.condition.Condition;
 import org.elasticsearch.xpack.core.watcher.condition.ExecutableCondition;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
-import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
+import org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils;
 import org.elasticsearch.xpack.core.watcher.transform.ExecutableTransform;
 import org.elasticsearch.xpack.core.watcher.transform.Transform;
 import org.elasticsearch.xpack.core.watcher.watch.Payload;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/throttler/AckThrottler.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/throttler/AckThrottler.java
@@ -6,19 +6,19 @@
 package org.elasticsearch.xpack.core.watcher.actions.throttler;
 
 import org.elasticsearch.xpack.core.watcher.actions.ActionStatus;
-import org.elasticsearch.xpack.core.watcher.actions.ActionStatus.AckStatus;
+import org.elasticsearch.protocol.xpack.watcher.status.ActionAckStatus;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 
 import static org.elasticsearch.xpack.core.watcher.actions.throttler.Throttler.Type.ACK;
-import static org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils.formatDate;
+import static org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils.formatDate;
 
 public class AckThrottler implements Throttler {
 
     @Override
     public Result throttle(String actionId, WatchExecutionContext ctx) {
         ActionStatus actionStatus = ctx.watch().status().actionStatus(actionId);
-        AckStatus ackStatus = actionStatus.ackStatus();
-        if (ackStatus.state() == AckStatus.State.ACKED) {
+        ActionAckStatus ackStatus = actionStatus.ackStatus();
+        if (ackStatus.state() == ActionAckStatus.State.ACKED) {
             return Result.throttle(ACK, "action [{}] was acked at [{}]", actionId, formatDate(ackStatus.timestamp()));
         }
         return Result.NO;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/execution/WatchExecutionContext.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/execution/WatchExecutionContext.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.watcher.execution;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
 import org.elasticsearch.xpack.core.watcher.actions.ActionWrapperResult;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/execution/WatchExecutionResult.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/execution/WatchExecutionResult.java
@@ -12,7 +12,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.watcher.actions.ActionWrapperResult;
 import org.elasticsearch.xpack.core.watcher.condition.Condition;
 import org.elasticsearch.xpack.core.watcher.input.Input;
-import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
+import org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils;
 import org.elasticsearch.xpack.core.watcher.transform.Transform;
 import org.joda.time.DateTime;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/history/WatchRecord.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/history/WatchRecord.java
@@ -15,7 +15,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.watcher.actions.Action;
 import org.elasticsearch.xpack.core.watcher.actions.ActionWrapperResult;
 import org.elasticsearch.xpack.core.watcher.condition.ExecutableCondition;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionResult;
 import org.elasticsearch.xpack.core.watcher.execution.Wid;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/WatcherUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/WatcherUtils.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import static org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils.formatDate;
+import static org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils.formatDate;
 
 public final class WatcherUtils {
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/xcontent/WatcherParams.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/xcontent/WatcherParams.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.xpack.core.watcher.support.xcontent;
 
 import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.xpack.core.watcher.watch.Watch;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -19,8 +18,8 @@ public class WatcherParams extends ToXContent.DelegatingMapParams {
     public static final WatcherParams HIDE_SECRETS = WatcherParams.builder().hideSecrets(true).build();
 
     private static final String HIDE_SECRETS_KEY = "hide_secrets";
-    private static final String HIDE_HEADERS = "hide_headers";
     private static final String DEBUG_KEY = "debug";
+    private static final String INCLUDE_STATUS_KEY = "include_status";
 
     public static boolean hideSecrets(ToXContent.Params params) {
         return wrap(params).hideSecrets();
@@ -30,8 +29,8 @@ public class WatcherParams extends ToXContent.DelegatingMapParams {
         return wrap(params).debug();
     }
 
-    public static boolean hideHeaders(ToXContent.Params params) {
-        return wrap(params).hideHeaders();
+    public static boolean includeStatus(ToXContent.Params params) {
+        return wrap(params).includeStatus();
     }
 
     private WatcherParams(Map<String, String> params, ToXContent.Params delegate) {
@@ -46,8 +45,8 @@ public class WatcherParams extends ToXContent.DelegatingMapParams {
         return paramAsBoolean(DEBUG_KEY, false);
     }
 
-    private boolean hideHeaders() {
-        return paramAsBoolean(HIDE_HEADERS, true);
+    private boolean includeStatus() {
+        return paramAsBoolean(INCLUDE_STATUS_KEY, false);
     }
 
     public static WatcherParams wrap(ToXContent.Params params) {
@@ -78,18 +77,13 @@ public class WatcherParams extends ToXContent.DelegatingMapParams {
             return this;
         }
 
-        public Builder hideHeaders(boolean hideHeaders) {
-            params.put(HIDE_HEADERS, String.valueOf(hideHeaders));
-            return this;
-        }
-
         public Builder debug(boolean debug) {
             params.put(DEBUG_KEY, String.valueOf(debug));
             return this;
         }
 
         public Builder includeStatus(boolean includeStatus) {
-            params.put(Watch.INCLUDE_STATUS_KEY, String.valueOf(includeStatus));
+            params.put(INCLUDE_STATUS_KEY, String.valueOf(includeStatus));
             return this;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/trigger/TriggerEvent.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/trigger/TriggerEvent.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.core.watcher.trigger;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
+import org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils;
 import org.joda.time.DateTime;
 
 import java.io.IOException;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/watch/Watch.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/watch/Watch.java
@@ -9,6 +9,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.protocol.xpack.watcher.status.ActionAckStatus;
 import org.elasticsearch.xpack.core.watcher.actions.ActionStatus;
 import org.elasticsearch.xpack.core.watcher.actions.ActionWrapper;
 import org.elasticsearch.xpack.core.watcher.condition.ExecutableCondition;
@@ -21,9 +22,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.core.watcher.support.xcontent.WatcherParams.includeStatus;
+
 public class Watch implements ToXContentObject {
 
-    public static final String INCLUDE_STATUS_KEY = "include_status";
     public static final String INDEX = ".watches";
     public static final String DOC_TYPE = "doc";
 
@@ -116,7 +118,7 @@ public class Watch implements ToXContentObject {
 
     public boolean acked(String actionId) {
         ActionStatus actionStatus = status.actionStatus(actionId);
-        return actionStatus.ackStatus().state() == ActionStatus.AckStatus.State.ACKED;
+        return actionStatus.ackStatus().state() == ActionAckStatus.State.ACKED;
     }
 
     @Override
@@ -154,7 +156,7 @@ public class Watch implements ToXContentObject {
         if (metadata != null) {
             builder.field(WatchField.METADATA.getPreferredName(), metadata);
         }
-        if (params.paramAsBoolean(INCLUDE_STATUS_KEY, false)) {
+        if (includeStatus(params)) {
             builder.field(WatchField.STATUS.getPreferredName(), status, params);
         }
         builder.endObject();

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/ExecutableIndexAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/ExecutableIndexAction.java
@@ -22,7 +22,7 @@ import org.elasticsearch.xpack.core.watcher.actions.Action;
 import org.elasticsearch.xpack.core.watcher.actions.Action.Result.Status;
 import org.elasticsearch.xpack.core.watcher.actions.ExecutableAction;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
-import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
+import org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils;
 import org.elasticsearch.xpack.core.watcher.support.xcontent.XContentSource;
 import org.elasticsearch.xpack.core.watcher.watch.Payload;
 import org.elasticsearch.xpack.watcher.support.ArrayObjectIterator;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/IndexAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/IndexAction.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.watcher.actions.Action;
-import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
+import org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils;
 import org.elasticsearch.xpack.core.watcher.support.xcontent.XContentSource;
 import org.joda.time.DateTimeZone;
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpRequest.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpRequest.java
@@ -17,7 +17,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.RestUtils;
-import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
+import org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils;
 import org.elasticsearch.xpack.core.watcher.support.WatcherUtils;
 import org.elasticsearch.xpack.core.watcher.support.xcontent.WatcherParams;
 import org.elasticsearch.xpack.core.watcher.support.xcontent.WatcherXContentParser;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpRequestTemplate.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpRequestTemplate.java
@@ -17,7 +17,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.RestUtils;
 import org.elasticsearch.script.ScriptType;
-import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
+import org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils;
 import org.elasticsearch.xpack.watcher.common.http.auth.HttpAuth;
 import org.elasticsearch.xpack.watcher.common.http.auth.HttpAuthRegistry;
 import org.elasticsearch.xpack.watcher.common.text.TextTemplate;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/AbstractCompareCondition.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/AbstractCompareCondition.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.watcher.condition;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.watcher.condition.ExecutableCondition;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
-import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
+import org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils;
 import org.elasticsearch.xpack.core.watcher.support.xcontent.ObjectPath;
 import org.elasticsearch.xpack.watcher.support.Variables;
 import org.joda.time.DateTime;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/LenientCompare.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/LenientCompare.java
@@ -5,7 +5,7 @@
  */
 package org.elasticsearch.xpack.watcher.condition;
 
-import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
+import org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/ExecutionService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/ExecutionService.java
@@ -20,7 +20,6 @@ import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.routing.Preference;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.metrics.MeanMetric;
@@ -29,26 +28,26 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.engine.DocumentMissingException;
+import org.elasticsearch.protocol.xpack.watcher.status.WatchStatusParams;
 import org.elasticsearch.xpack.core.watcher.actions.ActionWrapper;
 import org.elasticsearch.xpack.core.watcher.actions.ActionWrapperResult;
 import org.elasticsearch.xpack.core.watcher.common.stats.Counters;
 import org.elasticsearch.xpack.core.watcher.condition.Condition;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.execution.QueuedWatch;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionSnapshot;
 import org.elasticsearch.xpack.core.watcher.history.WatchRecord;
 import org.elasticsearch.xpack.core.watcher.input.Input;
+import org.elasticsearch.xpack.core.watcher.support.xcontent.WatcherParams;
 import org.elasticsearch.xpack.core.watcher.transform.Transform;
 import org.elasticsearch.xpack.core.watcher.trigger.TriggerEvent;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
 import org.elasticsearch.xpack.core.watcher.watch.WatchField;
-import org.elasticsearch.xpack.core.watcher.watch.WatchStatus;
 import org.elasticsearch.xpack.watcher.Watcher;
 import org.elasticsearch.xpack.watcher.history.HistoryStore;
 import org.elasticsearch.xpack.watcher.watch.WatchParser;
@@ -342,11 +341,8 @@ public class ExecutionService extends AbstractComponent {
         // at the moment we store the status together with the watch,
         // so we just need to update the watch itself
         // we do not want to update the status.state field, as it might have been deactivated inbetween
-        Map<String, String> parameters = MapBuilder.<String, String>newMapBuilder()
-            .put(Watch.INCLUDE_STATUS_KEY, "true")
-            .put(WatchStatus.INCLUDE_STATE, "false")
-            .immutableMap();
-        ToXContent.MapParams params = new ToXContent.MapParams(parameters);
+        WatchStatusParams statusParams = WatchStatusParams.builder().includeState(false).build();
+        WatcherParams params = WatcherParams.builder(statusParams).includeStatus(true).build();
         XContentBuilder source = JsonXContent.contentBuilder().
             startObject()
             .field(WatchField.STATUS.getPreferredName(), watch.status(), params)

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/history/HistoryStore.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/history/HistoryStore.java
@@ -17,7 +17,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.history.HistoryStoreField;
 import org.elasticsearch.xpack.core.watcher.history.WatchRecord;
 import org.elasticsearch.xpack.core.watcher.support.xcontent.WatcherParams;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/search/SearchInput.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/search/SearchInput.java
@@ -12,7 +12,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.watcher.input.Input;
-import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
+import org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils;
 import org.elasticsearch.xpack.core.watcher.watch.Payload;
 import org.elasticsearch.xpack.watcher.support.search.WatcherSearchTemplateRequest;
 import org.joda.time.DateTimeZone;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/search/SearchTransform.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/search/SearchTransform.java
@@ -11,7 +11,7 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
+import org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils;
 import org.elasticsearch.xpack.core.watcher.transform.Transform;
 import org.elasticsearch.xpack.core.watcher.watch.Payload;
 import org.elasticsearch.xpack.watcher.support.search.WatcherSearchTemplateRequest;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/activate/TransportActivateWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/activate/TransportActivateWatchAction.java
@@ -26,7 +26,7 @@ import org.elasticsearch.xpack.core.watcher.transport.actions.activate.ActivateW
 import org.elasticsearch.xpack.core.watcher.transport.actions.activate.ActivateWatchResponse;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
 import org.elasticsearch.xpack.core.watcher.watch.WatchField;
-import org.elasticsearch.xpack.core.watcher.watch.WatchStatus;
+import org.elasticsearch.protocol.xpack.watcher.status.WatchStatusField;
 import org.elasticsearch.xpack.watcher.transport.actions.WatcherTransportAction;
 import org.elasticsearch.xpack.watcher.watch.WatchParser;
 import org.joda.time.DateTime;
@@ -37,7 +37,7 @@ import java.time.Clock;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.ClientHelper.WATCHER_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
-import static org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils.writeDate;
+import static org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils.writeDate;
 import static org.joda.time.DateTimeZone.UTC;
 
 /**
@@ -99,10 +99,10 @@ public class TransportActivateWatchAction extends WatcherTransportAction<Activat
         try (XContentBuilder builder = jsonBuilder()) {
             builder.startObject()
                     .startObject(WatchField.STATUS.getPreferredName())
-                    .startObject(WatchStatus.Field.STATE.getPreferredName())
-                    .field(WatchStatus.Field.ACTIVE.getPreferredName(), active);
+                    .startObject(WatchStatusField.STATE.getPreferredName())
+                    .field(WatchStatusField.ACTIVE.getPreferredName(), active);
 
-            writeDate(WatchStatus.Field.TIMESTAMP.getPreferredName(), builder, now);
+            writeDate(WatchStatusField.TIMESTAMP.getPreferredName(), builder, now);
             builder.endObject().endObject().endObject();
             return builder;
         }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/put/TransportPutWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/put/TransportPutWatchAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.protocol.xpack.watcher.PutWatchResponse;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.protocol.xpack.watcher.status.WatchStatusParams;
 import org.elasticsearch.xpack.core.watcher.support.xcontent.WatcherParams;
 import org.elasticsearch.xpack.core.watcher.transport.actions.put.PutWatchAction;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
@@ -62,7 +63,8 @@ public class TransportPutWatchAction extends WatcherTransportAction<PutWatchRequ
     private final WatchParser parser;
     private final Client client;
     private static final ToXContent.Params DEFAULT_PARAMS =
-            WatcherParams.builder().hideSecrets(false).hideHeaders(false).includeStatus(true).build();
+            WatcherParams.builder(WatchStatusParams.builder().hideHeaders(false).build()).hideSecrets(false).includeStatus
+                    (true).build();
 
     @Inject
     public TransportPutWatchAction(Settings settings, TransportService transportService, ThreadPool threadPool, ActionFilters actionFilters,

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/ScheduleTriggerEngine.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/ScheduleTriggerEngine.java
@@ -9,7 +9,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
+import org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils;
 import org.elasticsearch.xpack.core.watcher.trigger.TriggerEvent;
 import org.elasticsearch.xpack.watcher.trigger.TriggerEngine;
 import org.elasticsearch.xpack.watcher.trigger.TriggerService;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/ScheduleTriggerEvent.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/ScheduleTriggerEvent.java
@@ -9,7 +9,7 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
+import org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils;
 import org.elasticsearch.xpack.core.watcher.trigger.TriggerEvent;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/watch/WatchParser.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/watch/WatchParser.java
@@ -23,7 +23,7 @@ import org.elasticsearch.xpack.core.watcher.common.secret.Secret;
 import org.elasticsearch.xpack.core.watcher.condition.ExecutableCondition;
 import org.elasticsearch.xpack.core.watcher.crypto.CryptoService;
 import org.elasticsearch.xpack.core.watcher.input.ExecutableInput;
-import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
+import org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils;
 import org.elasticsearch.xpack.core.watcher.support.xcontent.WatcherXContentParser;
 import org.elasticsearch.xpack.core.watcher.transform.ExecutableTransform;
 import org.elasticsearch.xpack.core.watcher.trigger.Trigger;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherIndexingListenerTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherIndexingListenerTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.watcher.watch.ClockMock;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
 import org.elasticsearch.xpack.core.watcher.watch.WatchStatus;
+import org.elasticsearch.protocol.xpack.watcher.status.WatchStatusState;
 import org.elasticsearch.xpack.watcher.WatcherIndexingListener.Configuration;
 import org.elasticsearch.xpack.watcher.WatcherIndexingListener.ShardAllocationConfiguration;
 import org.elasticsearch.xpack.watcher.trigger.TriggerService;
@@ -183,7 +184,7 @@ public class WatcherIndexingListenerTests extends ESTestCase {
     }
 
     private Watch mockWatch(String id, boolean active, boolean isNewWatch) {
-        WatchStatus.State watchState = mock(WatchStatus.State.class);
+        WatchStatusState watchState = mock(WatchStatusState.class);
         when(watchState.isActive()).thenReturn(active);
 
         WatchStatus watchStatus = mock(WatchStatus.class);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
@@ -46,6 +46,7 @@ import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.watcher.trigger.Trigger;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
 import org.elasticsearch.xpack.core.watcher.watch.WatchStatus;
+import org.elasticsearch.protocol.xpack.watcher.status.WatchStatusState;
 import org.elasticsearch.xpack.watcher.condition.InternalAlwaysCondition;
 import org.elasticsearch.xpack.watcher.execution.ExecutionService;
 import org.elasticsearch.xpack.watcher.execution.TriggeredWatchStore;
@@ -181,7 +182,7 @@ public class WatcherServiceTests extends ESTestCase {
             if (active) {
                 activeWatchCount++;
             }
-            WatchStatus.State state = new WatchStatus.State(active, DateTime.now(DateTimeZone.UTC));
+            WatchStatusState state = new WatchStatusState(active, DateTime.now(DateTimeZone.UTC));
             WatchStatus watchStatus = mock(WatchStatus.class);
             Watch watch = mock(Watch.class);
             when(watchStatus.state()).thenReturn(state);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/ActionWrapperTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/ActionWrapperTests.java
@@ -7,8 +7,10 @@ package org.elasticsearch.xpack.watcher.actions;
 
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.watcher.actions.Action;
+import org.elasticsearch.protocol.xpack.watcher.status.ActionAckStatus;
 import org.elasticsearch.xpack.core.watcher.actions.ActionStatus;
-import org.elasticsearch.xpack.core.watcher.actions.ActionStatus.AckStatus.State;
+import org.elasticsearch.protocol.xpack.watcher.status.ActionAckStatus.State;
+import org.elasticsearch.protocol.xpack.watcher.status.ActionStatusExecution;
 import org.elasticsearch.xpack.core.watcher.actions.ActionWrapper;
 import org.elasticsearch.xpack.core.watcher.actions.ActionWrapperResult;
 import org.elasticsearch.xpack.core.watcher.actions.ExecutableAction;
@@ -68,8 +70,8 @@ public class ActionWrapperTests extends ESTestCase {
     }
 
     private ActionStatus createActionStatus(State state) {
-        ActionStatus.AckStatus ackStatus = new ActionStatus.AckStatus(now, state);
-        ActionStatus.Execution execution = ActionStatus.Execution.successful(now);
+        ActionAckStatus ackStatus = new ActionAckStatus(now, state);
+        ActionStatusExecution execution = ActionStatusExecution.successful(now);
         return new ActionStatus(ackStatus, execution, execution, null);
     }
 }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/throttler/AckThrottlerTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/throttler/AckThrottlerTests.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.watcher.actions.throttler;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.protocol.xpack.watcher.status.ActionAckStatus;
 import org.elasticsearch.xpack.core.watcher.actions.ActionStatus;
 import org.elasticsearch.xpack.core.watcher.actions.throttler.AckThrottler;
 import org.elasticsearch.xpack.core.watcher.actions.throttler.Throttler;
@@ -17,7 +18,7 @@ import org.joda.time.DateTime;
 
 import java.time.Clock;
 
-import static org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils.formatDate;
+import static org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils.formatDate;
 import static org.elasticsearch.xpack.watcher.test.WatcherTestUtils.mockExecutionContext;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.is;
@@ -31,7 +32,7 @@ public class AckThrottlerTests extends ESTestCase {
         WatchExecutionContext ctx = mockExecutionContext("_watch", Payload.EMPTY);
         Watch watch = ctx.watch();
         ActionStatus actionStatus = mock(ActionStatus.class);
-        when(actionStatus.ackStatus()).thenReturn(new ActionStatus.AckStatus(timestamp, ActionStatus.AckStatus.State.ACKED));
+        when(actionStatus.ackStatus()).thenReturn(new ActionAckStatus(timestamp, ActionAckStatus.State.ACKED));
         WatchStatus watchStatus = mock(WatchStatus.class);
         when(watchStatus.actionStatus("_action")).thenReturn(actionStatus);
         when(watch.status()).thenReturn(watchStatus);
@@ -47,8 +48,8 @@ public class AckThrottlerTests extends ESTestCase {
         WatchExecutionContext ctx = mockExecutionContext("_watch", Payload.EMPTY);
         Watch watch = ctx.watch();
         ActionStatus actionStatus = mock(ActionStatus.class);
-        when(actionStatus.ackStatus()).thenReturn(new ActionStatus.AckStatus(timestamp,
-                ActionStatus.AckStatus.State.AWAITS_SUCCESSFUL_EXECUTION));
+        when(actionStatus.ackStatus()).thenReturn(new ActionAckStatus(timestamp,
+                ActionAckStatus.State.AWAITS_SUCCESSFUL_EXECUTION));
         WatchStatus watchStatus = mock(WatchStatus.class);
         when(watchStatus.actionStatus("_action")).thenReturn(actionStatus);
         when(watch.status()).thenReturn(watchStatus);
@@ -63,7 +64,7 @@ public class AckThrottlerTests extends ESTestCase {
         WatchExecutionContext ctx = mockExecutionContext("_watch", Payload.EMPTY);
         Watch watch = ctx.watch();
         ActionStatus actionStatus = mock(ActionStatus.class);
-        when(actionStatus.ackStatus()).thenReturn(new ActionStatus.AckStatus(timestamp, ActionStatus.AckStatus.State.ACKABLE));
+        when(actionStatus.ackStatus()).thenReturn(new ActionAckStatus(timestamp, ActionAckStatus.State.ACKABLE));
         WatchStatus watchStatus = mock(WatchStatus.class);
         when(watchStatus.actionStatus("_action")).thenReturn(actionStatus);
         when(watch.status()).thenReturn(watchStatus);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/throttler/ActionThrottleTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/throttler/ActionThrottleTests.java
@@ -14,7 +14,7 @@ import org.elasticsearch.protocol.xpack.watcher.PutWatchRequest;
 import org.elasticsearch.xpack.core.watcher.actions.Action;
 import org.elasticsearch.xpack.core.watcher.client.WatchSourceBuilder;
 import org.elasticsearch.xpack.core.watcher.execution.ActionExecutionMode;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.support.xcontent.ObjectPath;
 import org.elasticsearch.xpack.core.watcher.transport.actions.execute.ExecuteWatchRequestBuilder;
 import org.elasticsearch.xpack.core.watcher.transport.actions.execute.ExecuteWatchResponse;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/throttler/PeriodThrottlerTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/throttler/PeriodThrottlerTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.watcher.actions.throttler;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.watcher.actions.ActionStatus;
+import org.elasticsearch.protocol.xpack.watcher.status.ActionStatusExecution;
 import org.elasticsearch.xpack.core.watcher.actions.throttler.PeriodThrottler;
 import org.elasticsearch.xpack.core.watcher.actions.throttler.Throttler;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
@@ -34,7 +35,7 @@ public class PeriodThrottlerTests extends ESTestCase {
         ActionStatus actionStatus = mock(ActionStatus.class);
         DateTime now = new DateTime(Clock.systemUTC().millis());
         when(actionStatus.lastSuccessfulExecution())
-                .thenReturn(ActionStatus.Execution.successful(now.minusSeconds((int) period.seconds() - 1)));
+                .thenReturn(ActionStatusExecution.successful(now.minusSeconds((int) period.seconds() - 1)));
         WatchStatus status = mock(WatchStatus.class);
         when(status.actionStatus("_action")).thenReturn(actionStatus);
         when(ctx.watch().status()).thenReturn(status);
@@ -55,7 +56,7 @@ public class PeriodThrottlerTests extends ESTestCase {
         ActionStatus actionStatus = mock(ActionStatus.class);
         DateTime now = new DateTime(Clock.systemUTC().millis());
         when(actionStatus.lastSuccessfulExecution())
-                .thenReturn(ActionStatus.Execution.successful(now.minusSeconds((int) period.seconds() + 1)));
+                .thenReturn(ActionStatusExecution.successful(now.minusSeconds((int) period.seconds() + 1)));
         WatchStatus status = mock(WatchStatus.class);
         when(status.actionStatus("_action")).thenReturn(actionStatus);
         when(ctx.watch().status()).thenReturn(status);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/ExecutionServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/ExecutionServiceTests.java
@@ -45,7 +45,7 @@ import org.elasticsearch.xpack.core.watcher.common.stats.Counters;
 import org.elasticsearch.xpack.core.watcher.condition.Condition;
 import org.elasticsearch.xpack.core.watcher.condition.ExecutableCondition;
 import org.elasticsearch.xpack.core.watcher.execution.ExecutionPhase;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.execution.QueuedWatch;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionSnapshot;
@@ -61,6 +61,7 @@ import org.elasticsearch.xpack.core.watcher.watch.ClockMock;
 import org.elasticsearch.xpack.core.watcher.watch.Payload;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
 import org.elasticsearch.xpack.core.watcher.watch.WatchStatus;
+import org.elasticsearch.protocol.xpack.watcher.status.WatchStatusState;
 import org.elasticsearch.xpack.watcher.condition.InternalAlwaysCondition;
 import org.elasticsearch.xpack.watcher.condition.NeverCondition;
 import org.elasticsearch.xpack.watcher.history.HistoryStore;
@@ -961,7 +962,7 @@ public class ExecutionServiceTests extends ESTestCase {
         WatchExecutionContext ctx = mock(WatchExecutionContext.class);
         when(ctx.knownWatch()).thenReturn(true);
         WatchStatus status = mock(WatchStatus.class);
-        when(status.state()).thenReturn(new WatchStatus.State(false, now()));
+        when(status.state()).thenReturn(new WatchStatusState(false, now()));
         when(watch.status()).thenReturn(status);
         when(ctx.watch()).thenReturn(watch);
         Wid wid = new Wid(watch.id(), DateTime.now(UTC));
@@ -1069,7 +1070,7 @@ public class ExecutionServiceTests extends ESTestCase {
         when(watch.actions()).thenReturn(Collections.singletonList(actionWrapper));
 
         WatchStatus status = mock(WatchStatus.class);
-        when(status.state()).thenReturn(new WatchStatus.State(false, now()));
+        when(status.state()).thenReturn(new WatchStatusState(false, now()));
         when(watch.status()).thenReturn(status);
 
         WatchRecord watchRecord = executionService.execute(ctx);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryActionConditionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryActionConditionTests.java
@@ -17,7 +17,7 @@ import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xpack.core.watcher.client.WatchSourceBuilder;
 import org.elasticsearch.xpack.core.watcher.condition.Condition;
 import org.elasticsearch.xpack.core.watcher.condition.ExecutableCondition;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.input.Input;
 import org.elasticsearch.xpack.watcher.condition.CompareCondition;
 import org.elasticsearch.xpack.watcher.condition.InternalAlwaysCondition;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryStoreTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryStoreTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.watcher.actions.ActionStatus;
 import org.elasticsearch.xpack.core.watcher.actions.ActionWrapperResult;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionResult;
 import org.elasticsearch.xpack.core.watcher.execution.Wid;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateEmailMappingsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateEmailMappingsTests.java
@@ -11,7 +11,7 @@ import org.elasticsearch.protocol.xpack.watcher.PutWatchResponse;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.junit.annotations.TestLogging;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.history.HistoryStoreField;
 import org.elasticsearch.xpack.watcher.condition.InternalAlwaysCondition;
 import org.elasticsearch.xpack.watcher.notification.email.EmailTemplate;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateHttpMappingsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateHttpMappingsTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.history.HistoryStoreField;
 import org.elasticsearch.xpack.core.watcher.support.xcontent.ObjectPath;
 import org.elasticsearch.xpack.watcher.common.http.HttpMethod;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateIndexActionMappingsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateIndexActionMappingsTests.java
@@ -9,7 +9,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchResponse;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.history.HistoryStoreField;
 import org.elasticsearch.xpack.watcher.test.AbstractWatcherIntegrationTestCase;
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateSearchInputMappingsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateSearchInputMappingsTests.java
@@ -11,7 +11,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchResponse;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.history.HistoryStoreField;
 import org.elasticsearch.xpack.watcher.condition.InternalAlwaysCondition;
 import org.elasticsearch.xpack.watcher.support.search.WatcherSearchTemplateRequest;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateTimeMappingsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateTimeMappingsTests.java
@@ -11,7 +11,7 @@ import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchResponse;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.history.HistoryStoreField;
 import org.elasticsearch.xpack.watcher.condition.InternalAlwaysCondition;
 import org.elasticsearch.xpack.watcher.test.AbstractWatcherIntegrationTestCase;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherDateTimeUtilsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherDateTimeUtilsTests.java
@@ -11,7 +11,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
+import org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,7 +23,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils.parseTimeValueSupportingFractional;
+import static org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils.parseTimeValueSupportingFractional;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.is;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherUtilsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherUtilsTests.java
@@ -34,7 +34,7 @@ import java.util.Map;
 
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils.formatDate;
+import static org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils.formatDate;
 import static org.elasticsearch.xpack.core.watcher.support.WatcherUtils.flattenModel;
 import static org.elasticsearch.xpack.watcher.input.search.ExecutableSearchInput.DEFAULT_SEARCH_TYPE;
 import static org.elasticsearch.xpack.watcher.test.WatcherTestUtils.getRandomSupportedSearchType;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/AbstractWatcherIntegrationTestCase.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/AbstractWatcherIntegrationTestCase.java
@@ -42,7 +42,7 @@ import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.SecurityField;
 import org.elasticsearch.xpack.core.watcher.WatcherState;
 import org.elasticsearch.xpack.core.watcher.client.WatcherClient;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.execution.TriggeredWatchStoreField;
 import org.elasticsearch.xpack.core.watcher.history.HistoryStoreField;
 import org.elasticsearch.xpack.core.watcher.support.WatcherIndexTemplateRegistryField;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/BootStrapTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/BootStrapTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.watcher.condition.ExecutableCondition;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.execution.TriggeredWatchStoreField;
 import org.elasticsearch.xpack.core.watcher.execution.Wid;
 import org.elasticsearch.xpack.core.watcher.history.HistoryStoreField;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/WatchAckTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/WatchAckTests.java
@@ -16,8 +16,8 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchResponse;
 import org.elasticsearch.test.junit.annotations.TestLogging;
-import org.elasticsearch.xpack.core.watcher.actions.ActionStatus;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ActionAckStatus;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.history.HistoryStoreField;
 import org.elasticsearch.xpack.core.watcher.history.WatchRecord;
 import org.elasticsearch.xpack.core.watcher.transport.actions.ack.AckWatchRequestBuilder;
@@ -79,8 +79,8 @@ public class WatchAckTests extends AbstractWatcherIntegrationTestCase {
 
         timeWarp().trigger("_id", 4, TimeValue.timeValueSeconds(5));
         AckWatchResponse ackResponse = watcherClient().prepareAckWatch("_id").setActionIds("_a1").get();
-        assertThat(ackResponse.getStatus().actionStatus("_a1").ackStatus().state(), is(ActionStatus.AckStatus.State.ACKED));
-        assertThat(ackResponse.getStatus().actionStatus("_a2").ackStatus().state(), is(ActionStatus.AckStatus.State.ACKABLE));
+        assertThat(ackResponse.getStatus().actionStatus("_a1").ackStatus().state(), is(ActionAckStatus.State.ACKED));
+        assertThat(ackResponse.getStatus().actionStatus("_a2").ackStatus().state(), is(ActionAckStatus.State.ACKABLE));
 
         refresh();
         long a1CountAfterAck = docCount("actions1", "doc", matchAllQuery());
@@ -112,9 +112,9 @@ public class WatchAckTests extends AbstractWatcherIntegrationTestCase {
 
         Watch parsedWatch = watchParser().parse(getWatchResponse.getId(), true, getWatchResponse.getSource().getBytes(), XContentType.JSON);
         assertThat(parsedWatch.status().actionStatus("_a1").ackStatus().state(),
-                is(ActionStatus.AckStatus.State.AWAITS_SUCCESSFUL_EXECUTION));
+                is(ActionAckStatus.State.AWAITS_SUCCESSFUL_EXECUTION));
         assertThat(parsedWatch.status().actionStatus("_a2").ackStatus().state(),
-                is(ActionStatus.AckStatus.State.AWAITS_SUCCESSFUL_EXECUTION));
+                is(ActionAckStatus.State.AWAITS_SUCCESSFUL_EXECUTION));
 
         long throttledCount = docCount(HistoryStoreField.INDEX_PREFIX_WITH_TEMPLATE + "*", null,
                 matchQuery(WatchRecord.STATE.getPreferredName(), ExecutionState.ACKNOWLEDGED.id()));
@@ -147,8 +147,8 @@ public class WatchAckTests extends AbstractWatcherIntegrationTestCase {
         }
         AckWatchResponse ackResponse = ackWatchRequestBuilder.get();
 
-        assertThat(ackResponse.getStatus().actionStatus("_a1").ackStatus().state(), is(ActionStatus.AckStatus.State.ACKED));
-        assertThat(ackResponse.getStatus().actionStatus("_a2").ackStatus().state(), is(ActionStatus.AckStatus.State.ACKED));
+        assertThat(ackResponse.getStatus().actionStatus("_a1").ackStatus().state(), is(ActionAckStatus.State.ACKED));
+        assertThat(ackResponse.getStatus().actionStatus("_a2").ackStatus().state(), is(ActionAckStatus.State.ACKED));
 
         refresh();
         long a1CountAfterAck = docCount("actions1", "doc", matchAllQuery());
@@ -180,9 +180,9 @@ public class WatchAckTests extends AbstractWatcherIntegrationTestCase {
 
         Watch parsedWatch = watchParser().parse(getWatchResponse.getId(), true, getWatchResponse.getSource().getBytes(), XContentType.JSON);
         assertThat(parsedWatch.status().actionStatus("_a1").ackStatus().state(),
-                is(ActionStatus.AckStatus.State.AWAITS_SUCCESSFUL_EXECUTION));
+                is(ActionAckStatus.State.AWAITS_SUCCESSFUL_EXECUTION));
         assertThat(parsedWatch.status().actionStatus("_a2").ackStatus().state(),
-                is(ActionStatus.AckStatus.State.AWAITS_SUCCESSFUL_EXECUTION));
+                is(ActionAckStatus.State.AWAITS_SUCCESSFUL_EXECUTION));
 
         long throttledCount = docCount(HistoryStoreField.INDEX_PREFIX_WITH_TEMPLATE + "*", null,
                 matchQuery(WatchRecord.STATE.getPreferredName(), ExecutionState.ACKNOWLEDGED.id()));
@@ -206,7 +206,7 @@ public class WatchAckTests extends AbstractWatcherIntegrationTestCase {
         restartWatcherRandomly();
 
         AckWatchResponse ackResponse = watcherClient().prepareAckWatch("_name").get();
-        assertThat(ackResponse.getStatus().actionStatus("_id").ackStatus().state(), is(ActionStatus.AckStatus.State.ACKED));
+        assertThat(ackResponse.getStatus().actionStatus("_id").ackStatus().state(), is(ActionAckStatus.State.ACKED));
 
         refresh("actions");
         long countAfterAck = client().prepareSearch("actions").setTypes("action").setQuery(matchAllQuery()).get().getHits().getTotalHits();
@@ -215,7 +215,7 @@ public class WatchAckTests extends AbstractWatcherIntegrationTestCase {
         restartWatcherRandomly();
 
         GetWatchResponse watchResponse = watcherClient().getWatch(new GetWatchRequest("_name")).actionGet();
-        assertThat(watchResponse.getStatus().actionStatus("_id").ackStatus().state(), Matchers.equalTo(ActionStatus.AckStatus.State.ACKED));
+        assertThat(watchResponse.getStatus().actionStatus("_id").ackStatus().state(), Matchers.equalTo(ActionAckStatus.State.ACKED));
 
         refresh();
         GetResponse getResponse = client().get(new GetRequest(Watch.INDEX, Watch.DOC_TYPE, "_name")).actionGet();

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/action/activate/ActivateWatchTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/action/activate/ActivateWatchTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchResponse;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xpack.core.watcher.client.WatcherClient;
-import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
+import org.elasticsearch.protocol.xpack.watcher.status.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.support.xcontent.XContentSource;
 import org.elasticsearch.xpack.core.watcher.transport.actions.activate.ActivateWatchResponse;
 import org.elasticsearch.xpack.core.watcher.transport.actions.get.GetWatchResponse;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/action/execute/ExecuteWatchTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/action/execute/ExecuteWatchTests.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.watcher.transport.action.execute;
 
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchResponse;
+import org.elasticsearch.protocol.xpack.watcher.status.ActionAckStatus;
 import org.elasticsearch.xpack.core.watcher.actions.ActionStatus;
 import org.elasticsearch.xpack.core.watcher.client.WatcherClient;
 import org.elasticsearch.xpack.core.watcher.execution.ActionExecutionMode;
@@ -127,7 +128,7 @@ public class ExecuteWatchTests extends AbstractWatcherIntegrationTestCase {
             assertThat(status, notNullValue());
             ActionStatus actionStatus = status.actionStatus("log");
             assertThat(actionStatus, notNullValue());
-            assertThat(actionStatus.ackStatus().state(), is(ActionStatus.AckStatus.State.ACKED));
+            assertThat(actionStatus.ackStatus().state(), is(ActionAckStatus.State.ACKED));
         }
 
         ExecuteWatchResponse response = watcherClient.prepareExecuteWatch("_id")

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchStatusTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchStatusTests.java
@@ -12,9 +12,10 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.watcher.actions.ActionStatus;
-import org.elasticsearch.xpack.core.watcher.actions.ActionStatus.AckStatus.State;
-import org.elasticsearch.xpack.core.watcher.support.xcontent.WatcherParams;
+import org.elasticsearch.protocol.xpack.watcher.status.ActionAckStatus.State;
+import org.elasticsearch.protocol.xpack.watcher.status.WatchStatusParams;
 import org.elasticsearch.xpack.core.watcher.watch.WatchStatus;
+import org.elasticsearch.protocol.xpack.watcher.status.WatchStatusField;
 import org.elasticsearch.xpack.watcher.actions.logging.LoggingAction;
 
 import java.io.IOException;
@@ -59,19 +60,19 @@ public class WatchStatusTests extends ESTestCase {
             status.toXContent(builder, ToXContent.EMPTY_PARAMS);
             try (XContentParser parser = createParser(builder)) {
                 Map<String, Object> fields = parser.map();
-                assertThat(fields, not(hasKey(WatchStatus.Field.HEADERS.getPreferredName())));
+                assertThat(fields, not(hasKey(WatchStatusField.HEADERS.getPreferredName())));
             }
         }
 
         // but they are required when storing a watch
         try (XContentBuilder builder = jsonBuilder()) {
-            status.toXContent(builder, WatcherParams.builder().hideHeaders(false).build());
+            status.toXContent(builder, WatchStatusParams.builder().hideHeaders(false).build());
             try (XContentParser parser = createParser(builder)) {
                 parser.nextToken();
                 Map<String, Object> fields = parser.map();
-                assertThat(fields, hasKey(WatchStatus.Field.HEADERS.getPreferredName()));
-                assertThat(fields.get(WatchStatus.Field.HEADERS.getPreferredName()), instanceOf(Map.class));
-                Map<String, Object> extractedHeaders = (Map<String, Object>) fields.get(WatchStatus.Field.HEADERS.getPreferredName());
+                assertThat(fields, hasKey(WatchStatusField.HEADERS.getPreferredName()));
+                assertThat(fields.get(WatchStatusField.HEADERS.getPreferredName()), instanceOf(Map.class));
+                Map<String, Object> extractedHeaders = (Map<String, Object>) fields.get(WatchStatusField.HEADERS.getPreferredName());
                 assertThat(extractedHeaders, is(headers));
             }
         }

--- a/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/ActionAckStatus.java
+++ b/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/ActionAckStatus.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.protocol.xpack.watcher.status;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Objects;
+
+import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
+import static org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils.dateTimeFormatter;
+
+public class ActionAckStatus implements ToXContentObject {
+
+    public enum State {
+        AWAITS_SUCCESSFUL_EXECUTION((byte) 1),
+        ACKABLE((byte) 2),
+        ACKED((byte) 3);
+
+        private byte value;
+
+        State(byte value) {
+            this.value = value;
+        }
+
+        static State resolve(byte value) {
+            switch (value) {
+                case 1 : return AWAITS_SUCCESSFUL_EXECUTION;
+                case 2 : return ACKABLE;
+                case 3 : return ACKED;
+                default:
+                    throw new IllegalArgumentException(format("unknown action ack status state value [{}]", value));
+            }
+        }
+    }
+
+    private final DateTime timestamp;
+    private final State state;
+
+    public ActionAckStatus(DateTime timestamp, State state) {
+        this.timestamp = timestamp.toDateTime(DateTimeZone.UTC);
+        this.state = state;
+    }
+
+    public DateTime timestamp() {
+        return timestamp;
+    }
+
+    public State state() {
+        return state;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ActionAckStatus ackStatus = (ActionAckStatus) o;
+
+        return Objects.equals(timestamp, ackStatus.timestamp) &&  Objects.equals(state, ackStatus.state);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(timestamp, state);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.startObject()
+                .field(ActionStatusField.TIMESTAMP.getPreferredName()).value(dateTimeFormatter.printer().print(timestamp))
+                .field(ActionStatusField.ACK_STATUS_STATE.getPreferredName(), state.name().toLowerCase(Locale.ROOT))
+                .endObject();
+    }
+
+    public static ActionAckStatus parse(String watchId, String actionId, XContentParser parser) throws IOException {
+        DateTime timestamp = null;
+        State state = null;
+
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (ActionStatusField.TIMESTAMP.match(currentFieldName, parser.getDeprecationHandler())) {
+                timestamp = dateTimeFormatter.parser().parseDateTime(parser.text());
+            } else if (ActionStatusField.ACK_STATUS_STATE.match(currentFieldName, parser.getDeprecationHandler())) {
+                state = State.valueOf(parser.text().toUpperCase(Locale.ROOT));
+            } else {
+                throw new ElasticsearchParseException("could not parse action status for [{}/{}]. unexpected field [{}.{}]", watchId,
+                        actionId, ActionStatusField.ACK_STATUS.getPreferredName(), currentFieldName);
+            }
+        }
+        if (timestamp == null) {
+            throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field [{}.{}]",
+                    watchId, actionId, ActionStatusField.ACK_STATUS.getPreferredName(), ActionStatusField.TIMESTAMP.getPreferredName());
+        }
+        if (state == null) {
+            throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field [{}.{}]",
+                    watchId, actionId, ActionStatusField.ACK_STATUS.getPreferredName(),
+                    ActionStatusField.ACK_STATUS_STATE.getPreferredName());
+        }
+        return new ActionAckStatus(timestamp, state);
+    }
+
+    public static void writeTo(ActionAckStatus status, StreamOutput out) throws IOException {
+        out.writeLong(status.timestamp.getMillis());
+        out.writeByte(status.state.value);
+    }
+
+    public static ActionAckStatus readFrom(StreamInput in) throws IOException {
+        DateTime timestamp = new DateTime(in.readLong(), DateTimeZone.UTC);
+        State state = State.resolve(in.readByte());
+        return new ActionAckStatus(timestamp, state);
+    }
+
+    @Override
+    public String toString() {
+        return "ActionAckStatus{" +
+                "timestamp=" + timestamp +
+                ", state=" + state +
+                '}';
+    }
+}

--- a/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/ActionStatus.java
+++ b/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/ActionStatus.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.protocol.xpack.watcher.status;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.joda.time.DateTime;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class ActionStatus implements ToXContentObject {
+
+    private ActionAckStatus ackStatus;
+    @Nullable private ActionStatusExecution lastExecution;
+    @Nullable private ActionStatusExecution lastSuccessfulExecution;
+    @Nullable private ActionStatusThrottle lastThrottle;
+
+    public ActionStatus(DateTime now) {
+        this(new ActionAckStatus(now, ActionAckStatus.State.AWAITS_SUCCESSFUL_EXECUTION), null, null, null);
+    }
+
+    public ActionStatus(ActionAckStatus ackStatus, @Nullable ActionStatusExecution lastExecution,
+                        @Nullable ActionStatusExecution lastSuccessfulExecution, @Nullable ActionStatusThrottle lastThrottle) {
+        this.ackStatus = ackStatus;
+        this.lastExecution = lastExecution;
+        this.lastSuccessfulExecution = lastSuccessfulExecution;
+        this.lastThrottle = lastThrottle;
+    }
+
+    public ActionAckStatus ackStatus() {
+        return ackStatus;
+    }
+
+    public ActionStatusExecution lastExecution() {
+        return lastExecution;
+    }
+
+    public ActionStatusExecution lastSuccessfulExecution() {
+        return lastSuccessfulExecution;
+    }
+
+    public ActionStatusThrottle lastThrottle() {
+        return lastThrottle;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ActionStatus that = (ActionStatus) o;
+
+        return Objects.equals(ackStatus, that.ackStatus) &&
+                Objects.equals(lastExecution, that.lastExecution) &&
+                Objects.equals(lastSuccessfulExecution, that.lastSuccessfulExecution) &&
+                Objects.equals(lastThrottle, that.lastThrottle);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ackStatus, lastExecution, lastSuccessfulExecution, lastThrottle);
+    }
+
+
+    public static void writeTo(ActionStatus status, StreamOutput out) throws IOException {
+        ActionAckStatus.writeTo(status.ackStatus, out);
+        out.writeBoolean(status.lastExecution != null);
+        if (status.lastExecution != null) {
+            ActionStatusExecution.writeTo(status.lastExecution, out);
+        }
+        out.writeBoolean(status.lastSuccessfulExecution != null);
+        if (status.lastSuccessfulExecution != null) {
+            ActionStatusExecution.writeTo(status.lastSuccessfulExecution, out);
+        }
+        out.writeBoolean(status.lastThrottle != null);
+        if (status.lastThrottle != null) {
+            ActionStatusThrottle.writeTo(status.lastThrottle, out);
+        }
+    }
+
+    public static ActionStatus readFrom(StreamInput in) throws IOException {
+        ActionAckStatus ackStatus = ActionAckStatus.readFrom(in);
+        ActionStatusExecution lastExecution = in.readBoolean() ? ActionStatusExecution.readFrom(in) : null;
+        ActionStatusExecution lastSuccessfulExecution = in.readBoolean() ? ActionStatusExecution.readFrom(in) : null;
+        ActionStatusThrottle lastThrottle = in.readBoolean() ? ActionStatusThrottle.readFrom(in) : null;
+        return new ActionStatus(ackStatus, lastExecution, lastSuccessfulExecution, lastThrottle);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(ActionStatusField.ACK_STATUS.getPreferredName(), ackStatus, params);
+        if (lastExecution != null) {
+            builder.field(ActionStatusField.LAST_EXECUTION.getPreferredName(), lastExecution, params);
+        }
+        if (lastSuccessfulExecution != null) {
+            builder.field(ActionStatusField.LAST_SUCCESSFUL_EXECUTION.getPreferredName(), lastSuccessfulExecution, params);
+        }
+        if (lastThrottle != null) {
+            builder.field(ActionStatusField.LAST_THROTTLE.getPreferredName(), lastThrottle, params);
+        }
+        return builder.endObject();
+    }
+
+    public static ActionStatus parse(String watchId, String actionId, XContentParser parser) throws IOException {
+        ActionAckStatus ackStatus = null;
+        ActionStatusExecution lastExecution = null;
+        ActionStatusExecution lastSuccessfulExecution = null;
+        ActionStatusThrottle lastThrottle = null;
+
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (ActionStatusField.ACK_STATUS.match(currentFieldName, parser.getDeprecationHandler())) {
+                ackStatus = ActionAckStatus.parse(watchId, actionId, parser);
+            } else if (ActionStatusField.LAST_EXECUTION.match(currentFieldName, parser.getDeprecationHandler())) {
+                lastExecution = ActionStatusExecution.parse(watchId, actionId, parser);
+            } else if (ActionStatusField.LAST_SUCCESSFUL_EXECUTION.match(currentFieldName, parser.getDeprecationHandler())) {
+                lastSuccessfulExecution = ActionStatusExecution.parse(watchId, actionId, parser);
+            } else if (ActionStatusField.LAST_THROTTLE.match(currentFieldName, parser.getDeprecationHandler())) {
+                lastThrottle = ActionStatusThrottle.parse(watchId, actionId, parser);
+            } else {
+                throw new ElasticsearchParseException("could not parse action status for [{}/{}]. unexpected field [{}]", watchId,
+                        actionId, currentFieldName);
+            }
+        }
+        if (ackStatus == null) {
+            throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field [{}]", watchId,
+                    actionId, ActionStatusField.ACK_STATUS.getPreferredName());
+        }
+        return new ActionStatus(ackStatus, lastExecution, lastSuccessfulExecution, lastThrottle);
+    }
+
+    @Override
+    public String toString() {
+        return "ActionStatus{" +
+                "ackStatus=" + ackStatus +
+                ", lastExecution=" + lastExecution +
+                ", lastSuccessfulExecution=" + lastSuccessfulExecution +
+                ", lastThrottle=" + lastThrottle +
+                '}';
+    }
+}

--- a/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/ActionStatusExecution.java
+++ b/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/ActionStatusExecution.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.protocol.xpack.watcher.status;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils.dateTimeFormatter;
+
+public class ActionStatusExecution implements ToXContentObject {
+
+    public static ActionStatusExecution successful(DateTime timestamp) {
+        return new ActionStatusExecution(timestamp, true, null);
+    }
+
+    public static ActionStatusExecution failure(DateTime timestamp, String reason) {
+        return new ActionStatusExecution(timestamp, false, reason);
+    }
+
+    private final DateTime timestamp;
+    private final boolean successful;
+    private final String reason;
+
+    private ActionStatusExecution(DateTime timestamp, boolean successful, String reason) {
+        this.timestamp = timestamp.toDateTime(DateTimeZone.UTC);
+        this.successful = successful;
+        this.reason = reason;
+    }
+
+    public DateTime timestamp() {
+        return timestamp;
+    }
+
+    public boolean successful() {
+        return successful;
+    }
+
+    public String reason() {
+        return reason;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ActionStatusExecution execution = (ActionStatusExecution) o;
+
+        return Objects.equals(successful, execution.successful) &&
+               Objects.equals(timestamp, execution.timestamp) &&
+               Objects.equals(reason, execution.reason);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(timestamp, successful, reason);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(ActionStatusField.TIMESTAMP.getPreferredName()).value(dateTimeFormatter.printer().print(timestamp));
+        builder.field(ActionStatusField.EXECUTION_SUCCESSFUL.getPreferredName(), successful);
+        if (reason != null) {
+            builder.field(ActionStatusField.REASON.getPreferredName(), reason);
+        }
+        return builder.endObject();
+    }
+
+    public static ActionStatusExecution parse(String watchId, String actionId, XContentParser parser) throws IOException {
+        DateTime timestamp = null;
+        Boolean successful = null;
+        String reason = null;
+
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (ActionStatusField.TIMESTAMP.match(currentFieldName, parser.getDeprecationHandler())) {
+                timestamp = dateTimeFormatter.parser().parseDateTime(parser.text());
+            } else if (ActionStatusField.EXECUTION_SUCCESSFUL.match(currentFieldName, parser.getDeprecationHandler())) {
+                successful = parser.booleanValue();
+            } else if (ActionStatusField.REASON.match(currentFieldName, parser.getDeprecationHandler())) {
+                reason = parser.text();
+            } else {
+                throw new ElasticsearchParseException("could not parse action status for [{}/{}]. unexpected field [{}.{}]", watchId,
+                        actionId, ActionStatusField.LAST_EXECUTION.getPreferredName(), currentFieldName);
+            }
+        }
+        if (timestamp == null) {
+            throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field [{}.{}]",
+                    watchId, actionId, ActionStatusField.LAST_EXECUTION.getPreferredName(), ActionStatusField.TIMESTAMP.getPreferredName());
+        }
+        if (successful == null) {
+            throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field [{}.{}]",
+                    watchId, actionId, ActionStatusField.LAST_EXECUTION.getPreferredName(),
+                    ActionStatusField.EXECUTION_SUCCESSFUL.getPreferredName());
+        }
+        if (successful) {
+            return successful(timestamp);
+        }
+        if (reason == null) {
+            throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field for unsuccessful" +
+                    " execution [{}.{}]", watchId, actionId, ActionStatusField.LAST_EXECUTION.getPreferredName(),
+                    ActionStatusField.REASON.getPreferredName());
+        }
+        return failure(timestamp, reason);
+    }
+
+    public static void writeTo(ActionStatusExecution execution, StreamOutput out) throws IOException {
+        out.writeLong(execution.timestamp.getMillis());
+        out.writeBoolean(execution.successful);
+        if (!execution.successful) {
+            out.writeString(execution.reason);
+        }
+    }
+
+    public static ActionStatusExecution readFrom(StreamInput in) throws IOException {
+        DateTime timestamp = new DateTime(in.readLong(), DateTimeZone.UTC);
+        boolean successful = in.readBoolean();
+        if (successful) {
+            return successful(timestamp);
+        }
+        return failure(timestamp, in.readString());
+    }
+
+    @Override
+    public String toString() {
+        return "ActionStatusExecution{" +
+                "timestamp=" + timestamp +
+                ", successful=" + successful +
+                ", reason='" + reason + '\'' +
+                '}';
+    }
+}

--- a/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/ActionStatusField.java
+++ b/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/ActionStatusField.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.protocol.xpack.watcher.status;
+
+import org.elasticsearch.common.ParseField;
+
+public interface ActionStatusField {
+    ParseField ACK_STATUS = new ParseField("ack");
+    ParseField ACK_STATUS_STATE = new ParseField("state");
+
+    ParseField LAST_EXECUTION = new ParseField("last_execution");
+    ParseField LAST_SUCCESSFUL_EXECUTION = new ParseField("last_successful_execution");
+    ParseField EXECUTION_SUCCESSFUL = new ParseField("successful");
+
+    ParseField LAST_THROTTLE = new ParseField("last_throttle");
+
+    ParseField TIMESTAMP = new ParseField("timestamp");
+    ParseField REASON = new ParseField("reason");
+}

--- a/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/ActionStatusThrottle.java
+++ b/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/ActionStatusThrottle.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.protocol.xpack.watcher.status;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils.dateTimeFormatter;
+
+public class ActionStatusThrottle implements ToXContentObject {
+
+    private final DateTime timestamp;
+    private final String reason;
+
+    public ActionStatusThrottle(DateTime timestamp, String reason) {
+        this.timestamp = timestamp.toDateTime(DateTimeZone.UTC);
+        this.reason = reason;
+    }
+
+    public DateTime timestamp() {
+        return timestamp;
+    }
+
+    public String reason() {
+        return reason;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ActionStatusThrottle throttle = (ActionStatusThrottle) o;
+        return Objects.equals(timestamp, throttle.timestamp) && Objects.equals(reason, throttle.reason);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(timestamp, reason);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.startObject()
+                .field(ActionStatusField.TIMESTAMP.getPreferredName()).value(dateTimeFormatter.printer().print(timestamp))
+                .field(ActionStatusField.REASON.getPreferredName(), reason)
+                .endObject();
+    }
+
+    public static ActionStatusThrottle parse(String watchId, String actionId, XContentParser parser) throws IOException {
+        DateTime timestamp = null;
+        String reason = null;
+
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (ActionStatusField.TIMESTAMP.match(currentFieldName, parser.getDeprecationHandler())) {
+                timestamp = dateTimeFormatter.parser().parseDateTime(parser.text());
+            } else if (ActionStatusField.REASON.match(currentFieldName, parser.getDeprecationHandler())) {
+                reason = parser.text();
+            } else {
+                throw new ElasticsearchParseException("could not parse action status for [{}/{}]. unexpected field [{}.{}]", watchId,
+                        actionId, ActionStatusField.LAST_THROTTLE.getPreferredName(), currentFieldName);
+            }
+        }
+        if (timestamp == null) {
+            throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field [{}.{}]",
+                    watchId, actionId, ActionStatusField.LAST_THROTTLE.getPreferredName(), ActionStatusField.TIMESTAMP.getPreferredName());
+        }
+        if (reason == null) {
+            throw new ElasticsearchParseException("could not parse action status for [{}/{}]. missing required field [{}.{}]",
+                    watchId, actionId, ActionStatusField.LAST_THROTTLE.getPreferredName(), ActionStatusField.REASON.getPreferredName());
+        }
+        return new ActionStatusThrottle(timestamp, reason);
+    }
+
+    public static void writeTo(ActionStatusThrottle throttle, StreamOutput out) throws IOException {
+        out.writeLong(throttle.timestamp.getMillis());
+        out.writeString(throttle.reason);
+    }
+
+    public static ActionStatusThrottle readFrom(StreamInput in) throws IOException {
+        DateTime timestamp = new DateTime(in.readLong(), DateTimeZone.UTC);
+        return new ActionStatusThrottle(timestamp, in.readString());
+    }
+
+    @Override
+    public String toString() {
+        return "ActionStatusThrottle{" +
+                "timestamp=" + timestamp +
+                ", reason='" + reason + '\'' +
+                '}';
+    }
+}

--- a/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/ExecutionState.java
+++ b/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/ExecutionState.java
@@ -1,9 +1,22 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-package org.elasticsearch.xpack.core.watcher.execution;
+package org.elasticsearch.protocol.xpack.watcher.status;
 
 import java.util.Locale;
 
@@ -50,5 +63,7 @@ public enum ExecutionState {
     public String toString() {
         return id();
     }
+
+
 
 }

--- a/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/WatchStatus.java
+++ b/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/WatchStatus.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.protocol.xpack.watcher.status;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.joda.time.DateTime;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
+import static org.elasticsearch.protocol.xpack.watcher.status.WatchStatusParams.hideHeaders;
+import static org.elasticsearch.protocol.xpack.watcher.status.WatchStatusParams.includeState;
+import static org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils.parseDate;
+import static org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils.readDate;
+import static org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils.readOptionalDate;
+import static org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils.writeDate;
+import static org.elasticsearch.protocol.xpack.watcher.status.WatcherDateTimeUtils.writeOptionalDate;
+import static org.joda.time.DateTimeZone.UTC;
+
+public class WatchStatus implements ToXContentObject, Streamable {
+    private WatchStatusState state;
+    private Map<String, String> headers;
+    private Map<String, ActionStatus> actions;
+    private long version;
+
+    @Nullable private ExecutionState executionState;
+    @Nullable private DateTime lastChecked;
+    @Nullable private DateTime lastMetCondition;
+
+    // for serialization
+    private WatchStatus() {
+    }
+
+    public WatchStatus(long version, WatchStatusState state, ExecutionState executionState, DateTime lastChecked,
+                        DateTime lastMetCondition, Map<String, ActionStatus> actions, Map<String, String> headers) {
+        this.version = version;
+        this.lastChecked = lastChecked;
+        this.lastMetCondition = lastMetCondition;
+        this.actions = actions;
+        this.state = state;
+        this.executionState = executionState;
+        this.headers = headers;
+    }
+
+    public WatchStatusState state() {
+        return state;
+    }
+
+    public boolean checked() {
+        return lastChecked != null;
+    }
+
+    public DateTime lastChecked() {
+        return lastChecked;
+    }
+
+    public ActionStatus actionStatus(String actionId) {
+        return actions.get(actionId);
+    }
+
+    public long version() {
+        return version;
+    }
+
+    public ExecutionState executionState() {
+        return executionState;
+    }
+
+    public Map<String, String> headers() {
+        return headers;
+    }
+
+    public DateTime lastMetCondition() {
+        return lastMetCondition;
+    }
+
+    public Map<String, ActionStatus> actions() {
+        return actions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        WatchStatus that = (WatchStatus) o;
+
+        return Objects.equals(lastChecked, that.lastChecked) &&
+                Objects.equals(lastMetCondition, that.lastMetCondition) &&
+                Objects.equals(version, that.version) &&
+                Objects.equals(executionState, that.executionState) &&
+                Objects.equals(actions, that.actions) &&
+                Objects.equals(headers, that.headers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lastChecked, lastMetCondition, actions, version, executionState, headers);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeLong(version);
+        writeOptionalDate(out, lastChecked);
+        writeOptionalDate(out, lastMetCondition);
+        out.writeInt(actions.size());
+        for (Map.Entry<String, ActionStatus> entry : actions.entrySet()) {
+            out.writeString(entry.getKey());
+            ActionStatus.writeTo(entry.getValue(), out);
+        }
+        out.writeBoolean(state.isActive());
+        writeDate(out, state.getTimestamp());
+        out.writeBoolean(executionState != null);
+        if (executionState != null) {
+            out.writeString(executionState.id());
+        }
+        boolean statusHasHeaders = headers != null && headers.isEmpty() == false;
+        out.writeBoolean(statusHasHeaders);
+        if (statusHasHeaders) {
+            out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
+        }
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        version = in.readLong();
+        lastChecked = readOptionalDate(in, UTC);
+        lastMetCondition = readOptionalDate(in, UTC);
+        int count = in.readInt();
+        Map<String, ActionStatus> actions = new HashMap<>(count);
+        for (int i = 0; i < count; i++) {
+            actions.put(in.readString(), ActionStatus.readFrom(in));
+        }
+        this.actions = unmodifiableMap(actions);
+        state = new WatchStatusState(in.readBoolean(), readDate(in, UTC));
+        boolean executionStateExists = in.readBoolean();
+        if (executionStateExists) {
+            executionState = ExecutionState.resolve(in.readString());
+        }
+        if (in.readBoolean()) {
+            headers = in.readMap(StreamInput::readString, StreamInput::readString);
+        }
+    }
+
+    public static WatchStatus read(StreamInput in) throws IOException {
+        WatchStatus status = new WatchStatus();
+        status.readFrom(in);
+        return status;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (includeState(params)) {
+            builder.field(WatchStatusField.STATE.getPreferredName(), state, params);
+        }
+        if (lastChecked != null) {
+            builder.timeField(WatchStatusField.LAST_CHECKED.getPreferredName(), lastChecked);
+        }
+        if (lastMetCondition != null) {
+            builder.timeField(WatchStatusField.LAST_MET_CONDITION.getPreferredName(), lastMetCondition);
+        }
+        if (actions != null) {
+            builder.startObject(WatchStatusField.ACTIONS.getPreferredName());
+            for (Map.Entry<String, ActionStatus> entry : actions.entrySet()) {
+                builder.field(entry.getKey(), entry.getValue(), params);
+            }
+            builder.endObject();
+        }
+        if (executionState != null) {
+            builder.field(WatchStatusField.EXECUTION_STATE.getPreferredName(), executionState.id());
+        }
+        if (headers != null && headers.isEmpty() == false && hideHeaders(params) == false) {
+            builder.field(WatchStatusField.HEADERS.getPreferredName(), headers);
+        }
+        builder.field(WatchStatusField.VERSION.getPreferredName(), version);
+        return builder.endObject();
+    }
+
+    public static WatchStatus parse(String watchId, XContentParser parser) throws IOException {
+        WatchStatusState state = null;
+        ExecutionState executionState = null;
+        DateTime lastChecked = null;
+        DateTime lastMetCondition = null;
+        Map<String, ActionStatus> actions = null;
+        long version = -1;
+        Map<String, String> headers = Collections.emptyMap();
+
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (WatchStatusField.STATE.match(currentFieldName, parser.getDeprecationHandler())) {
+                try {
+                    state = WatchStatusState.parse(parser);
+                } catch (ElasticsearchParseException e) {
+                    throw new ElasticsearchParseException("could not parse watch status for [{}]. failed to parse field [{}]",
+                            e, watchId, currentFieldName);
+                }
+            } else if (WatchStatusField.VERSION.match(currentFieldName, parser.getDeprecationHandler())) {
+                if (token.isValue()) {
+                    version = parser.longValue();
+                } else {
+                    throw new ElasticsearchParseException("could not parse watch status for [{}]. expecting field [{}] to hold a long " +
+                            "value, found [{}] instead", watchId, currentFieldName, token);
+                }
+            } else if (WatchStatusField.LAST_CHECKED.match(currentFieldName, parser.getDeprecationHandler())) {
+                if (token.isValue()) {
+                    lastChecked = parseDate(currentFieldName, parser, UTC);
+                } else {
+                    throw new ElasticsearchParseException("could not parse watch status for [{}]. expecting field [{}] to hold a date " +
+                            "value, found [{}] instead", watchId, currentFieldName, token);
+                }
+            } else if (WatchStatusField.LAST_MET_CONDITION.match(currentFieldName, parser.getDeprecationHandler())) {
+                if (token.isValue()) {
+                    lastMetCondition = parseDate(currentFieldName, parser, UTC);
+                } else {
+                    throw new ElasticsearchParseException("could not parse watch status for [{}]. expecting field [{}] to hold a date " +
+                            "value, found [{}] instead", watchId, currentFieldName, token);
+                }
+            } else if (WatchStatusField.EXECUTION_STATE.match(currentFieldName, parser.getDeprecationHandler())) {
+                if (token.isValue()) {
+                    executionState = ExecutionState.resolve(parser.text());
+                } else {
+                    throw new ElasticsearchParseException("could not parse watch status for [{}]. expecting field [{}] to hold a string " +
+                            "value, found [{}] instead", watchId, currentFieldName, token);
+                }
+            } else if (WatchStatusField.ACTIONS.match(currentFieldName, parser.getDeprecationHandler())) {
+                actions = new HashMap<>();
+                if (token == XContentParser.Token.START_OBJECT) {
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                        if (token == XContentParser.Token.FIELD_NAME) {
+                            currentFieldName = parser.currentName();
+                        } else {
+                            ActionStatus actionStatus = ActionStatus.parse(watchId, currentFieldName, parser);
+                            actions.put(currentFieldName, actionStatus);
+                        }
+                    }
+                } else {
+                    throw new ElasticsearchParseException("could not parse watch status for [{}]. expecting field [{}] to be an object, " +
+                            "found [{}] instead", watchId, currentFieldName, token);
+                }
+            } else if (WatchStatusField.HEADERS.match(currentFieldName, parser.getDeprecationHandler())) {
+                if (token == XContentParser.Token.START_OBJECT) {
+                    headers = parser.mapStrings();
+                }
+            }
+        }
+
+        actions = actions == null ? emptyMap() : unmodifiableMap(actions);
+
+        return new WatchStatus(version, state, executionState, lastChecked, lastMetCondition, actions, headers);
+    }
+
+    @Override
+    public String toString() {
+        return "WatchStatus{" +
+                "state=" + state +
+                ", executionState=" + executionState +
+                ", lastChecked=" + lastChecked +
+                ", lastMetCondition=" + lastMetCondition +
+                ", version=" + version +
+                ", headers=" + headers +
+                ", actions=" + actions +
+                '}';
+    }
+}

--- a/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/WatchStatusField.java
+++ b/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/WatchStatusField.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.protocol.xpack.watcher.status;
+
+import org.elasticsearch.common.ParseField;
+
+public interface WatchStatusField {
+    ParseField STATE = new ParseField("state");
+    ParseField ACTIVE = new ParseField("active");
+    ParseField TIMESTAMP = new ParseField("timestamp");
+    ParseField LAST_CHECKED = new ParseField("last_checked");
+    ParseField LAST_MET_CONDITION = new ParseField("last_met_condition");
+    ParseField ACTIONS = new ParseField("actions");
+    ParseField VERSION = new ParseField("version");
+    ParseField EXECUTION_STATE = new ParseField("execution_state");
+    ParseField HEADERS = new ParseField("headers");
+}

--- a/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/WatchStatusParams.java
+++ b/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/WatchStatusParams.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.protocol.xpack.watcher.status;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.unmodifiableMap;
+
+public class WatchStatusParams extends ToXContent.DelegatingMapParams {
+    private static final String HIDE_HEADERS = "hide_headers";
+    private static final String INCLUDE_STATE = "include_state";
+
+    public WatchStatusParams(Map<String, String> params, ToXContent.Params delegate) {
+        super(params, delegate);
+    }
+
+    public static WatchStatusParams.Builder builder() {
+        return new Builder(ToXContent.EMPTY_PARAMS);
+    }
+
+    public static boolean hideHeaders(ToXContent.Params params) {
+        return params.paramAsBoolean(HIDE_HEADERS, true);
+    }
+
+    public static boolean includeState(ToXContent.Params params) {
+        return params.paramAsBoolean(INCLUDE_STATE, true);
+    }
+
+    public static class Builder {
+        private final ToXContent.Params delegate;
+        private final Map<String, String> params = new HashMap<>();
+
+        private Builder(ToXContent.Params delegate) {
+            this.delegate = delegate;
+        }
+
+        public Builder hideHeaders(boolean hideHeaders) {
+            params.put(HIDE_HEADERS, String.valueOf(hideHeaders));
+            return this;
+        }
+
+        public Builder includeState(boolean includeState) {
+            params.put(INCLUDE_STATE, String.valueOf(includeState));
+            return this;
+        }
+
+        public WatchStatusParams build() {
+            return new WatchStatusParams(unmodifiableMap(new HashMap<>(params)), delegate);
+        }
+    }
+
+}

--- a/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/WatchStatusState.java
+++ b/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/WatchStatusState.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.protocol.xpack.watcher.status;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.joda.time.DateTime;
+
+import java.io.IOException;
+
+import static org.joda.time.DateTimeZone.UTC;
+
+public class WatchStatusState implements ToXContentObject {
+
+    final boolean active;
+    final DateTime timestamp;
+
+    public WatchStatusState(boolean active, DateTime timestamp) {
+        this.active = active;
+        this.timestamp = timestamp;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public DateTime getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(WatchStatusField.ACTIVE.getPreferredName(), active);
+        WatcherDateTimeUtils.writeDate(WatchStatusField.TIMESTAMP.getPreferredName(), builder, timestamp);
+        return builder.endObject();
+    }
+
+    public static WatchStatusState parse(XContentParser parser) throws IOException {
+        if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
+            throw new ElasticsearchParseException("expected an object but found [{}] instead", parser.currentToken());
+        }
+        boolean active = true;
+        DateTime timestamp = DateTime.now(UTC);
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (WatchStatusField.ACTIVE.match(currentFieldName, parser.getDeprecationHandler())) {
+                active = parser.booleanValue();
+            } else if (WatchStatusField.TIMESTAMP.match(currentFieldName, parser.getDeprecationHandler())) {
+                timestamp = WatcherDateTimeUtils.parseDate(currentFieldName, parser, UTC);
+            }
+        }
+        return new WatchStatusState(active, timestamp);
+    }
+
+    @Override
+    public String toString() {
+        return "WatchStatusState{" +
+                "active=" + active +
+                ", timestamp=" + timestamp +
+                '}';
+    }
+}

--- a/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/WatcherDateTimeUtils.java
+++ b/x-pack/protocol/src/main/java/org/elasticsearch/protocol/xpack/watcher/status/WatcherDateTimeUtils.java
@@ -1,9 +1,22 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-package org.elasticsearch.xpack.core.watcher.support;
+package org.elasticsearch.protocol.xpack.watcher.status;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Nullable;


### PR DESCRIPTION
The pull request refactors WatchStatus to xpack/protocol.
During HLRC all xpack request/responses should be moved to the protocol project.
Several responses such as activate, deactivate, ack and get watch, contain WatchStatus field. The `WatchStatus` is a core object, that is stored in Lucene and it also contains some business logic.
Of course, having business logic methods in protocol project is not
appropriate and refactoring was required. There are were several options for the
refactoring:

1. Create completely independent `WatchStatus` class inside protocol project
(w/o business logic methods) and perform conversion from core status to
protocol status inside TransportActivateWatchAction. The drawback of this approach is code
duplication.
2. Create `WatchStatus` class (with fields and binary/JSON
serialization/deserialization) inside protocol and extend it by core `WatchStatus`.
The advantage of this approach - no code duplication, but the disadvantage is
that inheritance does not play nicely with subtyping inside the class fields.
For example, protocol `WatchStatus` should contain protocol `ActionStatus` and
core `WatchStatus` should contain core `ActionStatus`. This could be solved by
generics, but generics are required for each field and having protocol
WatchStatus with generics inside protocol is too heavy-weight.
3. Create `WatchStatus` class with fields and binary/JSON serialization
deserialization and have core `WatchStatus` with business logic methods but no
serialization/deserialization. And use `WatchStatus` not only as a protocol for
REST/transport client, but also as a class for storing core `WatchStatus` to
Lucene.
Finally, the 3rd approach was taken.
As a part of the refactoring inner static classes of `WatchStatus` and `ActionStatus` were moved to the upper level. Unfortunately, git does not understand the source for such files and thinks that this is newly added code.
I'm not sure if it makes sense to move `WatcherDateUtils` to protocol because currently `WatchStatus` uses just a couple of methods from this class and it should be easy to inline them to `WatchStatus` class directly.
Relates #29827