### PR TITLE
[TEST]  Run pre 6.4 nodes in non-FIPS JVMs

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -177,6 +177,9 @@ class NodeInfo {
             javaVersion = 8
         } else if (nodeVersion.onOrAfter("6.2.0") && nodeVersion.before("6.3.0")) {
             javaVersion = 9
+        } else if (project.inFipsJvm && nodeVersion.onOrAfter("6.3.0") && nodeVersion.before("6.4.0")) {
+            // Versions before 6.4.0 cannot be run in a FIPS 140 JVM
+            javaVersion = 10
         }
 
         args.addAll("-E", "node.portsfile=true")

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -178,7 +178,10 @@ class NodeInfo {
         } else if (nodeVersion.onOrAfter("6.2.0") && nodeVersion.before("6.3.0")) {
             javaVersion = 9
         } else if (project.inFipsJvm && nodeVersion.onOrAfter("6.3.0") && nodeVersion.before("6.4.0")) {
-            // Versions before 6.4.0 cannot be run in a FIPS 140 JVM
+            /*
+             * Elasticsearch versions before 6.4.0 cannot be run in a FIPS-140 JVM. If we're running
+             * bwc tests in a FIPS-140 JVM, ensure that the pre v6.4.0 nodes use a Java 10 JVM instead.
+             */
             javaVersion = 10
         }
 

--- a/x-pack/qa/full-cluster-restart/with-system-key/build.gradle
+++ b/x-pack/qa/full-cluster-restart/with-system-key/build.gradle
@@ -1,8 +1,0 @@
-import org.elasticsearch.gradle.test.RestIntegTestTask
-
-// Skip test on FIPS FIXME https://github.com/elastic/elasticsearch/issues/32737
-if (project.inFipsJvm) {
-    tasks.withType(RestIntegTestTask) {
-        enabled = false
-    }
-}

--- a/x-pack/qa/rolling-upgrade/with-system-key/build.gradle
+++ b/x-pack/qa/rolling-upgrade/with-system-key/build.gradle
@@ -1,10 +1,1 @@
-import org.elasticsearch.gradle.test.RestIntegTestTask
-
-// Skip test on FIPS FIXME https://github.com/elastic/elasticsearch/issues/32737
-if (project.inFipsJvm) {
-    tasks.withType(RestIntegTestTask) {
-        enabled = false
-    }
-}
-
 group = "${group}.x-pack.qa.rolling-upgrade.with-system-key"


### PR DESCRIPTION
Elasticsearch versions earlier than 6.4.0 cannot properly run in a
FIPS 140 JVM. This commit ensures that we use a non-FIPS JVM for
nodes that we spin up in BWC tests even when we're testing FIPS.

Resolves #32737 

It also reverts e497173 and e64bb48 and as such resolves #32868