### PR TITLE
Include fallback settings when checking dependencies

### DIFF
--- a/qa/ccs-unavailable-clusters/src/test/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
+++ b/qa/ccs-unavailable-clusters/src/test/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
@@ -235,7 +235,7 @@ public class CrossClusterSearchUnavailableClusterIT extends ESRestTestCase {
                         () -> client().performRequest(request));
                 assertEquals(400, responseException.getResponse().getStatusLine().getStatusCode());
                 assertThat(responseException.getMessage(),
-                        containsString("Missing required setting [cluster.remote.remote1.seeds] " +
+                        containsString("missing required setting [cluster.remote.remote1.seeds] " +
                                 "for setting [cluster.remote.remote1.skip_unavailable]"));
             }
 
@@ -251,7 +251,7 @@ public class CrossClusterSearchUnavailableClusterIT extends ESRestTestCase {
                 ResponseException responseException = expectThrows(ResponseException.class,
                         () -> client().performRequest(request));
                 assertEquals(400, responseException.getResponse().getStatusLine().getStatusCode());
-                assertThat(responseException.getMessage(), containsString("Missing required setting [cluster.remote.remote1.seeds] " +
+                assertThat(responseException.getMessage(), containsString("missing required setting [cluster.remote.remote1.seeds] " +
                         "for setting [cluster.remote.remote1.skip_unavailable]"));
             }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -468,7 +468,7 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
             }
             if (validateDependencies && settingsDependencies.isEmpty() == false) {
                 for (final Setting<?> settingDependency : settingsDependencies) {
-                    if (settingDependency.exists(settings, true) == false) {
+                    if (settingDependency.existsOrFallbackExists(settings) == false) {
                         final String message = String.format(
                                 Locale.ROOT,
                                 "missing required setting [%s] for setting [%s]",

--- a/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -468,7 +468,7 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
             }
             if (validateDependencies && settingsDependencies.isEmpty() == false) {
                 for (final Setting<?> settingDependency : settingsDependencies) {
-                    if (settingDependency.exists(settings) == false) {
+                    if (settingDependency.exists(settings, true) == false) {
                         final String message = String.format(
                                 Locale.ROOT,
                                 "missing required setting [%s] for setting [%s]",

--- a/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -461,16 +462,19 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
             }
             throw new IllegalArgumentException(msg);
         } else  {
-            Set<String> settingsDependencies = setting.getSettingsDependencies(key);
+            Set<Setting<?>> settingsDependencies = setting.getSettingsDependencies(key);
             if (setting.hasComplexMatcher()) {
                 setting = setting.getConcreteSetting(key);
             }
             if (validateDependencies && settingsDependencies.isEmpty() == false) {
-                Set<String> settingKeys = settings.keySet();
-                for (String requiredSetting : settingsDependencies) {
-                    if (settingKeys.contains(requiredSetting) == false) {
-                        throw new IllegalArgumentException("Missing required setting ["
-                            + requiredSetting + "] for setting [" + setting.getKey() + "]");
+                for (final Setting<?> settingDependency : settingsDependencies) {
+                    if (settingDependency.exists(settings) == false) {
+                        final String message = String.format(
+                                Locale.ROOT,
+                                "missing required setting [%s] for setting [%s]",
+                                settingDependency.getKey(),
+                                setting.getKey());
+                        throw new IllegalArgumentException(message);
                     }
                 }
             }

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -372,23 +372,26 @@ public class Setting<T> implements ToXContentObject {
      * @return true if the setting is present in the given settings instance, otherwise false
      */
     public boolean exists(final Settings settings) {
-        return exists(settings, false);
+        return exists(settings, /* includeFallbackSettings */ false);
     }
 
     /**
-     * Returns true if and only if this setting optionally including fallback settings is present in the given settings instance.
+     * Returns true if and only if this setting including fallback settings is present in the given settings instance.
      *
      * @param settings the settings
-     * @param fallback whether or not to include fallback settings
-     * @return true if the setting and optionally fallback settings is present in the given settings instance, otherwise false
+     * @return true if the setting including fallback settings is present in the given settings instance, otherwise false
      */
-    public boolean exists(final Settings settings, final boolean fallback) {
+    public boolean existsOrFallbackExists(final Settings settings) {
+        return exists(settings, /* includeFallbackSettings */ true);
+    }
+
+    private boolean exists(final Settings settings, final boolean includeFallbackSettings) {
         Setting<?> current = this;
         do {
             if (settings.keySet().contains(current.getKey())) {
                 return true;
             }
-            if (fallback == false) {
+            if (includeFallbackSettings == false) {
                 break;
             }
             current = current.fallbackSetting;

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -387,15 +387,12 @@ public class Setting<T> implements ToXContentObject {
 
     private boolean exists(final Settings settings, final boolean includeFallbackSettings) {
         Setting<?> current = this;
-        do {
-            if (settings.keySet().contains(current.getKey())) {
-                return true;
-            }
-            if (includeFallbackSettings == false) {
-                break;
-            }
-            current = current.fallbackSetting;
-        } while (current != null);
+        if (settings.keySet().contains(getKey())) {
+            return true;
+        }
+        if (includeFallbackSettings) {
+            return current.fallbackSetting.exists(settings, includeFallbackSettings);
+        }
         return false;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -366,12 +366,22 @@ public class Setting<T> implements ToXContentObject {
     }
 
     /**
-     * Returns <code>true</code> iff this setting is present in the given settings object. Otherwise <code>false</code>
+     * Returns true if and only if this setting is present in the given settings instance. Note that fallback settings are excluded.
+     *
+     * @param settings the settings
+     * @return true if the setting is present in the given settings instance, otherwise false
      */
     public boolean exists(final Settings settings) {
         return exists(settings, false);
     }
 
+    /**
+     * Returns true if and only if this setting optionally including fallback settings is present in the given settings instance.
+     *
+     * @param settings the settings
+     * @param fallback whether or not to include fallback settings
+     * @return true if the setting and optionally fallback settings is present in the given settings instance, otherwise false
+     */
     public boolean exists(final Settings settings, final boolean fallback) {
         Setting<?> current = this;
         do {

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -372,7 +372,7 @@ public class Setting<T> implements ToXContentObject {
      * @return true if the setting is present in the given settings instance, otherwise false
      */
     public boolean exists(final Settings settings) {
-        return exists(settings, /* includeFallbackSettings */ false);
+        return settings.keySet().contains(getKey());
     }
 
     /**
@@ -382,18 +382,7 @@ public class Setting<T> implements ToXContentObject {
      * @return true if the setting including fallback settings is present in the given settings instance, otherwise false
      */
     public boolean existsOrFallbackExists(final Settings settings) {
-        return exists(settings, /* includeFallbackSettings */ true);
-    }
-
-    private boolean exists(final Settings settings, final boolean includeFallbackSettings) {
-        Setting<?> current = this;
-        if (settings.keySet().contains(getKey())) {
-            return true;
-        }
-        if (includeFallbackSettings) {
-            return current.fallbackSetting.exists(settings, includeFallbackSettings);
-        }
-        return false;
+        return settings.keySet().contains(getKey()) || (fallbackSetting != null && fallbackSetting.existsOrFallbackExists(settings));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -369,10 +369,17 @@ public class Setting<T> implements ToXContentObject {
      * Returns <code>true</code> iff this setting is present in the given settings object. Otherwise <code>false</code>
      */
     public boolean exists(final Settings settings) {
+        return exists(settings, false);
+    }
+
+    public boolean exists(final Settings settings, final boolean fallback) {
         Setting<?> current = this;
         do {
             if (settings.keySet().contains(current.getKey())) {
                 return true;
+            }
+            if (fallback == false) {
+                break;
             }
             current = current.fallbackSetting;
         } while (current != null);

--- a/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -171,7 +171,7 @@ public class ScopedSettingsTests extends ESTestCase {
 
         IllegalArgumentException iae = expectThrows(IllegalArgumentException.class,
             () -> service.validate(Settings.builder().put("foo.test.bar", 7).build(), true));
-        assertEquals("Missing required setting [foo.test.name] for setting [foo.test.bar]", iae.getMessage());
+        assertEquals("missing required setting [foo.test.name] for setting [foo.test.bar]", iae.getMessage());
 
         service.validate(Settings.builder()
             .put("foo.test.name", "test")
@@ -179,6 +179,41 @@ public class ScopedSettingsTests extends ESTestCase {
             .build(), true);
 
         service.validate(Settings.builder().put("foo.test.bar", 7).build(), false);
+    }
+
+    public void testDependentSettingsWithFallback() {
+        Setting.AffixSetting<String> nameFallbackSetting =
+                Setting.affixKeySetting("fallback.", "name", k -> Setting.simpleString(k, Property.Dynamic, Property.NodeScope));
+        Setting.AffixSetting<String> nameSetting = Setting.affixKeySetting(
+                "foo.",
+                "name",
+                k -> Setting.simpleString(
+                        k,
+                        "_na_".equals(k)
+                                ? nameFallbackSetting.getConcreteSettingForNamespace(k)
+                                : nameFallbackSetting.getConcreteSetting(k.replaceAll("^foo", "fallback")),
+                        Property.Dynamic,
+                        Property.NodeScope));
+        Setting.AffixSetting<Integer> barSetting =
+                Setting.affixKeySetting("foo.", "bar", k -> Setting.intSetting(k, 1, Property.Dynamic, Property.NodeScope), nameSetting);
+
+        final AbstractScopedSettings service =
+                new ClusterSettings(Settings.EMPTY,new HashSet<>(Arrays.asList(nameFallbackSetting, nameSetting, barSetting)));
+
+        final IllegalArgumentException e = expectThrows(
+                IllegalArgumentException.class,
+                () -> service.validate(Settings.builder().put("foo.test.bar", 7).build(), true));
+        assertThat(e, hasToString(containsString("missing required setting [foo.test.name] for setting [foo.test.bar]")));
+
+        service.validate(Settings.builder()
+                .put("foo.test.name", "test")
+                .put("foo.test.bar", 7)
+                .build(), true);
+
+        service.validate(Settings.builder()
+                .put("fallback.test.name", "test")
+                .put("foo.test.bar", 7)
+                .build(), true);
     }
 
     public void testTupleAffixUpdateConsumer() {

--- a/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -205,15 +205,8 @@ public class ScopedSettingsTests extends ESTestCase {
                 () -> service.validate(Settings.builder().put("foo.test.bar", 7).build(), true));
         assertThat(e, hasToString(containsString("missing required setting [foo.test.name] for setting [foo.test.bar]")));
 
-        service.validate(Settings.builder()
-                .put("foo.test.name", "test")
-                .put("foo.test.bar", 7)
-                .build(), true);
-
-        service.validate(Settings.builder()
-                .put("fallback.test.name", "test")
-                .put("foo.test.bar", 7)
-                .build(), true);
+        service.validate(Settings.builder().put("foo.test.name", "test").put("foo.test.bar", 7).build(), true);
+        service.validate(Settings.builder().put("fallback.test.name", "test").put("foo.test.bar", 7).build(), true);
     }
 
     public void testTupleAffixUpdateConsumer() {

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -874,11 +874,11 @@ public class SettingTests extends ESTestCase {
         final Setting<String> fooSetting = new Setting<>(new Setting.SimpleKey("foo"), current, Function.identity(), Property.NodeScope);
         assertFalse(fooSetting.exists(Settings.EMPTY));
         if (randomBoolean()) {
-            assertTrue(fooSetting.exists(Settings.builder().put("foo", "bar").build(), randomBoolean()));
+            assertTrue(fooSetting.exists(Settings.builder().put("foo", "bar").build()));
         } else {
             final String setting = "fallback" + randomIntBetween(0, count - 1);
-            assertFalse(fooSetting.exists(Settings.builder().put(setting, "bar").build(), false));
-            assertTrue(fooSetting.exists(Settings.builder().put(setting, "bar").build(), true));
+            assertFalse(fooSetting.exists(Settings.builder().put(setting, "bar").build()));
+            assertTrue(fooSetting.existsOrFallbackExists(Settings.builder().put(setting, "bar").build()));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -856,4 +856,29 @@ public class SettingTests extends ESTestCase {
         assertThat(affixSetting.getNamespaces(Settings.builder().put("prefix.infix.suffix", "anything").build()), hasSize(1));
         assertThat(affixSetting.getNamespaces(Settings.builder().put("prefix.infix.suffix.anything", "anything").build()), hasSize(1));
     }
+
+    public void testExists() {
+        final Setting<?> fooSetting = Setting.simpleString("foo", Property.NodeScope);
+        assertFalse(fooSetting.exists(Settings.EMPTY));
+        assertTrue(fooSetting.exists(Settings.builder().put("foo", "bar").build()));
+    }
+
+    public void testExistsWithFallback() {
+        final int count = randomIntBetween(1, 16);
+        Setting<String> current = Setting.simpleString("fallback0", Property.NodeScope);
+        for (int i = 1; i < count; i++) {
+            final Setting<String> next =
+                    new Setting<>(new Setting.SimpleKey("fallback" + i), current, Function.identity(), Property.NodeScope);
+            current = next;
+        }
+        final Setting<String> fooSetting = new Setting<>(new Setting.SimpleKey("foo"), current, Function.identity(), Property.NodeScope);
+        assertFalse(fooSetting.exists(Settings.EMPTY));
+        if (randomBoolean()) {
+            assertTrue(fooSetting.exists(Settings.builder().put("foo", "bar").build()));
+        } else {
+            final String setting = "fallback" + randomIntBetween(0, count - 1);
+            assertTrue(fooSetting.exists(Settings.builder().put(setting, "bar").build()));
+        }
+    }
+
 }

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -874,10 +874,11 @@ public class SettingTests extends ESTestCase {
         final Setting<String> fooSetting = new Setting<>(new Setting.SimpleKey("foo"), current, Function.identity(), Property.NodeScope);
         assertFalse(fooSetting.exists(Settings.EMPTY));
         if (randomBoolean()) {
-            assertTrue(fooSetting.exists(Settings.builder().put("foo", "bar").build()));
+            assertTrue(fooSetting.exists(Settings.builder().put("foo", "bar").build(), randomBoolean()));
         } else {
             final String setting = "fallback" + randomIntBetween(0, count - 1);
-            assertTrue(fooSetting.exists(Settings.builder().put(setting, "bar").build()));
+            assertFalse(fooSetting.exists(Settings.builder().put(setting, "bar").build(), false));
+            assertTrue(fooSetting.exists(Settings.builder().put(setting, "bar").build(), true));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
@@ -129,18 +129,18 @@ public class UpdateSettingsIT extends ESIntegTestCase {
         IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () ->
             client().admin().cluster().prepareUpdateSettings().setPersistentSettings(Settings.builder()
                 .put("cluster.acc.test.pw", "asdf")).get());
-        assertEquals("Missing required setting [cluster.acc.test.user] for setting [cluster.acc.test.pw]", iae.getMessage());
+        assertEquals("missing required setting [cluster.acc.test.user] for setting [cluster.acc.test.pw]", iae.getMessage());
 
         iae = expectThrows(IllegalArgumentException.class, () ->
             client().admin().cluster().prepareUpdateSettings().setTransientSettings(Settings.builder()
                 .put("cluster.acc.test.pw", "asdf")).get());
-        assertEquals("Missing required setting [cluster.acc.test.user] for setting [cluster.acc.test.pw]", iae.getMessage());
+        assertEquals("missing required setting [cluster.acc.test.user] for setting [cluster.acc.test.pw]", iae.getMessage());
 
         iae = expectThrows(IllegalArgumentException.class, () ->
             client().admin().cluster().prepareUpdateSettings().setTransientSettings(Settings.builder()
                 .put("cluster.acc.test.pw", "asdf")).setPersistentSettings(Settings.builder()
             .put("cluster.acc.test.user", "asdf")).get());
-        assertEquals("Missing required setting [cluster.acc.test.user] for setting [cluster.acc.test.pw]", iae.getMessage());
+        assertEquals("missing required setting [cluster.acc.test.user] for setting [cluster.acc.test.pw]", iae.getMessage());
 
         if (randomBoolean()) {
             client().admin().cluster().prepareUpdateSettings().setTransientSettings(Settings.builder()
@@ -149,7 +149,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
             iae = expectThrows(IllegalArgumentException.class, () ->
                 client().admin().cluster().prepareUpdateSettings().setTransientSettings(Settings.builder()
                     .putNull("cluster.acc.test.user")).get());
-            assertEquals("Missing required setting [cluster.acc.test.user] for setting [cluster.acc.test.pw]", iae.getMessage());
+            assertEquals("missing required setting [cluster.acc.test.user] for setting [cluster.acc.test.pw]", iae.getMessage());
             client().admin().cluster().prepareUpdateSettings().setTransientSettings(Settings.builder()
                 .putNull("cluster.acc.test.pw")
                 .putNull("cluster.acc.test.user")).get();
@@ -161,7 +161,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
             iae = expectThrows(IllegalArgumentException.class, () ->
                 client().admin().cluster().prepareUpdateSettings().setPersistentSettings(Settings.builder()
                     .putNull("cluster.acc.test.user")).get());
-            assertEquals("Missing required setting [cluster.acc.test.user] for setting [cluster.acc.test.pw]", iae.getMessage());
+            assertEquals("missing required setting [cluster.acc.test.user] for setting [cluster.acc.test.pw]", iae.getMessage());
 
             client().admin().cluster().prepareUpdateSettings().setPersistentSettings(Settings.builder()
                 .putNull("cluster.acc.test.pw")
@@ -173,7 +173,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
     public void testUpdateDependentIndexSettings() {
         IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () ->
             prepareCreate("test",  Settings.builder().put("index.acc.test.pw", "asdf")).get());
-        assertEquals("Missing required setting [index.acc.test.user] for setting [index.acc.test.pw]", iae.getMessage());
+        assertEquals("missing required setting [index.acc.test.user] for setting [index.acc.test.pw]", iae.getMessage());
 
         createIndex("test");
         for (int i = 0; i < 2; i++) {
@@ -192,7 +192,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                             .put("index.acc.test.pw", "asdf"))
                     .execute()
                     .actionGet());
-            assertEquals("Missing required setting [index.acc.test.user] for setting [index.acc.test.pw]", iae.getMessage());
+            assertEquals("missing required setting [index.acc.test.user] for setting [index.acc.test.pw]", iae.getMessage());
 
             // user has no dependency
             client()
@@ -227,7 +227,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                             .putNull("index.acc.test.user"))
                     .execute()
                     .actionGet());
-            assertEquals("Missing required setting [index.acc.test.user] for setting [index.acc.test.pw]", iae.getMessage());
+            assertEquals("missing required setting [index.acc.test.user] for setting [index.acc.test.pw]", iae.getMessage());
 
             // now we are consistent
             client()

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -714,7 +714,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
         {
             Settings settings = Settings.builder().put("cluster.remote.foo.skip_unavailable", randomBoolean()).build();
             IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> service.validate(settings, true));
-            assertEquals("Missing required setting [cluster.remote.foo.seeds] for setting [cluster.remote.foo.skip_unavailable]",
+            assertEquals("missing required setting [cluster.remote.foo.seeds] for setting [cluster.remote.foo.skip_unavailable]",
                     iae.getMessage());
         }
         {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -257,9 +257,11 @@ public class Security extends Plugin implements ActionPlugin, IngestPlugin, Netw
 
     static final Setting<List<String>> AUDIT_OUTPUTS_SETTING =
         Setting.listSetting(SecurityField.setting("audit.outputs"),
-            s -> s.keySet().contains(SecurityField.setting("audit.outputs")) ?
-                Collections.emptyList() : Collections.singletonList(LoggingAuditTrail.NAME),
-            Function.identity(), Property.NodeScope);
+                Function.identity(),
+                s -> s.keySet().contains(SecurityField.setting("audit.outputs"))
+                        ? Collections.emptyList()
+                        : Collections.singletonList(LoggingAuditTrail.NAME),
+                Property.NodeScope);
 
     private final Settings settings;
     private final Environment env;


### PR DESCRIPTION
Today when checking settings dependencies, we do not check if fallback settings are present. This means, for example, that if `cluster.remote.*.seeds` falls back to `search.remote.*.seeds`, and `cluster.remote.*.skip_unavailable` and `search.remote.*.skip_unavailable` depend on `cluster.remote.*.seeds`, and we have set `search.remote.*.seeds` and `search.remote.*.skip_unavailable`, then validation will fail because it is expected that `cluster.remote.*.seeds` is set here. This commit addresses this by also checking fallback settings when validating dependencies. To do this, we add a new settings exist method that also checks for fallback settings, a case that was not possible previously.

Relates #33413
