### PR TITLE
Add latch countdown on failure in CCR license tests

### DIFF
--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrLicenseIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrLicenseIT.java
@@ -47,6 +47,7 @@ public class CcrLicenseIT extends ESSingleNodeTestCase {
                 new ActionListener<AcknowledgedResponse>() {
                     @Override
                     public void onResponse(final AcknowledgedResponse response) {
+                        latch.countDown();
                         fail();
                     }
 
@@ -69,6 +70,7 @@ public class CcrLicenseIT extends ESSingleNodeTestCase {
                 new ActionListener<CreateAndFollowIndexAction.Response>() {
                     @Override
                     public void onResponse(final CreateAndFollowIndexAction.Response response) {
+                        latch.countDown();
                         fail();
                     }
 
@@ -86,6 +88,7 @@ public class CcrLicenseIT extends ESSingleNodeTestCase {
         client().execute(CcrStatsAction.INSTANCE, new CcrStatsAction.TasksRequest(), new ActionListener<CcrStatsAction.TasksResponse>() {
             @Override
             public void onResponse(final CcrStatsAction.TasksResponse tasksResponse) {
+                latch.countDown();
                 fail();
             }
 


### PR DESCRIPTION
We have some listeners in the CCR license tests that invoke Assert#fail if the onSuccess method for the listener is unexpectedly invoked. This can leave the main test thread hanging until the test suite times out rather than failing quickly. This commit adds some latch countdowns so that we fail quickly if these cases are hit.

Relates #33496