### PR TITLE
TESTS+DISTR.: Fix testIndexCheckOnStartup Flake (#33349)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -2594,7 +2594,6 @@ public class IndexShardTests extends IndexShardTestCase {
         closeShards(newShard);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/33345")
     public void testIndexCheckOnStartup() throws Exception {
         final IndexShard indexShard = newStartedShard(true);
 
@@ -2648,7 +2647,7 @@ public class IndexShardTests extends IndexShardTestCase {
         try {
             closeShards(corruptedShard);
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), equalTo("CheckIndex failed"));
+            // Ignored because corrupted shard can throw various exceptions on close
         }
     }
 


### PR DESCRIPTION
* Ignore all `RuntimeException` since random
file corruption triggers other RTE in addition
to the randomly caught one
* closes #33345

backport PR just to run Jenkins