### PR TITLE
Fix ShardFollowNodeTask.Status equals and hash code

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
@@ -688,7 +688,7 @@ public abstract class ShardFollowNodeTask extends AllocatedPersistentTask {
             this.numberOfSuccessfulBulkOperations = numberOfSuccessfulBulkOperations;
             this.numberOfFailedBulkOperations = numberOfFailedBulkOperations;
             this.numberOfOperationsIndexed = numberOfOperationsIndexed;
-            this.fetchExceptions = fetchExceptions;
+            this.fetchExceptions = Objects.requireNonNull(fetchExceptions);
         }
 
         public Status(final StreamInput in) throws IOException {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
@@ -822,7 +822,8 @@ public abstract class ShardFollowNodeTask extends AllocatedPersistentTask {
                     operationsReceived == that.operationsReceived &&
                     totalTransferredBytes == that.totalTransferredBytes &&
                     numberOfSuccessfulBulkOperations == that.numberOfSuccessfulBulkOperations &&
-                    numberOfFailedBulkOperations == that.numberOfFailedBulkOperations;
+                    numberOfFailedBulkOperations == that.numberOfFailedBulkOperations &&
+                    fetchExceptions.equals(that.fetchExceptions);
         }
 
         @Override
@@ -844,7 +845,8 @@ public abstract class ShardFollowNodeTask extends AllocatedPersistentTask {
                     operationsReceived,
                     totalTransferredBytes,
                     numberOfSuccessfulBulkOperations,
-                    numberOfFailedBulkOperations);
+                    numberOfFailedBulkOperations,
+                    fetchExceptions);
 
         }
 


### PR DESCRIPTION
These were broken when fetch exceptions were introduced to the status object but equals and hash code were not updated then. This commit addresses that.

