### PR TITLE
SQL: Show/desc commands now support table ids

### DIFF
--- a/docs/reference/sql/concepts.asciidoc
+++ b/docs/reference/sql/concepts.asciidoc
@@ -9,7 +9,7 @@ NOTE: This documentation while trying to be complete, does assume the reader has
 
 As a general rule, {es-sql} as the name indicates provides a SQL interface to {es}. As such, it follows the SQL terminology and conventions first, whenever possible. However the backing engine itself is {es} for which {es-sql} was purposely created hence why features or concepts that are not available, or cannot be mapped correctly, in SQL appear
 in {es-sql}.
-Last but not least, {es-sql} tries to obey the https://en.wikipedia.org/wiki/Principle_of_least_astonishment[principle of least suprise], though as all things in the world, everything is relative.
+Last but not least, {es-sql} tries to obey the https://en.wikipedia.org/wiki/Principle_of_least_astonishment[principle of least surprise], though as all things in the world, everything is relative.
 
 === Mapping concepts across SQL and {es}
 
@@ -26,7 +26,7 @@ So let's start from the bottom; these roughly are:
 |`column`
 |`field`
 |In both cases, at the lowest level, data is stored in _named_ entries, of a variety of <<sql-data-types, data types>>, containing _one_ value. SQL calls such an entry a _column_ while {es} a _field_.
-Notice that in {es} a field can contain _multiple_ values of the same type (esentially a list) while in SQL, a _column_ can contain _exactly_ one value of said type.
+Notice that in {es} a field can contain _multiple_ values of the same type (essentially a list) while in SQL, a _column_ can contain _exactly_ one value of said type.
 {es-sql} will do its best to preserve the SQL semantic and, depending on the query, reject those that return fields with more than one value.
 
 |`row`
@@ -43,7 +43,7 @@ Notice that in {es} a field can contain _multiple_ values of the same type (esen
 
 |`catalog` or `database`
 |`cluster` instance 
-|In SQL, `catalog` or `database` are used interchangebly and represent a set of schemas that is, a number of tables.
+|In SQL, `catalog` or `database` are used interchangeably and represent a set of schemas that is, a number of tables.
 In {es} the set of indices available are grouped in a `cluster`. The semantics also differ a bit; a `database` is essentially yet another namespace (which can have some implications on the way data is stored) while an {es} `cluster` is a runtime instance, or rather a set of at least one {es} instance (typically running distributed).
 In practice this means that while in SQL one can potentially have multiple catalogs inside an instance, in {es} one is restricted to only _one_.
 
@@ -62,4 +62,4 @@ Multiple clusters, each with its own namespace, connected to each other in a fed
 
 |===
 
-As one can see while the mapping between the concepts are not exactly one to one and the semantics somewhat different, there are more things in common than differences. In fact, thanks to SQL declarative nature, many concepts can move across {es} transparently and the terminology of the two likely to be used interchangebly through-out the rest of the material.
+As one can see while the mapping between the concepts are not exactly one to one and the semantics somewhat different, there are more things in common than differences. In fact, thanks to SQL declarative nature, many concepts can move across {es} transparently and the terminology of the two likely to be used interchangeably through-out the rest of the material.

--- a/docs/reference/sql/language/index-patterns.asciidoc
+++ b/docs/reference/sql/language/index-patterns.asciidoc
@@ -1,0 +1,70 @@
+[role="xpack"]
+[testenv="basic"]
+[[sql-index-pattern]]
+== Index patterns
+
+{es-sql} supports two types of patterns for matching multiple indices or tables:
+
+* {es} multi-index
+
+The {es} notation for enumerating, including or excluding <<multi-index,multi index syntax>>
+is supported _as long_ as it is quoted or escaped as a table identifier.
+
+For example:
+
+["source","sql",subs="attributes,callouts,macros"]
+----
+include-tagged::{sql-specs}/docs.csv-spec[showTablesEsMultiIndex]
+----
+
+Notice the pattern is surrounded by double quotes `"`. It enumerated `*` meaning all indices however
+it excludes (due to `-`) all indices that start with `l`.
+This notation is very convenient and powerful as it allows both inclusion and exclusion, depending on
+the target naming convention.
+
+* SQL `LIKE` notation
+
+The common `LIKE` statement (including escaping if needed) to match a wildcard pattern, based on one `_`
+or multiple `%` characters.
+
+Using `SHOW TABLES` command again:
+
+["source","sql",subs="attributes,callouts,macros"]
+----
+include-tagged::{sql-specs}/docs.csv-spec[showTablesLikeWildcard]
+----
+
+The pattern matches all tables that start with `emp`. 
+
+This command supports _escaping_ as well, for example:
+
+["source","sql",subs="attributes,callouts,macros"]
+----
+include-tagged::{sql-specs}/docs.csv-spec[showTablesLikeEscape]
+----
+
+Notice how now `emp%` does not match any tables because `%`, which means match zero or more characters,
+has been escaped by `!` and thus becomes an regular char. And since there is no table named `emp%`,
+an empty table is returned.
+
+In a nutshell, the differences between the two type of patterns are:
+
+[cols="^h,^,^",options="header"]
+|===
+| Feature | Multi index | SQL `LIKE`
+
+| Type of quoting    | `"` | `'`
+| Inclusion          | Yes | Yes
+| Exclusion          | Yes | No
+| Enumeration        | Yes | No
+| One char pattern   | No  | `_`
+| Multi char pattern | `*` | `%`
+| Escaping           | No  | `ESCAPE`
+
+|===
+
+Which one to use, is up to you however try to stick to the same one across your queries for consistency.
+
+NOTE: As the query type of quoting between the two patterns is fairly similar (`"` vs `'`), {es-sql} _always_
+requires the keyword `LIKE` for SQL `LIKE` pattern.
+

--- a/docs/reference/sql/language/index.asciidoc
+++ b/docs/reference/sql/language/index.asciidoc
@@ -7,6 +7,8 @@ This chapter describes the SQL semantics supported in X-Pack namely:
 
 <<sql-data-types>>:: Data types
 <<sql-commands>>:: Commands
+<<sql-index-patterns>>:: Index patterns
 
 include::data-types.asciidoc[]
 include::syntax/index.asciidoc[]
+include::index-patterns.asciidoc[]

--- a/docs/reference/sql/language/syntax/describe-table.asciidoc
+++ b/docs/reference/sql/language/syntax/describe-table.asciidoc
@@ -6,14 +6,14 @@
 .Synopsis
 [source, sql]
 ----
-DESCRIBE table
+DESCRIBE [table identifier<1>|[LIKE pattern<2>]]
 ----
 
 or 
 
 [source, sql]
 ----
-DESC table
+DESC [table identifier<1>|[LIKE pattern<2>]]
 ----
 
 

--- a/docs/reference/sql/language/syntax/show-columns.asciidoc
+++ b/docs/reference/sql/language/syntax/show-columns.asciidoc
@@ -6,8 +6,14 @@
 .Synopsis
 [source, sql]
 ----
-SHOW COLUMNS [ FROM | IN ] ? table 
+SHOW COLUMNS [ FROM | IN ]? [ table identifier<1> | [ LIKE pattern<2> ] ]
 ----
+
+<1> single table identifier or double quoted es multi index
+<2> SQL LIKE pattern
+
+See <<sql-index-pattern, index patterns>> for more information about
+patterns.
 
 .Description
 
@@ -17,3 +23,4 @@ List the columns in table and their data type (and other attributes).
 ----
 include-tagged::{sql-specs}/docs.csv-spec[showColumns]
 ----
+

--- a/docs/reference/sql/language/syntax/show-functions.asciidoc
+++ b/docs/reference/sql/language/syntax/show-functions.asciidoc
@@ -6,7 +6,7 @@
 .Synopsis
 [source, sql]
 ----
-SHOW FUNCTIONS [ LIKE? pattern<1>? ]?
+SHOW FUNCTIONS [ LIKE pattern<1>? ]?
 ----
 
 <1> SQL match pattern

--- a/docs/reference/sql/language/syntax/show-tables.asciidoc
+++ b/docs/reference/sql/language/syntax/show-tables.asciidoc
@@ -6,10 +6,15 @@
 .Synopsis
 [source, sql]
 ----
-SHOW TABLES [ LIKE? pattern<1>? ]?
+SHOW TABLES [ table identifier<1> | [ LIKE pattern<2> ] ]?
 ----
 
-<1> SQL match pattern
+<1> single table identifier or double quoted es multi index
+<2> SQL LIKE pattern
+
+See <<sql-index-pattern, index patterns>> for more information about
+patterns.
+
 
 .Description
 
@@ -20,7 +25,15 @@ List the tables available to the current user and their type.
 include-tagged::{sql-specs}/docs.csv-spec[showTables]
 ----
 
-The `LIKE` clause can be used to restrict the list of names to the given pattern.
+Match multiple indices by using {es} <<multi-index,multi index syntax>>
+notation:
+
+["source","sql",subs="attributes,callouts,macros"]
+----
+include-tagged::{sql-specs}/docs.csv-spec[showTablesEsMultiIndex]
+----
+
+One can also use the `LIKE` clause to restrict the list of names to the given pattern.
 
 The pattern can be an exact match:
 ["source","sql",subs="attributes,callouts,macros"]

--- a/x-pack/plugin/sql/src/main/antlr/SqlBase.g4
+++ b/x-pack/plugin/sql/src/main/antlr/SqlBase.g4
@@ -50,18 +50,18 @@ statement
         )*
         ')')?
         statement                                                                                         #debug
-    | SHOW TABLES (LIKE? pattern)?                                                                        #showTables
-    | SHOW COLUMNS (FROM | IN) tableIdentifier                                                            #showColumns
-    | (DESCRIBE | DESC) tableIdentifier                                                                   #showColumns
-    | SHOW FUNCTIONS (LIKE? pattern)?                                                                     #showFunctions
+    | SHOW TABLES (tableLike=likePattern | tableIdent=tableIdentifier)?                                   #showTables
+    | SHOW COLUMNS (FROM | IN) (tableLike=likePattern | tableIdent=tableIdentifier)                       #showColumns
+    | (DESCRIBE | DESC) (tableLike=likePattern | tableIdent=tableIdentifier)                              #showColumns
+    | SHOW FUNCTIONS (likePattern)?                                                                       #showFunctions
     | SHOW SCHEMAS                                                                                        #showSchemas
     | SYS CATALOGS                                                                                        #sysCatalogs
-    | SYS TABLES (CATALOG LIKE? clusterPattern=pattern)?
-                 (LIKE? tablePattern=pattern)?
+    | SYS TABLES (CATALOG clusterLike=likePattern)?
+                 (tableLike=likePattern | tableIdent=tableIdentifier)?
                  (TYPE string (',' string)* )?                                                            #sysTables
     | SYS COLUMNS (CATALOG cluster=string)?
-                  (TABLE LIKE? indexPattern=pattern)?
-                  (LIKE? columnPattern=pattern)?                                                          #sysColumns
+                  (TABLE tableLike=likePattern | tableIdent=tableIdentifier)?
+                  (columnPattern=likePattern)?                                                            #sysColumns
     | SYS TYPES                                                                                           #sysTypes
     | SYS TABLE TYPES                                                                                     #sysTableTypes  
     ;
@@ -189,6 +189,10 @@ predicate
     | IS NOT? kind=NULL
     ;
 
+likePattern
+    : LIKE pattern
+    ;
+    
 pattern
     : value=string patternEscape?
     ;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolver.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolver.java
@@ -140,14 +140,16 @@ public class IndexResolver {
         boolean retrieveAliases = CollectionUtils.isEmpty(types) || types.contains(IndexType.ALIAS);
         boolean retrieveIndices = CollectionUtils.isEmpty(types) || types.contains(IndexType.INDEX);
 
+        String[] indices = Strings.commaDelimitedListToStringArray(indexWildcard);
         if (retrieveAliases) {
             GetAliasesRequest aliasRequest = new GetAliasesRequest()
                     .local(true)
-                    .aliases(indexWildcard)
+                    .indices(indices)
+                    .aliases(indices)
                     .indicesOptions(IndicesOptions.lenientExpandOpen());
     
             client.admin().indices().getAliases(aliasRequest, ActionListener.wrap(aliases ->
-                            resolveIndices(indexWildcard, javaRegex, aliases, retrieveIndices, listener),
+                            resolveIndices(indices, javaRegex, aliases, retrieveIndices, listener),
                             ex -> {
                                 // with security, two exception can be thrown:
                                 // INFE - if no alias matches
@@ -155,34 +157,36 @@ public class IndexResolver {
     
                                 // in both cases, that is allowed and we continue with the indices request
                                 if (ex instanceof IndexNotFoundException || ex instanceof ElasticsearchSecurityException) {
-                                    resolveIndices(indexWildcard, javaRegex, null, retrieveIndices, listener);
+                                    resolveIndices(indices, javaRegex, null, retrieveIndices, listener);
                                 } else {
                                     listener.onFailure(ex);
                                 }
                             }));
         } else {
-            resolveIndices(indexWildcard, javaRegex, null, retrieveIndices, listener);
+            resolveIndices(indices, javaRegex, null, retrieveIndices, listener);
         }
     }
 
-    private void resolveIndices(String indexWildcard, String javaRegex, GetAliasesResponse aliases,
+    private void resolveIndices(String[] indices, String javaRegex, GetAliasesResponse aliases,
             boolean retrieveIndices, ActionListener<Set<IndexInfo>> listener) {
 
         if (retrieveIndices) {
             GetIndexRequest indexRequest = new GetIndexRequest()
                     .local(true)
-                    .indices(indexWildcard)
+                    .indices(indices)
+                    .features(Feature.SETTINGS)
+                    .includeDefaults(false)
                     .indicesOptions(IndicesOptions.lenientExpandOpen());
     
             client.admin().indices().getIndex(indexRequest,
-                    ActionListener.wrap(indices -> filterResults(indexWildcard, javaRegex, aliases, indices, listener),
+                    ActionListener.wrap(response -> filterResults(javaRegex, aliases, response, listener),
                             listener::onFailure));
         } else {
-            filterResults(indexWildcard, javaRegex, aliases, null, listener);
+            filterResults(javaRegex, aliases, null, listener);
         }
     }
 
-    private void filterResults(String indexWildcard, String javaRegex, GetAliasesResponse aliases, GetIndexResponse indices,
+    private void filterResults(String javaRegex, GetAliasesResponse aliases, GetIndexResponse indices,
             ActionListener<Set<IndexInfo>> listener) {
         
         // since the index name does not support ?, filter the results manually
@@ -302,7 +306,6 @@ public class IndexResolver {
         return new GetIndexRequest()
                 .local(true)
                 .indices(Strings.commaDelimitedListToStringArray(index))
-                .features(Feature.MAPPINGS)
                 //lenient because we throw our own errors looking at the response e.g. if something was not resolved
                 //also because this way security doesn't throw authorization exceptions but rather honours ignore_unavailable
                 .indicesOptions(IndicesOptions.lenientExpandOpen());

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/CommandBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/CommandBuilder.java
@@ -121,12 +121,14 @@ abstract class CommandBuilder extends LogicalPlanBuilder {
 
     @Override
     public Object visitShowFunctions(ShowFunctionsContext ctx) {
-        return new ShowFunctions(source(ctx), visitPattern(ctx.pattern()));
+        return new ShowFunctions(source(ctx), visitLikePattern(ctx.likePattern()));
     }
 
     @Override
     public Object visitShowTables(ShowTablesContext ctx) {
-        return new ShowTables(source(ctx), visitPattern(ctx.pattern()));
+        TableIdentifier ti = visitTableIdentifier(ctx.tableIdent);
+        String index = ti != null ? ti.qualifiedIndex() : null;
+        return new ShowTables(source(ctx), index, visitLikePattern(ctx.likePattern()));
     }
 
     @Override
@@ -136,8 +138,9 @@ abstract class CommandBuilder extends LogicalPlanBuilder {
 
     @Override
     public Object visitShowColumns(ShowColumnsContext ctx) {
-        TableIdentifier identifier = visitTableIdentifier(ctx.tableIdentifier());
-        return new ShowColumns(source(ctx), identifier.index());
+        TableIdentifier ti = visitTableIdentifier(ctx.tableIdent);
+        String index = ti != null ? ti.qualifiedIndex() : null;
+        return new ShowColumns(source(ctx), index, visitLikePattern(ctx.likePattern()));
     }
 
     @Override
@@ -172,13 +175,17 @@ abstract class CommandBuilder extends LogicalPlanBuilder {
 
         // if the ODBC enumeration is specified, skip validation
         EnumSet<IndexType> set = types.isEmpty() ? null : EnumSet.copyOf(types);
-        return new SysTables(source(ctx), visitPattern(ctx.clusterPattern), visitPattern(ctx.tablePattern), set, legacyTableType);
+        TableIdentifier ti = visitTableIdentifier(ctx.tableIdent);
+        String index = ti != null ? ti.qualifiedIndex() : null;
+        return new SysTables(source(ctx), visitLikePattern(ctx.clusterLike), index, visitLikePattern(ctx.tableLike), set, legacyTableType);
     }
 
     @Override
     public Object visitSysColumns(SysColumnsContext ctx) {
-        Location loc = source(ctx);
-        return new SysColumns(loc, string(ctx.cluster), visitPattern(ctx.indexPattern), visitPattern(ctx.columnPattern));
+        TableIdentifier ti = visitTableIdentifier(ctx.tableIdent);
+        String index = ti != null ? ti.qualifiedIndex() : null;
+        return new SysColumns(source(ctx), string(ctx.cluster), index, visitLikePattern(ctx.tableLike),
+                visitLikePattern(ctx.columnPattern));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
@@ -63,6 +63,7 @@ import org.elasticsearch.xpack.sql.parser.SqlBaseParser.FunctionExpressionContex
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.FunctionTemplateContext;
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.GuidEscapedLiteralContext;
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.IntegerLiteralContext;
+import org.elasticsearch.xpack.sql.parser.SqlBaseParser.LikePatternContext;
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.LogicalBinaryContext;
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.LogicalNotContext;
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.MatchQueryContext;
@@ -218,6 +219,11 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
         }
 
         return pCtx.NOT() != null ? new Not(loc, e) : e;
+    }
+
+    @Override
+    public LikePattern visitLikePattern(LikePatternContext ctx) {
+        return ctx == null ? null : visitPattern(ctx.pattern());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/IdentifierBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/IdentifierBuilder.java
@@ -17,6 +17,10 @@ abstract class IdentifierBuilder extends AbstractBuilder {
 
     @Override
     public TableIdentifier visitTableIdentifier(TableIdentifierContext ctx) {
+        if (ctx == null) {
+            return null;
+        }
+
         Location source = source(ctx);
         ParseTree tree = ctx.name != null ? ctx.name : ctx.TABLE_IDENTIFIER();
         String index = tree.getText();

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseBaseListener.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseBaseListener.java
@@ -556,6 +556,18 @@ class SqlBaseBaseListener implements SqlBaseListener {
    *
    * <p>The default implementation does nothing.</p>
    */
+  @Override public void enterLikePattern(SqlBaseParser.LikePatternContext ctx) { }
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation does nothing.</p>
+   */
+  @Override public void exitLikePattern(SqlBaseParser.LikePatternContext ctx) { }
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation does nothing.</p>
+   */
   @Override public void enterPattern(SqlBaseParser.PatternContext ctx) { }
   /**
    * {@inheritDoc}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseBaseVisitor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseBaseVisitor.java
@@ -332,6 +332,13 @@ class SqlBaseBaseVisitor<T> extends AbstractParseTreeVisitor<T> implements SqlBa
    * <p>The default implementation returns the result of calling
    * {@link #visitChildren} on {@code ctx}.</p>
    */
+  @Override public T visitLikePattern(SqlBaseParser.LikePatternContext ctx) { return visitChildren(ctx); }
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation returns the result of calling
+   * {@link #visitChildren} on {@code ctx}.</p>
+   */
   @Override public T visitPattern(SqlBaseParser.PatternContext ctx) { return visitChildren(ctx); }
   /**
    * {@inheritDoc}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseListener.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseListener.java
@@ -510,6 +510,16 @@ interface SqlBaseListener extends ParseTreeListener {
    */
   void exitPredicate(SqlBaseParser.PredicateContext ctx);
   /**
+   * Enter a parse tree produced by {@link SqlBaseParser#likePattern}.
+   * @param ctx the parse tree
+   */
+  void enterLikePattern(SqlBaseParser.LikePatternContext ctx);
+  /**
+   * Exit a parse tree produced by {@link SqlBaseParser#likePattern}.
+   * @param ctx the parse tree
+   */
+  void exitLikePattern(SqlBaseParser.LikePatternContext ctx);
+  /**
    * Enter a parse tree produced by {@link SqlBaseParser#pattern}.
    * @param ctx the parse tree
    */

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseParser.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseParser.java
@@ -41,25 +41,26 @@ class SqlBaseParser extends Parser {
     RULE_setQuantifier = 14, RULE_selectItem = 15, RULE_relation = 16, RULE_joinRelation = 17, 
     RULE_joinType = 18, RULE_joinCriteria = 19, RULE_relationPrimary = 20, 
     RULE_expression = 21, RULE_booleanExpression = 22, RULE_predicated = 23, 
-    RULE_predicate = 24, RULE_pattern = 25, RULE_patternEscape = 26, RULE_valueExpression = 27, 
-    RULE_primaryExpression = 28, RULE_castExpression = 29, RULE_castTemplate = 30, 
-    RULE_extractExpression = 31, RULE_extractTemplate = 32, RULE_functionExpression = 33, 
-    RULE_functionTemplate = 34, RULE_functionName = 35, RULE_constant = 36, 
-    RULE_comparisonOperator = 37, RULE_booleanValue = 38, RULE_dataType = 39, 
-    RULE_qualifiedName = 40, RULE_identifier = 41, RULE_tableIdentifier = 42, 
-    RULE_quoteIdentifier = 43, RULE_unquoteIdentifier = 44, RULE_number = 45, 
-    RULE_string = 46, RULE_nonReserved = 47;
+    RULE_predicate = 24, RULE_likePattern = 25, RULE_pattern = 26, RULE_patternEscape = 27, 
+    RULE_valueExpression = 28, RULE_primaryExpression = 29, RULE_castExpression = 30, 
+    RULE_castTemplate = 31, RULE_extractExpression = 32, RULE_extractTemplate = 33, 
+    RULE_functionExpression = 34, RULE_functionTemplate = 35, RULE_functionName = 36, 
+    RULE_constant = 37, RULE_comparisonOperator = 38, RULE_booleanValue = 39, 
+    RULE_dataType = 40, RULE_qualifiedName = 41, RULE_identifier = 42, RULE_tableIdentifier = 43, 
+    RULE_quoteIdentifier = 44, RULE_unquoteIdentifier = 45, RULE_number = 46, 
+    RULE_string = 47, RULE_nonReserved = 48;
   public static final String[] ruleNames = {
     "singleStatement", "singleExpression", "statement", "query", "queryNoWith", 
     "limitClause", "queryTerm", "orderBy", "querySpecification", "fromClause", 
     "groupBy", "groupingElement", "groupingExpressions", "namedQuery", "setQuantifier", 
     "selectItem", "relation", "joinRelation", "joinType", "joinCriteria", 
     "relationPrimary", "expression", "booleanExpression", "predicated", "predicate", 
-    "pattern", "patternEscape", "valueExpression", "primaryExpression", "castExpression", 
-    "castTemplate", "extractExpression", "extractTemplate", "functionExpression", 
-    "functionTemplate", "functionName", "constant", "comparisonOperator", 
-    "booleanValue", "dataType", "qualifiedName", "identifier", "tableIdentifier", 
-    "quoteIdentifier", "unquoteIdentifier", "number", "string", "nonReserved"
+    "likePattern", "pattern", "patternEscape", "valueExpression", "primaryExpression", 
+    "castExpression", "castTemplate", "extractExpression", "extractTemplate", 
+    "functionExpression", "functionTemplate", "functionName", "constant", 
+    "comparisonOperator", "booleanValue", "dataType", "qualifiedName", "identifier", 
+    "tableIdentifier", "quoteIdentifier", "unquoteIdentifier", "number", "string", 
+    "nonReserved"
   };
 
   private static final String[] _LITERAL_NAMES = {
@@ -173,9 +174,9 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(96);
+      setState(98);
       statement();
-      setState(97);
+      setState(99);
       match(EOF);
       }
     }
@@ -220,9 +221,9 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(99);
+      setState(101);
       expression();
-      setState(100);
+      setState(102);
       match(EOF);
       }
     }
@@ -341,8 +342,9 @@ class SqlBaseParser extends Parser {
   }
   public static class SysColumnsContext extends StatementContext {
     public StringContext cluster;
-    public PatternContext indexPattern;
-    public PatternContext columnPattern;
+    public LikePatternContext tableLike;
+    public TableIdentifierContext tableIdent;
+    public LikePatternContext columnPattern;
     public TerminalNode SYS() { return getToken(SqlBaseParser.SYS, 0); }
     public TerminalNode COLUMNS() { return getToken(SqlBaseParser.COLUMNS, 0); }
     public TerminalNode CATALOG() { return getToken(SqlBaseParser.CATALOG, 0); }
@@ -350,15 +352,14 @@ class SqlBaseParser extends Parser {
     public StringContext string() {
       return getRuleContext(StringContext.class,0);
     }
-    public List<PatternContext> pattern() {
-      return getRuleContexts(PatternContext.class);
+    public List<LikePatternContext> likePattern() {
+      return getRuleContexts(LikePatternContext.class);
     }
-    public PatternContext pattern(int i) {
-      return getRuleContext(PatternContext.class,i);
+    public LikePatternContext likePattern(int i) {
+      return getRuleContext(LikePatternContext.class,i);
     }
-    public List<TerminalNode> LIKE() { return getTokens(SqlBaseParser.LIKE); }
-    public TerminalNode LIKE(int i) {
-      return getToken(SqlBaseParser.LIKE, i);
+    public TableIdentifierContext tableIdentifier() {
+      return getRuleContext(TableIdentifierContext.class,0);
     }
     public SysColumnsContext(StatementContext ctx) { copyFrom(ctx); }
     @Override
@@ -478,8 +479,9 @@ class SqlBaseParser extends Parser {
     }
   }
   public static class SysTablesContext extends StatementContext {
-    public PatternContext clusterPattern;
-    public PatternContext tablePattern;
+    public LikePatternContext clusterLike;
+    public LikePatternContext tableLike;
+    public TableIdentifierContext tableIdent;
     public TerminalNode SYS() { return getToken(SqlBaseParser.SYS, 0); }
     public TerminalNode TABLES() { return getToken(SqlBaseParser.TABLES, 0); }
     public TerminalNode CATALOG() { return getToken(SqlBaseParser.CATALOG, 0); }
@@ -490,15 +492,14 @@ class SqlBaseParser extends Parser {
     public StringContext string(int i) {
       return getRuleContext(StringContext.class,i);
     }
-    public List<PatternContext> pattern() {
-      return getRuleContexts(PatternContext.class);
+    public List<LikePatternContext> likePattern() {
+      return getRuleContexts(LikePatternContext.class);
     }
-    public PatternContext pattern(int i) {
-      return getRuleContext(PatternContext.class,i);
+    public LikePatternContext likePattern(int i) {
+      return getRuleContext(LikePatternContext.class,i);
     }
-    public List<TerminalNode> LIKE() { return getTokens(SqlBaseParser.LIKE); }
-    public TerminalNode LIKE(int i) {
-      return getToken(SqlBaseParser.LIKE, i);
+    public TableIdentifierContext tableIdentifier() {
+      return getRuleContext(TableIdentifierContext.class,0);
     }
     public SysTablesContext(StatementContext ctx) { copyFrom(ctx); }
     @Override
@@ -518,10 +519,9 @@ class SqlBaseParser extends Parser {
   public static class ShowFunctionsContext extends StatementContext {
     public TerminalNode SHOW() { return getToken(SqlBaseParser.SHOW, 0); }
     public TerminalNode FUNCTIONS() { return getToken(SqlBaseParser.FUNCTIONS, 0); }
-    public PatternContext pattern() {
-      return getRuleContext(PatternContext.class,0);
+    public LikePatternContext likePattern() {
+      return getRuleContext(LikePatternContext.class,0);
     }
-    public TerminalNode LIKE() { return getToken(SqlBaseParser.LIKE, 0); }
     public ShowFunctionsContext(StatementContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
@@ -538,12 +538,16 @@ class SqlBaseParser extends Parser {
     }
   }
   public static class ShowTablesContext extends StatementContext {
+    public LikePatternContext tableLike;
+    public TableIdentifierContext tableIdent;
     public TerminalNode SHOW() { return getToken(SqlBaseParser.SHOW, 0); }
     public TerminalNode TABLES() { return getToken(SqlBaseParser.TABLES, 0); }
-    public PatternContext pattern() {
-      return getRuleContext(PatternContext.class,0);
+    public LikePatternContext likePattern() {
+      return getRuleContext(LikePatternContext.class,0);
     }
-    public TerminalNode LIKE() { return getToken(SqlBaseParser.LIKE, 0); }
+    public TableIdentifierContext tableIdentifier() {
+      return getRuleContext(TableIdentifierContext.class,0);
+    }
     public ShowTablesContext(StatementContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
@@ -578,13 +582,18 @@ class SqlBaseParser extends Parser {
     }
   }
   public static class ShowColumnsContext extends StatementContext {
+    public LikePatternContext tableLike;
+    public TableIdentifierContext tableIdent;
     public TerminalNode SHOW() { return getToken(SqlBaseParser.SHOW, 0); }
     public TerminalNode COLUMNS() { return getToken(SqlBaseParser.COLUMNS, 0); }
+    public TerminalNode FROM() { return getToken(SqlBaseParser.FROM, 0); }
+    public TerminalNode IN() { return getToken(SqlBaseParser.IN, 0); }
+    public LikePatternContext likePattern() {
+      return getRuleContext(LikePatternContext.class,0);
+    }
     public TableIdentifierContext tableIdentifier() {
       return getRuleContext(TableIdentifierContext.class,0);
     }
-    public TerminalNode FROM() { return getToken(SqlBaseParser.FROM, 0); }
-    public TerminalNode IN() { return getToken(SqlBaseParser.IN, 0); }
     public TerminalNode DESCRIBE() { return getToken(SqlBaseParser.DESCRIBE, 0); }
     public TerminalNode DESC() { return getToken(SqlBaseParser.DESC, 0); }
     public ShowColumnsContext(StatementContext ctx) { copyFrom(ctx); }
@@ -608,14 +617,14 @@ class SqlBaseParser extends Parser {
     enterRule(_localctx, 4, RULE_statement);
     int _la;
     try {
-      setState(211);
+      setState(204);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,21,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,17,_ctx) ) {
       case 1:
         _localctx = new StatementDefaultContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(102);
+        setState(104);
         query();
         }
         break;
@@ -623,27 +632,27 @@ class SqlBaseParser extends Parser {
         _localctx = new ExplainContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(103);
+        setState(105);
         match(EXPLAIN);
-        setState(117);
+        setState(119);
         _errHandler.sync(this);
         switch ( getInterpreter().adaptivePredict(_input,2,_ctx) ) {
         case 1:
           {
-          setState(104);
+          setState(106);
           match(T__0);
-          setState(113);
+          setState(115);
           _errHandler.sync(this);
           _la = _input.LA(1);
           while (((((_la - 28)) & ~0x3f) == 0 && ((1L << (_la - 28)) & ((1L << (FORMAT - 28)) | (1L << (PLAN - 28)) | (1L << (VERIFY - 28)))) != 0)) {
             {
-            setState(111);
+            setState(113);
             switch (_input.LA(1)) {
             case PLAN:
               {
-              setState(105);
+              setState(107);
               match(PLAN);
-              setState(106);
+              setState(108);
               ((ExplainContext)_localctx).type = _input.LT(1);
               _la = _input.LA(1);
               if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ALL) | (1L << ANALYZED) | (1L << EXECUTABLE) | (1L << MAPPED) | (1L << OPTIMIZED) | (1L << PARSED))) != 0)) ) {
@@ -655,9 +664,9 @@ class SqlBaseParser extends Parser {
               break;
             case FORMAT:
               {
-              setState(107);
+              setState(109);
               match(FORMAT);
-              setState(108);
+              setState(110);
               ((ExplainContext)_localctx).format = _input.LT(1);
               _la = _input.LA(1);
               if ( !(_la==GRAPHVIZ || _la==TEXT) ) {
@@ -669,9 +678,9 @@ class SqlBaseParser extends Parser {
               break;
             case VERIFY:
               {
-              setState(109);
+              setState(111);
               match(VERIFY);
-              setState(110);
+              setState(112);
               ((ExplainContext)_localctx).verify = booleanValue();
               }
               break;
@@ -679,16 +688,16 @@ class SqlBaseParser extends Parser {
               throw new NoViableAltException(this);
             }
             }
-            setState(115);
+            setState(117);
             _errHandler.sync(this);
             _la = _input.LA(1);
           }
-          setState(116);
+          setState(118);
           match(T__1);
           }
           break;
         }
-        setState(119);
+        setState(121);
         statement();
         }
         break;
@@ -696,27 +705,27 @@ class SqlBaseParser extends Parser {
         _localctx = new DebugContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(120);
+        setState(122);
         match(DEBUG);
-        setState(132);
+        setState(134);
         _errHandler.sync(this);
         switch ( getInterpreter().adaptivePredict(_input,5,_ctx) ) {
         case 1:
           {
-          setState(121);
+          setState(123);
           match(T__0);
-          setState(128);
+          setState(130);
           _errHandler.sync(this);
           _la = _input.LA(1);
           while (_la==FORMAT || _la==PLAN) {
             {
-            setState(126);
+            setState(128);
             switch (_input.LA(1)) {
             case PLAN:
               {
-              setState(122);
+              setState(124);
               match(PLAN);
-              setState(123);
+              setState(125);
               ((DebugContext)_localctx).type = _input.LT(1);
               _la = _input.LA(1);
               if ( !(_la==ANALYZED || _la==OPTIMIZED) ) {
@@ -728,9 +737,9 @@ class SqlBaseParser extends Parser {
               break;
             case FORMAT:
               {
-              setState(124);
+              setState(126);
               match(FORMAT);
-              setState(125);
+              setState(127);
               ((DebugContext)_localctx).format = _input.LT(1);
               _la = _input.LA(1);
               if ( !(_la==GRAPHVIZ || _la==TEXT) ) {
@@ -744,16 +753,16 @@ class SqlBaseParser extends Parser {
               throw new NoViableAltException(this);
             }
             }
-            setState(130);
+            setState(132);
             _errHandler.sync(this);
             _la = _input.LA(1);
           }
-          setState(131);
+          setState(133);
           match(T__1);
           }
           break;
         }
-        setState(134);
+        setState(136);
         statement();
         }
         break;
@@ -761,28 +770,58 @@ class SqlBaseParser extends Parser {
         _localctx = new ShowTablesContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(135);
+        setState(137);
         match(SHOW);
-        setState(136);
+        setState(138);
         match(TABLES);
         setState(141);
-        _la = _input.LA(1);
-        if (((((_la - 40)) & ~0x3f) == 0 && ((1L << (_la - 40)) & ((1L << (LIKE - 40)) | (1L << (PARAM - 40)) | (1L << (STRING - 40)))) != 0)) {
+        switch (_input.LA(1)) {
+        case LIKE:
           {
-          setState(138);
-          _la = _input.LA(1);
-          if (_la==LIKE) {
-            {
-            setState(137);
-            match(LIKE);
-            }
+          setState(139);
+          ((ShowTablesContext)_localctx).tableLike = likePattern();
           }
-
+          break;
+        case ANALYZE:
+        case ANALYZED:
+        case CATALOGS:
+        case COLUMNS:
+        case DEBUG:
+        case EXECUTABLE:
+        case EXPLAIN:
+        case FORMAT:
+        case FUNCTIONS:
+        case GRAPHVIZ:
+        case MAPPED:
+        case OPTIMIZED:
+        case PARSED:
+        case PHYSICAL:
+        case PLAN:
+        case RLIKE:
+        case QUERY:
+        case SCHEMAS:
+        case SHOW:
+        case SYS:
+        case TABLES:
+        case TEXT:
+        case TYPE:
+        case TYPES:
+        case VERIFY:
+        case IDENTIFIER:
+        case DIGIT_IDENTIFIER:
+        case TABLE_IDENTIFIER:
+        case QUOTED_IDENTIFIER:
+        case BACKQUOTED_IDENTIFIER:
+          {
           setState(140);
-          pattern();
+          ((ShowTablesContext)_localctx).tableIdent = tableIdentifier();
           }
+          break;
+        case EOF:
+          break;
+        default:
+          throw new NoViableAltException(this);
         }
-
         }
         break;
       case 5:
@@ -800,48 +839,127 @@ class SqlBaseParser extends Parser {
         } else {
           consume();
         }
-        setState(146);
-        tableIdentifier();
+        setState(148);
+        switch (_input.LA(1)) {
+        case LIKE:
+          {
+          setState(146);
+          ((ShowColumnsContext)_localctx).tableLike = likePattern();
+          }
+          break;
+        case ANALYZE:
+        case ANALYZED:
+        case CATALOGS:
+        case COLUMNS:
+        case DEBUG:
+        case EXECUTABLE:
+        case EXPLAIN:
+        case FORMAT:
+        case FUNCTIONS:
+        case GRAPHVIZ:
+        case MAPPED:
+        case OPTIMIZED:
+        case PARSED:
+        case PHYSICAL:
+        case PLAN:
+        case RLIKE:
+        case QUERY:
+        case SCHEMAS:
+        case SHOW:
+        case SYS:
+        case TABLES:
+        case TEXT:
+        case TYPE:
+        case TYPES:
+        case VERIFY:
+        case IDENTIFIER:
+        case DIGIT_IDENTIFIER:
+        case TABLE_IDENTIFIER:
+        case QUOTED_IDENTIFIER:
+        case BACKQUOTED_IDENTIFIER:
+          {
+          setState(147);
+          ((ShowColumnsContext)_localctx).tableIdent = tableIdentifier();
+          }
+          break;
+        default:
+          throw new NoViableAltException(this);
+        }
         }
         break;
       case 6:
         _localctx = new ShowColumnsContext(_localctx);
         enterOuterAlt(_localctx, 6);
         {
-        setState(147);
+        setState(150);
         _la = _input.LA(1);
         if ( !(_la==DESC || _la==DESCRIBE) ) {
         _errHandler.recoverInline(this);
         } else {
           consume();
         }
-        setState(148);
-        tableIdentifier();
+        setState(153);
+        switch (_input.LA(1)) {
+        case LIKE:
+          {
+          setState(151);
+          ((ShowColumnsContext)_localctx).tableLike = likePattern();
+          }
+          break;
+        case ANALYZE:
+        case ANALYZED:
+        case CATALOGS:
+        case COLUMNS:
+        case DEBUG:
+        case EXECUTABLE:
+        case EXPLAIN:
+        case FORMAT:
+        case FUNCTIONS:
+        case GRAPHVIZ:
+        case MAPPED:
+        case OPTIMIZED:
+        case PARSED:
+        case PHYSICAL:
+        case PLAN:
+        case RLIKE:
+        case QUERY:
+        case SCHEMAS:
+        case SHOW:
+        case SYS:
+        case TABLES:
+        case TEXT:
+        case TYPE:
+        case TYPES:
+        case VERIFY:
+        case IDENTIFIER:
+        case DIGIT_IDENTIFIER:
+        case TABLE_IDENTIFIER:
+        case QUOTED_IDENTIFIER:
+        case BACKQUOTED_IDENTIFIER:
+          {
+          setState(152);
+          ((ShowColumnsContext)_localctx).tableIdent = tableIdentifier();
+          }
+          break;
+        default:
+          throw new NoViableAltException(this);
+        }
         }
         break;
       case 7:
         _localctx = new ShowFunctionsContext(_localctx);
         enterOuterAlt(_localctx, 7);
         {
-        setState(149);
-        match(SHOW);
-        setState(150);
-        match(FUNCTIONS);
         setState(155);
+        match(SHOW);
+        setState(156);
+        match(FUNCTIONS);
+        setState(158);
         _la = _input.LA(1);
-        if (((((_la - 40)) & ~0x3f) == 0 && ((1L << (_la - 40)) & ((1L << (LIKE - 40)) | (1L << (PARAM - 40)) | (1L << (STRING - 40)))) != 0)) {
+        if (_la==LIKE) {
           {
-          setState(152);
-          _la = _input.LA(1);
-          if (_la==LIKE) {
-            {
-            setState(151);
-            match(LIKE);
-            }
-          }
-
-          setState(154);
-          pattern();
+          setState(157);
+          likePattern();
           }
         }
 
@@ -851,9 +969,9 @@ class SqlBaseParser extends Parser {
         _localctx = new ShowSchemasContext(_localctx);
         enterOuterAlt(_localctx, 8);
         {
-        setState(157);
+        setState(160);
         match(SHOW);
-        setState(158);
+        setState(161);
         match(SCHEMAS);
         }
         break;
@@ -861,9 +979,9 @@ class SqlBaseParser extends Parser {
         _localctx = new SysCatalogsContext(_localctx);
         enterOuterAlt(_localctx, 9);
         {
-        setState(159);
+        setState(162);
         match(SYS);
-        setState(160);
+        setState(163);
         match(CATALOGS);
         }
         break;
@@ -871,69 +989,58 @@ class SqlBaseParser extends Parser {
         _localctx = new SysTablesContext(_localctx);
         enterOuterAlt(_localctx, 10);
         {
-        setState(161);
+        setState(164);
         match(SYS);
-        setState(162);
+        setState(165);
         match(TABLES);
         setState(168);
         _la = _input.LA(1);
         if (_la==CATALOG) {
           {
-          setState(163);
+          setState(166);
           match(CATALOG);
-          setState(165);
-          _la = _input.LA(1);
-          if (_la==LIKE) {
-            {
-            setState(164);
-            match(LIKE);
-            }
-          }
-
           setState(167);
-          ((SysTablesContext)_localctx).clusterPattern = pattern();
+          ((SysTablesContext)_localctx).clusterLike = likePattern();
           }
         }
 
-        setState(174);
-        _la = _input.LA(1);
-        if (((((_la - 40)) & ~0x3f) == 0 && ((1L << (_la - 40)) & ((1L << (LIKE - 40)) | (1L << (PARAM - 40)) | (1L << (STRING - 40)))) != 0)) {
+        setState(172);
+        _errHandler.sync(this);
+        switch ( getInterpreter().adaptivePredict(_input,11,_ctx) ) {
+        case 1:
+          {
+          setState(170);
+          ((SysTablesContext)_localctx).tableLike = likePattern();
+          }
+          break;
+        case 2:
           {
           setState(171);
-          _la = _input.LA(1);
-          if (_la==LIKE) {
-            {
-            setState(170);
-            match(LIKE);
-            }
+          ((SysTablesContext)_localctx).tableIdent = tableIdentifier();
           }
-
-          setState(173);
-          ((SysTablesContext)_localctx).tablePattern = pattern();
-          }
+          break;
         }
-
-        setState(185);
+        setState(183);
         _la = _input.LA(1);
         if (_la==TYPE) {
           {
-          setState(176);
+          setState(174);
           match(TYPE);
-          setState(177);
+          setState(175);
           string();
-          setState(182);
+          setState(180);
           _errHandler.sync(this);
           _la = _input.LA(1);
           while (_la==T__2) {
             {
             {
-            setState(178);
+            setState(176);
             match(T__2);
-            setState(179);
+            setState(177);
             string();
             }
             }
-            setState(184);
+            setState(182);
             _errHandler.sync(this);
             _la = _input.LA(1);
           }
@@ -946,56 +1053,78 @@ class SqlBaseParser extends Parser {
         _localctx = new SysColumnsContext(_localctx);
         enterOuterAlt(_localctx, 11);
         {
-        setState(187);
+        setState(185);
         match(SYS);
-        setState(188);
+        setState(186);
         match(COLUMNS);
-        setState(191);
+        setState(189);
         _la = _input.LA(1);
         if (_la==CATALOG) {
           {
-          setState(189);
+          setState(187);
           match(CATALOG);
-          setState(190);
+          setState(188);
           ((SysColumnsContext)_localctx).cluster = string();
           }
         }
 
-        setState(198);
-        _la = _input.LA(1);
-        if (_la==TABLE) {
+        setState(194);
+        switch (_input.LA(1)) {
+        case TABLE:
+          {
+          setState(191);
+          match(TABLE);
+          setState(192);
+          ((SysColumnsContext)_localctx).tableLike = likePattern();
+          }
+          break;
+        case ANALYZE:
+        case ANALYZED:
+        case CATALOGS:
+        case COLUMNS:
+        case DEBUG:
+        case EXECUTABLE:
+        case EXPLAIN:
+        case FORMAT:
+        case FUNCTIONS:
+        case GRAPHVIZ:
+        case MAPPED:
+        case OPTIMIZED:
+        case PARSED:
+        case PHYSICAL:
+        case PLAN:
+        case RLIKE:
+        case QUERY:
+        case SCHEMAS:
+        case SHOW:
+        case SYS:
+        case TABLES:
+        case TEXT:
+        case TYPE:
+        case TYPES:
+        case VERIFY:
+        case IDENTIFIER:
+        case DIGIT_IDENTIFIER:
+        case TABLE_IDENTIFIER:
+        case QUOTED_IDENTIFIER:
+        case BACKQUOTED_IDENTIFIER:
           {
           setState(193);
-          match(TABLE);
-          setState(195);
-          _la = _input.LA(1);
-          if (_la==LIKE) {
-            {
-            setState(194);
-            match(LIKE);
-            }
+          ((SysColumnsContext)_localctx).tableIdent = tableIdentifier();
           }
-
-          setState(197);
-          ((SysColumnsContext)_localctx).indexPattern = pattern();
-          }
+          break;
+        case EOF:
+        case LIKE:
+          break;
+        default:
+          throw new NoViableAltException(this);
         }
-
-        setState(204);
+        setState(197);
         _la = _input.LA(1);
-        if (((((_la - 40)) & ~0x3f) == 0 && ((1L << (_la - 40)) & ((1L << (LIKE - 40)) | (1L << (PARAM - 40)) | (1L << (STRING - 40)))) != 0)) {
+        if (_la==LIKE) {
           {
-          setState(201);
-          _la = _input.LA(1);
-          if (_la==LIKE) {
-            {
-            setState(200);
-            match(LIKE);
-            }
-          }
-
-          setState(203);
-          ((SysColumnsContext)_localctx).columnPattern = pattern();
+          setState(196);
+          ((SysColumnsContext)_localctx).columnPattern = likePattern();
           }
         }
 
@@ -1005,9 +1134,9 @@ class SqlBaseParser extends Parser {
         _localctx = new SysTypesContext(_localctx);
         enterOuterAlt(_localctx, 12);
         {
-        setState(206);
+        setState(199);
         match(SYS);
-        setState(207);
+        setState(200);
         match(TYPES);
         }
         break;
@@ -1015,11 +1144,11 @@ class SqlBaseParser extends Parser {
         _localctx = new SysTableTypesContext(_localctx);
         enterOuterAlt(_localctx, 13);
         {
-        setState(208);
+        setState(201);
         match(SYS);
-        setState(209);
+        setState(202);
         match(TABLE);
-        setState(210);
+        setState(203);
         match(TYPES);
         }
         break;
@@ -1073,34 +1202,34 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(222);
+      setState(215);
       _la = _input.LA(1);
       if (_la==WITH) {
         {
-        setState(213);
+        setState(206);
         match(WITH);
-        setState(214);
+        setState(207);
         namedQuery();
-        setState(219);
+        setState(212);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==T__2) {
           {
           {
-          setState(215);
+          setState(208);
           match(T__2);
-          setState(216);
+          setState(209);
           namedQuery();
           }
           }
-          setState(221);
+          setState(214);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
       }
 
-      setState(224);
+      setState(217);
       queryNoWith();
       }
     }
@@ -1156,42 +1285,42 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(226);
+      setState(219);
       queryTerm();
-      setState(237);
+      setState(230);
       _la = _input.LA(1);
       if (_la==ORDER) {
         {
-        setState(227);
+        setState(220);
         match(ORDER);
-        setState(228);
+        setState(221);
         match(BY);
-        setState(229);
+        setState(222);
         orderBy();
-        setState(234);
+        setState(227);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==T__2) {
           {
           {
-          setState(230);
+          setState(223);
           match(T__2);
-          setState(231);
+          setState(224);
           orderBy();
           }
           }
-          setState(236);
+          setState(229);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
       }
 
-      setState(240);
+      setState(233);
       _la = _input.LA(1);
       if (_la==LIMIT || _la==LIMIT_ESC) {
         {
-        setState(239);
+        setState(232);
         limitClause();
         }
       }
@@ -1240,14 +1369,14 @@ class SqlBaseParser extends Parser {
     enterRule(_localctx, 10, RULE_limitClause);
     int _la;
     try {
-      setState(247);
+      setState(240);
       switch (_input.LA(1)) {
       case LIMIT:
         enterOuterAlt(_localctx, 1);
         {
-        setState(242);
+        setState(235);
         match(LIMIT);
-        setState(243);
+        setState(236);
         ((LimitClauseContext)_localctx).limit = _input.LT(1);
         _la = _input.LA(1);
         if ( !(_la==ALL || _la==INTEGER_VALUE) ) {
@@ -1260,9 +1389,9 @@ class SqlBaseParser extends Parser {
       case LIMIT_ESC:
         enterOuterAlt(_localctx, 2);
         {
-        setState(244);
+        setState(237);
         match(LIMIT_ESC);
-        setState(245);
+        setState(238);
         ((LimitClauseContext)_localctx).limit = _input.LT(1);
         _la = _input.LA(1);
         if ( !(_la==ALL || _la==INTEGER_VALUE) ) {
@@ -1270,7 +1399,7 @@ class SqlBaseParser extends Parser {
         } else {
           consume();
         }
-        setState(246);
+        setState(239);
         match(ESC_END);
         }
         break;
@@ -1343,13 +1472,13 @@ class SqlBaseParser extends Parser {
     QueryTermContext _localctx = new QueryTermContext(_ctx, getState());
     enterRule(_localctx, 12, RULE_queryTerm);
     try {
-      setState(254);
+      setState(247);
       switch (_input.LA(1)) {
       case SELECT:
         _localctx = new QueryPrimaryDefaultContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(249);
+        setState(242);
         querySpecification();
         }
         break;
@@ -1357,11 +1486,11 @@ class SqlBaseParser extends Parser {
         _localctx = new SubqueryContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(250);
+        setState(243);
         match(T__0);
-        setState(251);
+        setState(244);
         queryNoWith();
-        setState(252);
+        setState(245);
         match(T__1);
         }
         break;
@@ -1413,13 +1542,13 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(256);
+      setState(249);
       expression();
-      setState(258);
+      setState(251);
       _la = _input.LA(1);
       if (_la==ASC || _la==DESC) {
         {
-        setState(257);
+        setState(250);
         ((OrderByContext)_localctx).ordering = _input.LT(1);
         _la = _input.LA(1);
         if ( !(_la==ASC || _la==DESC) ) {
@@ -1498,75 +1627,75 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(260);
+      setState(253);
       match(SELECT);
-      setState(262);
+      setState(255);
       _la = _input.LA(1);
       if (_la==ALL || _la==DISTINCT) {
         {
-        setState(261);
+        setState(254);
         setQuantifier();
         }
       }
 
-      setState(264);
+      setState(257);
       selectItem();
-      setState(269);
+      setState(262);
       _errHandler.sync(this);
       _la = _input.LA(1);
       while (_la==T__2) {
         {
         {
-        setState(265);
+        setState(258);
         match(T__2);
-        setState(266);
+        setState(259);
         selectItem();
         }
         }
-        setState(271);
+        setState(264);
         _errHandler.sync(this);
         _la = _input.LA(1);
       }
-      setState(273);
+      setState(266);
       _la = _input.LA(1);
       if (_la==FROM) {
         {
-        setState(272);
+        setState(265);
         fromClause();
         }
       }
 
-      setState(277);
+      setState(270);
       _la = _input.LA(1);
       if (_la==WHERE) {
         {
-        setState(275);
+        setState(268);
         match(WHERE);
-        setState(276);
+        setState(269);
         ((QuerySpecificationContext)_localctx).where = booleanExpression(0);
         }
       }
 
-      setState(282);
+      setState(275);
       _la = _input.LA(1);
       if (_la==GROUP) {
         {
-        setState(279);
+        setState(272);
         match(GROUP);
-        setState(280);
+        setState(273);
         match(BY);
-        setState(281);
+        setState(274);
         groupBy();
         }
       }
 
-      setState(286);
+      setState(279);
       _la = _input.LA(1);
       if (_la==HAVING) {
         {
-        setState(284);
+        setState(277);
         match(HAVING);
-        setState(285);
+        setState(278);
         ((QuerySpecificationContext)_localctx).having = booleanExpression(0);
         }
       }
@@ -1618,23 +1747,23 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(288);
+      setState(281);
       match(FROM);
-      setState(289);
+      setState(282);
       relation();
-      setState(294);
+      setState(287);
       _errHandler.sync(this);
       _la = _input.LA(1);
       while (_la==T__2) {
         {
         {
-        setState(290);
+        setState(283);
         match(T__2);
-        setState(291);
+        setState(284);
         relation();
         }
         }
-        setState(296);
+        setState(289);
         _errHandler.sync(this);
         _la = _input.LA(1);
       }
@@ -1687,30 +1816,30 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(298);
+      setState(291);
       _la = _input.LA(1);
       if (_la==ALL || _la==DISTINCT) {
         {
-        setState(297);
+        setState(290);
         setQuantifier();
         }
       }
 
-      setState(300);
+      setState(293);
       groupingElement();
-      setState(305);
+      setState(298);
       _errHandler.sync(this);
       _la = _input.LA(1);
       while (_la==T__2) {
         {
         {
-        setState(301);
+        setState(294);
         match(T__2);
-        setState(302);
+        setState(295);
         groupingElement();
         }
         }
-        setState(307);
+        setState(300);
         _errHandler.sync(this);
         _la = _input.LA(1);
       }
@@ -1765,7 +1894,7 @@ class SqlBaseParser extends Parser {
       _localctx = new SingleGroupingSetContext(_localctx);
       enterOuterAlt(_localctx, 1);
       {
-      setState(308);
+      setState(301);
       groupingExpressions();
       }
     }
@@ -1811,47 +1940,47 @@ class SqlBaseParser extends Parser {
     enterRule(_localctx, 24, RULE_groupingExpressions);
     int _la;
     try {
-      setState(323);
+      setState(316);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,41,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,37,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(310);
+        setState(303);
         match(T__0);
-        setState(319);
+        setState(312);
         _la = _input.LA(1);
         if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__0) | (1L << ANALYZE) | (1L << ANALYZED) | (1L << CAST) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << DEBUG) | (1L << EXECUTABLE) | (1L << EXISTS) | (1L << EXPLAIN) | (1L << EXTRACT) | (1L << FALSE) | (1L << FORMAT) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << LEFT) | (1L << MAPPED) | (1L << MATCH) | (1L << NOT) | (1L << NULL) | (1L << OPTIMIZED) | (1L << PARSED) | (1L << PHYSICAL) | (1L << PLAN) | (1L << RIGHT) | (1L << RLIKE) | (1L << QUERY) | (1L << SCHEMAS) | (1L << SHOW) | (1L << SYS) | (1L << TABLES))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (TEXT - 64)) | (1L << (TRUE - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (FUNCTION_ESC - 64)) | (1L << (DATE_ESC - 64)) | (1L << (TIME_ESC - 64)) | (1L << (TIMESTAMP_ESC - 64)) | (1L << (GUID_ESC - 64)) | (1L << (PLUS - 64)) | (1L << (MINUS - 64)) | (1L << (ASTERISK - 64)) | (1L << (PARAM - 64)) | (1L << (STRING - 64)) | (1L << (INTEGER_VALUE - 64)) | (1L << (DECIMAL_VALUE - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
           {
-          setState(311);
+          setState(304);
           expression();
-          setState(316);
+          setState(309);
           _errHandler.sync(this);
           _la = _input.LA(1);
           while (_la==T__2) {
             {
             {
-            setState(312);
+            setState(305);
             match(T__2);
-            setState(313);
+            setState(306);
             expression();
             }
             }
-            setState(318);
+            setState(311);
             _errHandler.sync(this);
             _la = _input.LA(1);
           }
           }
         }
 
-        setState(321);
+        setState(314);
         match(T__1);
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(322);
+        setState(315);
         expression();
         }
         break;
@@ -1902,15 +2031,15 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(325);
+      setState(318);
       ((NamedQueryContext)_localctx).name = identifier();
-      setState(326);
+      setState(319);
       match(AS);
-      setState(327);
+      setState(320);
       match(T__0);
-      setState(328);
+      setState(321);
       queryNoWith();
-      setState(329);
+      setState(322);
       match(T__1);
       }
     }
@@ -1954,7 +2083,7 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(331);
+      setState(324);
       _la = _input.LA(1);
       if ( !(_la==ALL || _la==DISTINCT) ) {
       _errHandler.recoverInline(this);
@@ -2017,22 +2146,22 @@ class SqlBaseParser extends Parser {
       _localctx = new SelectExpressionContext(_localctx);
       enterOuterAlt(_localctx, 1);
       {
-      setState(333);
+      setState(326);
       expression();
-      setState(338);
+      setState(331);
       _la = _input.LA(1);
       if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANALYZE) | (1L << ANALYZED) | (1L << AS) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << DEBUG) | (1L << EXECUTABLE) | (1L << EXPLAIN) | (1L << FORMAT) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << MAPPED) | (1L << OPTIMIZED) | (1L << PARSED) | (1L << PHYSICAL) | (1L << PLAN) | (1L << RLIKE) | (1L << QUERY) | (1L << SCHEMAS) | (1L << SHOW) | (1L << SYS) | (1L << TABLES))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (TEXT - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
         {
-        setState(335);
+        setState(328);
         _la = _input.LA(1);
         if (_la==AS) {
           {
-          setState(334);
+          setState(327);
           match(AS);
           }
         }
 
-        setState(337);
+        setState(330);
         identifier();
         }
       }
@@ -2086,19 +2215,19 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(340);
+      setState(333);
       relationPrimary();
-      setState(344);
+      setState(337);
       _errHandler.sync(this);
       _la = _input.LA(1);
       while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FULL) | (1L << INNER) | (1L << JOIN) | (1L << LEFT) | (1L << NATURAL) | (1L << RIGHT))) != 0)) {
         {
         {
-        setState(341);
+        setState(334);
         joinRelation();
         }
         }
-        setState(346);
+        setState(339);
         _errHandler.sync(this);
         _la = _input.LA(1);
       }
@@ -2152,7 +2281,7 @@ class SqlBaseParser extends Parser {
     enterRule(_localctx, 34, RULE_joinRelation);
     int _la;
     try {
-      setState(358);
+      setState(351);
       switch (_input.LA(1)) {
       case FULL:
       case INNER:
@@ -2162,18 +2291,18 @@ class SqlBaseParser extends Parser {
         enterOuterAlt(_localctx, 1);
         {
         {
-        setState(347);
+        setState(340);
         joinType();
         }
-        setState(348);
+        setState(341);
         match(JOIN);
-        setState(349);
+        setState(342);
         ((JoinRelationContext)_localctx).right = relationPrimary();
-        setState(351);
+        setState(344);
         _la = _input.LA(1);
         if (_la==ON || _la==USING) {
           {
-          setState(350);
+          setState(343);
           joinCriteria();
           }
         }
@@ -2183,13 +2312,13 @@ class SqlBaseParser extends Parser {
       case NATURAL:
         enterOuterAlt(_localctx, 2);
         {
-        setState(353);
+        setState(346);
         match(NATURAL);
-        setState(354);
+        setState(347);
         joinType();
-        setState(355);
+        setState(348);
         match(JOIN);
-        setState(356);
+        setState(349);
         ((JoinRelationContext)_localctx).right = relationPrimary();
         }
         break;
@@ -2238,17 +2367,17 @@ class SqlBaseParser extends Parser {
     enterRule(_localctx, 36, RULE_joinType);
     int _la;
     try {
-      setState(375);
+      setState(368);
       switch (_input.LA(1)) {
       case INNER:
       case JOIN:
         enterOuterAlt(_localctx, 1);
         {
-        setState(361);
+        setState(354);
         _la = _input.LA(1);
         if (_la==INNER) {
           {
-          setState(360);
+          setState(353);
           match(INNER);
           }
         }
@@ -2258,13 +2387,13 @@ class SqlBaseParser extends Parser {
       case LEFT:
         enterOuterAlt(_localctx, 2);
         {
-        setState(363);
+        setState(356);
         match(LEFT);
-        setState(365);
+        setState(358);
         _la = _input.LA(1);
         if (_la==OUTER) {
           {
-          setState(364);
+          setState(357);
           match(OUTER);
           }
         }
@@ -2274,13 +2403,13 @@ class SqlBaseParser extends Parser {
       case RIGHT:
         enterOuterAlt(_localctx, 3);
         {
-        setState(367);
+        setState(360);
         match(RIGHT);
-        setState(369);
+        setState(362);
         _la = _input.LA(1);
         if (_la==OUTER) {
           {
-          setState(368);
+          setState(361);
           match(OUTER);
           }
         }
@@ -2290,13 +2419,13 @@ class SqlBaseParser extends Parser {
       case FULL:
         enterOuterAlt(_localctx, 4);
         {
-        setState(371);
+        setState(364);
         match(FULL);
-        setState(373);
+        setState(366);
         _la = _input.LA(1);
         if (_la==OUTER) {
           {
-          setState(372);
+          setState(365);
           match(OUTER);
           }
         }
@@ -2354,43 +2483,43 @@ class SqlBaseParser extends Parser {
     enterRule(_localctx, 38, RULE_joinCriteria);
     int _la;
     try {
-      setState(391);
+      setState(384);
       switch (_input.LA(1)) {
       case ON:
         enterOuterAlt(_localctx, 1);
         {
-        setState(377);
+        setState(370);
         match(ON);
-        setState(378);
+        setState(371);
         booleanExpression(0);
         }
         break;
       case USING:
         enterOuterAlt(_localctx, 2);
         {
-        setState(379);
+        setState(372);
         match(USING);
-        setState(380);
+        setState(373);
         match(T__0);
-        setState(381);
+        setState(374);
         identifier();
-        setState(386);
+        setState(379);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==T__2) {
           {
           {
-          setState(382);
+          setState(375);
           match(T__2);
-          setState(383);
+          setState(376);
           identifier();
           }
           }
-          setState(388);
+          setState(381);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
-        setState(389);
+        setState(382);
         match(T__1);
         }
         break;
@@ -2495,29 +2624,29 @@ class SqlBaseParser extends Parser {
     enterRule(_localctx, 40, RULE_relationPrimary);
     int _la;
     try {
-      setState(418);
+      setState(411);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,60,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,56,_ctx) ) {
       case 1:
         _localctx = new TableNameContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(393);
+        setState(386);
         tableIdentifier();
-        setState(398);
+        setState(391);
         _la = _input.LA(1);
         if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANALYZE) | (1L << ANALYZED) | (1L << AS) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << DEBUG) | (1L << EXECUTABLE) | (1L << EXPLAIN) | (1L << FORMAT) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << MAPPED) | (1L << OPTIMIZED) | (1L << PARSED) | (1L << PHYSICAL) | (1L << PLAN) | (1L << RLIKE) | (1L << QUERY) | (1L << SCHEMAS) | (1L << SHOW) | (1L << SYS) | (1L << TABLES))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (TEXT - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
           {
-          setState(395);
+          setState(388);
           _la = _input.LA(1);
           if (_la==AS) {
             {
-            setState(394);
+            setState(387);
             match(AS);
             }
           }
 
-          setState(397);
+          setState(390);
           qualifiedName();
           }
         }
@@ -2528,26 +2657,26 @@ class SqlBaseParser extends Parser {
         _localctx = new AliasedQueryContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(400);
+        setState(393);
         match(T__0);
-        setState(401);
+        setState(394);
         queryNoWith();
-        setState(402);
+        setState(395);
         match(T__1);
-        setState(407);
+        setState(400);
         _la = _input.LA(1);
         if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANALYZE) | (1L << ANALYZED) | (1L << AS) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << DEBUG) | (1L << EXECUTABLE) | (1L << EXPLAIN) | (1L << FORMAT) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << MAPPED) | (1L << OPTIMIZED) | (1L << PARSED) | (1L << PHYSICAL) | (1L << PLAN) | (1L << RLIKE) | (1L << QUERY) | (1L << SCHEMAS) | (1L << SHOW) | (1L << SYS) | (1L << TABLES))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (TEXT - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
           {
-          setState(404);
+          setState(397);
           _la = _input.LA(1);
           if (_la==AS) {
             {
-            setState(403);
+            setState(396);
             match(AS);
             }
           }
 
-          setState(406);
+          setState(399);
           qualifiedName();
           }
         }
@@ -2558,26 +2687,26 @@ class SqlBaseParser extends Parser {
         _localctx = new AliasedRelationContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(409);
+        setState(402);
         match(T__0);
-        setState(410);
+        setState(403);
         relation();
-        setState(411);
+        setState(404);
         match(T__1);
-        setState(416);
+        setState(409);
         _la = _input.LA(1);
         if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANALYZE) | (1L << ANALYZED) | (1L << AS) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << DEBUG) | (1L << EXECUTABLE) | (1L << EXPLAIN) | (1L << FORMAT) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << MAPPED) | (1L << OPTIMIZED) | (1L << PARSED) | (1L << PHYSICAL) | (1L << PLAN) | (1L << RLIKE) | (1L << QUERY) | (1L << SCHEMAS) | (1L << SHOW) | (1L << SYS) | (1L << TABLES))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (TEXT - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
           {
-          setState(413);
+          setState(406);
           _la = _input.LA(1);
           if (_la==AS) {
             {
-            setState(412);
+            setState(405);
             match(AS);
             }
           }
 
-          setState(415);
+          setState(408);
           qualifiedName();
           }
         }
@@ -2626,7 +2755,7 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(420);
+      setState(413);
       booleanExpression(0);
       }
     }
@@ -2835,18 +2964,18 @@ class SqlBaseParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(471);
+      setState(464);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,64,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,60,_ctx) ) {
       case 1:
         {
         _localctx = new LogicalNotContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
 
-        setState(423);
+        setState(416);
         match(NOT);
-        setState(424);
+        setState(417);
         booleanExpression(8);
         }
         break;
@@ -2855,13 +2984,13 @@ class SqlBaseParser extends Parser {
         _localctx = new ExistsContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(425);
+        setState(418);
         match(EXISTS);
-        setState(426);
+        setState(419);
         match(T__0);
-        setState(427);
+        setState(420);
         query();
-        setState(428);
+        setState(421);
         match(T__1);
         }
         break;
@@ -2870,29 +2999,29 @@ class SqlBaseParser extends Parser {
         _localctx = new StringQueryContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(430);
+        setState(423);
         match(QUERY);
-        setState(431);
+        setState(424);
         match(T__0);
-        setState(432);
+        setState(425);
         ((StringQueryContext)_localctx).queryString = string();
-        setState(437);
+        setState(430);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==T__2) {
           {
           {
-          setState(433);
+          setState(426);
           match(T__2);
-          setState(434);
+          setState(427);
           ((StringQueryContext)_localctx).options = string();
           }
           }
-          setState(439);
+          setState(432);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
-        setState(440);
+        setState(433);
         match(T__1);
         }
         break;
@@ -2901,33 +3030,33 @@ class SqlBaseParser extends Parser {
         _localctx = new MatchQueryContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(442);
+        setState(435);
         match(MATCH);
-        setState(443);
+        setState(436);
         match(T__0);
-        setState(444);
+        setState(437);
         ((MatchQueryContext)_localctx).singleField = qualifiedName();
-        setState(445);
+        setState(438);
         match(T__2);
-        setState(446);
+        setState(439);
         ((MatchQueryContext)_localctx).queryString = string();
-        setState(451);
+        setState(444);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==T__2) {
           {
           {
-          setState(447);
+          setState(440);
           match(T__2);
-          setState(448);
+          setState(441);
           ((MatchQueryContext)_localctx).options = string();
           }
           }
-          setState(453);
+          setState(446);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
-        setState(454);
+        setState(447);
         match(T__1);
         }
         break;
@@ -2936,33 +3065,33 @@ class SqlBaseParser extends Parser {
         _localctx = new MultiMatchQueryContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(456);
+        setState(449);
         match(MATCH);
-        setState(457);
+        setState(450);
         match(T__0);
-        setState(458);
+        setState(451);
         ((MultiMatchQueryContext)_localctx).multiFields = string();
-        setState(459);
+        setState(452);
         match(T__2);
-        setState(460);
+        setState(453);
         ((MultiMatchQueryContext)_localctx).queryString = string();
-        setState(465);
+        setState(458);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==T__2) {
           {
           {
-          setState(461);
+          setState(454);
           match(T__2);
-          setState(462);
+          setState(455);
           ((MultiMatchQueryContext)_localctx).options = string();
           }
           }
-          setState(467);
+          setState(460);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
-        setState(468);
+        setState(461);
         match(T__1);
         }
         break;
@@ -2971,33 +3100,33 @@ class SqlBaseParser extends Parser {
         _localctx = new BooleanDefaultContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(470);
+        setState(463);
         predicated();
         }
         break;
       }
       _ctx.stop = _input.LT(-1);
-      setState(481);
+      setState(474);
       _errHandler.sync(this);
-      _alt = getInterpreter().adaptivePredict(_input,66,_ctx);
+      _alt = getInterpreter().adaptivePredict(_input,62,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           if ( _parseListeners!=null ) triggerExitRuleEvent();
           _prevctx = _localctx;
           {
-          setState(479);
+          setState(472);
           _errHandler.sync(this);
-          switch ( getInterpreter().adaptivePredict(_input,65,_ctx) ) {
+          switch ( getInterpreter().adaptivePredict(_input,61,_ctx) ) {
           case 1:
             {
             _localctx = new LogicalBinaryContext(new BooleanExpressionContext(_parentctx, _parentState));
             ((LogicalBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_booleanExpression);
-            setState(473);
+            setState(466);
             if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-            setState(474);
+            setState(467);
             ((LogicalBinaryContext)_localctx).operator = match(AND);
-            setState(475);
+            setState(468);
             ((LogicalBinaryContext)_localctx).right = booleanExpression(3);
             }
             break;
@@ -3006,20 +3135,20 @@ class SqlBaseParser extends Parser {
             _localctx = new LogicalBinaryContext(new BooleanExpressionContext(_parentctx, _parentState));
             ((LogicalBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_booleanExpression);
-            setState(476);
+            setState(469);
             if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
-            setState(477);
+            setState(470);
             ((LogicalBinaryContext)_localctx).operator = match(OR);
-            setState(478);
+            setState(471);
             ((LogicalBinaryContext)_localctx).right = booleanExpression(2);
             }
             break;
           }
           } 
         }
-        setState(483);
+        setState(476);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,66,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,62,_ctx);
       }
       }
     }
@@ -3066,14 +3195,14 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(484);
+      setState(477);
       valueExpression(0);
-      setState(486);
+      setState(479);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,67,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,63,_ctx) ) {
       case 1:
         {
-        setState(485);
+        setState(478);
         predicate();
         }
         break;
@@ -3149,145 +3278,192 @@ class SqlBaseParser extends Parser {
     enterRule(_localctx, 48, RULE_predicate);
     int _la;
     try {
-      setState(534);
+      setState(527);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,75,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,71,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(489);
+        setState(482);
         _la = _input.LA(1);
         if (_la==NOT) {
           {
-          setState(488);
+          setState(481);
           match(NOT);
           }
         }
 
-        setState(491);
+        setState(484);
         ((PredicateContext)_localctx).kind = match(BETWEEN);
-        setState(492);
+        setState(485);
         ((PredicateContext)_localctx).lower = valueExpression(0);
-        setState(493);
+        setState(486);
         match(AND);
-        setState(494);
+        setState(487);
         ((PredicateContext)_localctx).upper = valueExpression(0);
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(497);
+        setState(490);
         _la = _input.LA(1);
         if (_la==NOT) {
           {
-          setState(496);
+          setState(489);
           match(NOT);
           }
         }
 
-        setState(499);
+        setState(492);
         ((PredicateContext)_localctx).kind = match(IN);
-        setState(500);
+        setState(493);
         match(T__0);
-        setState(501);
+        setState(494);
         expression();
-        setState(506);
+        setState(499);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==T__2) {
           {
           {
-          setState(502);
+          setState(495);
           match(T__2);
-          setState(503);
+          setState(496);
           expression();
           }
           }
-          setState(508);
+          setState(501);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
-        setState(509);
+        setState(502);
         match(T__1);
         }
         break;
       case 3:
         enterOuterAlt(_localctx, 3);
         {
-        setState(512);
+        setState(505);
         _la = _input.LA(1);
         if (_la==NOT) {
           {
-          setState(511);
+          setState(504);
           match(NOT);
           }
         }
 
-        setState(514);
+        setState(507);
         ((PredicateContext)_localctx).kind = match(IN);
-        setState(515);
+        setState(508);
         match(T__0);
-        setState(516);
+        setState(509);
         query();
-        setState(517);
+        setState(510);
         match(T__1);
         }
         break;
       case 4:
         enterOuterAlt(_localctx, 4);
         {
-        setState(520);
+        setState(513);
         _la = _input.LA(1);
         if (_la==NOT) {
           {
-          setState(519);
+          setState(512);
           match(NOT);
           }
         }
 
-        setState(522);
+        setState(515);
         ((PredicateContext)_localctx).kind = match(LIKE);
-        setState(523);
+        setState(516);
         pattern();
         }
         break;
       case 5:
         enterOuterAlt(_localctx, 5);
         {
-        setState(525);
+        setState(518);
         _la = _input.LA(1);
         if (_la==NOT) {
           {
-          setState(524);
+          setState(517);
           match(NOT);
           }
         }
 
-        setState(527);
+        setState(520);
         ((PredicateContext)_localctx).kind = match(RLIKE);
-        setState(528);
+        setState(521);
         ((PredicateContext)_localctx).regex = string();
         }
         break;
       case 6:
         enterOuterAlt(_localctx, 6);
         {
-        setState(529);
+        setState(522);
         match(IS);
-        setState(531);
+        setState(524);
         _la = _input.LA(1);
         if (_la==NOT) {
           {
-          setState(530);
+          setState(523);
           match(NOT);
           }
         }
 
-        setState(533);
+        setState(526);
         ((PredicateContext)_localctx).kind = match(NULL);
         }
         break;
+      }
+    }
+    catch (RecognitionException re) {
+      _localctx.exception = re;
+      _errHandler.reportError(this, re);
+      _errHandler.recover(this, re);
+    }
+    finally {
+      exitRule();
+    }
+    return _localctx;
+  }
+
+  public static class LikePatternContext extends ParserRuleContext {
+    public TerminalNode LIKE() { return getToken(SqlBaseParser.LIKE, 0); }
+    public PatternContext pattern() {
+      return getRuleContext(PatternContext.class,0);
+    }
+    public LikePatternContext(ParserRuleContext parent, int invokingState) {
+      super(parent, invokingState);
+    }
+    @Override public int getRuleIndex() { return RULE_likePattern; }
+    @Override
+    public void enterRule(ParseTreeListener listener) {
+      if ( listener instanceof SqlBaseListener ) ((SqlBaseListener)listener).enterLikePattern(this);
+    }
+    @Override
+    public void exitRule(ParseTreeListener listener) {
+      if ( listener instanceof SqlBaseListener ) ((SqlBaseListener)listener).exitLikePattern(this);
+    }
+    @Override
+    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+      if ( visitor instanceof SqlBaseVisitor ) return ((SqlBaseVisitor<? extends T>)visitor).visitLikePattern(this);
+      else return visitor.visitChildren(this);
+    }
+  }
+
+  public final LikePatternContext likePattern() throws RecognitionException {
+    LikePatternContext _localctx = new LikePatternContext(_ctx, getState());
+    enterRule(_localctx, 50, RULE_likePattern);
+    try {
+      enterOuterAlt(_localctx, 1);
+      {
+      setState(529);
+      match(LIKE);
+      setState(530);
+      pattern();
       }
     }
     catch (RecognitionException re) {
@@ -3330,18 +3506,18 @@ class SqlBaseParser extends Parser {
 
   public final PatternContext pattern() throws RecognitionException {
     PatternContext _localctx = new PatternContext(_ctx, getState());
-    enterRule(_localctx, 50, RULE_pattern);
+    enterRule(_localctx, 52, RULE_pattern);
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(536);
+      setState(532);
       ((PatternContext)_localctx).value = string();
-      setState(538);
+      setState(534);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,76,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,72,_ctx) ) {
       case 1:
         {
-        setState(537);
+        setState(533);
         patternEscape();
         }
         break;
@@ -3387,27 +3563,27 @@ class SqlBaseParser extends Parser {
 
   public final PatternEscapeContext patternEscape() throws RecognitionException {
     PatternEscapeContext _localctx = new PatternEscapeContext(_ctx, getState());
-    enterRule(_localctx, 52, RULE_patternEscape);
+    enterRule(_localctx, 54, RULE_patternEscape);
     try {
-      setState(546);
+      setState(542);
       switch (_input.LA(1)) {
       case ESCAPE:
         enterOuterAlt(_localctx, 1);
         {
-        setState(540);
+        setState(536);
         match(ESCAPE);
-        setState(541);
+        setState(537);
         ((PatternEscapeContext)_localctx).escape = string();
         }
         break;
       case ESCAPE_ESC:
         enterOuterAlt(_localctx, 2);
         {
-        setState(542);
+        setState(538);
         match(ESCAPE_ESC);
-        setState(543);
+        setState(539);
         ((PatternEscapeContext)_localctx).escape = string();
-        setState(544);
+        setState(540);
         match(ESC_END);
         }
         break;
@@ -3545,14 +3721,14 @@ class SqlBaseParser extends Parser {
     int _parentState = getState();
     ValueExpressionContext _localctx = new ValueExpressionContext(_ctx, _parentState);
     ValueExpressionContext _prevctx = _localctx;
-    int _startState = 54;
-    enterRecursionRule(_localctx, 54, RULE_valueExpression, _p);
+    int _startState = 56;
+    enterRecursionRule(_localctx, 56, RULE_valueExpression, _p);
     int _la;
     try {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(552);
+      setState(548);
       switch (_input.LA(1)) {
       case T__0:
       case ANALYZE:
@@ -3606,7 +3782,7 @@ class SqlBaseParser extends Parser {
         _ctx = _localctx;
         _prevctx = _localctx;
 
-        setState(549);
+        setState(545);
         primaryExpression();
         }
         break;
@@ -3616,7 +3792,7 @@ class SqlBaseParser extends Parser {
         _localctx = new ArithmeticUnaryContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(550);
+        setState(546);
         ((ArithmeticUnaryContext)_localctx).operator = _input.LT(1);
         _la = _input.LA(1);
         if ( !(_la==PLUS || _la==MINUS) ) {
@@ -3624,7 +3800,7 @@ class SqlBaseParser extends Parser {
         } else {
           consume();
         }
-        setState(551);
+        setState(547);
         valueExpression(4);
         }
         break;
@@ -3632,25 +3808,25 @@ class SqlBaseParser extends Parser {
         throw new NoViableAltException(this);
       }
       _ctx.stop = _input.LT(-1);
-      setState(566);
+      setState(562);
       _errHandler.sync(this);
-      _alt = getInterpreter().adaptivePredict(_input,80,_ctx);
+      _alt = getInterpreter().adaptivePredict(_input,76,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           if ( _parseListeners!=null ) triggerExitRuleEvent();
           _prevctx = _localctx;
           {
-          setState(564);
+          setState(560);
           _errHandler.sync(this);
-          switch ( getInterpreter().adaptivePredict(_input,79,_ctx) ) {
+          switch ( getInterpreter().adaptivePredict(_input,75,_ctx) ) {
           case 1:
             {
             _localctx = new ArithmeticBinaryContext(new ValueExpressionContext(_parentctx, _parentState));
             ((ArithmeticBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_valueExpression);
-            setState(554);
+            setState(550);
             if (!(precpred(_ctx, 3))) throw new FailedPredicateException(this, "precpred(_ctx, 3)");
-            setState(555);
+            setState(551);
             ((ArithmeticBinaryContext)_localctx).operator = _input.LT(1);
             _la = _input.LA(1);
             if ( !(((((_la - 88)) & ~0x3f) == 0 && ((1L << (_la - 88)) & ((1L << (ASTERISK - 88)) | (1L << (SLASH - 88)) | (1L << (PERCENT - 88)))) != 0)) ) {
@@ -3658,7 +3834,7 @@ class SqlBaseParser extends Parser {
             } else {
               consume();
             }
-            setState(556);
+            setState(552);
             ((ArithmeticBinaryContext)_localctx).right = valueExpression(4);
             }
             break;
@@ -3667,9 +3843,9 @@ class SqlBaseParser extends Parser {
             _localctx = new ArithmeticBinaryContext(new ValueExpressionContext(_parentctx, _parentState));
             ((ArithmeticBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_valueExpression);
-            setState(557);
+            setState(553);
             if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-            setState(558);
+            setState(554);
             ((ArithmeticBinaryContext)_localctx).operator = _input.LT(1);
             _la = _input.LA(1);
             if ( !(_la==PLUS || _la==MINUS) ) {
@@ -3677,7 +3853,7 @@ class SqlBaseParser extends Parser {
             } else {
               consume();
             }
-            setState(559);
+            setState(555);
             ((ArithmeticBinaryContext)_localctx).right = valueExpression(3);
             }
             break;
@@ -3686,20 +3862,20 @@ class SqlBaseParser extends Parser {
             _localctx = new ComparisonContext(new ValueExpressionContext(_parentctx, _parentState));
             ((ComparisonContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_valueExpression);
-            setState(560);
+            setState(556);
             if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
-            setState(561);
+            setState(557);
             comparisonOperator();
-            setState(562);
+            setState(558);
             ((ComparisonContext)_localctx).right = valueExpression(2);
             }
             break;
           }
           } 
         }
-        setState(568);
+        setState(564);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,80,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,76,_ctx);
       }
       }
     }
@@ -3901,17 +4077,17 @@ class SqlBaseParser extends Parser {
 
   public final PrimaryExpressionContext primaryExpression() throws RecognitionException {
     PrimaryExpressionContext _localctx = new PrimaryExpressionContext(_ctx, getState());
-    enterRule(_localctx, 56, RULE_primaryExpression);
+    enterRule(_localctx, 58, RULE_primaryExpression);
     int _la;
     try {
-      setState(590);
+      setState(586);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,82,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,78,_ctx) ) {
       case 1:
         _localctx = new CastContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(569);
+        setState(565);
         castExpression();
         }
         break;
@@ -3919,7 +4095,7 @@ class SqlBaseParser extends Parser {
         _localctx = new ExtractContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(570);
+        setState(566);
         extractExpression();
         }
         break;
@@ -3927,7 +4103,7 @@ class SqlBaseParser extends Parser {
         _localctx = new ConstantDefaultContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(571);
+        setState(567);
         constant();
         }
         break;
@@ -3935,7 +4111,7 @@ class SqlBaseParser extends Parser {
         _localctx = new StarContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(572);
+        setState(568);
         match(ASTERISK);
         }
         break;
@@ -3943,18 +4119,18 @@ class SqlBaseParser extends Parser {
         _localctx = new StarContext(_localctx);
         enterOuterAlt(_localctx, 5);
         {
-        setState(576);
+        setState(572);
         _la = _input.LA(1);
         if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANALYZE) | (1L << ANALYZED) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << DEBUG) | (1L << EXECUTABLE) | (1L << EXPLAIN) | (1L << FORMAT) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << MAPPED) | (1L << OPTIMIZED) | (1L << PARSED) | (1L << PHYSICAL) | (1L << PLAN) | (1L << RLIKE) | (1L << QUERY) | (1L << SCHEMAS) | (1L << SHOW) | (1L << SYS) | (1L << TABLES))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (TEXT - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
           {
-          setState(573);
+          setState(569);
           qualifiedName();
-          setState(574);
+          setState(570);
           match(DOT);
           }
         }
 
-        setState(578);
+        setState(574);
         match(ASTERISK);
         }
         break;
@@ -3962,7 +4138,7 @@ class SqlBaseParser extends Parser {
         _localctx = new FunctionContext(_localctx);
         enterOuterAlt(_localctx, 6);
         {
-        setState(579);
+        setState(575);
         functionExpression();
         }
         break;
@@ -3970,11 +4146,11 @@ class SqlBaseParser extends Parser {
         _localctx = new SubqueryExpressionContext(_localctx);
         enterOuterAlt(_localctx, 7);
         {
-        setState(580);
+        setState(576);
         match(T__0);
-        setState(581);
+        setState(577);
         query();
-        setState(582);
+        setState(578);
         match(T__1);
         }
         break;
@@ -3982,7 +4158,7 @@ class SqlBaseParser extends Parser {
         _localctx = new ColumnReferenceContext(_localctx);
         enterOuterAlt(_localctx, 8);
         {
-        setState(584);
+        setState(580);
         identifier();
         }
         break;
@@ -3990,7 +4166,7 @@ class SqlBaseParser extends Parser {
         _localctx = new DereferenceContext(_localctx);
         enterOuterAlt(_localctx, 9);
         {
-        setState(585);
+        setState(581);
         qualifiedName();
         }
         break;
@@ -3998,11 +4174,11 @@ class SqlBaseParser extends Parser {
         _localctx = new ParenthesizedExpressionContext(_localctx);
         enterOuterAlt(_localctx, 10);
         {
-        setState(586);
+        setState(582);
         match(T__0);
-        setState(587);
+        setState(583);
         expression();
-        setState(588);
+        setState(584);
         match(T__1);
         }
         break;
@@ -4046,25 +4222,25 @@ class SqlBaseParser extends Parser {
 
   public final CastExpressionContext castExpression() throws RecognitionException {
     CastExpressionContext _localctx = new CastExpressionContext(_ctx, getState());
-    enterRule(_localctx, 58, RULE_castExpression);
+    enterRule(_localctx, 60, RULE_castExpression);
     try {
-      setState(597);
+      setState(593);
       switch (_input.LA(1)) {
       case CAST:
         enterOuterAlt(_localctx, 1);
         {
-        setState(592);
+        setState(588);
         castTemplate();
         }
         break;
       case FUNCTION_ESC:
         enterOuterAlt(_localctx, 2);
         {
-        setState(593);
+        setState(589);
         match(FUNCTION_ESC);
-        setState(594);
+        setState(590);
         castTemplate();
-        setState(595);
+        setState(591);
         match(ESC_END);
         }
         break;
@@ -4113,21 +4289,21 @@ class SqlBaseParser extends Parser {
 
   public final CastTemplateContext castTemplate() throws RecognitionException {
     CastTemplateContext _localctx = new CastTemplateContext(_ctx, getState());
-    enterRule(_localctx, 60, RULE_castTemplate);
+    enterRule(_localctx, 62, RULE_castTemplate);
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(599);
+      setState(595);
       match(CAST);
-      setState(600);
+      setState(596);
       match(T__0);
-      setState(601);
+      setState(597);
       expression();
-      setState(602);
+      setState(598);
       match(AS);
-      setState(603);
+      setState(599);
       dataType();
-      setState(604);
+      setState(600);
       match(T__1);
       }
     }
@@ -4169,25 +4345,25 @@ class SqlBaseParser extends Parser {
 
   public final ExtractExpressionContext extractExpression() throws RecognitionException {
     ExtractExpressionContext _localctx = new ExtractExpressionContext(_ctx, getState());
-    enterRule(_localctx, 62, RULE_extractExpression);
+    enterRule(_localctx, 64, RULE_extractExpression);
     try {
-      setState(611);
+      setState(607);
       switch (_input.LA(1)) {
       case EXTRACT:
         enterOuterAlt(_localctx, 1);
         {
-        setState(606);
+        setState(602);
         extractTemplate();
         }
         break;
       case FUNCTION_ESC:
         enterOuterAlt(_localctx, 2);
         {
-        setState(607);
+        setState(603);
         match(FUNCTION_ESC);
-        setState(608);
+        setState(604);
         extractTemplate();
-        setState(609);
+        setState(605);
         match(ESC_END);
         }
         break;
@@ -4237,21 +4413,21 @@ class SqlBaseParser extends Parser {
 
   public final ExtractTemplateContext extractTemplate() throws RecognitionException {
     ExtractTemplateContext _localctx = new ExtractTemplateContext(_ctx, getState());
-    enterRule(_localctx, 64, RULE_extractTemplate);
+    enterRule(_localctx, 66, RULE_extractTemplate);
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(613);
+      setState(609);
       match(EXTRACT);
-      setState(614);
+      setState(610);
       match(T__0);
-      setState(615);
+      setState(611);
       ((ExtractTemplateContext)_localctx).field = identifier();
-      setState(616);
+      setState(612);
       match(FROM);
-      setState(617);
+      setState(613);
       valueExpression(0);
-      setState(618);
+      setState(614);
       match(T__1);
       }
     }
@@ -4292,9 +4468,9 @@ class SqlBaseParser extends Parser {
 
   public final FunctionExpressionContext functionExpression() throws RecognitionException {
     FunctionExpressionContext _localctx = new FunctionExpressionContext(_ctx, getState());
-    enterRule(_localctx, 66, RULE_functionExpression);
+    enterRule(_localctx, 68, RULE_functionExpression);
     try {
-      setState(625);
+      setState(621);
       switch (_input.LA(1)) {
       case ANALYZE:
       case ANALYZED:
@@ -4329,18 +4505,18 @@ class SqlBaseParser extends Parser {
       case BACKQUOTED_IDENTIFIER:
         enterOuterAlt(_localctx, 1);
         {
-        setState(620);
+        setState(616);
         functionTemplate();
         }
         break;
       case FUNCTION_ESC:
         enterOuterAlt(_localctx, 2);
         {
-        setState(621);
+        setState(617);
         match(FUNCTION_ESC);
-        setState(622);
+        setState(618);
         functionTemplate();
-        setState(623);
+        setState(619);
         match(ESC_END);
         }
         break;
@@ -4393,50 +4569,50 @@ class SqlBaseParser extends Parser {
 
   public final FunctionTemplateContext functionTemplate() throws RecognitionException {
     FunctionTemplateContext _localctx = new FunctionTemplateContext(_ctx, getState());
-    enterRule(_localctx, 68, RULE_functionTemplate);
+    enterRule(_localctx, 70, RULE_functionTemplate);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(627);
+      setState(623);
       functionName();
-      setState(628);
+      setState(624);
       match(T__0);
-      setState(640);
+      setState(636);
       _la = _input.LA(1);
       if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__0) | (1L << ALL) | (1L << ANALYZE) | (1L << ANALYZED) | (1L << CAST) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << DEBUG) | (1L << DISTINCT) | (1L << EXECUTABLE) | (1L << EXISTS) | (1L << EXPLAIN) | (1L << EXTRACT) | (1L << FALSE) | (1L << FORMAT) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << LEFT) | (1L << MAPPED) | (1L << MATCH) | (1L << NOT) | (1L << NULL) | (1L << OPTIMIZED) | (1L << PARSED) | (1L << PHYSICAL) | (1L << PLAN) | (1L << RIGHT) | (1L << RLIKE) | (1L << QUERY) | (1L << SCHEMAS) | (1L << SHOW) | (1L << SYS) | (1L << TABLES))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (TEXT - 64)) | (1L << (TRUE - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (FUNCTION_ESC - 64)) | (1L << (DATE_ESC - 64)) | (1L << (TIME_ESC - 64)) | (1L << (TIMESTAMP_ESC - 64)) | (1L << (GUID_ESC - 64)) | (1L << (PLUS - 64)) | (1L << (MINUS - 64)) | (1L << (ASTERISK - 64)) | (1L << (PARAM - 64)) | (1L << (STRING - 64)) | (1L << (INTEGER_VALUE - 64)) | (1L << (DECIMAL_VALUE - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
         {
-        setState(630);
+        setState(626);
         _la = _input.LA(1);
         if (_la==ALL || _la==DISTINCT) {
           {
-          setState(629);
+          setState(625);
           setQuantifier();
           }
         }
 
-        setState(632);
+        setState(628);
         expression();
-        setState(637);
+        setState(633);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==T__2) {
           {
           {
-          setState(633);
+          setState(629);
           match(T__2);
-          setState(634);
+          setState(630);
           expression();
           }
           }
-          setState(639);
+          setState(635);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
       }
 
-      setState(642);
+      setState(638);
       match(T__1);
       }
     }
@@ -4478,21 +4654,21 @@ class SqlBaseParser extends Parser {
 
   public final FunctionNameContext functionName() throws RecognitionException {
     FunctionNameContext _localctx = new FunctionNameContext(_ctx, getState());
-    enterRule(_localctx, 70, RULE_functionName);
+    enterRule(_localctx, 72, RULE_functionName);
     try {
-      setState(647);
+      setState(643);
       switch (_input.LA(1)) {
       case LEFT:
         enterOuterAlt(_localctx, 1);
         {
-        setState(644);
+        setState(640);
         match(LEFT);
         }
         break;
       case RIGHT:
         enterOuterAlt(_localctx, 2);
         {
-        setState(645);
+        setState(641);
         match(RIGHT);
         }
         break;
@@ -4527,7 +4703,7 @@ class SqlBaseParser extends Parser {
       case BACKQUOTED_IDENTIFIER:
         enterOuterAlt(_localctx, 3);
         {
-        setState(646);
+        setState(642);
         identifier();
         }
         break;
@@ -4736,16 +4912,16 @@ class SqlBaseParser extends Parser {
 
   public final ConstantContext constant() throws RecognitionException {
     ConstantContext _localctx = new ConstantContext(_ctx, getState());
-    enterRule(_localctx, 72, RULE_constant);
+    enterRule(_localctx, 74, RULE_constant);
     try {
       int _alt;
-      setState(674);
+      setState(670);
       switch (_input.LA(1)) {
       case NULL:
         _localctx = new NullLiteralContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(649);
+        setState(645);
         match(NULL);
         }
         break;
@@ -4754,7 +4930,7 @@ class SqlBaseParser extends Parser {
         _localctx = new NumericLiteralContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(650);
+        setState(646);
         number();
         }
         break;
@@ -4763,7 +4939,7 @@ class SqlBaseParser extends Parser {
         _localctx = new BooleanLiteralContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(651);
+        setState(647);
         booleanValue();
         }
         break;
@@ -4771,7 +4947,7 @@ class SqlBaseParser extends Parser {
         _localctx = new StringLiteralContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(653); 
+        setState(649); 
         _errHandler.sync(this);
         _alt = 1;
         do {
@@ -4779,7 +4955,7 @@ class SqlBaseParser extends Parser {
           case 1:
             {
             {
-            setState(652);
+            setState(648);
             match(STRING);
             }
             }
@@ -4787,9 +4963,9 @@ class SqlBaseParser extends Parser {
           default:
             throw new NoViableAltException(this);
           }
-          setState(655); 
+          setState(651); 
           _errHandler.sync(this);
-          _alt = getInterpreter().adaptivePredict(_input,90,_ctx);
+          _alt = getInterpreter().adaptivePredict(_input,86,_ctx);
         } while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER );
         }
         break;
@@ -4797,7 +4973,7 @@ class SqlBaseParser extends Parser {
         _localctx = new ParamLiteralContext(_localctx);
         enterOuterAlt(_localctx, 5);
         {
-        setState(657);
+        setState(653);
         match(PARAM);
         }
         break;
@@ -4805,11 +4981,11 @@ class SqlBaseParser extends Parser {
         _localctx = new DateEscapedLiteralContext(_localctx);
         enterOuterAlt(_localctx, 6);
         {
-        setState(658);
+        setState(654);
         match(DATE_ESC);
-        setState(659);
+        setState(655);
         string();
-        setState(660);
+        setState(656);
         match(ESC_END);
         }
         break;
@@ -4817,11 +4993,11 @@ class SqlBaseParser extends Parser {
         _localctx = new TimeEscapedLiteralContext(_localctx);
         enterOuterAlt(_localctx, 7);
         {
-        setState(662);
+        setState(658);
         match(TIME_ESC);
-        setState(663);
+        setState(659);
         string();
-        setState(664);
+        setState(660);
         match(ESC_END);
         }
         break;
@@ -4829,11 +5005,11 @@ class SqlBaseParser extends Parser {
         _localctx = new TimestampEscapedLiteralContext(_localctx);
         enterOuterAlt(_localctx, 8);
         {
-        setState(666);
+        setState(662);
         match(TIMESTAMP_ESC);
-        setState(667);
+        setState(663);
         string();
-        setState(668);
+        setState(664);
         match(ESC_END);
         }
         break;
@@ -4841,11 +5017,11 @@ class SqlBaseParser extends Parser {
         _localctx = new GuidEscapedLiteralContext(_localctx);
         enterOuterAlt(_localctx, 9);
         {
-        setState(670);
+        setState(666);
         match(GUID_ESC);
-        setState(671);
+        setState(667);
         string();
-        setState(672);
+        setState(668);
         match(ESC_END);
         }
         break;
@@ -4892,12 +5068,12 @@ class SqlBaseParser extends Parser {
 
   public final ComparisonOperatorContext comparisonOperator() throws RecognitionException {
     ComparisonOperatorContext _localctx = new ComparisonOperatorContext(_ctx, getState());
-    enterRule(_localctx, 74, RULE_comparisonOperator);
+    enterRule(_localctx, 76, RULE_comparisonOperator);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(676);
+      setState(672);
       _la = _input.LA(1);
       if ( !(((((_la - 80)) & ~0x3f) == 0 && ((1L << (_la - 80)) & ((1L << (EQ - 80)) | (1L << (NEQ - 80)) | (1L << (LT - 80)) | (1L << (LTE - 80)) | (1L << (GT - 80)) | (1L << (GTE - 80)))) != 0)) ) {
       _errHandler.recoverInline(this);
@@ -4941,12 +5117,12 @@ class SqlBaseParser extends Parser {
 
   public final BooleanValueContext booleanValue() throws RecognitionException {
     BooleanValueContext _localctx = new BooleanValueContext(_ctx, getState());
-    enterRule(_localctx, 76, RULE_booleanValue);
+    enterRule(_localctx, 78, RULE_booleanValue);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(678);
+      setState(674);
       _la = _input.LA(1);
       if ( !(_la==FALSE || _la==TRUE) ) {
       _errHandler.recoverInline(this);
@@ -4999,12 +5175,12 @@ class SqlBaseParser extends Parser {
 
   public final DataTypeContext dataType() throws RecognitionException {
     DataTypeContext _localctx = new DataTypeContext(_ctx, getState());
-    enterRule(_localctx, 78, RULE_dataType);
+    enterRule(_localctx, 80, RULE_dataType);
     try {
       _localctx = new PrimitiveDataTypeContext(_localctx);
       enterOuterAlt(_localctx, 1);
       {
-      setState(680);
+      setState(676);
       identifier();
       }
     }
@@ -5051,30 +5227,30 @@ class SqlBaseParser extends Parser {
 
   public final QualifiedNameContext qualifiedName() throws RecognitionException {
     QualifiedNameContext _localctx = new QualifiedNameContext(_ctx, getState());
-    enterRule(_localctx, 80, RULE_qualifiedName);
+    enterRule(_localctx, 82, RULE_qualifiedName);
     try {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(687);
+      setState(683);
       _errHandler.sync(this);
-      _alt = getInterpreter().adaptivePredict(_input,92,_ctx);
+      _alt = getInterpreter().adaptivePredict(_input,88,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           {
           {
-          setState(682);
+          setState(678);
           identifier();
-          setState(683);
+          setState(679);
           match(DOT);
           }
           } 
         }
-        setState(689);
+        setState(685);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,92,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,88,_ctx);
       }
-      setState(690);
+      setState(686);
       identifier();
       }
     }
@@ -5117,15 +5293,15 @@ class SqlBaseParser extends Parser {
 
   public final IdentifierContext identifier() throws RecognitionException {
     IdentifierContext _localctx = new IdentifierContext(_ctx, getState());
-    enterRule(_localctx, 82, RULE_identifier);
+    enterRule(_localctx, 84, RULE_identifier);
     try {
-      setState(694);
+      setState(690);
       switch (_input.LA(1)) {
       case QUOTED_IDENTIFIER:
       case BACKQUOTED_IDENTIFIER:
         enterOuterAlt(_localctx, 1);
         {
-        setState(692);
+        setState(688);
         quoteIdentifier();
         }
         break;
@@ -5158,7 +5334,7 @@ class SqlBaseParser extends Parser {
       case DIGIT_IDENTIFIER:
         enterOuterAlt(_localctx, 2);
         {
-        setState(693);
+        setState(689);
         unquoteIdentifier();
         }
         break;
@@ -5208,46 +5384,46 @@ class SqlBaseParser extends Parser {
 
   public final TableIdentifierContext tableIdentifier() throws RecognitionException {
     TableIdentifierContext _localctx = new TableIdentifierContext(_ctx, getState());
-    enterRule(_localctx, 84, RULE_tableIdentifier);
+    enterRule(_localctx, 86, RULE_tableIdentifier);
     int _la;
     try {
-      setState(708);
+      setState(704);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,96,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,92,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(699);
+        setState(695);
         _la = _input.LA(1);
         if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANALYZE) | (1L << ANALYZED) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << DEBUG) | (1L << EXECUTABLE) | (1L << EXPLAIN) | (1L << FORMAT) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << MAPPED) | (1L << OPTIMIZED) | (1L << PARSED) | (1L << PHYSICAL) | (1L << PLAN) | (1L << RLIKE) | (1L << QUERY) | (1L << SCHEMAS) | (1L << SHOW) | (1L << SYS) | (1L << TABLES))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (TEXT - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
           {
-          setState(696);
+          setState(692);
           ((TableIdentifierContext)_localctx).catalog = identifier();
-          setState(697);
+          setState(693);
           match(T__3);
           }
         }
 
-        setState(701);
+        setState(697);
         match(TABLE_IDENTIFIER);
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(705);
+        setState(701);
         _errHandler.sync(this);
-        switch ( getInterpreter().adaptivePredict(_input,95,_ctx) ) {
+        switch ( getInterpreter().adaptivePredict(_input,91,_ctx) ) {
         case 1:
           {
-          setState(702);
+          setState(698);
           ((TableIdentifierContext)_localctx).catalog = identifier();
-          setState(703);
+          setState(699);
           match(T__3);
           }
           break;
         }
-        setState(707);
+        setState(703);
         ((TableIdentifierContext)_localctx).name = identifier();
         }
         break;
@@ -5312,15 +5488,15 @@ class SqlBaseParser extends Parser {
 
   public final QuoteIdentifierContext quoteIdentifier() throws RecognitionException {
     QuoteIdentifierContext _localctx = new QuoteIdentifierContext(_ctx, getState());
-    enterRule(_localctx, 86, RULE_quoteIdentifier);
+    enterRule(_localctx, 88, RULE_quoteIdentifier);
     try {
-      setState(712);
+      setState(708);
       switch (_input.LA(1)) {
       case QUOTED_IDENTIFIER:
         _localctx = new QuotedIdentifierContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(710);
+        setState(706);
         match(QUOTED_IDENTIFIER);
         }
         break;
@@ -5328,7 +5504,7 @@ class SqlBaseParser extends Parser {
         _localctx = new BackQuotedIdentifierContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(711);
+        setState(707);
         match(BACKQUOTED_IDENTIFIER);
         }
         break;
@@ -5398,15 +5574,15 @@ class SqlBaseParser extends Parser {
 
   public final UnquoteIdentifierContext unquoteIdentifier() throws RecognitionException {
     UnquoteIdentifierContext _localctx = new UnquoteIdentifierContext(_ctx, getState());
-    enterRule(_localctx, 88, RULE_unquoteIdentifier);
+    enterRule(_localctx, 90, RULE_unquoteIdentifier);
     try {
-      setState(717);
+      setState(713);
       switch (_input.LA(1)) {
       case IDENTIFIER:
         _localctx = new UnquotedIdentifierContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(714);
+        setState(710);
         match(IDENTIFIER);
         }
         break;
@@ -5438,7 +5614,7 @@ class SqlBaseParser extends Parser {
         _localctx = new UnquotedIdentifierContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(715);
+        setState(711);
         nonReserved();
         }
         break;
@@ -5446,7 +5622,7 @@ class SqlBaseParser extends Parser {
         _localctx = new DigitIdentifierContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(716);
+        setState(712);
         match(DIGIT_IDENTIFIER);
         }
         break;
@@ -5513,15 +5689,15 @@ class SqlBaseParser extends Parser {
 
   public final NumberContext number() throws RecognitionException {
     NumberContext _localctx = new NumberContext(_ctx, getState());
-    enterRule(_localctx, 90, RULE_number);
+    enterRule(_localctx, 92, RULE_number);
     try {
-      setState(721);
+      setState(717);
       switch (_input.LA(1)) {
       case DECIMAL_VALUE:
         _localctx = new DecimalLiteralContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(719);
+        setState(715);
         match(DECIMAL_VALUE);
         }
         break;
@@ -5529,7 +5705,7 @@ class SqlBaseParser extends Parser {
         _localctx = new IntegerLiteralContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(720);
+        setState(716);
         match(INTEGER_VALUE);
         }
         break;
@@ -5572,12 +5748,12 @@ class SqlBaseParser extends Parser {
 
   public final StringContext string() throws RecognitionException {
     StringContext _localctx = new StringContext(_ctx, getState());
-    enterRule(_localctx, 92, RULE_string);
+    enterRule(_localctx, 94, RULE_string);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(723);
+      setState(719);
       _la = _input.LA(1);
       if ( !(_la==PARAM || _la==STRING) ) {
       _errHandler.recoverInline(this);
@@ -5644,12 +5820,12 @@ class SqlBaseParser extends Parser {
 
   public final NonReservedContext nonReserved() throws RecognitionException {
     NonReservedContext _localctx = new NonReservedContext(_ctx, getState());
-    enterRule(_localctx, 94, RULE_nonReserved);
+    enterRule(_localctx, 96, RULE_nonReserved);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(725);
+      setState(721);
       _la = _input.LA(1);
       if ( !(((((_la - 6)) & ~0x3f) == 0 && ((1L << (_la - 6)) & ((1L << (ANALYZE - 6)) | (1L << (ANALYZED - 6)) | (1L << (CATALOGS - 6)) | (1L << (COLUMNS - 6)) | (1L << (DEBUG - 6)) | (1L << (EXECUTABLE - 6)) | (1L << (EXPLAIN - 6)) | (1L << (FORMAT - 6)) | (1L << (FUNCTIONS - 6)) | (1L << (GRAPHVIZ - 6)) | (1L << (MAPPED - 6)) | (1L << (OPTIMIZED - 6)) | (1L << (PARSED - 6)) | (1L << (PHYSICAL - 6)) | (1L << (PLAN - 6)) | (1L << (RLIKE - 6)) | (1L << (QUERY - 6)) | (1L << (SCHEMAS - 6)) | (1L << (SHOW - 6)) | (1L << (SYS - 6)) | (1L << (TABLES - 6)) | (1L << (TEXT - 6)) | (1L << (TYPE - 6)) | (1L << (TYPES - 6)) | (1L << (VERIFY - 6)))) != 0)) ) {
       _errHandler.recoverInline(this);
@@ -5673,7 +5849,7 @@ class SqlBaseParser extends Parser {
     switch (ruleIndex) {
     case 22:
       return booleanExpression_sempred((BooleanExpressionContext)_localctx, predIndex);
-    case 27:
+    case 28:
       return valueExpression_sempred((ValueExpressionContext)_localctx, predIndex);
     }
     return true;
@@ -5700,295 +5876,293 @@ class SqlBaseParser extends Parser {
   }
 
   public static final String _serializedATN =
-    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3l\u02da\4\2\t\2\4"+
+    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3l\u02d6\4\2\t\2\4"+
     "\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t"+
     "\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
     "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
     "\4\32\t\32\4\33\t\33\4\34\t\34\4\35\t\35\4\36\t\36\4\37\t\37\4 \t \4!"+
     "\t!\4\"\t\"\4#\t#\4$\t$\4%\t%\4&\t&\4\'\t\'\4(\t(\4)\t)\4*\t*\4+\t+\4"+
-    ",\t,\4-\t-\4.\t.\4/\t/\4\60\t\60\4\61\t\61\3\2\3\2\3\2\3\3\3\3\3\3\3\4"+
-    "\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\7\4r\n\4\f\4\16\4u\13\4\3\4\5\4x\n\4"+
-    "\3\4\3\4\3\4\3\4\3\4\3\4\3\4\7\4\u0081\n\4\f\4\16\4\u0084\13\4\3\4\5\4"+
-    "\u0087\n\4\3\4\3\4\3\4\3\4\5\4\u008d\n\4\3\4\5\4\u0090\n\4\3\4\3\4\3\4"+
-    "\3\4\3\4\3\4\3\4\3\4\3\4\5\4\u009b\n\4\3\4\5\4\u009e\n\4\3\4\3\4\3\4\3"+
-    "\4\3\4\3\4\3\4\3\4\5\4\u00a8\n\4\3\4\5\4\u00ab\n\4\3\4\5\4\u00ae\n\4\3"+
-    "\4\5\4\u00b1\n\4\3\4\3\4\3\4\3\4\7\4\u00b7\n\4\f\4\16\4\u00ba\13\4\5\4"+
-    "\u00bc\n\4\3\4\3\4\3\4\3\4\5\4\u00c2\n\4\3\4\3\4\5\4\u00c6\n\4\3\4\5\4"+
-    "\u00c9\n\4\3\4\5\4\u00cc\n\4\3\4\5\4\u00cf\n\4\3\4\3\4\3\4\3\4\3\4\5\4"+
-    "\u00d6\n\4\3\5\3\5\3\5\3\5\7\5\u00dc\n\5\f\5\16\5\u00df\13\5\5\5\u00e1"+
-    "\n\5\3\5\3\5\3\6\3\6\3\6\3\6\3\6\3\6\7\6\u00eb\n\6\f\6\16\6\u00ee\13\6"+
-    "\5\6\u00f0\n\6\3\6\5\6\u00f3\n\6\3\7\3\7\3\7\3\7\3\7\5\7\u00fa\n\7\3\b"+
-    "\3\b\3\b\3\b\3\b\5\b\u0101\n\b\3\t\3\t\5\t\u0105\n\t\3\n\3\n\5\n\u0109"+
-    "\n\n\3\n\3\n\3\n\7\n\u010e\n\n\f\n\16\n\u0111\13\n\3\n\5\n\u0114\n\n\3"+
-    "\n\3\n\5\n\u0118\n\n\3\n\3\n\3\n\5\n\u011d\n\n\3\n\3\n\5\n\u0121\n\n\3"+
-    "\13\3\13\3\13\3\13\7\13\u0127\n\13\f\13\16\13\u012a\13\13\3\f\5\f\u012d"+
-    "\n\f\3\f\3\f\3\f\7\f\u0132\n\f\f\f\16\f\u0135\13\f\3\r\3\r\3\16\3\16\3"+
-    "\16\3\16\7\16\u013d\n\16\f\16\16\16\u0140\13\16\5\16\u0142\n\16\3\16\3"+
-    "\16\5\16\u0146\n\16\3\17\3\17\3\17\3\17\3\17\3\17\3\20\3\20\3\21\3\21"+
-    "\5\21\u0152\n\21\3\21\5\21\u0155\n\21\3\22\3\22\7\22\u0159\n\22\f\22\16"+
-    "\22\u015c\13\22\3\23\3\23\3\23\3\23\5\23\u0162\n\23\3\23\3\23\3\23\3\23"+
-    "\3\23\5\23\u0169\n\23\3\24\5\24\u016c\n\24\3\24\3\24\5\24\u0170\n\24\3"+
-    "\24\3\24\5\24\u0174\n\24\3\24\3\24\5\24\u0178\n\24\5\24\u017a\n\24\3\25"+
-    "\3\25\3\25\3\25\3\25\3\25\3\25\7\25\u0183\n\25\f\25\16\25\u0186\13\25"+
-    "\3\25\3\25\5\25\u018a\n\25\3\26\3\26\5\26\u018e\n\26\3\26\5\26\u0191\n"+
-    "\26\3\26\3\26\3\26\3\26\5\26\u0197\n\26\3\26\5\26\u019a\n\26\3\26\3\26"+
-    "\3\26\3\26\5\26\u01a0\n\26\3\26\5\26\u01a3\n\26\5\26\u01a5\n\26\3\27\3"+
-    "\27\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\30\7"+
-    "\30\u01b6\n\30\f\30\16\30\u01b9\13\30\3\30\3\30\3\30\3\30\3\30\3\30\3"+
-    "\30\3\30\3\30\7\30\u01c4\n\30\f\30\16\30\u01c7\13\30\3\30\3\30\3\30\3"+
-    "\30\3\30\3\30\3\30\3\30\3\30\7\30\u01d2\n\30\f\30\16\30\u01d5\13\30\3"+
-    "\30\3\30\3\30\5\30\u01da\n\30\3\30\3\30\3\30\3\30\3\30\3\30\7\30\u01e2"+
-    "\n\30\f\30\16\30\u01e5\13\30\3\31\3\31\5\31\u01e9\n\31\3\32\5\32\u01ec"+
-    "\n\32\3\32\3\32\3\32\3\32\3\32\3\32\5\32\u01f4\n\32\3\32\3\32\3\32\3\32"+
-    "\3\32\7\32\u01fb\n\32\f\32\16\32\u01fe\13\32\3\32\3\32\3\32\5\32\u0203"+
-    "\n\32\3\32\3\32\3\32\3\32\3\32\3\32\5\32\u020b\n\32\3\32\3\32\3\32\5\32"+
-    "\u0210\n\32\3\32\3\32\3\32\3\32\5\32\u0216\n\32\3\32\5\32\u0219\n\32\3"+
-    "\33\3\33\5\33\u021d\n\33\3\34\3\34\3\34\3\34\3\34\3\34\5\34\u0225\n\34"+
-    "\3\35\3\35\3\35\3\35\5\35\u022b\n\35\3\35\3\35\3\35\3\35\3\35\3\35\3\35"+
-    "\3\35\3\35\3\35\7\35\u0237\n\35\f\35\16\35\u023a\13\35\3\36\3\36\3\36"+
-    "\3\36\3\36\3\36\3\36\5\36\u0243\n\36\3\36\3\36\3\36\3\36\3\36\3\36\3\36"+
-    "\3\36\3\36\3\36\3\36\3\36\5\36\u0251\n\36\3\37\3\37\3\37\3\37\3\37\5\37"+
-    "\u0258\n\37\3 \3 \3 \3 \3 \3 \3 \3!\3!\3!\3!\3!\5!\u0266\n!\3\"\3\"\3"+
-    "\"\3\"\3\"\3\"\3\"\3#\3#\3#\3#\3#\5#\u0274\n#\3$\3$\3$\5$\u0279\n$\3$"+
-    "\3$\3$\7$\u027e\n$\f$\16$\u0281\13$\5$\u0283\n$\3$\3$\3%\3%\3%\5%\u028a"+
-    "\n%\3&\3&\3&\3&\6&\u0290\n&\r&\16&\u0291\3&\3&\3&\3&\3&\3&\3&\3&\3&\3"+
-    "&\3&\3&\3&\3&\3&\3&\3&\5&\u02a5\n&\3\'\3\'\3(\3(\3)\3)\3*\3*\3*\7*\u02b0"+
-    "\n*\f*\16*\u02b3\13*\3*\3*\3+\3+\5+\u02b9\n+\3,\3,\3,\5,\u02be\n,\3,\3"+
-    ",\3,\3,\5,\u02c4\n,\3,\5,\u02c7\n,\3-\3-\5-\u02cb\n-\3.\3.\3.\5.\u02d0"+
-    "\n.\3/\3/\5/\u02d4\n/\3\60\3\60\3\61\3\61\3\61\2\4.8\62\2\4\6\b\n\f\16"+
-    "\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64\668:<>@BDFHJLNPRTVXZ\\^`\2"+
-    "\20\b\2\7\7\t\t\31\31,,\62\62\66\66\4\2\"\"BB\4\2\t\t\62\62\4\2\37\37"+
-    "%%\3\2\25\26\4\2\7\7aa\4\2\r\r\25\25\4\2\7\7\27\27\3\2XY\3\2Z\\\3\2RW"+
-    "\4\2\35\35CC\3\2_`\20\2\b\t\22\24\31\31\33\33\36\36!\",,\62\62\668:<>"+
-    "?ABDEGG\u0336\2b\3\2\2\2\4e\3\2\2\2\6\u00d5\3\2\2\2\b\u00e0\3\2\2\2\n"+
-    "\u00e4\3\2\2\2\f\u00f9\3\2\2\2\16\u0100\3\2\2\2\20\u0102\3\2\2\2\22\u0106"+
-    "\3\2\2\2\24\u0122\3\2\2\2\26\u012c\3\2\2\2\30\u0136\3\2\2\2\32\u0145\3"+
-    "\2\2\2\34\u0147\3\2\2\2\36\u014d\3\2\2\2 \u014f\3\2\2\2\"\u0156\3\2\2"+
-    "\2$\u0168\3\2\2\2&\u0179\3\2\2\2(\u0189\3\2\2\2*\u01a4\3\2\2\2,\u01a6"+
-    "\3\2\2\2.\u01d9\3\2\2\2\60\u01e6\3\2\2\2\62\u0218\3\2\2\2\64\u021a\3\2"+
-    "\2\2\66\u0224\3\2\2\28\u022a\3\2\2\2:\u0250\3\2\2\2<\u0257\3\2\2\2>\u0259"+
-    "\3\2\2\2@\u0265\3\2\2\2B\u0267\3\2\2\2D\u0273\3\2\2\2F\u0275\3\2\2\2H"+
-    "\u0289\3\2\2\2J\u02a4\3\2\2\2L\u02a6\3\2\2\2N\u02a8\3\2\2\2P\u02aa\3\2"+
-    "\2\2R\u02b1\3\2\2\2T\u02b8\3\2\2\2V\u02c6\3\2\2\2X\u02ca\3\2\2\2Z\u02cf"+
-    "\3\2\2\2\\\u02d3\3\2\2\2^\u02d5\3\2\2\2`\u02d7\3\2\2\2bc\5\6\4\2cd\7\2"+
-    "\2\3d\3\3\2\2\2ef\5,\27\2fg\7\2\2\3g\5\3\2\2\2h\u00d6\5\b\5\2iw\7\33\2"+
-    "\2js\7\3\2\2kl\78\2\2lr\t\2\2\2mn\7\36\2\2nr\t\3\2\2op\7G\2\2pr\5N(\2"+
-    "qk\3\2\2\2qm\3\2\2\2qo\3\2\2\2ru\3\2\2\2sq\3\2\2\2st\3\2\2\2tv\3\2\2\2"+
-    "us\3\2\2\2vx\7\4\2\2wj\3\2\2\2wx\3\2\2\2xy\3\2\2\2y\u00d6\5\6\4\2z\u0086"+
-    "\7\24\2\2{\u0082\7\3\2\2|}\78\2\2}\u0081\t\4\2\2~\177\7\36\2\2\177\u0081"+
-    "\t\3\2\2\u0080|\3\2\2\2\u0080~\3\2\2\2\u0081\u0084\3\2\2\2\u0082\u0080"+
-    "\3\2\2\2\u0082\u0083\3\2\2\2\u0083\u0085\3\2\2\2\u0084\u0082\3\2\2\2\u0085"+
-    "\u0087\7\4\2\2\u0086{\3\2\2\2\u0086\u0087\3\2\2\2\u0087\u0088\3\2\2\2"+
-    "\u0088\u00d6\5\6\4\2\u0089\u008a\7>\2\2\u008a\u008f\7A\2\2\u008b\u008d"+
-    "\7*\2\2\u008c\u008b\3\2\2\2\u008c\u008d\3\2\2\2\u008d\u008e\3\2\2\2\u008e"+
-    "\u0090\5\64\33\2\u008f\u008c\3\2\2\2\u008f\u0090\3\2\2\2\u0090\u00d6\3"+
-    "\2\2\2\u0091\u0092\7>\2\2\u0092\u0093\7\23\2\2\u0093\u0094\t\5\2\2\u0094"+
-    "\u00d6\5V,\2\u0095\u0096\t\6\2\2\u0096\u00d6\5V,\2\u0097\u0098\7>\2\2"+
-    "\u0098\u009d\7!\2\2\u0099\u009b\7*\2\2\u009a\u0099\3\2\2\2\u009a\u009b"+
-    "\3\2\2\2\u009b\u009c\3\2\2\2\u009c\u009e\5\64\33\2\u009d\u009a\3\2\2\2"+
-    "\u009d\u009e\3\2\2\2\u009e\u00d6\3\2\2\2\u009f\u00a0\7>\2\2\u00a0\u00d6"+
-    "\7<\2\2\u00a1\u00a2\7?\2\2\u00a2\u00d6\7\22\2\2\u00a3\u00a4\7?\2\2\u00a4"+
-    "\u00aa\7A\2\2\u00a5\u00a7\7\21\2\2\u00a6\u00a8\7*\2\2\u00a7\u00a6\3\2"+
-    "\2\2\u00a7\u00a8\3\2\2\2\u00a8\u00a9\3\2\2\2\u00a9\u00ab\5\64\33\2\u00aa"+
-    "\u00a5\3\2\2\2\u00aa\u00ab\3\2\2\2\u00ab\u00b0\3\2\2\2\u00ac\u00ae\7*"+
-    "\2\2\u00ad\u00ac\3\2\2\2\u00ad\u00ae\3\2\2\2\u00ae\u00af\3\2\2\2\u00af"+
-    "\u00b1\5\64\33\2\u00b0\u00ad\3\2\2\2\u00b0\u00b1\3\2\2\2\u00b1\u00bb\3"+
-    "\2\2\2\u00b2\u00b3\7D\2\2\u00b3\u00b8\5^\60\2\u00b4\u00b5\7\5\2\2\u00b5"+
-    "\u00b7\5^\60\2\u00b6\u00b4\3\2\2\2\u00b7\u00ba\3\2\2\2\u00b8\u00b6\3\2"+
-    "\2\2\u00b8\u00b9\3\2\2\2\u00b9\u00bc\3\2\2\2\u00ba\u00b8\3\2\2\2\u00bb"+
-    "\u00b2\3\2\2\2\u00bb\u00bc\3\2\2\2\u00bc\u00d6\3\2\2\2\u00bd\u00be\7?"+
-    "\2\2\u00be\u00c1\7\23\2\2\u00bf\u00c0\7\21\2\2\u00c0\u00c2\5^\60\2\u00c1"+
-    "\u00bf\3\2\2\2\u00c1\u00c2\3\2\2\2\u00c2\u00c8\3\2\2\2\u00c3\u00c5\7@"+
-    "\2\2\u00c4\u00c6\7*\2\2\u00c5\u00c4\3\2\2\2\u00c5\u00c6\3\2\2\2\u00c6"+
-    "\u00c7\3\2\2\2\u00c7\u00c9\5\64\33\2\u00c8\u00c3\3\2\2\2\u00c8\u00c9\3"+
-    "\2\2\2\u00c9\u00ce\3\2\2\2\u00ca\u00cc\7*\2\2\u00cb\u00ca\3\2\2\2\u00cb"+
-    "\u00cc\3\2\2\2\u00cc\u00cd\3\2\2\2\u00cd\u00cf\5\64\33\2\u00ce\u00cb\3"+
-    "\2\2\2\u00ce\u00cf\3\2\2\2\u00cf\u00d6\3\2\2\2\u00d0\u00d1\7?\2\2\u00d1"+
-    "\u00d6\7E\2\2\u00d2\u00d3\7?\2\2\u00d3\u00d4\7@\2\2\u00d4\u00d6\7E\2\2"+
-    "\u00d5h\3\2\2\2\u00d5i\3\2\2\2\u00d5z\3\2\2\2\u00d5\u0089\3\2\2\2\u00d5"+
-    "\u0091\3\2\2\2\u00d5\u0095\3\2\2\2\u00d5\u0097\3\2\2\2\u00d5\u009f\3\2"+
-    "\2\2\u00d5\u00a1\3\2\2\2\u00d5\u00a3\3\2\2\2\u00d5\u00bd\3\2\2\2\u00d5"+
-    "\u00d0\3\2\2\2\u00d5\u00d2\3\2\2\2\u00d6\7\3\2\2\2\u00d7\u00d8\7I\2\2"+
-    "\u00d8\u00dd\5\34\17\2\u00d9\u00da\7\5\2\2\u00da\u00dc\5\34\17\2\u00db"+
-    "\u00d9\3\2\2\2\u00dc\u00df\3\2\2\2\u00dd\u00db\3\2\2\2\u00dd\u00de\3\2"+
-    "\2\2\u00de\u00e1\3\2\2\2\u00df\u00dd\3\2\2\2\u00e0\u00d7\3\2\2\2\u00e0"+
-    "\u00e1\3\2\2\2\u00e1\u00e2\3\2\2\2\u00e2\u00e3\5\n\6\2\u00e3\t\3\2\2\2"+
-    "\u00e4\u00ef\5\16\b\2\u00e5\u00e6\7\64\2\2\u00e6\u00e7\7\17\2\2\u00e7"+
-    "\u00ec\5\20\t\2\u00e8\u00e9\7\5\2\2\u00e9\u00eb\5\20\t\2\u00ea\u00e8\3"+
-    "\2\2\2\u00eb\u00ee\3\2\2\2\u00ec\u00ea\3\2\2\2\u00ec\u00ed\3\2\2\2\u00ed"+
-    "\u00f0\3\2\2\2\u00ee\u00ec\3\2\2\2\u00ef\u00e5\3\2\2\2\u00ef\u00f0\3\2"+
-    "\2\2\u00f0\u00f2\3\2\2\2\u00f1\u00f3\5\f\7\2\u00f2\u00f1\3\2\2\2\u00f2"+
-    "\u00f3\3\2\2\2\u00f3\13\3\2\2\2\u00f4\u00f5\7+\2\2\u00f5\u00fa\t\7\2\2"+
-    "\u00f6\u00f7\7L\2\2\u00f7\u00f8\t\7\2\2\u00f8\u00fa\7Q\2\2\u00f9\u00f4"+
-    "\3\2\2\2\u00f9\u00f6\3\2\2\2\u00fa\r\3\2\2\2\u00fb\u0101\5\22\n\2\u00fc"+
-    "\u00fd\7\3\2\2\u00fd\u00fe\5\n\6\2\u00fe\u00ff\7\4\2\2\u00ff\u0101\3\2"+
-    "\2\2\u0100\u00fb\3\2\2\2\u0100\u00fc\3\2\2\2\u0101\17\3\2\2\2\u0102\u0104"+
-    "\5,\27\2\u0103\u0105\t\b\2\2\u0104\u0103\3\2\2\2\u0104\u0105\3\2\2\2\u0105"+
-    "\21\3\2\2\2\u0106\u0108\7=\2\2\u0107\u0109\5\36\20\2\u0108\u0107\3\2\2"+
-    "\2\u0108\u0109\3\2\2\2\u0109\u010a\3\2\2\2\u010a\u010f\5 \21\2\u010b\u010c"+
-    "\7\5\2\2\u010c\u010e\5 \21\2\u010d\u010b\3\2\2\2\u010e\u0111\3\2\2\2\u010f"+
-    "\u010d\3\2\2\2\u010f\u0110\3\2\2\2\u0110\u0113\3\2\2\2\u0111\u010f\3\2"+
-    "\2\2\u0112\u0114\5\24\13\2\u0113\u0112\3\2\2\2\u0113\u0114\3\2\2\2\u0114"+
-    "\u0117\3\2\2\2\u0115\u0116\7H\2\2\u0116\u0118\5.\30\2\u0117\u0115\3\2"+
-    "\2\2\u0117\u0118\3\2\2\2\u0118\u011c\3\2\2\2\u0119\u011a\7#\2\2\u011a"+
-    "\u011b\7\17\2\2\u011b\u011d\5\26\f\2\u011c\u0119\3\2\2\2\u011c\u011d\3"+
-    "\2\2\2\u011d\u0120\3\2\2\2\u011e\u011f\7$\2\2\u011f\u0121\5.\30\2\u0120"+
-    "\u011e\3\2\2\2\u0120\u0121\3\2\2\2\u0121\23\3\2\2\2\u0122\u0123\7\37\2"+
-    "\2\u0123\u0128\5\"\22\2\u0124\u0125\7\5\2\2\u0125\u0127\5\"\22\2\u0126"+
-    "\u0124\3\2\2\2\u0127\u012a\3\2\2\2\u0128\u0126\3\2\2\2\u0128\u0129\3\2"+
-    "\2\2\u0129\25\3\2\2\2\u012a\u0128\3\2\2\2\u012b\u012d\5\36\20\2\u012c"+
-    "\u012b\3\2\2\2\u012c\u012d\3\2\2\2\u012d\u012e\3\2\2\2\u012e\u0133\5\30"+
-    "\r\2\u012f\u0130\7\5\2\2\u0130\u0132\5\30\r\2\u0131\u012f\3\2\2\2\u0132"+
-    "\u0135\3\2\2\2\u0133\u0131\3\2\2\2\u0133\u0134\3\2\2\2\u0134\27\3\2\2"+
-    "\2\u0135\u0133\3\2\2\2\u0136\u0137\5\32\16\2\u0137\31\3\2\2\2\u0138\u0141"+
-    "\7\3\2\2\u0139\u013e\5,\27\2\u013a\u013b\7\5\2\2\u013b\u013d\5,\27\2\u013c"+
-    "\u013a\3\2\2\2\u013d\u0140\3\2\2\2\u013e\u013c\3\2\2\2\u013e\u013f\3\2"+
-    "\2\2\u013f\u0142\3\2\2\2\u0140\u013e\3\2\2\2\u0141\u0139\3\2\2\2\u0141"+
-    "\u0142\3\2\2\2\u0142\u0143\3\2\2\2\u0143\u0146\7\4\2\2\u0144\u0146\5,"+
-    "\27\2\u0145\u0138\3\2\2\2\u0145\u0144\3\2\2\2\u0146\33\3\2\2\2\u0147\u0148"+
-    "\5T+\2\u0148\u0149\7\f\2\2\u0149\u014a\7\3\2\2\u014a\u014b\5\n\6\2\u014b"+
-    "\u014c\7\4\2\2\u014c\35\3\2\2\2\u014d\u014e\t\t\2\2\u014e\37\3\2\2\2\u014f"+
-    "\u0154\5,\27\2\u0150\u0152\7\f\2\2\u0151\u0150\3\2\2\2\u0151\u0152\3\2"+
-    "\2\2\u0152\u0153\3\2\2\2\u0153\u0155\5T+\2\u0154\u0151\3\2\2\2\u0154\u0155"+
-    "\3\2\2\2\u0155!\3\2\2\2\u0156\u015a\5*\26\2\u0157\u0159\5$\23\2\u0158"+
-    "\u0157\3\2\2\2\u0159\u015c\3\2\2\2\u015a\u0158\3\2\2\2\u015a\u015b\3\2"+
-    "\2\2\u015b#\3\2\2\2\u015c\u015a\3\2\2\2\u015d\u015e\5&\24\2\u015e\u015f"+
-    "\7(\2\2\u015f\u0161\5*\26\2\u0160\u0162\5(\25\2\u0161\u0160\3\2\2\2\u0161"+
-    "\u0162\3\2\2\2\u0162\u0169\3\2\2\2\u0163\u0164\7.\2\2\u0164\u0165\5&\24"+
-    "\2\u0165\u0166\7(\2\2\u0166\u0167\5*\26\2\u0167\u0169\3\2\2\2\u0168\u015d"+
-    "\3\2\2\2\u0168\u0163\3\2\2\2\u0169%\3\2\2\2\u016a\u016c\7&\2\2\u016b\u016a"+
-    "\3\2\2\2\u016b\u016c\3\2\2\2\u016c\u017a\3\2\2\2\u016d\u016f\7)\2\2\u016e"+
-    "\u0170\7\65\2\2\u016f\u016e\3\2\2\2\u016f\u0170\3\2\2\2\u0170\u017a\3"+
-    "\2\2\2\u0171\u0173\79\2\2\u0172\u0174\7\65\2\2\u0173\u0172\3\2\2\2\u0173"+
-    "\u0174\3\2\2\2\u0174\u017a\3\2\2\2\u0175\u0177\7 \2\2\u0176\u0178\7\65"+
-    "\2\2\u0177\u0176\3\2\2\2\u0177\u0178\3\2\2\2\u0178\u017a\3\2\2\2\u0179"+
-    "\u016b\3\2\2\2\u0179\u016d\3\2\2\2\u0179\u0171\3\2\2\2\u0179\u0175\3\2"+
-    "\2\2\u017a\'\3\2\2\2\u017b\u017c\7\61\2\2\u017c\u018a\5.\30\2\u017d\u017e"+
-    "\7F\2\2\u017e\u017f\7\3\2\2\u017f\u0184\5T+\2\u0180\u0181\7\5\2\2\u0181"+
-    "\u0183\5T+\2\u0182\u0180\3\2\2\2\u0183\u0186\3\2\2\2\u0184\u0182\3\2\2"+
-    "\2\u0184\u0185\3\2\2\2\u0185\u0187\3\2\2\2\u0186\u0184\3\2\2\2\u0187\u0188"+
-    "\7\4\2\2\u0188\u018a\3\2\2\2\u0189\u017b\3\2\2\2\u0189\u017d\3\2\2\2\u018a"+
-    ")\3\2\2\2\u018b\u0190\5V,\2\u018c\u018e\7\f\2\2\u018d\u018c\3\2\2\2\u018d"+
-    "\u018e\3\2\2\2\u018e\u018f\3\2\2\2\u018f\u0191\5R*\2\u0190\u018d\3\2\2"+
-    "\2\u0190\u0191\3\2\2\2\u0191\u01a5\3\2\2\2\u0192\u0193\7\3\2\2\u0193\u0194"+
-    "\5\n\6\2\u0194\u0199\7\4\2\2\u0195\u0197\7\f\2\2\u0196\u0195\3\2\2\2\u0196"+
-    "\u0197\3\2\2\2\u0197\u0198\3\2\2\2\u0198\u019a\5R*\2\u0199\u0196\3\2\2"+
-    "\2\u0199\u019a\3\2\2\2\u019a\u01a5\3\2\2\2\u019b\u019c\7\3\2\2\u019c\u019d"+
-    "\5\"\22\2\u019d\u01a2\7\4\2\2\u019e\u01a0\7\f\2\2\u019f\u019e\3\2\2\2"+
-    "\u019f\u01a0\3\2\2\2\u01a0\u01a1\3\2\2\2\u01a1\u01a3\5R*\2\u01a2\u019f"+
-    "\3\2\2\2\u01a2\u01a3\3\2\2\2\u01a3\u01a5\3\2\2\2\u01a4\u018b\3\2\2\2\u01a4"+
-    "\u0192\3\2\2\2\u01a4\u019b\3\2\2\2\u01a5+\3\2\2\2\u01a6\u01a7\5.\30\2"+
-    "\u01a7-\3\2\2\2\u01a8\u01a9\b\30\1\2\u01a9\u01aa\7/\2\2\u01aa\u01da\5"+
-    ".\30\n\u01ab\u01ac\7\32\2\2\u01ac\u01ad\7\3\2\2\u01ad\u01ae\5\b\5\2\u01ae"+
-    "\u01af\7\4\2\2\u01af\u01da\3\2\2\2\u01b0\u01b1\7;\2\2\u01b1\u01b2\7\3"+
-    "\2\2\u01b2\u01b7\5^\60\2\u01b3\u01b4\7\5\2\2\u01b4\u01b6\5^\60\2\u01b5"+
-    "\u01b3\3\2\2\2\u01b6\u01b9\3\2\2\2\u01b7\u01b5\3\2\2\2\u01b7\u01b8\3\2"+
-    "\2\2\u01b8\u01ba\3\2\2\2\u01b9\u01b7\3\2\2\2\u01ba\u01bb\7\4\2\2\u01bb"+
-    "\u01da\3\2\2\2\u01bc\u01bd\7-\2\2\u01bd\u01be\7\3\2\2\u01be\u01bf\5R*"+
-    "\2\u01bf\u01c0\7\5\2\2\u01c0\u01c5\5^\60\2\u01c1\u01c2\7\5\2\2\u01c2\u01c4"+
-    "\5^\60\2\u01c3\u01c1\3\2\2\2\u01c4\u01c7\3\2\2\2\u01c5\u01c3\3\2\2\2\u01c5"+
-    "\u01c6\3\2\2\2\u01c6\u01c8\3\2\2\2\u01c7\u01c5\3\2\2\2\u01c8\u01c9\7\4"+
-    "\2\2\u01c9\u01da\3\2\2\2\u01ca\u01cb\7-\2\2\u01cb\u01cc\7\3\2\2\u01cc"+
-    "\u01cd\5^\60\2\u01cd\u01ce\7\5\2\2\u01ce\u01d3\5^\60\2\u01cf\u01d0\7\5"+
-    "\2\2\u01d0\u01d2\5^\60\2\u01d1\u01cf\3\2\2\2\u01d2\u01d5\3\2\2\2\u01d3"+
-    "\u01d1\3\2\2\2\u01d3\u01d4\3\2\2\2\u01d4\u01d6\3\2\2\2\u01d5\u01d3\3\2"+
-    "\2\2\u01d6\u01d7\7\4\2\2\u01d7\u01da\3\2\2\2\u01d8\u01da\5\60\31\2\u01d9"+
-    "\u01a8\3\2\2\2\u01d9\u01ab\3\2\2\2\u01d9\u01b0\3\2\2\2\u01d9\u01bc\3\2"+
-    "\2\2\u01d9\u01ca\3\2\2\2\u01d9\u01d8\3\2\2\2\u01da\u01e3\3\2\2\2\u01db"+
-    "\u01dc\f\4\2\2\u01dc\u01dd\7\n\2\2\u01dd\u01e2\5.\30\5\u01de\u01df\f\3"+
-    "\2\2\u01df\u01e0\7\63\2\2\u01e0\u01e2\5.\30\4\u01e1\u01db\3\2\2\2\u01e1"+
-    "\u01de\3\2\2\2\u01e2\u01e5\3\2\2\2\u01e3\u01e1\3\2\2\2\u01e3\u01e4\3\2"+
-    "\2\2\u01e4/\3\2\2\2\u01e5\u01e3\3\2\2\2\u01e6\u01e8\58\35\2\u01e7\u01e9"+
-    "\5\62\32\2\u01e8\u01e7\3\2\2\2\u01e8\u01e9\3\2\2\2\u01e9\61\3\2\2\2\u01ea"+
-    "\u01ec\7/\2\2\u01eb\u01ea\3\2\2\2\u01eb\u01ec\3\2\2\2\u01ec\u01ed\3\2"+
-    "\2\2\u01ed\u01ee\7\16\2\2\u01ee\u01ef\58\35\2\u01ef\u01f0\7\n\2\2\u01f0"+
-    "\u01f1\58\35\2\u01f1\u0219\3\2\2\2\u01f2\u01f4\7/\2\2\u01f3\u01f2\3\2"+
-    "\2\2\u01f3\u01f4\3\2\2\2\u01f4\u01f5\3\2\2\2\u01f5\u01f6\7%\2\2\u01f6"+
-    "\u01f7\7\3\2\2\u01f7\u01fc\5,\27\2\u01f8\u01f9\7\5\2\2\u01f9\u01fb\5,"+
-    "\27\2\u01fa\u01f8\3\2\2\2\u01fb\u01fe\3\2\2\2\u01fc\u01fa\3\2\2\2\u01fc"+
-    "\u01fd\3\2\2\2\u01fd\u01ff\3\2\2\2\u01fe\u01fc\3\2\2\2\u01ff\u0200\7\4"+
-    "\2\2\u0200\u0219\3\2\2\2\u0201\u0203\7/\2\2\u0202\u0201\3\2\2\2\u0202"+
-    "\u0203\3\2\2\2\u0203\u0204\3\2\2\2\u0204\u0205\7%\2\2\u0205\u0206\7\3"+
-    "\2\2\u0206\u0207\5\b\5\2\u0207\u0208\7\4\2\2\u0208\u0219\3\2\2\2\u0209"+
-    "\u020b\7/\2\2\u020a\u0209\3\2\2\2\u020a\u020b\3\2\2\2\u020b\u020c\3\2"+
-    "\2\2\u020c\u020d\7*\2\2\u020d\u0219\5\64\33\2\u020e\u0210\7/\2\2\u020f"+
-    "\u020e\3\2\2\2\u020f\u0210\3\2\2\2\u0210\u0211\3\2\2\2\u0211\u0212\7:"+
-    "\2\2\u0212\u0219\5^\60\2\u0213\u0215\7\'\2\2\u0214\u0216\7/\2\2\u0215"+
-    "\u0214\3\2\2\2\u0215\u0216\3\2\2\2\u0216\u0217\3\2\2\2\u0217\u0219\7\60"+
-    "\2\2\u0218\u01eb\3\2\2\2\u0218\u01f3\3\2\2\2\u0218\u0202\3\2\2\2\u0218"+
-    "\u020a\3\2\2\2\u0218\u020f\3\2\2\2\u0218\u0213\3\2\2\2\u0219\63\3\2\2"+
-    "\2\u021a\u021c\5^\60\2\u021b\u021d\5\66\34\2\u021c\u021b\3\2\2\2\u021c"+
-    "\u021d\3\2\2\2\u021d\65\3\2\2\2\u021e\u021f\7\30\2\2\u021f\u0225\5^\60"+
-    "\2\u0220\u0221\7J\2\2\u0221\u0222\5^\60\2\u0222\u0223\7Q\2\2\u0223\u0225"+
-    "\3\2\2\2\u0224\u021e\3\2\2\2\u0224\u0220\3\2\2\2\u0225\67\3\2\2\2\u0226"+
-    "\u0227\b\35\1\2\u0227\u022b\5:\36\2\u0228\u0229\t\n\2\2\u0229\u022b\5"+
-    "8\35\6\u022a\u0226\3\2\2\2\u022a\u0228\3\2\2\2\u022b\u0238\3\2\2\2\u022c"+
-    "\u022d\f\5\2\2\u022d\u022e\t\13\2\2\u022e\u0237\58\35\6\u022f\u0230\f"+
-    "\4\2\2\u0230\u0231\t\n\2\2\u0231\u0237\58\35\5\u0232\u0233\f\3\2\2\u0233"+
-    "\u0234\5L\'\2\u0234\u0235\58\35\4\u0235\u0237\3\2\2\2\u0236\u022c\3\2"+
-    "\2\2\u0236\u022f\3\2\2\2\u0236\u0232\3\2\2\2\u0237\u023a\3\2\2\2\u0238"+
-    "\u0236\3\2\2\2\u0238\u0239\3\2\2\2\u02399\3\2\2\2\u023a\u0238\3\2\2\2"+
-    "\u023b\u0251\5<\37\2\u023c\u0251\5@!\2\u023d\u0251\5J&\2\u023e\u0251\7"+
-    "Z\2\2\u023f\u0240\5R*\2\u0240\u0241\7^\2\2\u0241\u0243\3\2\2\2\u0242\u023f"+
-    "\3\2\2\2\u0242\u0243\3\2\2\2\u0243\u0244\3\2\2\2\u0244\u0251\7Z\2\2\u0245"+
-    "\u0251\5D#\2\u0246\u0247\7\3\2\2\u0247\u0248\5\b\5\2\u0248\u0249\7\4\2"+
-    "\2\u0249\u0251\3\2\2\2\u024a\u0251\5T+\2\u024b\u0251\5R*\2\u024c\u024d"+
-    "\7\3\2\2\u024d\u024e\5,\27\2\u024e\u024f\7\4\2\2\u024f\u0251\3\2\2\2\u0250"+
-    "\u023b\3\2\2\2\u0250\u023c\3\2\2\2\u0250\u023d\3\2\2\2\u0250\u023e\3\2"+
-    "\2\2\u0250\u0242\3\2\2\2\u0250\u0245\3\2\2\2\u0250\u0246\3\2\2\2\u0250"+
-    "\u024a\3\2\2\2\u0250\u024b\3\2\2\2\u0250\u024c\3\2\2\2\u0251;\3\2\2\2"+
-    "\u0252\u0258\5> \2\u0253\u0254\7K\2\2\u0254\u0255\5> \2\u0255\u0256\7"+
-    "Q\2\2\u0256\u0258\3\2\2\2\u0257\u0252\3\2\2\2\u0257\u0253\3\2\2\2\u0258"+
-    "=\3\2\2\2\u0259\u025a\7\20\2\2\u025a\u025b\7\3\2\2\u025b\u025c\5,\27\2"+
-    "\u025c\u025d\7\f\2\2\u025d\u025e\5P)\2\u025e\u025f\7\4\2\2\u025f?\3\2"+
-    "\2\2\u0260\u0266\5B\"\2\u0261\u0262\7K\2\2\u0262\u0263\5B\"\2\u0263\u0264"+
-    "\7Q\2\2\u0264\u0266\3\2\2\2\u0265\u0260\3\2\2\2\u0265\u0261\3\2\2\2\u0266"+
-    "A\3\2\2\2\u0267\u0268\7\34\2\2\u0268\u0269\7\3\2\2\u0269\u026a\5T+\2\u026a"+
-    "\u026b\7\37\2\2\u026b\u026c\58\35\2\u026c\u026d\7\4\2\2\u026dC\3\2\2\2"+
-    "\u026e\u0274\5F$\2\u026f\u0270\7K\2\2\u0270\u0271\5F$\2\u0271\u0272\7"+
-    "Q\2\2\u0272\u0274\3\2\2\2\u0273\u026e\3\2\2\2\u0273\u026f\3\2\2\2\u0274"+
-    "E\3\2\2\2\u0275\u0276\5H%\2\u0276\u0282\7\3\2\2\u0277\u0279\5\36\20\2"+
-    "\u0278\u0277\3\2\2\2\u0278\u0279\3\2\2\2\u0279\u027a\3\2\2\2\u027a\u027f"+
-    "\5,\27\2\u027b\u027c\7\5\2\2\u027c\u027e\5,\27\2\u027d\u027b\3\2\2\2\u027e"+
-    "\u0281\3\2\2\2\u027f\u027d\3\2\2\2\u027f\u0280\3\2\2\2\u0280\u0283\3\2"+
-    "\2\2\u0281\u027f\3\2\2\2\u0282\u0278\3\2\2\2\u0282\u0283\3\2\2\2\u0283"+
-    "\u0284\3\2\2\2\u0284\u0285\7\4\2\2\u0285G\3\2\2\2\u0286\u028a\7)\2\2\u0287"+
-    "\u028a\79\2\2\u0288\u028a\5T+\2\u0289\u0286\3\2\2\2\u0289\u0287\3\2\2"+
-    "\2\u0289\u0288\3\2\2\2\u028aI\3\2\2\2\u028b\u02a5\7\60\2\2\u028c\u02a5"+
-    "\5\\/\2\u028d\u02a5\5N(\2\u028e\u0290\7`\2\2\u028f\u028e\3\2\2\2\u0290"+
-    "\u0291\3\2\2\2\u0291\u028f\3\2\2\2\u0291\u0292\3\2\2\2\u0292\u02a5\3\2"+
-    "\2\2\u0293\u02a5\7_\2\2\u0294\u0295\7M\2\2\u0295\u0296\5^\60\2\u0296\u0297"+
-    "\7Q\2\2\u0297\u02a5\3\2\2\2\u0298\u0299\7N\2\2\u0299\u029a\5^\60\2\u029a"+
-    "\u029b\7Q\2\2\u029b\u02a5\3\2\2\2\u029c\u029d\7O\2\2\u029d\u029e\5^\60"+
-    "\2\u029e\u029f\7Q\2\2\u029f\u02a5\3\2\2\2\u02a0\u02a1\7P\2\2\u02a1\u02a2"+
-    "\5^\60\2\u02a2\u02a3\7Q\2\2\u02a3\u02a5\3\2\2\2\u02a4\u028b\3\2\2\2\u02a4"+
-    "\u028c\3\2\2\2\u02a4\u028d\3\2\2\2\u02a4\u028f\3\2\2\2\u02a4\u0293\3\2"+
-    "\2\2\u02a4\u0294\3\2\2\2\u02a4\u0298\3\2\2\2\u02a4\u029c\3\2\2\2\u02a4"+
-    "\u02a0\3\2\2\2\u02a5K\3\2\2\2\u02a6\u02a7\t\f\2\2\u02a7M\3\2\2\2\u02a8"+
-    "\u02a9\t\r\2\2\u02a9O\3\2\2\2\u02aa\u02ab\5T+\2\u02abQ\3\2\2\2\u02ac\u02ad"+
-    "\5T+\2\u02ad\u02ae\7^\2\2\u02ae\u02b0\3\2\2\2\u02af\u02ac\3\2\2\2\u02b0"+
-    "\u02b3\3\2\2\2\u02b1\u02af\3\2\2\2\u02b1\u02b2\3\2\2\2\u02b2\u02b4\3\2"+
-    "\2\2\u02b3\u02b1\3\2\2\2\u02b4\u02b5\5T+\2\u02b5S\3\2\2\2\u02b6\u02b9"+
-    "\5X-\2\u02b7\u02b9\5Z.\2\u02b8\u02b6\3\2\2\2\u02b8\u02b7\3\2\2\2\u02b9"+
-    "U\3\2\2\2\u02ba\u02bb\5T+\2\u02bb\u02bc\7\6\2\2\u02bc\u02be\3\2\2\2\u02bd"+
-    "\u02ba\3\2\2\2\u02bd\u02be\3\2\2\2\u02be\u02bf\3\2\2\2\u02bf\u02c7\7e"+
-    "\2\2\u02c0\u02c1\5T+\2\u02c1\u02c2\7\6\2\2\u02c2\u02c4\3\2\2\2\u02c3\u02c0"+
-    "\3\2\2\2\u02c3\u02c4\3\2\2\2\u02c4\u02c5\3\2\2\2\u02c5\u02c7\5T+\2\u02c6"+
-    "\u02bd\3\2\2\2\u02c6\u02c3\3\2\2\2\u02c7W\3\2\2\2\u02c8\u02cb\7f\2\2\u02c9"+
-    "\u02cb\7g\2\2\u02ca\u02c8\3\2\2\2\u02ca\u02c9\3\2\2\2\u02cbY\3\2\2\2\u02cc"+
-    "\u02d0\7c\2\2\u02cd\u02d0\5`\61\2\u02ce\u02d0\7d\2\2\u02cf\u02cc\3\2\2"+
-    "\2\u02cf\u02cd\3\2\2\2\u02cf\u02ce\3\2\2\2\u02d0[\3\2\2\2\u02d1\u02d4"+
-    "\7b\2\2\u02d2\u02d4\7a\2\2\u02d3\u02d1\3\2\2\2\u02d3\u02d2\3\2\2\2\u02d4"+
-    "]\3\2\2\2\u02d5\u02d6\t\16\2\2\u02d6_\3\2\2\2\u02d7\u02d8\t\17\2\2\u02d8"+
-    "a\3\2\2\2fqsw\u0080\u0082\u0086\u008c\u008f\u009a\u009d\u00a7\u00aa\u00ad"+
-    "\u00b0\u00b8\u00bb\u00c1\u00c5\u00c8\u00cb\u00ce\u00d5\u00dd\u00e0\u00ec"+
-    "\u00ef\u00f2\u00f9\u0100\u0104\u0108\u010f\u0113\u0117\u011c\u0120\u0128"+
-    "\u012c\u0133\u013e\u0141\u0145\u0151\u0154\u015a\u0161\u0168\u016b\u016f"+
-    "\u0173\u0177\u0179\u0184\u0189\u018d\u0190\u0196\u0199\u019f\u01a2\u01a4"+
-    "\u01b7\u01c5\u01d3\u01d9\u01e1\u01e3\u01e8\u01eb\u01f3\u01fc\u0202\u020a"+
-    "\u020f\u0215\u0218\u021c\u0224\u022a\u0236\u0238\u0242\u0250\u0257\u0265"+
-    "\u0273\u0278\u027f\u0282\u0289\u0291\u02a4\u02b1\u02b8\u02bd\u02c3\u02c6"+
-    "\u02ca\u02cf\u02d3";
+    ",\t,\4-\t-\4.\t.\4/\t/\4\60\t\60\4\61\t\61\4\62\t\62\3\2\3\2\3\2\3\3\3"+
+    "\3\3\3\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\7\4t\n\4\f\4\16\4w\13\4\3\4"+
+    "\5\4z\n\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\7\4\u0083\n\4\f\4\16\4\u0086\13"+
+    "\4\3\4\5\4\u0089\n\4\3\4\3\4\3\4\3\4\3\4\5\4\u0090\n\4\3\4\3\4\3\4\3\4"+
+    "\3\4\5\4\u0097\n\4\3\4\3\4\3\4\5\4\u009c\n\4\3\4\3\4\3\4\5\4\u00a1\n\4"+
+    "\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\5\4\u00ab\n\4\3\4\3\4\5\4\u00af\n\4\3"+
+    "\4\3\4\3\4\3\4\7\4\u00b5\n\4\f\4\16\4\u00b8\13\4\5\4\u00ba\n\4\3\4\3\4"+
+    "\3\4\3\4\5\4\u00c0\n\4\3\4\3\4\3\4\5\4\u00c5\n\4\3\4\5\4\u00c8\n\4\3\4"+
+    "\3\4\3\4\3\4\3\4\5\4\u00cf\n\4\3\5\3\5\3\5\3\5\7\5\u00d5\n\5\f\5\16\5"+
+    "\u00d8\13\5\5\5\u00da\n\5\3\5\3\5\3\6\3\6\3\6\3\6\3\6\3\6\7\6\u00e4\n"+
+    "\6\f\6\16\6\u00e7\13\6\5\6\u00e9\n\6\3\6\5\6\u00ec\n\6\3\7\3\7\3\7\3\7"+
+    "\3\7\5\7\u00f3\n\7\3\b\3\b\3\b\3\b\3\b\5\b\u00fa\n\b\3\t\3\t\5\t\u00fe"+
+    "\n\t\3\n\3\n\5\n\u0102\n\n\3\n\3\n\3\n\7\n\u0107\n\n\f\n\16\n\u010a\13"+
+    "\n\3\n\5\n\u010d\n\n\3\n\3\n\5\n\u0111\n\n\3\n\3\n\3\n\5\n\u0116\n\n\3"+
+    "\n\3\n\5\n\u011a\n\n\3\13\3\13\3\13\3\13\7\13\u0120\n\13\f\13\16\13\u0123"+
+    "\13\13\3\f\5\f\u0126\n\f\3\f\3\f\3\f\7\f\u012b\n\f\f\f\16\f\u012e\13\f"+
+    "\3\r\3\r\3\16\3\16\3\16\3\16\7\16\u0136\n\16\f\16\16\16\u0139\13\16\5"+
+    "\16\u013b\n\16\3\16\3\16\5\16\u013f\n\16\3\17\3\17\3\17\3\17\3\17\3\17"+
+    "\3\20\3\20\3\21\3\21\5\21\u014b\n\21\3\21\5\21\u014e\n\21\3\22\3\22\7"+
+    "\22\u0152\n\22\f\22\16\22\u0155\13\22\3\23\3\23\3\23\3\23\5\23\u015b\n"+
+    "\23\3\23\3\23\3\23\3\23\3\23\5\23\u0162\n\23\3\24\5\24\u0165\n\24\3\24"+
+    "\3\24\5\24\u0169\n\24\3\24\3\24\5\24\u016d\n\24\3\24\3\24\5\24\u0171\n"+
+    "\24\5\24\u0173\n\24\3\25\3\25\3\25\3\25\3\25\3\25\3\25\7\25\u017c\n\25"+
+    "\f\25\16\25\u017f\13\25\3\25\3\25\5\25\u0183\n\25\3\26\3\26\5\26\u0187"+
+    "\n\26\3\26\5\26\u018a\n\26\3\26\3\26\3\26\3\26\5\26\u0190\n\26\3\26\5"+
+    "\26\u0193\n\26\3\26\3\26\3\26\3\26\5\26\u0199\n\26\3\26\5\26\u019c\n\26"+
+    "\5\26\u019e\n\26\3\27\3\27\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\30"+
+    "\3\30\3\30\3\30\3\30\7\30\u01af\n\30\f\30\16\30\u01b2\13\30\3\30\3\30"+
+    "\3\30\3\30\3\30\3\30\3\30\3\30\3\30\7\30\u01bd\n\30\f\30\16\30\u01c0\13"+
+    "\30\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\30\7\30\u01cb\n\30\f\30"+
+    "\16\30\u01ce\13\30\3\30\3\30\3\30\5\30\u01d3\n\30\3\30\3\30\3\30\3\30"+
+    "\3\30\3\30\7\30\u01db\n\30\f\30\16\30\u01de\13\30\3\31\3\31\5\31\u01e2"+
+    "\n\31\3\32\5\32\u01e5\n\32\3\32\3\32\3\32\3\32\3\32\3\32\5\32\u01ed\n"+
+    "\32\3\32\3\32\3\32\3\32\3\32\7\32\u01f4\n\32\f\32\16\32\u01f7\13\32\3"+
+    "\32\3\32\3\32\5\32\u01fc\n\32\3\32\3\32\3\32\3\32\3\32\3\32\5\32\u0204"+
+    "\n\32\3\32\3\32\3\32\5\32\u0209\n\32\3\32\3\32\3\32\3\32\5\32\u020f\n"+
+    "\32\3\32\5\32\u0212\n\32\3\33\3\33\3\33\3\34\3\34\5\34\u0219\n\34\3\35"+
+    "\3\35\3\35\3\35\3\35\3\35\5\35\u0221\n\35\3\36\3\36\3\36\3\36\5\36\u0227"+
+    "\n\36\3\36\3\36\3\36\3\36\3\36\3\36\3\36\3\36\3\36\3\36\7\36\u0233\n\36"+
+    "\f\36\16\36\u0236\13\36\3\37\3\37\3\37\3\37\3\37\3\37\3\37\5\37\u023f"+
+    "\n\37\3\37\3\37\3\37\3\37\3\37\3\37\3\37\3\37\3\37\3\37\3\37\3\37\5\37"+
+    "\u024d\n\37\3 \3 \3 \3 \3 \5 \u0254\n \3!\3!\3!\3!\3!\3!\3!\3\"\3\"\3"+
+    "\"\3\"\3\"\5\"\u0262\n\"\3#\3#\3#\3#\3#\3#\3#\3$\3$\3$\3$\3$\5$\u0270"+
+    "\n$\3%\3%\3%\5%\u0275\n%\3%\3%\3%\7%\u027a\n%\f%\16%\u027d\13%\5%\u027f"+
+    "\n%\3%\3%\3&\3&\3&\5&\u0286\n&\3\'\3\'\3\'\3\'\6\'\u028c\n\'\r\'\16\'"+
+    "\u028d\3\'\3\'\3\'\3\'\3\'\3\'\3\'\3\'\3\'\3\'\3\'\3\'\3\'\3\'\3\'\3\'"+
+    "\3\'\5\'\u02a1\n\'\3(\3(\3)\3)\3*\3*\3+\3+\3+\7+\u02ac\n+\f+\16+\u02af"+
+    "\13+\3+\3+\3,\3,\5,\u02b5\n,\3-\3-\3-\5-\u02ba\n-\3-\3-\3-\3-\5-\u02c0"+
+    "\n-\3-\5-\u02c3\n-\3.\3.\5.\u02c7\n.\3/\3/\3/\5/\u02cc\n/\3\60\3\60\5"+
+    "\60\u02d0\n\60\3\61\3\61\3\62\3\62\3\62\2\4.:\63\2\4\6\b\n\f\16\20\22"+
+    "\24\26\30\32\34\36 \"$&(*,.\60\62\64\668:<>@BDFHJLNPRTVXZ\\^`b\2\20\b"+
+    "\2\7\7\t\t\31\31,,\62\62\66\66\4\2\"\"BB\4\2\t\t\62\62\4\2\37\37%%\3\2"+
+    "\25\26\4\2\7\7aa\4\2\r\r\25\25\4\2\7\7\27\27\3\2XY\3\2Z\\\3\2RW\4\2\35"+
+    "\35CC\3\2_`\20\2\b\t\22\24\31\31\33\33\36\36!\",,\62\62\668:<>?ABDEGG"+
+    "\u0330\2d\3\2\2\2\4g\3\2\2\2\6\u00ce\3\2\2\2\b\u00d9\3\2\2\2\n\u00dd\3"+
+    "\2\2\2\f\u00f2\3\2\2\2\16\u00f9\3\2\2\2\20\u00fb\3\2\2\2\22\u00ff\3\2"+
+    "\2\2\24\u011b\3\2\2\2\26\u0125\3\2\2\2\30\u012f\3\2\2\2\32\u013e\3\2\2"+
+    "\2\34\u0140\3\2\2\2\36\u0146\3\2\2\2 \u0148\3\2\2\2\"\u014f\3\2\2\2$\u0161"+
+    "\3\2\2\2&\u0172\3\2\2\2(\u0182\3\2\2\2*\u019d\3\2\2\2,\u019f\3\2\2\2."+
+    "\u01d2\3\2\2\2\60\u01df\3\2\2\2\62\u0211\3\2\2\2\64\u0213\3\2\2\2\66\u0216"+
+    "\3\2\2\28\u0220\3\2\2\2:\u0226\3\2\2\2<\u024c\3\2\2\2>\u0253\3\2\2\2@"+
+    "\u0255\3\2\2\2B\u0261\3\2\2\2D\u0263\3\2\2\2F\u026f\3\2\2\2H\u0271\3\2"+
+    "\2\2J\u0285\3\2\2\2L\u02a0\3\2\2\2N\u02a2\3\2\2\2P\u02a4\3\2\2\2R\u02a6"+
+    "\3\2\2\2T\u02ad\3\2\2\2V\u02b4\3\2\2\2X\u02c2\3\2\2\2Z\u02c6\3\2\2\2\\"+
+    "\u02cb\3\2\2\2^\u02cf\3\2\2\2`\u02d1\3\2\2\2b\u02d3\3\2\2\2de\5\6\4\2"+
+    "ef\7\2\2\3f\3\3\2\2\2gh\5,\27\2hi\7\2\2\3i\5\3\2\2\2j\u00cf\5\b\5\2ky"+
+    "\7\33\2\2lu\7\3\2\2mn\78\2\2nt\t\2\2\2op\7\36\2\2pt\t\3\2\2qr\7G\2\2r"+
+    "t\5P)\2sm\3\2\2\2so\3\2\2\2sq\3\2\2\2tw\3\2\2\2us\3\2\2\2uv\3\2\2\2vx"+
+    "\3\2\2\2wu\3\2\2\2xz\7\4\2\2yl\3\2\2\2yz\3\2\2\2z{\3\2\2\2{\u00cf\5\6"+
+    "\4\2|\u0088\7\24\2\2}\u0084\7\3\2\2~\177\78\2\2\177\u0083\t\4\2\2\u0080"+
+    "\u0081\7\36\2\2\u0081\u0083\t\3\2\2\u0082~\3\2\2\2\u0082\u0080\3\2\2\2"+
+    "\u0083\u0086\3\2\2\2\u0084\u0082\3\2\2\2\u0084\u0085\3\2\2\2\u0085\u0087"+
+    "\3\2\2\2\u0086\u0084\3\2\2\2\u0087\u0089\7\4\2\2\u0088}\3\2\2\2\u0088"+
+    "\u0089\3\2\2\2\u0089\u008a\3\2\2\2\u008a\u00cf\5\6\4\2\u008b\u008c\7>"+
+    "\2\2\u008c\u008f\7A\2\2\u008d\u0090\5\64\33\2\u008e\u0090\5X-\2\u008f"+
+    "\u008d\3\2\2\2\u008f\u008e\3\2\2\2\u008f\u0090\3\2\2\2\u0090\u00cf\3\2"+
+    "\2\2\u0091\u0092\7>\2\2\u0092\u0093\7\23\2\2\u0093\u0096\t\5\2\2\u0094"+
+    "\u0097\5\64\33\2\u0095\u0097\5X-\2\u0096\u0094\3\2\2\2\u0096\u0095\3\2"+
+    "\2\2\u0097\u00cf\3\2\2\2\u0098\u009b\t\6\2\2\u0099\u009c\5\64\33\2\u009a"+
+    "\u009c\5X-\2\u009b\u0099\3\2\2\2\u009b\u009a\3\2\2\2\u009c\u00cf\3\2\2"+
+    "\2\u009d\u009e\7>\2\2\u009e\u00a0\7!\2\2\u009f\u00a1\5\64\33\2\u00a0\u009f"+
+    "\3\2\2\2\u00a0\u00a1\3\2\2\2\u00a1\u00cf\3\2\2\2\u00a2\u00a3\7>\2\2\u00a3"+
+    "\u00cf\7<\2\2\u00a4\u00a5\7?\2\2\u00a5\u00cf\7\22\2\2\u00a6\u00a7\7?\2"+
+    "\2\u00a7\u00aa\7A\2\2\u00a8\u00a9\7\21\2\2\u00a9\u00ab\5\64\33\2\u00aa"+
+    "\u00a8\3\2\2\2\u00aa\u00ab\3\2\2\2\u00ab\u00ae\3\2\2\2\u00ac\u00af\5\64"+
+    "\33\2\u00ad\u00af\5X-\2\u00ae\u00ac\3\2\2\2\u00ae\u00ad\3\2\2\2\u00ae"+
+    "\u00af\3\2\2\2\u00af\u00b9\3\2\2\2\u00b0\u00b1\7D\2\2\u00b1\u00b6\5`\61"+
+    "\2\u00b2\u00b3\7\5\2\2\u00b3\u00b5\5`\61\2\u00b4\u00b2\3\2\2\2\u00b5\u00b8"+
+    "\3\2\2\2\u00b6\u00b4\3\2\2\2\u00b6\u00b7\3\2\2\2\u00b7\u00ba\3\2\2\2\u00b8"+
+    "\u00b6\3\2\2\2\u00b9\u00b0\3\2\2\2\u00b9\u00ba\3\2\2\2\u00ba\u00cf\3\2"+
+    "\2\2\u00bb\u00bc\7?\2\2\u00bc\u00bf\7\23\2\2\u00bd\u00be\7\21\2\2\u00be"+
+    "\u00c0\5`\61\2\u00bf\u00bd\3\2\2\2\u00bf\u00c0\3\2\2\2\u00c0\u00c4\3\2"+
+    "\2\2\u00c1\u00c2\7@\2\2\u00c2\u00c5\5\64\33\2\u00c3\u00c5\5X-\2\u00c4"+
+    "\u00c1\3\2\2\2\u00c4\u00c3\3\2\2\2\u00c4\u00c5\3\2\2\2\u00c5\u00c7\3\2"+
+    "\2\2\u00c6\u00c8\5\64\33\2\u00c7\u00c6\3\2\2\2\u00c7\u00c8\3\2\2\2\u00c8"+
+    "\u00cf\3\2\2\2\u00c9\u00ca\7?\2\2\u00ca\u00cf\7E\2\2\u00cb\u00cc\7?\2"+
+    "\2\u00cc\u00cd\7@\2\2\u00cd\u00cf\7E\2\2\u00cej\3\2\2\2\u00cek\3\2\2\2"+
+    "\u00ce|\3\2\2\2\u00ce\u008b\3\2\2\2\u00ce\u0091\3\2\2\2\u00ce\u0098\3"+
+    "\2\2\2\u00ce\u009d\3\2\2\2\u00ce\u00a2\3\2\2\2\u00ce\u00a4\3\2\2\2\u00ce"+
+    "\u00a6\3\2\2\2\u00ce\u00bb\3\2\2\2\u00ce\u00c9\3\2\2\2\u00ce\u00cb\3\2"+
+    "\2\2\u00cf\7\3\2\2\2\u00d0\u00d1\7I\2\2\u00d1\u00d6\5\34\17\2\u00d2\u00d3"+
+    "\7\5\2\2\u00d3\u00d5\5\34\17\2\u00d4\u00d2\3\2\2\2\u00d5\u00d8\3\2\2\2"+
+    "\u00d6\u00d4\3\2\2\2\u00d6\u00d7\3\2\2\2\u00d7\u00da\3\2\2\2\u00d8\u00d6"+
+    "\3\2\2\2\u00d9\u00d0\3\2\2\2\u00d9\u00da\3\2\2\2\u00da\u00db\3\2\2\2\u00db"+
+    "\u00dc\5\n\6\2\u00dc\t\3\2\2\2\u00dd\u00e8\5\16\b\2\u00de\u00df\7\64\2"+
+    "\2\u00df\u00e0\7\17\2\2\u00e0\u00e5\5\20\t\2\u00e1\u00e2\7\5\2\2\u00e2"+
+    "\u00e4\5\20\t\2\u00e3\u00e1\3\2\2\2\u00e4\u00e7\3\2\2\2\u00e5\u00e3\3"+
+    "\2\2\2\u00e5\u00e6\3\2\2\2\u00e6\u00e9\3\2\2\2\u00e7\u00e5\3\2\2\2\u00e8"+
+    "\u00de\3\2\2\2\u00e8\u00e9\3\2\2\2\u00e9\u00eb\3\2\2\2\u00ea\u00ec\5\f"+
+    "\7\2\u00eb\u00ea\3\2\2\2\u00eb\u00ec\3\2\2\2\u00ec\13\3\2\2\2\u00ed\u00ee"+
+    "\7+\2\2\u00ee\u00f3\t\7\2\2\u00ef\u00f0\7L\2\2\u00f0\u00f1\t\7\2\2\u00f1"+
+    "\u00f3\7Q\2\2\u00f2\u00ed\3\2\2\2\u00f2\u00ef\3\2\2\2\u00f3\r\3\2\2\2"+
+    "\u00f4\u00fa\5\22\n\2\u00f5\u00f6\7\3\2\2\u00f6\u00f7\5\n\6\2\u00f7\u00f8"+
+    "\7\4\2\2\u00f8\u00fa\3\2\2\2\u00f9\u00f4\3\2\2\2\u00f9\u00f5\3\2\2\2\u00fa"+
+    "\17\3\2\2\2\u00fb\u00fd\5,\27\2\u00fc\u00fe\t\b\2\2\u00fd\u00fc\3\2\2"+
+    "\2\u00fd\u00fe\3\2\2\2\u00fe\21\3\2\2\2\u00ff\u0101\7=\2\2\u0100\u0102"+
+    "\5\36\20\2\u0101\u0100\3\2\2\2\u0101\u0102\3\2\2\2\u0102\u0103\3\2\2\2"+
+    "\u0103\u0108\5 \21\2\u0104\u0105\7\5\2\2\u0105\u0107\5 \21\2\u0106\u0104"+
+    "\3\2\2\2\u0107\u010a\3\2\2\2\u0108\u0106\3\2\2\2\u0108\u0109\3\2\2\2\u0109"+
+    "\u010c\3\2\2\2\u010a\u0108\3\2\2\2\u010b\u010d\5\24\13\2\u010c\u010b\3"+
+    "\2\2\2\u010c\u010d\3\2\2\2\u010d\u0110\3\2\2\2\u010e\u010f\7H\2\2\u010f"+
+    "\u0111\5.\30\2\u0110\u010e\3\2\2\2\u0110\u0111\3\2\2\2\u0111\u0115\3\2"+
+    "\2\2\u0112\u0113\7#\2\2\u0113\u0114\7\17\2\2\u0114\u0116\5\26\f\2\u0115"+
+    "\u0112\3\2\2\2\u0115\u0116\3\2\2\2\u0116\u0119\3\2\2\2\u0117\u0118\7$"+
+    "\2\2\u0118\u011a\5.\30\2\u0119\u0117\3\2\2\2\u0119\u011a\3\2\2\2\u011a"+
+    "\23\3\2\2\2\u011b\u011c\7\37\2\2\u011c\u0121\5\"\22\2\u011d\u011e\7\5"+
+    "\2\2\u011e\u0120\5\"\22\2\u011f\u011d\3\2\2\2\u0120\u0123\3\2\2\2\u0121"+
+    "\u011f\3\2\2\2\u0121\u0122\3\2\2\2\u0122\25\3\2\2\2\u0123\u0121\3\2\2"+
+    "\2\u0124\u0126\5\36\20\2\u0125\u0124\3\2\2\2\u0125\u0126\3\2\2\2\u0126"+
+    "\u0127\3\2\2\2\u0127\u012c\5\30\r\2\u0128\u0129\7\5\2\2\u0129\u012b\5"+
+    "\30\r\2\u012a\u0128\3\2\2\2\u012b\u012e\3\2\2\2\u012c\u012a\3\2\2\2\u012c"+
+    "\u012d\3\2\2\2\u012d\27\3\2\2\2\u012e\u012c\3\2\2\2\u012f\u0130\5\32\16"+
+    "\2\u0130\31\3\2\2\2\u0131\u013a\7\3\2\2\u0132\u0137\5,\27\2\u0133\u0134"+
+    "\7\5\2\2\u0134\u0136\5,\27\2\u0135\u0133\3\2\2\2\u0136\u0139\3\2\2\2\u0137"+
+    "\u0135\3\2\2\2\u0137\u0138\3\2\2\2\u0138\u013b\3\2\2\2\u0139\u0137\3\2"+
+    "\2\2\u013a\u0132\3\2\2\2\u013a\u013b\3\2\2\2\u013b\u013c\3\2\2\2\u013c"+
+    "\u013f\7\4\2\2\u013d\u013f\5,\27\2\u013e\u0131\3\2\2\2\u013e\u013d\3\2"+
+    "\2\2\u013f\33\3\2\2\2\u0140\u0141\5V,\2\u0141\u0142\7\f\2\2\u0142\u0143"+
+    "\7\3\2\2\u0143\u0144\5\n\6\2\u0144\u0145\7\4\2\2\u0145\35\3\2\2\2\u0146"+
+    "\u0147\t\t\2\2\u0147\37\3\2\2\2\u0148\u014d\5,\27\2\u0149\u014b\7\f\2"+
+    "\2\u014a\u0149\3\2\2\2\u014a\u014b\3\2\2\2\u014b\u014c\3\2\2\2\u014c\u014e"+
+    "\5V,\2\u014d\u014a\3\2\2\2\u014d\u014e\3\2\2\2\u014e!\3\2\2\2\u014f\u0153"+
+    "\5*\26\2\u0150\u0152\5$\23\2\u0151\u0150\3\2\2\2\u0152\u0155\3\2\2\2\u0153"+
+    "\u0151\3\2\2\2\u0153\u0154\3\2\2\2\u0154#\3\2\2\2\u0155\u0153\3\2\2\2"+
+    "\u0156\u0157\5&\24\2\u0157\u0158\7(\2\2\u0158\u015a\5*\26\2\u0159\u015b"+
+    "\5(\25\2\u015a\u0159\3\2\2\2\u015a\u015b\3\2\2\2\u015b\u0162\3\2\2\2\u015c"+
+    "\u015d\7.\2\2\u015d\u015e\5&\24\2\u015e\u015f\7(\2\2\u015f\u0160\5*\26"+
+    "\2\u0160\u0162\3\2\2\2\u0161\u0156\3\2\2\2\u0161\u015c\3\2\2\2\u0162%"+
+    "\3\2\2\2\u0163\u0165\7&\2\2\u0164\u0163\3\2\2\2\u0164\u0165\3\2\2\2\u0165"+
+    "\u0173\3\2\2\2\u0166\u0168\7)\2\2\u0167\u0169\7\65\2\2\u0168\u0167\3\2"+
+    "\2\2\u0168\u0169\3\2\2\2\u0169\u0173\3\2\2\2\u016a\u016c\79\2\2\u016b"+
+    "\u016d\7\65\2\2\u016c\u016b\3\2\2\2\u016c\u016d\3\2\2\2\u016d\u0173\3"+
+    "\2\2\2\u016e\u0170\7 \2\2\u016f\u0171\7\65\2\2\u0170\u016f\3\2\2\2\u0170"+
+    "\u0171\3\2\2\2\u0171\u0173\3\2\2\2\u0172\u0164\3\2\2\2\u0172\u0166\3\2"+
+    "\2\2\u0172\u016a\3\2\2\2\u0172\u016e\3\2\2\2\u0173\'\3\2\2\2\u0174\u0175"+
+    "\7\61\2\2\u0175\u0183\5.\30\2\u0176\u0177\7F\2\2\u0177\u0178\7\3\2\2\u0178"+
+    "\u017d\5V,\2\u0179\u017a\7\5\2\2\u017a\u017c\5V,\2\u017b\u0179\3\2\2\2"+
+    "\u017c\u017f\3\2\2\2\u017d\u017b\3\2\2\2\u017d\u017e\3\2\2\2\u017e\u0180"+
+    "\3\2\2\2\u017f\u017d\3\2\2\2\u0180\u0181\7\4\2\2\u0181\u0183\3\2\2\2\u0182"+
+    "\u0174\3\2\2\2\u0182\u0176\3\2\2\2\u0183)\3\2\2\2\u0184\u0189\5X-\2\u0185"+
+    "\u0187\7\f\2\2\u0186\u0185\3\2\2\2\u0186\u0187\3\2\2\2\u0187\u0188\3\2"+
+    "\2\2\u0188\u018a\5T+\2\u0189\u0186\3\2\2\2\u0189\u018a\3\2\2\2\u018a\u019e"+
+    "\3\2\2\2\u018b\u018c\7\3\2\2\u018c\u018d\5\n\6\2\u018d\u0192\7\4\2\2\u018e"+
+    "\u0190\7\f\2\2\u018f\u018e\3\2\2\2\u018f\u0190\3\2\2\2\u0190\u0191\3\2"+
+    "\2\2\u0191\u0193\5T+\2\u0192\u018f\3\2\2\2\u0192\u0193\3\2\2\2\u0193\u019e"+
+    "\3\2\2\2\u0194\u0195\7\3\2\2\u0195\u0196\5\"\22\2\u0196\u019b\7\4\2\2"+
+    "\u0197\u0199\7\f\2\2\u0198\u0197\3\2\2\2\u0198\u0199\3\2\2\2\u0199\u019a"+
+    "\3\2\2\2\u019a\u019c\5T+\2\u019b\u0198\3\2\2\2\u019b\u019c\3\2\2\2\u019c"+
+    "\u019e\3\2\2\2\u019d\u0184\3\2\2\2\u019d\u018b\3\2\2\2\u019d\u0194\3\2"+
+    "\2\2\u019e+\3\2\2\2\u019f\u01a0\5.\30\2\u01a0-\3\2\2\2\u01a1\u01a2\b\30"+
+    "\1\2\u01a2\u01a3\7/\2\2\u01a3\u01d3\5.\30\n\u01a4\u01a5\7\32\2\2\u01a5"+
+    "\u01a6\7\3\2\2\u01a6\u01a7\5\b\5\2\u01a7\u01a8\7\4\2\2\u01a8\u01d3\3\2"+
+    "\2\2\u01a9\u01aa\7;\2\2\u01aa\u01ab\7\3\2\2\u01ab\u01b0\5`\61\2\u01ac"+
+    "\u01ad\7\5\2\2\u01ad\u01af\5`\61\2\u01ae\u01ac\3\2\2\2\u01af\u01b2\3\2"+
+    "\2\2\u01b0\u01ae\3\2\2\2\u01b0\u01b1\3\2\2\2\u01b1\u01b3\3\2\2\2\u01b2"+
+    "\u01b0\3\2\2\2\u01b3\u01b4\7\4\2\2\u01b4\u01d3\3\2\2\2\u01b5\u01b6\7-"+
+    "\2\2\u01b6\u01b7\7\3\2\2\u01b7\u01b8\5T+\2\u01b8\u01b9\7\5\2\2\u01b9\u01be"+
+    "\5`\61\2\u01ba\u01bb\7\5\2\2\u01bb\u01bd\5`\61\2\u01bc\u01ba\3\2\2\2\u01bd"+
+    "\u01c0\3\2\2\2\u01be\u01bc\3\2\2\2\u01be\u01bf\3\2\2\2\u01bf\u01c1\3\2"+
+    "\2\2\u01c0\u01be\3\2\2\2\u01c1\u01c2\7\4\2\2\u01c2\u01d3\3\2\2\2\u01c3"+
+    "\u01c4\7-\2\2\u01c4\u01c5\7\3\2\2\u01c5\u01c6\5`\61\2\u01c6\u01c7\7\5"+
+    "\2\2\u01c7\u01cc\5`\61\2\u01c8\u01c9\7\5\2\2\u01c9\u01cb\5`\61\2\u01ca"+
+    "\u01c8\3\2\2\2\u01cb\u01ce\3\2\2\2\u01cc\u01ca\3\2\2\2\u01cc\u01cd\3\2"+
+    "\2\2\u01cd\u01cf\3\2\2\2\u01ce\u01cc\3\2\2\2\u01cf\u01d0\7\4\2\2\u01d0"+
+    "\u01d3\3\2\2\2\u01d1\u01d3\5\60\31\2\u01d2\u01a1\3\2\2\2\u01d2\u01a4\3"+
+    "\2\2\2\u01d2\u01a9\3\2\2\2\u01d2\u01b5\3\2\2\2\u01d2\u01c3\3\2\2\2\u01d2"+
+    "\u01d1\3\2\2\2\u01d3\u01dc\3\2\2\2\u01d4\u01d5\f\4\2\2\u01d5\u01d6\7\n"+
+    "\2\2\u01d6\u01db\5.\30\5\u01d7\u01d8\f\3\2\2\u01d8\u01d9\7\63\2\2\u01d9"+
+    "\u01db\5.\30\4\u01da\u01d4\3\2\2\2\u01da\u01d7\3\2\2\2\u01db\u01de\3\2"+
+    "\2\2\u01dc\u01da\3\2\2\2\u01dc\u01dd\3\2\2\2\u01dd/\3\2\2\2\u01de\u01dc"+
+    "\3\2\2\2\u01df\u01e1\5:\36\2\u01e0\u01e2\5\62\32\2\u01e1\u01e0\3\2\2\2"+
+    "\u01e1\u01e2\3\2\2\2\u01e2\61\3\2\2\2\u01e3\u01e5\7/\2\2\u01e4\u01e3\3"+
+    "\2\2\2\u01e4\u01e5\3\2\2\2\u01e5\u01e6\3\2\2\2\u01e6\u01e7\7\16\2\2\u01e7"+
+    "\u01e8\5:\36\2\u01e8\u01e9\7\n\2\2\u01e9\u01ea\5:\36\2\u01ea\u0212\3\2"+
+    "\2\2\u01eb\u01ed\7/\2\2\u01ec\u01eb\3\2\2\2\u01ec\u01ed\3\2\2\2\u01ed"+
+    "\u01ee\3\2\2\2\u01ee\u01ef\7%\2\2\u01ef\u01f0\7\3\2\2\u01f0\u01f5\5,\27"+
+    "\2\u01f1\u01f2\7\5\2\2\u01f2\u01f4\5,\27\2\u01f3\u01f1\3\2\2\2\u01f4\u01f7"+
+    "\3\2\2\2\u01f5\u01f3\3\2\2\2\u01f5\u01f6\3\2\2\2\u01f6\u01f8\3\2\2\2\u01f7"+
+    "\u01f5\3\2\2\2\u01f8\u01f9\7\4\2\2\u01f9\u0212\3\2\2\2\u01fa\u01fc\7/"+
+    "\2\2\u01fb\u01fa\3\2\2\2\u01fb\u01fc\3\2\2\2\u01fc\u01fd\3\2\2\2\u01fd"+
+    "\u01fe\7%\2\2\u01fe\u01ff\7\3\2\2\u01ff\u0200\5\b\5\2\u0200\u0201\7\4"+
+    "\2\2\u0201\u0212\3\2\2\2\u0202\u0204\7/\2\2\u0203\u0202\3\2\2\2\u0203"+
+    "\u0204\3\2\2\2\u0204\u0205\3\2\2\2\u0205\u0206\7*\2\2\u0206\u0212\5\66"+
+    "\34\2\u0207\u0209\7/\2\2\u0208\u0207\3\2\2\2\u0208\u0209\3\2\2\2\u0209"+
+    "\u020a\3\2\2\2\u020a\u020b\7:\2\2\u020b\u0212\5`\61\2\u020c\u020e\7\'"+
+    "\2\2\u020d\u020f\7/\2\2\u020e\u020d\3\2\2\2\u020e\u020f\3\2\2\2\u020f"+
+    "\u0210\3\2\2\2\u0210\u0212\7\60\2\2\u0211\u01e4\3\2\2\2\u0211\u01ec\3"+
+    "\2\2\2\u0211\u01fb\3\2\2\2\u0211\u0203\3\2\2\2\u0211\u0208\3\2\2\2\u0211"+
+    "\u020c\3\2\2\2\u0212\63\3\2\2\2\u0213\u0214\7*\2\2\u0214\u0215\5\66\34"+
+    "\2\u0215\65\3\2\2\2\u0216\u0218\5`\61\2\u0217\u0219\58\35\2\u0218\u0217"+
+    "\3\2\2\2\u0218\u0219\3\2\2\2\u0219\67\3\2\2\2\u021a\u021b\7\30\2\2\u021b"+
+    "\u0221\5`\61\2\u021c\u021d\7J\2\2\u021d\u021e\5`\61\2\u021e\u021f\7Q\2"+
+    "\2\u021f\u0221\3\2\2\2\u0220\u021a\3\2\2\2\u0220\u021c\3\2\2\2\u02219"+
+    "\3\2\2\2\u0222\u0223\b\36\1\2\u0223\u0227\5<\37\2\u0224\u0225\t\n\2\2"+
+    "\u0225\u0227\5:\36\6\u0226\u0222\3\2\2\2\u0226\u0224\3\2\2\2\u0227\u0234"+
+    "\3\2\2\2\u0228\u0229\f\5\2\2\u0229\u022a\t\13\2\2\u022a\u0233\5:\36\6"+
+    "\u022b\u022c\f\4\2\2\u022c\u022d\t\n\2\2\u022d\u0233\5:\36\5\u022e\u022f"+
+    "\f\3\2\2\u022f\u0230\5N(\2\u0230\u0231\5:\36\4\u0231\u0233\3\2\2\2\u0232"+
+    "\u0228\3\2\2\2\u0232\u022b\3\2\2\2\u0232\u022e\3\2\2\2\u0233\u0236\3\2"+
+    "\2\2\u0234\u0232\3\2\2\2\u0234\u0235\3\2\2\2\u0235;\3\2\2\2\u0236\u0234"+
+    "\3\2\2\2\u0237\u024d\5> \2\u0238\u024d\5B\"\2\u0239\u024d\5L\'\2\u023a"+
+    "\u024d\7Z\2\2\u023b\u023c\5T+\2\u023c\u023d\7^\2\2\u023d\u023f\3\2\2\2"+
+    "\u023e\u023b\3\2\2\2\u023e\u023f\3\2\2\2\u023f\u0240\3\2\2\2\u0240\u024d"+
+    "\7Z\2\2\u0241\u024d\5F$\2\u0242\u0243\7\3\2\2\u0243\u0244\5\b\5\2\u0244"+
+    "\u0245\7\4\2\2\u0245\u024d\3\2\2\2\u0246\u024d\5V,\2\u0247\u024d\5T+\2"+
+    "\u0248\u0249\7\3\2\2\u0249\u024a\5,\27\2\u024a\u024b\7\4\2\2\u024b\u024d"+
+    "\3\2\2\2\u024c\u0237\3\2\2\2\u024c\u0238\3\2\2\2\u024c\u0239\3\2\2\2\u024c"+
+    "\u023a\3\2\2\2\u024c\u023e\3\2\2\2\u024c\u0241\3\2\2\2\u024c\u0242\3\2"+
+    "\2\2\u024c\u0246\3\2\2\2\u024c\u0247\3\2\2\2\u024c\u0248\3\2\2\2\u024d"+
+    "=\3\2\2\2\u024e\u0254\5@!\2\u024f\u0250\7K\2\2\u0250\u0251\5@!\2\u0251"+
+    "\u0252\7Q\2\2\u0252\u0254\3\2\2\2\u0253\u024e\3\2\2\2\u0253\u024f\3\2"+
+    "\2\2\u0254?\3\2\2\2\u0255\u0256\7\20\2\2\u0256\u0257\7\3\2\2\u0257\u0258"+
+    "\5,\27\2\u0258\u0259\7\f\2\2\u0259\u025a\5R*\2\u025a\u025b\7\4\2\2\u025b"+
+    "A\3\2\2\2\u025c\u0262\5D#\2\u025d\u025e\7K\2\2\u025e\u025f\5D#\2\u025f"+
+    "\u0260\7Q\2\2\u0260\u0262\3\2\2\2\u0261\u025c\3\2\2\2\u0261\u025d\3\2"+
+    "\2\2\u0262C\3\2\2\2\u0263\u0264\7\34\2\2\u0264\u0265\7\3\2\2\u0265\u0266"+
+    "\5V,\2\u0266\u0267\7\37\2\2\u0267\u0268\5:\36\2\u0268\u0269\7\4\2\2\u0269"+
+    "E\3\2\2\2\u026a\u0270\5H%\2\u026b\u026c\7K\2\2\u026c\u026d\5H%\2\u026d"+
+    "\u026e\7Q\2\2\u026e\u0270\3\2\2\2\u026f\u026a\3\2\2\2\u026f\u026b\3\2"+
+    "\2\2\u0270G\3\2\2\2\u0271\u0272\5J&\2\u0272\u027e\7\3\2\2\u0273\u0275"+
+    "\5\36\20\2\u0274\u0273\3\2\2\2\u0274\u0275\3\2\2\2\u0275\u0276\3\2\2\2"+
+    "\u0276\u027b\5,\27\2\u0277\u0278\7\5\2\2\u0278\u027a\5,\27\2\u0279\u0277"+
+    "\3\2\2\2\u027a\u027d\3\2\2\2\u027b\u0279\3\2\2\2\u027b\u027c\3\2\2\2\u027c"+
+    "\u027f\3\2\2\2\u027d\u027b\3\2\2\2\u027e\u0274\3\2\2\2\u027e\u027f\3\2"+
+    "\2\2\u027f\u0280\3\2\2\2\u0280\u0281\7\4\2\2\u0281I\3\2\2\2\u0282\u0286"+
+    "\7)\2\2\u0283\u0286\79\2\2\u0284\u0286\5V,\2\u0285\u0282\3\2\2\2\u0285"+
+    "\u0283\3\2\2\2\u0285\u0284\3\2\2\2\u0286K\3\2\2\2\u0287\u02a1\7\60\2\2"+
+    "\u0288\u02a1\5^\60\2\u0289\u02a1\5P)\2\u028a\u028c\7`\2\2\u028b\u028a"+
+    "\3\2\2\2\u028c\u028d\3\2\2\2\u028d\u028b\3\2\2\2\u028d\u028e\3\2\2\2\u028e"+
+    "\u02a1\3\2\2\2\u028f\u02a1\7_\2\2\u0290\u0291\7M\2\2\u0291\u0292\5`\61"+
+    "\2\u0292\u0293\7Q\2\2\u0293\u02a1\3\2\2\2\u0294\u0295\7N\2\2\u0295\u0296"+
+    "\5`\61\2\u0296\u0297\7Q\2\2\u0297\u02a1\3\2\2\2\u0298\u0299\7O\2\2\u0299"+
+    "\u029a\5`\61\2\u029a\u029b\7Q\2\2\u029b\u02a1\3\2\2\2\u029c\u029d\7P\2"+
+    "\2\u029d\u029e\5`\61\2\u029e\u029f\7Q\2\2\u029f\u02a1\3\2\2\2\u02a0\u0287"+
+    "\3\2\2\2\u02a0\u0288\3\2\2\2\u02a0\u0289\3\2\2\2\u02a0\u028b\3\2\2\2\u02a0"+
+    "\u028f\3\2\2\2\u02a0\u0290\3\2\2\2\u02a0\u0294\3\2\2\2\u02a0\u0298\3\2"+
+    "\2\2\u02a0\u029c\3\2\2\2\u02a1M\3\2\2\2\u02a2\u02a3\t\f\2\2\u02a3O\3\2"+
+    "\2\2\u02a4\u02a5\t\r\2\2\u02a5Q\3\2\2\2\u02a6\u02a7\5V,\2\u02a7S\3\2\2"+
+    "\2\u02a8\u02a9\5V,\2\u02a9\u02aa\7^\2\2\u02aa\u02ac\3\2\2\2\u02ab\u02a8"+
+    "\3\2\2\2\u02ac\u02af\3\2\2\2\u02ad\u02ab\3\2\2\2\u02ad\u02ae\3\2\2\2\u02ae"+
+    "\u02b0\3\2\2\2\u02af\u02ad\3\2\2\2\u02b0\u02b1\5V,\2\u02b1U\3\2\2\2\u02b2"+
+    "\u02b5\5Z.\2\u02b3\u02b5\5\\/\2\u02b4\u02b2\3\2\2\2\u02b4\u02b3\3\2\2"+
+    "\2\u02b5W\3\2\2\2\u02b6\u02b7\5V,\2\u02b7\u02b8\7\6\2\2\u02b8\u02ba\3"+
+    "\2\2\2\u02b9\u02b6\3\2\2\2\u02b9\u02ba\3\2\2\2\u02ba\u02bb\3\2\2\2\u02bb"+
+    "\u02c3\7e\2\2\u02bc\u02bd\5V,\2\u02bd\u02be\7\6\2\2\u02be\u02c0\3\2\2"+
+    "\2\u02bf\u02bc\3\2\2\2\u02bf\u02c0\3\2\2\2\u02c0\u02c1\3\2\2\2\u02c1\u02c3"+
+    "\5V,\2\u02c2\u02b9\3\2\2\2\u02c2\u02bf\3\2\2\2\u02c3Y\3\2\2\2\u02c4\u02c7"+
+    "\7f\2\2\u02c5\u02c7\7g\2\2\u02c6\u02c4\3\2\2\2\u02c6\u02c5\3\2\2\2\u02c7"+
+    "[\3\2\2\2\u02c8\u02cc\7c\2\2\u02c9\u02cc\5b\62\2\u02ca\u02cc\7d\2\2\u02cb"+
+    "\u02c8\3\2\2\2\u02cb\u02c9\3\2\2\2\u02cb\u02ca\3\2\2\2\u02cc]\3\2\2\2"+
+    "\u02cd\u02d0\7b\2\2\u02ce\u02d0\7a\2\2\u02cf\u02cd\3\2\2\2\u02cf\u02ce"+
+    "\3\2\2\2\u02d0_\3\2\2\2\u02d1\u02d2\t\16\2\2\u02d2a\3\2\2\2\u02d3\u02d4"+
+    "\t\17\2\2\u02d4c\3\2\2\2bsuy\u0082\u0084\u0088\u008f\u0096\u009b\u00a0"+
+    "\u00aa\u00ae\u00b6\u00b9\u00bf\u00c4\u00c7\u00ce\u00d6\u00d9\u00e5\u00e8"+
+    "\u00eb\u00f2\u00f9\u00fd\u0101\u0108\u010c\u0110\u0115\u0119\u0121\u0125"+
+    "\u012c\u0137\u013a\u013e\u014a\u014d\u0153\u015a\u0161\u0164\u0168\u016c"+
+    "\u0170\u0172\u017d\u0182\u0186\u0189\u018f\u0192\u0198\u019b\u019d\u01b0"+
+    "\u01be\u01cc\u01d2\u01da\u01dc\u01e1\u01e4\u01ec\u01f5\u01fb\u0203\u0208"+
+    "\u020e\u0211\u0218\u0220\u0226\u0232\u0234\u023e\u024c\u0253\u0261\u026f"+
+    "\u0274\u027b\u027e\u0285\u028d\u02a0\u02ad\u02b4\u02b9\u02bf\u02c2\u02c6"+
+    "\u02cb\u02cf";
   public static final ATN _ATN =
     new ATNDeserializer().deserialize(_serializedATN.toCharArray());
   static {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseVisitor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseVisitor.java
@@ -307,6 +307,12 @@ interface SqlBaseVisitor<T> extends ParseTreeVisitor<T> {
    */
   T visitPredicate(SqlBaseParser.PredicateContext ctx);
   /**
+   * Visit a parse tree produced by {@link SqlBaseParser#likePattern}.
+   * @param ctx the parse tree
+   * @return the visitor result
+   */
+  T visitLikePattern(SqlBaseParser.LikePatternContext ctx);
+  /**
    * Visit a parse tree produced by {@link SqlBaseParser#pattern}.
    * @param ctx the parse tree
    * @return the visitor result

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/TableIdentifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/TableIdentifier.java
@@ -53,6 +53,10 @@ public class TableIdentifier {
         return location;
     }
 
+    public String qualifiedIndex() {
+        return cluster != null ? cluster + ":" + index : index;
+    }
+
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowColumns.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowColumns.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.plan.logical.command;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xpack.sql.expression.Attribute;
 import org.elasticsearch.xpack.sql.expression.FieldAttribute;
+import org.elasticsearch.xpack.sql.expression.regex.LikePattern;
 import org.elasticsearch.xpack.sql.session.Rows;
 import org.elasticsearch.xpack.sql.session.SchemaRowSet;
 import org.elasticsearch.xpack.sql.session.SqlSession;
@@ -29,19 +30,25 @@ import static java.util.Collections.emptyList;
 public class ShowColumns extends Command {
 
     private final String index;
+    private final LikePattern pattern;
 
-    public ShowColumns(Location location, String index) {
+    public ShowColumns(Location location, String index, LikePattern pattern) {
         super(location);
         this.index = index;
+        this.pattern = pattern;
     }
 
     public String index() {
         return index;
     }
 
+    public LikePattern pattern() {
+        return pattern;
+    }
+
     @Override
     protected NodeInfo<ShowColumns> info() {
-        return NodeInfo.create(this, ShowColumns::new, index);
+        return NodeInfo.create(this, ShowColumns::new, index, pattern);
     }
 
     @Override
@@ -51,7 +58,9 @@ public class ShowColumns extends Command {
 
     @Override
     public void execute(SqlSession session, ActionListener<SchemaRowSet> listener) {
-        session.indexResolver().resolveWithSameMapping(index, null, ActionListener.wrap(
+        String idx = index != null ? index : (pattern != null ? pattern.asIndexNameWildcard() : "*");
+        String regex = pattern != null ? pattern.asJavaRegex() : null;
+        session.indexResolver().resolveWithSameMapping(idx, regex, ActionListener.wrap(
                 indexResult -> {
                     List<List<?>> rows = emptyList();
                     if (indexResult.isValid()) {
@@ -81,7 +90,7 @@ public class ShowColumns extends Command {
 
     @Override
     public int hashCode() {
-        return Objects.hash(index);
+        return Objects.hash(index, pattern);
     }
 
     @Override
@@ -95,6 +104,7 @@ public class ShowColumns extends Command {
         }
 
         ShowColumns other = (ShowColumns) obj;
-        return Objects.equals(index, other.index);
+        return Objects.equals(index, other.index)
+                && Objects.equals(pattern, other.pattern);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowTables.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowTables.java
@@ -22,16 +22,22 @@ import static java.util.stream.Collectors.toList;
 
 public class ShowTables extends Command {
 
+    private final String index;
     private final LikePattern pattern;
 
-    public ShowTables(Location location, LikePattern pattern) {
+    public ShowTables(Location location, String index, LikePattern pattern) {
         super(location);
+        this.index = index;
         this.pattern = pattern;
     }
 
     @Override
     protected NodeInfo<ShowTables> info() {
-        return NodeInfo.create(this, ShowTables::new, pattern);
+        return NodeInfo.create(this, ShowTables::new, index, pattern);
+    }
+
+    public String index() {
+        return index;
     }
 
     public LikePattern pattern() {
@@ -45,9 +51,9 @@ public class ShowTables extends Command {
 
     @Override
     public final void execute(SqlSession session, ActionListener<SchemaRowSet> listener) {
-        String index = pattern != null ? pattern.asIndexNameWildcard() : "*";
+        String idx = index != null ? index : (pattern != null ? pattern.asIndexNameWildcard() : "*");
         String regex = pattern != null ? pattern.asJavaRegex() : null;
-        session.indexResolver().resolveNames(index, regex, null, ActionListener.wrap(result -> {
+        session.indexResolver().resolveNames(idx, regex, null, ActionListener.wrap(result -> {
             listener.onResponse(Rows.of(output(), result.stream()
                  .map(t -> asList(t.name(), t.type().toSql()))
                 .collect(toList())));
@@ -56,7 +62,7 @@ public class ShowTables extends Command {
 
     @Override
     public int hashCode() {
-        return Objects.hash(pattern);
+        return Objects.hash(index, pattern);
     }
 
     @Override
@@ -70,6 +76,7 @@ public class ShowTables extends Command {
         }
 
         ShowTables other = (ShowTables) obj;
-        return Objects.equals(pattern, other.pattern);
+        return Objects.equals(index, other.index) 
+                && Objects.equals(pattern, other.pattern);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumns.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumns.java
@@ -39,19 +39,21 @@ import static org.elasticsearch.xpack.sql.type.DataType.SHORT;
 public class SysColumns extends Command {
 
     private final String catalog;
-    private final LikePattern indexPattern;
+    private final String index;
+    private final LikePattern pattern;
     private final LikePattern columnPattern;
 
-    public SysColumns(Location location, String catalog, LikePattern indexPattern, LikePattern columnPattern) {
+    public SysColumns(Location location, String catalog, String index, LikePattern pattern, LikePattern columnPattern) {
         super(location);
         this.catalog = catalog;
-        this.indexPattern = indexPattern;
+        this.index = index;
+        this.pattern = pattern;
         this.columnPattern = columnPattern;
     }
 
     @Override
     protected NodeInfo<SysColumns> info() {
-        return NodeInfo.create(this, SysColumns::new, catalog, indexPattern, columnPattern);
+        return NodeInfo.create(this, SysColumns::new, catalog, index, pattern, columnPattern);
     }
 
     @Override
@@ -94,12 +96,12 @@ public class SysColumns extends Command {
             return;
         }
 
-        String index = indexPattern != null ? indexPattern.asIndexNameWildcard() : "*";
-        String regex = indexPattern != null ? indexPattern.asJavaRegex() : null;
+        String idx = index != null ? index : (pattern != null ? pattern.asIndexNameWildcard() : "*");
+        String regex = pattern != null ? pattern.asJavaRegex() : null;
 
         Pattern columnMatcher = columnPattern != null ? Pattern.compile(columnPattern.asJavaRegex()) : null;
 
-        session.indexResolver().resolveAsSeparateMappings(index, regex, ActionListener.wrap(esIndices -> {
+        session.indexResolver().resolveAsSeparateMappings(idx, regex, ActionListener.wrap(esIndices -> {
             List<List<?>> rows = new ArrayList<>();
             for (EsIndex esIndex : esIndices) {
                 fillInRows(cluster, esIndex.name(), esIndex.mapping(), null, rows, columnMatcher);
@@ -165,7 +167,7 @@ public class SysColumns extends Command {
     
     @Override
     public int hashCode() {
-        return Objects.hash(catalog, indexPattern, columnPattern);
+        return Objects.hash(catalog, index, pattern, columnPattern);
     }
 
     @Override
@@ -180,7 +182,8 @@ public class SysColumns extends Command {
 
         SysColumns other = (SysColumns) obj;
         return Objects.equals(catalog, other.catalog)
-                && Objects.equals(indexPattern, other.indexPattern)
+                && Objects.equals(index, other.index)
+                && Objects.equals(pattern, other.pattern)
                 && Objects.equals(columnPattern, other.columnPattern);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
@@ -32,16 +32,18 @@ import static org.elasticsearch.xpack.sql.util.StringUtils.SQL_WILDCARD;
 
 public class SysTables extends Command {
 
+    private final String index;
     private final LikePattern pattern;
     private final LikePattern clusterPattern;
     private final EnumSet<IndexType> types;
     // flag indicating whether tables are reported as `TABLE` or `BASE TABLE`
     private final boolean legacyTableTypes;
 
-    public SysTables(Location location, LikePattern clusterPattern, LikePattern pattern, EnumSet<IndexType> types,
+    public SysTables(Location location, LikePattern clusterPattern, String index, LikePattern pattern, EnumSet<IndexType> types,
             boolean legacyTableTypes) {
         super(location);
         this.clusterPattern = clusterPattern;
+        this.index = index;
         this.pattern = pattern;
         this.types = types;
         this.legacyTableTypes = legacyTableTypes;
@@ -49,7 +51,7 @@ public class SysTables extends Command {
 
     @Override
     protected NodeInfo<SysTables> info() {
-        return NodeInfo.create(this, SysTables::new, clusterPattern, pattern, types, legacyTableTypes);
+        return NodeInfo.create(this, SysTables::new, clusterPattern, index, pattern, types, legacyTableTypes);
     }
 
     @Override
@@ -111,10 +113,10 @@ public class SysTables extends Command {
             return;
         }
 
-        String index = pattern != null ? pattern.asIndexNameWildcard() : "*";
+        String idx = index != null ? index : (pattern != null ? pattern.asIndexNameWildcard() : "*");
         String regex = pattern != null ? pattern.asJavaRegex() : null;
 
-        session.indexResolver().resolveNames(index, regex, types, ActionListener.wrap(result -> listener.onResponse(
+        session.indexResolver().resolveNames(idx, regex, types, ActionListener.wrap(result -> listener.onResponse(
                 Rows.of(output(), result.stream()
                  // sort by type (which might be legacy), then by name
                  .sorted(Comparator.<IndexInfo, String> comparing(i -> legacyName(i.type()))
@@ -139,7 +141,7 @@ public class SysTables extends Command {
 
     @Override
     public int hashCode() {
-        return Objects.hash(clusterPattern, pattern, types);
+        return Objects.hash(clusterPattern, index, pattern, types);
     }
 
     @Override
@@ -154,6 +156,7 @@ public class SysTables extends Command {
 
         SysTables other = (SysTables) obj;
         return Objects.equals(clusterPattern, other.clusterPattern)
+                && Objects.equals(index, other.index)
                 && Objects.equals(pattern, other.pattern)
                 && Objects.equals(types, other.types);
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
@@ -139,7 +139,7 @@ public class OptimizerTests extends ESTestCase {
     }
 
     public void testPruneSubqueryAliases() {
-        ShowTables s = new ShowTables(EMPTY, null);
+        ShowTables s = new ShowTables(EMPTY, null, null);
         SubQueryAlias plan = new SubQueryAlias(EMPTY, s, "show");
         LogicalPlan result = new PruneSubqueryAliases().apply(plan);
         assertEquals(result, s);

--- a/x-pack/qa/sql/src/main/resources/command.csv-spec
+++ b/x-pack/qa/sql/src/main/resources/command.csv-spec
@@ -121,7 +121,7 @@ ABS             |SCALAR
 ;
 
 showFunctionsWithLeadingPattern
-SHOW FUNCTIONS '%DAY%';
+SHOW FUNCTIONS LIKE '%DAY%';
 
     name:s      |    type:s
 DAY_OF_MONTH    |SCALAR
@@ -133,15 +133,94 @@ MINUTE_OF_DAY   |SCALAR
 ;
 
 showTables
-SHOW TABLES 'test_emp';
+SHOW TABLES;
+
+       name        |     type      
+test_alias         |ALIAS          
+test_alias_emp     |ALIAS          
+test_emp           |BASE TABLE     
+test_emp_copy      |BASE TABLE     
+test_emp_with_nulls|BASE TABLE     
+;
+
+showTablesSimpleLike
+SHOW TABLES LIKE 'test_emp';
 
  name:s        | type:s
 test_emp       |BASE TABLE
 ;
 
+showTablesMultiLike
+SHOW TABLES LIKE 'test_emp%';
+
+ name:s            | type:s
+test_emp           |BASE TABLE     
+test_emp_copy      |BASE TABLE     
+test_emp_with_nulls|BASE TABLE   
+;
+
+showTablesIdentifier
+SHOW TABLES "test_emp";
+
+ name:s        | type:s
+test_emp       |BASE TABLE
+;
+
+showTablesIdentifierPattern
+SHOW TABLES "test_e*,-test_emp";
+
+ name:s            | type:s
+test_emp_copy      |BASE TABLE
+test_emp_with_nulls|BASE TABLE
+;
+
 // DESCRIBE
 
-describe
+describeSimpleLike
+DESCRIBE LIKE 'test_emp';
+
+       column:s      |   type:s
+birth_date           | TIMESTAMP
+dep                  | STRUCT
+dep.dep_id           | VARCHAR
+dep.dep_name         | VARCHAR
+dep.dep_name.keyword | VARCHAR
+dep.from_date        | TIMESTAMP
+dep.to_date          | TIMESTAMP
+emp_no               | INTEGER
+first_name           | VARCHAR
+first_name.keyword   | VARCHAR
+gender               | VARCHAR
+hire_date            | TIMESTAMP
+languages            | TINYINT
+last_name            | VARCHAR
+last_name.keyword    | VARCHAR
+salary               | INTEGER
+;
+
+describeMultiLike
+DESCRIBE LIKE 'test_emp%';
+
+       column:s      |   type:s
+birth_date           | TIMESTAMP
+dep                  | STRUCT
+dep.dep_id           | VARCHAR
+dep.dep_name         | VARCHAR
+dep.dep_name.keyword | VARCHAR
+dep.from_date        | TIMESTAMP
+dep.to_date          | TIMESTAMP
+emp_no               | INTEGER
+first_name           | VARCHAR
+first_name.keyword   | VARCHAR
+gender               | VARCHAR
+hire_date            | TIMESTAMP
+languages            | TINYINT
+last_name            | VARCHAR
+last_name.keyword    | VARCHAR
+salary               | INTEGER
+;
+
+describeSimpleIdentifier
 DESCRIBE "test_emp";
 
        column:s      |   type:s
@@ -164,8 +243,8 @@ salary               | INTEGER
 ;
 
 
-describeIncludeExclude
-DESCRIBE "test_emp*,-test_alias*";
+describeIncludeExcludeIdentifier
+DESCRIBE "test_emp*,-test_emp_*";
 
 column:s             |   type:s
 birth_date           | TIMESTAMP

--- a/x-pack/qa/sql/src/main/resources/docs.csv-spec
+++ b/x-pack/qa/sql/src/main/resources/docs.csv-spec
@@ -148,6 +148,29 @@ emp            |BASE TABLE
 // end::showTablesLikeMixed
 ;
 
+showTablesLikeEscape
+// tag::showTablesLikeEscape
+SHOW TABLES LIKE 'emp!%' ESCAPE '!';
+
+     name      |     type      
+---------------+---------------
+
+// end::showTablesLikeEscape
+;
+
+
+showTablesEsMultiIndex
+// tag::showTablesEsMultiIndex
+SHOW TABLES "*,-l*";
+
+     name      |     type      
+---------------+---------------
+emp            |BASE TABLE     
+employees      |ALIAS
+          
+// end:showTablesEsMultiIndex
+;
+
 ///////////////////////////////
 //
 // Show Functions
@@ -286,7 +309,7 @@ ABS            |SCALAR
 
 showFunctionsWithPattern
 // tag::showFunctionsWithPattern
-SHOW FUNCTIONS '%DAY%';
+SHOW FUNCTIONS LIKE '%DAY%';
 
      name      |     type      
 ---------------+---------------


### PR DESCRIPTION
Extend SHOW TABLES, DESCRIBE and SHOW COLUMNS to support table
identifers not just SQL LIKE pattern.
This allows both Elasticsearch-style multi-index patterns and SQL LIKE.
To disambiguate between the two (as the " vs ' can be easy to miss),
the grammar now requires LIKE keyword as a prefix for all LIKE-like
patterns.

Also added some docs comparing the two types of patterns.

Fix #33294