### PR TITLE
[ML] Prevent NPE parsing the stop datafeed request.

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedAction.java
@@ -73,14 +73,13 @@ public class StopDatafeedAction extends Action<StopDatafeedAction.Response> {
         }
 
         private String datafeedId;
-        private String[] resolvedStartedDatafeedIds;
+        private String[] resolvedStartedDatafeedIds = new String[] {};
         private TimeValue stopTimeout = DEFAULT_TIMEOUT;
         private boolean force = false;
         private boolean allowNoDatafeeds = true;
 
         public Request(String datafeedId) {
             this.datafeedId = ExceptionsHelper.requireNonNull(datafeedId, DatafeedConfig.ID.getPreferredName());
-            this.resolvedStartedDatafeedIds = new String[] { datafeedId };
         }
 
         public Request() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedActionRequestTests.java
@@ -24,6 +24,9 @@ public class StopDatafeedActionRequestTests extends AbstractStreamableXContentTe
         if (randomBoolean()) {
             request.setAllowNoDatafeeds(randomBoolean());
         }
+        if (randomBoolean()) {
+            request.setResolvedStartedDatafeedIds(generateRandomStringArray(4, 8, false));
+        }
         return request;
     }
 


### PR DESCRIPTION
If a stop datafeed request is sent to a non-master node and the request contains parameters in the request body e.g.
```
POST _xpack/ml/datafeeds/my-datafeed/_stop
{
  "timeout": "30s"
} 
``` 
then a NullPointerException is thrown streaming the request as one of the fields is not initialised by all constructors. 

Before this fix an alternative is to pass the options as query parameters in which case the field is safely initialised. 
```
POST _xpack/ml/datafeeds/my-datafeed/_stop?timeout=30s
```