### PR TITLE
Build analysis-icu client JAR

### DIFF
--- a/plugins/analysis-icu/build.gradle
+++ b/plugins/analysis-icu/build.gradle
@@ -22,6 +22,7 @@ import org.elasticsearch.gradle.precommit.ForbiddenApisCliTask
 esplugin {
   description 'The ICU Analysis plugin integrates Lucene ICU module into elasticsearch, adding ICU relates analysis components.'
   classname 'org.elasticsearch.plugin.analysis.icu.AnalysisICUPlugin'
+  hasClientJar = true
 }
 
 tasks.withType(ForbiddenApisCliTask) {


### PR DESCRIPTION
This plugin needs to be able to be installed client side because it contains doc values formats that can be returned to the transport client. To keep this simple for developers, we publish the client JAR to Maven so that they can depend on the plugin in their POM and install the plugin there.