### PR TITLE
Re enable ml bwc tests

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
@@ -162,8 +162,7 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
         }
 
         // BWC for removed per-partition normalization
-        // Version check is temporarily against the latest to satisfy CI tests
-        // TODO change to V_6_5_0 after successful backport to 6.x
+        // TODO Remove in 7.0.0
         if (in.getVersion().before(Version.V_6_5_0)) {
             in.readBoolean();
         }
@@ -197,8 +196,7 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
         }
 
         // BWC for removed per-partition normalization
-        // Version check is temporarily against the latest to satisfy CI tests
-        // TODO change to V_6_5_0 after successful backport to 6.x
+        // TODO Remove in 7.0.0
         if (out.getVersion().before(Version.V_6_5_0)) {
             out.writeBoolean(false);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
@@ -164,7 +164,7 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
         // BWC for removed per-partition normalization
         // Version check is temporarily against the latest to satisfy CI tests
         // TODO change to V_6_5_0 after successful backport to 6.x
-        if (in.getVersion().before(Version.V_7_0_0_alpha1)) {
+        if (in.getVersion().before(Version.V_6_5_0)) {
             in.readBoolean();
         }
     }
@@ -199,7 +199,7 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
         // BWC for removed per-partition normalization
         // Version check is temporarily against the latest to satisfy CI tests
         // TODO change to V_6_5_0 after successful backport to 6.x
-        if (out.getVersion().before(Version.V_7_0_0_alpha1)) {
+        if (out.getVersion().before(Version.V_6_5_0)) {
             out.writeBoolean(false);
         }
     }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
@@ -1,10 +1,4 @@
 ---
-setup:
-    - skip:
-        version: "all"
-        reason: "Temporarily disabled while backporting https://github.com/elastic/elasticsearch/pull/32816"
-
----
 "Test get old cluster job":
   - do:
       xpack.ml.get_jobs:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/40_ml_datafeed_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/40_ml_datafeed_crud.yml
@@ -1,10 +1,4 @@
 ---
-setup:
-    - skip:
-        version: "all"
-        reason: "Temporarily disabled while backporting https://github.com/elastic/elasticsearch/pull/32816"
-
----
 "Test old cluster datafeed":
   - do:
       xpack.ml.get_datafeeds:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/30_ml_jobs_crud.yml
@@ -1,10 +1,4 @@
 ---
-setup:
-    - skip:
-        version: "all"
-        reason: "Temporarily disabled while backporting https://github.com/elastic/elasticsearch/pull/32816"
-
----
 "Put job on the old cluster and post some data":
 
   - do:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/40_ml_datafeed_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/40_ml_datafeed_crud.yml
@@ -1,10 +1,4 @@
 ---
-setup:
-    - skip:
-        version: "all"
-        reason: "Temporarily disabled while backporting https://github.com/elastic/elasticsearch/pull/32816"
-
----
 "Put job and datafeed in old cluster":
 
   - do:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
@@ -1,8 +1,4 @@
 setup:
- - skip:
-     version: "all"
-     reason: "Temporarily disabled while backporting https://github.com/elastic/elasticsearch/pull/32816"
-
  - do:
      cluster.health:
         wait_for_status: green

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/40_ml_datafeed_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/40_ml_datafeed_crud.yml
@@ -1,8 +1,4 @@
 setup:
-  - skip:
-      version: "all"
-      reason: "Temporarily disabled while backporting https://github.com/elastic/elasticsearch/pull/32816"
-
   - do:
      cluster.health:
         wait_for_status: green


### PR DESCRIPTION
Re-enable BWC tests for ML now that #32816 has been backported to 6.x

