### PR TITLE
Remove old unused test script files (#29328)

### DIFF
--- a/docs/src/test/cluster/config/scripts/calculate_score.painless
+++ b/docs/src/test/cluster/config/scripts/calculate_score.painless
@@ -1,1 +1,0 @@
-Math.log(_score * 2) + params.my_modifier

--- a/docs/src/test/cluster/config/scripts/my_combine_script.painless
+++ b/docs/src/test/cluster/config/scripts/my_combine_script.painless
@@ -1,5 +1,0 @@
-double profit = 0;
-for (t in params._agg.transactions) {
-  profit += t
-}
-return profit

--- a/docs/src/test/cluster/config/scripts/my_init_script.painless
+++ b/docs/src/test/cluster/config/scripts/my_init_script.painless
@@ -1,1 +1,0 @@
-params._agg.transactions = []

--- a/docs/src/test/cluster/config/scripts/my_map_script.painless
+++ b/docs/src/test/cluster/config/scripts/my_map_script.painless
@@ -1,1 +1,0 @@
-params._agg.transactions.add(doc.type.value == 'sale' ? doc.amount.value : -1 * doc.amount.value)

--- a/docs/src/test/cluster/config/scripts/my_reduce_script.painless
+++ b/docs/src/test/cluster/config/scripts/my_reduce_script.painless
@@ -1,5 +1,0 @@
-double profit = 0;
-for (a in params._aggs) {
-  profit += a
-}
-return profit

--- a/docs/src/test/cluster/config/scripts/my_script.painless
+++ b/docs/src/test/cluster/config/scripts/my_script.painless
@@ -1,2 +1,0 @@
-// Simple script to load a field. Not really a good example, but a simple one.
-doc[params.field].value


### PR DESCRIPTION
I noticed these still referenced the old `params._agg/_aggs` values when working on #29328. Per the comment thread in that issue they are no longer used, so I'm removing them instead of updating them.