### PR TITLE
HLRC: Fix Compile Error From Missing Throws

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
@@ -70,7 +70,7 @@ final class MLRequestConverters {
         return request;
     }
 
-    static Request openJob(OpenJobRequest openJobRequest) {
+    static Request openJob(OpenJobRequest openJobRequest) throws IOException {
         String endpoint = new EndpointBuilder()
                 .addPathPartAsIs("_xpack")
                 .addPathPartAsIs("ml")


### PR DESCRIPTION
* 50441f97ae745814db96c262e99d0f465aca5b2c removed the throws, breaking compilation here
