### PR TITLE
DOCS: Make ellipsis optional in /cat/thread_pool

### DIFF
--- a/docs/reference/cat/thread_pool.asciidoc
+++ b/docs/reference/cat/thread_pool.asciidoc
@@ -22,7 +22,7 @@ node-0 flush               0 0 0
 ...
 node-0 write               0 0 0
 --------------------------------------------------
-// TESTRESPONSE[s/\.\.\./(node-0 \\S+ 0 0 0\n)+/]
+// TESTRESPONSE[s/\.\.\./(node-0 \\S+ 0 0 0\n)*/]
 // TESTRESPONSE[s/\d+/\\d+/ _cat]
 // The substitutions do two things:
 // 1. Expect any number of extra thread pools. This allows us to only list a

--- a/docs/reference/cat/thread_pool.asciidoc
+++ b/docs/reference/cat/thread_pool.asciidoc
@@ -16,9 +16,10 @@ Which looks like:
 --------------------------------------------------
 node-0 analyze             0 0 0
 ...
-node-0 fetch_shard_started 0 0 0
 node-0 fetch_shard_store   0 0 0
 node-0 flush               0 0 0
+...
+node-0 search              0 0 0
 ...
 node-0 write               0 0 0
 --------------------------------------------------

--- a/docs/reference/cat/thread_pool.asciidoc
+++ b/docs/reference/cat/thread_pool.asciidoc
@@ -16,10 +16,9 @@ Which looks like:
 --------------------------------------------------
 node-0 analyze             0 0 0
 ...
+node-0 fetch_shard_started 0 0 0
 node-0 fetch_shard_store   0 0 0
 node-0 flush               0 0 0
-...
-node-0 search              0 0 0
 ...
 node-0 write               0 0 0
 --------------------------------------------------


### PR DESCRIPTION
The fix proposed in #31442 fails with the oss distro because the added
3dots does not match anything with the default oss while a 3dots
expression requires matching at least one thread pool.

This change makes a 3dots optional so the thread_pool list can match 
both the oss distro (without ccr) and default distro (with ccr).

Relates #31442
