### PR TITLE
Fix typos

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -66,7 +66,7 @@ class BuildPlugin implements Plugin<Project> {
     void apply(Project project) {
         if (project.pluginManager.hasPlugin('elasticsearch.standalone-rest-test')) {
               throw new InvalidUserDataException('elasticsearch.standalone-test, '
-                + 'elasticearch.standalone-rest-test, and elasticsearch.build '
+                + 'elasticsearch.standalone-rest-test, and elasticsearch.build '
                 + 'are mutually exclusive')
         }
         final String minimumGradleVersion

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -63,7 +63,7 @@ class PrecommitTasks {
              * (which provides NamingConventionsCheck) and :test:logger-usage
              * which provides the logger usage check. Since the build tools
              * don't use the logger usage check because they don't have any
-             * of Elaticsearch's loggers and :test:logger-usage actually does
+             * of Elasticsearch's loggers and :test:logger-usage actually does
              * use the NamingConventionsCheck we break the circular dependency
              * here.
              */

--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -71,7 +71,7 @@ thirdPartyAudit.excludes = [
   'org.apache.log.Logger',
 ]
 
-// Support for testing reindex-from-remote against old Elaticsearch versions
+// Support for testing reindex-from-remote against old Elasticsearch versions
 configurations {
   oldesFixture
   es2

--- a/x-pack/docs/en/watcher/customizing-watches.asciidoc
+++ b/x-pack/docs/en/watcher/customizing-watches.asciidoc
@@ -49,7 +49,7 @@ initial payload.
 A <<input-search, search>> input contains a `request` object that specifies the
 indices you want to search, the {ref}/search-request-search-type.html[search type],
 and the search request body. The `body` field of a search input is the same as
-the body of an Elasticsearch `_search` request, making the full Elaticsearch
+the body of an Elasticsearch `_search` request, making the full Elasticsearch
 Query DSL available for you to use.
 
 For example, the following `search` input loads the latest VIX quote:

--- a/x-pack/plugin/security/src/main/resources/meta-plugin-descriptor.properties
+++ b/x-pack/plugin/security/src/main/resources/meta-plugin-descriptor.properties
@@ -5,7 +5,7 @@
 #
 # meta-foo.zip <-- zip file for the meta plugin, with this structure:
 #|____elasticsearch/
-#| |____   <bundled_plugin_1> <-- The plugin files for bundled_plugin_1 (the content of the elastisearch directory)
+#| |____   <bundled_plugin_1> <-- The plugin files for bundled_plugin_1 (the content of the elasticsearch directory)
 #| |____   <bundled_plugin_2>  <-- The plugin files for bundled_plugin_2
 #| |____   meta-plugin-descriptor.properties <-- example contents below:
 #


### PR DESCRIPTION
This commit fixes some typos in the docs and source code.

Extracted from #32815