### PR TITLE
Enable FIPS140LicenseBootstrapCheck

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -302,7 +302,8 @@ public class Security extends Plugin implements ActionPlugin, IngestPlugin, Netw
                 new TLSLicenseBootstrapCheck(),
                 new FIPS140SecureSettingsBootstrapCheck(settings, env),
                 new FIPS140JKSKeystoreBootstrapCheck(settings),
-                new FIPS140PasswordHashingAlgorithmBootstrapCheck(settings)));
+                new FIPS140PasswordHashingAlgorithmBootstrapCheck(settings),
+                new FIPS140LicenseBootstrapCheck(XPackSettings.FIPS_MODE_ENABLED.get(settings))));
             checks.addAll(InternalRealms.getBootstrapChecks(settings, env));
             this.bootstrapChecks = Collections.unmodifiableList(checks);
             Automatons.updateMaxDeterminizedStates(settings);


### PR DESCRIPTION
This commit ensures that `xpack.security.fips_mode.enabled: true` cannot be set in a node that doesn't have the appropriate license. The bootstrap check was introduced in #32437 but was not enabled. 