### PR TITLE
Remove underscore from auto-follow API

### DIFF
--- a/x-pack/plugin/ccr/qa/multi-cluster-with-non-compliant-license/src/test/java/org/elasticsearch/xpack/ccr/CcrMultiClusterLicenseIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster-with-non-compliant-license/src/test/java/org/elasticsearch/xpack/ccr/CcrMultiClusterLicenseIT.java
@@ -48,7 +48,7 @@ public class CcrMultiClusterLicenseIT extends ESRestTestCase {
 
     public void testAutoFollow() throws Exception {
         if (runningAgainstLeaderCluster == false) {
-            final Request request = new Request("PUT", "/_ccr/_auto_follow/leader_cluster");
+            final Request request = new Request("PUT", "/_ccr/auto_follow/leader_cluster");
             request.setJsonEntity("{\"leader_index_patterns\":[\"*\"]}");
             client().performRequest(request);
 

--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexIT.java
@@ -81,7 +81,7 @@ public class FollowIndexIT extends ESRestTestCase {
     public void testAutoFollowPatterns() throws Exception {
         assumeFalse("Test should only run when both clusters are running", runningAgainstLeaderCluster);
 
-        Request request = new Request("PUT", "/_ccr/_auto_follow/leader_cluster");
+        Request request = new Request("PUT", "/_ccr/auto_follow/leader_cluster");
         request.setJsonEntity("{\"leader_index_patterns\": [\"logs-*\"]}");
         assertOK(client().performRequest(request));
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestDeleteAutoFollowPatternAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestDeleteAutoFollowPatternAction.java
@@ -21,7 +21,7 @@ public class RestDeleteAutoFollowPatternAction extends BaseRestHandler {
 
     public RestDeleteAutoFollowPatternAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.DELETE, "/_ccr/_auto_follow/{leader_cluster_alias}", this);
+        controller.registerHandler(RestRequest.Method.DELETE, "/_ccr/auto_follow/{leader_cluster_alias}", this);
     }
 
     @Override

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestPutAutoFollowPatternAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestPutAutoFollowPatternAction.java
@@ -22,7 +22,7 @@ public class RestPutAutoFollowPatternAction extends BaseRestHandler {
 
     public RestPutAutoFollowPatternAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.PUT, "/_ccr/_auto_follow/{leader_cluster_alias}", this);
+        controller.registerHandler(RestRequest.Method.PUT, "/_ccr/auto_follow/{leader_cluster_alias}", this);
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.delete_auto_follow_pattern.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.delete_auto_follow_pattern.json
@@ -3,8 +3,8 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_ccr/_auto_follow/{leader_cluster_alias}",
-      "paths": [ "/_ccr/_auto_follow/{leader_cluster_alias}" ],
+      "path": "/_ccr/auto_follow/{leader_cluster_alias}",
+      "paths": [ "/_ccr/auto_follow/{leader_cluster_alias}" ],
       "parts": {
         "leader_cluster_alias": {
           "type": "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.put_auto_follow_pattern.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.put_auto_follow_pattern.json
@@ -3,8 +3,8 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current",
     "methods": [ "PUT" ],
     "url": {
-      "path": "/_ccr/_auto_follow/{leader_cluster_alias}",
-      "paths": [ "/_ccr/_auto_follow/{leader_cluster_alias}" ],
+      "path": "/_ccr/auto_follow/{leader_cluster_alias}",
+      "paths": [ "/_ccr/auto_follow/{leader_cluster_alias}" ],
       "parts": {
         "leader_cluster_alias": {
           "type": "string",


### PR DESCRIPTION
This commit removes the leading underscore from _auto_follow in the auto-follow API endpoints.

