### PR TITLE
Do not use ctx.vars.email_recipient in the e-mail From header

### DIFF
--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_cluster_status.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_cluster_status.json
@@ -162,7 +162,6 @@
       },
       "email": {
         "to": "X-Pack Admin <{{ctx.vars.email_recipient}}>",
-        "from": "X-Pack Admin <{{ctx.vars.email_recipient}}>",
         "subject": "[{{#ctx.vars.is_new}}NEW{{/ctx.vars.is_new}}{{#ctx.vars.is_resolved}}RESOLVED{{/ctx.vars.is_resolved}}] {{ctx.metadata.name}} [{{ctx.vars.state}}]",
         "body": {
           "text": "{{#ctx.vars.is_resolved}}This cluster alert has been resolved: {{/ctx.vars.is_resolved}}{{ctx.payload.prefix}} {{ctx.payload.message}}"

--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_nodes.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_nodes.json
@@ -170,7 +170,6 @@
       },
       "email": {
         "profile": "standard",
-        "from": "X-Pack Admin <{{ctx.vars.email_recipient}}>",
         "to": [
           "X-Pack Admin <{{ctx.vars.email_recipient}}>"
         ],

--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_version_mismatch.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_version_mismatch.json
@@ -158,7 +158,6 @@
       },
       "email": {
         "to": "X-Pack Admin <{{ctx.vars.email_recipient}}>",
-        "from": "X-Pack Admin <{{ctx.vars.email_recipient}}>",
         "subject": "[{{#ctx.vars.is_new}}NEW{{/ctx.vars.is_new}}{{#ctx.vars.is_resolved}}RESOLVED{{/ctx.vars.is_resolved}}] {{ctx.metadata.name}}",
         "body": {
           "text": "{{#ctx.vars.is_resolved}}This cluster alert has been resolved: {{/ctx.vars.is_resolved}}{{ctx.payload.prefix}} {{ctx.payload.message}}"

--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/kibana_version_mismatch.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/kibana_version_mismatch.json
@@ -178,7 +178,6 @@
       },
       "email": {
         "to": "X-Pack Admin <{{ctx.vars.email_recipient}}>",
-        "from": "X-Pack Admin <{{ctx.vars.email_recipient}}>",
         "subject": "[{{#ctx.vars.is_new}}NEW{{/ctx.vars.is_new}}{{#ctx.vars.is_resolved}}RESOLVED{{/ctx.vars.is_resolved}}] {{ctx.metadata.name}}",
         "body": {
           "text": "{{#ctx.vars.is_resolved}}This cluster alert has been resolved: {{/ctx.vars.is_resolved}}{{ctx.payload.prefix}} {{ctx.payload.message}}"

--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/logstash_version_mismatch.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/logstash_version_mismatch.json
@@ -178,7 +178,6 @@
       },
       "email": {
         "to": "X-Pack Admin <{{ctx.vars.email_recipient}}>",
-        "from": "X-Pack Admin <{{ctx.vars.email_recipient}}>",
         "subject": "[{{#ctx.vars.is_new}}NEW{{/ctx.vars.is_new}}{{#ctx.vars.is_resolved}}RESOLVED{{/ctx.vars.is_resolved}}] {{ctx.metadata.name}}",
         "body": {
           "text": "{{#ctx.vars.is_resolved}}This cluster alert has been resolved: {{/ctx.vars.is_resolved}}{{ctx.payload.prefix}} {{ctx.payload.message}}"

--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/xpack_license_expiration.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/xpack_license_expiration.json
@@ -151,7 +151,6 @@
       },
       "email": {
         "to": "X-Pack Admin <{{ctx.vars.email_recipient}}>",
-        "from": "X-Pack Admin <{{ctx.vars.email_recipient}}>",
         "subject": "[{{#ctx.vars.is_new}}NEW{{/ctx.vars.is_new}}{{#ctx.vars.is_resolved}}RESOLVED{{/ctx.vars.is_resolved}}] {{ctx.metadata.name}}",
         "body": {
           "text": "{{#ctx.vars.is_resolved}}This cluster alert has been resolved: {{/ctx.vars.is_resolved}} This cluster's license {{#ctx.vars.is_new}}is going to expire on {{ctx.payload.metadata.time}}{{/ctx.vars.is_new}}{{#ctx.vars.is_resolved}}was going to expire{{ctx.payload.metadata.time}}{{/ctx.vars.is_resolved}}. {{#ctx.vars.is_new}}{{ctx.payload.message}}{{/ctx.vars.is_new}}"


### PR DESCRIPTION
Do not set the e-mail From header to the same value as the To header
in the default watches. Otherwise those watches fail if the e-mail server
verifies the From header. If we do not specify any From header at all
it will be read from the 'xpack.notification.email.account' section
in the elasticsearch.yml configuration file.