### PR TITLE
Lazy evaluate java9home

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -211,7 +211,7 @@ class BuildPlugin implements Plugin<Project> {
             project.rootProject.ext.minimumRuntimeVersion = minimumRuntimeVersion
             project.rootProject.ext.inFipsJvm = inFipsJvm
             project.rootProject.ext.gradleJavaVersion = JavaVersion.toVersion(gradleJavaVersion)
-            project.rootProject.ext.java9Home = findJavaHome("9")
+            project.rootProject.ext.java9Home = "${-> findJavaHome("9")}"
         }
 
         project.targetCompatibility = project.rootProject.ext.minimumRuntimeVersion

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ForbiddenApisCliTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ForbiddenApisCliTask.java
@@ -51,7 +51,8 @@ public class ForbiddenApisCliTask extends DefaultTask {
     private JavaVersion targetCompatibility;
     private FileCollection classesDirs;
     private SourceSet sourceSet;
-    private String javaHome;
+    // This needs to be an object so it can hold Groovy GStrings
+    private Object javaHome;
 
     @Input
     public JavaVersion getTargetCompatibility() {
@@ -142,11 +143,11 @@ public class ForbiddenApisCliTask extends DefaultTask {
     }
 
     @Input
-    public String getJavaHome() {
+    public Object getJavaHome() {
         return javaHome;
     }
 
-    public void setJavaHome(String javaHome) {
+    public void setJavaHome(Object javaHome) {
         this.javaHome = javaHome;
     }
 


### PR DESCRIPTION
So that the env var has to be set only if really needed and not at config time.

will add a test to make sure this doesn't happen again in a subsequent PR.
