### PR TITLE
[DOCS] Moves graph to docs folder

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -101,6 +101,7 @@ buildRestTests.docs = fileTree(projectDir) {
   exclude 'reference/rollup/apis/delete-job.asciidoc'
   exclude 'reference/rollup/apis/get-job.asciidoc'
   exclude 'reference/rollup/apis/rollup-caps.asciidoc'
+  exclude 'reference/graph/explore.asciidoc'
 }
 
 listSnippets.docs = buildRestTests.docs

--- a/docs/reference/graph/explore.asciidoc
+++ b/docs/reference/graph/explore.asciidoc
@@ -1,4 +1,5 @@
 [role="xpack"]
+[testenv="platinum"]
 [[graph-explore-api]]
 == Explore API
 

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -19,7 +19,7 @@ directly to configure and access {xpack} features.
 
 
 include::info.asciidoc[]
-include::{xes-repo-dir}/rest-api/graph/explore.asciidoc[]
+include::{es-repo-dir}/graph/explore.asciidoc[]
 include::{es-repo-dir}/licensing/index.asciidoc[]
 include::{es-repo-dir}/migration/migration.asciidoc[]
 include::{es-repo-dir}/ml/apis/ml-api.asciidoc[]

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -92,7 +92,6 @@ buildRestTests.docs = fileTree(projectDir) {
     exclude 'build'
     // These file simply doesn't pass yet. We should figure out how to fix them.
     exclude 'en/watcher/reference/actions.asciidoc'
-    exclude 'en/rest-api/graph/explore.asciidoc'
 }
 
 Map<String, String> setups = buildRestTests.setups


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/30665 

This PR moves the graph API content from x-pack/docs/rest-api/graph to docs/reference/graph
