### PR TITLE
Protect ScriptedMetricIT test cases against failures on 0-doc shards (#32959)

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -108,8 +108,14 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     aggScript(vars, state -> state.put((String) XContentMapValues.extractValue("params.param1", vars),
                         XContentMapValues.extractValue("params.param2", vars))));
 
-            scripts.put("vars.multiplier = 3", vars ->
-                    ((Map<String, Object>) vars.get("vars")).put("multiplier", 3));
+            scripts.put("vars.multiplier = 3", vars -> {
+                ((Map<String, Object>) vars.get("vars")).put("multiplier", 3);
+
+                Map<String, Object> state = (Map<String, Object>) vars.get("state");
+                state.put("list", new ArrayList());
+
+                return state;
+            });
 
             scripts.put("state.list.add(vars.multiplier)", vars ->
                     aggScript(vars, state -> {


### PR DESCRIPTION
Fixes #32959

Randomized test conditions that cause some shards to have no docs on them
failed due to test asserts that relied on a lazy initialization side effect
from the map script. After this fix:

- Test cases with the relevant init script are protected
- Test cases with the relevant combine or reduce scripts were already
  protected, because the combine and reduce scripts safely handle this case.

This fixes a bug that made it through #31597 so the fix will need to be backported to 6.x or pulled into #32944.