### PR TITLE
Favor running compile tasks before pre-commit

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -21,7 +21,6 @@ package org.elasticsearch.gradle.precommit
 import org.elasticsearch.gradle.ExportElasticsearchBuildResourcesTask
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.artifacts.Configuration
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.quality.Checkstyle
 /**
@@ -70,14 +69,19 @@ class PrecommitTasks {
             precommitTasks.add(configureLoggerUsage(project))
         }
 
+        // We want to get any compilation error before running the pre-commit checks.
+        project.sourceSets.all { sourceSet ->
+            precommitTasks.each { task ->
+                task.shouldRunAfter(sourceSet.getClassesTaskName())
+            }
+        }
 
-        Map<String, Object> precommitOptions = [
+        return project.tasks.create([
             name: 'precommit',
             group: JavaBasePlugin.VERIFICATION_GROUP,
             description: 'Runs all non-test checks.',
             dependsOn: precommitTasks
-        ]
-        return project.tasks.create(precommitOptions)
+        ])
     }
 
     private static Task configureJarHell(Project project) {


### PR DESCRIPTION
With this change we won't need to call `./gradlew compileJava` before calling `precommit`.
This is not 100% what CI achieved. To do that we would need to set up this relationship between all the tasks between all the projects so that compile is done for all projects first, not just this one. 
I think this will be sufficient and we can leave the rest up to Gradle as it will already order projects based on dependencies. 