### PR TITLE
Reverse logic for CCR license checks

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/CreateAndFollowIndexAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/CreateAndFollowIndexAction.java
@@ -221,21 +221,21 @@ public class CreateAndFollowIndexAction extends Action<CreateAndFollowIndexActio
         @Override
         protected void masterOperation(
                 final Request request, final ClusterState state, final ActionListener<Response> listener) throws Exception {
-            if (ccrLicenseChecker.isCcrAllowed()) {
-                final String[] indices = new String[]{request.getFollowRequest().getLeaderIndex()};
-                final Map<String, List<String>> remoteClusterIndices = remoteClusterService.groupClusterIndices(indices, s -> false);
-                if (remoteClusterIndices.containsKey(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY)) {
-                    createFollowerIndexAndFollowLocalIndex(request, state, listener);
-                } else {
-                    assert remoteClusterIndices.size() == 1;
-                    final Map.Entry<String, List<String>> entry = remoteClusterIndices.entrySet().iterator().next();
-                    assert entry.getValue().size() == 1;
-                    final String clusterAlias = entry.getKey();
-                    final String leaderIndex = entry.getValue().get(0);
-                    createFollowerIndexAndFollowRemoteIndex(request, clusterAlias, leaderIndex, listener);
-                }
-            } else {
+            if (ccrLicenseChecker.isCcrAllowed() == false) {
                 listener.onFailure(LicenseUtils.newComplianceException("ccr"));
+                return;
+            }
+            final String[] indices = new String[]{request.getFollowRequest().getLeaderIndex()};
+            final Map<String, List<String>> remoteClusterIndices = remoteClusterService.groupClusterIndices(indices, s -> false);
+            if (remoteClusterIndices.containsKey(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY)) {
+                createFollowerIndexAndFollowLocalIndex(request, state, listener);
+            } else {
+                assert remoteClusterIndices.size() == 1;
+                final Map.Entry<String, List<String>> entry = remoteClusterIndices.entrySet().iterator().next();
+                assert entry.getValue().size() == 1;
+                final String clusterAlias = entry.getKey();
+                final String leaderIndex = entry.getValue().get(0);
+                createFollowerIndexAndFollowRemoteIndex(request, clusterAlias, leaderIndex, listener);
             }
         }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/FollowIndexAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/FollowIndexAction.java
@@ -328,21 +328,21 @@ public class FollowIndexAction extends Action<AcknowledgedResponse> {
         protected void doExecute(final Task task,
                                  final Request request,
                                  final ActionListener<AcknowledgedResponse> listener) {
-            if (ccrLicenseChecker.isCcrAllowed()) {
-                final String[] indices = new String[]{request.leaderIndex};
-                final Map<String, List<String>> remoteClusterIndices = remoteClusterService.groupClusterIndices(indices, s -> false);
-                if (remoteClusterIndices.containsKey(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY)) {
-                    followLocalIndex(request, listener);
-                } else {
-                    assert remoteClusterIndices.size() == 1;
-                    final Map.Entry<String, List<String>> entry = remoteClusterIndices.entrySet().iterator().next();
-                    assert entry.getValue().size() == 1;
-                    final String clusterAlias = entry.getKey();
-                    final String leaderIndex = entry.getValue().get(0);
-                    followRemoteIndex(request, clusterAlias, leaderIndex, listener);
-                }
-            } else {
+            if (ccrLicenseChecker.isCcrAllowed() == false) {
                 listener.onFailure(LicenseUtils.newComplianceException("ccr"));
+                return;
+            }
+            final String[] indices = new String[]{request.leaderIndex};
+            final Map<String, List<String>> remoteClusterIndices = remoteClusterService.groupClusterIndices(indices, s -> false);
+            if (remoteClusterIndices.containsKey(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY)) {
+                followLocalIndex(request, listener);
+            } else {
+                assert remoteClusterIndices.size() == 1;
+                final Map.Entry<String, List<String>> entry = remoteClusterIndices.entrySet().iterator().next();
+                assert entry.getValue().size() == 1;
+                final String clusterAlias = entry.getKey();
+                final String leaderIndex = entry.getValue().get(0);
+                followRemoteIndex(request, clusterAlias, leaderIndex, listener);
             }
         }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportCcrStatsAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportCcrStatsAction.java
@@ -65,11 +65,11 @@ public class TransportCcrStatsAction extends TransportTasksAction<
             final Task task,
             final CcrStatsAction.TasksRequest request,
             final ActionListener<CcrStatsAction.TasksResponse> listener) {
-        if (ccrLicenseChecker.isCcrAllowed()) {
-            super.doExecute(task, request, listener);
-        } else {
+        if (ccrLicenseChecker.isCcrAllowed() == false) {
             listener.onFailure(LicenseUtils.newComplianceException("ccr"));
+            return;
         }
+        super.doExecute(task, request, listener);
     }
 
     @Override


### PR DESCRIPTION
This commit reverses the logic for CCR license checks in a few actions. This is done so that the successful case, which tends to be a larger block of code, does not require indentation.

Relates #33496