### PR TITLE
Fix assertion in AbstractSimpleTransportTestCase

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -2650,7 +2650,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 public void onConnectionOpened(final Transport.Connection connection) {
                     closeConnectionChannel(connection);
                     try {
-                        assertBusy(connection::isClosed);
+                        assertBusy(() -> assertTrue(connection.isClosed()));
                     } catch (Exception e) {
                         throw new AssertionError(e);
                     }


### PR DESCRIPTION
This is a follow-up to #32956. That commit incorrectly used assertBusy
which led to a possible race in the test. This commit fixes it.