### PR TITLE
correct spelling of response in filter_path

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_common.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_common.json
@@ -23,7 +23,7 @@
     },
     "filter_path": {
       "type": "list",
-      "description": "A comma-separated list of filters used to reduce the respone."
+      "description": "A comma-separated list of filters used to reduce the response."
     }
   }
 }


### PR DESCRIPTION
This commit corrects the spelling of response in the description of
filter_path in the REST API spec.
