### PR TITLE
add notion of version and creation_date to LifecyclePolicyMetadata

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicyMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicyMetadata.java
@@ -30,8 +30,8 @@ public class LifecyclePolicyMetadata extends AbstractDiffable<LifecyclePolicyMet
     static final ParseField POLICY = new ParseField("policy");
     static final ParseField HEADERS = new ParseField("headers");
     static final ParseField VERSION = new ParseField("version");
-    static final ParseField CREATION_DATE = new ParseField("creation_date");
-    static final ParseField CREATION_DATE_STRING = new ParseField("creation_date_string");
+    static final ParseField MODIFIED_DATE = new ParseField("modified_date");
+    static final ParseField MODIFIED_DATE_STRING = new ParseField("modified_date_string");
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<LifecyclePolicyMetadata, String> PARSER = new ConstructingObjectParser<>("policy_metadata",
@@ -43,8 +43,8 @@ public class LifecyclePolicyMetadata extends AbstractDiffable<LifecyclePolicyMet
         PARSER.declareObject(ConstructingObjectParser.constructorArg(), LifecyclePolicy::parse, POLICY);
         PARSER.declareField(ConstructingObjectParser.constructorArg(), XContentParser::mapStrings, HEADERS, ValueType.OBJECT);
         PARSER.declareLong(ConstructingObjectParser.constructorArg(), VERSION);
-        PARSER.declareLong(ConstructingObjectParser.constructorArg(), CREATION_DATE);
-        PARSER.declareString(ConstructingObjectParser.constructorArg(), CREATION_DATE_STRING);
+        PARSER.declareLong(ConstructingObjectParser.constructorArg(), MODIFIED_DATE);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), MODIFIED_DATE_STRING);
     }
 
     public static LifecyclePolicyMetadata parse(XContentParser parser, String name) {
@@ -54,13 +54,13 @@ public class LifecyclePolicyMetadata extends AbstractDiffable<LifecyclePolicyMet
     private final LifecyclePolicy policy;
     private final Map<String, String> headers;
     private final long version;
-    private final long creationDate;
+    private final long modifiedDate;
 
-    public LifecyclePolicyMetadata(LifecyclePolicy policy, Map<String, String> headers, long version, long creationDate) {
+    public LifecyclePolicyMetadata(LifecyclePolicy policy, Map<String, String> headers, long version, long modifiedDate) {
         this.policy = policy;
         this.headers = headers;
         this.version = version;
-        this.creationDate = creationDate;
+        this.modifiedDate = modifiedDate;
     }
 
     @SuppressWarnings("unchecked")
@@ -68,7 +68,7 @@ public class LifecyclePolicyMetadata extends AbstractDiffable<LifecyclePolicyMet
         this.policy = new LifecyclePolicy(in);
         this.headers = (Map<String, String>) in.readGenericValue();
         this.version = in.readVLong();
-        this.creationDate = in.readVLong();
+        this.modifiedDate = in.readVLong();
     }
 
     public Map<String, String> getHeaders() {
@@ -87,13 +87,13 @@ public class LifecyclePolicyMetadata extends AbstractDiffable<LifecyclePolicyMet
         return version;
     }
 
-    public long getCreationDate() {
-        return creationDate;
+    public long getModifiedDate() {
+        return modifiedDate;
     }
 
-    public String getCreationDateString() {
-        ZonedDateTime creationDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(creationDate), ZoneOffset.UTC);
-        return creationDateTime.toString();
+    public String getModifiedDateString() {
+        ZonedDateTime modifiedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(modifiedDate), ZoneOffset.UTC);
+        return modifiedDateTime.toString();
     }
 
     @Override
@@ -102,8 +102,8 @@ public class LifecyclePolicyMetadata extends AbstractDiffable<LifecyclePolicyMet
         builder.field(POLICY.getPreferredName(), policy);
         builder.field(HEADERS.getPreferredName(), headers);
         builder.field(VERSION.getPreferredName(), version);
-        builder.field(CREATION_DATE.getPreferredName(), creationDate);
-        builder.field(CREATION_DATE_STRING.getPreferredName(), getCreationDateString());
+        builder.field(MODIFIED_DATE.getPreferredName(), modifiedDate);
+        builder.field(MODIFIED_DATE_STRING.getPreferredName(), getModifiedDateString());
         builder.endObject();
         return builder;
     }
@@ -113,12 +113,12 @@ public class LifecyclePolicyMetadata extends AbstractDiffable<LifecyclePolicyMet
         policy.writeTo(out);
         out.writeGenericValue(headers);
         out.writeVLong(version);
-        out.writeVLong(creationDate);
+        out.writeVLong(modifiedDate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(policy, headers, version, creationDate);
+        return Objects.hash(policy, headers, version, modifiedDate);
     }
 
     @Override
@@ -133,7 +133,7 @@ public class LifecyclePolicyMetadata extends AbstractDiffable<LifecyclePolicyMet
         return Objects.equals(policy, other.policy) &&
             Objects.equals(headers, other.headers) &&
             Objects.equals(version, other.version) &&
-            Objects.equals(creationDate, other.creationDate);
+            Objects.equals(modifiedDate, other.modifiedDate);
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicyMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicyMetadata.java
@@ -18,23 +18,33 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.Objects;
 
 public class LifecyclePolicyMetadata extends AbstractDiffable<LifecyclePolicyMetadata>
         implements ToXContentObject, Diffable<LifecyclePolicyMetadata> {
 
-    public static final ParseField POLICY = new ParseField("policy");
-    public static final ParseField HEADERS = new ParseField("headers");
+    static final ParseField POLICY = new ParseField("policy");
+    static final ParseField HEADERS = new ParseField("headers");
+    static final ParseField VERSION = new ParseField("version");
+    static final ParseField CREATION_DATE = new ParseField("creation_date");
+    static final ParseField CREATION_DATE_STRING = new ParseField("creation_date_string");
+
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<LifecyclePolicyMetadata, String> PARSER = new ConstructingObjectParser<>("policy_metadata",
             a -> {
                 LifecyclePolicy policy = (LifecyclePolicy) a[0];
-                return new LifecyclePolicyMetadata(policy, (Map<String, String>) a[1]);
+                return new LifecyclePolicyMetadata(policy, (Map<String, String>) a[1], (long) a[2], (long) a[3]);
             });
     static {
         PARSER.declareObject(ConstructingObjectParser.constructorArg(), LifecyclePolicy::parse, POLICY);
         PARSER.declareField(ConstructingObjectParser.constructorArg(), XContentParser::mapStrings, HEADERS, ValueType.OBJECT);
+        PARSER.declareLong(ConstructingObjectParser.constructorArg(), VERSION);
+        PARSER.declareLong(ConstructingObjectParser.constructorArg(), CREATION_DATE);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), CREATION_DATE_STRING);
     }
 
     public static LifecyclePolicyMetadata parse(XContentParser parser, String name) {
@@ -43,16 +53,22 @@ public class LifecyclePolicyMetadata extends AbstractDiffable<LifecyclePolicyMet
 
     private final LifecyclePolicy policy;
     private final Map<String, String> headers;
+    private final long version;
+    private final long creationDate;
 
-    public LifecyclePolicyMetadata(LifecyclePolicy policy, Map<String, String> headers) {
+    public LifecyclePolicyMetadata(LifecyclePolicy policy, Map<String, String> headers, long version, long creationDate) {
         this.policy = policy;
         this.headers = headers;
+        this.version = version;
+        this.creationDate = creationDate;
     }
 
     @SuppressWarnings("unchecked")
     public LifecyclePolicyMetadata(StreamInput in) throws IOException {
         this.policy = new LifecyclePolicy(in);
         this.headers = (Map<String, String>) in.readGenericValue();
+        this.version = in.readVLong();
+        this.creationDate = in.readVLong();
     }
 
     public Map<String, String> getHeaders() {
@@ -67,11 +83,27 @@ public class LifecyclePolicyMetadata extends AbstractDiffable<LifecyclePolicyMet
         return policy.getName();
     }
 
+    public long getVersion() {
+        return version;
+    }
+
+    public long getCreationDate() {
+        return creationDate;
+    }
+
+    public String getCreationDateString() {
+        ZonedDateTime creationDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(creationDate), ZoneOffset.UTC);
+        return creationDateTime.toString();
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(POLICY.getPreferredName(), policy);
         builder.field(HEADERS.getPreferredName(), headers);
+        builder.field(VERSION.getPreferredName(), version);
+        builder.field(CREATION_DATE.getPreferredName(), creationDate);
+        builder.field(CREATION_DATE_STRING.getPreferredName(), getCreationDateString());
         builder.endObject();
         return builder;
     }
@@ -80,11 +112,13 @@ public class LifecyclePolicyMetadata extends AbstractDiffable<LifecyclePolicyMet
     public void writeTo(StreamOutput out) throws IOException {
         policy.writeTo(out);
         out.writeGenericValue(headers);
+        out.writeVLong(version);
+        out.writeVLong(creationDate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(policy, headers);
+        return Objects.hash(policy, headers, version, creationDate);
     }
 
     @Override
@@ -97,7 +131,9 @@ public class LifecyclePolicyMetadata extends AbstractDiffable<LifecyclePolicyMet
         }
         LifecyclePolicyMetadata other = (LifecyclePolicyMetadata) obj;
         return Objects.equals(policy, other.policy) &&
-            Objects.equals(headers, other.headers);
+            Objects.equals(headers, other.headers) &&
+            Objects.equals(version, other.version) &&
+            Objects.equals(creationDate, other.creationDate);
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/action/GetLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/action/GetLifecycleAction.java
@@ -57,7 +57,7 @@ public class GetLifecycleAction extends Action<GetLifecycleAction.Response> {
             for (LifecyclePolicyResponseItem item : policies) {
                 builder.startObject(item.getLifecyclePolicy().getName());
                 builder.field("version", item.getVersion());
-                builder.field("creation_date", item.getCreationDate());
+                builder.field("modified_date", item.getModifiedDate());
                 builder.field("policy", item.getLifecyclePolicy());
                 builder.endObject();
             }
@@ -156,25 +156,25 @@ public class GetLifecycleAction extends Action<GetLifecycleAction.Response> {
     public static class LifecyclePolicyResponseItem implements Writeable {
         private final LifecyclePolicy lifecyclePolicy;
         private final long version;
-        private final String creationDate;
+        private final String modifiedDate;
 
-        public LifecyclePolicyResponseItem(LifecyclePolicy lifecyclePolicy, long version, String creationDate) {
+        public LifecyclePolicyResponseItem(LifecyclePolicy lifecyclePolicy, long version, String modifiedDate) {
             this.lifecyclePolicy = lifecyclePolicy;
             this.version = version;
-            this.creationDate = creationDate;
+            this.modifiedDate = modifiedDate;
         }
 
         LifecyclePolicyResponseItem(StreamInput in) throws IOException {
             this.lifecyclePolicy = new LifecyclePolicy(in);
             this.version = in.readVLong();
-            this.creationDate = in.readString();
+            this.modifiedDate = in.readString();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             lifecyclePolicy.writeTo(out);
             out.writeVLong(version);
-            out.writeString(creationDate);
+            out.writeString(modifiedDate);
         }
 
         public LifecyclePolicy getLifecyclePolicy() {
@@ -185,13 +185,13 @@ public class GetLifecycleAction extends Action<GetLifecycleAction.Response> {
             return version;
         }
 
-        public String getCreationDate() {
-            return creationDate;
+        public String getModifiedDate() {
+            return modifiedDate;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(lifecyclePolicy, version, creationDate);
+            return Objects.hash(lifecyclePolicy, version, modifiedDate);
         }
 
         @Override
@@ -205,7 +205,7 @@ public class GetLifecycleAction extends Action<GetLifecycleAction.Response> {
             LifecyclePolicyResponseItem other = (LifecyclePolicyResponseItem) obj;
             return Objects.equals(lifecyclePolicy, other.lifecyclePolicy) &&
                 Objects.equals(version, other.version) &&
-                Objects.equals(creationDate, other.creationDate);
+                Objects.equals(modifiedDate, other.modifiedDate);
         }
 
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicyMetadataTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicyMetadataTests.java
@@ -75,7 +75,8 @@ public class LifecyclePolicyMetadataTests extends AbstractSerializingTestCase<Li
         for (int i = 0; i < numberHeaders; i++) {
             headers.put(randomAlphaOfLength(10), randomAlphaOfLength(10));
         }
-        return new LifecyclePolicyMetadata(LifecyclePolicyTests.randomTimeseriesLifecyclePolicy(lifecycleName), headers);
+        return new LifecyclePolicyMetadata(LifecyclePolicyTests.randomTimeseriesLifecyclePolicy(lifecycleName), headers,
+            randomNonNegativeLong(), randomNonNegativeLong());
     }
 
     @Override
@@ -87,7 +88,9 @@ public class LifecyclePolicyMetadataTests extends AbstractSerializingTestCase<Li
     protected LifecyclePolicyMetadata mutateInstance(LifecyclePolicyMetadata instance) throws IOException {
         LifecyclePolicy policy = instance.getPolicy();
         Map<String, String> headers = instance.getHeaders();
-        switch (between(0, 1)) {
+        long version = instance.getVersion();
+        long creationDate = instance.getCreationDate();
+        switch (between(0, 3)) {
         case 0:
             policy = new LifecyclePolicy(TimeseriesLifecycleType.INSTANCE, policy.getName() + randomAlphaOfLengthBetween(1, 5),
                     policy.getPhases());
@@ -96,10 +99,16 @@ public class LifecyclePolicyMetadataTests extends AbstractSerializingTestCase<Li
             headers = new HashMap<>(headers);
             headers.put(randomAlphaOfLength(11), randomAlphaOfLength(11));
             break;
+        case 2:
+            version++;
+            break;
+        case 3:
+            creationDate++;
+            break;
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
-        return new LifecyclePolicyMetadata(policy, headers);
+        return new LifecyclePolicyMetadata(policy, headers, version, creationDate);
     }
 
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicyMetadataTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicyMetadataTests.java
@@ -89,7 +89,7 @@ public class LifecyclePolicyMetadataTests extends AbstractSerializingTestCase<Li
         LifecyclePolicy policy = instance.getPolicy();
         Map<String, String> headers = instance.getHeaders();
         long version = instance.getVersion();
-        long creationDate = instance.getCreationDate();
+        long creationDate = instance.getModifiedDate();
         switch (between(0, 3)) {
         case 0:
             policy = new LifecyclePolicy(TimeseriesLifecycleType.INSTANCE, policy.getName() + randomAlphaOfLengthBetween(1, 5),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/action/GetLifecycleResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/action/GetLifecycleResponseTests.java
@@ -5,19 +5,18 @@
  */
 package org.elasticsearch.xpack.core.indexlifecycle.action;
 
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.test.AbstractStreamableTestCase;
 import org.elasticsearch.xpack.core.indexlifecycle.LifecycleAction;
-import org.elasticsearch.xpack.core.indexlifecycle.LifecyclePolicy;
 import org.elasticsearch.xpack.core.indexlifecycle.LifecycleType;
 import org.elasticsearch.xpack.core.indexlifecycle.MockAction;
 import org.elasticsearch.xpack.core.indexlifecycle.TestLifecycleType;
+import org.elasticsearch.xpack.core.indexlifecycle.action.GetLifecycleAction.LifecyclePolicyResponseItem;
 import org.elasticsearch.xpack.core.indexlifecycle.action.GetLifecycleAction.Response;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 import static org.elasticsearch.xpack.core.indexlifecycle.LifecyclePolicyTests.randomTestLifecyclePolicy;
 
@@ -26,12 +25,12 @@ public class GetLifecycleResponseTests extends AbstractStreamableTestCase<GetLif
     @Override
     protected Response createTestInstance() {
         String randomPrefix = randomAlphaOfLength(5);
-        Map<LifecyclePolicy, Tuple<Long, String>> policyMap = new HashMap<>();
+        List<LifecyclePolicyResponseItem> responseItems = new ArrayList<>();
         for (int i = 0; i < randomIntBetween(0, 2); i++) {
-            policyMap.put(randomTestLifecyclePolicy(randomPrefix + i),
-                new Tuple<>(randomNonNegativeLong(), randomAlphaOfLength(8)));
+            responseItems.add(new LifecyclePolicyResponseItem(randomTestLifecyclePolicy(randomPrefix + i),
+                randomNonNegativeLong(), randomAlphaOfLength(8)));
         }
-        return new Response(policyMap);
+        return new Response(responseItems);
     }
 
     @Override
@@ -47,17 +46,18 @@ public class GetLifecycleResponseTests extends AbstractStreamableTestCase<GetLif
 
     @Override
     protected Response mutateInstance(Response response) {
-        Map<LifecyclePolicy, Tuple<Long, String>> policyMap = new HashMap<>(response.getPoliciesToMetadata());
-        if (policyMap.size() > 0) {
+        List<LifecyclePolicyResponseItem> responseItems = new ArrayList<>(response.getPolicies());
+        if (responseItems.size() > 0) {
             if (randomBoolean()) {
-                policyMap.put(randomTestLifecyclePolicy(randomAlphaOfLength(5)),
-                    new Tuple<>(randomNonNegativeLong(), randomAlphaOfLength(4)));
+                responseItems.add(new LifecyclePolicyResponseItem(randomTestLifecyclePolicy(randomAlphaOfLength(5)),
+                    randomNonNegativeLong(), randomAlphaOfLength(4)));
             } else {
-                policyMap.remove(randomFrom(response.getPoliciesToMetadata().keySet()));
+                responseItems.remove(0);
             }
         } else {
-            policyMap.put(randomTestLifecyclePolicy(randomAlphaOfLength(2)), new Tuple<>(randomNonNegativeLong(), randomAlphaOfLength(4)));
+            responseItems.add(new LifecyclePolicyResponseItem(randomTestLifecyclePolicy(randomAlphaOfLength(2)),
+                randomNonNegativeLong(), randomAlphaOfLength(4)));
         }
-        return new Response(policyMap);
+        return new Response(responseItems);
     }
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportGetLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportGetLifecycleAction.java
@@ -15,23 +15,20 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.indexlifecycle.IndexLifecycleMetadata;
-import org.elasticsearch.xpack.core.indexlifecycle.LifecyclePolicy;
 import org.elasticsearch.xpack.core.indexlifecycle.LifecyclePolicyMetadata;
 import org.elasticsearch.xpack.core.indexlifecycle.action.GetLifecycleAction;
+import org.elasticsearch.xpack.core.indexlifecycle.action.GetLifecycleAction.LifecyclePolicyResponseItem;
 import org.elasticsearch.xpack.core.indexlifecycle.action.GetLifecycleAction.Request;
 import org.elasticsearch.xpack.core.indexlifecycle.action.GetLifecycleAction.Response;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class TransportGetLifecycleAction extends TransportMasterNodeAction<Request, Response> {
 
@@ -73,12 +70,12 @@ public class TransportGetLifecycleAction extends TransportMasterNodeAction<Reque
                     requestedPolicies.add(policyMetadata);
                 }
             }
-            Map<LifecyclePolicy, Tuple<Long, String>> policyMap = new HashMap<>(requestedPolicies.size());
+            List<LifecyclePolicyResponseItem> responseItems = new ArrayList<>(requestedPolicies.size());
             for (LifecyclePolicyMetadata policyMetadata : requestedPolicies) {
-                policyMap.put(policyMetadata.getPolicy(),
-                    new Tuple<>(policyMetadata.getVersion(), policyMetadata.getCreationDateString()));
+                responseItems.add(new LifecyclePolicyResponseItem(policyMetadata.getPolicy(),
+                    policyMetadata.getVersion(), policyMetadata.getCreationDateString()));
             }
-            listener.onResponse(new Response(policyMap));
+            listener.onResponse(new Response(responseItems));
         }
     }
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/ExecuteStepsUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/ExecuteStepsUpdateTaskTests.java
@@ -94,9 +94,12 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
         LifecyclePolicy invalidPolicy = newTestLifecyclePolicy(invalidPolicyName,
             Collections.singletonMap(invalidPhase.getName(), invalidPhase));
         Map<String, LifecyclePolicyMetadata> policyMap = new HashMap<>();
-        policyMap.put(mixedPolicyName, new LifecyclePolicyMetadata(mixedPolicy, Collections.emptyMap()));
-        policyMap.put(allClusterPolicyName, new LifecyclePolicyMetadata(allClusterPolicy, Collections.emptyMap()));
-        policyMap.put(invalidPolicyName, new LifecyclePolicyMetadata(invalidPolicy, Collections.emptyMap()));
+        policyMap.put(mixedPolicyName, new LifecyclePolicyMetadata(mixedPolicy, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong()));
+        policyMap.put(allClusterPolicyName, new LifecyclePolicyMetadata(allClusterPolicy, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong()));
+        policyMap.put(invalidPolicyName, new LifecyclePolicyMetadata(invalidPolicy, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong()));
         policyStepsRegistry = new PolicyStepsRegistry(NamedXContentRegistry.EMPTY);
 
         indexName = randomAlphaOfLength(5);

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleInitialisationIT.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleInitialisationIT.java
@@ -12,7 +12,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -148,12 +147,11 @@ public class IndexLifecycleInitialisationIT extends ESIntegTestCase {
         // assert version and creation_date
         GetLifecycleAction.Response getLifecycleResponse = client().execute(GetLifecycleAction.INSTANCE,
             new GetLifecycleAction.Request()).get();
-        assertThat(getLifecycleResponse.getPoliciesToMetadata().size(), equalTo(1));
-        Map.Entry<LifecyclePolicy, Tuple<Long, String>> getPolicyEntry = getLifecycleResponse.getPoliciesToMetadata().entrySet()
-            .iterator().next();
-        assertThat(getPolicyEntry.getKey(), equalTo(lifecyclePolicy));
-        assertThat(getPolicyEntry.getValue().v1(), equalTo(1L));
-        long actualCreationDate = Instant.parse(getPolicyEntry.getValue().v2()).toEpochMilli();
+        assertThat(getLifecycleResponse.getPolicies().size(), equalTo(1));
+        GetLifecycleAction.LifecyclePolicyResponseItem responseItem = getLifecycleResponse.getPolicies().get(0);
+        assertThat(responseItem.getLifecyclePolicy(), equalTo(lifecyclePolicy));
+        assertThat(responseItem.getVersion(), equalTo(1L));
+        long actualCreationDate = Instant.parse(responseItem.getCreationDate()).toEpochMilli();
         assertThat(actualCreationDate,
             is(both(greaterThanOrEqualTo(lowerBoundCreationDate)).and(lessThanOrEqualTo(upperBoundCreationDate))));
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleInitialisationIT.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleInitialisationIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -36,10 +37,12 @@ import org.elasticsearch.xpack.core.indexlifecycle.MockAction;
 import org.elasticsearch.xpack.core.indexlifecycle.Phase;
 import org.elasticsearch.xpack.core.indexlifecycle.Step;
 import org.elasticsearch.xpack.core.indexlifecycle.TerminalPolicyStep;
+import org.elasticsearch.xpack.core.indexlifecycle.action.GetLifecycleAction;
 import org.elasticsearch.xpack.core.indexlifecycle.action.PutLifecycleAction;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -57,6 +60,10 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.xpack.core.indexlifecycle.LifecyclePolicyTestsUtils.newLockableLifecyclePolicy;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.core.CombinableMatcher.both;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 
 @ESIntegTestCase.ClusterScope(scope = Scope.TEST, numDataNodes = 0)
@@ -133,8 +140,23 @@ public class IndexLifecycleInitialisationIT extends ESIntegTestCase {
         final String node1 = getLocalNodeId(server_1);
         logger.info("Creating lifecycle [test_lifecycle]");
         PutLifecycleAction.Request putLifecycleRequest = new PutLifecycleAction.Request(lifecyclePolicy);
+        long lowerBoundCreationDate = Instant.now().toEpochMilli();
         PutLifecycleAction.Response putLifecycleResponse = client().execute(PutLifecycleAction.INSTANCE, putLifecycleRequest).get();
         assertAcked(putLifecycleResponse);
+        long upperBoundCreationDate = Instant.now().toEpochMilli();
+
+        // assert version and creation_date
+        GetLifecycleAction.Response getLifecycleResponse = client().execute(GetLifecycleAction.INSTANCE,
+            new GetLifecycleAction.Request()).get();
+        assertThat(getLifecycleResponse.getPoliciesToMetadata().size(), equalTo(1));
+        Map.Entry<LifecyclePolicy, Tuple<Long, String>> getPolicyEntry = getLifecycleResponse.getPoliciesToMetadata().entrySet()
+            .iterator().next();
+        assertThat(getPolicyEntry.getKey(), equalTo(lifecyclePolicy));
+        assertThat(getPolicyEntry.getValue().v1(), equalTo(1L));
+        long actualCreationDate = Instant.parse(getPolicyEntry.getValue().v2()).toEpochMilli();
+        assertThat(actualCreationDate,
+            is(both(greaterThanOrEqualTo(lowerBoundCreationDate)).and(lessThanOrEqualTo(upperBoundCreationDate))));
+
         logger.info("Creating index [test]");
         CreateIndexResponse createIndexResponse = client().admin().indices().create(createIndexRequest("test").settings(settings))
                 .actionGet();

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleInitialisationIT.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleInitialisationIT.java
@@ -139,21 +139,21 @@ public class IndexLifecycleInitialisationIT extends ESIntegTestCase {
         final String node1 = getLocalNodeId(server_1);
         logger.info("Creating lifecycle [test_lifecycle]");
         PutLifecycleAction.Request putLifecycleRequest = new PutLifecycleAction.Request(lifecyclePolicy);
-        long lowerBoundCreationDate = Instant.now().toEpochMilli();
+        long lowerBoundModifiedDate = Instant.now().toEpochMilli();
         PutLifecycleAction.Response putLifecycleResponse = client().execute(PutLifecycleAction.INSTANCE, putLifecycleRequest).get();
         assertAcked(putLifecycleResponse);
-        long upperBoundCreationDate = Instant.now().toEpochMilli();
+        long upperBoundModifiedDate = Instant.now().toEpochMilli();
 
-        // assert version and creation_date
+        // assert version and modified_date
         GetLifecycleAction.Response getLifecycleResponse = client().execute(GetLifecycleAction.INSTANCE,
             new GetLifecycleAction.Request()).get();
         assertThat(getLifecycleResponse.getPolicies().size(), equalTo(1));
         GetLifecycleAction.LifecyclePolicyResponseItem responseItem = getLifecycleResponse.getPolicies().get(0);
         assertThat(responseItem.getLifecyclePolicy(), equalTo(lifecyclePolicy));
         assertThat(responseItem.getVersion(), equalTo(1L));
-        long actualCreationDate = Instant.parse(responseItem.getCreationDate()).toEpochMilli();
-        assertThat(actualCreationDate,
-            is(both(greaterThanOrEqualTo(lowerBoundCreationDate)).and(lessThanOrEqualTo(upperBoundCreationDate))));
+        long actualModifiedDate = Instant.parse(responseItem.getModifiedDate()).toEpochMilli();
+        assertThat(actualModifiedDate,
+            is(both(greaterThanOrEqualTo(lowerBoundModifiedDate)).and(lessThanOrEqualTo(upperBoundModifiedDate))));
 
         logger.info("Creating index [test]");
         CreateIndexResponse createIndexResponse = client().admin().indices().create(createIndexRequest("test").settings(settings))

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleMetadataTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleMetadataTests.java
@@ -54,7 +54,8 @@ public class IndexLifecycleMetadataTests extends AbstractDiffableSerializationTe
         Map<String, LifecyclePolicyMetadata> policies = new HashMap<>(numPolicies);
         for (int i = 0; i < numPolicies; i++) {
             LifecyclePolicy policy = randomTimeseriesLifecyclePolicy(randomAlphaOfLength(4) + i);
-            policies.put(policy.getName(), new LifecyclePolicyMetadata(policy, Collections.emptyMap()));
+            policies.put(policy.getName(), new LifecyclePolicyMetadata(policy, Collections.emptyMap(),
+                randomNonNegativeLong(), randomNonNegativeLong()));
         }
         return new IndexLifecycleMetadata(policies, randomFrom(OperationMode.values()));
     }
@@ -108,7 +109,8 @@ public class IndexLifecycleMetadataTests extends AbstractDiffableSerializationTe
         OperationMode mode = metadata.getOperationMode();
         if (randomBoolean()) {
             String policyName = randomAlphaOfLength(10);
-            policies.put(policyName, new LifecyclePolicyMetadata(randomTimeseriesLifecyclePolicy(policyName), Collections.emptyMap()));
+            policies.put(policyName, new LifecyclePolicyMetadata(randomTimeseriesLifecyclePolicy(policyName), Collections.emptyMap(),
+                randomNonNegativeLong(), randomNonNegativeLong()));
         } else {
             mode = randomValueOtherThan(metadata.getOperationMode(), () -> randomFrom(OperationMode.values()));
         }
@@ -148,7 +150,8 @@ public class IndexLifecycleMetadataTests extends AbstractDiffableSerializationTe
                 phases.put(phaseName, new Phase(phaseName, after, actions));
             }
             String policyName = randomAlphaOfLength(10);
-            policies.put(policyName, new LifecyclePolicyMetadata(newTestLifecyclePolicy(policyName, phases), Collections.emptyMap()));
+            policies.put(policyName, new LifecyclePolicyMetadata(newTestLifecyclePolicy(policyName, phases), Collections.emptyMap(),
+                randomNonNegativeLong(), randomNonNegativeLong()));
         }
         return new IndexLifecycleMetadata(policies, mode);
     }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunnerTests.java
@@ -1072,7 +1072,8 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         MockAsyncActionStep step = new MockAsyncActionStep(stepKey, null);
         step.setWillComplete(true);
         SortedMap<String, LifecyclePolicyMetadata> lifecyclePolicyMap = new TreeMap<>(Collections.singletonMap(policyName,
-            new LifecyclePolicyMetadata(createPolicy(policyName, null, step.getKey()), new HashMap<>())));
+            new LifecyclePolicyMetadata(createPolicy(policyName, null, step.getKey()), new HashMap<>(),
+                randomNonNegativeLong(), randomNonNegativeLong())));
         Index index = new Index("my_index",  "uuid");
         Map<String, Step> firstStepMap = Collections.singletonMap(policyName, step);
         Map<StepKey, Step> policySteps = Collections.singletonMap(step.getKey(), step);

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunnerTests.java
@@ -560,7 +560,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
             () -> LifecyclePolicyTests.randomTestLifecyclePolicy("policy"));
         Phase nextPhase = policy.getPhases().values().stream().findFirst().get();
         List<LifecyclePolicyMetadata> policyMetadatas = Collections.singletonList(
-            new LifecyclePolicyMetadata(policy, Collections.emptyMap()));
+            new LifecyclePolicyMetadata(policy, Collections.emptyMap(), randomNonNegativeLong(), randomNonNegativeLong()));
         StepKey currentStep = new StepKey("current_phase", "current_action", "current_step");
         StepKey nextStep = new StepKey(nextPhase.getName(), "next_action", "next_step");
         long now = randomNonNegativeLong();
@@ -645,7 +645,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
             () -> LifecyclePolicyTests.randomTestLifecyclePolicy(policyName));
         Phase nextPhase = policy.getPhases().values().stream().findFirst().get();
         List<LifecyclePolicyMetadata> policyMetadatas = Collections.singletonList(
-            new LifecyclePolicyMetadata(policy, Collections.emptyMap()));
+            new LifecyclePolicyMetadata(policy, Collections.emptyMap(), randomNonNegativeLong(), randomNonNegativeLong()));
         StepKey currentStepKey = new StepKey("current_phase", "current_action", "current_step");
         StepKey nextStepKey = new StepKey(nextPhase.getName(), "next_action", "next_step");
         long now = randomNonNegativeLong();
@@ -894,8 +894,10 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
                 .put(LifecycleSettings.LIFECYCLE_ACTION, currentStep.getAction())
                 .put(LifecycleSettings.LIFECYCLE_STEP, currentStep.getName()).put(LifecycleSettings.LIFECYCLE_SKIP, true);
         List<LifecyclePolicyMetadata> policyMetadatas = new ArrayList<>();
-        policyMetadatas.add(new LifecyclePolicyMetadata(oldPolicy, Collections.emptyMap()));
-        policyMetadatas.add(new LifecyclePolicyMetadata(newPolicy, Collections.emptyMap()));
+        policyMetadatas.add(new LifecyclePolicyMetadata(oldPolicy, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong()));
+        policyMetadatas.add(new LifecyclePolicyMetadata(newPolicy, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong()));
         ClusterState clusterState = buildClusterState(indexName, indexSettingsBuilder, policyMetadatas);
         Index index = clusterState.metaData().index(indexName).getIndex();
         Index[] indices = new Index[] { index };
@@ -940,7 +942,8 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
                 .put(LifecycleSettings.LIFECYCLE_ACTION, currentStep.getAction())
                 .put(LifecycleSettings.LIFECYCLE_STEP, currentStep.getName()).put(LifecycleSettings.LIFECYCLE_SKIP, true);
         List<LifecyclePolicyMetadata> policyMetadatas = new ArrayList<>();
-        policyMetadatas.add(new LifecyclePolicyMetadata(oldPolicy, Collections.emptyMap()));
+        policyMetadatas.add(new LifecyclePolicyMetadata(oldPolicy, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong()));
         ClusterState clusterState = buildClusterState(indexName, indexSettingsBuilder, policyMetadatas);
         Index index = new Index("doesnt_exist", "im_not_here");
         Index[] indices = new Index[] { index };
@@ -989,7 +992,8 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
                 .put(LifecycleSettings.LIFECYCLE_ACTION, currentStep.getAction())
                 .put(LifecycleSettings.LIFECYCLE_STEP, currentStep.getName()).put(LifecycleSettings.LIFECYCLE_SKIP, true);
         List<LifecyclePolicyMetadata> policyMetadatas = new ArrayList<>();
-        policyMetadatas.add(new LifecyclePolicyMetadata(oldPolicy, Collections.emptyMap()));
+        policyMetadatas.add(new LifecyclePolicyMetadata(oldPolicy, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong()));
         ClusterState clusterState = buildClusterState(indexName, indexSettingsBuilder, policyMetadatas);
         Index index = clusterState.metaData().index(indexName).getIndex();
         Index[] indices = new Index[] { index };
@@ -1025,7 +1029,8 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
                 .put(LifecycleSettings.LIFECYCLE_ACTION, currentStep.getAction())
                 .put(LifecycleSettings.LIFECYCLE_STEP, currentStep.getName()).put(LifecycleSettings.LIFECYCLE_SKIP, true);
         List<LifecyclePolicyMetadata> policyMetadatas = new ArrayList<>();
-        policyMetadatas.add(new LifecyclePolicyMetadata(oldPolicy, Collections.emptyMap()));
+        policyMetadatas.add(new LifecyclePolicyMetadata(oldPolicy, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong()));
         ClusterState clusterState = buildClusterState(indexName, indexSettingsBuilder, policyMetadatas);
         Index index = new Index("doesnt_exist", "im_not_here");
         Index[] indices = new Index[] { index };
@@ -1048,7 +1053,8 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
                 .put(LifecycleSettings.LIFECYCLE_ACTION, currentStep.getAction())
                 .put(LifecycleSettings.LIFECYCLE_STEP, currentStep.getName()).put(LifecycleSettings.LIFECYCLE_SKIP, true);
         List<LifecyclePolicyMetadata> policyMetadatas = new ArrayList<>();
-        policyMetadatas.add(new LifecyclePolicyMetadata(oldPolicy, Collections.emptyMap()));
+        policyMetadatas.add(new LifecyclePolicyMetadata(oldPolicy, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong()));
         ClusterState clusterState = buildClusterState(indexName, indexSettingsBuilder, policyMetadatas);
         Index index = clusterState.metaData().index(indexName).getIndex();
         Index[] indices = new Index[] { index };

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleServiceTests.java
@@ -113,7 +113,8 @@ public class IndexLifecycleServiceTests extends ESTestCase {
         Phase phase = new Phase("phase", TimeValue.ZERO, Collections.singletonMap("action", mockAction));
         LifecyclePolicy policy = newTestLifecyclePolicy(policyName, Collections.singletonMap(phase.getName(), phase));
         SortedMap<String, LifecyclePolicyMetadata> policyMap = new TreeMap<>();
-        policyMap.put(policyName, new LifecyclePolicyMetadata(policy, Collections.emptyMap()));
+        policyMap.put(policyName, new LifecyclePolicyMetadata(policy, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong()));
         Index index = new Index(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
         IndexMetaData indexMetadata = IndexMetaData.builder(index.getName())
             .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey(), policyName))
@@ -144,7 +145,8 @@ public class IndexLifecycleServiceTests extends ESTestCase {
         Phase phase = new Phase("phase", TimeValue.ZERO, Collections.singletonMap("action", mockAction));
         LifecyclePolicy policy = newTestLifecyclePolicy(policyName, Collections.singletonMap(phase.getName(), phase));
         SortedMap<String, LifecyclePolicyMetadata> policyMap = new TreeMap<>();
-        policyMap.put(policyName, new LifecyclePolicyMetadata(policy, Collections.emptyMap()));
+        policyMap.put(policyName, new LifecyclePolicyMetadata(policy, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong()));
         Index index = new Index(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
         IndexMetaData indexMetadata = IndexMetaData.builder(index.getName())
             .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey(), policyName)
@@ -184,7 +186,8 @@ public class IndexLifecycleServiceTests extends ESTestCase {
         Phase phase = new Phase("phase", TimeValue.ZERO, Collections.singletonMap("action", mockAction));
         LifecyclePolicy policy = newTestLifecyclePolicy(policyName, Collections.singletonMap(phase.getName(), phase));
         SortedMap<String, LifecyclePolicyMetadata> policyMap = new TreeMap<>();
-        policyMap.put(policyName, new LifecyclePolicyMetadata(policy, Collections.emptyMap()));
+        policyMap.put(policyName, new LifecyclePolicyMetadata(policy, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong()));
         Index index = new Index(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
         IndexMetaData indexMetadata = IndexMetaData.builder(index.getName())
             .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey(), policyName)

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/MoveToErrorStepUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/MoveToErrorStepUpdateTaskTests.java
@@ -50,7 +50,8 @@ public class MoveToErrorStepUpdateTaskTests extends ESTestCase {
             .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
         index = indexMetadata.getIndex();
         IndexLifecycleMetadata ilmMeta = new IndexLifecycleMetadata(
-            Collections.singletonMap(policy, new LifecyclePolicyMetadata(lifecyclePolicy, Collections.emptyMap())),
+            Collections.singletonMap(policy, new LifecyclePolicyMetadata(lifecyclePolicy, Collections.emptyMap(),
+                randomNonNegativeLong(), randomNonNegativeLong())),
             OperationMode.RUNNING);
         MetaData metaData = MetaData.builder()
             .persistentSettings(settings(Version.CURRENT).build())

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/MoveToNextStepUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/MoveToNextStepUpdateTaskTests.java
@@ -47,7 +47,8 @@ public class MoveToNextStepUpdateTaskTests extends ESTestCase {
         index = indexMetadata.getIndex();
         lifecyclePolicy = LifecyclePolicyTests.randomTestLifecyclePolicy(policy);
         IndexLifecycleMetadata ilmMeta = new IndexLifecycleMetadata(
-            Collections.singletonMap(policy, new LifecyclePolicyMetadata(lifecyclePolicy, Collections.emptyMap())),
+            Collections.singletonMap(policy, new LifecyclePolicyMetadata(lifecyclePolicy, Collections.emptyMap(),
+                randomNonNegativeLong(), randomNonNegativeLong())),
             OperationMode.RUNNING);
         MetaData metaData = MetaData.builder()
             .persistentSettings(settings(Version.CURRENT).build())

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/PolicyStepsRegistryTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/PolicyStepsRegistryTests.java
@@ -116,7 +116,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
             headers.put(randomAlphaOfLength(10), randomAlphaOfLength(10));
         }
         Map<String, LifecyclePolicyMetadata> policyMap = Collections.singletonMap(newPolicy.getName(),
-                new LifecyclePolicyMetadata(newPolicy, headers));
+                new LifecyclePolicyMetadata(newPolicy, headers, randomNonNegativeLong(), randomNonNegativeLong()));
         IndexLifecycleMetadata lifecycleMetadata = new IndexLifecycleMetadata(policyMap, OperationMode.RUNNING);
         MetaData metaData = MetaData.builder()
             .persistentSettings(settings(Version.CURRENT).build())
@@ -203,7 +203,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
             headers.put(randomAlphaOfLength(10), randomAlphaOfLength(10));
         }
         Map<String, LifecyclePolicyMetadata> policyMap = Collections.singletonMap(newPolicy.getName(),
-                new LifecyclePolicyMetadata(newPolicy, headers));
+            new LifecyclePolicyMetadata(newPolicy, headers, randomNonNegativeLong(), randomNonNegativeLong()));
         IndexLifecycleMetadata lifecycleMetadata = new IndexLifecycleMetadata(policyMap, OperationMode.RUNNING);
         MetaData metaData = MetaData.builder()
             .persistentSettings(settings(Version.CURRENT).build())
@@ -224,7 +224,8 @@ public class PolicyStepsRegistryTests extends ESTestCase {
         // swap out policy
         newPolicy = LifecyclePolicyTests.randomTestLifecyclePolicy(policyName);
         lifecycleMetadata = new IndexLifecycleMetadata(Collections.singletonMap(policyName,
-                                                new LifecyclePolicyMetadata(newPolicy, Collections.emptyMap())), OperationMode.RUNNING);
+            new LifecyclePolicyMetadata(newPolicy, Collections.emptyMap(),
+                randomNonNegativeLong(), randomNonNegativeLong())), OperationMode.RUNNING);
         currentState = ClusterState.builder(currentState)
             .metaData(MetaData.builder(metaData).putCustom(IndexLifecycleMetadata.TYPE, lifecycleMetadata)).build();
         registry.update(currentState, client);
@@ -256,7 +257,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
             headers.put(randomAlphaOfLength(10), randomAlphaOfLength(10));
         }
         Map<String, LifecyclePolicyMetadata> policyMap = Collections.singletonMap(newPolicy.getName(),
-            new LifecyclePolicyMetadata(newPolicy, headers));
+            new LifecyclePolicyMetadata(newPolicy, headers, randomNonNegativeLong(), randomNonNegativeLong()));
         IndexLifecycleMetadata lifecycleMetadata = new IndexLifecycleMetadata(policyMap, OperationMode.RUNNING);
         MetaData metaData = MetaData.builder()
             .persistentSettings(settings(Version.CURRENT).build())
@@ -300,7 +301,8 @@ public class PolicyStepsRegistryTests extends ESTestCase {
         assertThat(((ShrinkStep) gotStep).getNumberOfShards(), equalTo(1));
 
         // Update the policy with the new policy, but keep the phase the same
-        policyMap = Collections.singletonMap(updatedPolicy.getName(), new LifecyclePolicyMetadata(updatedPolicy, headers));
+        policyMap = Collections.singletonMap(updatedPolicy.getName(), new LifecyclePolicyMetadata(updatedPolicy, headers,
+            randomNonNegativeLong(), randomNonNegativeLong()));
         lifecycleMetadata = new IndexLifecycleMetadata(policyMap, OperationMode.RUNNING);
         metaData = MetaData.builder(metaData)
             .putCustom(IndexLifecycleMetadata.TYPE, lifecycleMetadata)

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/10_basic.yml
@@ -46,8 +46,10 @@ setup:
       acknowledge: true
       ilm.get_lifecycle:
         lifecycle: "my_timeseries_lifecycle"
-  - match: { my_timeseries_lifecycle.phases.warm.after: "10s" }
-  - match: { my_timeseries_lifecycle.phases.delete.after: "30s" }
+  - match: { my_timeseries_lifecycle.version: 1 }
+  - is_true: my_timeseries_lifecycle.creation_date
+  - match: { my_timeseries_lifecycle.policy.phases.warm.after: "10s" }
+  - match: { my_timeseries_lifecycle.policy.phases.delete.after: "30s" }
 
   - do:
       acknowledge: true
@@ -91,8 +93,10 @@ setup:
       acknowledge: true
       ilm.get_lifecycle:
         lifecycle: "my_timeseries_lifecycle"
-  - match: { my_timeseries_lifecycle.phases.warm.after: "10s" }
-  - match: { my_timeseries_lifecycle.phases.delete.after: "30s" }
+  - match: { my_timeseries_lifecycle.version: 1 }
+  - is_true: my_timeseries_lifecycle.creation_date
+  - match: { my_timeseries_lifecycle.policy.phases.warm.after: "10s" }
+  - match: { my_timeseries_lifecycle.policy.phases.delete.after: "30s" }
 
 
   - do:
@@ -139,8 +143,10 @@ setup:
       acknowledge: true
       ilm.get_lifecycle:
         lifecycle: "my_timeseries_lifecycle"
-  - match: { my_timeseries_lifecycle.phases.warm.after: "300s" }
-  - match: { my_timeseries_lifecycle.phases.delete.after: "600s" }
+  - match: { my_timeseries_lifecycle.version: 2 }
+  - is_true: my_timeseries_lifecycle.creation_date
+  - match: { my_timeseries_lifecycle.policy.phases.warm.after: "300s" }
+  - match: { my_timeseries_lifecycle.policy.phases.delete.after: "600s" }
 
   - do:
       acknowledge: true
@@ -193,8 +199,8 @@ setup:
       acknowledge: true
       ilm.get_lifecycle:
         lifecycle: "my_timeseries_lifecycle"
-  - match: { my_timeseries_lifecycle.phases.warm.after: "10s" }
-  - match: { my_timeseries_lifecycle.phases.delete.after: "30s" }
+  - match: { my_timeseries_lifecycle.policy.phases.warm.after: "10s" }
+  - match: { my_timeseries_lifecycle.policy.phases.delete.after: "30s" }
 
   - do:
       indices.create:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/10_basic.yml
@@ -47,7 +47,7 @@ setup:
       ilm.get_lifecycle:
         lifecycle: "my_timeseries_lifecycle"
   - match: { my_timeseries_lifecycle.version: 1 }
-  - is_true: my_timeseries_lifecycle.creation_date
+  - is_true: my_timeseries_lifecycle.modified_date
   - match: { my_timeseries_lifecycle.policy.phases.warm.after: "10s" }
   - match: { my_timeseries_lifecycle.policy.phases.delete.after: "30s" }
 
@@ -94,7 +94,7 @@ setup:
       ilm.get_lifecycle:
         lifecycle: "my_timeseries_lifecycle"
   - match: { my_timeseries_lifecycle.version: 1 }
-  - is_true: my_timeseries_lifecycle.creation_date
+  - is_true: my_timeseries_lifecycle.modified_date
   - match: { my_timeseries_lifecycle.policy.phases.warm.after: "10s" }
   - match: { my_timeseries_lifecycle.policy.phases.delete.after: "30s" }
 
@@ -144,7 +144,7 @@ setup:
       ilm.get_lifecycle:
         lifecycle: "my_timeseries_lifecycle"
   - match: { my_timeseries_lifecycle.version: 2 }
-  - is_true: my_timeseries_lifecycle.creation_date
+  - is_true: my_timeseries_lifecycle.modified_date
   - match: { my_timeseries_lifecycle.policy.phases.warm.after: "300s" }
   - match: { my_timeseries_lifecycle.policy.phases.delete.after: "600s" }
 


### PR DESCRIPTION
It is useful to keep track of which version of a policy is currently
being executed by a specific index. For management purposes, it would
also be useful to know at which time the latest version was inserted
so that an audit trail is left for reconciling changes happening in ILM.

The work here only adds a notion of version and creation_date to the lifecycle-metadata. The index settings are not updated with which version their currently executed `phase_definition` is because these settings are to be moved to custom indexmetadata anyways, and I would prefer to minimize conflicts here, happy to do this in a follow-up if the time is right.