### PR TITLE
Don't build bwc on assemble

### DIFF
--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -51,6 +51,7 @@ subprojects {
   apply plugin: 'distribution'
   // Not published so no need to assemble
   assemble.enabled = false
+  assemble.dependsOn.remove('buildBwcVersion')
 
   File checkoutDir = file("${buildDir}/bwc/checkout-${bwcBranch}")
 
@@ -196,11 +197,11 @@ subprojects {
   }
 
   if (gradle.startParameter.taskNames == ["assemble"]) {
-    // Gradle needs the `artifacts` declaration, including `buildBy` bellow to make projects dependencies on this
+    // Gradle needs the `artifacts` declaration, including `builtBy` bellow to make projects dependencies on this
     // project work, but it will also trigger the build of these for the `assemble` task.
     // Since these are only used for testing, we don't want to assemble them if `assemble` is the single command being
     // ran.
-    logger.info("Skipping BWC builds")
+    logger.info("Skipping BWC builds since `assemble` is the only task name provided on the command line")
   } else {
     artifacts {
       for (File artifactFile : artifactFiles) {

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -195,11 +195,19 @@ subprojects {
     }
   }
 
-  artifacts {
-    for (File artifactFile : artifactFiles) {
-      String artifactName = artifactFile.name.contains('oss') ? 'elasticsearch-oss' : 'elasticsearch'
-      String suffix = artifactFile.toString()[-3..-1]
-      'default' file: artifactFile, name: artifactName, type: suffix, builtBy: buildBwcVersion
+  if (gradle.startParameter.taskNames == ["assemble"]) {
+    // Gradle needs the `artifacts` declaration, including `buildBy` bellow to make projects dependencies on this
+    // project work, but it will also trigger the build of these for the `assemble` task.
+    // Since these are only used for testing, we don't want to assemble them if `assemble` is the single command being
+    // ran.
+    logger.info("Skipping BWC builds")
+  } else {
+    artifacts {
+      for (File artifactFile : artifactFiles) {
+        String artifactName = artifactFile.name.contains('oss') ? 'elasticsearch-oss' : 'elasticsearch'
+        String suffix = artifactFile.toString()[-3..-1]
+        'default' file: artifactFile, name: artifactName, type: suffix, builtBy: buildBwcVersion
+      }
     }
   }
 }


### PR DESCRIPTION
Gradle triggers the build of artifacts even if assemble is disabled.
Most users will not need bwc distributions after running `./gradlew
assemble` so instead of forcing them to add `-x buildBwcVersion`, we
detect this and skip the configuration of the artifacts.

