### PR TITLE
Implement suggested fix from #30606

### DIFF
--- a/distribution/src/bin/elasticsearch.bat
+++ b/distribution/src/bin/elasticsearch.bat
@@ -41,9 +41,9 @@ IF ERRORLEVEL 1 (
 	EXIT /B %ERRORLEVEL%
 )
 
-set "ES_JVM_OPTIONS=%ES_PATH_CONF%\jvm.options"
+set ES_JVM_OPTIONS="%ES_PATH_CONF%\jvm.options"
 @setlocal
-for /F "usebackq delims=" %%a in (`"%JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.JvmOptionsParser" "!ES_JVM_OPTIONS!" || echo jvm_options_parser_failed"`) do set JVM_OPTIONS=%%a
+for /F "usebackq delims=" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.JvmOptionsParser" "!ES_JVM_OPTIONS!" ^|^| echo jvm_options_parser_failed`) do set JVM_OPTIONS=%%a
 @endlocal & set "MAYBE_JVM_OPTIONS_PARSER_FAILED=%JVM_OPTIONS%" & set ES_JAVA_OPTS=%JVM_OPTIONS:${ES_TMPDIR}=!ES_TMPDIR!% %ES_JAVA_OPTS%
 
 if "%MAYBE_JVM_OPTIONS_PARSER_FAILED%" == "jvm_options_parser_failed" (

--- a/distribution/src/bin/elasticsearch.bat
+++ b/distribution/src/bin/elasticsearch.bat
@@ -41,7 +41,7 @@ IF ERRORLEVEL 1 (
 	EXIT /B %ERRORLEVEL%
 )
 
-set ES_JVM_OPTIONS="%ES_PATH_CONF%\jvm.options"
+set ES_JVM_OPTIONS=%ES_PATH_CONF%\jvm.options
 @setlocal
 for /F "usebackq delims=" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.JvmOptionsParser" "!ES_JVM_OPTIONS!" ^|^| echo jvm_options_parser_failed`) do set JVM_OPTIONS=%%a
 @endlocal & set "MAYBE_JVM_OPTIONS_PARSER_FAILED=%JVM_OPTIONS%" & set ES_JAVA_OPTS=%JVM_OPTIONS:${ES_TMPDIR}=!ES_TMPDIR!% %ES_JAVA_OPTS%


### PR DESCRIPTION
Fixes: #30606

While setting up my new Windows 10 Pro laptop I took the default path for installing the Java 10 JRE;
"C:\Program Files (x86)\Common Files\Oracle\Java" 

I'm running a Kibana script that downloads and starts the latest elasticsearch snapshot but it kept failing with this error;
`ERROR \Common was unexpected at this time.`

@Dobatymo and @Lashchev suggested variations on a fix in #30606.  I applied the changes exactly as Lashchev suggested here https://github.com/elastic/elasticsearch/issues/30606#issuecomment-399904716

It resolved this problem for me.

NOTE: In my case, I had the JRE installed to that default path, and although I had the jdk 10 installed, I did not have JAVA_HOME set, so it was using the java executable from the JRE that was in my path var.

If I set my JAVA_HOME variable (my jdk path has no spaces or parenthesis) I can start elasticsearch without this fix.  But we should fix this problem since it would a common case for Windows users to download the JRE, take the default installation path, and then try to start Elasticsearch.

