### PR TITLE
Security index expands to a single replica

### DIFF
--- a/x-pack/plugin/core/src/main/resources/security-index-template.json
+++ b/x-pack/plugin/core/src/main/resources/security-index-template.json
@@ -4,7 +4,7 @@
   "settings" : {
     "number_of_shards" : 1,
     "number_of_replicas" : 0,
-    "auto_expand_replicas" : "0-all",
+    "auto_expand_replicas" : "0-1",
     "index.priority": 1000,
     "index.format": 6,
     "analysis" : {


### PR DESCRIPTION
This change removes the use 0-all for auto expand replicas for the
security index. The use of 0-all causes some unexpected behavior with
certain allocation settings. This change allows us to avoid these with
a default install. If necessary, the number of replicas can be tuned by
the user.

Closes #29933
Closes #29712