### PR TITLE
Find CCR QA sub-projects automatically

### DIFF
--- a/x-pack/plugin/ccr/build.gradle
+++ b/x-pack/plugin/ccr/build.gradle
@@ -32,12 +32,17 @@ task internalClusterTest(type: RandomizedTestingTask,
     systemProperty 'es.set.netty.runtime.available.processors', 'false'
 }
 
+check.dependsOn internalClusterTest
 internalClusterTest.mustRunAfter test
-check.dependsOn(
-        internalClusterTest,
-        'qa:multi-cluster:followClusterTest',
-        'qa:multi-cluster-with-incompatible-license:followClusterTest',
-        'qa:multi-cluster-with-security:followClusterTest')
+
+// add all sub-projects of the qa sub-project
+gradle.projectsEvaluated {
+    project.subprojects
+            .find { it.path == project.path + ":qa" }
+            .subprojects
+            .findAll { it.path.startsWith(project.path + ":qa") }
+            .each { check.dependsOn it.check }
+}
 
 dependencies {
     compileOnly "org.elasticsearch:elasticsearch:${version}"


### PR DESCRIPTION
Today we are by-hand maintaining a list of CCR QA sub-projects that the check task depends on. This commit simplifies this by finding these sub-projects automatically and adding their check task as dependencies of the CCR check task.

