### PR TITLE
[DOCS] TLS file resources are reloadable

### DIFF
--- a/x-pack/docs/en/security/securing-communications/tls-http.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-http.asciidoc
@@ -81,3 +81,8 @@ NOTE: All TLS-related node settings are considered to be highly sensitive and
 therefore are not exposed via the
 {ref}/cluster-nodes-info.html#cluster-nodes-info[nodes info API] For more
 information about any of these settings, see <<security-settings>>.
+
+NOTE: {es} monitors all files (certificates, keys, keystores, truststores) that
+are configured as values of TLS-related node settings and will reload them upon
+modification. Files are polled for changes at a frequency determined by the global
+{es} `resource.reload.interval.high` setting, which defaults to 5 seconds.

--- a/x-pack/docs/en/security/securing-communications/tls-http.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-http.asciidoc
@@ -77,12 +77,17 @@ bin/elasticsearch-keystore add xpack.security.http.ssl.secure_key_passphrase
 
 . Restart {es}.
 
-NOTE: All TLS-related node settings are considered to be highly sensitive and
+[NOTE]
+===============================
+* All TLS-related node settings are considered to be highly sensitive and
 therefore are not exposed via the
 {ref}/cluster-nodes-info.html#cluster-nodes-info[nodes info API] For more
 information about any of these settings, see <<security-settings>>.
 
-NOTE: {es} monitors all files (certificates, keys, keystores, truststores) that
-are configured as values of TLS-related node settings and will reload them upon
-modification. Files are polled for changes at a frequency determined by the global
-{es} `resource.reload.interval.high` setting, which defaults to 5 seconds.
+* {es} monitors all files such as certificates, keys, keystores, or truststores 
+that are configured as values of TLS-related node settings. If you update any of 
+these files (for example, when your hostnames change or your certificates are 
+due to expire), {es} reloads them. The files are polled for changes at 
+a frequency determined by the global {es} `resource.reload.interval.high` 
+setting, which defaults to 5 seconds.
+===============================

--- a/x-pack/docs/en/security/securing-communications/tls-http.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-http.asciidoc
@@ -75,15 +75,14 @@ bin/elasticsearch-keystore add xpack.security.http.ssl.secure_key_passphrase
 -----------------------------------------------------------
 --
 
-. (Optional) Change how often the certificates, keys, keystores, and truststores 
-are checked. {es} monitors all files that are configured as values of 
-TLS-related node settings and reloads them when they change. By default, files 
-are polled for changes every 5 seconds. To change this interval, use the {es} 
-`resource.reload.interval.high` setting. 
-
 . Restart {es}.
 
 NOTE: All TLS-related node settings are considered to be highly sensitive and
 therefore are not exposed via the
 {ref}/cluster-nodes-info.html#cluster-nodes-info[nodes info API] For more
 information about any of these settings, see <<security-settings>>.
+
+NOTE: {es} monitors all files (certificates, keys, keystores, truststores) that
+are configured as values of TLS-related node settings and will reload them upon
+modification. Files are polled for changes at a frequency determined by the global
+{es} `resource.reload.interval.high` setting, which defaults to 5 seconds.

--- a/x-pack/docs/en/security/securing-communications/tls-http.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-http.asciidoc
@@ -75,14 +75,15 @@ bin/elasticsearch-keystore add xpack.security.http.ssl.secure_key_passphrase
 -----------------------------------------------------------
 --
 
+. (Optional) Change how often the certificates, keys, keystores, and truststores 
+are checked. {es} monitors all files that are configured as values of 
+TLS-related node settings and reloads them when they change. By default, files 
+are polled for changes every 5 seconds. To change this interval, use the {es} 
+`resource.reload.interval.high` setting. 
+
 . Restart {es}.
 
 NOTE: All TLS-related node settings are considered to be highly sensitive and
 therefore are not exposed via the
 {ref}/cluster-nodes-info.html#cluster-nodes-info[nodes info API] For more
 information about any of these settings, see <<security-settings>>.
-
-NOTE: {es} monitors all files (certificates, keys, keystores, truststores) that
-are configured as values of TLS-related node settings and will reload them upon
-modification. Files are polled for changes at a frequency determined by the global
-{es} `resource.reload.interval.high` setting, which defaults to 5 seconds.

--- a/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
@@ -86,6 +86,12 @@ bin/elasticsearch-keystore add xpack.security.transport.ssl.secure_key_passphras
 -----------------------------------------------------------
 --
 
+. (Optional) Change how often the certificates, keys, keystores, and truststores 
+are checked. {es} monitors all files that are configured as values of 
+TLS-related node settings and reloads them when they change. By default, files 
+are polled for changes every 5 seconds. To change this interval, use the {es} 
+`resource.reload.interval.high` setting. 
+
 . Restart {es}.
 +
 --
@@ -99,8 +105,3 @@ NOTE: All TLS-related node settings are considered to be highly sensitive and
 therefore are not exposed via the
 {ref}/cluster-nodes-info.html#cluster-nodes-info[nodes info API] For more
 information about any of these settings, see <<security-settings>>.
-
-NOTE: {es} monitors all files (certificates, keys, keystores, truststores) that
-are configured as values of TLS-related node settings and will reload them upon
-modification. Files are polled for changes at a frequency determined by the global
-{es} `resource.reload.interval.high` setting, which defaults to 5 seconds.

--- a/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
@@ -95,12 +95,17 @@ vice-versa). After enabling TLS you must restart all nodes in order to maintain
 communication across the cluster.
 --
 
-NOTE: All TLS-related node settings are considered to be highly sensitive and
+[NOTE]
+===============================
+* All TLS-related node settings are considered to be highly sensitive and
 therefore are not exposed via the
 {ref}/cluster-nodes-info.html#cluster-nodes-info[nodes info API] For more
 information about any of these settings, see <<security-settings>>.
 
-NOTE: {es} monitors all files (certificates, keys, keystores, truststores) that
-are configured as values of TLS-related node settings and will reload them upon
-modification. Files are polled for changes at a frequency determined by the global
-{es} `resource.reload.interval.high` setting, which defaults to 5 seconds.
+* {es} monitors all files such as certificates, keys, keystores, or truststores 
+that are configured as values of TLS-related node settings. If you update any of 
+these files (for example, when your hostnames change or your certificates are 
+due to expire), {es} reloads them. The files are polled for changes at 
+a frequency determined by the global {es} `resource.reload.interval.high` 
+setting, which defaults to 5 seconds.
+===============================

--- a/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
@@ -86,12 +86,6 @@ bin/elasticsearch-keystore add xpack.security.transport.ssl.secure_key_passphras
 -----------------------------------------------------------
 --
 
-. (Optional) Change how often the certificates, keys, keystores, and truststores 
-are checked. {es} monitors all files that are configured as values of 
-TLS-related node settings and reloads them when they change. By default, files 
-are polled for changes every 5 seconds. To change this interval, use the {es} 
-`resource.reload.interval.high` setting. 
-
 . Restart {es}.
 +
 --
@@ -105,3 +99,8 @@ NOTE: All TLS-related node settings are considered to be highly sensitive and
 therefore are not exposed via the
 {ref}/cluster-nodes-info.html#cluster-nodes-info[nodes info API] For more
 information about any of these settings, see <<security-settings>>.
+
+NOTE: {es} monitors all files (certificates, keys, keystores, truststores) that
+are configured as values of TLS-related node settings and will reload them upon
+modification. Files are polled for changes at a frequency determined by the global
+{es} `resource.reload.interval.high` setting, which defaults to 5 seconds.

--- a/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
@@ -99,3 +99,8 @@ NOTE: All TLS-related node settings are considered to be highly sensitive and
 therefore are not exposed via the
 {ref}/cluster-nodes-info.html#cluster-nodes-info[nodes info API] For more
 information about any of these settings, see <<security-settings>>.
+
+NOTE: {es} monitors all files (certificates, keys, keystores, truststores) that
+are configured as values of TLS-related node settings and will reload them upon
+modification. Files are polled for changes at a frequency determined by the global
+{es} `resource.reload.interval.high` setting, which defaults to 5 seconds.


### PR DESCRIPTION
Make clearer that file resources that are used as key trust material
are polled and will be reloaded upon modification.