### PR TITLE
SQL: Fix result column names for arithmetic functions

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/Expressions.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/Expressions.java
@@ -82,7 +82,13 @@ public abstract class Expressions {
     }
 
     public static String name(Expression e) {
-        return e instanceof NamedExpression ? ((NamedExpression) e).name() : e.nodeName();
+        if (e instanceof NamedExpression) {
+            return ((NamedExpression) e).name();
+        } else if (e instanceof Literal) {
+            return e.toString();
+        } else {
+            return e.nodeName();
+        }
     }
 
     public static List<String> names(Collection<? extends Expression> e) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/ScalarFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/ScalarFunction.java
@@ -10,6 +10,7 @@ import org.elasticsearch.xpack.sql.expression.Attribute;
 import org.elasticsearch.xpack.sql.expression.Expression;
 import org.elasticsearch.xpack.sql.expression.Expressions;
 import org.elasticsearch.xpack.sql.expression.FieldAttribute;
+import org.elasticsearch.xpack.sql.expression.LiteralAttribute;
 import org.elasticsearch.xpack.sql.expression.function.Function;
 import org.elasticsearch.xpack.sql.expression.function.aggregate.AggregateFunctionAttribute;
 import org.elasticsearch.xpack.sql.expression.function.scalar.processor.definition.ProcessorDefinition;
@@ -68,6 +69,9 @@ public abstract class ScalarFunction extends Function {
             if (attr instanceof AggregateFunctionAttribute) {
                 return asScriptFrom((AggregateFunctionAttribute) attr);
             }
+            if (attr instanceof LiteralAttribute) {
+                return asScriptFrom((LiteralAttribute) attr);
+            }
             // fall-back to
             return asScriptFrom((FieldAttribute) attr);
         }
@@ -96,6 +100,12 @@ public abstract class ScalarFunction extends Function {
         return new ScriptTemplate(formatScript("{}"),
                 paramsBuilder().agg(aggregate).build(),
                 aggregate.dataType());
+    }
+
+    protected ScriptTemplate asScriptFrom(LiteralAttribute literal) {
+        return new ScriptTemplate(formatScript("{}"),
+            paramsBuilder().variable(literal.literal()).build(),
+            literal.dataType());
     }
 
     protected String formatScript(String scriptTemplate) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/arithmetic/ArithmeticFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/arithmetic/ArithmeticFunction.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar.arithmetic;
 
 import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.FieldAttribute;
 import org.elasticsearch.xpack.sql.expression.Literal;
 import org.elasticsearch.xpack.sql.expression.function.scalar.arithmetic.BinaryArithmeticProcessor.BinaryArithmeticOperation;
 import org.elasticsearch.xpack.sql.expression.function.scalar.math.BinaryNumericFunction;
@@ -65,7 +66,7 @@ public abstract class ArithmeticFunction extends BinaryNumericFunction {
     public String name() {
         StringBuilder sb = new StringBuilder();
         sb.append("(");
-        sb.append(left());
+        appendFunctionArg(left(), sb);
         if (!(left() instanceof Literal)) {
             sb.insert(1, "(");
             sb.append(")");
@@ -74,7 +75,7 @@ public abstract class ArithmeticFunction extends BinaryNumericFunction {
         sb.append(operation);
         sb.append(" ");
         int pos = sb.length();
-        sb.append(right());
+        appendFunctionArg(right(), sb);
         if (!(right() instanceof Literal)) {
             sb.insert(pos, "(");
             sb.append(")");
@@ -88,7 +89,11 @@ public abstract class ArithmeticFunction extends BinaryNumericFunction {
         return name() + "#" + functionId();
     }
 
-    protected boolean useParanthesis() {
-        return !(left() instanceof Literal) || !(right() instanceof Literal);
+    private void appendFunctionArg(Expression arg, StringBuilder sb) {
+        if (arg instanceof FieldAttribute) {
+            sb.append(((FieldAttribute) arg).name());
+        } else {
+            sb.append(arg);
+        }
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/arithmetic/ArithmeticFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/arithmetic/ArithmeticFunction.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar.arithmetic;
 
 import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.Expressions;
 import org.elasticsearch.xpack.sql.expression.FieldAttribute;
 import org.elasticsearch.xpack.sql.expression.Literal;
 import org.elasticsearch.xpack.sql.expression.function.scalar.arithmetic.BinaryArithmeticProcessor.BinaryArithmeticOperation;
@@ -66,7 +67,7 @@ public abstract class ArithmeticFunction extends BinaryNumericFunction {
     public String name() {
         StringBuilder sb = new StringBuilder();
         sb.append("(");
-        appendFunctionArg(left(), sb);
+        sb.append(Expressions.name(left()));
         if (!(left() instanceof Literal)) {
             sb.insert(1, "(");
             sb.append(")");
@@ -75,7 +76,7 @@ public abstract class ArithmeticFunction extends BinaryNumericFunction {
         sb.append(operation);
         sb.append(" ");
         int pos = sb.length();
-        appendFunctionArg(right(), sb);
+        sb.append(Expressions.name(right()));
         if (!(right() instanceof Literal)) {
             sb.insert(pos, "(");
             sb.append(")");
@@ -87,13 +88,5 @@ public abstract class ArithmeticFunction extends BinaryNumericFunction {
     @Override
     public String toString() {
         return name() + "#" + functionId();
-    }
-
-    private void appendFunctionArg(Expression arg, StringBuilder sb) {
-        if (arg instanceof FieldAttribute) {
-            sb.append(((FieldAttribute) arg).name());
-        } else {
-            sb.append(arg);
-        }
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/arithmetic/ArithmeticFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/arithmetic/ArithmeticFunction.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.sql.expression.function.scalar.arithmetic;
 
 import org.elasticsearch.xpack.sql.expression.Expression;
 import org.elasticsearch.xpack.sql.expression.Expressions;
-import org.elasticsearch.xpack.sql.expression.FieldAttribute;
 import org.elasticsearch.xpack.sql.expression.Literal;
 import org.elasticsearch.xpack.sql.expression.function.scalar.arithmetic.BinaryArithmeticProcessor.BinaryArithmeticOperation;
 import org.elasticsearch.xpack.sql.expression.function.scalar.math.BinaryNumericFunction;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/NamedExpressionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/NamedExpressionTests.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.sql.expression.function;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.expression.FieldAttribute;
 import org.elasticsearch.xpack.sql.expression.Literal;
 import org.elasticsearch.xpack.sql.expression.function.scalar.arithmetic.Add;
 import org.elasticsearch.xpack.sql.expression.function.scalar.arithmetic.Div;
@@ -13,7 +14,10 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.arithmetic.Mod;
 import org.elasticsearch.xpack.sql.expression.function.scalar.arithmetic.Mul;
 import org.elasticsearch.xpack.sql.expression.function.scalar.arithmetic.Neg;
 import org.elasticsearch.xpack.sql.expression.function.scalar.arithmetic.Sub;
+import org.elasticsearch.xpack.sql.type.DataType;
+import org.elasticsearch.xpack.sql.type.EsField;
 
+import static java.util.Collections.emptyMap;
 import static org.elasticsearch.xpack.sql.tree.Location.EMPTY;
 
 public class NamedExpressionTests extends ESTestCase {
@@ -36,6 +40,12 @@ public class NamedExpressionTests extends ESTestCase {
 
         Neg neg = new Neg(EMPTY, l(5));
         assertEquals("-5", neg.name());
+    }
+
+    public void testNameForArithmeticFunctionAppliedOnTableColumn() {
+        FieldAttribute fa = new FieldAttribute(EMPTY, "myField", new EsField("myESField", DataType.INTEGER, emptyMap(), true));
+        Add add = new Add(EMPTY, fa, l(10));
+        assertEquals("((myField) + 10)", add.name());
     }
 
     private static Literal l(Object value) {

--- a/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/CsvTestUtils.java
+++ b/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/CsvTestUtils.java
@@ -113,18 +113,18 @@ public final class CsvTestUtils {
     }
 
     private static Tuple<String, String> extractColumnTypesFromHeader(String header) {
-        String[] columnTypes = Strings.delimitedListToStringArray(header, "|", " \t");
+        String[] columnTypes = Strings.tokenizeToStringArray(header, "|");
         StringBuilder types = new StringBuilder();
         StringBuilder columns = new StringBuilder();
         for (String column : columnTypes) {
-            String[] nameType = Strings.delimitedListToStringArray(column, ":");
+            String[] nameType = Strings.delimitedListToStringArray(column.trim(), ":");
             assertThat("If at least one column has a type associated with it, all columns should have types", nameType, arrayWithSize(2));
             if (types.length() > 0) {
                 types.append(",");
                 columns.append("|");
             }
-            columns.append(nameType[0]);
-            types.append(resolveColumnType(nameType[1]));
+            columns.append(nameType[0].trim());
+            types.append(resolveColumnType(nameType[1].trim()));
         }
         return new Tuple<>(columns.toString(), types.toString());
     }

--- a/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/JdbcAssert.java
+++ b/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/JdbcAssert.java
@@ -176,8 +176,8 @@ public class JdbcAssert {
                     Object expectedObject = expected.getObject(column);
                     Object actualObject = lenient ? actual.getObject(column, expectedColumnClass) : actual.getObject(column);
 
-                    String msg = format(Locale.ROOT, "Different result for column [" + metaData.getColumnName(column) + "], "
-                            + "entry [" + (count + 1) + "]");
+                    String msg = format(Locale.ROOT, "Different result for column [%s], entry [%d]",
+                        metaData.getColumnName(column), count + 1);
 
                     // handle nulls first
                     if (expectedObject == null || actualObject == null) {

--- a/x-pack/qa/sql/src/main/resources/functions.csv-spec
+++ b/x-pack/qa/sql/src/main/resources/functions.csv-spec
@@ -407,3 +407,11 @@ SELECT CONCAT(CONCAT(SUBSTRING("first_name",1,LENGTH("first_name")-2),UCASE(LEFT
 ---------------+---------------------------------------------
 AlejandRo      |2
 ;
+
+
+checkColumnNameWithNestedArithmeticFunctionCallsOnTableColumn
+SELECT CHAR(emp_no % 10000) FROM "test_emp" WHERE emp_no > 10064 ORDER BY emp_no LIMIT 1;
+
+CHAR(((emp_no) % 10000)):s
+A
+;

--- a/x-pack/qa/sql/src/main/resources/functions.csv-spec
+++ b/x-pack/qa/sql/src/main/resources/functions.csv-spec
@@ -415,3 +415,18 @@ SELECT CHAR(emp_no % 10000) FROM "test_emp" WHERE emp_no > 10064 ORDER BY emp_no
 CHAR(((emp_no) % 10000)):s
 A
 ;
+
+checkColumnNameWithComplexNestedArithmeticFunctionCallsOnTableColumn1
+SELECT CHAR(emp_no % (7000 + 3000)) FROM "test_emp" WHERE emp_no > 10065 ORDER BY emp_no LIMIT 1;
+
+CHAR(((emp_no) % ((7000 + 3000)))):s
+B
+;
+
+
+checkColumnNameWithComplexNestedArithmeticFunctionCallsOnTableColumn2
+SELECT CHAR((emp_no % (emp_no - 1 + 1)) + 67) FROM "test_emp" WHERE emp_no > 10066 ORDER BY emp_no LIMIT 1;
+
+CHAR(((((emp_no) % (((((emp_no) - 1)) + 1)))) + 67)):s
+C
+;

--- a/x-pack/qa/sql/src/main/resources/math.sql-spec
+++ b/x-pack/qa/sql/src/main/resources/math.sql-spec
@@ -128,7 +128,9 @@ mathATan2
 // tag::atan2
 SELECT ATAN2(emp_no, emp_no) m, first_name FROM "test_emp" WHERE emp_no < 10010 ORDER BY emp_no;
 // end::atan2
-mathPower
 // tag::power
+mathPowerPositive
 SELECT POWER(emp_no, 2) m, first_name FROM "test_emp" WHERE emp_no < 10010 ORDER BY emp_no;
+mathPowerNegative
+SELECT POWER(salary, -1) m, first_name FROM "test_emp" WHERE emp_no < 10010 ORDER BY emp_no;
 // end::power


### PR DESCRIPTION
Previously, When an arithmetic function is applied on a
table column in the `SELECT` clause the name of the result
column name contained weird characters used internally when
processing the SQL statement. E.g.:

  `SELECT CHAR(emp_no % 10000) FROM "test_emp"`

returned:

  `CHAR((emp_no{f}#14) % 10000))`

as the column name instead of:

  `CHAR((emp_no) % 10000))`

Fixes: https://github.com/elastic/elasticsearch/issues/31869