### PR TITLE
HLRC: split cluster request converters

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterClient.java
@@ -56,7 +56,7 @@ public final class ClusterClient {
      */
     public ClusterUpdateSettingsResponse putSettings(ClusterUpdateSettingsRequest clusterUpdateSettingsRequest, RequestOptions options)
             throws IOException {
-        return restHighLevelClient.performRequestAndParseEntity(clusterUpdateSettingsRequest, RequestConverters::clusterPutSettings,
+        return restHighLevelClient.performRequestAndParseEntity(clusterUpdateSettingsRequest, ClusterRequestConverters::clusterPutSettings,
                 options, ClusterUpdateSettingsResponse::fromXContent, emptySet());
     }
 
@@ -70,7 +70,7 @@ public final class ClusterClient {
      */
     public void putSettingsAsync(ClusterUpdateSettingsRequest clusterUpdateSettingsRequest, RequestOptions options,
                                  ActionListener<ClusterUpdateSettingsResponse> listener) {
-        restHighLevelClient.performRequestAsyncAndParseEntity(clusterUpdateSettingsRequest, RequestConverters::clusterPutSettings,
+        restHighLevelClient.performRequestAsyncAndParseEntity(clusterUpdateSettingsRequest, ClusterRequestConverters::clusterPutSettings,
                 options, ClusterUpdateSettingsResponse::fromXContent, listener, emptySet());
     }
 
@@ -85,7 +85,7 @@ public final class ClusterClient {
      */
     public ClusterGetSettingsResponse getSettings(ClusterGetSettingsRequest clusterGetSettingsRequest, RequestOptions options)
         throws IOException {
-        return restHighLevelClient.performRequestAndParseEntity(clusterGetSettingsRequest, RequestConverters::clusterGetSettings,
+        return restHighLevelClient.performRequestAndParseEntity(clusterGetSettingsRequest, ClusterRequestConverters::clusterGetSettings,
             options, ClusterGetSettingsResponse::fromXContent, emptySet());
     }
 
@@ -99,7 +99,7 @@ public final class ClusterClient {
      */
     public void getSettingsAsync(ClusterGetSettingsRequest clusterGetSettingsRequest, RequestOptions options,
                                  ActionListener<ClusterGetSettingsResponse> listener) {
-        restHighLevelClient.performRequestAsyncAndParseEntity(clusterGetSettingsRequest, RequestConverters::clusterGetSettings,
+        restHighLevelClient.performRequestAsyncAndParseEntity(clusterGetSettingsRequest, ClusterRequestConverters::clusterGetSettings,
             options, ClusterGetSettingsResponse::fromXContent, listener, emptySet());
     }
 
@@ -115,7 +115,7 @@ public final class ClusterClient {
      * @throws IOException in case there is a problem sending the request or parsing back the response
      */
     public ClusterHealthResponse health(ClusterHealthRequest healthRequest, RequestOptions options) throws IOException {
-        return restHighLevelClient.performRequestAndParseEntity(healthRequest, RequestConverters::clusterHealth, options,
+        return restHighLevelClient.performRequestAndParseEntity(healthRequest, ClusterRequestConverters::clusterHealth, options,
                 ClusterHealthResponse::fromXContent, singleton(RestStatus.REQUEST_TIMEOUT.getStatus()));
     }
 
@@ -129,7 +129,7 @@ public final class ClusterClient {
      * @param listener the listener to be notified upon request completion
      */
     public void healthAsync(ClusterHealthRequest healthRequest, RequestOptions options, ActionListener<ClusterHealthResponse> listener) {
-        restHighLevelClient.performRequestAsyncAndParseEntity(healthRequest, RequestConverters::clusterHealth, options,
+        restHighLevelClient.performRequestAsyncAndParseEntity(healthRequest, ClusterRequestConverters::clusterHealth, options,
                 ClusterHealthResponse::fromXContent, listener, singleton(RestStatus.REQUEST_TIMEOUT.getStatus()));
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterRequestConverters.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPut;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.action.admin.cluster.settings.ClusterGetSettingsRequest;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.common.Strings;
+
+import java.io.IOException;
+
+final class ClusterRequestConverters {
+
+    static Request clusterPutSettings(ClusterUpdateSettingsRequest clusterUpdateSettingsRequest) throws IOException {
+        Request request = new Request(HttpPut.METHOD_NAME, "/_cluster/settings");
+
+        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        parameters.withTimeout(clusterUpdateSettingsRequest.timeout());
+        parameters.withMasterTimeout(clusterUpdateSettingsRequest.masterNodeTimeout());
+
+        request.setEntity(RequestConverters.createEntity(clusterUpdateSettingsRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        return request;
+    }
+
+    static Request clusterGetSettings(ClusterGetSettingsRequest clusterGetSettingsRequest) throws IOException {
+        Request request = new Request(HttpGet.METHOD_NAME, "/_cluster/settings");
+
+        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        parameters.withLocal(clusterGetSettingsRequest.local());
+        parameters.withIncludeDefaults(clusterGetSettingsRequest.includeDefaults());
+        parameters.withMasterTimeout(clusterGetSettingsRequest.masterNodeTimeout());
+
+        return request;
+    }
+
+    static Request clusterHealth(ClusterHealthRequest healthRequest) {
+        String[] indices = healthRequest.indices() == null ? Strings.EMPTY_ARRAY : healthRequest.indices();
+        String endpoint = new RequestConverters.EndpointBuilder()
+            .addPathPartAsIs("_cluster/health")
+            .addCommaSeparatedPathParts(indices)
+            .build();
+        Request request = new Request(HttpGet.METHOD_NAME, endpoint);
+
+        new RequestConverters.Params(request)
+            .withWaitForStatus(healthRequest.waitForStatus())
+            .withWaitForNoRelocatingShards(healthRequest.waitForNoRelocatingShards())
+            .withWaitForNoInitializingShards(healthRequest.waitForNoInitializingShards())
+            .withWaitForActiveShards(healthRequest.waitForActiveShards(), ActiveShardCount.NONE)
+            .withWaitForNodes(healthRequest.waitForNodes())
+            .withWaitForEvents(healthRequest.waitForEvents())
+            .withTimeout(healthRequest.timeout())
+            .withMasterTimeout(healthRequest.masterNodeTimeout())
+            .withLocal(healthRequest.local())
+            .withLevel(healthRequest.level());
+        return request;
+    }
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -36,8 +36,6 @@ import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteReposito
 import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesRequest;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.elasticsearch.action.admin.cluster.repositories.verify.VerifyRepositoryRequest;
-import org.elasticsearch.action.admin.cluster.settings.ClusterGetSettingsRequest;
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
@@ -724,28 +722,6 @@ final class RequestConverters {
         return request;
     }
 
-    static Request clusterPutSettings(ClusterUpdateSettingsRequest clusterUpdateSettingsRequest) throws IOException {
-        Request request = new Request(HttpPut.METHOD_NAME, "/_cluster/settings");
-
-        Params parameters = new Params(request);
-        parameters.withTimeout(clusterUpdateSettingsRequest.timeout());
-        parameters.withMasterTimeout(clusterUpdateSettingsRequest.masterNodeTimeout());
-
-        request.setEntity(createEntity(clusterUpdateSettingsRequest, REQUEST_BODY_CONTENT_TYPE));
-        return request;
-    }
-
-    static Request clusterGetSettings(ClusterGetSettingsRequest clusterGetSettingsRequest) throws IOException {
-        Request request = new Request(HttpGet.METHOD_NAME, "/_cluster/settings");
-
-        Params parameters = new Params(request);
-        parameters.withLocal(clusterGetSettingsRequest.local());
-        parameters.withIncludeDefaults(clusterGetSettingsRequest.includeDefaults());
-        parameters.withMasterTimeout(clusterGetSettingsRequest.masterNodeTimeout());
-
-        return request;
-    }
-
     static Request getPipeline(GetPipelineRequest getPipelineRequest) {
         String endpoint = new EndpointBuilder()
             .addPathPartAsIs("_ingest/pipeline")
@@ -800,28 +776,6 @@ final class RequestConverters {
             .withNodes(listTaskRequest.getNodes())
             .withActions(listTaskRequest.getActions())
             .putParam("group_by", "none");
-        return request;
-    }
-
-    static Request clusterHealth(ClusterHealthRequest healthRequest) {
-        String[] indices = healthRequest.indices() == null ? Strings.EMPTY_ARRAY : healthRequest.indices();
-        String endpoint = new EndpointBuilder()
-            .addPathPartAsIs("_cluster/health")
-            .addCommaSeparatedPathParts(indices)
-            .build();
-        Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-
-        new Params(request)
-            .withWaitForStatus(healthRequest.waitForStatus())
-            .withWaitForNoRelocatingShards(healthRequest.waitForNoRelocatingShards())
-            .withWaitForNoInitializingShards(healthRequest.waitForNoInitializingShards())
-            .withWaitForActiveShards(healthRequest.waitForActiveShards(), ActiveShardCount.NONE)
-            .withWaitForNodes(healthRequest.waitForNodes())
-            .withWaitForEvents(healthRequest.waitForEvents())
-            .withTimeout(healthRequest.timeout())
-            .withMasterTimeout(healthRequest.masterNodeTimeout())
-            .withLocal(healthRequest.local())
-            .withLevel(healthRequest.level());
         return request;
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ClusterRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ClusterRequestConvertersTests.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPut;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.action.admin.cluster.settings.ClusterGetSettingsRequest;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class ClusterRequestConvertersTests extends ESTestCase {
+
+    public void testClusterPutSettings() throws IOException {
+        ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest();
+        Map<String, String> expectedParams = new HashMap<>();
+        RequestConvertersTests.setRandomMasterTimeout(request, expectedParams);
+        RequestConvertersTests.setRandomTimeout(request::timeout, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT, expectedParams);
+
+        Request expectedRequest = ClusterRequestConverters.clusterPutSettings(request);
+        Assert.assertEquals("/_cluster/settings", expectedRequest.getEndpoint());
+        Assert.assertEquals(HttpPut.METHOD_NAME, expectedRequest.getMethod());
+        Assert.assertEquals(expectedParams, expectedRequest.getParameters());
+    }
+
+    public void testClusterGetSettings() throws IOException {
+        ClusterGetSettingsRequest request = new ClusterGetSettingsRequest();
+        Map<String, String> expectedParams = new HashMap<>();
+        RequestConvertersTests.setRandomMasterTimeout(request, expectedParams);
+        request.includeDefaults(ESTestCase.randomBoolean());
+        if (request.includeDefaults()) {
+            expectedParams.put("include_defaults", String.valueOf(true));
+        }
+
+        Request expectedRequest = ClusterRequestConverters.clusterGetSettings(request);
+        Assert.assertEquals("/_cluster/settings", expectedRequest.getEndpoint());
+        Assert.assertEquals(HttpGet.METHOD_NAME, expectedRequest.getMethod());
+        Assert.assertEquals(expectedParams, expectedRequest.getParameters());
+    }
+
+    public void testClusterHealth() {
+        ClusterHealthRequest healthRequest = new ClusterHealthRequest();
+        Map<String, String> expectedParams = new HashMap<>();
+        RequestConvertersTests.setRandomLocal(healthRequest, expectedParams);
+        String timeoutType = ESTestCase.randomFrom("timeout", "masterTimeout", "both", "none");
+        String timeout = ESTestCase.randomTimeValue();
+        String masterTimeout = ESTestCase.randomTimeValue();
+        switch (timeoutType) {
+            case "timeout":
+                healthRequest.timeout(timeout);
+                expectedParams.put("timeout", timeout);
+                // If Master Timeout wasn't set it uses the same value as Timeout
+                expectedParams.put("master_timeout", timeout);
+                break;
+            case "masterTimeout":
+                expectedParams.put("timeout", "30s");
+                healthRequest.masterNodeTimeout(masterTimeout);
+                expectedParams.put("master_timeout", masterTimeout);
+                break;
+            case "both":
+                healthRequest.timeout(timeout);
+                expectedParams.put("timeout", timeout);
+                healthRequest.masterNodeTimeout(timeout);
+                expectedParams.put("master_timeout", timeout);
+                break;
+            case "none":
+                expectedParams.put("timeout", "30s");
+                expectedParams.put("master_timeout", "30s");
+                break;
+            default:
+                throw new UnsupportedOperationException();
+        }
+        RequestConvertersTests.setRandomWaitForActiveShards(healthRequest::waitForActiveShards, ActiveShardCount.NONE, expectedParams);
+        if (ESTestCase.randomBoolean()) {
+            ClusterHealthRequest.Level level = ESTestCase.randomFrom(ClusterHealthRequest.Level.values());
+            healthRequest.level(level);
+            expectedParams.put("level", level.name().toLowerCase(Locale.ROOT));
+        } else {
+            expectedParams.put("level", "cluster");
+        }
+        if (ESTestCase.randomBoolean()) {
+            Priority priority = ESTestCase.randomFrom(Priority.values());
+            healthRequest.waitForEvents(priority);
+            expectedParams.put("wait_for_events", priority.name().toLowerCase(Locale.ROOT));
+        }
+        if (ESTestCase.randomBoolean()) {
+            ClusterHealthStatus status = ESTestCase.randomFrom(ClusterHealthStatus.values());
+            healthRequest.waitForStatus(status);
+            expectedParams.put("wait_for_status", status.name().toLowerCase(Locale.ROOT));
+        }
+        if (ESTestCase.randomBoolean()) {
+            boolean waitForNoInitializingShards = ESTestCase.randomBoolean();
+            healthRequest.waitForNoInitializingShards(waitForNoInitializingShards);
+            if (waitForNoInitializingShards) {
+                expectedParams.put("wait_for_no_initializing_shards", Boolean.TRUE.toString());
+            }
+        }
+        if (ESTestCase.randomBoolean()) {
+            boolean waitForNoRelocatingShards = ESTestCase.randomBoolean();
+            healthRequest.waitForNoRelocatingShards(waitForNoRelocatingShards);
+            if (waitForNoRelocatingShards) {
+                expectedParams.put("wait_for_no_relocating_shards", Boolean.TRUE.toString());
+            }
+        }
+        String[] indices = ESTestCase.randomBoolean() ? null : RequestConvertersTests.randomIndicesNames(0, 5);
+        healthRequest.indices(indices);
+
+        Request request = ClusterRequestConverters.clusterHealth(healthRequest);
+        Assert.assertThat(request, CoreMatchers.notNullValue());
+        Assert.assertThat(request.getMethod(), equalTo(HttpGet.METHOD_NAME));
+        Assert.assertThat(request.getEntity(), nullValue());
+        if (indices != null && indices.length > 0) {
+            Assert.assertThat(request.getEndpoint(), equalTo("/_cluster/health/" + String.join(",", indices)));
+        } else {
+            Assert.assertThat(request.getEndpoint(), equalTo("/_cluster/health"));
+        }
+        Assert.assertThat(request.getParameters(), equalTo(expectedParams));
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
@@ -134,6 +134,7 @@ public abstract class ESRestHighLevelClientTestCase extends ESRestTestCase {
         ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest();
         request.persistentSettings(persistentSettings);
         request.transientSettings(transientSettings);
-        assertOK(client().performRequest(RequestConverters.clusterPutSettings(request)));
+        assertTrue(execute(
+            request, highLevelClient().cluster()::putSettings, highLevelClient().cluster()::putSettingsAsync).isAcknowledged());
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -29,15 +29,12 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.DocWriteRequest;
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
 import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteRepositoryRequest;
 import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesRequest;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.elasticsearch.action.admin.cluster.repositories.verify.VerifyRepositoryRequest;
-import org.elasticsearch.action.admin.cluster.settings.ClusterGetSettingsRequest;
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
@@ -97,10 +94,8 @@ import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.RequestConverters.EndpointBuilder;
-import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.CheckedFunction;
-import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -156,7 +151,6 @@ import org.elasticsearch.search.suggest.completion.CompletionSuggestionBuilder;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.RandomObjects;
-import org.hamcrest.CoreMatchers;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -1838,33 +1832,6 @@ public class RequestConvertersTests extends ESTestCase {
         assertToXContentBody(resizeRequest, request.getEntity());
     }
 
-    public void testClusterPutSettings() throws IOException {
-        ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest();
-        Map<String, String> expectedParams = new HashMap<>();
-        setRandomMasterTimeout(request, expectedParams);
-        setRandomTimeout(request::timeout, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT, expectedParams);
-
-        Request expectedRequest = RequestConverters.clusterPutSettings(request);
-        assertEquals("/_cluster/settings", expectedRequest.getEndpoint());
-        assertEquals(HttpPut.METHOD_NAME, expectedRequest.getMethod());
-        assertEquals(expectedParams, expectedRequest.getParameters());
-    }
-
-    public void testClusterGetSettings() throws IOException {
-        ClusterGetSettingsRequest request = new ClusterGetSettingsRequest();
-        Map<String, String> expectedParams = new HashMap<>();
-        setRandomMasterTimeout(request, expectedParams);
-        request.includeDefaults(randomBoolean());
-        if (request.includeDefaults()) {
-            expectedParams.put("include_defaults", String.valueOf(true));
-        }
-
-        Request expectedRequest = RequestConverters.clusterGetSettings(request);
-        assertEquals("/_cluster/settings", expectedRequest.getEndpoint());
-        assertEquals(HttpGet.METHOD_NAME, expectedRequest.getMethod());
-        assertEquals(expectedParams, expectedRequest.getParameters());
-    }
-
     public void testPutPipeline() throws IOException {
         String pipelineId = "some_pipeline_id";
         PutPipelineRequest request = new PutPipelineRequest(
@@ -1940,85 +1907,6 @@ public class RequestConvertersTests extends ESTestCase {
         assertEquals(HttpPost.METHOD_NAME, expectedRequest.getMethod());
         assertEquals(expectedParams, expectedRequest.getParameters());
         assertToXContentBody(request, expectedRequest.getEntity());
-    }
-
-    public void testClusterHealth() {
-        ClusterHealthRequest healthRequest = new ClusterHealthRequest();
-        Map<String, String> expectedParams = new HashMap<>();
-        setRandomLocal(healthRequest, expectedParams);
-        String timeoutType = randomFrom("timeout", "masterTimeout", "both", "none");
-        String timeout = randomTimeValue();
-        String masterTimeout = randomTimeValue();
-        switch (timeoutType) {
-            case "timeout":
-                healthRequest.timeout(timeout);
-                expectedParams.put("timeout", timeout);
-                // If Master Timeout wasn't set it uses the same value as Timeout
-                expectedParams.put("master_timeout", timeout);
-                break;
-            case "masterTimeout":
-                expectedParams.put("timeout", "30s");
-                healthRequest.masterNodeTimeout(masterTimeout);
-                expectedParams.put("master_timeout", masterTimeout);
-                break;
-            case "both":
-                healthRequest.timeout(timeout);
-                expectedParams.put("timeout", timeout);
-                healthRequest.masterNodeTimeout(timeout);
-                expectedParams.put("master_timeout", timeout);
-                break;
-            case "none":
-                expectedParams.put("timeout", "30s");
-                expectedParams.put("master_timeout", "30s");
-                break;
-            default:
-                throw new UnsupportedOperationException();
-        }
-        setRandomWaitForActiveShards(healthRequest::waitForActiveShards, ActiveShardCount.NONE, expectedParams);
-        if (randomBoolean()) {
-            ClusterHealthRequest.Level level = randomFrom(ClusterHealthRequest.Level.values());
-            healthRequest.level(level);
-            expectedParams.put("level", level.name().toLowerCase(Locale.ROOT));
-        } else {
-            expectedParams.put("level", "cluster");
-        }
-        if (randomBoolean()) {
-            Priority priority = randomFrom(Priority.values());
-            healthRequest.waitForEvents(priority);
-            expectedParams.put("wait_for_events", priority.name().toLowerCase(Locale.ROOT));
-        }
-        if (randomBoolean()) {
-            ClusterHealthStatus status = randomFrom(ClusterHealthStatus.values());
-            healthRequest.waitForStatus(status);
-            expectedParams.put("wait_for_status", status.name().toLowerCase(Locale.ROOT));
-        }
-        if (randomBoolean()) {
-            boolean waitForNoInitializingShards = randomBoolean();
-            healthRequest.waitForNoInitializingShards(waitForNoInitializingShards);
-            if (waitForNoInitializingShards) {
-                expectedParams.put("wait_for_no_initializing_shards", Boolean.TRUE.toString());
-            }
-        }
-        if (randomBoolean()) {
-            boolean waitForNoRelocatingShards = randomBoolean();
-            healthRequest.waitForNoRelocatingShards(waitForNoRelocatingShards);
-            if (waitForNoRelocatingShards) {
-                expectedParams.put("wait_for_no_relocating_shards", Boolean.TRUE.toString());
-            }
-        }
-        String[] indices = randomBoolean() ? null : randomIndicesNames(0, 5);
-        healthRequest.indices(indices);
-
-        Request request = RequestConverters.clusterHealth(healthRequest);
-        assertThat(request, CoreMatchers.notNullValue());
-        assertThat(request.getMethod(), equalTo(HttpGet.METHOD_NAME));
-        assertThat(request.getEntity(), nullValue());
-        if (indices != null && indices.length > 0) {
-            assertThat(request.getEndpoint(), equalTo("/_cluster/health/" + String.join(",", indices)));
-        } else {
-            assertThat(request.getEndpoint(), equalTo("/_cluster/health"));
-        }
-        assertThat(request.getParameters(), equalTo(expectedParams));
     }
 
     public void testRollover() throws IOException {
@@ -2920,11 +2808,11 @@ public class RequestConvertersTests extends ESTestCase {
         }
     }
 
-    private static void setRandomLocal(MasterNodeReadRequest<?> request, Map<String, String> expectedParams) {
+    static void setRandomLocal(MasterNodeReadRequest<?> request, Map<String, String> expectedParams) {
         setRandomLocal(request::local, expectedParams);
     }
 
-    private static void setRandomTimeout(Consumer<String> setter, TimeValue defaultTimeout, Map<String, String> expectedParams) {
+    static void setRandomTimeout(Consumer<String> setter, TimeValue defaultTimeout, Map<String, String> expectedParams) {
         if (randomBoolean()) {
             String timeout = randomTimeValue();
             setter.accept(timeout);
@@ -2934,7 +2822,7 @@ public class RequestConvertersTests extends ESTestCase {
         }
     }
 
-    private static void setRandomMasterTimeout(MasterNodeRequest<?> request, Map<String, String> expectedParams) {
+    static void setRandomMasterTimeout(MasterNodeRequest<?> request, Map<String, String> expectedParams) {
         if (randomBoolean()) {
             String masterTimeout = randomTimeValue();
             request.masterNodeTimeout(masterTimeout);
@@ -2948,8 +2836,8 @@ public class RequestConvertersTests extends ESTestCase {
         setRandomWaitForActiveShards(setter, ActiveShardCount.DEFAULT, expectedParams);
     }
 
-    private static void setRandomWaitForActiveShards(Consumer<ActiveShardCount> setter, ActiveShardCount defaultActiveShardCount,
-                                                     Map<String, String> expectedParams) {
+    static void setRandomWaitForActiveShards(Consumer<ActiveShardCount> setter, ActiveShardCount defaultActiveShardCount,
+                                             Map<String, String> expectedParams) {
         if (randomBoolean()) {
             int waitForActiveShardsInt = randomIntBetween(-1, 5);
             String waitForActiveShardsString;
@@ -3009,7 +2897,7 @@ public class RequestConvertersTests extends ESTestCase {
         return excludesParam.toString();
     }
 
-    private static String[] randomIndicesNames(int minIndicesNum, int maxIndicesNum) {
+    static String[] randomIndicesNames(int minIndicesNum, int maxIndicesNum) {
         int numIndices = randomIntBetween(minIndicesNum, maxIndicesNum);
         String[] indices = new String[numIndices];
         for (int i = 0; i < numIndices; i++) {


### PR DESCRIPTION
In an effort to encapsulate the different clients, the request
converters are being shuffled around. This splits the ClusterClient
request converters.
