### PR TITLE
ingest: minor - update test to include dissect

### DIFF
--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/10_basic.yml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/10_basic.yml
@@ -10,9 +10,11 @@
 
     - contains:  { nodes.$master.modules: { name: ingest-common } }
     - contains:  { nodes.$master.ingest.processors: { type: append } }
+    - contains:  { nodes.$master.ingest.processors: { type: bytes } }
     - contains:  { nodes.$master.ingest.processors: { type: convert } }
     - contains:  { nodes.$master.ingest.processors: { type: date } }
     - contains:  { nodes.$master.ingest.processors: { type: date_index_name } }
+    - contains:  { nodes.$master.ingest.processors: { type: dissect } }
     - contains:  { nodes.$master.ingest.processors: { type: dot_expander } }
     - contains:  { nodes.$master.ingest.processors: { type: fail } }
     - contains:  { nodes.$master.ingest.processors: { type: foreach } }
@@ -30,4 +32,3 @@
     - contains:  { nodes.$master.ingest.processors: { type: split } }
     - contains:  { nodes.$master.ingest.processors: { type: trim } }
     - contains:  { nodes.$master.ingest.processors: { type: uppercase } }
-    - contains:  { nodes.$master.ingest.processors: { type: bytes } }


### PR DESCRIPTION
This change also includes placing the bytes processor in the correct
order (helps to avoid merge conflict when back patching processors)
