### PR TITLE
TESTS+DISTR.: Fix testIndexCheckOnStartup Flake

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -2596,7 +2596,6 @@ public class IndexShardTests extends IndexShardTestCase {
         closeShards(newShard);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/33345")
     public void testIndexCheckOnStartup() throws Exception {
         final IndexShard indexShard = newStartedShard(true);
 
@@ -2650,7 +2649,7 @@ public class IndexShardTests extends IndexShardTestCase {
         try {
             closeShards(corruptedShard);
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), equalTo("CheckIndex failed"));
+            // Ignored because corrupted shard can throw various exceptions on close
         }
     }
 


### PR DESCRIPTION
* Ignore all `RuntimeException` since random
file corruption triggers other RTE in addition
to the randomly caught one
  * In the reported case it throws "java.lang.IllegalArgumentException: Illegal field number: -65281"
  * -> It's probably fine to just suppress here instead of trying to foresee+catch all possible exceptions that a randomly corrupted file can trigger?
* closes #33345