### PR TITLE
Update docker.asciidoc

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -61,6 +61,12 @@ ifeval::["{release-state}"!="unreleased"]
 docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" {docker-image}
 --------------------------------------------
 
+If you want to use the java client to access your node, add the cluster name in the settings: 
+
+--------------------------------------------
+Settings.builder().put("cluster.name", "docker-cluster")
+--------------------------------------------
+
 endif::[]
 
 [[docker-cli-run-prod-mode]]


### PR DESCRIPTION
We just spent a lot of time figuring out why we could not connect to the development docker instance from java, even though health checks looked fine. 
Finally, we had to set the cluster name manually (which is not the case when running it without docker). 

Imo, it would benefit future readers, if this was mentioned.
