### PR TITLE
[Docs] Add search timeout caveats

### DIFF
--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -119,10 +119,14 @@ Individual searches can have a timeout as part of the
 <<search-request-body>>. Since search requests can originate from many
 sources, Elasticsearch has a dynamic cluster-level setting for a global
 search timeout that applies to all search requests that do not set a
-timeout in the <<search-request-body>>. The default value is no global
-timeout. The setting key is `search.default_search_timeout` and can be
-set using the <<cluster-update-settings>> endpoints. Setting this value
-to `-1` resets the global search timeout to no timeout.
+timeout in the request body. These requests will be canceled after
+the specified time using the mechanism described in the following section on
+<<global-search-cancellation>>. Therefore the same caveats about timeout
+responsiveness apply.
+
+The setting key is `search.default_search_timeout` and can be set using the
+<<cluster-update-settings>> endpoints. The default value is no global timeout.
+Setting this value to `-1` resets the global search timeout to no timeout.
 
 [float]
 [[global-search-cancellation]]

--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -119,7 +119,7 @@ Individual searches can have a timeout as part of the
 <<search-request-body>>. Since search requests can originate from many
 sources, Elasticsearch has a dynamic cluster-level setting for a global
 search timeout that applies to all search requests that do not set a
-timeout in the request body. These requests will be canceled after
+timeout in the request body. These requests will be cancelled after
 the specified time using the mechanism described in the following section on
 <<global-search-cancellation>>. Therefore the same caveats about timeout
 responsiveness apply.

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -60,7 +60,9 @@ And here is a sample response:
 
     A search timeout, bounding the search request to be executed within the
     specified time value and bail with the hits accumulated up to that point
-    when expired. Defaults to no timeout. See <<time-units>>.
+    when expired. Search requests are canceled after the timeout is reached using
+    the <<global-search-cancellation>> mechanism.
+    Defaults to no timeout. See <<time-units>>.
 
 `from`::
 


### PR DESCRIPTION
Global search timeouts and timeouts specified in the search request body use the
same internal mechanism as search cancellation. Therefore the same caveats
apply, mostly around the responsiveness of the timeout which gets only checked
by a running search on segment boundaries by default.

Closes #31263