### PR TITLE
[DOCS] Rename X-Pack Commands section

### DIFF
--- a/docs/reference/commands/index.asciidoc
+++ b/docs/reference/commands/index.asciidoc
@@ -1,18 +1,17 @@
-[role="xpack"]
-[[xpack-commands]]
-= {xpack} Commands
+[[commands]]
+= Commands
 
 [partintro]
 --
 
-{xpack} includes commands that help you configure security:
+{es} includes the following commands that help you configure security:
 
 * <<certgen>>
 * <<certutil>>
 * <<migrate-tool>>
-* <<saml-metadata>>
 * <<setup-passwords>>
 * <<syskeygen>>
+* <<saml-metadata>>
 * <<users-command>>
 
 --
@@ -20,7 +19,7 @@
 include::certgen.asciidoc[]
 include::certutil.asciidoc[]
 include::migrate-tool.asciidoc[]
-include::saml-metadata.asciidoc[]
 include::setup-passwords.asciidoc[]
 include::syskeygen.asciidoc[]
+include::saml-metadata.asciidoc[]
 include::users-command.asciidoc[]

--- a/docs/reference/commands/index.asciidoc
+++ b/docs/reference/commands/index.asciidoc
@@ -10,9 +10,9 @@ tasks from the command line:
 * <<certgen>>
 * <<certutil>>
 * <<migrate-tool>>
+* <<saml-metadata>>
 * <<setup-passwords>>
 * <<syskeygen>>
-* <<saml-metadata>>
 * <<users-command>>
 
 --
@@ -20,7 +20,7 @@ tasks from the command line:
 include::certgen.asciidoc[]
 include::certutil.asciidoc[]
 include::migrate-tool.asciidoc[]
+include::saml-metadata.asciidoc[]
 include::setup-passwords.asciidoc[]
 include::syskeygen.asciidoc[]
-include::saml-metadata.asciidoc[]
 include::users-command.asciidoc[]

--- a/docs/reference/commands/index.asciidoc
+++ b/docs/reference/commands/index.asciidoc
@@ -1,10 +1,11 @@
 [[commands]]
-= Commands
+= Command line tools
 
 [partintro]
 --
 
-{es} includes the following commands that help you configure security:
+{es} provides the following tools for configuring security and performing other 
+tasks from the command line:
 
 * <<certgen>>
 * <<certutil>>

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -544,3 +544,8 @@ You can use the following APIs to add, remove, and retrieve role mappings:
 === Privilege APIs
 
 See <<security-api-has-privileges>>.
+
+[role="exclude",id="xpack-commands"]
+=== X-Pack commands
+
+See <<commands>>. 


### PR DESCRIPTION
Renames the "X-Pack Commands" section such that it can contain reference information for other commands too. 

Related to  https://github.com/elastic/elasticsearch/pull/32281/files/5f6b084324c607a92020909df6730c8e8a4b10f6#r211410593