### PR TITLE
Fix pom for build-tools

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -24,15 +24,6 @@ plugins {
   id 'groovy'
 }
 
-gradlePlugin {
-  plugins {
-    simplePlugin {
-      id = 'elasticsearch.clusterformation'
-      implementationClass = 'org.elasticsearch.gradle.clusterformation.ClusterformationPlugin'
-    }
-  }
-}
-
 group = 'org.elasticsearch.gradle'
 
 String minimumGradleVersion = file('src/main/resources/minimumGradleVersion').text.trim()

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/elasticsearch.clusterformation.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/elasticsearch.clusterformation.properties
@@ -1,0 +1,1 @@
+implementation-class=org.elasticsearch.gradle.clusterformation.ClusterformationPlugin


### PR DESCRIPTION
Looks like `java-gradle-plugin` reconfigures the pom.
Stop using it since we don't publish to Gradle plugin portal.
