### PR TITLE
[DOCS] fix a couple of typos

### DIFF
--- a/docs/reference/rollup/rollup-search-limitations.asciidoc
+++ b/docs/reference/rollup/rollup-search-limitations.asciidoc
@@ -107,7 +107,7 @@ It's recommended to just configure a single job with the smallest granularity th
 as needed.
 
 That said, if multiple jobs are present in a single rollup index with varying intervals, the search endpoint will identify and use the job(s)
-with the largest interval to satisfy the search reques.
+with the largest interval to satisfy the search request.
 
 [float]
 === Limited querying components

--- a/docs/reference/setup/setup-xclient.asciidoc
+++ b/docs/reference/setup/setup-xclient.asciidoc
@@ -11,7 +11,7 @@ cluster where {xpack} is installed, then you must download and configure the
 
 . Add the {xpack} transport JAR file to your *CLASSPATH*. You can download the {xpack}
 distribution and extract the JAR file manually or you can get it from the
-https://artifacts.elastic.co/maven/org/elasticsearch/client/x-pack-transport/{version}/x-pack-transport-{version}.jar[Elasticsearc Maven repository].
+https://artifacts.elastic.co/maven/org/elasticsearch/client/x-pack-transport/{version}/x-pack-transport-{version}.jar[Elasticsearch Maven repository].
 As with any dependency, you will also need its transitive dependencies. Refer to the
 https://artifacts.elastic.co/maven/org/elasticsearch/client/x-pack-transport/{version}/x-pack-transport-{version}.pom[X-Pack POM file
 for your version] when downloading for offline usage.

--- a/docs/reference/upgrade/set-paths-tip.asciidoc
+++ b/docs/reference/upgrade/set-paths-tip.asciidoc
@@ -2,7 +2,7 @@
 ================================================
 
 When you extract the zip or tarball packages, the `elasticsearch-n.n.n`
-directory contains the Elasticsearh `config`, `data`, `logs` and
+directory contains the Elasticsearch `config`, `data`, `logs` and
 `plugins` directories.
 
 We recommend moving these directories out of the Elasticsearch directory


### PR DESCRIPTION
Hello,

This pull request is to fix a couple of typos I spotted in the documentation.

Please tell me if there is any problem with it.

I also tried to run the docs-related checks but didn't succeed:

```
$ ./gradlew -p docs check

> Task :docs:integTestCluster#wait FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':docs:integTestCluster#wait'.
> Failed to start elasticsearch: timed out after 30 seconds

...

BUILD FAILED in 5m 42s
364 actionable tasks: 77 executed, 287 up-to-date
```

Thank you.