### PR TITLE
Update query_cache.asciidoc

### DIFF
--- a/docs/reference/modules/indices/query_cache.asciidoc
+++ b/docs/reference/modules/indices/query_cache.asciidoc
@@ -5,7 +5,7 @@ The query cache is responsible for caching the results of queries.
 There is one queries cache per node that is shared by all shards.
 The cache implements an LRU eviction policy: when a cache becomes full, the
 least recently used data is evicted to make way for new data.
-(It is not possible to look at the contents being cached.)
+It is not possible to look at the contents being cached.
 
 The query cache only caches queries which are being used in a filter context.
 

--- a/docs/reference/modules/indices/query_cache.asciidoc
+++ b/docs/reference/modules/indices/query_cache.asciidoc
@@ -5,6 +5,7 @@ The query cache is responsible for caching the results of queries.
 There is one queries cache per node that is shared by all shards.
 The cache implements an LRU eviction policy: when a cache becomes full, the
 least recently used data is evicted to make way for new data.
+(It is not possible to look at the contents being cached.)
 
 The query cache only caches queries which are being used in a filter context.
 


### PR DESCRIPTION
We should state that the cached contents cannot be seen, as I have had a user ask if this was possible, and my understanding is that it is not possible.
If seeing the contents is on the roadmap, then we can also state this, but I did not find such evidence.