### PR TITLE
Disable assemble task instead of removing it

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -21,10 +21,7 @@ apply plugin: 'elasticsearch.build'
 apply plugin: 'application'
 mainClassName = 'org.openjdk.jmh.Main'
 
-// Not published so no need to assemble
-tasks.remove(assemble)
-build.dependsOn.remove('assemble')
-
+assemble.enabled = false
 archivesBaseName = 'elasticsearch-benchmarks'
 
 test.enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -579,13 +579,11 @@ gradle.projectsEvaluated {
     if (project.path.startsWith(':qa')) {
       Task assemble = project.tasks.findByName('assemble')
       if (assemble) {
-        project.tasks.remove(assemble)
-        project.build.dependsOn.remove('assemble')
+        assemble.enabled = false
       }
       Task dependenciesInfo = project.tasks.findByName('dependenciesInfo')
       if (dependenciesInfo) {
-        project.tasks.remove(dependenciesInfo)
-        project.precommit.dependsOn.remove('dependenciesInfo')
+        dependenciesInfo.enabled = false
       }
     }
   }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -547,7 +547,7 @@ class BuildPlugin implements Plugin<Project> {
             }
             // build poms with assemble (if the assemble task exists)
             Task assemble = project.tasks.findByName('assemble')
-            if (assemble && assemble.enabled == true) {
+            if (assemble && assemble.enabled) {
                 assemble.dependsOn(generatePOMTask)
             }
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -547,7 +547,7 @@ class BuildPlugin implements Plugin<Project> {
             }
             // build poms with assemble (if the assemble task exists)
             Task assemble = project.tasks.findByName('assemble')
-            if (assemble) {
+            if (assemble && assemble.enabled == true) {
                 assemble.dependsOn(generatePOMTask)
             }
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
@@ -35,8 +35,7 @@ public class DocsTestPlugin extends RestTestPlugin {
         // The distribution can be configured with -Dtests.distribution on the command line
         project.integTestCluster.distribution = System.getProperty('tests.distribution', 'zip')
         // Docs are published separately so no need to assemble
-        project.tasks.remove(project.assemble)
-        project.build.dependsOn.remove('assemble')
+        project.tasks.assemble.enabled = false
         Map<String, String> defaultSubstitutions = [
             /* These match up with the asciidoc syntax for substitutions but
              * the values may differ. In particular {version} needs to resolve

--- a/client/benchmark/build.gradle
+++ b/client/benchmark/build.gradle
@@ -23,8 +23,7 @@ apply plugin: 'application'
 group = 'org.elasticsearch.client'
 
 // Not published so no need to assemble
-tasks.remove(assemble)
-build.dependsOn.remove('assemble')
+assemble.enabled = true
 
 archivesBaseName = 'client-benchmarks'
 mainClassName = 'org.elasticsearch.client.benchmark.BenchmarkMain'

--- a/client/client-benchmark-noop-api-plugin/build.gradle
+++ b/client/client-benchmark-noop-api-plugin/build.gradle
@@ -28,8 +28,7 @@ esplugin {
 }
 
 // Not published so no need to assemble
-tasks.remove(assemble)
-build.dependsOn.remove('assemble')
+assemble.enabled = false
 
 dependencyLicenses.enabled = false
 dependenciesInfo.enabled = false

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -50,8 +50,7 @@ subprojects {
 
   apply plugin: 'distribution'
   // Not published so no need to assemble
-  tasks.remove(assemble)
-  build.dependsOn.remove('assemble')
+  assemble.enabled = false
 
   File checkoutDir = file("${buildDir}/bwc/checkout-${bwcBranch}")
 

--- a/plugins/examples/build.gradle
+++ b/plugins/examples/build.gradle
@@ -3,8 +3,7 @@ gradle.projectsEvaluated {
   subprojects {
     Task assemble = project.tasks.findByName('assemble')
     if (assemble) {
-      project.tasks.remove(assemble)
-      project.build.dependsOn.remove('assemble')
+      assemble.enabled = false
     }
   }
 }

--- a/x-pack/plugin/ccr/qa/build.gradle
+++ b/x-pack/plugin/ccr/qa/build.gradle
@@ -5,8 +5,7 @@ gradle.projectsEvaluated {
   subprojects {
     Task assemble = project.tasks.findByName('assemble')
     if (assemble) {
-      project.tasks.remove(assemble)
-      project.build.dependsOn.remove('assemble')
+      assemble.enabled = false
     }
   }
 }

--- a/x-pack/plugin/ml/qa/build.gradle
+++ b/x-pack/plugin/ml/qa/build.gradle
@@ -20,12 +20,11 @@ gradle.projectsEvaluated {
     subprojects {
         Task assemble = project.tasks.findByName('assemble')
         if (assemble) {
-            project.tasks.remove(assemble)
-            project.build.dependsOn.remove('assemble')
+            assemble.enabled = false
         }
         Task dependenciesInfo = project.tasks.findByName('dependenciesInfo')
         if (dependenciesInfo) {
-            project.precommit.dependsOn.remove('dependenciesInfo')
+            dependenciesInfo.enabled = false
         }
     }
 }

--- a/x-pack/qa/build.gradle
+++ b/x-pack/qa/build.gradle
@@ -25,12 +25,11 @@ gradle.projectsEvaluated {
   subprojects {
     Task assemble = project.tasks.findByName('assemble')
     if (assemble) {
-      project.tasks.remove(assemble)
-      project.build.dependsOn.remove('assemble')
+      assemble.enabled = false
     }
     Task dependenciesInfo = project.tasks.findByName('dependenciesInfo')
     if (dependenciesInfo) {
-      project.precommit.dependsOn.remove('dependenciesInfo')
+      dependenciesInfo.enabled = false
     }
   }
 }


### PR DESCRIPTION
Right now running `./gradlew assemble` fails because of projects that remove it. 
Gradle is making steps to make it impossible to remove tasks, there are already deprecation around it,
and it seems like removing tasks doesn't remove them from everywhere. 
The problem was triggered by cd378d5cc9ffe84705761b5c7c6f0b26215cdd36 which on the surface has nothing to do with how this failed. 
There's also #33343 for dealing with  the testing task. 
With this change, the assemble task is disabled instead of removed so we are more in-line with what Gradle expects. 
On the long term I would like to move publishing into it's own plugin instead of assigning  special meaning to disabling the `assemble` task, making it opt-in rather than opt-out.