### PR TITLE
Skip rebalancing when cluster_concurrent_rebalance threshold reached

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
@@ -61,6 +61,11 @@ public class ConcurrentRebalanceAllocationDecider extends AllocationDecider {
 
     @Override
     public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
+        return canRebalance(allocation);
+    }
+    
+    @Override
+    public Decision canRebalance(RoutingAllocation allocation) {
         if (clusterConcurrentRebalance == -1) {
             return allocation.decision(Decision.YES, NAME, "unlimited concurrent rebalances are allowed");
         }
@@ -75,10 +80,5 @@ public class ConcurrentRebalanceAllocationDecider extends AllocationDecider {
         return allocation.decision(Decision.YES, NAME,
                 "below threshold [%d] for concurrent rebalances, current rebalance shard count [%d]",
                 clusterConcurrentRebalance, relocatingShards);
-    }
-    
-    @Override
-    public Decision canRebalance(RoutingAllocation allocation) {
-        return canRebalance(null, allocation);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
@@ -76,4 +76,9 @@ public class ConcurrentRebalanceAllocationDecider extends AllocationDecider {
                 "below threshold [%d] for concurrent rebalances, current rebalance shard count [%d]",
                 clusterConcurrentRebalance, relocatingShards);
     }
+    
+    @Override
+    public Decision canRebalance(RoutingAllocation allocation) {
+        return canRebalance(null, allocation);
+    }
 }


### PR DESCRIPTION
Follow-up from #27628 
This is a pre-emptive check during shard relocation. Most of the time during relocation when relocating shards are more than the _cluster_concurrent_rebalance_ we are skipping rebalancing instead of iterating over all the shards and returning a `THROTTLE` decision. This results in faster shard iteration.

**Benchmarking**
- Data nodes (i3.8xlarge) AWS EC2
- Master node (c4.8xlarge) AWS EC2
- Shards (count 25k, 2500 indices, 5 primary, 1 replica, size 5gb)
- Cluster settings 
`"indices.recovery.max_bytes_per_sec" : "300mb"`
`"cluster.routing.allocation.node_concurrent_recoveries" : "4"`
`"cluster.routing.allocation.cluster_concurrent_rebalance" : "2"`
- OS version `4.9.38-16.35.amzn1.x86_64`
- JRE `1.8`
- Performed relocation from 100 data nodes to 100 data nodes. 
Time spent on rebalance, tp90 is `732ms`, total time spent in allocation tp90 is `4820ms` without optimization.This optimization cuts down the time spent in rebalance which is roughly 15% of the time spent in a single iteration made by the master 