### PR TITLE
[ML-Dataframe] Use AsyncTwoPhaseIndexer

### DIFF
--- a/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/FeatureIndexBuilder.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/FeatureIndexBuilder.java
@@ -36,7 +36,7 @@ import org.elasticsearch.xpack.ml.featureindexbuilder.action.StartFeatureIndexBu
 import org.elasticsearch.xpack.ml.featureindexbuilder.action.TransportPutFeatureIndexBuilderJobAction;
 import org.elasticsearch.xpack.ml.featureindexbuilder.action.TransportStartFeatureIndexBuilderJobAction;
 import org.elasticsearch.xpack.ml.featureindexbuilder.job.FeatureIndexBuilderJob;
-import org.elasticsearch.xpack.ml.featureindexbuilder.job.FeatureIndexBuilderJobTask;
+import org.elasticsearch.xpack.ml.featureindexbuilder.job.FeatureIndexBuilderJobPersistentTasksExecutor;
 import org.elasticsearch.xpack.ml.featureindexbuilder.rest.action.RestPutFeatureIndexBuilderJobAction;
 import org.elasticsearch.xpack.ml.featureindexbuilder.rest.action.RestStartFeatureIndexBuilderJobAction;
 
@@ -127,7 +127,7 @@ public class FeatureIndexBuilder extends Plugin implements ActionPlugin, Persist
         }
 
         SchedulerEngine schedulerEngine = new SchedulerEngine(settings, Clock.systemUTC());
-        return Collections.singletonList(new FeatureIndexBuilderJobTask.FeatureIndexBuilderJobPersistentTasksExecutor(settings, client,
+        return Collections.singletonList(new FeatureIndexBuilderJobPersistentTasksExecutor(settings, client,
                 schedulerEngine, threadPool));
     }
     @Override

--- a/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/action/TransportPutFeatureIndexBuilderJobAction.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/action/TransportPutFeatureIndexBuilderJobAction.java
@@ -7,9 +7,11 @@
 package org.elasticsearch.xpack.ml.featureindexbuilder.action;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -17,6 +19,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.persistent.PersistentTasksService;
@@ -29,8 +32,14 @@ import org.elasticsearch.xpack.ml.featureindexbuilder.action.PutFeatureIndexBuil
 import org.elasticsearch.xpack.ml.featureindexbuilder.job.FeatureIndexBuilderJob;
 import org.elasticsearch.xpack.ml.featureindexbuilder.job.FeatureIndexBuilderJobConfig;
 
+import static org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings.DOC_TYPE;
+
 public class TransportPutFeatureIndexBuilderJobAction
         extends TransportMasterNodeAction<PutFeatureIndexBuilderJobAction.Request, PutFeatureIndexBuilderJobAction.Response> {
+
+    // TODO: hack, to be replaced
+    private static final String PIVOT_INDEX = "pivot-reviews";
+
     private final XPackLicenseState licenseState;
     private final PersistentTasksService persistentTasksService;
     private final Client client;
@@ -67,7 +76,7 @@ public class TransportPutFeatureIndexBuilderJobAction
         XPackPlugin.checkReadyForXPackCustomMetadata(clusterState);
 
         FeatureIndexBuilderJob job = createFeatureIndexBuilderJob(request.getConfig(), threadPool);
-
+        createIndex(client, job.getConfig().getId());
         startPersistentTask(job, listener, persistentTasksService);
     }
 
@@ -89,5 +98,35 @@ public class TransportPutFeatureIndexBuilderJobAction
     @Override
     protected ClusterBlockException checkBlock(PutFeatureIndexBuilderJobAction.Request request, ClusterState state) {
         return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+
+    /*
+     * Mocked demo case
+     *
+     * TODO: everything below will be replaced with proper implementation read from job configuration 
+     */
+    private static void createIndex(Client client, String suffix) {
+
+        String indexName = PIVOT_INDEX + "_" + suffix;
+        CreateIndexRequest request = new CreateIndexRequest(indexName);
+
+        request.settings(Settings.builder() // <1>
+                .put("index.number_of_shards", 1).put("index.number_of_replicas", 0));
+        request.mapping(DOC_TYPE, // <1>
+                "{\n" +
+                "  \"" + DOC_TYPE + "\": {\n" +
+                "    \"properties\": {\n" +
+                "      \"reviewerId\": {\n" +
+                "        \"type\": \"keyword\"\n" +
+                "      },\n" +
+                "      \"avg_rating\": {\n" +
+                "        \"type\": \"integer\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}", // <2>
+                XContentType.JSON);
+        IndicesAdminClient adminClient = client.admin().indices();
+        adminClient.create(request).actionGet();
     }
 }

--- a/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderIndexer.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderIndexer.java
@@ -7,10 +7,14 @@
 package org.elasticsearch.xpack.ml.featureindexbuilder.job;
 
 import org.apache.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.bulk.BulkAction;
 import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
@@ -23,23 +27,28 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation.Bucket;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeValuesSourceBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
 import org.elasticsearch.search.aggregations.metrics.avg.InternalAvg;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.indexing.AsyncTwoPhaseIndexer;
+import org.elasticsearch.xpack.core.indexing.IndexerState;
+import org.elasticsearch.xpack.core.indexing.IterationResult;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings.DOC_TYPE;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
-public class FeatureIndexBuilderIndexer {
+public class FeatureIndexBuilderIndexer extends AsyncTwoPhaseIndexer<Map<String, Object>, FeatureIndexBuilderJobStats> {
     private static final String PIVOT_INDEX = "pivot-reviews";
     private static final String SOURCE_INDEX = "anonreviews";
 
@@ -47,77 +56,115 @@ public class FeatureIndexBuilderIndexer {
     private FeatureIndexBuilderJob job;
     private Client client;
 
-    public FeatureIndexBuilderIndexer(FeatureIndexBuilderJob job, Client client) {
+    public FeatureIndexBuilderIndexer(Executor executor, FeatureIndexBuilderJob job, AtomicReference<IndexerState> initialState,
+            Map<String, Object> initialPosition, Client client) {
+        super(executor, initialState, initialPosition, new FeatureIndexBuilderJobStats());
 
         this.job = job;
         this.client = client;
-        logger.info("delete pivot-reviews");
-        
     }
 
-    public synchronized void start() {
-        deleteIndex(client);
-
-        createIndex(client);
-        
-        int runs = 0;
-
-        Map<String, Object> after = null;
-        logger.info("start feature indexing");
-        SearchResponse response;
-        
-        try {
-            response = runQuery(client, after);
-
-            CompositeAggregation compositeAggregation = response.getAggregations().get("feature");
-            after = compositeAggregation.afterKey();
-
-            while (after != null) {
-                indexBuckets(compositeAggregation);
-
-                ++runs;
-                response = runQuery(client, after);
-
-                compositeAggregation = response.getAggregations().get("feature");
-                after = compositeAggregation.afterKey();
-                
-                //after = null;
-            }
-            
-            indexBuckets(compositeAggregation);
-        } catch (InterruptedException | ExecutionException e) {
-            logger.error("Failed to build feature index", e);
-        }
-
-        logger.info("Finished feature indexing");
+    @Override
+    protected String getJobId() {
+        return job.getConfig().getId();
     }
 
-    private void indexBuckets(CompositeAggregation compositeAggregation) {
-        BulkRequest bulkIndexRequest = new BulkRequest();
-        try {
-            for (Bucket b : compositeAggregation.getBuckets()) {
+    @Override
+    protected void onStartJob(long now) {
+    }
 
-                InternalAvg avgAgg = b.getAggregations().get("avg_rating");
+    @Override
+    protected IterationResult<Map<String, Object>> doProcess(SearchResponse searchResponse) {
+        final CompositeAggregation agg = searchResponse.getAggregations().get("feature");
+        return new IterationResult<>(processBuckets(agg), agg.afterKey(), agg.getBuckets().isEmpty());
+    }
 
-                XContentBuilder builder;
+    private List<IndexRequest> processBuckets(CompositeAggregation agg) {
+        return agg.getBuckets().stream().map(b -> {
+            InternalAvg avgAgg = b.getAggregations().get("avg_rating");
+            XContentBuilder builder;
+            try {
                 builder = jsonBuilder();
+
                 builder.startObject();
                 builder.field("reviewerId", b.getKey().get("reviewerId"));
                 builder.field("avg_rating", avgAgg.getValue());
                 builder.endObject();
-                bulkIndexRequest.add(new IndexRequest(PIVOT_INDEX, DOC_TYPE).source(builder));
-
+            } catch (IOException e) {
+                throw new RuntimeException(e);
             }
-            client.bulk(bulkIndexRequest);
-        } catch (IOException e) {
-            logger.error("Failed to index", e);
+            IndexRequest request = new IndexRequest(PIVOT_INDEX, DOC_TYPE).source(builder);
+            return request;
+        }).collect(Collectors.toList());
+    }
+
+    @Override
+    protected SearchRequest buildSearchRequest() {
+
+        final Map<String, Object> position = getPosition();
+
+        if (position == null) {
+            deleteIndex(client);
+            createIndex(client);
+        }
+
+        SearchRequest request = buildFeatureQuery(position);
+
+        return request;
+    }
+
+    @Override
+    protected void doNextSearch(SearchRequest request, ActionListener<SearchResponse> nextPhase) {
+        ClientHelper.executeWithHeadersAsync(job.getHeaders(), ClientHelper.ML_ORIGIN, client, SearchAction.INSTANCE, request, nextPhase);
+    }
+
+    @Override
+    protected void doNextBulk(BulkRequest request, ActionListener<BulkResponse> nextPhase) {
+        ClientHelper.executeWithHeadersAsync(job.getHeaders(), ClientHelper.ML_ORIGIN, client, BulkAction.INSTANCE, request, nextPhase);
+    }
+
+    @Override
+    protected void doSaveState(IndexerState indexerState, Map<String, Object> position, Runnable next) {
+        if (indexerState.equals(IndexerState.ABORTING)) {
+            // If we're aborting, just invoke `next` (which is likely an onFailure handler)
+            next.run();
+        } else {
+            // to be implemented
+
+            final FeatureIndexBuilderJobState state = new FeatureIndexBuilderJobState(indexerState);
+            logger.info("Updating persistent state of job [" + job.getConfig().getId() + "] to [" + state.toString() + "]");
+
+            // TODO: we can not persist the state right now, need to be called from the task
+            next.run();
+            // updatePersistentTaskState(state, ActionListener.wrap(task -> next.run(), exc
+            // -> {
+            // We failed to update the persistent task for some reason,
+            // set our flag back to what it was before
+            // next.run();
+            // }));
+
         }
     }
-    
+
+    @Override
+    protected void onFailure(Exception exc) {
+        logger.warn("FeatureIndexBuilder job [" + job.getConfig().getId() + "] failed with an exception: ", exc);
+    }
+
+    @Override
+    protected void onFinish() {
+        logger.info("Finished indexing for job [" + job.getConfig().getId() + "]");
+    }
+
+    @Override
+    protected void onAbort() {
+        logger.info("FeatureIndexBuilder job [" + job.getConfig().getId() + "] received abort request, stopping indexer");
+    }
+
     /*
      * Hardcoded demo case for pivoting
      */
-    
+
     private static void deleteIndex(Client client) {
         DeleteIndexRequest deleteIndex = new DeleteIndexRequest(PIVOT_INDEX);
 
@@ -127,46 +174,35 @@ public class FeatureIndexBuilderIndexer {
         } catch (IndexNotFoundException e) {
         }
     }
-    
+
     private static void createIndex(Client client) {
-     
+
         CreateIndexRequest request = new CreateIndexRequest(PIVOT_INDEX);
         request.settings(Settings.builder() // <1>
-                .put("index.number_of_shards", 1)
-                .put("index.number_of_replicas", 0)
-            );
+                .put("index.number_of_shards", 1).put("index.number_of_replicas", 0));
         request.mapping(DOC_TYPE, // <1>
-                "{\n" +
-                "  \"" + DOC_TYPE + "\": {\n" +
-                "    \"properties\": {\n" +
-                "      \"reviewerId\": {\n" +
-                "        \"type\": \"keyword\"\n" +
-                "      },\n" +
-                "      \"avg_rating\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }\n" +
-                "}", // <2>
+                "{\n" + "  \"" + DOC_TYPE + "\": {\n" + "    \"properties\": {\n" + "      \"reviewerId\": {\n"
+                        + "        \"type\": \"keyword\"\n" + "      },\n" + "      \"avg_rating\": {\n" + "        \"type\": \"integer\"\n"
+                        + "      }\n" + "    }\n" + "  }\n" + "}", // <2>
                 XContentType.JSON);
         IndicesAdminClient adminClient = client.admin().indices();
         adminClient.create(request).actionGet();
     }
-    
+
     private static SearchRequest buildFeatureQuery(Map<String, Object> after) {
         QueryBuilder queryBuilder = new MatchAllQueryBuilder();
         SearchRequest searchRequest = new SearchRequest(SOURCE_INDEX);
-        
+
         List<CompositeValuesSourceBuilder<?>> sources = new ArrayList<>();
         sources.add(new TermsValuesSourceBuilder("reviewerId").field("reviewerId"));
-        
+
         CompositeAggregationBuilder compositeAggregation = new CompositeAggregationBuilder("feature", sources);
         compositeAggregation.size(1000);
-        
+
         if (after != null) {
             compositeAggregation.aggregateAfter(after);
         }
-        
+
         compositeAggregation.subAggregation(AggregationBuilders.avg("avg_rating").field("rating"));
         compositeAggregation.subAggregation(AggregationBuilders.cardinality("dc_vendors").field("vendorId"));
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
@@ -174,21 +210,7 @@ public class FeatureIndexBuilderIndexer {
         sourceBuilder.size(0);
         sourceBuilder.query(queryBuilder);
         searchRequest.source(sourceBuilder);
-        
+
         return searchRequest;
-    }
-    
-    private static SearchResponse runQuery(Client client, Map<String, Object> after) throws InterruptedException, ExecutionException {
-        
-        SearchRequest request = buildFeatureQuery(after);
-        SearchResponse response  = client.search(request).get();
-        
-        return response;
-    }
-    
-    private static void indexResult() {
-        
-        
-        
     }
 }

--- a/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderIndexer.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderIndexer.java
@@ -7,22 +7,10 @@
 package org.elasticsearch.xpack.ml.featureindexbuilder.job;
 
 import org.apache.log4j.Logger;
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
-import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
-import org.elasticsearch.action.bulk.BulkAction;
-import org.elasticsearch.action.bulk.BulkRequest;
-import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -32,7 +20,6 @@ import org.elasticsearch.search.aggregations.bucket.composite.CompositeValuesSou
 import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
 import org.elasticsearch.search.aggregations.metrics.avg.InternalAvg;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.indexing.AsyncTwoPhaseIndexer;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.indexing.IterationResult;
@@ -48,20 +35,18 @@ import java.util.stream.Collectors;
 import static org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings.DOC_TYPE;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
-public class FeatureIndexBuilderIndexer extends AsyncTwoPhaseIndexer<Map<String, Object>, FeatureIndexBuilderJobStats> {
+public abstract class FeatureIndexBuilderIndexer extends AsyncTwoPhaseIndexer<Map<String, Object>, FeatureIndexBuilderJobStats> {
     private static final String PIVOT_INDEX = "pivot-reviews";
     private static final String SOURCE_INDEX = "anonreviews";
 
     private static final Logger logger = Logger.getLogger(FeatureIndexBuilderIndexer.class.getName());
     private FeatureIndexBuilderJob job;
-    private Client client;
 
     public FeatureIndexBuilderIndexer(Executor executor, FeatureIndexBuilderJob job, AtomicReference<IndexerState> initialState,
-            Map<String, Object> initialPosition, Client client) {
+            Map<String, Object> initialPosition) {
         super(executor, initialState, initialPosition, new FeatureIndexBuilderJobStats());
 
         this.job = job;
-        this.client = client;
     }
 
     @Override
@@ -93,7 +78,9 @@ public class FeatureIndexBuilderIndexer extends AsyncTwoPhaseIndexer<Map<String,
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-            IndexRequest request = new IndexRequest(PIVOT_INDEX, DOC_TYPE).source(builder);
+
+            String indexName = PIVOT_INDEX + "_" + job.getConfig().getId();
+            IndexRequest request = new IndexRequest(indexName, DOC_TYPE).source(builder);
             return request;
         }).collect(Collectors.toList());
     }
@@ -102,93 +89,15 @@ public class FeatureIndexBuilderIndexer extends AsyncTwoPhaseIndexer<Map<String,
     protected SearchRequest buildSearchRequest() {
 
         final Map<String, Object> position = getPosition();
-
-        if (position == null) {
-            deleteIndex(client);
-            createIndex(client);
-        }
-
         SearchRequest request = buildFeatureQuery(position);
-
         return request;
     }
 
-    @Override
-    protected void doNextSearch(SearchRequest request, ActionListener<SearchResponse> nextPhase) {
-        ClientHelper.executeWithHeadersAsync(job.getHeaders(), ClientHelper.ML_ORIGIN, client, SearchAction.INSTANCE, request, nextPhase);
-    }
-
-    @Override
-    protected void doNextBulk(BulkRequest request, ActionListener<BulkResponse> nextPhase) {
-        ClientHelper.executeWithHeadersAsync(job.getHeaders(), ClientHelper.ML_ORIGIN, client, BulkAction.INSTANCE, request, nextPhase);
-    }
-
-    @Override
-    protected void doSaveState(IndexerState indexerState, Map<String, Object> position, Runnable next) {
-        if (indexerState.equals(IndexerState.ABORTING)) {
-            // If we're aborting, just invoke `next` (which is likely an onFailure handler)
-            next.run();
-        } else {
-            // to be implemented
-
-            final FeatureIndexBuilderJobState state = new FeatureIndexBuilderJobState(indexerState);
-            logger.info("Updating persistent state of job [" + job.getConfig().getId() + "] to [" + state.toString() + "]");
-
-            // TODO: we can not persist the state right now, need to be called from the task
-            next.run();
-            // updatePersistentTaskState(state, ActionListener.wrap(task -> next.run(), exc
-            // -> {
-            // We failed to update the persistent task for some reason,
-            // set our flag back to what it was before
-            // next.run();
-            // }));
-
-        }
-    }
-
-    @Override
-    protected void onFailure(Exception exc) {
-        logger.warn("FeatureIndexBuilder job [" + job.getConfig().getId() + "] failed with an exception: ", exc);
-    }
-
-    @Override
-    protected void onFinish() {
-        logger.info("Finished indexing for job [" + job.getConfig().getId() + "]");
-    }
-
-    @Override
-    protected void onAbort() {
-        logger.info("FeatureIndexBuilder job [" + job.getConfig().getId() + "] received abort request, stopping indexer");
-    }
-
     /*
-     * Hardcoded demo case for pivoting
+     * Mocked demo case
+     * 
+     * TODO: everything below will be replaced with proper implementation read from job configuration 
      */
-
-    private static void deleteIndex(Client client) {
-        DeleteIndexRequest deleteIndex = new DeleteIndexRequest(PIVOT_INDEX);
-
-        IndicesAdminClient adminClient = client.admin().indices();
-        try {
-            adminClient.delete(deleteIndex).actionGet();
-        } catch (IndexNotFoundException e) {
-        }
-    }
-
-    private static void createIndex(Client client) {
-
-        CreateIndexRequest request = new CreateIndexRequest(PIVOT_INDEX);
-        request.settings(Settings.builder() // <1>
-                .put("index.number_of_shards", 1).put("index.number_of_replicas", 0));
-        request.mapping(DOC_TYPE, // <1>
-                "{\n" + "  \"" + DOC_TYPE + "\": {\n" + "    \"properties\": {\n" + "      \"reviewerId\": {\n"
-                        + "        \"type\": \"keyword\"\n" + "      },\n" + "      \"avg_rating\": {\n" + "        \"type\": \"integer\"\n"
-                        + "      }\n" + "    }\n" + "  }\n" + "}", // <2>
-                XContentType.JSON);
-        IndicesAdminClient adminClient = client.admin().indices();
-        adminClient.create(request).actionGet();
-    }
-
     private static SearchRequest buildFeatureQuery(Map<String, Object> after) {
         QueryBuilder queryBuilder = new MatchAllQueryBuilder();
         SearchRequest searchRequest = new SearchRequest(SOURCE_INDEX);

--- a/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderIndexer.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderIndexer.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.indexing.IterationResult;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +65,11 @@ public abstract class FeatureIndexBuilderIndexer extends AsyncTwoPhaseIndexer<Ma
         return new IterationResult<>(processBuckets(agg), agg.afterKey(), agg.getBuckets().isEmpty());
     }
 
+    /*
+     * Mocked demo case
+     *
+     * TODO: replace with proper implementation
+     */
     private List<IndexRequest> processBuckets(CompositeAggregation agg) {
         return agg.getBuckets().stream().map(b -> {
             InternalAvg avgAgg = b.getAggregations().get("avg_rating");
@@ -76,7 +82,7 @@ public abstract class FeatureIndexBuilderIndexer extends AsyncTwoPhaseIndexer<Ma
                 builder.field("avg_rating", avgAgg.getValue());
                 builder.endObject();
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new UncheckedIOException(e);
             }
 
             String indexName = PIVOT_INDEX + "_" + job.getConfig().getId();

--- a/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderJob.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderJob.java
@@ -16,6 +16,8 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.XPackPlugin;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 
 public class FeatureIndexBuilderJob implements XPackPlugin.XPackPersistentTaskParams {
@@ -91,5 +93,9 @@ public class FeatureIndexBuilderJob implements XPackPlugin.XPackPersistentTaskPa
     @Override
     public int hashCode() {
         return Objects.hash(config);
+    }
+
+    public Map<String, String> getHeaders() {
+        return Collections.emptyMap();
     }
 }

--- a/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderJobPersistentTasksExecutor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.featureindexbuilder.job;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.persistent.AllocatedPersistentTask;
+import org.elasticsearch.persistent.PersistentTaskState;
+import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
+import org.elasticsearch.persistent.PersistentTasksExecutor;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
+import org.elasticsearch.xpack.ml.featureindexbuilder.FeatureIndexBuilder;
+
+import java.util.Map;
+
+public class FeatureIndexBuilderJobPersistentTasksExecutor extends PersistentTasksExecutor<FeatureIndexBuilderJob> {
+    private final Client client;
+    private final SchedulerEngine schedulerEngine;
+    private final ThreadPool threadPool;
+
+    public FeatureIndexBuilderJobPersistentTasksExecutor(Settings settings, Client client, SchedulerEngine schedulerEngine,
+            ThreadPool threadPool) {
+        super(settings, "xpack/feature_index_builder/job", FeatureIndexBuilder.TASK_THREAD_POOL_NAME);
+        this.client = client;
+        this.schedulerEngine = schedulerEngine;
+        this.threadPool = threadPool;
+    }
+
+    @Override
+    protected void nodeOperation(AllocatedPersistentTask task, @Nullable FeatureIndexBuilderJob params, PersistentTaskState state) {
+        FeatureIndexBuilderJobTask buildTask = (FeatureIndexBuilderJobTask) task;
+        SchedulerEngine.Job schedulerJob = new SchedulerEngine.Job(FeatureIndexBuilderJobTask.SCHEDULE_NAME + "_" + params.getConfig().getId(), next());
+
+        // Note that while the task is added to the scheduler here, the internal state
+        // will prevent
+        // it from doing any work until the task is "started" via the StartJob api
+        schedulerEngine.register(buildTask);
+        schedulerEngine.add(schedulerJob);
+
+        logger.info("FeatureIndexBuilder job [" + params.getConfig().getId() + "] created.");
+    }
+
+    static SchedulerEngine.Schedule next() {
+        return (startTime, now) -> {
+            return now + 1000; // to be fixed, hardcode something
+        };
+    }
+
+    @Override
+    protected AllocatedPersistentTask createTask(long id, String type, String action, TaskId parentTaskId,
+            PersistentTasksCustomMetaData.PersistentTask<FeatureIndexBuilderJob> persistentTask, Map<String, String> headers) {
+        return new FeatureIndexBuilderJobTask(id, type, action, parentTaskId, persistentTask.getParams(),
+                (FeatureIndexBuilderJobState) persistentTask.getState(), client, schedulerEngine, threadPool, headers);
+    }
+}

--- a/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderJobPersistentTasksExecutor.java
@@ -36,7 +36,8 @@ public class FeatureIndexBuilderJobPersistentTasksExecutor extends PersistentTas
     @Override
     protected void nodeOperation(AllocatedPersistentTask task, @Nullable FeatureIndexBuilderJob params, PersistentTaskState state) {
         FeatureIndexBuilderJobTask buildTask = (FeatureIndexBuilderJobTask) task;
-        SchedulerEngine.Job schedulerJob = new SchedulerEngine.Job(FeatureIndexBuilderJobTask.SCHEDULE_NAME + "_" + params.getConfig().getId(), next());
+        SchedulerEngine.Job schedulerJob = new SchedulerEngine.Job(
+                FeatureIndexBuilderJobTask.SCHEDULE_NAME + "_" + params.getConfig().getId(), next());
 
         // Note that while the task is added to the scheduler here, the internal state
         // will prevent

--- a/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderJobStats.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderJobStats.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.featureindexbuilder.job;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.indexing.IndexerJobStats;
+
+import java.io.IOException;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+
+public class FeatureIndexBuilderJobStats extends IndexerJobStats {
+    private static ParseField NUM_PAGES = new ParseField("pages_processed");
+    private static ParseField NUM_INPUT_DOCUMENTS = new ParseField("documents_processed");
+    private static ParseField NUM_OUTPUT_DOCUMENTS = new ParseField("documents_indexed");
+    private static ParseField NUM_INVOCATIONS = new ParseField("trigger_count");
+
+    public static final ConstructingObjectParser<FeatureIndexBuilderJobStats, Void> PARSER = new ConstructingObjectParser<>(
+            NAME.getPreferredName(),
+            args -> new FeatureIndexBuilderJobStats((long) args[0], (long) args[1], (long) args[2], (long) args[3]));
+
+    static {
+        PARSER.declareLong(constructorArg(), NUM_PAGES);
+        PARSER.declareLong(constructorArg(), NUM_INPUT_DOCUMENTS);
+        PARSER.declareLong(constructorArg(), NUM_OUTPUT_DOCUMENTS);
+        PARSER.declareLong(constructorArg(), NUM_INVOCATIONS);
+    }
+
+    public FeatureIndexBuilderJobStats() {
+        super();
+    }
+
+    public FeatureIndexBuilderJobStats(long numPages, long numInputDocuments, long numOuputDocuments, long numInvocations) {
+        super(numPages, numInputDocuments, numOuputDocuments, numInvocations);
+    }
+
+    public FeatureIndexBuilderJobStats(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(NUM_PAGES.getPreferredName(), numPages);
+        builder.field(NUM_INPUT_DOCUMENTS.getPreferredName(), numInputDocuments);
+        builder.field(NUM_OUTPUT_DOCUMENTS.getPreferredName(), numOuputDocuments);
+        builder.field(NUM_INVOCATIONS.getPreferredName(), numInvocations);
+        builder.endObject();
+        return builder;
+    }
+
+    public static FeatureIndexBuilderJobStats fromXContent(XContentParser parser) {
+        try {
+            return PARSER.parse(parser, null);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderJobTask.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderJobTask.java
@@ -8,19 +8,20 @@ package org.elasticsearch.xpack.ml.featureindexbuilder.job;
 
 import org.apache.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkAction;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
-import org.elasticsearch.persistent.PersistentTaskState;
-import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
-import org.elasticsearch.persistent.PersistentTasksExecutor;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine.Event;
-import org.elasticsearch.xpack.ml.featureindexbuilder.FeatureIndexBuilder;
 import org.elasticsearch.xpack.ml.featureindexbuilder.action.StartFeatureIndexBuilderJobAction;
 import org.elasticsearch.xpack.ml.featureindexbuilder.action.StartFeatureIndexBuilderJobAction.Response;
 
@@ -30,64 +31,24 @@ import java.util.concurrent.atomic.AtomicReference;
 public class FeatureIndexBuilderJobTask extends AllocatedPersistentTask implements SchedulerEngine.Listener {
 
     private static final Logger logger = Logger.getLogger(FeatureIndexBuilderJobTask.class.getName());
+
+    private final FeatureIndexBuilderJob job;
+    private final ThreadPool threadPool;
     private final FeatureIndexBuilderIndexer indexer;
 
     static final String SCHEDULE_NAME = "xpack/feature_index_builder/job" + "/schedule";
-
-    public static class FeatureIndexBuilderJobPersistentTasksExecutor extends PersistentTasksExecutor<FeatureIndexBuilderJob> {
-        private final Client client;
-        private final SchedulerEngine schedulerEngine;
-        private final ThreadPool threadPool;
-
-        public FeatureIndexBuilderJobPersistentTasksExecutor(Settings settings, Client client, SchedulerEngine schedulerEngine,
-                ThreadPool threadPool) {
-            super(settings, "xpack/feature_index_builder/job", FeatureIndexBuilder.TASK_THREAD_POOL_NAME);
-            this.client = client;
-            this.schedulerEngine = schedulerEngine;
-            this.threadPool = threadPool;
-        }
-
-        @Override
-        protected void nodeOperation(AllocatedPersistentTask task, @Nullable FeatureIndexBuilderJob params, PersistentTaskState state) {
-            FeatureIndexBuilderJobTask buildTask = (FeatureIndexBuilderJobTask) task;
-            SchedulerEngine.Job schedulerJob = new SchedulerEngine.Job(SCHEDULE_NAME + "_" + params.getConfig().getId(), next());
-
-            // Note that while the task is added to the scheduler here, the internal state
-            // will prevent
-            // it from doing any work until the task is "started" via the StartJob api
-            schedulerEngine.register(buildTask);
-            schedulerEngine.add(schedulerJob);
-
-            logger.info("FeatureIndexBuilder job [" + params.getConfig().getId() + "] created.");
-        }
-
-        static SchedulerEngine.Schedule next() {
-            return (startTime, now) -> {
-                return now + 1000; // to be fixed, hardcode something
-            };
-        }
-
-        @Override
-        protected AllocatedPersistentTask createTask(long id, String type, String action, TaskId parentTaskId,
-                PersistentTasksCustomMetaData.PersistentTask<FeatureIndexBuilderJob> persistentTask, Map<String, String> headers) {
-            return new FeatureIndexBuilderJobTask(id, type, action, parentTaskId, persistentTask.getParams(),
-                    (FeatureIndexBuilderJobState) persistentTask.getState(), client, schedulerEngine, threadPool, headers);
-        }
-    }
-
-    private final FeatureIndexBuilderJob job;
 
     public FeatureIndexBuilderJobTask(long id, String type, String action, TaskId parentTask, FeatureIndexBuilderJob job,
             FeatureIndexBuilderJobState state, Client client, SchedulerEngine schedulerEngine, ThreadPool threadPool,
             Map<String, String> headers) {
         super(id, type, action, "" + "_" + job.getConfig().getId(), parentTask, headers);
         this.job = job;
+        this.threadPool = threadPool;
         logger.info("construct job task");
         // todo: simplistic implementation for now
         IndexerState initialState = IndexerState.STOPPED;
         Map<String, Object> initialPosition = null;
-        this.indexer = new FeatureIndexBuilderIndexer(threadPool.executor(ThreadPool.Names.GENERIC), job,
-                new AtomicReference<>(initialState), initialPosition, client);
+        this.indexer = new ClientFeatureIndexBuilderIndexer(job, new AtomicReference<>(initialState), initialPosition, client);
     }
 
     public FeatureIndexBuilderJobConfig getConfig() {
@@ -108,4 +69,59 @@ public class FeatureIndexBuilderJobTask extends AllocatedPersistentTask implemen
         }
     }
 
+    protected class ClientFeatureIndexBuilderIndexer extends FeatureIndexBuilderIndexer {
+        private final Client client;
+
+        public ClientFeatureIndexBuilderIndexer(FeatureIndexBuilderJob job, AtomicReference<IndexerState> initialState,
+                Map<String, Object> initialPosition, Client client) {
+            super(threadPool.executor(ThreadPool.Names.GENERIC), job, initialState, initialPosition);
+            this.client = client;
+        }
+
+        @Override
+        protected void doNextSearch(SearchRequest request, ActionListener<SearchResponse> nextPhase) {
+            ClientHelper.executeWithHeadersAsync(job.getHeaders(), ClientHelper.ML_ORIGIN, client, SearchAction.INSTANCE, request,
+                    nextPhase);
+        }
+
+        @Override
+        protected void doNextBulk(BulkRequest request, ActionListener<BulkResponse> nextPhase) {
+            ClientHelper.executeWithHeadersAsync(job.getHeaders(), ClientHelper.ML_ORIGIN, client, BulkAction.INSTANCE, request, nextPhase);
+        }
+
+        @Override
+        protected void doSaveState(IndexerState indexerState, Map<String, Object> position, Runnable next) {
+            if (indexerState.equals(IndexerState.ABORTING)) {
+                // If we're aborting, just invoke `next` (which is likely an onFailure handler)
+                next.run();
+            } else {
+                // to be implemented
+
+                final FeatureIndexBuilderJobState state = new FeatureIndexBuilderJobState(indexerState);
+                logger.info("Updating persistent state of job [" + job.getConfig().getId() + "] to [" + state.toString() + "]");
+
+                // TODO: we can not persist the state right now, need to be called from the task
+                updatePersistentTaskState(state, ActionListener.wrap(task -> next.run(), exc -> {
+                    // We failed to update the persistent task for some reason,
+                    // set our flag back to what it was before
+                    next.run();
+                }));
+            }
+        }
+
+        @Override
+        protected void onFailure(Exception exc) {
+            logger.warn("FeatureIndexBuilder job [" + job.getConfig().getId() + "] failed with an exception: ", exc);
+        }
+
+        @Override
+        protected void onFinish() {
+            logger.info("Finished indexing for job [" + job.getConfig().getId() + "]");
+        }
+
+        @Override
+        protected void onAbort() {
+            logger.info("FeatureIndexBuilder job [" + job.getConfig().getId() + "] received abort request, stopping indexer");
+        }
+    }
 }


### PR DESCRIPTION
**FEATURE BRANCH PR**

Replace mocked indexer and use AsyncTwoPhaseIndexer (introduced in #32743) instead.

Note: Inner operations are still mocked, although the destination index now uses the job id as a suffix.
