### PR TITLE
Fix plugin build test on Windows

### DIFF
--- a/buildSrc/src/test/java/org/elasticsearch/gradle/BuildExamplePluginsIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/BuildExamplePluginsIT.java
@@ -158,8 +158,12 @@ public class BuildExamplePluginsIT extends GradleIntegrationTestCase {
         Objects.requireNonNull(property, "test.local-test-repo-path not passed to tests");
         File file = new File(property);
         assertTrue("Expected " + property + " to exist, but it did not!", file.exists());
-        // Use / on Windows too
-        return file.getAbsolutePath().replace("\\", "/");
+        if (File.separator.equals("\\")) {
+            // Use / on Windows too, the build script is not happy with \
+            return file.getAbsolutePath().replace(File.separator, "/");
+        } else {
+            return file.getAbsolutePath();
+        }
     }
 
 }

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/BuildExamplePluginsIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/BuildExamplePluginsIT.java
@@ -158,7 +158,8 @@ public class BuildExamplePluginsIT extends GradleIntegrationTestCase {
         Objects.requireNonNull(property, "test.local-test-repo-path not passed to tests");
         File file = new File(property);
         assertTrue("Expected " + property + " to exist, but it did not!", file.exists());
-        return file.getAbsolutePath();
+        // Use / on Windows too
+        return file.getAbsolutePath().replace("\\", "/");
     }
 
 }


### PR DESCRIPTION
Replace slashes for windows, Gradle knows how to interpret the paths correctly. 