### PR TITLE
Renames XPackField.INDEX _LIFCYCLE value to "ilm"

### DIFF
--- a/docs/reference/rest-api/info.asciidoc
+++ b/docs/reference/rest-api/info.asciidoc
@@ -67,7 +67,7 @@ Example response:
          "available" : false,
          "enabled" : true
       },
-      "index_lifecycle" : {
+      "ilm" : {
          "description" : "Index lifecycle management for the Elastic Stack",
          "available" : true,
          "enabled" : true

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackField.java
@@ -32,7 +32,7 @@ public final class XPackField {
     /** Name constant for the rollup feature. */
     public static final String ROLLUP = "rollup";
     /** Name constant for the index lifecycle feature. */
-    public static final String INDEX_LIFECYCLE = "index_lifecycle";
+    public static final String INDEX_LIFECYCLE = "ilm";
 
     private XPackField() {}
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycle.java
@@ -90,7 +90,6 @@ import java.util.function.Supplier;
 import static java.util.Collections.emptyList;
 
 public class IndexLifecycle extends Plugin implements ActionPlugin {
-    public static final String NAME = "index_lifecycle";
     private final SetOnce<IndexLifecycleService> indexLifecycleInitialisationService = new SetOnce<>();
     private Settings settings;
     private boolean enabled;

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleService.java
@@ -23,10 +23,11 @@ import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.xpack.core.indexlifecycle.OperationMode;
+import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.indexlifecycle.IndexLifecycleMetadata;
 import org.elasticsearch.xpack.core.indexlifecycle.LifecyclePolicy;
 import org.elasticsearch.xpack.core.indexlifecycle.LifecycleSettings;
+import org.elasticsearch.xpack.core.indexlifecycle.OperationMode;
 import org.elasticsearch.xpack.core.indexlifecycle.ShrinkAction;
 import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
@@ -120,7 +121,7 @@ public class IndexLifecycleService extends AbstractComponent
                 scheduler.set(new SchedulerEngine(settings, clock));
                 scheduler.get().register(this);
             }
-            scheduledJob = new SchedulerEngine.Job(IndexLifecycle.NAME, new TimeValueSchedule(pollInterval));
+            scheduledJob = new SchedulerEngine.Job(XPackField.INDEX_LIFECYCLE, new TimeValueSchedule(pollInterval));
             scheduler.get().add(scheduledJob);
         }
     }
@@ -151,14 +152,14 @@ public class IndexLifecycleService extends AbstractComponent
 
     private void cancelJob() {
         if (scheduler.get() != null) {
-            scheduler.get().remove(IndexLifecycle.NAME);
+            scheduler.get().remove(XPackField.INDEX_LIFECYCLE);
             scheduledJob = null;
         }
     }
 
     @Override
     public void triggered(SchedulerEngine.Event event) {
-        if (event.getJobName().equals(IndexLifecycle.NAME)) {
+        if (event.getJobName().equals(XPackField.INDEX_LIFECYCLE)) {
             logger.trace("job triggered: " + event.getJobName() + ", " + event.getScheduledTime() + ", " + event.getTriggeredTime());
             triggerPolicies(clusterService.state(), false);
         }


### PR DESCRIPTION
This brings the name in line with everywhere else and means that name
seen on the feature usage and `GET _xpack` APIs will match the plugin
name.

This change also removes `IndexLifcycle.NAME` since this was only used
to name the scheduler job and that can be done using
`XPackField.INDEX_LIFECYCLE` instead

