### PR TITLE
Consider multi release jars when running third party audit

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -87,6 +87,7 @@ class PrecommitTasks {
             dependsOn(buildResources)
             signatureFile = buildResources.copy("forbidden/third-party-audit.txt")
             javaHome = project.runtimeJavaHome
+            targetCompatibility = project.runtimeJavaVersion
         }
         return thirdPartyAuditTask
     }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -304,21 +304,6 @@ thirdPartyAudit.excludes = [
   'com.google.common.geometry.S2LatLng',
 ]
 
-if (project.runtimeJavaVersion <= JavaVersion.VERSION_1_8) {
-  thirdPartyAudit.excludes += [
-          // Used by Log4J 2.11.1
-            'java.io.ObjectInputFilter',
-            'java.io.ObjectInputFilter$Config',
-            'java.io.ObjectInputFilter$FilterInfo',
-            'java.io.ObjectInputFilter$Status',
-          // added in 9
-            'java.lang.ProcessHandle',
-            'java.lang.StackWalker',
-            'java.lang.StackWalker$Option',
-            'java.lang.StackWalker$StackFrame'
-  ]
-}
-
 if (project.runtimeJavaVersion > JavaVersion.VERSION_1_8) {
   thirdPartyAudit.excludes += ['javax.xml.bind.DatatypeConverter']
 }

--- a/test/logger-usage/build.gradle
+++ b/test/logger-usage/build.gradle
@@ -43,22 +43,3 @@ thirdPartyAudit.excludes = [
   'org.osgi.framework.wiring.BundleWire',
   'org.osgi.framework.wiring.BundleWiring'
 ]
-
-if (project.runtimeJavaVersion <= JavaVersion.VERSION_1_8) {
-  // Used by Log4J 2.11.1
-  thirdPartyAudit.excludes += [
-    'java.io.ObjectInputFilter',
-    'java.io.ObjectInputFilter$Config',
-    'java.io.ObjectInputFilter$FilterInfo',
-    'java.io.ObjectInputFilter$Status'
-  ]
-}
-
-if (project.runtimeJavaVersion == JavaVersion.VERSION_1_8) {
-  thirdPartyAudit.excludes += [
-     'java.lang.ProcessHandle',
-     'java.lang.StackWalker',
-     'java.lang.StackWalker$Option',
-     'java.lang.StackWalker$StackFrame'
-  ]
-}

--- a/x-pack/plugin/sql/sql-action/build.gradle
+++ b/x-pack/plugin/sql/sql-action/build.gradle
@@ -139,22 +139,3 @@ thirdPartyAudit.excludes = [
         'org.zeromq.ZMQ$Socket',
         'org.zeromq.ZMQ'
 ]
-
-if (project.runtimeJavaVersion <= JavaVersion.VERSION_1_8) {
-    // Used by Log4J 2.11.1
-    thirdPartyAudit.excludes += [
-      'java.io.ObjectInputFilter',
-      'java.io.ObjectInputFilter$Config',
-      'java.io.ObjectInputFilter$FilterInfo',
-      'java.io.ObjectInputFilter$Status'
-    ]
-}
-
-if (project.runtimeJavaVersion == JavaVersion.VERSION_1_8) {
-    thirdPartyAudit.excludes += [
-      'java.lang.ProcessHandle',
-      'java.lang.StackWalker',
-      'java.lang.StackWalker$Option',
-      'java.lang.StackWalker$StackFrame'
-    ]
-}


### PR DESCRIPTION
Exclude classes meant for newer versions than what we are auditing against, those classes won't be found. There's no reason to exclude JDK classes from newer versions, with this PR,  we will not extract them in the first place.