### PR TITLE
[TEST] Add some security access control yaml tests for Rollup

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/security_tests.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/security_tests.yml
@@ -1,0 +1,343 @@
+setup:
+  - skip:
+      features: headers
+
+  - do:
+      cluster.health:
+          wait_for_status: yellow
+
+
+
+---
+teardown:
+  - do:
+      xpack.security.delete_user:
+        username: "test_user"
+        ignore: 404
+
+  - do:
+      xpack.security.delete_role:
+        name: "foo_only_access"
+        ignore: 404
+
+---
+"Index-based access":
+
+  - do:
+      xpack.security.put_role:
+        name: "foo_only_access"
+        body:  >
+            {
+              "cluster": [ "all" ],
+              "indices": [
+                { "names": ["foo"], "privileges": ["all"] },
+                { "names": ["rollup"], "privileges": ["all"] }
+              ]
+            }
+
+  - do:
+      xpack.security.put_user:
+        username: "test_user"
+        body:  >
+          {
+            "password" : "x-pack-test-password",
+            "roles" : [ "foo_only_access" ],
+            "full_name" : "foo only"
+          }
+
+  - do:
+      indices.create:
+        index: foo
+        body:
+          mappings:
+            _doc:
+              properties:
+                timestamp:
+                  type: date
+                value_field:
+                  type: integer
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      index:
+        index: foo
+        type: _doc
+        body:
+          timestamp: 123
+          value_field: 1232
+
+  - do:
+      indices.create:
+        index: foobar
+        body:
+          mappings:
+            _doc:
+              properties:
+                timestamp:
+                  type: date
+                value_field:
+                  type: integer
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      index:
+        index: foobar
+        type: _doc
+        body:
+          timestamp: 123
+          value_field: 456
+
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      indices.refresh:
+        index: foo
+
+  # This index pattern will match both indices, but we only have permission to read one
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      xpack.rollup.put_job:
+        id: foo
+        body:  >
+          {
+            "index_pattern": "foo*",
+            "rollup_index": "rollup",
+            "cron": "*/1 * * * * ?",
+            "page_size" :10,
+            "groups" : {
+              "date_histogram": {
+                "field": "timestamp",
+                "interval": "1s"
+              }
+            },
+            "metrics": [
+              {
+                "field": "value_field",
+                "metrics": ["min", "max", "sum"]
+              }
+            ]
+          }
+
+  - is_true: acknowledged
+
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      xpack.rollup.start_job:
+        id: foo
+  - is_true: started
+
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      indices.refresh:
+        index: rollup
+
+  # this is a hacky way to sleep for 5s, since we will never have 10 nodes
+  - do:
+      catch: request_timeout
+      cluster.health:
+        wait_for_nodes: 10
+        timeout: "5s"
+  - match:
+     timed_out: true
+
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      xpack.rollup.get_jobs:
+        id: foo
+  - match:
+        jobs.0.stats.documents_processed: 1
+
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      search:
+        index: foo
+        body:
+          query:
+            match_all: {}
+
+  - match:
+      hits.total: 1
+
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      search:
+        index: rollup
+        body:
+          query:
+            match_all: {}
+
+  - match:
+      hits.total: 1
+  - match:
+      hits.hits.0._id: "foo$VxMkzTqILshClbtbFi4-rQ"
+  - match:
+      hits.hits.0._source:
+        timestamp.date_histogram.time_zone: "UTC"
+        timestamp.date_histogram.timestamp: 0
+        value_field.max.value: 1232.0
+        _rollup.version: 2
+        timestamp.date_histogram.interval: "1s"
+        value_field.sum.value: 1232.0
+        value_field.min.value: 1232.0
+        timestamp.date_histogram._count: 1
+        _rollup.id: "foo"
+
+
+---
+"Attribute-based access":
+
+  - do:
+      xpack.security.put_role:
+        name: "foo_only_access"
+        body:  >
+            {
+              "cluster": [ "all" ],
+              "indices": [
+                {
+                    "names": ["foo"],
+                    "privileges": ["all"],
+                    "query": {
+                        "template": {
+                            "source": "{\"bool\":{\"filter\":[{\"term\":{\"visibility\":\"public\"}}]}}"
+                        }
+                    }
+                },
+                { "names": ["rollup"], "privileges": ["all"] }
+              ]
+            }
+
+  - do:
+      xpack.security.put_user:
+        username: "test_user"
+        body:  >
+          {
+            "password" : "x-pack-test-password",
+            "roles" : [ "foo_only_access" ],
+            "full_name" : "foo only"
+          }
+
+  - do:
+      indices.create:
+        index: foo
+        body:
+          mappings:
+            _doc:
+              properties:
+                timestamp:
+                  type: date
+                value_field:
+                  type: integer
+                visibility:
+                  type: keyword
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      index:
+        index: foo
+        type: _doc
+        body:
+          timestamp: 123
+          value_field: 1232
+          visibility: "public"
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      index:
+        index: foobar
+        type: _doc
+        body:
+          timestamp: 123
+          value_field: 456
+          visibility: "private"
+
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      indices.refresh:
+        index: foo
+
+  # Index contains two docs, but we should only be able to see one of them
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      xpack.rollup.put_job:
+        id: foo
+        body:  >
+          {
+            "index_pattern": "foo",
+            "rollup_index": "rollup",
+            "cron": "*/1 * * * * ?",
+            "page_size" :10,
+            "groups" : {
+              "date_histogram": {
+                "field": "timestamp",
+                "interval": "1s"
+              }
+            },
+            "metrics": [
+              {
+                "field": "value_field",
+                "metrics": ["min", "max", "sum"]
+              }
+            ]
+          }
+  - is_true: acknowledged
+
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      xpack.rollup.start_job:
+        id: foo
+  - is_true: started
+
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      indices.refresh:
+        index: rollup
+
+  # this is a hacky way to sleep for 5s, since we will never have 10 nodes
+  - do:
+      catch: request_timeout
+      cluster.health:
+        wait_for_nodes: 10
+        timeout: "5s"
+  - match:
+     timed_out: true
+
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      xpack.rollup.get_jobs:
+        id: foo
+  - match:
+        jobs.0.stats.documents_processed: 1
+
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      search:
+        index: foo
+        body:
+          query:
+            match_all: {}
+
+  - match:
+      hits.total: 1
+
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      search:
+        index: rollup
+        body:
+          query:
+            match_all: {}
+
+  - match:
+      hits.total: 1
+  - match:
+      hits.hits.0._id: "foo$VxMkzTqILshClbtbFi4-rQ"
+  - match:
+      hits.hits.0._source:
+        timestamp.date_histogram.time_zone: "UTC"
+        timestamp.date_histogram.timestamp: 0
+        value_field.max.value: 1232.0
+        _rollup.version: 2
+        timestamp.date_histogram.interval: "1s"
+        value_field.sum.value: 1232.0
+        value_field.min.value: 1232.0
+        timestamp.date_histogram._count: 1
+        _rollup.id: "foo"


### PR DESCRIPTION
No need for review, these tests were just sufficiently complicated that I wanted a CI run on them first before merging :)

These two tests compliment the existing unit tests which check Rollup's ACL/security integration.

The first test creates to indices, puts a document in each one, and then assigns a role to the test user that can only access one of the indices. A rollup job is created with a pattern that would match both indices, and we verify that only the allowed document was rolled up (e.g. verifying that the unpermissioned index stays hidden).

The second test creates a single index with two documents tagged by the keyword "public"/"private".  An attribute-based role is created that only allows viewing "public" documents.  We then verify the rollup job only rolled the "public" doc, and not the "private" one.
