### PR TITLE
[ML] The sort field on get records should default to the record_score

### DIFF
--- a/docs/java-rest/high-level/ml/get-records.asciidoc
+++ b/docs/java-rest/high-level/ml/get-records.asciidoc
@@ -58,7 +58,7 @@ include-tagged::{doc-tests}/MlClientDocumentationIT.java[x-pack-ml-get-records-s
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/MlClientDocumentationIT.java[x-pack-ml-get-records-end]
+include-tagged::{doc-tests}/MlClientDocumentationIT.java[x-pack-ml-get-records-start]
 --------------------------------------------------
 <1> Records with timestamps on or after this time will be returned.
 

--- a/docs/java-rest/high-level/ml/get-records.asciidoc
+++ b/docs/java-rest/high-level/ml/get-records.asciidoc
@@ -54,7 +54,7 @@ include-tagged::{doc-tests}/MlClientDocumentationIT.java[x-pack-ml-get-records-r
 --------------------------------------------------
 include-tagged::{doc-tests}/MlClientDocumentationIT.java[x-pack-ml-get-records-sort]
 --------------------------------------------------
-<1> The field to sort records on. Defaults to `influencer_score`.
+<1> The field to sort records on. Defaults to `record_score`.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetRecordsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetRecordsAction.java
@@ -23,7 +23,6 @@ import org.elasticsearch.xpack.core.ml.action.util.PageParams;
 import org.elasticsearch.xpack.core.ml.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.results.AnomalyRecord;
-import org.elasticsearch.xpack.core.ml.job.results.Influencer;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
@@ -79,7 +78,7 @@ public class GetRecordsAction extends Action<GetRecordsAction.Response> {
         private boolean excludeInterim = false;
         private PageParams pageParams = new PageParams();
         private double recordScoreFilter = 0.0;
-        private String sort = Influencer.INFLUENCER_SCORE.getPreferredName();
+        private String sort = RECORD_SCORE_FILTER.getPreferredName();
         private boolean descending = true;
 
         public Request() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/results/RestGetRecordsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/results/RestGetRecordsAction.java
@@ -12,11 +12,10 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
-import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.core.ml.action.GetRecordsAction;
 import org.elasticsearch.xpack.core.ml.action.util.PageParams;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
-import org.elasticsearch.xpack.core.ml.job.results.AnomalyRecord;
+import org.elasticsearch.xpack.ml.MachineLearning;
 
 import java.io.IOException;
 
@@ -54,8 +53,7 @@ public class RestGetRecordsAction extends BaseRestHandler {
             request.setRecordScore(
                     Double.parseDouble(restRequest.param(GetRecordsAction.Request.RECORD_SCORE_FILTER.getPreferredName(),
                             String.valueOf(request.getRecordScoreFilter()))));
-            request.setSort(restRequest.param(GetRecordsAction.Request.SORT.getPreferredName(),
-                    AnomalyRecord.RECORD_SCORE.getPreferredName()));
+            request.setSort(restRequest.param(GetRecordsAction.Request.SORT.getPreferredName(), request.getSort()));
             request.setDescending(restRequest.paramAsBoolean(GetRecordsAction.Request.DESCENDING.getPreferredName(),
                     request.isDescending()));
         }


### PR DESCRIPTION
This is not changing the behaviour as when the sort field was set
to `influencer_score` the secondary sort would be used and that
was using the `record_score` at the highest priority.
