### PR TITLE
Zen2: Add leader-side join handling logic

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
@@ -227,6 +227,7 @@ public class CoordinationState extends AbstractComponent {
         boolean added = joinVotes.addVote(join.getSourceNode());
         boolean prevElectionWon = electionWon;
         electionWon = isElectionQuorum(joinVotes);
+        assert !prevElectionWon || electionWon; // we cannot go from won to not won
         logger.debug("handleJoin: added join {} from [{}] for election, electionWon={} lastAcceptedTerm={} lastAcceptedVersion={}", join,
             join.getSourceNode(), electionWon, lastAcceptedTerm, getLastAcceptedVersion());
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -193,11 +193,14 @@ public class Coordinator extends AbstractLifecycleComponent {
             if (mode == Mode.LEADER) {
                 assert coordinationState.get().electionWon();
                 assert lastKnownLeader.isPresent() && lastKnownLeader.get().equals(getLocalNode());
+                assert joinAccumulator instanceof JoinHelper.LeaderJoinAccumulator;
             } else if (mode == Mode.FOLLOWER) {
                 assert coordinationState.get().electionWon() == false : getLocalNode() + " is FOLLOWER so electionWon() should be false";
                 assert lastKnownLeader.isPresent() && (lastKnownLeader.get().equals(getLocalNode()) == false);
+                assert joinAccumulator instanceof JoinHelper.FollowerJoinAccumulator;
             } else {
                 assert mode == Mode.CANDIDATE;
+                assert joinAccumulator instanceof JoinHelper.CandidateJoinAccumulator;
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -34,6 +34,8 @@ public class Coordinator extends AbstractLifecycleComponent {
     private final TransportService transportService;
     private final JoinHelper joinHelper;
     private final Supplier<CoordinationState.PersistedState> persistedStateSupplier;
+    // TODO: the following two fields are package-private as some tests require access to them
+    // These tests can be rewritten to use public methods once Coordinator is more feature-complete
     final Object mutex = new Object();
     final SetOnce<CoordinationState> coordinationState = new SetOnce<>(); // initialized on start-up (see doStart)
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -118,7 +118,7 @@ public class Coordinator extends AbstractLifecycleComponent {
 
         if (mode != Mode.CANDIDATE) {
             mode = Mode.CANDIDATE;
-            joinAccumulator.failPendingJoins("becoming candidate");
+            joinAccumulator.close(mode);
             joinAccumulator = joinHelper.new CandidateJoinAccumulator();
         }
     }
@@ -130,7 +130,7 @@ public class Coordinator extends AbstractLifecycleComponent {
 
         mode = Mode.LEADER;
         lastKnownLeader = Optional.of(getLocalNode());
-        joinAccumulator.submitPendingJoins();
+        joinAccumulator.close(mode);
         joinAccumulator = joinHelper.new LeaderJoinAccumulator();
     }
 
@@ -140,7 +140,7 @@ public class Coordinator extends AbstractLifecycleComponent {
 
         if (mode != Mode.FOLLOWER) {
             mode = Mode.FOLLOWER;
-            joinAccumulator.failPendingJoins("started following " + leaderNode);
+            joinAccumulator.close(mode);
             joinAccumulator = new JoinHelper.FollowerJoinAccumulator();
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.cluster.coordination;
 
 import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.cluster.coordination.JoinHelper.JoinCallback;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.MasterService;
@@ -185,16 +184,10 @@ public class Coordinator extends AbstractLifecycleComponent {
             } else if (mode == Mode.FOLLOWER) {
                 assert coordinationState.get().electionWon() == false : getLocalNode() + " is FOLLOWER so electionWon() should be false";
                 assert lastKnownLeader.isPresent() && (lastKnownLeader.get().equals(getLocalNode()) == false);
-                assert joinHelper.getNumberOfPendingJoins() == 0;
             } else {
                 assert mode == Mode.CANDIDATE;
             }
         }
-    }
-
-    // this is just used because the test doesn't simulate sending the join requests through the transport service - TODO remove it
-    public void handleJoinRequest(JoinRequest joinRequest, JoinCallback joinCallback) {
-        joinHelper.handleJoinRequest(joinRequest, joinCallback);
     }
 
     public enum Mode {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -1,12 +1,12 @@
 package org.elasticsearch.cluster.coordination;
 
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.cluster.coordination.JoinHelper.JoinCallback;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.discovery.zen.MembershipAction;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.Optional;
@@ -14,44 +14,25 @@ import java.util.function.Supplier;
 
 public class Coordinator extends AbstractLifecycleComponent {
 
-    private final Object mutex = new Object();
     private final TransportService transportService;
+    private final JoinHelper joinHelper;
     private final Supplier<CoordinationState.PersistedState> persistedStateSupplier;
-
-    private final SetOnce<CoordinationState> consensusState = new SetOnce<>(); // initialized on start-up (see doStart)
+    private final Object mutex = new Object();
+    private final SetOnce<CoordinationState> coordinationState = new SetOnce<>(); // initialized on start-up (see doStart)
 
     private volatile Mode mode;
     private Optional<DiscoveryNode> lastKnownLeader;
     private Optional<Join> lastJoin;
-    private final JoinHelper joinHelper;
 
     public Coordinator(Settings settings, TransportService transportService, AllocationService allocationService,
                        MasterService masterService, Supplier<CoordinationState.PersistedState> persistedStateSupplier) {
         super(settings);
         this.transportService = transportService;
+        this.joinHelper = new JoinHelper(settings, allocationService, masterService, transportService, this::getCurrentTerm,
+            this::handleJoinRequest);
         this.persistedStateSupplier = persistedStateSupplier;
-        this.mode = null;
-        lastKnownLeader = Optional.empty();
-        lastJoin = Optional.empty();
-
-        joinHelper = new JoinHelper(settings, allocationService, masterService, transportService, this::getCurrentTerm) {
-            @Override
-            public void handleJoinRequest(JoinRequest joinRequest, MembershipAction.JoinCallback joinCallback) {
-                Coordinator.this.handleJoinRequest(joinRequest, joinCallback);
-            }
-        };
-    }
-
-    // package-visible for testing
-    long getCurrentTerm() {
-        synchronized (mutex) {
-            return consensusState.get().getCurrentTerm();
-        }
-    }
-
-    // package-visible for testing
-    Mode getMode() {
-        return mode;
+        this.lastKnownLeader = Optional.empty();
+        this.lastJoin = Optional.empty();
     }
 
     private Optional<Join> ensureTermAtLeast(DiscoveryNode sourceNode, long targetTerm) {
@@ -65,7 +46,7 @@ public class Coordinator extends AbstractLifecycleComponent {
     private Join joinLeaderInTerm(StartJoinRequest startJoinRequest) {
         assert Thread.holdsLock(mutex) : "Coordinator mutex not held";
         logger.debug("joinLeaderInTerm: from [{}] with term {}", startJoinRequest.getSourceNode(), startJoinRequest.getTerm());
-        Join join = consensusState.get().handleStartJoin(startJoinRequest);
+        Join join = coordinationState.get().handleStartJoin(startJoinRequest);
         lastJoin = Optional.of(join);
         if (mode == Mode.CANDIDATE) {
             // refresh required because current term has changed
@@ -77,7 +58,7 @@ public class Coordinator extends AbstractLifecycleComponent {
         return join;
     }
 
-    public void handleJoinRequest(JoinRequest joinRequest, MembershipAction.JoinCallback joinCallback) {
+    public void handleJoinRequest(JoinRequest joinRequest, JoinCallback joinCallback) {
         assert Thread.holdsLock(mutex) == false;
         transportService.connectToNode(joinRequest.getSourceNode());
 
@@ -86,7 +67,7 @@ public class Coordinator extends AbstractLifecycleComponent {
         }
     }
 
-    private void handleJoinRequestUnderLock(JoinRequest joinRequest, MembershipAction.JoinCallback joinCallback) {
+    private void handleJoinRequestUnderLock(JoinRequest joinRequest, JoinCallback joinCallback) {
         assert Thread.holdsLock(mutex) : "Coordinator mutex not held";
         logger.trace("handleJoinRequestUnderLock: as {}, handling {}", mode, joinRequest);
         if (mode == Mode.LEADER) {
@@ -108,27 +89,14 @@ public class Coordinator extends AbstractLifecycleComponent {
 
         optionalJoinToSelf.ifPresent(this::handleJoin); // if someone thinks we should be master, let's try to become one
 
-        final CoordinationState state = consensusState.get();
+        final CoordinationState state = coordinationState.get();
         boolean prevElectionWon = state.electionWon();
         boolean addedJoin = state.handleJoin(join);
-        assert !prevElectionWon || state.electionWon(); // we cannot go from won to not won
-
-//        if (addedJoin && mode == Legislator.Mode.LEADER && currentPublication.isPresent() == false) {
-//            scheduleReconfigurationIfSuboptimal();
-//        }
 
         if (prevElectionWon == false && state.electionWon()) {
             assert mode == Mode.CANDIDATE : "expected candidate but was " + mode;
-
             becomeLeader("handleJoin");
-
-            try {
-                joinHelper.clearAndSendJoins();
-            } catch (IllegalStateException e) {
-                // TODO fix NodeJoinController and remove this
-                assert e.getMessage().contains("is already queued");
-                becomeCandidate("handleJoin");
-            }
+            joinHelper.clearAndSendJoins();
         }
     }
 
@@ -167,14 +135,27 @@ public class Coordinator extends AbstractLifecycleComponent {
         lastKnownLeader = Optional.of(leaderNode);
     }
 
-    public DiscoveryNode getLocalNode() {
+    // package-visible for testing
+    long getCurrentTerm() {
+        synchronized (mutex) {
+            return coordinationState.get().getCurrentTerm();
+        }
+    }
+
+    // package-visible for testing
+    Mode getMode() {
+        return mode;
+    }
+
+    // package-visible for testing
+    DiscoveryNode getLocalNode() {
         return transportService.getLocalNode();
     }
 
     @Override
     protected void doStart() {
         CoordinationState.PersistedState persistedState = persistedStateSupplier.get();
-        consensusState.set(new CoordinationState(settings, getLocalNode(), persistedState));
+        coordinationState.set(new CoordinationState(settings, getLocalNode(), persistedState));
     }
 
     public void startInitialJoin() {
@@ -196,10 +177,10 @@ public class Coordinator extends AbstractLifecycleComponent {
     public void invariant() {
         synchronized (mutex) {
             if (mode == Mode.LEADER) {
-                assert consensusState.get().electionWon();
+                assert coordinationState.get().electionWon();
                 assert lastKnownLeader.isPresent() && lastKnownLeader.get().equals(getLocalNode());
             } else if (mode == Mode.FOLLOWER) {
-                assert consensusState.get().electionWon() == false : getLocalNode() + " is FOLLOWER so electionWon() should be false";
+                assert coordinationState.get().electionWon() == false : getLocalNode() + " is FOLLOWER so electionWon() should be false";
                 assert lastKnownLeader.isPresent() && (lastKnownLeader.get().equals(getLocalNode()) == false);
             } else {
                 assert mode == Mode.CANDIDATE;

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -1,159 +1,45 @@
 package org.elasticsearch.cluster.coordination;
 
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskConfig;
-import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.MasterService;
-import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.discovery.zen.ElectMasterService;
 import org.elasticsearch.discovery.zen.MembershipAction;
-import org.elasticsearch.discovery.zen.NodeJoinController;
-import org.elasticsearch.discovery.zen.NodeJoinController.JoinTaskExecutor;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.threadpool.ThreadPool.Names;
-import org.elasticsearch.transport.TransportException;
-import org.elasticsearch.transport.TransportResponse;
-import org.elasticsearch.transport.TransportResponse.Empty;
-import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-//TODO: add a test that sends random joins and checks if the join led to success (the fake masterservice fully manages state)
-// i.e. similar to NodeJoinControllerTests
 public class Coordinator extends AbstractLifecycleComponent {
 
-    public static final String JOIN_ACTION_NAME = "internal:discovery/zen2/join";
-
     private final Object mutex = new Object();
-    private Mode mode;
-    private Optional<DiscoveryNode> lastKnownLeader;
-    private Optional<Join> lastJoin;
-    private final SetOnce<CoordinationState> consensusState = new SetOnce<>();
     private final TransportService transportService;
-    private final MasterService masterService;
-
-
-    private final JoinTaskExecutor joinTaskExecutor;
     private final Supplier<CoordinationState.PersistedState> persistedStateSupplier;
 
-    // similar to NodeJoinController.ElectionContext.joinRequestAccumulator, captures joins on election
-    private final Map<DiscoveryNode, MembershipAction.JoinCallback> joinRequestAccumulator = new HashMap<>();
+    private final SetOnce<CoordinationState> consensusState = new SetOnce<>(); // initialized on start-up (see doStart)
 
+    private volatile Mode mode;
+    private Optional<DiscoveryNode> lastKnownLeader;
+    private Optional<Join> lastJoin;
+    private final JoinHelper joinHelper;
 
     public Coordinator(Settings settings, TransportService transportService, AllocationService allocationService,
                        MasterService masterService, Supplier<CoordinationState.PersistedState> persistedStateSupplier) {
         super(settings);
         this.transportService = transportService;
-        this.masterService = masterService;
         this.persistedStateSupplier = persistedStateSupplier;
-        this.mode = Mode.CANDIDATE;
+        this.mode = null;
         lastKnownLeader = Optional.empty();
         lastJoin = Optional.empty();
-        // disable minimum_master_nodes check
-        final ElectMasterService electMasterService = new ElectMasterService(settings) {
 
+        joinHelper = new JoinHelper(settings, allocationService, masterService, transportService, this::getCurrentTerm) {
             @Override
-            public boolean hasEnoughMasterNodes(Iterable<DiscoveryNode> nodes) {
-                return true;
+            public void handleJoinRequest(JoinRequest joinRequest, MembershipAction.JoinCallback joinCallback) {
+                Coordinator.this.handleJoinRequest(joinRequest, joinCallback);
             }
-
-            @Override
-            public void logMinimumMasterNodesWarningIfNecessary(ClusterState oldState, ClusterState newState) {
-                // ignore
-            }
-
         };
-
-        // reuse JoinTaskExecutor implementation from ZenDiscovery, but hack some checks
-        this.joinTaskExecutor = new JoinTaskExecutor(allocationService, electMasterService, logger) {
-
-            @Override
-            public ClusterTasksResult<DiscoveryNode> execute(ClusterState currentState, List<DiscoveryNode> joiningNodes) throws Exception {
-                // This is called when preparing the next cluster state for publication. There is no guarantee that the term we see here is
-                // the term under which this state will eventually be published: the current term may be increased after this check due to
-                // some other activity. That the term is correct is, however, checked properly during publication, so it is sufficient to
-                // check it here on a best-effort basis. This is fine because a concurrent change indicates the existence of another leader
-                // in a higher term which will cause this node to stand down.
-
-                final long currentTerm = getCurrentTerm(); // TODO perhaps this can be a volatile read?
-                if (currentState.term() != currentTerm) {
-                    currentState = ClusterState.builder(currentState).term(currentTerm).build();
-                }
-                return super.execute(currentState, joiningNodes);
-            }
-
-        };
-    }
-
-    private void registerTransportActions() {
-        transportService.registerRequestHandler(JOIN_ACTION_NAME, Names.GENERIC, false, false,
-            JoinRequest::new,
-            (request, channel, task) -> handleJoinRequest(request, new MembershipAction.JoinCallback() {
-                @Override
-                public void onSuccess() {
-                    try {
-                        channel.sendResponse(Empty.INSTANCE);
-                    } catch (IOException e) {
-                        onFailure(e);
-                    }
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    try {
-                        channel.sendResponse(e);
-                    } catch (Exception inner) {
-                        inner.addSuppressed(e);
-                        logger.warn("failed to send back failure on join request", inner);
-                    }
-                }
-            }));
-    }
-
-    // TODO: maybe add this method in a follow-up.
-    private void sendOptionalJoin(DiscoveryNode destination, Optional<Join> optionalJoin) {
-        // No synchronisation required
-        transportService.sendRequest(destination, JOIN_ACTION_NAME, new JoinRequest(getLocalNode(), optionalJoin),
-            new TransportResponseHandler<Empty>() {
-                @Override
-                public Empty read(StreamInput in) {
-                    return Empty.INSTANCE;
-                }
-
-                @Override
-                public void handleResponse(Empty response) {
-                    // No synchronisation required
-                    logger.debug("SendJoinResponseHandler: successfully joined {}", destination);
-                }
-
-                @Override
-                public void handleException(TransportException exp) {
-                    // No synchronisation required
-                    if (exp.getRootCause() instanceof CoordinationStateRejectedException) {
-                        logger.debug("SendJoinResponseHandler: [{}] failed: {}", destination, exp.getRootCause().getMessage());
-                    } else {
-                        logger.debug(() -> new ParameterizedMessage("SendJoinResponseHandler: [{}] failed", destination), exp);
-                    }
-                }
-
-                @Override
-                public String executor() {
-                    return Names.GENERIC;
-                }
-            });
     }
 
     // package-visible for testing
@@ -165,13 +51,11 @@ public class Coordinator extends AbstractLifecycleComponent {
 
     // package-visible for testing
     Mode getMode() {
-        synchronized (mutex) {
-            return mode;
-        }
+        return mode;
     }
 
     private Optional<Join> ensureTermAtLeast(DiscoveryNode sourceNode, long targetTerm) {
-        assert Thread.holdsLock(mutex) : "Legislator mutex not held";
+        assert Thread.holdsLock(mutex) : "Coordinator mutex not held";
         if (getCurrentTerm() < targetTerm) {
             return Optional.of(joinLeaderInTerm(new StartJoinRequest(sourceNode, targetTerm)));
         }
@@ -179,7 +63,7 @@ public class Coordinator extends AbstractLifecycleComponent {
     }
 
     private Join joinLeaderInTerm(StartJoinRequest startJoinRequest) {
-        assert Thread.holdsLock(mutex) : "Legislator mutex not held";
+        assert Thread.holdsLock(mutex) : "Coordinator mutex not held";
         logger.debug("joinLeaderInTerm: from [{}] with term {}", startJoinRequest.getSourceNode(), startJoinRequest.getTerm());
         Join join = consensusState.get().handleStartJoin(startJoinRequest);
         lastJoin = Optional.of(join);
@@ -194,7 +78,7 @@ public class Coordinator extends AbstractLifecycleComponent {
     }
 
     public void handleJoinRequest(JoinRequest joinRequest, MembershipAction.JoinCallback joinCallback) {
-
+        assert Thread.holdsLock(mutex) == false;
         transportService.connectToNode(joinRequest.getSourceNode());
 
         synchronized (mutex) {
@@ -203,34 +87,23 @@ public class Coordinator extends AbstractLifecycleComponent {
     }
 
     private void handleJoinRequestUnderLock(JoinRequest joinRequest, MembershipAction.JoinCallback joinCallback) {
-        assert Thread.holdsLock(mutex) : "Legislator mutex not held";
+        assert Thread.holdsLock(mutex) : "Coordinator mutex not held";
         logger.trace("handleJoinRequestUnderLock: as {}, handling {}", mode, joinRequest);
         if (mode == Mode.LEADER) {
-            // submit as cluster state update task
-            masterService.submitStateUpdateTask("zen-disco-node-join",
-                joinRequest.getSourceNode(), ClusterStateTaskConfig.build(Priority.URGENT),
-                joinTaskExecutor, new NodeJoinController.JoinTaskListener(joinCallback, logger));
+            joinHelper.joinLeader(joinRequest, joinCallback);
         } else {
-            MembershipAction.JoinCallback prev = joinRequestAccumulator.put(joinRequest.getSourceNode(), joinCallback);
-            if (prev != null) {
-                prev.onFailure(new CoordinationStateRejectedException("received a newer join from " + joinRequest.getSourceNode()));
-            }
+            joinHelper.addJoinCallback(joinRequest, joinCallback);
         }
 
         try {
             joinRequest.getOptionalJoin().ifPresent(this::handleJoin);
         } catch (CoordinationStateRejectedException exception) {
-            final MembershipAction.JoinCallback callback = joinRequestAccumulator.remove(joinRequest.getSourceNode());
-            if (callback == null) {
-                logger.trace("handleJoinRequestUnderLock: submitted task to master service, but vote was rejected", exception);
-            } else {
-                callback.onFailure(exception);
-            }
+            joinHelper.removeAndFail(joinRequest, exception);
         }
     }
 
     private void handleJoin(Join join) {
-        assert Thread.holdsLock(mutex) : "Legislator mutex not held";
+        assert Thread.holdsLock(mutex) : "Coordinator mutex not held";
         Optional<Join> optionalJoinToSelf = ensureTermAtLeast(getLocalNode(), join.getTerm());
 
         optionalJoinToSelf.ifPresent(this::handleJoin); // if someone thinks we should be master, let's try to become one
@@ -249,42 +122,14 @@ public class Coordinator extends AbstractLifecycleComponent {
 
             becomeLeader("handleJoin");
 
-            Map<DiscoveryNode, ClusterStateTaskListener> pendingAsTasks = getPendingAsTasks();
-            joinRequestAccumulator.clear();
-
-            final String source = "zen-disco-elected-as-master ([" + pendingAsTasks.size() + "] nodes joined)";
-            // noop listener, the election finished listener determines result
-            pendingAsTasks.put(NodeJoinController.BECOME_MASTER_TASK, (source1, e) -> {
-            });
-            // TODO: should we take any further action when FINISH_ELECTION_TASK fails?
-            pendingAsTasks.put(NodeJoinController.FINISH_ELECTION_TASK, (source1, e) -> {
-            });
-
             try {
-                masterService.submitStateUpdateTasks(source, pendingAsTasks, ClusterStateTaskConfig.build(Priority.URGENT),
-                    joinTaskExecutor);
+                joinHelper.clearAndSendJoins();
             } catch (IllegalStateException e) {
                 // TODO fix NodeJoinController and remove this
                 assert e.getMessage().contains("is already queued");
                 becomeCandidate("handleJoin");
             }
         }
-    }
-
-    // copied from NodeJoinController.getPendingAsTasks
-    private Map<DiscoveryNode, ClusterStateTaskListener> getPendingAsTasks() {
-        assert Thread.holdsLock(mutex) : "Legislator mutex not held";
-        Map<DiscoveryNode, ClusterStateTaskListener> tasks = new HashMap<>();
-        joinRequestAccumulator.forEach((key, value) -> tasks.put(key,
-            new NodeJoinController.JoinTaskListener(value, logger)));
-        return tasks;
-    }
-
-    private void clearJoins() {
-        assert Thread.holdsLock(mutex) : "Legislator mutex not held";
-        joinRequestAccumulator.values().forEach(
-            joinCallback -> joinCallback.onFailure(new CoordinationStateRejectedException("node stepped down as leader")));
-        joinRequestAccumulator.clear();
     }
 
     private void becomeCandidate(String method) {
@@ -294,7 +139,7 @@ public class Coordinator extends AbstractLifecycleComponent {
         if (mode != Mode.CANDIDATE) {
             mode = Mode.CANDIDATE;
 
-            clearJoins();
+            joinHelper.clearJoins();
         }
     }
 
@@ -316,7 +161,7 @@ public class Coordinator extends AbstractLifecycleComponent {
 
             mode = Mode.FOLLOWER;
 
-            clearJoins();
+            joinHelper.clearJoins();
         }
 
         lastKnownLeader = Optional.of(leaderNode);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.elasticsearch.cluster.coordination;
 
 import org.apache.lucene.util.SetOnce;

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -127,7 +127,7 @@ public class Coordinator extends AbstractLifecycleComponent {
 
         if (mode != Mode.FOLLOWER) {
             mode = Mode.FOLLOWER;
-            joinHelper.clearAndFailJoins("following another master : " + leaderNode);
+            joinHelper.clearAndFailPendingJoins("following another master : " + leaderNode);
         }
 
         lastKnownLeader = Optional.of(leaderNode);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -1,0 +1,295 @@
+package org.elasticsearch.cluster.coordination;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskConfig;
+import org.elasticsearch.cluster.ClusterStateTaskListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.service.MasterService;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.discovery.zen.ElectMasterService;
+import org.elasticsearch.discovery.zen.MembershipAction;
+import org.elasticsearch.discovery.zen.NodeJoinController;
+import org.elasticsearch.discovery.zen.NodeJoinController.JoinTaskExecutor;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+//TODO: add a test that sends random joins and checks if the join led to success (the fake masterservice fully manages state)
+// i.e. similar to NodeJoinControllerTests
+public class Coordinator extends AbstractLifecycleComponent {
+
+    private final Object mutex = new Object();
+    private Mode mode;
+    private Optional<DiscoveryNode> lastKnownLeader;
+    private Optional<Join> lastJoin;
+    private final SetOnce<CoordinationState> consensusState = new SetOnce<>();
+    private final TransportService transportService;
+    private final MasterService masterService;
+
+
+    private final JoinTaskExecutor joinTaskExecutor;
+
+    // similar to NodeJoinController.ElectionContext.joinRequestAccumulator, captures joins on election
+    private final Map<DiscoveryNode, MembershipAction.JoinCallback> joinRequestAccumulator = new HashMap<>();
+
+
+    public Coordinator(Settings settings, TransportService transportService, AllocationService allocationService,
+                       MasterService masterService) {
+        super(settings);
+        this.transportService = transportService;
+        this.masterService = masterService;
+        this.mode = Mode.CANDIDATE;
+        lastKnownLeader = Optional.empty();
+        lastJoin = Optional.empty();
+        // disable minimum_master_nodes check
+        final ElectMasterService electMasterService = new ElectMasterService(settings) {
+
+            @Override
+            public boolean hasEnoughMasterNodes(Iterable<DiscoveryNode> nodes) {
+                return true;
+            }
+
+            @Override
+            public void logMinimumMasterNodesWarningIfNecessary(ClusterState oldState, ClusterState newState) {
+                // ignore
+            }
+
+        };
+
+        // reuse JoinTaskExecutor implementation from ZenDiscovery, but hack some checks
+        this.joinTaskExecutor = new JoinTaskExecutor(allocationService, electMasterService, logger) {
+
+            @Override
+            public ClusterTasksResult<DiscoveryNode> execute(ClusterState currentState, List<DiscoveryNode> joiningNodes) throws Exception {
+                // This is called when preparing the next cluster state for publication. There is no guarantee that the term we see here is
+                // the term under which this state will eventually be published: the current term may be increased after this check due to
+                // some other activity. That the term is correct is, however, checked properly during publication, so it is sufficient to
+                // check it here on a best-effort basis. This is fine because a concurrent change indicates the existence of another leader
+                // in a higher term which will cause this node to stand down.
+
+                final long currentTerm = getCurrentTerm(); // TODO perhaps this can be a volatile read?
+                if (currentState.term() != currentTerm) {
+                    currentState = ClusterState.builder(currentState).term(currentTerm).build();
+                }
+                return super.execute(currentState, joiningNodes);
+            }
+
+        };
+    }
+
+    // package-visible for testing
+    long getCurrentTerm() {
+        synchronized (mutex) {
+            return consensusState.get().getCurrentTerm();
+        }
+    }
+
+    // package-visible for testing
+    Mode getMode() {
+        synchronized (mutex) {
+            return mode;
+        }
+    }
+
+    private Optional<Join> ensureTermAtLeast(DiscoveryNode sourceNode, long targetTerm) {
+        assert Thread.holdsLock(mutex) : "Legislator mutex not held";
+        if (getCurrentTerm() < targetTerm) {
+            return Optional.of(joinLeaderInTerm(new StartJoinRequest(sourceNode, targetTerm)));
+        }
+        return Optional.empty();
+    }
+
+    private Join joinLeaderInTerm(StartJoinRequest startJoinRequest) {
+        assert Thread.holdsLock(mutex) : "Legislator mutex not held";
+        logger.debug("joinLeaderInTerm: from [{}] with term {}", startJoinRequest.getSourceNode(), startJoinRequest.getTerm());
+        Join join = consensusState.get().handleStartJoin(startJoinRequest);
+        lastJoin = Optional.of(join);
+        if (mode == Mode.CANDIDATE) {
+            // refresh required because current term has changed
+            // TODO: heartbeatRequestResponder = new Legislator.HeartbeatRequestResponder();
+        } else {
+            // becomeCandidate refreshes responders
+            becomeCandidate("joinLeaderInTerm");
+        }
+        return join;
+    }
+
+    public void handleJoinRequest(JoinRequest joinRequest, MembershipAction.JoinCallback joinCallback) {
+
+        transportService.connectToNode(joinRequest.getSourceNode());
+
+        synchronized (mutex) {
+            handleJoinRequestUnderLock(joinRequest, joinCallback);
+        }
+    }
+
+    private void handleJoinRequestUnderLock(JoinRequest joinRequest, MembershipAction.JoinCallback joinCallback) {
+        assert Thread.holdsLock(mutex) : "Legislator mutex not held";
+        logger.trace("handleJoinRequestUnderLock: as {}, handling {}", mode, joinRequest);
+        if (mode == Mode.LEADER) {
+            // submit as cluster state update task
+            masterService.submitStateUpdateTask("zen-disco-node-join",
+                joinRequest.getSourceNode(), ClusterStateTaskConfig.build(Priority.URGENT),
+                joinTaskExecutor, new NodeJoinController.JoinTaskListener(joinCallback, logger));
+        } else {
+            MembershipAction.JoinCallback prev = joinRequestAccumulator.put(joinRequest.getSourceNode(), joinCallback);
+            if (prev != null) {
+                prev.onFailure(new CoordinationStateRejectedException("received a newer join from " + joinRequest.getSourceNode()));
+            }
+        }
+
+        try {
+            joinRequest.getOptionalJoin().ifPresent(this::handleJoin);
+        } catch (CoordinationStateRejectedException exception) {
+            final MembershipAction.JoinCallback callback = joinRequestAccumulator.remove(joinRequest.getSourceNode());
+            if (callback == null) {
+                logger.trace("handleJoinRequestUnderLock: submitted task to master service, but vote was rejected", exception);
+            } else {
+                callback.onFailure(exception);
+            }
+        }
+    }
+
+    private void handleJoin(Join join) {
+        assert Thread.holdsLock(mutex) : "Legislator mutex not held";
+        Optional<Join> optionalJoinToSelf = ensureTermAtLeast(getLocalNode(), join.getTerm());
+
+        optionalJoinToSelf.ifPresent(this::handleJoin); // if someone thinks we should be master, let's try to become one
+
+        final CoordinationState state = consensusState.get();
+        boolean prevElectionWon = state.electionWon();
+        boolean addedJoin = state.handleJoin(join);
+        assert !prevElectionWon || state.electionWon(); // we cannot go from won to not won
+
+//        if (addedJoin && mode == Legislator.Mode.LEADER && currentPublication.isPresent() == false) {
+//            scheduleReconfigurationIfSuboptimal();
+//        }
+
+        if (prevElectionWon == false && state.electionWon()) {
+            assert mode == Mode.CANDIDATE : "expected candidate but was " + mode;
+
+            becomeLeader("handleJoin");
+
+            Map<DiscoveryNode, ClusterStateTaskListener> pendingAsTasks = getPendingAsTasks();
+            joinRequestAccumulator.clear();
+
+            final String source = "zen-disco-elected-as-master ([" + pendingAsTasks.size() + "] nodes joined)";
+            // noop listener, the election finished listener determines result
+            pendingAsTasks.put(NodeJoinController.BECOME_MASTER_TASK, (source1, e) -> {
+            });
+            // TODO: should we take any further action when FINISH_ELECTION_TASK fails?
+            pendingAsTasks.put(NodeJoinController.FINISH_ELECTION_TASK, (source1, e) -> {
+            });
+
+            try {
+                masterService.submitStateUpdateTasks(source, pendingAsTasks, ClusterStateTaskConfig.build(Priority.URGENT),
+                    joinTaskExecutor);
+            } catch (IllegalStateException e) {
+                // TODO fix NodeJoinController and remove this
+                assert e.getMessage().contains("is already queued");
+                becomeCandidate("handleJoin");
+            }
+        }
+    }
+
+    // copied from NodeJoinController.getPendingAsTasks
+    private Map<DiscoveryNode, ClusterStateTaskListener> getPendingAsTasks() {
+        assert Thread.holdsLock(mutex) : "Legislator mutex not held";
+        Map<DiscoveryNode, ClusterStateTaskListener> tasks = new HashMap<>();
+        joinRequestAccumulator.forEach((key, value) -> tasks.put(key,
+            new NodeJoinController.JoinTaskListener(value, logger)));
+        return tasks;
+    }
+
+    private void clearJoins() {
+        assert Thread.holdsLock(mutex) : "Legislator mutex not held";
+        joinRequestAccumulator.values().forEach(
+            joinCallback -> joinCallback.onFailure(new CoordinationStateRejectedException("node stepped down as leader")));
+        joinRequestAccumulator.clear();
+    }
+
+    private void becomeCandidate(String method) {
+        assert Thread.holdsLock(mutex) : "Legislator mutex not held";
+        logger.debug("{}: becoming CANDIDATE (was {}, lastKnownLeader was [{}])", method, mode, lastKnownLeader);
+
+        if (mode != Mode.CANDIDATE) {
+            mode = Mode.CANDIDATE;
+
+            clearJoins();
+        }
+    }
+
+    private void becomeLeader(String method) {
+        assert Thread.holdsLock(mutex) : "Legislator mutex not held";
+        assert mode != Mode.LEADER;
+
+        logger.debug("{}: becoming LEADER (was {}, lastKnownLeader was [{}])", method, mode, lastKnownLeader);
+
+        mode = Mode.LEADER;
+        lastKnownLeader = Optional.of(getLocalNode());
+    }
+
+    private void becomeFollower(String method, DiscoveryNode leaderNode) {
+        assert Thread.holdsLock(mutex) : "Legislator mutex not held";
+
+        if (mode != Mode.FOLLOWER) {
+            logger.debug("{}: becoming FOLLOWER of [{}] (was {}, lastKnownLeader was [{}])", method, leaderNode, mode, lastKnownLeader);
+
+            mode = Mode.FOLLOWER;
+
+            clearJoins();
+        }
+
+        lastKnownLeader = Optional.of(leaderNode);
+    }
+
+    public DiscoveryNode getLocalNode() {
+        return transportService.getLocalNode();
+    }
+
+    @Override
+    protected void doStart() {
+
+    }
+
+    public void startInitialJoin() {
+        synchronized (mutex) {
+            becomeCandidate("startInitialJoin");
+        }
+    }
+
+    @Override
+    protected void doStop() {
+
+    }
+
+    @Override
+    protected void doClose() {
+
+    }
+
+    public void invariant() {
+        synchronized (mutex) {
+            if (mode == Mode.LEADER) {
+                assert consensusState.get().electionWon();
+                assert lastKnownLeader.isPresent() && lastKnownLeader.get().equals(getLocalNode());
+            } else if (mode == Mode.FOLLOWER) {
+                assert consensusState.get().electionWon() == false : getLocalNode() + " is FOLLOWER so electionWon() should be false";
+                assert lastKnownLeader.isPresent() && (lastKnownLeader.get().equals(getLocalNode()) == false);
+            } else {
+                assert mode == Mode.CANDIDATE;
+            }
+        }
+    }
+
+    public enum Mode {
+        CANDIDATE, LEADER, FOLLOWER
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -182,7 +182,6 @@ public class Coordinator extends AbstractLifecycleComponent {
             if (mode == Mode.LEADER) {
                 assert coordinationState.get().electionWon();
                 assert lastKnownLeader.isPresent() && lastKnownLeader.get().equals(getLocalNode());
-                // assert joinHelper.getNumberOfPendingJoins() == 0; // not true any more, may not have submitted to the master service yet
             } else if (mode == Mode.FOLLOWER) {
                 assert coordinationState.get().electionWon() == false : getLocalNode() + " is FOLLOWER so electionWon() should be false";
                 assert lastKnownLeader.isPresent() && (lastKnownLeader.get().equals(getLocalNode()) == false);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -239,12 +239,18 @@ public class JoinHelper extends AbstractComponent {
                 pendingAsTasks.put(task, new JoinTaskListener(task, value));
             });
 
+            final String stateUpdateSource = "elected-as-master ([" + pendingAsTasks.size() + "] nodes joined)";
+
             pendingAsTasks.put(JoinTaskExecutor.BECOME_MASTER_TASK, (source, e) -> {
             });
             pendingAsTasks.put(JoinTaskExecutor.FINISH_ELECTION_TASK, (source, e) -> {
             });
-            final String source = "elected-as-master ([" + pendingAsTasks.size() + "] nodes joined)";
-            masterService.submitStateUpdateTasks(source, pendingAsTasks, ClusterStateTaskConfig.build(Priority.URGENT), joinTaskExecutor);
+            masterService.submitStateUpdateTasks(stateUpdateSource, pendingAsTasks, ClusterStateTaskConfig.build(Priority.URGENT), joinTaskExecutor);
+        }
+
+        @Override
+        public String toString() {
+            return "CandidateJoinAccumulator{" + joinRequestAccumulator.keySet() + '}';
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -110,7 +110,17 @@ public class JoinHelper extends AbstractComponent {
         transportService.connectToNode(joinRequest.getSourceNode());
 
         final Optional<Join> optionalJoin = joinRequest.getOptionalJoin();
-        final boolean justBecameLeader = optionalJoin.isPresent() && joinHandler.test(optionalJoin.get());
+        final boolean justBecameLeader;
+        if (optionalJoin.isPresent()) {
+            try {
+                justBecameLeader = joinHandler.test(optionalJoin.get());
+            } catch (CoordinationStateRejectedException e) {
+                joinCallback.onFailure(e);
+                return;
+            }
+        } else {
+            justBecameLeader = false;
+        }
 
         synchronized (mutex) {
             joinAccumulator.handleJoinRequest(joinRequest.getSourceNode(), joinCallback);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -1,0 +1,192 @@
+package org.elasticsearch.cluster.coordination;
+
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskConfig;
+import org.elasticsearch.cluster.ClusterStateTaskListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.service.MasterService;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.discovery.zen.ElectMasterService;
+import org.elasticsearch.discovery.zen.MembershipAction.JoinCallback;
+import org.elasticsearch.discovery.zen.NodeJoinController;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportResponseHandler;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.LongSupplier;
+
+//TODO: add a test that sends random joins and checks if the join led to success (the fake masterservice fully manages state)
+// i.e. similar to NodeJoinControllerTests
+public abstract class JoinHelper extends AbstractComponent {
+
+    public static final String JOIN_ACTION_NAME = "internal:discovery/zen2/join";
+
+    // similar to NodeJoinController.ElectionContext.joinRequestAccumulator, captures joins on election
+    private final Map<DiscoveryNode, JoinCallback> joinRequestAccumulator = new HashMap<>();
+
+    private final NodeJoinController.JoinTaskExecutor joinTaskExecutor;
+    private final MasterService masterService;
+
+    private final TransportService transportService;
+
+    JoinHelper(Settings settings, AllocationService allocationService, MasterService masterService, TransportService transportService,
+               LongSupplier currentTermSupplier) {
+        super(settings);
+
+        this.masterService = masterService;
+        this.transportService = transportService;
+
+        // disable minimum_master_nodes check
+        final ElectMasterService electMasterService = new ElectMasterService(settings) {
+
+            @Override
+            public boolean hasEnoughMasterNodes(Iterable<DiscoveryNode> nodes) {
+                return true;
+            }
+
+            @Override
+            public void logMinimumMasterNodesWarningIfNecessary(ClusterState oldState, ClusterState newState) {
+                // ignore
+            }
+
+        };
+
+        // reuse JoinTaskExecutor implementation from ZenDiscovery, but hack some checks
+        this.joinTaskExecutor = new NodeJoinController.JoinTaskExecutor(allocationService, electMasterService, logger) {
+
+            @Override
+            public ClusterTasksResult<DiscoveryNode> execute(ClusterState currentState, List<DiscoveryNode> joiningNodes) throws Exception {
+                // This is called when preparing the next cluster state for publication. There is no guarantee that the term we see here is
+                // the term under which this state will eventually be published: the current term may be increased after this check due to
+                // some other activity. That the term is correct is, however, checked properly during publication, so it is sufficient to
+                // check it here on a best-effort basis. This is fine because a concurrent change indicates the existence of another leader
+                // in a higher term which will cause this node to stand down.
+
+                final long currentTerm = currentTermSupplier.getAsLong();
+                if (currentState.term() != currentTerm) {
+                    currentState = ClusterState.builder(currentState).term(currentTerm).build();
+                }
+                return super.execute(currentState, joiningNodes);
+            }
+
+        };
+
+        transportService.registerRequestHandler(JOIN_ACTION_NAME, ThreadPool.Names.GENERIC, false, false,
+            JoinRequest::new,
+            (request, channel, task) -> handleJoinRequest(request, new JoinCallback() {
+                @Override
+                public void onSuccess() {
+                    try {
+                        channel.sendResponse(TransportResponse.Empty.INSTANCE);
+                    } catch (IOException e) {
+                        onFailure(e);
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    try {
+                        channel.sendResponse(e);
+                    } catch (Exception inner) {
+                        inner.addSuppressed(e);
+                        logger.warn("failed to send back failure on join request", inner);
+                    }
+                }
+            }));
+    }
+
+    public abstract void handleJoinRequest(JoinRequest joinRequest, JoinCallback joinCallback);
+
+    // TODO: maybe add this method in a follow-up.
+    public void sendOptionalJoin(DiscoveryNode destination, Optional<Join> optionalJoin) {
+        // No synchronisation required
+        transportService.sendRequest(destination, JOIN_ACTION_NAME, new JoinRequest(transportService.getLocalNode(), optionalJoin),
+            new TransportResponseHandler<TransportResponse.Empty>() {
+                @Override
+                public TransportResponse.Empty read(StreamInput in) {
+                    return TransportResponse.Empty.INSTANCE;
+                }
+
+                @Override
+                public void handleResponse(TransportResponse.Empty response) {
+                    // No synchronisation required
+                    logger.debug("SendJoinResponseHandler: successfully joined {}", destination);
+                }
+
+                @Override
+                public void handleException(TransportException exp) {
+                    // No synchronisation required
+                    if (exp.getRootCause() instanceof CoordinationStateRejectedException) {
+                        logger.debug("SendJoinResponseHandler: [{}] failed: {}", destination, exp.getRootCause().getMessage());
+                    } else {
+                        logger.debug(() -> new ParameterizedMessage("SendJoinResponseHandler: [{}] failed", destination), exp);
+                    }
+                }
+
+                @Override
+                public String executor() {
+                    return ThreadPool.Names.GENERIC;
+                }
+            });
+    }
+
+    public void addJoinCallback(JoinRequest joinRequest, JoinCallback joinCallback) {
+        JoinCallback prev = joinRequestAccumulator.put(joinRequest.getSourceNode(), joinCallback);
+        if (prev != null) {
+            prev.onFailure(new CoordinationStateRejectedException("received a newer join from " + joinRequest.getSourceNode()));
+        }
+    }
+
+    public void removeAndFail(JoinRequest joinRequest, CoordinationStateRejectedException exception) {
+        final JoinCallback callback = joinRequestAccumulator.remove(joinRequest.getSourceNode());
+        if (callback == null) {
+            logger.trace("handleJoinRequestUnderLock: submitted task to master service, but vote was rejected", exception);
+        } else {
+            callback.onFailure(exception);
+        }
+    }
+
+    public void clearJoins() {
+        joinRequestAccumulator.values().forEach(
+            joinCallback -> joinCallback.onFailure(new CoordinationStateRejectedException("node stepped down as leader")));
+        joinRequestAccumulator.clear();
+    }
+
+    public void clearAndSendJoins() {
+        final Map<DiscoveryNode, ClusterStateTaskListener> pendingAsTasks = new HashMap<>();
+        joinRequestAccumulator.forEach((key, value) -> pendingAsTasks.put(key,
+            new NodeJoinController.JoinTaskListener(value, logger)));
+        joinRequestAccumulator.clear();
+
+        final String source = "zen-disco-elected-as-master ([" + pendingAsTasks.size() + "] nodes joined)";
+        // noop listener, the election finished listener determines result
+        pendingAsTasks.put(NodeJoinController.BECOME_MASTER_TASK, (source1, e) -> {
+        });
+        // TODO: should we take any further action when FINISH_ELECTION_TASK fails?
+        pendingAsTasks.put(NodeJoinController.FINISH_ELECTION_TASK, (source1, e) -> {
+        });
+
+        masterService.submitStateUpdateTasks(source, pendingAsTasks, ClusterStateTaskConfig.build(Priority.URGENT),
+            joinTaskExecutor);
+    }
+
+    public void joinLeader(JoinRequest joinRequest, JoinCallback joinCallback) {
+        // submit as cluster state update task
+        masterService.submitStateUpdateTask("zen-disco-node-join",
+            joinRequest.getSourceNode(), ClusterStateTaskConfig.build(Priority.URGENT),
+            joinTaskExecutor, new NodeJoinController.JoinTaskListener(joinCallback, logger));
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -106,7 +106,7 @@ public class JoinHelper extends AbstractComponent {
             }));
     }
 
-    void handleJoinRequest(JoinRequest joinRequest, JoinCallback joinCallback) {
+    private void handleJoinRequest(JoinRequest joinRequest, JoinCallback joinCallback) {
         transportService.connectToNode(joinRequest.getSourceNode());
 
         final Optional<Join> optionalJoin = joinRequest.getOptionalJoin();
@@ -133,12 +133,6 @@ public class JoinHelper extends AbstractComponent {
         synchronized (mutex) {
             joinAccumulator.failPendingJoins("started following " + leaderNode);
             joinAccumulator = new FollowerJoinAccumulator();
-        }
-    }
-
-    public int getNumberOfPendingJoins() {
-        synchronized (mutex) {
-            return joinAccumulator.getNumberOfPendingJoins();
         }
     }
 
@@ -181,10 +175,6 @@ public class JoinHelper extends AbstractComponent {
         }
 
         default void submitPendingJoins() {
-        }
-
-        default int getNumberOfPendingJoins() {
-            return 0;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -107,7 +107,7 @@ public class JoinHelper extends AbstractComponent {
         return joinRequestAccumulator.size();
     }
 
-    public void clearAndFailJoins(String reason) {
+    public void clearAndFailPendingJoins(String reason) {
         joinRequestAccumulator.values().forEach(
             joinCallback -> joinCallback.onFailure(new CoordinationStateRejectedException(reason)));
         joinRequestAccumulator.clear();

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -235,7 +235,8 @@ public class JoinHelper extends AbstractComponent {
             });
             pendingAsTasks.put(JoinTaskExecutor.FINISH_ELECTION_TASK, (source, e) -> {
             });
-            masterService.submitStateUpdateTasks(stateUpdateSource, pendingAsTasks, ClusterStateTaskConfig.build(Priority.URGENT), joinTaskExecutor);
+            masterService.submitStateUpdateTasks(stateUpdateSource, pendingAsTasks, ClusterStateTaskConfig.build(Priority.URGENT),
+                joinTaskExecutor);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
@@ -33,6 +33,7 @@ public class JoinRequest extends TransportRequest {
     private final Optional<Join> optionalJoin;
 
     public JoinRequest(DiscoveryNode sourceNode, Optional<Join> optionalJoin) {
+        assert optionalJoin.isPresent() == false || optionalJoin.get().getSourceNode().equals(sourceNode);
         this.sourceNode = sourceNode;
         this.optionalJoin = optionalJoin;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
@@ -1,10 +1,14 @@
 package org.elasticsearch.cluster.coordination;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.transport.TransportRequest;
 
+import java.io.IOException;
 import java.util.Optional;
 
-public class JoinRequest {
+public class JoinRequest extends TransportRequest {
 
     private final DiscoveryNode sourceNode;
 
@@ -15,6 +19,19 @@ public class JoinRequest {
         this.optionalJoin = optionalJoin;
     }
 
+    public JoinRequest(StreamInput in) throws IOException {
+        super(in);
+        sourceNode = new DiscoveryNode(in);
+        optionalJoin = Optional.ofNullable(in.readOptionalWriteable(Join::new));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        sourceNode.writeTo(out);
+        out.writeOptionalWriteable(optionalJoin.orElse(null));
+    }
+
     public DiscoveryNode getSourceNode() {
         return sourceNode;
     }
@@ -23,4 +40,29 @@ public class JoinRequest {
         return optionalJoin;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof JoinRequest)) return false;
+
+        JoinRequest that = (JoinRequest) o;
+
+        if (!sourceNode.equals(that.sourceNode)) return false;
+        return optionalJoin.equals(that.optionalJoin);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = sourceNode.hashCode();
+        result = 31 * result + optionalJoin.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "JoinRequest{" +
+            "sourceNode=" + sourceNode +
+            ", optionalJoin=" + optionalJoin +
+            '}';
+    }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
@@ -1,0 +1,26 @@
+package org.elasticsearch.cluster.coordination;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+
+import java.util.Optional;
+
+public class JoinRequest {
+
+    private final DiscoveryNode sourceNode;
+
+    private final Optional<Join> optionalJoin;
+
+    public JoinRequest(DiscoveryNode sourceNode, Optional<Join> optionalJoin) {
+        this.sourceNode = sourceNode;
+        this.optionalJoin = optionalJoin;
+    }
+
+    public DiscoveryNode getSourceNode() {
+        return sourceNode;
+    }
+
+    public Optional<Join> getOptionalJoin() {
+        return optionalJoin;
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.elasticsearch.cluster.coordination;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;

--- a/server/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
@@ -341,15 +341,15 @@ public class NodeJoinController extends AbstractComponent {
 
     }
 
-    public static class JoinTaskListener implements ClusterStateTaskListener {
+    static class JoinTaskListener implements ClusterStateTaskListener {
         final List<MembershipAction.JoinCallback> callbacks;
         private final Logger logger;
 
-        public JoinTaskListener(MembershipAction.JoinCallback callback, Logger logger) {
+        JoinTaskListener(MembershipAction.JoinCallback callback, Logger logger) {
             this(Collections.singletonList(callback), logger);
         }
 
-        public JoinTaskListener(List<MembershipAction.JoinCallback> callbacks, Logger logger) {
+        JoinTaskListener(List<MembershipAction.JoinCallback> callbacks, Logger logger) {
             this.callbacks = callbacks;
             this.logger = logger;
         }

--- a/server/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
@@ -341,15 +341,15 @@ public class NodeJoinController extends AbstractComponent {
 
     }
 
-    static class JoinTaskListener implements ClusterStateTaskListener {
+    public static class JoinTaskListener implements ClusterStateTaskListener {
         final List<MembershipAction.JoinCallback> callbacks;
         private final Logger logger;
 
-        JoinTaskListener(MembershipAction.JoinCallback callback, Logger logger) {
+        public JoinTaskListener(MembershipAction.JoinCallback callback, Logger logger) {
             this(Collections.singletonList(callback), logger);
         }
 
-        JoinTaskListener(List<MembershipAction.JoinCallback> callbacks, Logger logger) {
+        public JoinTaskListener(List<MembershipAction.JoinCallback> callbacks, Logger logger) {
             this.callbacks = callbacks;
             this.logger = logger;
         }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/MessagesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/MessagesTests.java
@@ -176,7 +176,7 @@ public class MessagesTests extends ESTestCase {
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(initialJoinRequest,
             joinRequest -> copyWriteable(joinRequest, writableRegistry(), JoinRequest::new),
             joinRequest -> {
-                if (randomBoolean()) {
+                if (randomBoolean() && joinRequest.getOptionalJoin().isPresent() == false) {
                     return new JoinRequest(createNode(randomAlphaOfLength(20)), joinRequest.getOptionalJoin());
                 } else {
                     // change OptionalJoin
@@ -184,7 +184,7 @@ public class MessagesTests extends ESTestCase {
                     if (joinRequest.getOptionalJoin().isPresent() && randomBoolean()) {
                         newOptionalJoin = Optional.empty();
                     } else {
-                        newOptionalJoin = Optional.of(new Join(createNode(randomAlphaOfLength(10)), createNode(randomAlphaOfLength(10)),
+                        newOptionalJoin = Optional.of(new Join(joinRequest.getSourceNode(), createNode(randomAlphaOfLength(10)),
                             randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()));
                     }
                     return new JoinRequest(joinRequest.getSourceNode(), newOptionalJoin);

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/MessagesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/MessagesTests.java
@@ -168,6 +168,30 @@ public class MessagesTests extends ESTestCase {
             });
     }
 
+    public void testJoinRequestEqualsHashCodeSerialization() {
+        Join initialJoin = new Join(createNode(randomAlphaOfLength(10)), createNode(randomAlphaOfLength(10)), randomNonNegativeLong(),
+            randomNonNegativeLong(), randomNonNegativeLong());
+        JoinRequest initialJoinRequest = new JoinRequest(initialJoin.getSourceNode(),
+            randomBoolean() ? Optional.empty() : Optional.of(initialJoin));
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(initialJoinRequest,
+            joinRequest -> copyWriteable(joinRequest, writableRegistry(), JoinRequest::new),
+            joinRequest -> {
+                if (randomBoolean()) {
+                    return new JoinRequest(createNode(randomAlphaOfLength(20)), joinRequest.getOptionalJoin());
+                } else {
+                    // change OptionalJoin
+                    final Optional<Join> newOptionalJoin;
+                    if (joinRequest.getOptionalJoin().isPresent() && randomBoolean()) {
+                        newOptionalJoin = Optional.empty();
+                    } else {
+                        newOptionalJoin = Optional.of(new Join(createNode(randomAlphaOfLength(10)), createNode(randomAlphaOfLength(10)),
+                            randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()));
+                    }
+                    return new JoinRequest(joinRequest.getSourceNode(), newOptionalJoin);
+                }
+            });
+    }
+
     public ClusterState randomClusterState() {
         return CoordinationStateTests.clusterState(randomNonNegativeLong(), randomNonNegativeLong(), createNode(randomAlphaOfLength(10)),
             new ClusterState.VotingConfiguration(Sets.newHashSet(generateRandomStringArray(10, 10, false))),

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.cluster.service.MasterServiceTests;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.BaseFuture;
-import org.elasticsearch.discovery.zen.MembershipAction;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.junit.annotations.TestLogging;
@@ -24,9 +23,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -144,7 +140,7 @@ public class NodeJoinTests extends ESTestCase {
         logger.debug("starting {}", future);
         // clone the node before submitting to simulate an incoming join, which is guaranteed to have a new
         // disco node object serialized off the network
-        coordinator.handleJoinRequest(joinRequest, new MembershipAction.JoinCallback() {
+        coordinator.handleJoinRequest(joinRequest, new JoinHelper.JoinCallback() {
             @Override
             public void onSuccess() {
                 logger.debug("{} completed", future);

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -1,0 +1,196 @@
+package org.elasticsearch.cluster.coordination;
+
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterState.VotingConfiguration;
+import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.MasterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.BaseFuture;
+import org.elasticsearch.discovery.zen.MembershipAction;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.emptyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NodeJoinTests extends ESTestCase {
+
+    private static ThreadPool threadPool;
+
+    private MasterService masterService;
+    private Coordinator coordinator;
+
+    @BeforeClass
+    public static void beforeClass() {
+        threadPool = new TestThreadPool("NodeJoinControllerTests");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+        threadPool = null;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        masterService.close();
+    }
+
+    private static ClusterState initialState(boolean withMaster, DiscoveryNode localNode, long term, VotingConfiguration config) {
+        ClusterState initialClusterState = ClusterState.builder(new ClusterName(ClusterServiceUtils.class.getSimpleName()))
+            .nodes(DiscoveryNodes.builder()
+                .add(localNode)
+                .localNodeId(localNode.getId())
+                .masterNodeId(withMaster ? localNode.getId() : null))
+            .term(term)
+            .version(1)
+            .lastAcceptedConfiguration(config)
+            .lastCommittedConfiguration(config)
+            .blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK).build();
+        return initialClusterState;
+    }
+
+    private void setupMasterServiceAndNodeJoinController(long term, ClusterState initialState) {
+        if (masterService != null || coordinator != null) {
+            throw new IllegalStateException("method setupMasterServiceAndNodeJoinController can only be called once");
+        }
+        masterService = ClusterServiceUtils.createMasterService(threadPool, initialState);
+        TransportService transportService = mock(TransportService.class);
+        when(transportService.getLocalNode()).thenReturn(initialState.nodes().getLocalNode());
+        coordinator = new Coordinator(Settings.EMPTY,
+            transportService,
+            ESAllocationTestCase.createAllocationService(Settings.EMPTY),
+            masterService,
+            () -> new CoordinationStateTests.InMemoryPersistedState(term, initialState));
+        coordinator.start();
+        coordinator.startInitialJoin();
+    }
+
+    protected DiscoveryNode newNode(int i) {
+        return newNode(i, randomBoolean());
+    }
+
+    protected DiscoveryNode newNode(int i, boolean master) {
+        Set<DiscoveryNode.Role> roles = new HashSet<>();
+        if (master) {
+            roles.add(DiscoveryNode.Role.MASTER);
+        }
+        final String prefix = master ? "master_" : "data_";
+        return new DiscoveryNode(prefix + i, i + "", buildNewFakeTransportAddress(), emptyMap(), roles, Version.CURRENT);
+    }
+
+    private DiscoveryNode cloneNode(DiscoveryNode node) {
+        return new DiscoveryNode(node.getName(), node.getId(), node.getEphemeralId(), node.getHostName(), node.getHostAddress(),
+            node.getAddress(), node.getAttributes(), node.getRoles(), node.getVersion());
+    }
+
+    private void joinNode(final JoinRequest joinRequest) throws InterruptedException, ExecutionException {
+        joinNodeAsync(joinRequest).get();
+    }
+
+    static class SimpleFuture extends BaseFuture<Void> {
+        final String description;
+
+        SimpleFuture(String description) {
+            this.description = description;
+        }
+
+        public void markAsDone() {
+            set(null);
+        }
+
+        public void markAsFailed(Throwable t) {
+            setException(t);
+        }
+
+        @Override
+        public String toString() {
+            return "future [" + description + "]";
+        }
+    }
+
+    private SimpleFuture joinNodeAsync(final JoinRequest joinRequest) {
+        final SimpleFuture future = new SimpleFuture("join of " + joinRequest + "]");
+        logger.debug("starting {}", future);
+        // clone the node before submitting to simulate an incoming join, which is guaranteed to have a new
+        // disco node object serialized off the network
+        coordinator.handleJoinRequest(joinRequest, new MembershipAction.JoinCallback() {
+            @Override
+            public void onSuccess() {
+                logger.debug("{} completed", future);
+                future.markAsDone();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.error(() -> new ParameterizedMessage("unexpected error for {}", future), e);
+                future.markAsFailed(e);
+            }
+        });
+        return future;
+    }
+
+    public void testSimpleJoinAccumulation() throws InterruptedException, ExecutionException {
+        DiscoveryNode localNode = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Collections.emptyMap(),
+            new HashSet<>(Arrays.asList(DiscoveryNode.Role.values())), Version.CURRENT);
+        setupMasterServiceAndNodeJoinController(1L,
+            initialState(true, localNode, 1L, new VotingConfiguration(Collections.singleton(localNode.getId()))));
+        List<DiscoveryNode> nodes = new ArrayList<>();
+        nodes.add(localNode);
+
+        int nodeId = 0;
+        for (int i = randomInt(5); i > 0; i--) {
+            DiscoveryNode node = newNode(nodeId++);
+            nodes.add(node);
+            JoinRequest joinRequest = new JoinRequest(node, Optional.of(new Join(node, localNode, 2, 2, 3)));
+            joinNode(joinRequest);
+        }
+//        nodeJoinController.startElectionContext();
+//        ArrayList<Future<Void>> pendingJoins = new ArrayList<>();
+//        for (int i = randomInt(5); i > 0; i--) {
+//            DiscoveryNode node = newNode(nodeId++);
+//            nodes.add(node);
+//            pendingJoins.add(joinNodeAsync(node));
+//        }
+//        nodeJoinController.stopElectionContext("test");
+//        boolean hadSyncJoin = false;
+//        for (int i = randomInt(5); i > 0; i--) {
+//            DiscoveryNode node = newNode(nodeId++);
+//            nodes.add(node);
+//            joinNode(node);
+//            hadSyncJoin = true;
+//        }
+//        if (hadSyncJoin) {
+//            for (Future<Void> joinFuture : pendingJoins) {
+//                assertThat(joinFuture.isDone(), equalTo(true));
+//            }
+//        }
+//        for (Future<Void> joinFuture : pendingJoins) {
+//            joinFuture.get();
+//        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -379,7 +379,7 @@ public class NodeJoinTests extends ESTestCase {
         assertFalse(isLocalNodeElectedMaster());
         assertThat(expectThrows(CoordinationStateRejectedException.class,
             () -> FutureUtils.get(fut)).getMessage(),
-            containsString("started following"));
+            containsString("became follower"));
         assertFalse(isLocalNodeElectedMaster());
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.elasticsearch.cluster.coordination;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -335,7 +335,7 @@ public class NodeJoinTests extends ESTestCase {
         assertFalse(isLocalNodeElectedMaster());
         assertThat(expectThrows(CoordinationStateRejectedException.class,
             () -> FutureUtils.get(fut)).getMessage(),
-            containsString("following another master"));
+            containsString("started following"));
         assertFalse(isLocalNodeElectedMaster());
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -50,7 +50,7 @@ public class NodeJoinTests extends ESTestCase {
 
     @BeforeClass
     public static void beforeClass() {
-        threadPool = new TestThreadPool("NodeJoinControllerTests");
+        threadPool = new TestThreadPool(NodeJoinTests.getTestClass().getName());
     }
 
     @AfterClass
@@ -172,7 +172,7 @@ public class NodeJoinTests extends ESTestCase {
 
         // we need at least a quorum of voting nodes with a correct term
 
-        List<Thread> threads = randomSubsetOf(nodes).stream().map(node -> new Thread(() -> {
+        List<Thread> threads = nodes.stream().map(node -> new Thread(() -> {
             JoinRequest joinRequest = new JoinRequest(node, Optional.of(new Join(node, localNode, 2, 1, 1)));
             try {
                 joinNode(joinRequest);

--- a/server/src/test/java/org/elasticsearch/indices/cluster/FakeThreadPoolMasterService.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/FakeThreadPoolMasterService.java
@@ -50,7 +50,7 @@ public class FakeThreadPoolMasterService extends MasterService {
     private boolean taskInProgress = false;
     private boolean waitForPublish = false;
 
-    FakeThreadPoolMasterService(String serviceName, Consumer<Runnable> onTaskAvailableToRun) {
+    public FakeThreadPoolMasterService(String serviceName, Consumer<Runnable> onTaskAvailableToRun) {
         super(Settings.EMPTY, createMockThreadPool());
         this.name = serviceName;
         this.onTaskAvailableToRun = onTaskAvailableToRun;

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -969,7 +969,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     /**
-     * Returns a random subset of values (including a potential empty list)
+     * Returns a random subset of values (including a potential empty list, or the full original list)
      */
     public static <T> List<T> randomSubsetOf(Collection<T> collection) {
         return randomSubsetOf(randomInt(collection.size()), collection);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -972,7 +972,7 @@ public abstract class ESTestCase extends LuceneTestCase {
      * Returns a random subset of values (including a potential empty list)
      */
     public static <T> List<T> randomSubsetOf(Collection<T> collection) {
-        return randomSubsetOf(randomInt(Math.max(collection.size() - 1, 0)), collection);
+        return randomSubsetOf(randomInt(collection.size()), collection);
     }
 
     /**


### PR DESCRIPTION
Adds the logic for handling joins by a prospective leader. Introduces the Coordinator class with the basic lifecycle modes (candidate, leader, follower) as well as a JoinHelper class that contains most of the plumbing for handling joins.