### PR TITLE
Use JDK 10 for 6.4 BWC builds

### DIFF
--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -157,7 +157,7 @@ subprojects {
       environment('JAVA_HOME', getJavaHome(it, 8))
     } else if ("6.2".equals(bwcBranch)) {
       environment('JAVA_HOME', getJavaHome(it, 9))
-    } else if (["6.3", "6.x"].contains(bwcBranch)) {
+    } else if (["6.3", "6.4", "6.x"].contains(bwcBranch)) {
       environment('JAVA_HOME', getJavaHome(it, 10))
     } else {
       environment('JAVA_HOME', project.compilerJavaHome)


### PR DESCRIPTION
The 6.4 release will officially be built with JDK 10. We should push JDK 10 down to the BWC builds for the 6.4 branch then too.