### PR TITLE
Add infrastructure to upgrade settings

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -179,8 +179,12 @@ public class TransportClusterUpdateSettingsAction extends
 
             @Override
             public ClusterState execute(final ClusterState currentState) {
-                ClusterState clusterState =
-                        updater.updateSettings(currentState, request.transientSettings(), request.persistentSettings(), logger);
+                final ClusterState clusterState =
+                        updater.updateSettings(
+                                currentState,
+                                clusterSettings.upgradeSettings(request.transientSettings()),
+                                clusterSettings.upgradeSettings(request.persistentSettings()),
+                                logger);
                 changed = clusterState != currentState;
                 return clusterState;
             }

--- a/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.client.transport;
 
-import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionModule;
@@ -44,6 +43,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.node.InternalSettingsPreparer;
@@ -146,7 +146,8 @@ public abstract class TransportClient extends AbstractClient {
             for (final ExecutorBuilder<?> builder : threadPool.builders()) {
                 additionalSettings.addAll(builder.getRegisteredSettings());
             }
-            SettingsModule settingsModule = new SettingsModule(settings, additionalSettings, additionalSettingsFilter);
+            SettingsModule settingsModule =
+                    new SettingsModule(settings, additionalSettings, additionalSettingsFilter, Collections.emptyList());
 
             SearchModule searchModule = new SearchModule(settings, true, pluginsService.filterPlugins(SearchPlugin.class));
             IndicesModule indicesModule = new IndicesModule(Collections.emptyList());

--- a/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -147,7 +147,7 @@ public abstract class TransportClient extends AbstractClient {
                 additionalSettings.addAll(builder.getRegisteredSettings());
             }
             SettingsModule settingsModule =
-                    new SettingsModule(settings, additionalSettings, additionalSettingsFilter, Collections.emptyList());
+                    new SettingsModule(settings, additionalSettings, additionalSettingsFilter, Collections.emptySet());
 
             SearchModule searchModule = new SearchModule(settings, true, pluginsService.filterPlugins(SearchPlugin.class));
             IndicesModule indicesModule = new IndicesModule(Collections.emptyList());

--- a/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -22,7 +22,6 @@ package org.elasticsearch.common.settings;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.search.spell.LevenshteinDistance;
 import org.apache.lucene.util.CollectionUtil;
-import org.elasticsearch.Assertions;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;

--- a/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -63,7 +63,7 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
     protected AbstractScopedSettings(
             final Settings settings,
             final Set<Setting<?>> settingsSet,
-            final List<SettingUpgrader<?>> settingUpgraders,
+            final Set<SettingUpgrader<?>> settingUpgraders,
             final Setting.Property scope) {
         super(settings);
         this.lastSettingsApplied = Settings.EMPTY;

--- a/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -797,7 +797,7 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
                 builder.put(upgrade.getKey(), upgrade.getValue());
             }
         }
-        // we only return a new instance of there was an upgrade
+        // we only return a new instance if there was an upgrade
         return changed ? builder.build() : settings;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -70,10 +70,12 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
 
         this.settingUpgraders =
                 Collections.unmodifiableMap(
-                settingUpgraders.stream()
-                .collect(Collectors.toMap(
-                        SettingUpgrader::getSetting,
-                        u -> e -> new AbstractMap.SimpleEntry<>(u.getKey(e.getKey()), u.getValue(e.getValue())))));
+                        settingUpgraders
+                                .stream()
+                                .collect(
+                                        Collectors.toMap(
+                                                SettingUpgrader::getSetting,
+                                                u -> e -> new AbstractMap.SimpleEntry<>(u.getKey(e.getKey()), u.getValue(e.getValue())))));
 
         this.scope = scope;
         Map<String, Setting<?>> complexMatchers = new HashMap<>();

--- a/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -775,20 +775,29 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
         return null;
     }
 
+    /**
+     * Upgrade all settings eligible for upgrade in the specified settings instance.
+     *
+     * @param settings the settings instance that might contain settings to be upgraded
+     * @return a new settings instance if any settings required upgrade, otherwise the same settings instance as specified
+     */
     public Settings upgradeSettings(final Settings settings) {
         final Settings.Builder builder = Settings.builder();
-        boolean changed = false;
+        boolean changed = false; // track if any settings were upgraded
         for (final String key : settings.keySet()) {
             final Setting<?> setting = getRaw(key);
             final Function<Map.Entry<String, String>, Map.Entry<String, String>> upgrader = settingUpgraders.get(setting);
             if (upgrader == null) {
+                // the setting does not have an upgrader, copy the setting
                 builder.copy(key, settings);
             } else {
+                // the setting has an upgrader, so mark that we have changed a setting and apply the upgrade logic
                 changed = true;
                 final Map.Entry<String, String> upgrade = upgrader.apply(new Entry(key, settings));
                 builder.put(upgrade.getKey(), upgrade.getValue());
             }
         }
+        // we only return a new instance of there was an upgrade
         return changed ? builder.build() : settings;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -110,12 +110,12 @@ import java.util.function.Predicate;
 public final class ClusterSettings extends AbstractScopedSettings {
     public ClusterSettings(Settings nodeSettings, Set<Setting<?>> settingsSet) {
         super(nodeSettings, settingsSet, Collections.emptyList(), Property.NodeScope);
-        addSettingsUpdater(new LoggingSettingUpdater(nodeSettings));
     }
 
     public ClusterSettings(
             final Settings nodeSettings, final Set<Setting<?>> settingsSet, final List<SettingUpgrader<?>> settingUpgraders) {
         super(nodeSettings, settingsSet, settingUpgraders, Property.NodeScope);
+        addSettingsUpdater(new LoggingSettingUpdater(nodeSettings));
     }
 
     private static final class LoggingSettingUpdater implements SettingUpdater<Settings> {

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -108,8 +108,8 @@ import java.util.function.Predicate;
  * Encapsulates all valid cluster level settings.
  */
 public final class ClusterSettings extends AbstractScopedSettings {
-    public ClusterSettings(Settings nodeSettings, Set<Setting<?>> settingsSet) {
-        super(nodeSettings, settingsSet, Collections.emptyList(), Property.NodeScope);
+    public ClusterSettings(final Settings nodeSettings, final Set<Setting<?>> settingsSet) {
+        this(nodeSettings, settingsSet, Collections.emptyList());
     }
 
     public ClusterSettings(

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -109,11 +109,11 @@ import java.util.function.Predicate;
  */
 public final class ClusterSettings extends AbstractScopedSettings {
     public ClusterSettings(final Settings nodeSettings, final Set<Setting<?>> settingsSet) {
-        this(nodeSettings, settingsSet, Collections.emptyList());
+        this(nodeSettings, settingsSet, Collections.emptySet());
     }
 
     public ClusterSettings(
-            final Settings nodeSettings, final Set<Setting<?>> settingsSet, final List<SettingUpgrader<?>> settingUpgraders) {
+            final Settings nodeSettings, final Set<Setting<?>> settingsSet, final Set<SettingUpgrader<?>> settingUpgraders) {
         super(nodeSettings, settingsSet, settingUpgraders, Property.NodeScope);
         addSettingsUpdater(new LoggingSettingUpdater(nodeSettings));
     }

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -100,6 +100,7 @@ import org.elasticsearch.watcher.ResourceWatcherService;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -108,8 +109,13 @@ import java.util.function.Predicate;
  */
 public final class ClusterSettings extends AbstractScopedSettings {
     public ClusterSettings(Settings nodeSettings, Set<Setting<?>> settingsSet) {
-        super(nodeSettings, settingsSet, Property.NodeScope);
+        super(nodeSettings, settingsSet, Collections.emptyList(), Property.NodeScope);
         addSettingsUpdater(new LoggingSettingUpdater(nodeSettings));
+    }
+
+    public ClusterSettings(
+            final Settings nodeSettings, final Set<Setting<?>> settingsSet, final List<SettingUpgrader<?>> settingUpgraders) {
+        super(nodeSettings, settingsSet, settingUpgraders, Property.NodeScope);
     }
 
     private static final class LoggingSettingUpdater implements SettingUpdater<Settings> {
@@ -436,4 +442,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     IndexGraveyard.SETTING_MAX_TOMBSTONES,
                     EnableAssignmentDecider.CLUSTER_TASKS_ALLOCATION_ENABLE_SETTING
             )));
+
+    public static List<SettingUpgrader<?>> BUILT_IN_SETTING_UPGRADERS = Collections.emptyList();
+
 }

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -178,7 +178,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
     public static final IndexScopedSettings DEFAULT_SCOPED_SETTINGS = new IndexScopedSettings(Settings.EMPTY, BUILT_IN_INDEX_SETTINGS);
 
     public IndexScopedSettings(Settings settings, Set<Setting<?>> settingsSet) {
-        super(settings, settingsSet, Collections.emptyList(), Property.IndexScope);
+        super(settings, settingsSet, Collections.emptySet(), Property.IndexScope);
     }
 
     private IndexScopedSettings(Settings settings, IndexScopedSettings other, IndexMetaData metaData) {

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -178,7 +178,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
     public static final IndexScopedSettings DEFAULT_SCOPED_SETTINGS = new IndexScopedSettings(Settings.EMPTY, BUILT_IN_INDEX_SETTINGS);
 
     public IndexScopedSettings(Settings settings, Set<Setting<?>> settingsSet) {
-        super(settings, settingsSet, Property.IndexScope);
+        super(settings, settingsSet, Collections.emptyList(), Property.IndexScope);
     }
 
     private IndexScopedSettings(Settings settings, IndexScopedSettings other, IndexMetaData metaData) {

--- a/server/src/main/java/org/elasticsearch/common/settings/SettingUpgrader.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SettingUpgrader.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.settings;
+
+public interface SettingUpgrader<T> {
+
+    Setting<T> getSetting();
+
+    String getKey(String key);
+
+    String getValue(String value);
+
+}

--- a/server/src/main/java/org/elasticsearch/common/settings/SettingUpgrader.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SettingUpgrader.java
@@ -19,12 +19,34 @@
 
 package org.elasticsearch.common.settings;
 
+/**
+ * Represents the logic to upgrade a setting.
+ *
+ * @param <T>
+ */
 public interface SettingUpgrader<T> {
 
+    /**
+     * The setting upgraded by this upgrader.
+     *
+     * @return
+     */
     Setting<T> getSetting();
 
+    /**
+     * The logic to upgrade the setting key, for example by mapping the old setting key to the new setting key.
+     *
+     * @param key the setting key to upgrade
+     * @return the upgraded setting key
+     */
     String getKey(String key);
 
+    /**
+     * The logic to upgrade the setting value.
+     *
+     * @param value the setting value to upgrade
+     * @return the upgraded setting value
+     */
     default String getValue(final String value) {
         return value;
     }

--- a/server/src/main/java/org/elasticsearch/common/settings/SettingUpgrader.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SettingUpgrader.java
@@ -25,6 +25,8 @@ public interface SettingUpgrader<T> {
 
     String getKey(String key);
 
-    String getValue(String value);
+    default String getValue(final String value) {
+        return value;
+    }
 
 }

--- a/server/src/main/java/org/elasticsearch/common/settings/SettingUpgrader.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SettingUpgrader.java
@@ -22,14 +22,14 @@ package org.elasticsearch.common.settings;
 /**
  * Represents the logic to upgrade a setting.
  *
- * @param <T>
+ * @param <T> the type of the underlying setting
  */
 public interface SettingUpgrader<T> {
 
     /**
      * The setting upgraded by this upgrader.
      *
-     * @return
+     * @return the setting
      */
     Setting<T> getSetting();
 

--- a/server/src/main/java/org/elasticsearch/gateway/Gateway.java
+++ b/server/src/main/java/org/elasticsearch/gateway/Gateway.java
@@ -137,20 +137,25 @@ public class Gateway extends AbstractComponent {
                 }
             }
         }
+        final ClusterState.Builder builder = upgradeAndArchiveUnknownOrInvalidSettings(metaDataBuilder);
+        listener.onSuccess(builder.build());
+    }
+
+    ClusterState.Builder upgradeAndArchiveUnknownOrInvalidSettings(MetaData.Builder metaDataBuilder) {
         final ClusterSettings clusterSettings = clusterService.getClusterSettings();
         metaDataBuilder.persistentSettings(
             clusterSettings.archiveUnknownOrInvalidSettings(
-                metaDataBuilder.persistentSettings(),
+                clusterSettings.upgradeSettings(metaDataBuilder.persistentSettings()),
                 e -> logUnknownSetting("persistent", e),
                 (e, ex) -> logInvalidSetting("persistent", e, ex)));
         metaDataBuilder.transientSettings(
             clusterSettings.archiveUnknownOrInvalidSettings(
-                metaDataBuilder.transientSettings(),
+                clusterSettings.upgradeSettings(metaDataBuilder.transientSettings()),
                 e -> logUnknownSetting("transient", e),
                 (e, ex) -> logInvalidSetting("transient", e, ex)));
         ClusterState.Builder builder = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.get(settings));
         builder.metaData(metaDataBuilder);
-        listener.onSuccess(builder.build());
+        return builder;
     }
 
     private void logUnknownSetting(String settingType, Map.Entry<String, String> e) {

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -73,6 +73,7 @@ import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.settings.SettingUpgrader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.common.transport.BoundTransportAddress;
@@ -151,6 +152,7 @@ import org.elasticsearch.usage.UsageService;
 import org.elasticsearch.watcher.ResourceWatcherService;
 
 import javax.net.ssl.SNIHostName;
+
 import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.IOException;
@@ -360,7 +362,15 @@ public abstract class Node implements Closeable {
             AnalysisModule analysisModule = new AnalysisModule(this.environment, pluginsService.filterPlugins(AnalysisPlugin.class));
             // this is as early as we can validate settings at this point. we already pass them to ScriptModule as well as ThreadPool
             // so we might be late here already
-            final SettingsModule settingsModule = new SettingsModule(this.settings, additionalSettings, additionalSettingsFilter);
+
+            final List<SettingUpgrader<?>> settingsUpgraders = pluginsService.filterPlugins(Plugin.class)
+                    .stream()
+                    .map(Plugin::getSettingUpgraders)
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
+
+            final SettingsModule settingsModule =
+                    new SettingsModule(this.settings, additionalSettings, additionalSettingsFilter, settingsUpgraders);
             scriptModule.registerClusterSettingsListeners(settingsModule.getClusterSettings());
             resourcesToClose.add(resourceWatcherService);
             final NetworkService networkService = new NetworkService(

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -363,11 +363,11 @@ public abstract class Node implements Closeable {
             // this is as early as we can validate settings at this point. we already pass them to ScriptModule as well as ThreadPool
             // so we might be late here already
 
-            final List<SettingUpgrader<?>> settingsUpgraders = pluginsService.filterPlugins(Plugin.class)
+            final Set<SettingUpgrader<?>> settingsUpgraders = pluginsService.filterPlugins(Plugin.class)
                     .stream()
                     .map(Plugin::getSettingUpgraders)
                     .flatMap(List::stream)
-                    .collect(Collectors.toList());
+                    .collect(Collectors.toSet());
 
             final SettingsModule settingsModule =
                     new SettingsModule(this.settings, additionalSettings, additionalSettingsFilter, settingsUpgraders);

--- a/server/src/main/java/org/elasticsearch/plugins/Plugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/Plugin.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.SettingUpgrader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -171,6 +172,15 @@ public abstract class Plugin implements Closeable {
      * Returns a list of additional settings filter for this plugin
      */
     public List<String> getSettingsFilter() { return Collections.emptyList(); }
+
+    /**
+     * Get the setting upgraders provided by this plugin.
+     *
+     * @return the settings upgraders
+     */
+    public List<SettingUpgrader<?>> getSettingUpgraders() {
+        return Collections.emptyList();
+    }
 
     /**
      * Provides a function to modify global custom meta data on startup.

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexActionTests.java
@@ -43,6 +43,8 @@ import org.junit.Before;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.Collections.emptyList;
+
 public class GetIndexActionTests extends ESSingleNodeTestCase {
 
     private TransportService transportService;
@@ -58,7 +60,7 @@ public class GetIndexActionTests extends ESSingleNodeTestCase {
     public void setUp() throws Exception {
         super.setUp();
 
-        settingsFilter = new SettingsModule(Settings.EMPTY, Collections.emptyList(), Collections.emptyList()).getSettingsFilter();
+        settingsFilter = new SettingsModule(Settings.EMPTY, emptyList(), emptyList(), emptyList()).getSettingsFilter();
         threadPool = new TestThreadPool("GetIndexActionTests");
         clusterService = getInstanceFromNode(ClusterService.class);
         indicesService = getInstanceFromNode(IndicesService.class);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexActionTests.java
@@ -40,10 +40,10 @@ import org.elasticsearch.transport.TransportService;
 import org.junit.After;
 import org.junit.Before;
 
-import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 
 public class GetIndexActionTests extends ESSingleNodeTestCase {
 
@@ -60,14 +60,14 @@ public class GetIndexActionTests extends ESSingleNodeTestCase {
     public void setUp() throws Exception {
         super.setUp();
 
-        settingsFilter = new SettingsModule(Settings.EMPTY, emptyList(), emptyList(), emptyList()).getSettingsFilter();
+        settingsFilter = new SettingsModule(Settings.EMPTY, emptyList(), emptyList(), emptySet()).getSettingsFilter();
         threadPool = new TestThreadPool("GetIndexActionTests");
         clusterService = getInstanceFromNode(ClusterService.class);
         indicesService = getInstanceFromNode(IndicesService.class);
         CapturingTransport capturingTransport = new CapturingTransport();
         transportService = capturingTransport.createCapturingTransportService(clusterService.getSettings(), threadPool,
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
-            boundAddress -> clusterService.localNode(), null, Collections.emptySet());
+            boundAddress -> clusterService.localNode(), null, emptySet());
         transportService.start();
         transportService.acceptIncomingRequests();
         getIndexAction = new GetIndexActionTests.TestTransportGetIndexAction();
@@ -108,7 +108,7 @@ public class GetIndexActionTests extends ESSingleNodeTestCase {
 
         TestTransportGetIndexAction() {
             super(Settings.EMPTY, GetIndexActionTests.this.transportService, GetIndexActionTests.this.clusterService,
-                GetIndexActionTests.this.threadPool, settingsFilter, new ActionFilters(Collections.emptySet()),
+                GetIndexActionTests.this.threadPool, settingsFilter, new ActionFilters(emptySet()),
                 new GetIndexActionTests.Resolver(Settings.EMPTY), indicesService, IndexScopedSettings.DEFAULT_SCOPED_SETTINGS);
         }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsActionTests.java
@@ -42,6 +42,7 @@ import org.junit.Before;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.Collections.emptyList;
 import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
 
 public class GetSettingsActionTests extends ESTestCase {
@@ -71,7 +72,7 @@ public class GetSettingsActionTests extends ESTestCase {
     public void setUp() throws Exception {
         super.setUp();
 
-        settingsFilter = new SettingsModule(Settings.EMPTY, Collections.emptyList(), Collections.emptyList()).getSettingsFilter();
+        settingsFilter = new SettingsModule(Settings.EMPTY, emptyList(), emptyList(), emptyList()).getSettingsFilter();
         threadPool = new TestThreadPool("GetSettingsActionTests");
         clusterService = createClusterService(threadPool);
         CapturingTransport capturingTransport = new CapturingTransport();

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsActionTests.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
 
 public class GetSettingsActionTests extends ESTestCase {
@@ -72,7 +73,7 @@ public class GetSettingsActionTests extends ESTestCase {
     public void setUp() throws Exception {
         super.setUp();
 
-        settingsFilter = new SettingsModule(Settings.EMPTY, emptyList(), emptyList(), emptyList()).getSettingsFilter();
+        settingsFilter = new SettingsModule(Settings.EMPTY, emptyList(), emptyList(), emptySet()).getSettingsFilter();
         threadPool = new TestThreadPool("GetSettingsActionTests");
         clusterService = createClusterService(threadPool);
         CapturingTransport capturingTransport = new CapturingTransport();

--- a/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -1056,7 +1056,8 @@ public class ScopedSettingsTests extends ESTestCase {
                 new ClusterSettings(
                         Settings.EMPTY,
                         new HashSet<>(Arrays.asList(oldSetting, newSetting, remainingSetting)),
-                        Collections.singletonList(new SettingUpgrader<String>() {
+                        Collections.singleton(new SettingUpgrader<String>() {
+
                             @Override
                             public Setting<String> getSetting() {
                                 return oldSetting;
@@ -1071,6 +1072,7 @@ public class ScopedSettingsTests extends ESTestCase {
                             public String getValue(final String value) {
                                 return "new." + value;
                             }
+
                         }));
 
         final Settings settings =
@@ -1095,7 +1097,7 @@ public class ScopedSettingsTests extends ESTestCase {
                 new ClusterSettings(
                         Settings.EMPTY,
                         new HashSet<>(Arrays.asList(oldSetting, newSetting, remainingSetting)),
-                        Collections.singletonList(new SettingUpgrader<String>() {
+                        Collections.singleton(new SettingUpgrader<String>() {
 
                             @Override
                             public Setting<String> getSetting() {
@@ -1126,8 +1128,8 @@ public class ScopedSettingsTests extends ESTestCase {
                 new ClusterSettings(
                         Settings.EMPTY,
                         new HashSet<>(Arrays.asList(oldSetting, newSetting, remainingSetting)),
+                        Collections.singleton(new SettingUpgrader<String>() {
 
-                        Collections.singletonList(new SettingUpgrader<String>() {
                             @Override
                             public Setting<String> getSetting() {
                                 return oldSetting;

--- a/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -1107,11 +1107,6 @@ public class ScopedSettingsTests extends ESTestCase {
                                 return "foo.new";
                             }
 
-                            @Override
-                            public String getValue(final String value) {
-                                return value;
-                            }
-
                         }));
 
         final Settings settings = Settings.builder().put("foo.remaining", randomAlphaOfLength(8)).build();

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsModuleTests.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 
 import java.util.Arrays;
 
-import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 import static org.hamcrest.Matchers.containsString;
 
 public class SettingsModuleTests extends ModuleTestCase {
@@ -104,14 +104,14 @@ public class SettingsModuleTests extends ModuleTestCase {
         try {
             new SettingsModule(settings, Arrays.asList(Setting.boolSetting("foo.bar", true, Property.NodeScope),
             Setting.boolSetting("bar.foo", true, Property.NodeScope, Property.Filtered),
-            Setting.boolSetting("bar.baz", true, Property.NodeScope)), Arrays.asList("foo.*", "bar.foo"), emptyList());
+            Setting.boolSetting("bar.baz", true, Property.NodeScope)), Arrays.asList("foo.*", "bar.foo"), emptySet());
             fail();
         } catch (IllegalArgumentException ex) {
             assertEquals("filter [bar.foo] has already been registered", ex.getMessage());
         }
         SettingsModule module = new SettingsModule(settings, Arrays.asList(Setting.boolSetting("foo.bar", true, Property.NodeScope),
             Setting.boolSetting("bar.foo", true, Property.NodeScope, Property.Filtered),
-            Setting.boolSetting("bar.baz", true, Property.NodeScope)), Arrays.asList("foo.*"), emptyList());
+            Setting.boolSetting("bar.baz", true, Property.NodeScope)), Arrays.asList("foo.*"), emptySet());
         assertInstanceBinding(module, Settings.class, (s) -> s == settings);
         assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).size() == 1);
         assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).keySet().contains("bar.baz"));

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsModuleTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 
 import java.util.Arrays;
 
+import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.containsString;
 
 public class SettingsModuleTests extends ModuleTestCase {
@@ -103,14 +104,14 @@ public class SettingsModuleTests extends ModuleTestCase {
         try {
             new SettingsModule(settings, Arrays.asList(Setting.boolSetting("foo.bar", true, Property.NodeScope),
             Setting.boolSetting("bar.foo", true, Property.NodeScope, Property.Filtered),
-            Setting.boolSetting("bar.baz", true, Property.NodeScope)), Arrays.asList("foo.*", "bar.foo"));
+            Setting.boolSetting("bar.baz", true, Property.NodeScope)), Arrays.asList("foo.*", "bar.foo"), emptyList());
             fail();
         } catch (IllegalArgumentException ex) {
             assertEquals("filter [bar.foo] has already been registered", ex.getMessage());
         }
         SettingsModule module = new SettingsModule(settings, Arrays.asList(Setting.boolSetting("foo.bar", true, Property.NodeScope),
             Setting.boolSetting("bar.foo", true, Property.NodeScope, Property.Filtered),
-            Setting.boolSetting("bar.baz", true, Property.NodeScope)), Arrays.asList("foo.*"));
+            Setting.boolSetting("bar.baz", true, Property.NodeScope)), Arrays.asList("foo.*"), emptyList());
         assertInstanceBinding(module, Settings.class, (s) -> s == settings);
         assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).size() == 1);
         assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).keySet().contains("bar.baz"));

--- a/server/src/test/java/org/elasticsearch/common/settings/UpgradeSettingsIT.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/UpgradeSettingsIT.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.settings;
+
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequestBuilder;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.watcher.ResourceWatcherService;
+import org.junit.After;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class UpgradeSettingsIT extends ESSingleNodeTestCase {
+
+    @After
+    public void cleanup() throws Exception {
+                client()
+                        .admin()
+                        .cluster()
+                        .prepareUpdateSettings()
+                        .setPersistentSettings(Settings.builder().putNull("*"))
+                        .setTransientSettings(Settings.builder().putNull("*"))
+                        .get();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Collections.singletonList(UpgradeSettingsPlugin.class);
+    }
+
+    public static class UpgradeSettingsPlugin extends Plugin {
+
+        static final Setting<?> oldSetting = Setting.simpleString("foo.old", Setting.Property.Dynamic, Setting.Property.NodeScope);
+        static final Setting<?> newSetting = Setting.simpleString("foo.new", Setting.Property.Dynamic, Setting.Property.NodeScope);
+
+        public UpgradeSettingsPlugin(){
+
+        }
+
+        @Override
+        public Collection<Object> createComponents(
+                final Client client,
+                final ClusterService clusterService,
+                final ThreadPool threadPool,
+                final ResourceWatcherService resourceWatcherService,
+                final ScriptService scriptService,
+                final NamedXContentRegistry xContentRegistry,
+                final Environment environment,
+                final NodeEnvironment nodeEnvironment,
+                final NamedWriteableRegistry namedWriteableRegistry) {
+            clusterService.getClusterSettings().addSettingsUpgrader(
+                    oldSetting,
+                    entry -> new AbstractMap.SimpleEntry<>("foo.new", entry.getValue()));
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<Setting<?>> getSettings() {
+            return Arrays.asList(oldSetting, newSetting);
+        }
+
+    }
+
+    public void testUpgradePersistentSettingsOnUpdate() {
+        runUpgradeSettingsOnUpdateTest((settings, builder) -> builder.setPersistentSettings(settings), MetaData::persistentSettings);
+    }
+
+    public void testUpgradeTransientSettingsOnUpdate() {
+        runUpgradeSettingsOnUpdateTest((settings, builder) -> builder.setTransientSettings(settings), MetaData::transientSettings);
+    }
+
+    private void runUpgradeSettingsOnUpdateTest(
+            final BiConsumer<Settings, ClusterUpdateSettingsRequestBuilder> consumer,
+            final Function<MetaData, Settings> settingsFunction) {
+        final String value = randomAlphaOfLength(8);
+        final ClusterUpdateSettingsRequestBuilder builder =
+                client()
+                        .admin()
+                        .cluster()
+                        .prepareUpdateSettings();
+        consumer.accept(Settings.builder().put("foo.old", value).build(), builder);
+        builder.get();
+
+        final ClusterStateResponse response = client()
+                .admin()
+                .cluster()
+                .prepareState()
+                .clear()
+                .setMetaData(true)
+                .get();
+
+        assertFalse(UpgradeSettingsPlugin.oldSetting.exists(settingsFunction.apply(response.getState().metaData())));
+        assertTrue(UpgradeSettingsPlugin.newSetting.exists(settingsFunction.apply(response.getState().metaData())));
+        assertThat(UpgradeSettingsPlugin.newSetting.get(settingsFunction.apply(response.getState().metaData())), equalTo(value));
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayTests.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gateway;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.AbstractMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class GatewayTests extends ESTestCase {
+
+    public void testUpgradePersistentSettings() {
+        runUpgradeSettings(MetaData.Builder::persistentSettings, MetaData::persistentSettings);
+    }
+
+    public void testUpgradeTransientSettings() {
+        runUpgradeSettings(MetaData.Builder::transientSettings, MetaData::transientSettings);
+    }
+
+    private void runUpgradeSettings(
+            final BiConsumer<MetaData.Builder, Settings> applySettingsToBuilder, final Function<MetaData, Settings> metaDataSettings) {
+        final Setting<?> oldSetting = Setting.simpleString("foo.old", Setting.Property.Dynamic, Setting.Property.NodeScope);
+        final Setting<?> newSetting = Setting.simpleString("foo.new", Setting.Property.Dynamic, Setting.Property.NodeScope);
+        final Set<Setting<?>> settingsSet =
+                new HashSet<>(
+                        Stream.concat(
+                                ClusterSettings.BUILT_IN_CLUSTER_SETTINGS.stream(),
+                                Stream.of(oldSetting, newSetting))
+                                .collect(Collectors.toList()));
+        final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, settingsSet);
+        clusterSettings.addSettingsUpgrader(oldSetting, entry -> new AbstractMap.SimpleEntry<>("foo.new", entry.getValue()));
+        final ClusterService clusterService = new ClusterService(Settings.EMPTY, clusterSettings, null);
+        final Gateway gateway = new Gateway(Settings.EMPTY, clusterService, null, null);
+        final MetaData.Builder builder = MetaData.builder();
+        final Settings settings = Settings.builder().put("foo.old", randomAlphaOfLength(8)).build();
+        applySettingsToBuilder.accept(builder, settings);
+        final ClusterState state = gateway.upgradeAndArchiveUnknownOrInvalidSettings(builder).build();
+        assertFalse(oldSetting.exists(metaDataSettings.apply(state.metaData())));
+        assertTrue(newSetting.exists(metaDataSettings.apply(state.metaData())));
+        assertThat(newSetting.get(metaDataSettings.apply(state.metaData())), equalTo(oldSetting.get(settings)));
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayTests.java
@@ -58,7 +58,8 @@ public class GatewayTests extends ESTestCase {
         final ClusterSettings clusterSettings = new ClusterSettings(
                 Settings.EMPTY,
                 settingsSet,
-                Collections.singletonList(new SettingUpgrader<String>() {
+                Collections.singleton(new SettingUpgrader<String>() {
+
                     @Override
                     public Setting<String> getSetting() {
                         return oldSetting;
@@ -73,6 +74,7 @@ public class GatewayTests extends ESTestCase {
                     public String getValue(final String value) {
                         return "new." + value;
                     }
+
                 }));
         final ClusterService clusterService = new ClusterService(Settings.EMPTY, clusterSettings, null);
         final Gateway gateway = new Gateway(Settings.EMPTY, clusterService, null, null);

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayTests.java
@@ -54,7 +54,7 @@ public class GatewayTests extends ESTestCase {
         final Set<Setting<?>> settingsSet =
                 Stream.concat(
                         ClusterSettings.BUILT_IN_CLUSTER_SETTINGS.stream(),
-                        Stream.of(oldSetting, newSetting)).collect(Collectors.toSet()))
+                        Stream.of(oldSetting, newSetting)).collect(Collectors.toSet());
         final ClusterSettings clusterSettings = new ClusterSettings(
                 Settings.EMPTY,
                 settingsSet,

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayTests.java
@@ -53,11 +53,9 @@ public class GatewayTests extends ESTestCase {
         final Setting<String> oldSetting = Setting.simpleString("foo.old", Setting.Property.Dynamic, Setting.Property.NodeScope);
         final Setting<String> newSetting = Setting.simpleString("foo.new", Setting.Property.Dynamic, Setting.Property.NodeScope);
         final Set<Setting<?>> settingsSet =
-                new HashSet<>(
-                        Stream.concat(
-                                ClusterSettings.BUILT_IN_CLUSTER_SETTINGS.stream(),
-                                Stream.of(oldSetting, newSetting))
-                                .collect(Collectors.toList()));
+                Stream.concat(
+                        ClusterSettings.BUILT_IN_CLUSTER_SETTINGS.stream(),
+                        Stream.of(oldSetting, newSetting)).collect(Collectors.toSet()))
         final ClusterSettings clusterSettings = new ClusterSettings(
                 Settings.EMPTY,
                 settingsSet,

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -341,7 +341,7 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
             ScriptModule scriptModule = createScriptModule(pluginsService.filterPlugins(ScriptPlugin.class));
             List<Setting<?>> additionalSettings = pluginsService.getPluginSettings();
             SettingsModule settingsModule =
-                    new SettingsModule(nodeSettings, additionalSettings, pluginsService.getPluginSettingsFilter(), Collections.emptyList());
+                    new SettingsModule(nodeSettings, additionalSettings, pluginsService.getPluginSettingsFilter(), Collections.emptySet());
             searchModule = new SearchModule(nodeSettings, false, pluginsService.filterPlugins(SearchPlugin.class));
             IndicesModule indicesModule = new IndicesModule(pluginsService.filterPlugins(MapperPlugin.class));
             List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -340,7 +340,8 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
                     clientInvocationHandler);
             ScriptModule scriptModule = createScriptModule(pluginsService.filterPlugins(ScriptPlugin.class));
             List<Setting<?>> additionalSettings = pluginsService.getPluginSettings();
-            SettingsModule settingsModule = new SettingsModule(nodeSettings, additionalSettings, pluginsService.getPluginSettingsFilter());
+            SettingsModule settingsModule =
+                    new SettingsModule(nodeSettings, additionalSettings, pluginsService.getPluginSettingsFilter(), Collections.emptyList());
             searchModule = new SearchModule(nodeSettings, false, pluginsService.filterPlugins(SearchPlugin.class));
             IndicesModule indicesModule = new IndicesModule(pluginsService.filterPlugins(MapperPlugin.class));
             List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmSettings.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xpack.core.security.SecurityExtension;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -181,7 +182,8 @@ public class RealmSettings {
         settingSet.add(TYPE_SETTING);
         settingSet.add(ENABLED_SETTING);
         settingSet.add(ORDER_SETTING);
-        final AbstractScopedSettings validator = new AbstractScopedSettings(settings, settingSet, Setting.Property.NodeScope) { };
+        final AbstractScopedSettings validator =
+                new AbstractScopedSettings(settings, settingSet, Collections.emptyList(), Setting.Property.NodeScope) { };
         try {
             validator.validate(settings, false);
         } catch (RuntimeException e) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmSettings.java
@@ -183,7 +183,7 @@ public class RealmSettings {
         settingSet.add(ENABLED_SETTING);
         settingSet.add(ORDER_SETTING);
         final AbstractScopedSettings validator =
-                new AbstractScopedSettings(settings, settingSet, Collections.emptyList(), Setting.Property.NodeScope) { };
+                new AbstractScopedSettings(settings, settingSet, Collections.emptySet(), Setting.Property.NodeScope) { };
         try {
             validator.validate(settings, false);
         } catch (RuntimeException e) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SettingsFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SettingsFilterTests.java
@@ -20,6 +20,7 @@ import org.hamcrest.Matcher;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -122,7 +123,7 @@ public class SettingsFilterTests extends ESTestCase {
         List<String> settingsFilterList = new ArrayList<>();
         settingsFilterList.addAll(securityPlugin.getSettingsFilter());
         // custom settings, potentially added by a plugin
-        SettingsModule settingsModule = new SettingsModule(settings, settingList, settingsFilterList, Collections.emptyList());
+        SettingsModule settingsModule = new SettingsModule(settings, settingList, settingsFilterList, Collections.emptySet());
 
         Injector injector = Guice.createInjector(settingsModule);
         SettingsFilter settingsFilter = injector.getInstance(SettingsFilter.class);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SettingsFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SettingsFilterTests.java
@@ -21,6 +21,7 @@ import org.hamcrest.Matcher;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -121,7 +122,7 @@ public class SettingsFilterTests extends ESTestCase {
         List<String> settingsFilterList = new ArrayList<>();
         settingsFilterList.addAll(securityPlugin.getSettingsFilter());
         // custom settings, potentially added by a plugin
-        SettingsModule settingsModule = new SettingsModule(settings, settingList, settingsFilterList);
+        SettingsModule settingsModule = new SettingsModule(settings, settingList, settingsFilterList, Collections.emptyList());
 
         Injector injector = Guice.createInjector(settingsModule);
         SettingsFilter settingsFilter = injector.getInstance(SettingsFilter.class);


### PR DESCRIPTION
In some cases we want to deprecate a setting, and then automatically upgrade uses of that setting to a replacement setting. This commit adds infrastructure for this so that we can upgrade settings when recovering the cluster state, as well as when such settings are dynamically applied on cluster update settings requests. This commit only focuses on cluster settings, index settings can build on this infrastructure in a follow-up.