### PR TITLE
Fix classpath security checks for external tests.

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -177,8 +177,11 @@ public class BootstrapForTesting {
     private static void addClassCodebase(Map<String, URL> codebases, String name, String classname) {
         try {
             Class<?> clazz = BootstrapForTesting.class.getClassLoader().loadClass(classname);
-            if (codebases.put(name, clazz.getProtectionDomain().getCodeSource().getLocation()) != null) {
-                throw new IllegalStateException("Already added " + name + " codebase for testing");
+            URL location = clazz.getProtectionDomain().getCodeSource().getLocation();
+            if (location.toString().endsWith(".jar") == false) {
+                if (codebases.put(name, location) != null) {
+                    throw new IllegalStateException("Already added " + name + " codebase for testing");
+                }
             }
         } catch (ClassNotFoundException e) {
             // no class, fall through to not add. this can happen for any tests that do not include


### PR DESCRIPTION
This commit checks that when we manually add a class to
the codebase map, that it does in-fact not exist on the classpath
in a jar.  This will only be true if we are using the test framework
externally such as when a user develops a plugin.

This check is only needed when running tests via an IDE such as IntelliJ.

Closes #33045