### PR TITLE
CCR: Use single global checkpoint to normalize range

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
@@ -297,12 +297,13 @@ public class ShardChangesAction extends Action<ShardChangesAction.Response> {
         if (indexShard.state() != IndexShardState.STARTED) {
             throw new IndexShardNotStartedException(indexShard.shardId(), indexShard.state());
         }
-        if (fromSeqNo > indexShard.getGlobalCheckpoint()) {
+        if (fromSeqNo > globalCheckpoint) {
             return EMPTY_OPERATIONS_ARRAY;
         }
         int seenBytes = 0;
         // - 1 is needed, because toSeqNo is inclusive
         long toSeqNo = Math.min(globalCheckpoint, (fromSeqNo + maxOperationCount) - 1);
+        assert fromSeqNo <= toSeqNo : "invalid range from_seqno[" + fromSeqNo + "] > to_seqno[" + toSeqNo + "]";
         final List<Translog.Operation> operations = new ArrayList<>();
         try (Translog.Snapshot snapshot = indexShard.newChangesSnapshot("ccr", fromSeqNo, toSeqNo, true)) {
             Translog.Operation op;


### PR DESCRIPTION
We may use different global checkpoint values to validate/normalize the range of a change request if the global checkpoint is advanced between these calls. If this is the case, then we generate an invalid request range and cause the follow task aborted.

```
  1> Caused by: java.lang.IllegalArgumentException: Invalid range; from_seqno [17], to_seqno [16]
  1>     at org.elasticsearch.index.engine.LuceneChangesSnapshot.<init>(LuceneChangesSnapshot.java:86) ~[elasticsearch-7.0.0-alpha1-SNAPSHOT.jar:7.0.0-alpha1-SNAPSHOT]
  1>     at org.elasticsearch.index.engine.InternalEngine.newChangesSnapshot(InternalEngine.java:2421) ~[elasticsearch-7.0.0-alpha1-SNAPSHOT.jar:7.0.0-alpha1-SNAPSHOT]
  1>     at org.elasticsearch.index.shard.IndexShard.newChangesSnapshot(IndexShard.java:1673) ~[elasticsearch-7.0.0-alpha1-SNAPSHOT.jar:7.0.0-alpha1-SNAPSHOT]
  1>     at org.elasticsearch.xpack.ccr.action.ShardChangesAction.getOperations(ShardChangesAction.java:307) ~[main/:?]
```

CI: 
- https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+multijob-unix-compatibility/os=opensuse/2661/console
- https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+6.x+release-tests/1018/console