### PR TITLE
[Kerberos] Skip unsupported languages for tests

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
@@ -74,6 +74,13 @@ public abstract class KerberosTestCase extends ESTestCase {
         unsupportedLocaleLanguages.add("ne");
         unsupportedLocaleLanguages.add("dz");
         unsupportedLocaleLanguages.add("mzn");
+        unsupportedLocaleLanguages.add("mr");
+        unsupportedLocaleLanguages.add("as");
+        unsupportedLocaleLanguages.add("bn");
+        unsupportedLocaleLanguages.add("lrc");
+        unsupportedLocaleLanguages.add("my");
+        unsupportedLocaleLanguages.add("ps");
+        unsupportedLocaleLanguages.add("ur");
     }
 
     @BeforeClass


### PR DESCRIPTION
Ran for all locales in the system to find locales which caused
problems in tests due to incorrect generalized time handling
in SimpleKdcServer.

Closes#33228