### PR TITLE
Removes redundant test method in SQL tests

### DIFF
--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractorTests.java
@@ -52,11 +52,6 @@ public class FieldHitExtractorTests extends AbstractWireSerializingTestCase<Fiel
         return new FieldHitExtractor(instance.fieldName() + "mutated", null, true, instance.hitName());
     }
 
-    @AwaitsFix(bugUrl = "implement after we're sure of the InnerHitExtractor's implementation")
-    public void testGetNested() throws IOException {
-        fail("implement after we're sure of the InnerHitExtractor's implementation");
-    }
-
     public void testGetDottedValueWithDocValues() {
         String grandparent = randomAlphaOfLength(5);
         String parent = randomAlphaOfLength(5);


### PR DESCRIPTION
Creating a PR to ensure the build is green before pushing