### PR TITLE
[TEST] Add permission for kerberos test

### DIFF
--- a/x-pack/plugin/security/src/main/plugin-metadata/plugin-security.policy
+++ b/x-pack/plugin/security/src/main/plugin-metadata/plugin-security.policy
@@ -59,3 +59,9 @@ grant codeBase "${codebase.httpasyncclient}" {
   // rest client uses system properties which gets the default proxy
   permission java.net.NetPermission "getProxySelector";
 };
+
+grant codeBase "${codebase.mina-core}" {
+   // kerberos test simple kdc server component depends on apache mina,
+   // which internally requires this permission
+   permission java.lang.RuntimePermission "accessClassInPackage.sun.reflect";
+};

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
@@ -128,7 +128,9 @@ public abstract class KerberosTestCase extends ESTestCase {
 
     @After
     public void tearDownMiniKdc() throws IOException, PrivilegedActionException {
-        simpleKdcLdapServer.stop();
+        if (simpleKdcLdapServer != null) {
+            simpleKdcLdapServer.stop();
+        }
     }
 
     /**


### PR DESCRIPTION
The test SimpleKdcLdapServerTests#testPrincipalCreationAndSearchOnLdap
fails intermittently and I could not reproduce this locally.

There were two exceptions from the console logs of which one might be
the reason for the failure. When simple Kdc LDAP server starts,
internally it starts Kdc server and LDAP server. Kdc server then tries
to connect to configured LDAP backend and during this process it
waits for the connection to succeed, meanwhile checking for deadlocks
in between. During this deadlock check, it needs permission to
`accessClassInPackage.sun.reflect`, the fix here is to add the
required permission so that the check does not throw an exception.

I think once we fix this issue, we may have something to look forward
if there is indeed a deadlock or its just waiting for the process
to complete on slow test runs.
Added a null check in after test method.

See #32739
