### PR TITLE
Highlight that index_phrases only works if no slop is used

### DIFF
--- a/docs/reference/mapping/types/text.asciidoc
+++ b/docs/reference/mapping/types/text.asciidoc
@@ -99,7 +99,7 @@ The following parameters are accepted by `text` fields:
 `index_phrases`::
 
     If enabled, two-term word combinations ('shingles') are indexed into a separate
-    field.  This allows exact phrase queries to run more efficiently, at the expense
+    field.  This allows exact phrase queries (no slop) to run more efficiently, at the expense
     of a larger index.  Note that this works best when stopwords are not removed,
     as phrases containing stopwords will not use the subsidiary field and will fall
     back to a standard phrase query.  Accepts `true` or `false` (default).


### PR DESCRIPTION
Highlight that `index_phrases` only works if no slop is used at query time.