### PR TITLE
[ML] Change Datafeed actions to read config from the config index

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.core.ml;
 
-import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.AbstractDiffable;
@@ -295,7 +294,7 @@ public class MlMetadata implements XPackPlugin.XPackMetaDataCustom {
 
         public Builder putDatafeed(DatafeedConfig datafeedConfig, Map<String, String> headers) {
             if (datafeeds.containsKey(datafeedConfig.getId())) {
-                throw new ResourceAlreadyExistsException("A datafeed with id [" + datafeedConfig.getId() + "] already exists");
+                throw ExceptionsHelper.datafeedAlreadyExists(datafeedConfig.getId());
             }
             String jobId = datafeedConfig.getJobId();
             checkJobIsAvailableForDatafeed(jobId);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
@@ -204,7 +204,7 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
         }
     }
 
-    String getJobId() {
+    public String getJobId() {
         return jobId;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -41,7 +41,7 @@ public final class Messages {
     public static final String DATAFEED_MISSING_MAX_AGGREGATION_FOR_TIME_FIELD = "Missing max aggregation for time_field [{0}]";
     public static final String DATAFEED_FREQUENCY_MUST_BE_MULTIPLE_OF_AGGREGATIONS_INTERVAL =
             "Datafeed frequency [{0}] must be a multiple of the aggregation interval [{1}]";
-    public static final String DATAFEED_ID_ALREADY_TAKEN = "A datafeed with Id [{0}] already exists";
+    public static final String DATAFEED_ID_ALREADY_TAKEN = "A datafeed with id [{0}] already exists";
 
     public static final String FILTER_NOT_FOUND = "No filter with id [{0}] exists";
     public static final String FILTER_CONTAINS_TOO_MANY_ITEMS = "Filter [{0}] contains too many items; up to [{1}] items are allowed";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -41,6 +41,7 @@ public final class Messages {
     public static final String DATAFEED_MISSING_MAX_AGGREGATION_FOR_TIME_FIELD = "Missing max aggregation for time_field [{0}]";
     public static final String DATAFEED_FREQUENCY_MUST_BE_MULTIPLE_OF_AGGREGATIONS_INTERVAL =
             "Datafeed frequency [{0}] must be a multiple of the aggregation interval [{1}]";
+    public static final String DATAFEED_ID_ALREADY_TAKEN = "A datafeed with Id [{0}] already exists";
 
     public static final String FILTER_NOT_FOUND = "No filter with id [{0}] exists";
     public static final String FILTER_CONTAINS_TOO_MANY_ITEMS = "Filter [{0}] contains too many items; up to [{1}] items are allowed";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExceptionsHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExceptionsHelper.java
@@ -30,6 +30,10 @@ public class ExceptionsHelper {
         return new ResourceNotFoundException(Messages.getMessage(Messages.DATAFEED_NOT_FOUND, datafeedId));
     }
 
+    public static ResourceAlreadyExistsException datafeedAlreadyExists(String datafeedId) {
+        return new ResourceAlreadyExistsException(Messages.getMessage(Messages.DATAFEED_ID_ALREADY_TAKEN, datafeedId));
+    }
+
     public static ElasticsearchException serverError(String msg) {
         return new ElasticsearchException(msg);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
@@ -123,6 +123,7 @@ public class TransportDeleteDatafeedAction extends TransportMasterNodeAction<Del
         if (MlTasks.getDatafeedTask(request.getDatafeedId(), tasks) != null) {
             listener.onFailure(ExceptionsHelper.conflictStatusException(
                     Messages.getMessage(Messages.DATAFEED_CANNOT_DELETE_IN_CURRENT_STATE, request.getDatafeedId(), DatafeedState.STARTED)));
+            return;
         }
 
         datafeedConfigProvider.deleteDatafeedConfig(request.getDatafeedId(), ActionListener.wrap(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
@@ -11,42 +11,48 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.persistent.PersistentTasksService;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.core.XPackPlugin;
-import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.DeleteDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.IsolateDatafeedAction;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
+import org.elasticsearch.xpack.core.ml.job.messages.Messages;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
 public class TransportDeleteDatafeedAction extends TransportMasterNodeAction<DeleteDatafeedAction.Request, AcknowledgedResponse> {
 
-    private Client client;
-    private PersistentTasksService persistentTasksService;
+    private final Client client;
+    private final DatafeedConfigProvider datafeedConfigProvider;
+    private final ClusterService clusterService;
+    private final PersistentTasksService persistentTasksService;
 
     @Inject
     public TransportDeleteDatafeedAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                          ThreadPool threadPool, ActionFilters actionFilters,
                                          IndexNameExpressionResolver indexNameExpressionResolver,
-                                         Client client, PersistentTasksService persistentTasksService) {
+                                         Client client, PersistentTasksService persistentTasksService,
+                                         NamedXContentRegistry xContentRegistry) {
         super(settings, DeleteDatafeedAction.NAME, transportService, clusterService, threadPool, actionFilters,
                 indexNameExpressionResolver, DeleteDatafeedAction.Request::new);
         this.client = client;
+        this.datafeedConfigProvider = new DatafeedConfigProvider(client, settings, xContentRegistry);
         this.persistentTasksService = persistentTasksService;
+        this.clusterService = clusterService;
     }
 
     @Override
@@ -65,14 +71,14 @@ public class TransportDeleteDatafeedAction extends TransportMasterNodeAction<Del
         if (request.isForce()) {
             forceDeleteDatafeed(request, state, listener);
         } else {
-            deleteDatafeedFromMetadata(request, listener);
+            deleteDatafeedConfig(request, listener);
         }
     }
 
     private void forceDeleteDatafeed(DeleteDatafeedAction.Request request, ClusterState state,
                                      ActionListener<AcknowledgedResponse> listener) {
         ActionListener<Boolean> finalListener = ActionListener.wrap(
-                response -> deleteDatafeedFromMetadata(request, listener),
+                response -> deleteDatafeedConfig(request, listener),
                 listener::onFailure
         );
 
@@ -111,28 +117,18 @@ public class TransportDeleteDatafeedAction extends TransportMasterNodeAction<Del
         }
     }
 
-    private void deleteDatafeedFromMetadata(DeleteDatafeedAction.Request request, ActionListener<AcknowledgedResponse> listener) {
-        clusterService.submitStateUpdateTask("delete-datafeed-" + request.getDatafeedId(),
-                new AckedClusterStateUpdateTask<AcknowledgedResponse>(request, listener) {
+    private void deleteDatafeedConfig(DeleteDatafeedAction.Request request, ActionListener<AcknowledgedResponse> listener) {
+        // Check datafeed is stopped
+        PersistentTasksCustomMetaData tasks = clusterService.state().getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
+        if (MlTasks.getDatafeedTask(request.getDatafeedId(), tasks) != null) {
+            listener.onFailure(ExceptionsHelper.conflictStatusException(
+                    Messages.getMessage(Messages.DATAFEED_CANNOT_DELETE_IN_CURRENT_STATE, request.getDatafeedId(), DatafeedState.STARTED)));
+        }
 
-                    @Override
-                    protected AcknowledgedResponse newResponse(boolean acknowledged) {
-                        return new AcknowledgedResponse(acknowledged);
-                    }
-
-                    @Override
-                    public ClusterState execute(ClusterState currentState) {
-                        XPackPlugin.checkReadyForXPackCustomMetadata(currentState);
-                        MlMetadata currentMetadata = MlMetadata.getMlMetadata(currentState);
-                        PersistentTasksCustomMetaData persistentTasks =
-                                currentState.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
-                        MlMetadata newMetadata = new MlMetadata.Builder(currentMetadata)
-                                .removeDatafeed(request.getDatafeedId(), persistentTasks).build();
-                        return ClusterState.builder(currentState).metaData(
-                                MetaData.builder(currentState.getMetaData()).putCustom(MlMetadata.TYPE, newMetadata).build())
-                                .build();
-                    }
-                });
+        datafeedConfigProvider.deleteDatafeedConfig(request.getDatafeedId(), ActionListener.wrap(
+                deleteResponse -> listener.onResponse(new AcknowledgedResponse(true)),
+                listener::onFailure
+        ));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
@@ -80,7 +80,7 @@ public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<G
                     }
 
                     // Merge cluster state and index configs
-                    List<DatafeedConfig> datafeeds = new ArrayList<>();
+                    List<DatafeedConfig> datafeeds = new ArrayList<>(datafeedBuilders.size() + clusterStateConfigs.values().size());
                     for (DatafeedConfig.Builder builder: datafeedBuilders) {
                         datafeeds.add(builder.build());
                     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml.action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -15,27 +16,38 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsAction;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<GetDatafeedsAction.Request,
         GetDatafeedsAction.Response> {
 
+    private final DatafeedConfigProvider datafeedConfigProvider;
+
     @Inject
     public TransportGetDatafeedsAction(Settings settings, TransportService transportService,
                                        ClusterService clusterService, ThreadPool threadPool,
                                        ActionFilters actionFilters,
-                                       IndexNameExpressionResolver indexNameExpressionResolver) {
+                                       IndexNameExpressionResolver indexNameExpressionResolver,
+                                       Client client, NamedXContentRegistry xContentRegistry) {
         super(settings, GetDatafeedsAction.NAME, transportService, clusterService, threadPool, actionFilters,
                 indexNameExpressionResolver, GetDatafeedsAction.Request::new);
+
+        datafeedConfigProvider = new DatafeedConfigProvider(client, settings, xContentRegistry);
     }
 
     @Override
@@ -50,18 +62,51 @@ public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<G
 
     @Override
     protected void masterOperation(GetDatafeedsAction.Request request, ClusterState state,
-                                   ActionListener<GetDatafeedsAction.Response> listener) throws Exception {
+                                   ActionListener<GetDatafeedsAction.Response> listener) {
         logger.debug("Get datafeed '{}'", request.getDatafeedId());
 
-        MlMetadata mlMetadata = MlMetadata.getMlMetadata(state);
-        Set<String> expandedDatafeedIds = mlMetadata.expandDatafeedIds(request.getDatafeedId(), request.allowNoDatafeeds());
-        List<DatafeedConfig> datafeedConfigs = new ArrayList<>();
+        Map<String, DatafeedConfig> clusterStateConfigs =
+                expandClusterStateDatafeeds(request.getDatafeedId(), request.allowNoDatafeeds(), state);
+
+        datafeedConfigProvider.expandDatafeedConfigs(request.getDatafeedId(), request.allowNoDatafeeds(), ActionListener.wrap(
+                datafeedBuilders -> {
+                    // Check for duplicate datafeeds
+                    for (DatafeedConfig.Builder datafeed : datafeedBuilders) {
+                        if (clusterStateConfigs.containsKey(datafeed.getId())) {
+                            listener.onFailure(new IllegalStateException("Datafeed [" + datafeed.getId() + "] configuration " +
+                                    "exists in both clusterstate and index"));
+                            return;
+                        }
+                    }
+
+                    // Merge cluster state and index configs
+                    List<DatafeedConfig> datafeeds = new ArrayList<>();
+                    for (DatafeedConfig.Builder builder: datafeedBuilders) {
+                        datafeeds.add(builder.build());
+                    }
+
+                    datafeeds.addAll(clusterStateConfigs.values());
+                    Collections.sort(datafeeds, Comparator.comparing(DatafeedConfig::getId));
+                    listener.onResponse(new GetDatafeedsAction.Response(new QueryPage<>(datafeeds, datafeeds.size(),
+                            DatafeedConfig.RESULTS_FIELD)));
+                },
+                listener::onFailure
+        ));
+    }
+
+    Map<String, DatafeedConfig> expandClusterStateDatafeeds(String datafeedExpression, boolean allowNoDatafeeds,
+                                                            ClusterState clusterState) {
+
+        Map<String, DatafeedConfig> configById = new HashMap<>();
+
+        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
+        Set<String> expandedDatafeedIds = mlMetadata.expandDatafeedIds(datafeedExpression, allowNoDatafeeds);
+
         for (String expandedDatafeedId : expandedDatafeedIds) {
-            datafeedConfigs.add(mlMetadata.getDatafeed(expandedDatafeedId));
+            configById.put(expandedDatafeedId, mlMetadata.getDatafeed(expandedDatafeedId));
         }
 
-        listener.onResponse(new GetDatafeedsAction.Response(new QueryPage<>(datafeedConfigs, datafeedConfigs.size(),
-                DatafeedConfig.RESULTS_FIELD)));
+        return configById;
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDatafeedAction.java
@@ -152,7 +152,7 @@ public class TransportPutDatafeedAction extends TransportMasterNodeAction<PutDat
         };
 
         CheckedConsumer<Boolean, Exception> jobOk = ok ->
-            validateDatafeedAgainstJob(request.getDatafeed(), ActionListener.wrap(validationOk, listener::onFailure));;
+            validateDatafeedAgainstJob(request.getDatafeed(), ActionListener.wrap(validationOk, listener::onFailure));
 
         checkJobDoesNotHaveADatafeed(jobId, ActionListener.wrap(jobOk, listener::onFailure));
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDatafeedAction.java
@@ -5,21 +5,23 @@
  */
 package org.elasticsearch.xpack.ml.action;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.CheckedConsumer;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.license.LicenseUtils;
@@ -28,16 +30,20 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackField;
-import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedJobValidator;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesAction;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesRequest;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.support.Exceptions;
+import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
+import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 
 import java.io.IOException;
 import java.util.Map;
@@ -46,20 +52,26 @@ public class TransportPutDatafeedAction extends TransportMasterNodeAction<PutDat
 
     private final XPackLicenseState licenseState;
     private final Client client;
-
+    private final ClusterService clusterService;
     private final SecurityContext securityContext;
+    private final DatafeedConfigProvider datafeedConfigProvider;
+    private final JobConfigProvider jobConfigProvider;
 
     @Inject
     public TransportPutDatafeedAction(Settings settings, TransportService transportService,
                                       ClusterService clusterService, ThreadPool threadPool, Client client,
                                       XPackLicenseState licenseState, ActionFilters actionFilters,
-                                      IndexNameExpressionResolver indexNameExpressionResolver) {
+                                      IndexNameExpressionResolver indexNameExpressionResolver,
+                                      NamedXContentRegistry xContentRegistry) {
         super(settings, PutDatafeedAction.NAME, transportService, clusterService, threadPool,
                 actionFilters, indexNameExpressionResolver, PutDatafeedAction.Request::new);
         this.licenseState = licenseState;
         this.client = client;
+        this.clusterService = clusterService;
         this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings) ?
                 new SecurityContext(settings, threadPool.getThreadContext()) : null;
+        this.datafeedConfigProvider = new DatafeedConfigProvider(client, settings, xContentRegistry);
+        this.jobConfigProvider = new JobConfigProvider(client, settings);
     }
 
     @Override
@@ -124,33 +136,74 @@ public class TransportPutDatafeedAction extends TransportMasterNodeAction<PutDat
     private void putDatafeed(PutDatafeedAction.Request request, Map<String, String> headers,
                              ActionListener<PutDatafeedAction.Response> listener) {
 
-        clusterService.submitStateUpdateTask(
-                "put-datafeed-" + request.getDatafeed().getId(),
-                new AckedClusterStateUpdateTask<PutDatafeedAction.Response>(request, listener) {
+        String datafeedId = request.getDatafeed().getId();
+        String jobId = request.getDatafeed().getJobId();
+        ElasticsearchException validationError = checkConfigsAreNotDefinedInClusterState(datafeedId, jobId);
+        if (validationError != null) {
+            listener.onFailure(validationError);
+            return;
+        }
 
-                    @Override
-                    protected PutDatafeedAction.Response newResponse(boolean acknowledged) {
-                        if (acknowledged) {
-                            logger.info("Created datafeed [{}]", request.getDatafeed().getId());
-                        }
-                        return new PutDatafeedAction.Response(request.getDatafeed());
-                    }
+        CheckedConsumer<Boolean, Exception> validationOk = ok -> {
+            datafeedConfigProvider.putDatafeedConfig(request.getDatafeed(), headers, ActionListener.wrap(
+                    indexResponse -> listener.onResponse(new PutDatafeedAction.Response(request.getDatafeed())),
+                    listener::onFailure
+            ));
+        };
 
-                    @Override
-                    public ClusterState execute(ClusterState currentState) {
-                        return putDatafeed(request, headers, currentState);
-                    }
-                });
+        CheckedConsumer<Boolean, Exception> jobOk = ok ->
+            validateDatafeedAgainstJob(request.getDatafeed(), ActionListener.wrap(validationOk, listener::onFailure));;
+
+        checkJobDoesNotHaveADatafeed(jobId, ActionListener.wrap(jobOk, listener::onFailure));
     }
 
-    private ClusterState putDatafeed(PutDatafeedAction.Request request, Map<String, String> headers, ClusterState clusterState) {
-        XPackPlugin.checkReadyForXPackCustomMetadata(clusterState);
-        MlMetadata currentMetadata = MlMetadata.getMlMetadata(clusterState);
-        MlMetadata newMetadata = new MlMetadata.Builder(currentMetadata)
-                .putDatafeed(request.getDatafeed(), headers).build();
-        return ClusterState.builder(clusterState).metaData(
-                MetaData.builder(clusterState.getMetaData()).putCustom(MlMetadata.TYPE, newMetadata).build())
-                .build();
+    /**
+     * Returns an exception if a datafeed with the same Id is defined in the
+     * cluster state or the job is in the cluster state and already has a datafeed
+     */
+    @Nullable
+    private ElasticsearchException checkConfigsAreNotDefinedInClusterState(String datafeedId, String jobId) {
+        ClusterState clusterState = clusterService.state();
+        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
+
+        if (mlMetadata.getDatafeed(datafeedId) != null) {
+            return ExceptionsHelper.datafeedAlreadyExists(datafeedId);
+        }
+
+        if (mlMetadata.getDatafeedByJobId(jobId).isPresent()) {
+            return ExceptionsHelper.conflictStatusException("Cannot create datafeed [" + datafeedId + "] as a " +
+                    "job [" + jobId + "] defined in the cluster state references a datafeed with the same Id");
+        }
+
+        return null;
+    }
+
+    private void checkJobDoesNotHaveADatafeed(String jobId, ActionListener<Boolean> listener) {
+        datafeedConfigProvider.findDatafeedForJobId(jobId, ActionListener.wrap(
+                datafeedIds -> {
+                    if (datafeedIds.isEmpty()) {
+                        listener.onResponse(Boolean.TRUE);
+                    } else {
+                        listener.onFailure(ExceptionsHelper.conflictStatusException("A datafeed [" + datafeedIds.iterator().next()
+                                + "] already exists for job [" + jobId + "]"));
+                    }
+                },
+                listener::onFailure
+        ));
+    }
+
+    private void validateDatafeedAgainstJob(DatafeedConfig config, ActionListener<Boolean> listener) {
+        jobConfigProvider.getJob(config.getJobId(), ActionListener.wrap(
+                jobBuilder -> {
+                    try {
+                        DatafeedJobValidator.validate(config, jobBuilder.build());
+                        listener.onResponse(Boolean.TRUE);
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
+                },
+                listener::onFailure
+        ));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDatafeedAction.java
@@ -8,34 +8,47 @@ package org.elasticsearch.xpack.ml.action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
-import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.core.ml.MlMetadata;
+import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
-import org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdate;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedJobValidator;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
+import org.elasticsearch.xpack.core.ml.job.messages.Messages;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
+import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 
 import java.util.Map;
 
 public class TransportUpdateDatafeedAction extends TransportMasterNodeAction<UpdateDatafeedAction.Request, PutDatafeedAction.Response> {
 
+    private final DatafeedConfigProvider datafeedConfigProvider;
+    private final JobConfigProvider jobConfigProvider;
+
     @Inject
     public TransportUpdateDatafeedAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                          ThreadPool threadPool, ActionFilters actionFilters,
-                                         IndexNameExpressionResolver indexNameExpressionResolver) {
+                                         IndexNameExpressionResolver indexNameExpressionResolver,
+                                         Client client, NamedXContentRegistry xContentRegistry) {
         super(settings, UpdateDatafeedAction.NAME, transportService, clusterService, threadPool, actionFilters,
                 indexNameExpressionResolver, UpdateDatafeedAction.Request::new);
+
+        datafeedConfigProvider = new DatafeedConfigProvider(client, settings, xContentRegistry);
+        jobConfigProvider = new JobConfigProvider(client, settings);
     }
 
     @Override
@@ -50,34 +63,74 @@ public class TransportUpdateDatafeedAction extends TransportMasterNodeAction<Upd
 
     @Override
     protected void masterOperation(UpdateDatafeedAction.Request request, ClusterState state,
-                                   ActionListener<PutDatafeedAction.Response> listener) {
+                                   ActionListener<PutDatafeedAction.Response> listener) throws Exception {
         final Map<String, String> headers = threadPool.getThreadContext().getHeaders();
 
-        clusterService.submitStateUpdateTask("update-datafeed-" + request.getUpdate().getId(),
-                new AckedClusterStateUpdateTask<PutDatafeedAction.Response>(request, listener) {
-                    private volatile DatafeedConfig updatedDatafeed;
+        // Check datafeed is stopped
+        PersistentTasksCustomMetaData tasks = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
+        if (MlTasks.getDatafeedTask(request.getUpdate().getId(), tasks) != null) {
+            listener.onFailure(ExceptionsHelper.conflictStatusException(
+                    Messages.getMessage(Messages.DATAFEED_CANNOT_UPDATE_IN_CURRENT_STATE,
+                            request.getUpdate().getId(), DatafeedState.STARTED)));
+            return;
+        }
 
-                    @Override
-                    protected PutDatafeedAction.Response newResponse(boolean acknowledged) {
-                        if (acknowledged) {
-                            logger.info("Updated datafeed [{}]", request.getUpdate().getId());
-                        }
-                        return new PutDatafeedAction.Response(updatedDatafeed);
-                    }
+        String datafeedId = request.getUpdate().getId();
 
-                    @Override
-                    public ClusterState execute(ClusterState currentState) {
-                        DatafeedUpdate update = request.getUpdate();
-                        MlMetadata currentMetadata = MlMetadata.getMlMetadata(currentState);
-                        PersistentTasksCustomMetaData persistentTasks =
-                                currentState.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
-                        MlMetadata newMetadata = new MlMetadata.Builder(currentMetadata)
-                                .updateDatafeed(update, persistentTasks, headers).build();
-                        updatedDatafeed = newMetadata.getDatafeed(update.getId());
-                        return ClusterState.builder(currentState).metaData(
-                                MetaData.builder(currentState.getMetaData()).putCustom(MlMetadata.TYPE, newMetadata).build()).build();
+        CheckedConsumer<Boolean, Exception> updateConsumer = ok -> {
+            datafeedConfigProvider.updateDatefeedConfig(request.getUpdate().getId(), request.getUpdate(), headers,
+                    this::validateDatafeedJob,
+                    ActionListener.wrap(
+                            updatedConfig -> listener.onResponse(new PutDatafeedAction.Response(updatedConfig)),
+                            listener::onFailure
+                    ));
+        };
+
+
+        if (request.getUpdate().getJobId() != null) {
+            checkJobDoesNotHaveADifferentDatafeed(request.getUpdate().getJobId(), datafeedId,
+                    ActionListener.wrap(updateConsumer, listener::onFailure));
+        } else {
+            updateConsumer.accept(Boolean.TRUE);
+        }
+    }
+
+    private void validateDatafeedJob(DatafeedConfig updatedConfig, ActionListener<Boolean> listener) {
+        jobConfigProvider.getJob(updatedConfig.getJobId(), ActionListener.wrap(
+                jobBuilder -> {
+                    try {
+                        DatafeedJobValidator.validate(updatedConfig, jobBuilder.build());
+                        listener.onResponse(Boolean.TRUE);
+                    } catch (Exception e) {
+                        listener.onFailure(e);
                     }
-                });
+                },
+                listener::onFailure
+        ));
+    }
+
+    /*
+     * This is a check against changing the datafeed's jobId and that job
+     * already having a datafeed.
+     * The job the updated datafeed refers to should have no datafeed or
+     * if it does have a datafeed it must be the one we are updating
+     */
+    private void checkJobDoesNotHaveADifferentDatafeed(String jobId, String datafeedId, ActionListener<Boolean> listener) {
+        datafeedConfigProvider.findDatafeedForJobId(jobId, ActionListener.wrap(
+                datafeedIds -> {
+                    if (datafeedIds.isEmpty()) {
+                        // Ok the job does not have a datafeed
+                        listener.onResponse(Boolean.TRUE);
+                    } else if (datafeedIds.size() == 1 && datafeedIds.contains(datafeedId)) {
+                        // Ok the job has the datafeed being updated
+                        listener.onResponse(Boolean.TRUE);
+                    } else {
+                        listener.onFailure(ExceptionsHelper.conflictStatusException("A datafeed [" + datafeedIds.iterator().next()
+                                + "] already exists for job [" + jobId + "]"));
+                    }
+                },
+                listener::onFailure
+        ));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
@@ -171,7 +171,6 @@ public class DatafeedConfigProvider extends AbstractComponent {
      */
     public void findDatafeedForJobId(String jobId, ActionListener<Set<String>> listener) {
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildDatafeedJobIdQuery(jobId));
-        sourceBuilder.sort(DatafeedConfig.ID.getPreferredName());
         sourceBuilder.fetchSource(false);
         sourceBuilder.docValueField(DatafeedConfig.ID.getPreferredName());
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
@@ -41,8 +42,10 @@ import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.index.query.WildcardQueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdate;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
@@ -57,6 +60,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
@@ -86,17 +91,40 @@ public class DatafeedConfigProvider extends AbstractComponent {
      * @param config The datafeed configuration
      * @param listener Index response listener
      */
-    public void putDatafeedConfig(DatafeedConfig config, ActionListener<IndexResponse> listener) {
+    public void putDatafeedConfig(DatafeedConfig config, Map<String, String> headers, ActionListener<IndexResponse> listener) {
+
+        if (headers.isEmpty() == false) {
+            // Filter any values in headers that aren't security fields
+            DatafeedConfig.Builder builder = new DatafeedConfig.Builder(config);
+            Map<String, String> securityHeaders = headers.entrySet().stream()
+                    .filter(e -> ClientHelper.SECURITY_HEADER_FILTERS.contains(e.getKey()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            builder.setHeaders(securityHeaders);
+            config = builder.build();
+        }
+
+        final String datafeedId = config.getId();
+
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             XContentBuilder source = config.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
 
             IndexRequest indexRequest =  client.prepareIndex(AnomalyDetectorsIndex.configIndexName(),
-                    ElasticsearchMappings.DOC_TYPE, DatafeedConfig.documentId(config.getId()))
+                    ElasticsearchMappings.DOC_TYPE, DatafeedConfig.documentId(datafeedId))
                     .setSource(source)
                     .setOpType(DocWriteRequest.OpType.CREATE)
                     .request();
 
-            executeAsyncWithOrigin(client, ML_ORIGIN, IndexAction.INSTANCE, indexRequest, listener);
+            executeAsyncWithOrigin(client, ML_ORIGIN, IndexAction.INSTANCE, indexRequest, ActionListener.wrap(
+                    listener::onResponse,
+                    e -> {
+                        if (e instanceof VersionConflictEngineException) {
+                            // the dafafeed already exists
+                            listener.onFailure(ExceptionsHelper.datafeedAlreadyExists(datafeedId));
+                        } else {
+                            listener.onFailure(e);
+                        }
+                    }
+            ));
 
         } catch (IOException e) {
             listener.onFailure(new ElasticsearchParseException("Failed to serialise datafeed config with id [" + config.getId() + "]", e));
@@ -132,6 +160,44 @@ public class DatafeedConfigProvider extends AbstractComponent {
     }
 
     /**
+     * Find any datafeeds that are used by job {@code jobid} i.e. the
+     * datafeed that references job {@code jobid}.
+     *
+     * In theory there should never be more than one datafeed referencing a
+     * particular job.
+     *
+     * @param jobId     The job to find
+     * @param listener  Datafeed Id listener
+     */
+    public void findDatafeedForJobId(String jobId, ActionListener<Set<String>> listener) {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildDatafeedJobIdQuery(jobId));
+        sourceBuilder.sort(DatafeedConfig.ID.getPreferredName());
+        sourceBuilder.fetchSource(false);
+        sourceBuilder.docValueField(DatafeedConfig.ID.getPreferredName());
+
+        SearchRequest searchRequest = client.prepareSearch(AnomalyDetectorsIndex.configIndexName())
+                .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+                .setSource(sourceBuilder).request();
+
+        executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, searchRequest,
+                ActionListener.<SearchResponse>wrap(
+                        response -> {
+                            Set<String> datafeedIds = new HashSet<>();
+                            SearchHit[] hits = response.getHits().getHits();
+                            // There should be 0 or 1 datafeeds referencing the same job
+                            assert hits.length <= 1;
+
+                            for (SearchHit hit : hits) {
+                                datafeedIds.add(hit.field(DatafeedConfig.ID.getPreferredName()).getValue());
+                            }
+
+                            listener.onResponse(datafeedIds);
+                        },
+                        listener::onFailure)
+                , client::search);
+    }
+
+    /**
      * Delete the datafeed config document
      *
      * @param datafeedId The datafeed id
@@ -161,12 +227,19 @@ public class DatafeedConfigProvider extends AbstractComponent {
      * Get the datafeed config and apply the {@code update}
      * then index the modified config setting the version in the request.
      *
+     * The {@code validator} consumer can be used to perform extra validation
+     * but it must call the passed ActionListener. For example a no-op validator
+     * would be {@code (updatedConfig, listener) -> listener.onResponse(Boolean.TRUE)}
+     *
      * @param datafeedId The Id of the datafeed to update
      * @param update The update
      * @param headers Datafeed headers applied with the update
+     * @param validator BiConsumer that accepts the updated config and can perform
+     *                  extra validations. {@code validator} must call the passed listener
      * @param updatedConfigListener Updated datafeed config listener
      */
     public void updateDatefeedConfig(String datafeedId, DatafeedUpdate update, Map<String, String> headers,
+                          BiConsumer<DatafeedConfig, ActionListener<Boolean>> validator,
                           ActionListener<DatafeedConfig> updatedConfigListener) {
         GetRequest getRequest = new GetRequest(AnomalyDetectorsIndex.configIndexName(),
                 ElasticsearchMappings.DOC_TYPE, DatafeedConfig.documentId(datafeedId));
@@ -197,26 +270,19 @@ public class DatafeedConfigProvider extends AbstractComponent {
                     return;
                 }
 
-                try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
-                    XContentBuilder updatedSource = updatedConfig.toXContent(builder, ToXContent.EMPTY_PARAMS);
-                    IndexRequest indexRequest = client.prepareIndex(AnomalyDetectorsIndex.configIndexName(),
-                            ElasticsearchMappings.DOC_TYPE, DatafeedConfig.documentId(updatedConfig.getId()))
-                            .setSource(updatedSource)
-                            .setVersion(version)
-                            .request();
+                ActionListener<Boolean> validatedListener = ActionListener.wrap(
+                        ok -> {
+                            indexUpdatedConfig(updatedConfig, version, ActionListener.wrap(
+                                    indexResponse -> {
+                                        assert indexResponse.getResult() == DocWriteResponse.Result.UPDATED;
+                                        updatedConfigListener.onResponse(updatedConfig);
+                                    },
+                                    updatedConfigListener::onFailure));
+                        },
+                        updatedConfigListener::onFailure
+                );
 
-                    executeAsyncWithOrigin(client, ML_ORIGIN, IndexAction.INSTANCE, indexRequest, ActionListener.wrap(
-                            indexResponse -> {
-                                assert indexResponse.getResult() == DocWriteResponse.Result.UPDATED;
-                                updatedConfigListener.onResponse(updatedConfig);
-                            },
-                            updatedConfigListener::onFailure
-                    ));
-
-                } catch (IOException e) {
-                    updatedConfigListener.onFailure(
-                            new ElasticsearchParseException("Failed to serialise datafeed config with id [" + datafeedId + "]", e));
-                }
+                validator.accept(updatedConfig, validatedListener);
             }
 
             @Override
@@ -224,6 +290,23 @@ public class DatafeedConfigProvider extends AbstractComponent {
                 updatedConfigListener.onFailure(e);
             }
         });
+    }
+
+    private void indexUpdatedConfig(DatafeedConfig updatedConfig, long version, ActionListener<IndexResponse> listener) {
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            XContentBuilder updatedSource = updatedConfig.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
+            IndexRequest indexRequest = client.prepareIndex(AnomalyDetectorsIndex.configIndexName(),
+                    ElasticsearchMappings.DOC_TYPE, DatafeedConfig.documentId(updatedConfig.getId()))
+                    .setSource(updatedSource)
+                    .setVersion(version)
+                    .request();
+
+            executeAsyncWithOrigin(client, ML_ORIGIN, IndexAction.INSTANCE, indexRequest, listener);
+
+        } catch (IOException e) {
+            listener.onFailure(
+                    new ElasticsearchParseException("Failed to serialise datafeed config with id [" + updatedConfig.getId() + "]", e));
+        }
     }
 
     /**
@@ -252,10 +335,10 @@ public class DatafeedConfigProvider extends AbstractComponent {
      */
     public void expandDatafeedIds(String expression, boolean allowNoDatafeeds, ActionListener<Set<String>> listener) {
         String [] tokens = ExpandedIdsMatcher.tokenizeExpression(expression);
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildQuery(tokens));
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildDatafeedIdQuery(tokens));
         sourceBuilder.sort(DatafeedConfig.ID.getPreferredName());
-        String [] includes = new String[] {DatafeedConfig.ID.getPreferredName()};
-        sourceBuilder.fetchSource(includes, null);
+        sourceBuilder.fetchSource(false);
+        sourceBuilder.docValueField(DatafeedConfig.ID.getPreferredName());
 
         SearchRequest searchRequest = client.prepareSearch(AnomalyDetectorsIndex.configIndexName())
                 .setIndicesOptions(IndicesOptions.lenientExpandOpen())
@@ -269,7 +352,7 @@ public class DatafeedConfigProvider extends AbstractComponent {
                             Set<String> datafeedIds = new HashSet<>();
                             SearchHit[] hits = response.getHits().getHits();
                             for (SearchHit hit : hits) {
-                                datafeedIds.add((String)hit.getSourceAsMap().get(DatafeedConfig.ID.getPreferredName()));
+                                datafeedIds.add(hit.field(DatafeedConfig.ID.getPreferredName()).getValue());
                             }
 
                             requiredMatches.filterMatchedIds(datafeedIds);
@@ -301,7 +384,7 @@ public class DatafeedConfigProvider extends AbstractComponent {
     // NORELEASE datafeed configs should be paged or have a mechanism to return all jobs if there are many of them
     public void expandDatafeedConfigs(String expression, boolean allowNoDatafeeds, ActionListener<List<DatafeedConfig.Builder>> listener) {
         String [] tokens = ExpandedIdsMatcher.tokenizeExpression(expression);
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildQuery(tokens));
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildDatafeedIdQuery(tokens));
         sourceBuilder.sort(DatafeedConfig.ID.getPreferredName());
 
         SearchRequest searchRequest = client.prepareSearch(AnomalyDetectorsIndex.configIndexName())
@@ -342,15 +425,15 @@ public class DatafeedConfigProvider extends AbstractComponent {
 
     }
 
-    private QueryBuilder buildQuery(String [] tokens) {
-        QueryBuilder jobQuery = new TermQueryBuilder(DatafeedConfig.CONFIG_TYPE.getPreferredName(), DatafeedConfig.TYPE);
+    private QueryBuilder buildDatafeedIdQuery(String [] tokens) {
+        QueryBuilder datafeedQuery = new TermQueryBuilder(DatafeedConfig.CONFIG_TYPE.getPreferredName(), DatafeedConfig.TYPE);
         if (Strings.isAllOrWildcard(tokens)) {
             // match all
-            return jobQuery;
+            return datafeedQuery;
         }
 
         BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
-        boolQueryBuilder.filter(jobQuery);
+        boolQueryBuilder.filter(datafeedQuery);
         BoolQueryBuilder shouldQueries = new BoolQueryBuilder();
 
         List<String> terms = new ArrayList<>();
@@ -370,6 +453,13 @@ public class DatafeedConfigProvider extends AbstractComponent {
             boolQueryBuilder.filter(shouldQueries);
         }
 
+        return boolQueryBuilder;
+    }
+
+    private QueryBuilder buildDatafeedJobIdQuery(String jobId) {
+        BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+        boolQueryBuilder.filter(new TermQueryBuilder(DatafeedConfig.CONFIG_TYPE.getPreferredName(), DatafeedConfig.TYPE));
+        boolQueryBuilder.filter(new TermQueryBuilder(Job.ID.getPreferredName(), jobId));
         return boolQueryBuilder;
     }
 


### PR DESCRIPTION
Changes the datafeed get, put, update and delete actions to use datafeed configs stored in the index