### PR TITLE
[DOCS] Adds machine learning 6.4.0 highlights

### DIFF
--- a/docs/reference/release-notes/highlights-6.4.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.4.0.asciidoc
@@ -16,6 +16,22 @@ See also <<release-notes-6.4.0,{es} 6.4.0 release notes>>.
 * Add multiplexing token filter - This new token filter allows you to run tokens through multiple different tokenfilters and stack the results. For example, you can now easily index the original form of a token, its lowercase form and a stemmed form all at the same position, allowing you to search for stemmed and unstemmed tokens in the same field. For more information, see <<analysis-multiplexer-tokenfilter,Multiplexer token filter>>.
 
 [float]
+=== Machine learning
+
+* Improve your machine learning results with custom rules. If you want to fine 
+tune your machine learning results (for example, to skip anomalies related to 
+certain servers), you can now create custom rules in {kib} and by using {ml} APIs. 
+Custom rules instruct anomaly detectors to change their behavior based on 
+domain-specific knowledge that you provide. See 
+{stack-ov}/ml-configuring-detector-custom-rules.html[Customizing detectors with custom rules]
+* The {ml} analytics can now detect specific change points in a time series, 
+such as step changes, linear scaling, and time shifts (for example, related to 
+daylight savings). There is also a new probability model that can predict when 
+step changes might occur. As a result, the {ml} results are more robust and can 
+make more accurate predictions when these types of changes are present in your 
+data. 
+
+[float]
 === Mappings
 
 * `alias` field type - A new field type can now be added in the mappings. An `alias` field allows a field to be defined in the mappings which is an alias of another field meaning that the alias name can be used when referring to the field. For example the mapping in an index may have a `hostname` field and the mapping might define a alias field `host_name` so that when a user searches using thee field `host_name` it actually searches the `hostname` field. This can be useful for helping migrate between schemas where field names have been changed an for searching across multiple indexes which may have different field names for the same information. For more information, see <<alias, Alias field type>>
@@ -41,3 +57,4 @@ changes ranges include https://github.com/elastic/elasticsearch/pulls?q=is%3Aclo
 
 Specifically we want to highlight the https://github.com/elastic/elasticsearch/pull/30414[added support for AWS session tokens] to both 
 the EC2 discovery plugin and the S3 repository plugins. This allows Elasticsearch to use AWS devices protected by multi factor authentication.
+


### PR DESCRIPTION
Related to https://github.com/elastic/ml-cpp/pull/183

This PR adds machine learning items to the Elasticsearch 6.4.0 Release Highlights (https://www.elastic.co/guide/en/elasticsearch/reference/6.4/release-highlights-6.4.0.html). In particular, they're related to https://github.com/elastic/ml-cpp/pull/92 and https://github.com/elastic/elasticsearch/pull/31110

If there are other items that should be added to these highlights, let me know!