### PR TITLE
[DOCS] Moves authorization to docs folder

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -33,6 +33,8 @@ buildRestTests.expectedUnconvertedCandidates = [
         'reference/ml/apis/post-data.asciidoc',
         'reference/ml/apis/revert-snapshot.asciidoc',
         'reference/ml/apis/update-snapshot.asciidoc',
+        'reference/security/authorization/run-as-privilege.asciidoc',
+        'reference/security/authorization/custom-roles-provider.asciidoc',
 ]
 
 integTestCluster {

--- a/docs/reference/security/authorization/alias-privileges.asciidoc
+++ b/docs/reference/security/authorization/alias-privileges.asciidoc
@@ -1,4 +1,5 @@
 [role="xpack"]
+[testenv="gold"]
 [[securing-aliases]]
 === Granting privileges for indices and aliases
 

--- a/docs/reference/security/authorization/custom-roles-provider.asciidoc
+++ b/docs/reference/security/authorization/custom-roles-provider.asciidoc
@@ -1,4 +1,5 @@
 [role="xpack"]
+[testenv="platinum"]
 [[custom-roles-provider]]
 === Custom roles provider extension
 

--- a/docs/reference/security/authorization/field-and-document-access-control.asciidoc
+++ b/docs/reference/security/authorization/field-and-document-access-control.asciidoc
@@ -1,4 +1,5 @@
 [role="xpack"]
+[testenv="platinum"]
 [[field-and-document-access-control]]
 === Setting up field and document level security
 

--- a/docs/reference/security/authorization/managing-roles.asciidoc
+++ b/docs/reference/security/authorization/managing-roles.asciidoc
@@ -164,6 +164,7 @@ POST /_xpack/security/role/clicks_admin
 }
 -----------
 // CONSOLE
+// TEST[skip:non-compliant license]
 
 Based on the above definition, users owning the `clicks_admin` role can:
 

--- a/docs/reference/security/authorization/managing-roles.asciidoc
+++ b/docs/reference/security/authorization/managing-roles.asciidoc
@@ -1,4 +1,5 @@
 [role="xpack"]
+[testenv="gold"]
 [[defining-roles]]
 === Defining roles
 

--- a/docs/reference/security/authorization/mapping-roles.asciidoc
+++ b/docs/reference/security/authorization/mapping-roles.asciidoc
@@ -1,4 +1,5 @@
 [role="xpack"]
+[testenv="gold"]
 [[mapping-roles]]
 === Mapping users and groups to roles
 

--- a/docs/reference/security/authorization/mapping-roles.asciidoc
+++ b/docs/reference/security/authorization/mapping-roles.asciidoc
@@ -101,6 +101,7 @@ PUT _xpack/security/role_mapping/admins
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[skip:non-compliant license]
 
 [source,js]
 --------------------------------------------------
@@ -115,6 +116,7 @@ PUT _xpack/security/role_mapping/basic_users
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[skip:non-compliant license]
 
 [float]
 [[pki-role-mapping]]
@@ -145,6 +147,7 @@ PUT _xpack/security/role_mapping/admin_user
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[skip:non-compliant license]
 
 [source,js]
 --------------------------------------------------
@@ -156,3 +159,4 @@ PUT _xpack/security/role_mapping/basic_user
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[skip:non-compliant license]

--- a/docs/reference/security/authorization/role-templates.asciidoc
+++ b/docs/reference/security/authorization/role-templates.asciidoc
@@ -33,6 +33,7 @@ POST /_xpack/security/role/example1
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[skip:non-compliant license]
 
 You can access the following information through the `_user` variable:
 
@@ -70,3 +71,4 @@ POST /_xpack/security/role/example2
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[skip:non-compliant license]

--- a/docs/reference/security/authorization/role-templates.asciidoc
+++ b/docs/reference/security/authorization/role-templates.asciidoc
@@ -1,4 +1,5 @@
 [[templating-role-query]]
+[testenv="platinum"]
 ==== Templating a role query
 
 When you create a role, you can specify a query that defines the 

--- a/docs/reference/security/authorization/run-as-privilege.asciidoc
+++ b/docs/reference/security/authorization/run-as-privilege.asciidoc
@@ -1,4 +1,5 @@
 [role="xpack"]
+[testenv="gold"]
 [[run-as-privilege]]
 === Submitting requests on behalf of other users
 

--- a/docs/reference/security/authorization/set-security-user.asciidoc
+++ b/docs/reference/security/authorization/set-security-user.asciidoc
@@ -1,3 +1,4 @@
+[testenv="gold"]
 [[set-security-user-processor]]
 ==== Pre-processing documents to add security details
 

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -11,9 +11,7 @@ apply plugin: 'elasticsearch.docs-test'
 buildRestTests.expectedUnconvertedCandidates = [
         'en/rest-api/watcher/put-watch.asciidoc',
         'en/security/authentication/user-cache.asciidoc',
-        'en/security/authorization/run-as-privilege.asciidoc',
         'en/security/ccs-clients-integrations/http.asciidoc',
-        'en/security/authorization/custom-roles-provider.asciidoc',
         'en/rest-api/watcher/stats.asciidoc',
         'en/watcher/example-watches/watching-time-series-data.asciidoc',
 ]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/30665 

This PR moves the authorization content from x-pack/docs/security/authorization to docs/reference/security/authorization