### PR TITLE
[DOCS] Changes release state

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -11,7 +11,7 @@
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:   unreleased
+:release-state:   released
 
 :issue:           https://github.com/elastic/elasticsearch/issues/
 :ml-issue:        https://github.com/elastic/ml-cpp/issues/


### PR DESCRIPTION
This PR updates the release-state attribute, which makes the installation instructions start appearing in the Elasticsearch Reference, among other things. 