### PR TITLE
Build: forked compiler max memory matches jvmArgs

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -601,7 +601,6 @@ class BuildPlugin implements Plugin<Project> {
                 } else {
                     options.fork = true
                     options.forkOptions.javaHome = compilerJavaHomeFile
-                    options.forkOptions.memoryMaximumSize = "512m"
                 }
                 if (targetCompatibilityVersion == JavaVersion.VERSION_1_8) {
                     // compile with compact 3 profile by default

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.daemon=false
 org.gradle.jvmargs=-Xmx2g
+options.forkOptions.memoryMaximumSize=2G

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.daemon=false
 org.gradle.jvmargs=-Xmx2g
-options.forkOptions.memoryMaximumSize=2G
+options.forkOptions.memoryMaximumSize=2g


### PR DESCRIPTION
This commit removes the setting of the fork options maximum memory size
in our build plugin and instead adds the value in the gradle.properties
file to be alongside the value set in jvmArgs.

This change is necessary when using parallel compilation as 512m is not
sufficient for parallel compilation on some machines.