### PR TITLE
Only fetch mapping updates when necessary

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
@@ -161,10 +161,10 @@ public class ShardChangesAction extends Action<ShardChangesAction.Response> {
 
     public static final class Response extends ActionResponse {
 
-        private long indexMetadataVersion;
+        private long mappingVersion;
 
-        public long getIndexMetadataVersion() {
-            return indexMetadataVersion;
+        public long getMappingVersion() {
+            return mappingVersion;
         }
 
         private long globalCheckpoint;
@@ -188,8 +188,8 @@ public class ShardChangesAction extends Action<ShardChangesAction.Response> {
         Response() {
         }
 
-        Response(final long indexMetadataVersion, final long globalCheckpoint, final long maxSeqNo, final Translog.Operation[] operations) {
-            this.indexMetadataVersion = indexMetadataVersion;
+        Response(final long mappingVersion, final long globalCheckpoint, final long maxSeqNo, final Translog.Operation[] operations) {
+            this.mappingVersion = mappingVersion;
             this.globalCheckpoint = globalCheckpoint;
             this.maxSeqNo = maxSeqNo;
             this.operations = operations;
@@ -198,7 +198,7 @@ public class ShardChangesAction extends Action<ShardChangesAction.Response> {
         @Override
         public void readFrom(final StreamInput in) throws IOException {
             super.readFrom(in);
-            indexMetadataVersion = in.readVLong();
+            mappingVersion = in.readVLong();
             globalCheckpoint = in.readZLong();
             maxSeqNo = in.readZLong();
             operations = in.readArray(Translog.Operation::readOperation, Translog.Operation[]::new);
@@ -207,7 +207,7 @@ public class ShardChangesAction extends Action<ShardChangesAction.Response> {
         @Override
         public void writeTo(final StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeVLong(indexMetadataVersion);
+            out.writeVLong(mappingVersion);
             out.writeZLong(globalCheckpoint);
             out.writeZLong(maxSeqNo);
             out.writeArray(Translog.Operation::writeOperation, operations);
@@ -218,7 +218,7 @@ public class ShardChangesAction extends Action<ShardChangesAction.Response> {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             final Response that = (Response) o;
-            return indexMetadataVersion == that.indexMetadataVersion &&
+            return mappingVersion == that.mappingVersion &&
                     globalCheckpoint == that.globalCheckpoint &&
                     maxSeqNo == that.maxSeqNo &&
                     Arrays.equals(operations, that.operations);
@@ -226,7 +226,7 @@ public class ShardChangesAction extends Action<ShardChangesAction.Response> {
 
         @Override
         public int hashCode() {
-            return Objects.hash(indexMetadataVersion, globalCheckpoint, maxSeqNo, Arrays.hashCode(operations));
+            return Objects.hash(mappingVersion, globalCheckpoint, maxSeqNo, Arrays.hashCode(operations));
         }
     }
 
@@ -252,7 +252,7 @@ public class ShardChangesAction extends Action<ShardChangesAction.Response> {
             IndexService indexService = indicesService.indexServiceSafe(request.getShard().getIndex());
             IndexShard indexShard = indexService.getShard(request.getShard().id());
             final SeqNoStats seqNoStats =  indexShard.seqNoStats();
-            final long indexMetaDataVersion = clusterService.state().metaData().index(shardId.getIndex()).getVersion();
+            final long mappingVersion = clusterService.state().metaData().index(shardId.getIndex()).getMappingVersion();
 
             final Translog.Operation[] operations = getOperations(
                     indexShard,
@@ -260,7 +260,7 @@ public class ShardChangesAction extends Action<ShardChangesAction.Response> {
                     request.fromSeqNo,
                     request.maxOperationCount,
                     request.maxOperationSizeInBytes);
-            return new Response(indexMetaDataVersion, seqNoStats.getGlobalCheckpoint(), seqNoStats.getMaxSeqNo(), operations);
+            return new Response(mappingVersion, seqNoStats.getGlobalCheckpoint(), seqNoStats.getMaxSeqNo(), operations);
         }
 
         @Override

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -115,7 +115,7 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
                     putMappingRequest.type(mappingMetaData.type());
                     putMappingRequest.source(mappingMetaData.source().string(), XContentType.JSON);
                     followerClient.admin().indices().putMapping(putMappingRequest, ActionListener.wrap(
-                        putMappingResponse -> handler.accept(indexMetaData.getVersion()),
+                        putMappingResponse -> handler.accept(indexMetaData.getMappingVersion()),
                         errorHandler));
                 }, errorHandler));
             }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesResponseTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesResponseTests.java
@@ -12,7 +12,7 @@ public class ShardChangesResponseTests extends AbstractStreamableTestCase<ShardC
 
     @Override
     protected ShardChangesAction.Response createTestInstance() {
-        final long indexMetadataVersion = randomNonNegativeLong();
+        final long mappingVersion = randomNonNegativeLong();
         final long leaderGlobalCheckpoint = randomNonNegativeLong();
         final long leaderMaxSeqNo = randomLongBetween(leaderGlobalCheckpoint, Long.MAX_VALUE);
         final int numOps = randomInt(8);
@@ -20,7 +20,7 @@ public class ShardChangesResponseTests extends AbstractStreamableTestCase<ShardC
         for (int i = 0; i < numOps; i++) {
             operations[i] = new Translog.NoOp(i, 0, "test");
         }
-        return new ShardChangesAction.Response(indexMetadataVersion, leaderGlobalCheckpoint, leaderMaxSeqNo, operations);
+        return new ShardChangesAction.Response(mappingVersion, leaderGlobalCheckpoint, leaderMaxSeqNo, operations);
     }
 
     @Override

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskStatusTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskStatusTests.java
@@ -65,7 +65,7 @@ public class ShardFollowNodeTaskStatusTests extends AbstractSerializingTestCase<
         assertThat(newInstance.numberOfConcurrentReads(), equalTo(expectedInstance.numberOfConcurrentReads()));
         assertThat(newInstance.numberOfConcurrentWrites(), equalTo(expectedInstance.numberOfConcurrentWrites()));
         assertThat(newInstance.numberOfQueuedWrites(), equalTo(expectedInstance.numberOfQueuedWrites()));
-        assertThat(newInstance.indexMetadataVersion(), equalTo(expectedInstance.indexMetadataVersion()));
+        assertThat(newInstance.mappingVersion(), equalTo(expectedInstance.mappingVersion()));
         assertThat(newInstance.totalFetchTimeMillis(), equalTo(expectedInstance.totalFetchTimeMillis()));
         assertThat(newInstance.numberOfSuccessfulFetches(), equalTo(expectedInstance.numberOfSuccessfulFetches()));
         assertThat(newInstance.numberOfFailedFetches(), equalTo(expectedInstance.numberOfFailedFetches()));

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
@@ -209,7 +209,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
                         try {
                             Translog.Operation[] ops = ShardChangesAction.getOperations(indexShard, seqNoStats.getGlobalCheckpoint(), from,
                                 maxOperationCount, params.getMaxBatchSizeInBytes());
-                            // Hard code index metadata version, this is ok, as mapping updates are not tested here.
+                            // hard code mapping version; this is ok, as mapping updates are not tested here
                             final ShardChangesAction.Response response =
                                     new ShardChangesAction.Response(1L, seqNoStats.getGlobalCheckpoint(), seqNoStats.getMaxSeqNo(), ops);
                             handler.accept(response);

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ccr/stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ccr/stats.yml
@@ -33,7 +33,7 @@
   - gte: { bar.0.number_of_concurrent_reads: 0 }
   - match: { bar.0.number_of_concurrent_writes: 0 }
   - match: { bar.0.number_of_queued_writes: 0 }
-  - gte: { bar.0.index_metadata_version: 0 }
+  - gte: { bar.0.mapping_version: 0 }
   - gte: { bar.0.total_fetch_time_millis: 0 }
   - gte: { bar.0.number_of_successful_fetches: 0 }
   - gte: { bar.0.number_of_failed_fetches: 0 }


### PR DESCRIPTION
Today we fetch the mapping from the leader and apply it as a mapping update whenever the index metadata version on the leader changes. Yet, the index metadata can change for many reasons other than a mapping update (e.g., settings updates, adding an alias, or a replica being promoted to a primary among many other reasons). This commit builds on the addition of a mapping version to the index metadata to only fetch mapping updates when the mapping version increases. This reduces the number of these fetches and application of mappings on the follower to the bare minimum.

Relates #33147
