### PR TITLE
Rename "after" to "minimum_age" in lifecycle definition

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/Phase.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/Phase.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  */
 public class Phase implements ToXContentObject {
 
-    static final ParseField AFTER_FIELD = new ParseField("after");
+    static final ParseField MINIMUM_AGE = new ParseField("minimum_age");
     static final ParseField ACTIONS_FIELD = new ParseField("actions");
 
     @SuppressWarnings("unchecked")
@@ -49,7 +49,7 @@ public class Phase implements ToXContentObject {
             .collect(Collectors.toMap(LifecycleAction::getName, Function.identity()))));
     static {
         PARSER.declareField(ConstructingObjectParser.optionalConstructorArg(),
-            (p, c) -> TimeValue.parseTimeValue(p.text(), AFTER_FIELD.getPreferredName()), AFTER_FIELD, ValueType.VALUE);
+            (p, c) -> TimeValue.parseTimeValue(p.text(), MINIMUM_AGE.getPreferredName()), MINIMUM_AGE, ValueType.VALUE);
         PARSER.declareNamedObjects(ConstructingObjectParser.constructorArg(),
             (p, c, n) -> p.namedObject(LifecycleAction.class, n, null), v -> {
                 throw new IllegalArgumentException("ordered " + ACTIONS_FIELD.getPreferredName() + " are not supported");
@@ -62,12 +62,12 @@ public class Phase implements ToXContentObject {
 
     private final String name;
     private final Map<String, LifecycleAction> actions;
-    private final TimeValue after;
+    private final TimeValue minimumAge;
 
     /**
      * @param name
      *            the name of this {@link Phase}.
-     * @param after
+     * @param minimumAge
      *            the age of the index when the index should move to this
      *            {@link Phase}.
      * @param actions
@@ -75,12 +75,12 @@ public class Phase implements ToXContentObject {
      *            during this {@link Phase}. The keys in this map are the associated
      *            action names.
      */
-    public Phase(String name, TimeValue after, Map<String, LifecycleAction> actions) {
+    public Phase(String name, TimeValue minimumAge, Map<String, LifecycleAction> actions) {
         this.name = name;
-        if (after == null) {
-            this.after = TimeValue.ZERO;
+        if (minimumAge == null) {
+            this.minimumAge = TimeValue.ZERO;
         } else {
-            this.after = after;
+            this.minimumAge = minimumAge;
         }
         this.actions = actions;
     }
@@ -89,8 +89,8 @@ public class Phase implements ToXContentObject {
      * @return the age of the index when the index should move to this
      *         {@link Phase}.
      */
-    public TimeValue getAfter() {
-        return after;
+    public TimeValue getMinimumAge() {
+        return minimumAge;
     }
 
     /**
@@ -111,7 +111,7 @@ public class Phase implements ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(AFTER_FIELD.getPreferredName(), after.getStringRep());
+        builder.field(MINIMUM_AGE.getPreferredName(), minimumAge.getStringRep());
         builder.field(ACTIONS_FIELD.getPreferredName(), actions);
         builder.endObject();
         return builder;
@@ -119,7 +119,7 @@ public class Phase implements ToXContentObject {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, after, actions);
+        return Objects.hash(name, minimumAge, actions);
     }
 
     @Override
@@ -132,7 +132,7 @@ public class Phase implements ToXContentObject {
         }
         Phase other = (Phase) obj;
         return Objects.equals(name, other.name) &&
-            Objects.equals(after, other.after) &&
+            Objects.equals(minimumAge, other.minimumAge) &&
             Objects.equals(actions, other.actions);
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/PhaseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/PhaseTests.java
@@ -71,6 +71,6 @@ public class PhaseTests extends AbstractXContentTestCase<Phase> {
 
     public void testDefaultAfter() {
         Phase phase = new Phase(randomAlphaOfLength(20), null, Collections.emptyMap());
-        assertEquals(TimeValue.ZERO, phase.getAfter());
+        assertEquals(TimeValue.ZERO, phase.getMinimumAge());
     }
 }

--- a/x-pack/docs/en/ilm/set-up-lifecycle-policy.asciidoc
+++ b/x-pack/docs/en/ilm/set-up-lifecycle-policy.asciidoc
@@ -20,7 +20,7 @@ PUT _ilm/my_policy
         }
       },
       "delete": {
-        "after": "30d",
+        "minimum_age": "30d",
         "actions": {
           "delete": {} <2>
         }

--- a/x-pack/docs/en/ilm/using-policies-rollover.asciidoc
+++ b/x-pack/docs/en/ilm/using-policies-rollover.asciidoc
@@ -39,7 +39,7 @@ when the index size reaches 25GB. The old index is subsequently deleted after
 
 NOTE: Once an index rolls over, {ilm} uses the timestamp of the rollover
 operation rather than the index creation time to evaluate when to move the
-index to the next phase. For indices that have rolled over, the `after`
+index to the next phase. For indices that have rolled over, the `minimum_age`
 criteria specified for a phase is relative to the rollover time for indices. In
 this example, that means the index will be deleted 30 days after rollover, not
 30 days from when the index was created.
@@ -58,7 +58,7 @@ PUT /_ilm/my_policy
         }
       },
       "delete": {
-        "after": "30d",
+        "minimum_age": "30d",
         "actions": {
           "delete": {}
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/Phase.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/Phase.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  */
 public class Phase implements ToXContentObject, Writeable {
 
-    public static final ParseField AFTER_FIELD = new ParseField("after");
+    public static final ParseField MINIMUM_AGE = new ParseField("minimum_age");
     public static final ParseField ACTIONS_FIELD = new ParseField("actions");
 
     @SuppressWarnings("unchecked")
@@ -40,7 +40,7 @@ public class Phase implements ToXContentObject, Writeable {
                     .collect(Collectors.toMap(LifecycleAction::getWriteableName, Function.identity()))));
     static {
         PARSER.declareField(ConstructingObjectParser.optionalConstructorArg(),
-                (p, c) -> TimeValue.parseTimeValue(p.text(), AFTER_FIELD.getPreferredName()), AFTER_FIELD, ValueType.VALUE);
+                (p, c) -> TimeValue.parseTimeValue(p.text(), MINIMUM_AGE.getPreferredName()), MINIMUM_AGE, ValueType.VALUE);
         PARSER.declareNamedObjects(ConstructingObjectParser.constructorArg(),
                 (p, c, n) -> p.namedObject(LifecycleAction.class, n, null), v -> {
                     throw new IllegalArgumentException("ordered " + ACTIONS_FIELD.getPreferredName() + " are not supported");
@@ -53,12 +53,12 @@ public class Phase implements ToXContentObject, Writeable {
 
     private final String name;
     private final Map<String, LifecycleAction> actions;
-    private final TimeValue after;
+    private final TimeValue minimumAge;
 
     /**
      * @param name
      *            the name of this {@link Phase}.
-     * @param after
+     * @param minimumAge
      *            the age of the index when the index should move to this
      *            {@link Phase}.
      * @param actions
@@ -67,12 +67,12 @@ public class Phase implements ToXContentObject, Writeable {
      *            action names. The order of these actions is defined
      *            by the {@link LifecycleType}
      */
-    public Phase(String name, TimeValue after, Map<String, LifecycleAction> actions) {
+    public Phase(String name, TimeValue minimumAge, Map<String, LifecycleAction> actions) {
         this.name = name;
-        if (after == null) {
-            this.after = TimeValue.ZERO;
+        if (minimumAge == null) {
+            this.minimumAge = TimeValue.ZERO;
         } else {
-            this.after = after;
+            this.minimumAge = minimumAge;
         }
         this.actions = actions;
     }
@@ -82,7 +82,7 @@ public class Phase implements ToXContentObject, Writeable {
      */
     public Phase(StreamInput in) throws IOException {
         this.name = in.readString();
-        this.after = in.readTimeValue();
+        this.minimumAge = in.readTimeValue();
         int size = in.readVInt();
         TreeMap<String, LifecycleAction> actions = new TreeMap<>();
         for (int i = 0; i < size; i++) {
@@ -94,7 +94,7 @@ public class Phase implements ToXContentObject, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
-        out.writeTimeValue(after);
+        out.writeTimeValue(minimumAge);
         out.writeVInt(actions.size());
         for (Map.Entry<String, LifecycleAction> entry : actions.entrySet()) {
             out.writeString(entry.getKey());
@@ -106,8 +106,8 @@ public class Phase implements ToXContentObject, Writeable {
      * @return the age of the index when the index should move to this
      *         {@link Phase}.
      */
-    public TimeValue getAfter() {
-        return after;
+    public TimeValue getMinimumAge() {
+        return minimumAge;
     }
 
     /**
@@ -128,7 +128,7 @@ public class Phase implements ToXContentObject, Writeable {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(AFTER_FIELD.getPreferredName(), after.getStringRep());
+        builder.field(MINIMUM_AGE.getPreferredName(), minimumAge.getStringRep());
         builder.field(ACTIONS_FIELD.getPreferredName(), actions);
         builder.endObject();
         return builder;
@@ -136,7 +136,7 @@ public class Phase implements ToXContentObject, Writeable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, after, actions);
+        return Objects.hash(name, minimumAge, actions);
     }
 
     @Override
@@ -149,7 +149,7 @@ public class Phase implements ToXContentObject, Writeable {
         }
         Phase other = (Phase) obj;
         return Objects.equals(name, other.name) &&
-                Objects.equals(after, other.after) &&
+                Objects.equals(minimumAge, other.minimumAge) &&
                 Objects.equals(actions, other.actions);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/TimeseriesLifecycleType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/TimeseriesLifecycleType.java
@@ -76,7 +76,7 @@ public class TimeseriesLifecycleType implements LifecycleType {
                 } else if (phase.getActions().containsKey(ReadOnlyAction.NAME) == false){
                     Map<String, LifecycleAction> actionMap = new HashMap<>(phase.getActions());
                     actionMap.put(ReadOnlyAction.NAME, ReadOnlyAction.INSTANCE);
-                    phase = new Phase(phase.getName(), phase.getAfter(), actionMap);
+                    phase = new Phase(phase.getName(), phase.getMinimumAge(), actionMap);
                 }
             }
             if (phase != null) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/PhaseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/PhaseTests.java
@@ -69,7 +69,7 @@ public class PhaseTests extends AbstractSerializingTestCase<Phase> {
     @Override
     protected Phase mutateInstance(Phase instance) throws IOException {
         String name = instance.getName();
-        TimeValue after = instance.getAfter();
+        TimeValue after = instance.getMinimumAge();
         Map<String, LifecycleAction> actions = instance.getActions();
         switch (between(0, 2)) {
         case 0:
@@ -90,6 +90,6 @@ public class PhaseTests extends AbstractSerializingTestCase<Phase> {
 
     public void testDefaultAfter() {
         Phase phase = new Phase(randomAlphaOfLength(20), null, Collections.emptyMap());
-        assertEquals(TimeValue.ZERO, phase.getAfter());
+        assertEquals(TimeValue.ZERO, phase.getMinimumAge());
     }
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/PolicyStepsRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/PolicyStepsRegistry.java
@@ -271,7 +271,7 @@ public class PolicyStepsRegistry {
                 // We don't have that phase registered, proceed right through it
                 return TimeValue.ZERO;
             } else {
-                return retrievedPhase.getAfter();
+                return retrievedPhase.getMinimumAge();
             }
         }
     }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/10_basic.yml
@@ -25,7 +25,7 @@ setup:
              "policy": {
                "phases": {
                  "warm": {
-                   "after": "10s",
+                   "minimum_age": "10s",
                    "actions": {
                      "forcemerge": {
                        "max_num_segments": 10000
@@ -33,7 +33,7 @@ setup:
                    }
                  },
                  "delete": {
-                   "after": "30s",
+                   "minimum_age": "30s",
                    "actions": {
                      "delete": {}
                    }
@@ -48,8 +48,8 @@ setup:
         lifecycle: "my_timeseries_lifecycle"
   - match: { my_timeseries_lifecycle.version: 1 }
   - is_true: my_timeseries_lifecycle.modified_date
-  - match: { my_timeseries_lifecycle.policy.phases.warm.after: "10s" }
-  - match: { my_timeseries_lifecycle.policy.phases.delete.after: "30s" }
+  - match: { my_timeseries_lifecycle.policy.phases.warm.minimum_age: "10s" }
+  - match: { my_timeseries_lifecycle.policy.phases.delete.minimum_age: "30s" }
 
   - do:
       acknowledge: true
@@ -72,7 +72,7 @@ setup:
              "policy": {
                "phases": {
                  "warm": {
-                   "after": "10s",
+                   "minimum_age": "10s",
                    "actions": {
                      "forcemerge": {
                        "max_num_segments": 10000
@@ -80,7 +80,7 @@ setup:
                    }
                  },
                  "delete": {
-                   "after": "30s",
+                   "minimum_age": "30s",
                    "actions": {
                      "delete": {}
                    }
@@ -95,8 +95,8 @@ setup:
         lifecycle: "my_timeseries_lifecycle"
   - match: { my_timeseries_lifecycle.version: 1 }
   - is_true: my_timeseries_lifecycle.modified_date
-  - match: { my_timeseries_lifecycle.policy.phases.warm.after: "10s" }
-  - match: { my_timeseries_lifecycle.policy.phases.delete.after: "30s" }
+  - match: { my_timeseries_lifecycle.policy.phases.warm.minimum_age: "10s" }
+  - match: { my_timeseries_lifecycle.policy.phases.delete.minimum_age: "30s" }
 
 
   - do:
@@ -122,7 +122,7 @@ setup:
              "policy": {
                "phases": {
                  "warm": {
-                   "after": "300s",
+                   "minimum_age": "300s",
                    "actions": {
                      "forcemerge": {
                        "max_num_segments": 10000
@@ -130,7 +130,7 @@ setup:
                    }
                  },
                  "delete": {
-                   "after": "600s",
+                   "minimum_age": "600s",
                    "actions": {
                      "delete": {}
                    }
@@ -145,8 +145,8 @@ setup:
         lifecycle: "my_timeseries_lifecycle"
   - match: { my_timeseries_lifecycle.version: 2 }
   - is_true: my_timeseries_lifecycle.modified_date
-  - match: { my_timeseries_lifecycle.policy.phases.warm.after: "300s" }
-  - match: { my_timeseries_lifecycle.policy.phases.delete.after: "600s" }
+  - match: { my_timeseries_lifecycle.policy.phases.warm.minimum_age: "300s" }
+  - match: { my_timeseries_lifecycle.policy.phases.delete.minimum_age: "600s" }
 
   - do:
       acknowledge: true
@@ -178,7 +178,7 @@ setup:
              "policy": {
                "phases": {
                  "warm": {
-                   "after": "10s",
+                   "minimum_age": "10s",
                    "actions": {
                      "forcemerge": {
                        "max_num_segments": 10000
@@ -186,7 +186,7 @@ setup:
                    }
                  },
                  "delete": {
-                   "after": "30s",
+                   "minimum_age": "30s",
                    "actions": {
                      "delete": {}
                    }
@@ -199,8 +199,8 @@ setup:
       acknowledge: true
       ilm.get_lifecycle:
         lifecycle: "my_timeseries_lifecycle"
-  - match: { my_timeseries_lifecycle.policy.phases.warm.after: "10s" }
-  - match: { my_timeseries_lifecycle.policy.phases.delete.after: "30s" }
+  - match: { my_timeseries_lifecycle.policy.phases.warm.minimum_age: "10s" }
+  - match: { my_timeseries_lifecycle.policy.phases.delete.minimum_age: "30s" }
 
   - do:
       indices.create:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/20_move_to_step.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/20_move_to_step.yml
@@ -12,7 +12,7 @@ setup:
              "policy": {
                "phases": {
                  "warm": {
-                   "after": "1000s",
+                   "minimum_age": "1000s",
                    "actions": {
                      "forcemerge": {
                        "max_num_segments": 10000
@@ -20,7 +20,7 @@ setup:
                    }
                  },
                  "hot": {
-                   "after": "1000s",
+                   "minimum_age": "1000s",
                    "actions": { }
                  }
                }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/30_retry.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/30_retry.yml
@@ -13,7 +13,7 @@ setup:
              "policy": {
                "phases": {
                  "warm": {
-                   "after": "1000s",
+                   "minimum_age": "1000s",
                    "actions": {
                      "forcemerge": {
                        "max_num_segments": 10000
@@ -21,7 +21,7 @@ setup:
                    }
                  },
                  "hot": {
-                   "after": "1000s",
+                   "minimum_age": "1000s",
                    "actions": { }
                  }
                }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/40_explain_lifecycle.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/40_explain_lifecycle.yml
@@ -12,7 +12,7 @@ setup:
              "policy": {
                "phases": {
                  "warm": {
-                   "after": "1000s",
+                   "minimum_age": "1000s",
                    "actions": {
                      "forcemerge": {
                        "max_num_segments": 10000
@@ -20,7 +20,7 @@ setup:
                    }
                  },
                  "hot": {
-                   "after": "1000s",
+                   "minimum_age": "1000s",
                    "actions": { }
                  }
                }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/50_set_policy_for_index.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/50_set_policy_for_index.yml
@@ -12,7 +12,7 @@ setup:
              "policy": {
                "phases": {
                  "warm": {
-                   "after": "1000s",
+                   "minimum_age": "1000s",
                    "actions": {
                      "forcemerge": {
                        "max_num_segments": 10000
@@ -20,7 +20,7 @@ setup:
                    }
                  },
                  "hot": {
-                   "after": "1000s",
+                   "minimum_age": "1000s",
                    "actions": { }
                  }
                }
@@ -41,7 +41,7 @@ setup:
              "policy": {
                "phases": {
                  "warm": {
-                   "after": "1000s",
+                   "minimum_age": "1000s",
                    "actions": {
                      "forcemerge": {
                        "max_num_segments": 10000
@@ -49,7 +49,7 @@ setup:
                    }
                  },
                  "hot": {
-                   "after": "1000s",
+                   "minimum_age": "1000s",
                    "actions": { }
                  }
                }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/60_operation_mode.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/60_operation_mode.yml
@@ -19,7 +19,7 @@ setup:
              "policy": {
                "phases": {
                  "warm": {
-                   "after": "10s",
+                   "minimum_age": "10s",
                    "actions": {
                      "forcemerge": {
                        "max_num_segments": 10000
@@ -27,7 +27,7 @@ setup:
                    }
                  },
                  "delete": {
-                   "after": "30s",
+                   "minimum_age": "30s",
                    "actions": {
                      "delete": {}
                    }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/60_remove_policy_for_index.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ilm/60_remove_policy_for_index.yml
@@ -12,7 +12,7 @@ setup:
              "policy": {
                "phases": {
                  "warm": {
-                   "after": "1000s",
+                   "minimum_age": "1000s",
                    "actions": {
                      "forcemerge": {
                        "max_num_segments": 10000
@@ -20,7 +20,7 @@ setup:
                    }
                  },
                  "hot": {
-                   "after": "1000s",
+                   "minimum_age": "1000s",
                    "actions": { }
                  }
                }
@@ -41,7 +41,7 @@ setup:
              "policy": {
                "phases": {
                  "warm": {
-                   "after": "1000s",
+                   "minimum_age": "1000s",
                    "actions": {
                      "forcemerge": {
                        "max_num_segments": 10000
@@ -49,7 +49,7 @@ setup:
                    }
                  },
                  "hot": {
-                   "after": "1000s",
+                   "minimum_age": "1000s",
                    "actions": { }
                  }
                }


### PR DESCRIPTION
This renames the "after" field to better reflect what the meaning is.

Supercedes #32624
