### PR TITLE
Fix docs for fixed filename for heap dump path

### DIFF
--- a/docs/reference/setup/important-settings/heap-dump-path.asciidoc
+++ b/docs/reference/setup/important-settings/heap-dump-path.asciidoc
@@ -8,8 +8,8 @@ distributions, and the `data` directory under the root of the
 Elasticsearch installation for the <<zip-targz,tar and zip>> archive
 distributions). If this path is not suitable for receiving heap dumps,
 you should modify the entry `-XX:HeapDumpPath=...` in
-<<jvm-options,`jvm.options`>>. If you specify a fixed filename instead
-of a directory, the JVM will repeatedly use the same file; this is one
-mechanism for preventing heap dumps from accumulating in the heap dump
-path. Alternatively, you can configure a scheduled task via your OS to
-remove heap dumps that are older than a configured age.
+<<jvm-options,`jvm.options`>>. If you specify a directory, the JVM
+will generate a filename for the heap dump based on the PID of the running
+instance. If you specify a fixed filename instead of a directory, the file must
+not exist when the JVM needs to perform a heap dump on an out of memory
+exception, otherwise the heap dump will fail.


### PR DESCRIPTION
The docs here incorrectly state that it is okay for a heap dump file to exist when heap dump path is configured to a fixed filename. This is incorrect, the JVM will fail to write the heap dump if a heap dump file already exists at the specified location (see the DumpWriter constructor DumpWriter::DumpWriter(const char* path) in the JVM source).

Closes #32873
