### PR TITLE
Build: Create elasticsearch.is-ide plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,14 +127,8 @@ Map<String, String> buildMetadataMap = buildMetadataValue.tokenize(';').collectE
 
 // injecting groovy property variables into all projects
 allprojects {
+  apply plugin: 'elasticsearch.is-ide'
   project.ext {
-    // for ide hacks...
-    isEclipse = System.getProperty("eclipse.launcher") != null ||   // Detects gradle launched from Eclipse's IDE
-            System.getProperty("eclipse.application") != null ||    // Detects gradle launched from the Eclipse compiler server
-            gradle.startParameter.taskNames.contains('eclipse') ||  // Detects gradle launched from the command line to do eclipse stuff
-            gradle.startParameter.taskNames.contains('cleanEclipse')
-    isIdea = System.getProperty("idea.active") != null || gradle.startParameter.taskNames.contains('idea') || gradle.startParameter.taskNames.contains('cleanIdea')
-
     // for BWC testing
     bwcVersions = versions
 
@@ -512,24 +506,6 @@ allprojects {
   tasks.cleanEclipse.dependsOn(wipeEclipseSettings)
   // otherwise the eclipse merging is *super confusing*
   tasks.eclipse.dependsOn(cleanEclipse, copyEclipseSettings)
-}
-
-allprojects {
-  /*
-   * IntelliJ and Eclipse don't know about the shadow plugin so when we're
-   * in "IntelliJ mode" or "Eclipse mode" switch "bundle" dependencies into
-   * regular "compile" dependencies. This isn't needed for the project
-   * itself because the IDE configuration is done by SourceSets but it is
-   * *is* needed for projects that depends on the project doing the shadowing.
-   * Without this they won't properly depend on the shadowed project.
-   */
-  if (isEclipse || isIdea) {
-    project.plugins.withType(ShadowPlugin).whenPluginAdded {
-      project.afterEvaluate {
-        project.configurations.compile.extendsFrom project.configurations.bundle
-      }
-    }
-  }
 }
 
 // we need to add the same --debug-jvm option as

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/IsIdePlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/IsIdePlugin.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.ExtraPropertiesExtension;
+
+import java.util.List;
+
+/**
+ * Sets {@code project.isEclipse} and @{code project.isIdea}. They are set to
+ * true if the build is running in that IDE or false if it isn't.
+ */
+public class IsIdePlugin implements Plugin<Project> {
+    public void apply(Project project) {
+        ExtraPropertiesExtension ext = project.getExtensions().getByType(ExtraPropertiesExtension.class);
+        List<String> startTasks = project.getGradle().getStartParameter().getTaskNames();
+        /*
+         * Note: This ******must****** line up with the logic in
+         * settings.gradle or Eclipse users will have a bad time.
+         */
+        ext.set("isEclipse",
+                   System.getProperty("eclipse.launcher") != null    // Detects gradle launched from the Eclipse IDE
+                || System.getProperty("eclipse.application") != null // Detects gradle launched from the Eclipse compiler server
+                || startTasks.contains("eclipse")                    // Detects gradle launched from the command line to do Eclipse stuff
+                || startTasks.contains("cleanEclipse"));
+        ext.set("isIdea",
+                   System.getProperty("idea.active") != null         // Detects gradle launched from the IntelliJ
+                || startTasks.contains("idea")                       // Detects gradle launched from the command line to do IntelliJ stuff
+                || startTasks.contains("cleanIdea"));
+    }
+}

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/elasticsearch.is-ide.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/elasticsearch.is-ide.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+implementation-class=org.elasticsearch.gradle.IsIdePlugin

--- a/settings.gradle
+++ b/settings.gradle
@@ -78,6 +78,10 @@ addSubProjects('', new File(rootProject.projectDir, 'plugins'))
 addSubProjects('', new File(rootProject.projectDir, 'qa'))
 addSubProjects('', new File(rootProject.projectDir, 'x-pack'))
 
+/*
+ * Note: This ******must****** line up with the logic in IsIdePlugin or Eclipse
+ * users will have a bad time.
+ */
 List startTasks = gradle.startParameter.taskNames
 boolean isEclipse =
     System.getProperty("eclipse.launcher") != null ||    // Detects gradle launched from the Eclipse IDE


### PR DESCRIPTION
This moves the IDE detection code from `build.gradle` into a plugin that
you can get with `apply plugin: 'elasticsearch.is-ide'`. This is useful
because it allows us to move some of our IDE customization code from
`build.gradle` into `BuildPlugin` which should mean that external users
will get the shadow plugin configured correctly.

This does *not* move any more IDE customization into BuildPlugin because
it is a lot more opinionated.
