### PR TITLE
Build: Check for empty Javadoc bits

### DIFF
--- a/buildSrc/src/main/resources/checkstyle.xml
+++ b/buildSrc/src/main/resources/checkstyle.xml
@@ -80,5 +80,11 @@
       <property name="ignoreComments" value="true" />
     </module>
     <!-- end Orwellian suppression of Serializable -->
+
+    <!-- Prevent empty javadoc tags like @param or @throws since they are
+      unhelpful. Java 11 doesn't allow empty @param tags and this catches
+      that too which is nice because it prevents us from merging code that
+      will fail in Java 11. -->
+    <module name="NonEmptyAtclauseDescription"/>
   </module>
 </module>

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/DiscountedCumulativeGain.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/DiscountedCumulativeGain.java
@@ -44,7 +44,7 @@ import static org.elasticsearch.index.rankeval.EvaluationMetric.joinHitsWithRati
  * Metric implementing Discounted Cumulative Gain.
  * The `normalize` parameter can be set to calculate the normalized NDCG (set to {@code false} by default).<br>
  * The optional `unknown_doc_rating` parameter can be used to specify a default rating for unlabeled documents.
- * @see <a href="https://en.wikipedia.org/wiki/Discounted_cumulative_gain#Discounted_Cumulative_Gain">Discounted Cumulative Gain</a><br>
+ * @see <a href="https://en.wikipedia.org/wiki/Discounted_cumulative_gain#Discounted_Cumulative_Gain">Discounted Cumulative Gain</a>
  */
 public class DiscountedCumulativeGain implements EvaluationMetric {
 
@@ -337,4 +337,3 @@ public class DiscountedCumulativeGain implements EvaluationMetric {
         }
     }
 }
-

--- a/server/src/main/java/org/elasticsearch/common/inject/Initializer.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/Initializer.java
@@ -53,9 +53,8 @@ class Initializer {
     /**
      * Registers an instance for member injection when that step is performed.
      *
-     * @param instance an instance that optionally has members to be injected (each annotated with
+     * @param instance an instance that optionally has members to be injected (each annotated with {@code @Inject}).
      * @param source   the source location that this injection was requested
-     * @Inject).
      */
     public <T> Initializable<T> requestInjection(InjectorImpl injector, T instance, Object source,
                                                  Set<InjectionPoint> injectionPoints) {

--- a/x-pack/qa/kerberos-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SpnegoHttpClientConfigCallbackHandler.java
+++ b/x-pack/qa/kerberos-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SpnegoHttpClientConfigCallbackHandler.java
@@ -142,7 +142,6 @@ public class SpnegoHttpClientConfigCallbackHandler implements HttpClientConfigCa
      * returns {@link LoginContext}
      *
      * @return {@link LoginContext}
-     * @throws PrivilegedActionException
      */
     public synchronized LoginContext login() throws PrivilegedActionException {
         if (this.loginContext == null) {
@@ -175,9 +174,8 @@ public class SpnegoHttpClientConfigCallbackHandler implements HttpClientConfigCa
      *            Subject.doAs
      * @param acc the {@link AccessControlContext} to be tied to the specified
      *            subject and action see
-     *            {@link Subject#doAsPrivileged(Subject, PrivilegedExceptionAction, AccessControlContext)
+     *            {@link Subject#doAsPrivileged(Subject, PrivilegedExceptionAction, AccessControlContext)}
      * @return the value returned by the PrivilegedExceptionAction's run method
-     * @throws PrivilegedActionException
      */
     static <T> T doAsPrivilegedWrapper(final Subject subject, final PrivilegedExceptionAction<T> action, final AccessControlContext acc)
             throws PrivilegedActionException {


### PR DESCRIPTION
Adds a checkstyle check that fails if there are Javadoc bits like
`@throws` or `@param` that are empty. Empty `@param`s already fail the
build when we build with Java 11. This should have us catch these
problems on the intake build instead of that Java 11 builds.

It isn't without problems:
1. It seems to be ever so slightly more strict than regular Javadoc.
2. It slows down checkstyle because it now has to parse Javadoc. Running
checkstyle on the server directory goes from about 35 seconds to about
45 seconds on my laptop.
