### PR TITLE
Switch some watcher tests to new style Requests

### DIFF
--- a/x-pack/qa/smoke-test-monitoring-with-watcher/src/test/java/org/elasticsearch/smoketest/MonitoringWithWatcherRestIT.java
+++ b/x-pack/qa/smoke-test-monitoring-with-watcher/src/test/java/org/elasticsearch/smoketest/MonitoringWithWatcherRestIT.java
@@ -5,12 +5,10 @@
  */
 package org.elasticsearch.smoketest;
 
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
 import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -23,7 +21,6 @@ import org.elasticsearch.xpack.watcher.trigger.schedule.IntervalSchedule;
 import org.junit.After;
 
 import java.io.IOException;
-import java.util.Collections;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.watcher.input.InputBuilders.simpleInput;
@@ -36,25 +33,25 @@ public class MonitoringWithWatcherRestIT extends ESRestTestCase {
 
     @After
     public void cleanExporters() throws Exception {
-        String body = Strings.toString(jsonBuilder().startObject().startObject("transient")
-                .nullField("xpack.monitoring.exporters.*")
-                .endObject().endObject());
-        assertOK(adminClient().performRequest("PUT", "_cluster/settings", Collections.emptyMap(),
-                new StringEntity(body, ContentType.APPLICATION_JSON)));
-
-        assertOK(adminClient().performRequest("DELETE", ".watch*", Collections.emptyMap()));
+        Request request = new Request("PUT", "/_cluster/settings");
+        request.setJsonEntity(Strings.toString(jsonBuilder().startObject()
+                .startObject("transient")
+                    .nullField("xpack.monitoring.exporters.*")
+                .endObject().endObject()));
+        adminClient().performRequest(request);
+        adminClient().performRequest(new Request("DELETE", "/.watch*"));
     }
 
     public void testThatLocalExporterAddsWatches() throws Exception {
         String watchId = createMonitoringWatch();
 
-        String body = BytesReference.bytes(jsonBuilder().startObject().startObject("transient")
-                .field("xpack.monitoring.exporters.my_local_exporter.type", "local")
-                .field("xpack.monitoring.exporters.my_local_exporter.cluster_alerts.management.enabled", true)
-                .endObject().endObject()).utf8ToString();
-
-        adminClient().performRequest("PUT", "_cluster/settings", Collections.emptyMap(),
-                new StringEntity(body, ContentType.APPLICATION_JSON));
+        Request request = new Request("PUT", "/_cluster/settings");
+        request.setJsonEntity(Strings.toString(jsonBuilder().startObject()
+                .startObject("transient")
+                    .field("xpack.monitoring.exporters.my_local_exporter.type", "local")
+                    .field("xpack.monitoring.exporters.my_local_exporter.cluster_alerts.management.enabled", true)
+                .endObject().endObject()));
+        adminClient().performRequest(request);
 
         assertTotalWatchCount(ClusterAlertsUtil.WATCH_IDS.length);
 
@@ -65,14 +62,14 @@ public class MonitoringWithWatcherRestIT extends ESRestTestCase {
         String watchId = createMonitoringWatch();
         String httpHost = getHttpHost();
 
-        String body = BytesReference.bytes(jsonBuilder().startObject().startObject("transient")
-                .field("xpack.monitoring.exporters.my_http_exporter.type", "http")
-                .field("xpack.monitoring.exporters.my_http_exporter.host", httpHost)
-                .field("xpack.monitoring.exporters.my_http_exporter.cluster_alerts.management.enabled", true)
-                .endObject().endObject()).utf8ToString();
-
-        adminClient().performRequest("PUT", "_cluster/settings", Collections.emptyMap(),
-                new StringEntity(body, ContentType.APPLICATION_JSON));
+        Request request = new Request("PUT", "/_cluster/settings");
+        request.setJsonEntity(Strings.toString(jsonBuilder().startObject()
+                .startObject("transient")
+                    .field("xpack.monitoring.exporters.my_http_exporter.type", "http")
+                    .field("xpack.monitoring.exporters.my_http_exporter.host", httpHost)
+                    .field("xpack.monitoring.exporters.my_http_exporter.cluster_alerts.management.enabled", true)
+                .endObject().endObject()));
+        adminClient().performRequest(request);
 
         assertTotalWatchCount(ClusterAlertsUtil.WATCH_IDS.length);
 
@@ -80,15 +77,15 @@ public class MonitoringWithWatcherRestIT extends ESRestTestCase {
     }
 
     private void assertMonitoringWatchHasBeenOverWritten(String watchId) throws Exception {
-        ObjectPath path = ObjectPath.createFromResponse(client().performRequest("GET", "_xpack/watcher/watch/" + watchId));
+        ObjectPath path = ObjectPath.createFromResponse(client().performRequest(new Request("GET", "/_xpack/watcher/watch/" + watchId)));
         String interval = path.evaluate("watch.trigger.schedule.interval");
         assertThat(interval, is("1m"));
     }
 
     private void assertTotalWatchCount(int expectedWatches) throws Exception {
         assertBusy(() -> {
-            assertOK(client().performRequest("POST", ".watches/_refresh"));
-            ObjectPath path = ObjectPath.createFromResponse(client().performRequest("POST", ".watches/_count"));
+            assertOK(client().performRequest(new Request("POST", "/.watches/_refresh")));
+            ObjectPath path = ObjectPath.createFromResponse(client().performRequest(new Request("POST", "/.watches/_count")));
             int count = path.evaluate("count");
             assertThat(count, is(expectedWatches));
         });
@@ -97,28 +94,28 @@ public class MonitoringWithWatcherRestIT extends ESRestTestCase {
     private String createMonitoringWatch() throws Exception {
         String clusterUUID = getClusterUUID();
         String watchId = clusterUUID + "_kibana_version_mismatch";
-        String sampleWatch = WatchSourceBuilders.watchBuilder()
+        Request request = new Request("PUT", "/_xpack/watcher/watch/" + watchId);
+        request.setJsonEntity(WatchSourceBuilders.watchBuilder()
                 .trigger(TriggerBuilders.schedule(new IntervalSchedule(new IntervalSchedule.Interval(1000, MINUTES))))
                 .input(simpleInput())
                 .addAction("logme", ActionBuilders.loggingAction("foo"))
-                .buildAsBytes(XContentType.JSON).utf8ToString();
-        client().performRequest("PUT", "_xpack/watcher/watch/" + watchId, Collections.emptyMap(),
-                new StringEntity(sampleWatch, ContentType.APPLICATION_JSON));
+                .buildAsBytes(XContentType.JSON).utf8ToString());
+        client().performRequest(request);
         return watchId;
     }
 
     private String getClusterUUID() throws Exception {
-        Response response = client().performRequest("GET", "_cluster/state/metadata", Collections.emptyMap());
+        Response response = client().performRequest(new Request("GET", "/_cluster/state/metadata"));
         ObjectPath objectPath = ObjectPath.createFromResponse(response);
         String clusterUUID = objectPath.evaluate("metadata.cluster_uuid");
         return clusterUUID;
     }
 
     public String getHttpHost() throws IOException {
-        ObjectPath path = ObjectPath.createFromResponse(client().performRequest("GET", "_cluster/state", Collections.emptyMap()));
+        ObjectPath path = ObjectPath.createFromResponse(client().performRequest(new Request("GET", "/_cluster/state")));
         String masterNodeId = path.evaluate("master_node");
 
-        ObjectPath nodesPath = ObjectPath.createFromResponse(client().performRequest("GET", "_nodes", Collections.emptyMap()));
+        ObjectPath nodesPath = ObjectPath.createFromResponse(client().performRequest(new Request("GET", "/_nodes")));
         String httpHost = nodesPath.evaluate("nodes." + masterNodeId + ".http.publish_address");
         return httpHost;
     }

--- a/x-pack/qa/smoke-test-watcher-with-security/src/test/java/org/elasticsearch/smoketest/SmokeTestWatcherWithSecurityClientYamlTestSuiteIT.java
+++ b/x-pack/qa/smoke-test-watcher-with-security/src/test/java/org/elasticsearch/smoketest/SmokeTestWatcherWithSecurityClientYamlTestSuiteIT.java
@@ -7,9 +7,7 @@ package org.elasticsearch.smoketest;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.elasticsearch.client.Response;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -49,9 +47,9 @@ public class SmokeTestWatcherWithSecurityClientYamlTestSuiteIT extends ESClientY
                 emptyList(), emptyMap());
 
         // create one document in this index, so we can test in the YAML tests, that the index cannot be accessed
-        Response resp = adminClient().performRequest("PUT", "/index_not_allowed_to_read/doc/1", Collections.emptyMap(),
-                new StringEntity("{\"foo\":\"bar\"}", ContentType.APPLICATION_JSON));
-        assertThat(resp.getStatusLine().getStatusCode(), is(201));
+        Request request = new Request("PUT", "/index_not_allowed_to_read/doc/1");
+        request.setJsonEntity("{\"foo\":\"bar\"}");
+        adminClient().performRequest(request);
 
         assertBusy(() -> {
             ClientYamlTestResponse response =
@@ -129,4 +127,3 @@ public class SmokeTestWatcherWithSecurityClientYamlTestSuiteIT extends ESClientY
             .build();
     }
 }
-

--- a/x-pack/qa/smoke-test-watcher/src/test/java/org/elasticsearch/smoketest/SmokeTestWatcherTestSuiteIT.java
+++ b/x-pack/qa/smoke-test-watcher/src/test/java/org/elasticsearch/smoketest/SmokeTestWatcherTestSuiteIT.java
@@ -5,8 +5,7 @@
  */
 package org.elasticsearch.smoketest;
 
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
@@ -23,7 +22,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static java.util.Collections.emptyMap;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -39,15 +37,15 @@ public class SmokeTestWatcherTestSuiteIT extends ESRestTestCase {
     @Before
     public void startWatcher() throws Exception {
         // delete the watcher history to not clutter with entries from other test
-        assertOK(adminClient().performRequest("DELETE", ".watcher-history-*"));
+        assertOK(adminClient().performRequest(new Request("DELETE", "/.watcher-history-*")));
 
         assertBusy(() -> {
-            Response response = adminClient().performRequest("GET", "_xpack/watcher/stats");
+            Response response = adminClient().performRequest(new Request("GET", "/_xpack/watcher/stats"));
             String state = ObjectPath.createFromResponse(response).evaluate("stats.0.watcher_state");
 
             switch (state) {
                 case "stopped":
-                    Response startResponse = adminClient().performRequest("POST", "/_xpack/watcher/_start");
+                    Response startResponse = adminClient().performRequest(new Request("POST", "/_xpack/watcher/_start"));
                     boolean isAcknowledged = ObjectPath.createFromResponse(startResponse).evaluate("acknowledged");
                     assertThat(isAcknowledged, is(true));
                     break;
@@ -65,7 +63,7 @@ public class SmokeTestWatcherTestSuiteIT extends ESRestTestCase {
 
         assertBusy(() -> {
             for (String template : WatcherIndexTemplateRegistryField.TEMPLATE_NAMES) {
-                Response templateExistsResponse = adminClient().performRequest("HEAD", "_template/" + template, emptyMap());
+                Response templateExistsResponse = adminClient().performRequest(new Request("HEAD", "/_template/" + template));
                 assertThat(templateExistsResponse.getStatusLine().getStatusCode(), is(200));
             }
         });
@@ -74,7 +72,7 @@ public class SmokeTestWatcherTestSuiteIT extends ESRestTestCase {
     @After
     public void stopWatcher() throws Exception {
         assertBusy(() -> {
-            Response response = adminClient().performRequest("GET", "_xpack/watcher/stats", emptyMap());
+            Response response = adminClient().performRequest(new Request("GET", "/_xpack/watcher/stats"));
             String state = ObjectPath.createFromResponse(response).evaluate("stats.0.watcher_state");
 
             switch (state) {
@@ -86,7 +84,7 @@ public class SmokeTestWatcherTestSuiteIT extends ESRestTestCase {
                 case "starting":
                     throw new AssertionError("waiting until starting state reached started state to stop");
                 case "started":
-                    Response stopResponse = adminClient().performRequest("POST", "/_xpack/watcher/_stop", emptyMap());
+                    Response stopResponse = adminClient().performRequest(new Request("POST", "/_xpack/watcher/_stop"));
                     boolean isAcknowledged = ObjectPath.createFromResponse(stopResponse).evaluate("acknowledged");
                     assertThat(isAcknowledged, is(true));
                     break;
@@ -112,12 +110,12 @@ public class SmokeTestWatcherTestSuiteIT extends ESRestTestCase {
         String watchId = "cluster_health_watch";
 
         // get master publish address
-        Response clusterStateResponse = adminClient().performRequest("GET", "_cluster/state");
+        Response clusterStateResponse = adminClient().performRequest(new Request("GET", "/_cluster/state"));
         ObjectPath clusterState = ObjectPath.createFromResponse(clusterStateResponse);
         String masterNode = clusterState.evaluate("master_node");
         assertThat(masterNode, is(notNullValue()));
 
-        Response statsResponse = adminClient().performRequest("GET", "_nodes");
+        Response statsResponse = adminClient().performRequest(new Request("GET", "/_nodes"));
         ObjectPath stats = ObjectPath.createFromResponse(statsResponse);
         String address = stats.evaluate("nodes." + masterNode + ".http.publish_address");
         assertThat(address, is(notNullValue()));
@@ -163,16 +161,15 @@ public class SmokeTestWatcherTestSuiteIT extends ESRestTestCase {
     }
 
     private void indexWatch(String watchId, XContentBuilder builder) throws Exception {
-        StringEntity entity = new StringEntity(Strings.toString(builder), ContentType.APPLICATION_JSON);
-
-        Response response = client().performRequest("PUT", "_xpack/watcher/watch/" + watchId, emptyMap(), entity);
-        assertOK(response);
+        Request request = new Request("PUT", "/_xpack/watcher/watch/" + watchId);
+        request.setJsonEntity(Strings.toString(builder));
+        Response response = client().performRequest(request);
         Map<String, Object> responseMap = entityAsMap(response);
         assertThat(responseMap, hasEntry("_id", watchId));
     }
 
     private void deleteWatch(String watchId) throws IOException {
-        Response response = client().performRequest("DELETE", "_xpack/watcher/watch/" + watchId);
+        Response response = client().performRequest(new Request("DELETE", "/_xpack/watcher/watch/" + watchId));
         assertOK(response);
         ObjectPath path = ObjectPath.createFromResponse(response);
         boolean found = path.evaluate("found");
@@ -182,7 +179,7 @@ public class SmokeTestWatcherTestSuiteIT extends ESRestTestCase {
     private ObjectPath getWatchHistoryEntry(String watchId) throws Exception {
         final AtomicReference<ObjectPath> objectPathReference = new AtomicReference<>();
         assertBusy(() -> {
-            client().performRequest("POST", ".watcher-history-*/_refresh");
+            client().performRequest(new Request("POST", "/.watcher-history-*/_refresh"));
 
             try (XContentBuilder builder = jsonBuilder()) {
                 builder.startObject();
@@ -194,8 +191,9 @@ public class SmokeTestWatcherTestSuiteIT extends ESRestTestCase {
                     .endObject().endArray();
                 builder.endObject();
 
-                StringEntity entity = new StringEntity(Strings.toString(builder), ContentType.APPLICATION_JSON);
-                Response response = client().performRequest("POST", ".watcher-history-*/_search", emptyMap(), entity);
+                Request searchRequest = new Request("POST", "/.watcher-history-*/_search");
+                searchRequest.setJsonEntity(Strings.toString(builder));
+                Response response = client().performRequest(searchRequest);
                 ObjectPath objectPath = ObjectPath.createFromResponse(response);
                 int totalHits = objectPath.evaluate("hits.total");
                 assertThat(totalHits, is(greaterThanOrEqualTo(1)));
@@ -208,7 +206,7 @@ public class SmokeTestWatcherTestSuiteIT extends ESRestTestCase {
     }
 
     private void assertWatchCount(int expectedWatches) throws IOException {
-        Response watcherStatsResponse = adminClient().performRequest("GET", "_xpack/watcher/stats");
+        Response watcherStatsResponse = adminClient().performRequest(new Request("GET", "/_xpack/watcher/stats"));
         ObjectPath objectPath = ObjectPath.createFromResponse(watcherStatsResponse);
         int watchCount = objectPath.evaluate("stats.0.watch_count");
         assertThat(watchCount, is(expectedWatches));


### PR DESCRIPTION
In #29623 we added `Request` object flavored requests to the low level
REST client and in #30315 we deprecated the old `performRequest`s. This
changes all calls in the `x-pack/qa/smoke-test-monitoring-with-watcher`,
`x-pack/qa/smoke-test-watcher`, and
`x-pack/qa/smoke-test-watcher-with-security` projects to use the new
versions.
