### PR TITLE
SQL: Improve alias vs index resolution

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolver.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolver.java
@@ -16,6 +16,8 @@ import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest.Feature;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.IndicesOptions.Option;
+import org.elasticsearch.action.support.IndicesOptions.WildcardStates;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
@@ -117,6 +119,10 @@ public class IndexResolver {
         }
     }
 
+    private static final IndicesOptions INDICES_ONLY_OPTIONS = new IndicesOptions(
+            EnumSet.of(Option.ALLOW_NO_INDICES, Option.IGNORE_UNAVAILABLE, Option.IGNORE_ALIASES), EnumSet.of(WildcardStates.OPEN));
+
+
     private final Client client;
     private final String clusterName;
 
@@ -144,7 +150,6 @@ public class IndexResolver {
         if (retrieveAliases) {
             GetAliasesRequest aliasRequest = new GetAliasesRequest()
                     .local(true)
-                    .indices(indices)
                     .aliases(indices)
                     .indicesOptions(IndicesOptions.lenientExpandOpen());
     
@@ -176,7 +181,7 @@ public class IndexResolver {
                     .indices(indices)
                     .features(Feature.SETTINGS)
                     .includeDefaults(false)
-                    .indicesOptions(IndicesOptions.lenientExpandOpen());
+                    .indicesOptions(INDICES_ONLY_OPTIONS);
     
             client.admin().indices().getIndex(indexRequest,
                     ActionListener.wrap(response -> filterResults(javaRegex, aliases, response, listener),

--- a/x-pack/qa/sql/src/main/resources/command.csv-spec
+++ b/x-pack/qa/sql/src/main/resources/command.csv-spec
@@ -174,6 +174,14 @@ test_emp_copy      |BASE TABLE
 test_emp_with_nulls|BASE TABLE
 ;
 
+showTablesIdentifierPatternOnAliases
+SHOW TABLES "test*,-test_emp*";
+
+ name:s        | type:s
+test_alias     |ALIAS          
+test_alias_emp |ALIAS          
+;
+
 // DESCRIBE
 
 describeSimpleLike


### PR DESCRIPTION
Follow-up to #33363 which improves pattern resolution for aliases vs indices.


