### PR TITLE
[Rollup] Fix Caps Comparator to handle calendar/fixed time

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/job/DateHistogramGroupConfigSerializingTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/job/DateHistogramGroupConfigSerializingTests.java
@@ -125,6 +125,20 @@ public class DateHistogramGroupConfigSerializingTests extends AbstractSerializin
         assertThat(e.validationErrors().size(), equalTo(0));
     }
 
+    public void testValidateWeek() {
+        ActionRequestValidationException e = new ActionRequestValidationException();
+        Map<String, Map<String, FieldCapabilities>> responseMap = new HashMap<>();
+
+        // Have to mock fieldcaps because the ctor's aren't public...
+        FieldCapabilities fieldCaps = mock(FieldCapabilities.class);
+        when(fieldCaps.isAggregatable()).thenReturn(true);
+        responseMap.put("my_field", Collections.singletonMap("date", fieldCaps));
+
+        DateHistogramGroupConfig config = new DateHistogramGroupConfig("my_field", new DateHistogramInterval("1w"), null, null);
+        config.validateMappings(responseMap, e);
+        assertThat(e.validationErrors().size(), equalTo(0));
+    }
+
     /**
      * Tests that a DateHistogramGroupConfig can be serialized/deserialized correctly after
      * the timezone was changed from DateTimeZone to String.


### PR DESCRIPTION
The comparator used TimeValue parsing, which meant it couldn't handle calendar time.  This fixes the comparator to handle either (and potentially mixed).  The mixing shouldn't be an issue since the validation code upstream will prevent it, but was simplest to allow the comparator to handle both.

Related to #32052 
