### PR TITLE
Adds checks to ensure index metadata exists when we try to use it

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/AllocationRoutedStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/AllocationRoutedStepTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.xpack.core.indexlifecycle.ClusterStateWaitStep.Result;
@@ -288,9 +287,9 @@ public class AllocationRoutedStepTests extends AbstractStepTestCase<AllocationRo
 
         AllocationRoutedStep step = createRandomInstance();
 
-        IndexNotFoundException thrownException = expectThrows(IndexNotFoundException.class, () -> step.isConditionMet(index, clusterState));
-        assertEquals("Index not found when executing " + step.getKey().getAction() + " lifecycle action.", thrownException.getMessage());
-        assertEquals(index.getName(), thrownException.getIndex().getName());
+        Result actualResult = step.isConditionMet(index, clusterState);
+        assertFalse(actualResult.isComplete());
+        assertNull(actualResult.getInfomationContext());
     }
 
     private void assertAllocateStatus(Index index, int shards, int replicas, AllocationRoutedStep step, Settings.Builder existingSettings,

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/ExecuteStepsUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/ExecuteStepsUpdateTask.java
@@ -66,6 +66,7 @@ public class ExecuteStepsUpdateTask extends ClusterStateUpdateTask {
         Step currentStep = startStep;
         IndexMetaData indexMetaData = currentState.metaData().index(index);
         if (indexMetaData == null) {
+            logger.debug("lifecycle for index [{}] executed but index no longer exists", index.getName());
             // This index doesn't exist any more, there's nothing to execute currently
             return currentState;
         }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunner.java
@@ -158,6 +158,10 @@ public class IndexLifecycleRunner {
     }
 
     private void runPolicy(IndexMetaData indexMetaData, ClusterState currentState) {
+        if (indexMetaData == null) {
+            // This index doesn't exist any more, there's nothing to execute
+            return;
+        }
         Settings indexSettings = indexMetaData.getSettings();
         String policy = LifecycleSettings.LIFECYCLE_NAME_SETTING.get(indexSettings);
         runPolicy(policy, indexMetaData, currentState, false);

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/SetStepInfoUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/SetStepInfoUpdateTask.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.indexlifecycle;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.index.Index;
@@ -48,7 +49,12 @@ public class SetStepInfoUpdateTask extends ClusterStateUpdateTask {
 
     @Override
     public ClusterState execute(ClusterState currentState) throws IOException {
-        Settings indexSettings = currentState.getMetaData().index(index).getSettings();
+        IndexMetaData idxMeta = currentState.getMetaData().index(index);
+        if (idxMeta == null) {
+            // Index must have been since deleted, ignore it
+            return currentState;
+        }
+        Settings indexSettings = idxMeta.getSettings();
         if (policy.equals(LifecycleSettings.LIFECYCLE_NAME_SETTING.get(indexSettings))
                 && currentStepKey.equals(IndexLifecycleRunner.getCurrentStepKey(indexSettings))) {
             return IndexLifecycleRunner.addStepInfoToClusterState(index, currentState, stepInfo);


### PR DESCRIPTION
IF the index no longer exists when we try to retrieve the index metadata it's been delete since the policy was triggered and there is nothing for us to do. Currently in a few places we throw a NPE if this happens which, although it does not affect the execution result is ugly and logs a needless stack trace which suggests something might be wrong even though its not. This change makes sure we check for when this happens, logs a debug message and then ignores execution of that index for whatever operation is in progress.