### PR TITLE
[DOCS] Adds x-pack release highlight

### DIFF
--- a/docs/reference/release-notes/highlights-6.3.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.3.0.asciidoc
@@ -13,6 +13,23 @@ NOTE: We want your feedback on the experimental features in this release! Let
 us know what you’d like to see next and any problems you encounter.
 
 [float]
+=== License management and X-Pack code
+
+Starting with version 6.3, the default distribution of {es} contains open source 
+and free commercial features and access to paid commercial features. You no 
+longer need to install {xpack} as a separate step. When you install {es}, it 
+generates a basic license with no expiration date. All the free commercial 
+features are enabled by default and will never expire. 
+
+You can view the status of your license, update your license, or start a 30-day 
+trial of platinum features by using the <<licensing-apis>> or {kib}. The trial 
+enables you to try out features such as security, machine learning, alerting, 
+graph capabilities, and more.
+
+For more information about licenses, see https://www.elastic.co/subscriptions
+
+
+[float]
 === SQL
 This experimental feature enables users who are familiar with SQL to
 use SQL statements to query Elasticsearch indices. In addition to querying


### PR DESCRIPTION
The 6.3.0 Release Highlights are missing any mention of the inclusion of X-Pack in the default installation images.

This PR adds that information, based on information in https://www.elastic.co/guide/en/elasticsearch/reference/6.3/zip-targz.html, https://www.elastic.co/blog/elastic-stack-6-3-0-released, and https://www.elastic.co/guide/en/kibana/6.3/release-highlights-6.3.0.html#_license_management_and_x_pack_code