### PR TITLE
[DOCS] Move breaking change info re rejecting regex search if regex string is too long

### DIFF
--- a/docs/reference/migration/migrate_6_0/search.asciidoc
+++ b/docs/reference/migration/migrate_6_0/search.asciidoc
@@ -215,13 +215,6 @@ The ability to query and index context enabled suggestions without contexts
 has been deprecated. Context enabled suggestion queries without contexts have
 to visit every suggestion, which degrades the search performance considerably.
 
-==== Limiting the length of regex that can be used in a Regexp Query request
-
-Regexp Query with long string made of many operators may run into a stack overflow.
-To safeguard against this, the maximum length of regex that can be used in a
-Regexp Query request has been limited to 1000. This default maximum can be changed
-for a particular index with the index setting `index.max_regex_length`.
-
 ==== Limiting the max number of expansion of span_multi queries
 
 `span_multi` queries will hit too many clauses failure if the number of terms that match the

--- a/docs/reference/migration/migrate_6_4.asciidoc
+++ b/docs/reference/migration/migrate_6_4.asciidoc
@@ -36,6 +36,17 @@ to follow up the operation with a request to adjust to the desired settings on
 the target index, or send the desired value of these settings with the resize
 operation.
 
+[[breaking_64_search_changes]]
+=== Search and query DSL changes
+
+==== Limiting the length of regex that can be used in a Regexp Query request
+
+Executing a <<query-dsl-regexp-query,Regexp Query>> with a long regex string may 
+degrade search performance. To safeguard against this, the maximum length of 
+regex that can be used in a Regexp Query request has been limited to 1000. This 
+default maximum can be changed for a particular index with the index setting 
+`index.max_regex_length`.
+
 [[breaking_64_scripting_changes]]
 === Scripting
 

--- a/docs/reference/migration/migrate_6_4.asciidoc
+++ b/docs/reference/migration/migrate_6_4.asciidoc
@@ -41,11 +41,10 @@ operation.
 
 ==== Limiting the length of regex that can be used in a Regexp Query request
 
-Executing a <<query-dsl-regexp-query,Regexp Query>> with a long regex string may 
-degrade search performance. To safeguard against this, the maximum length of 
-regex that can be used in a Regexp Query request has been limited to 1000. This 
-default maximum can be changed for a particular index with the index setting 
-`index.max_regex_length`.
+<<query-dsl-regexp-query,Regexp Query>> with long string made of many operators may run into a stack overflow.
+To safeguard against this, the maximum length of regex that can be used in a
+Regexp Query request has been limited to 1000. This default maximum can be changed
+for a particular index with the index setting `index.max_regex_length`.
 
 [[breaking_64_scripting_changes]]
 === Scripting


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/31131

Per discussion with @mayya-sharipova, this is a breaking change in 6.4 not 6.0