### PR TITLE
Painless: Fix Bindings Bug

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/BindingTest.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/BindingTest.java
@@ -26,7 +26,7 @@ public class BindingTest {
         this.state = state0 + state1;
     }
 
-    public int testAddWithState(int stateless) {
-        return stateless + state;
+    public int testAddWithState(int istateless, double dstateless) {
+        return istateless + state + (int)dstateless;
     }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupBuilder.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupBuilder.java
@@ -908,7 +908,7 @@ public final class PainlessLookupBuilder {
         int methodTypeParametersSize = javaMethod.getParameterCount();
 
         for (int typeParameterIndex = 0; typeParameterIndex < methodTypeParametersSize; ++typeParameterIndex) {
-            Class<?> typeParameter = typeParameters.get(typeParameterIndex);
+            Class<?> typeParameter = typeParameters.get(constructorTypeParametersSize + typeParameterIndex);
 
             if (isValidType(typeParameter) == false) {
                 throw new IllegalArgumentException("type parameter [" + typeToCanonicalTypeName(typeParameter) + "] not found " +

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
@@ -177,5 +177,5 @@ class org.elasticsearch.painless.FeatureTest no_import {
 
 # for testing
 static {
-  int testAddWithState(int, int, int) bound_to org.elasticsearch.painless.BindingTest
+  int testAddWithState(int, int, int, double) bound_to org.elasticsearch.painless.BindingTest
 }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BindingsTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BindingsTests.java
@@ -28,11 +28,11 @@ import java.util.Map;
 public class BindingsTests extends ScriptTestCase {
 
     public void testBasicBinding() {
-        assertEquals(15, exec("testAddWithState(4, 5, 6)"));
+        assertEquals(15, exec("testAddWithState(4, 5, 6, 0.0)"));
     }
 
     public void testRepeatedBinding() {
-        String script = "testAddWithState(4, 5, params.test)";
+        String script = "testAddWithState(4, 5, params.test, 0.0)";
         Map<String, Object> params = new HashMap<>();
         ExecutableScript.Factory factory = scriptEngine.compile(null, script, ExecutableScript.CONTEXT, Collections.emptyMap());
         ExecutableScript executableScript = factory.newInstance(params);
@@ -48,7 +48,7 @@ public class BindingsTests extends ScriptTestCase {
     }
 
     public void testBoundBinding() {
-        String script = "testAddWithState(4, params.bound, params.test)";
+        String script = "testAddWithState(4, params.bound, params.test, 0.0)";
         Map<String, Object> params = new HashMap<>();
         ExecutableScript.Factory factory = scriptEngine.compile(null, script, ExecutableScript.CONTEXT, Collections.emptyMap());
         ExecutableScript executableScript = factory.newInstance(params);


### PR DESCRIPTION
When the change was made to the format for in the whitelist for bindings, parameters from both the constructor and the method were combined into a single list instead of separate lists. The check for method parameters was being executed from the start of the combined list rather than the correct position.  The tests for bindings used a constructor and a method that only used the int types so this was not caught.  The test has been changed to also use a double type and this issue is fixed within this PR.