### PR TITLE
Test: Fix test name

### DIFF
--- a/distribution/archives/integ-test-zip/src/test/java/org/elasticsearch/test/rest/WaitForRefreshAndCloseIT.java
+++ b/distribution/archives/integ-test-zip/src/test/java/org/elasticsearch/test/rest/WaitForRefreshAndCloseIT.java
@@ -37,7 +37,7 @@ import java.util.Map;
 /**
  * Tests that wait for refresh is fired if the index is closed.
  */
-public class WaitForRefreshAndCloseTests extends ESRestTestCase {
+public class WaitForRefreshAndCloseIT extends ESRestTestCase {
     @Before
     public void setupIndex() throws IOException {
         try {


### PR DESCRIPTION
This test has the wrong name and hasn't been automatically running. This
fixes the name so we'll run it.
