### PR TITLE
Update the Flush API documentation

### DIFF
--- a/docs/reference/indices/flush.asciidoc
+++ b/docs/reference/indices/flush.asciidoc
@@ -2,11 +2,12 @@
 == Flush
 
 The flush API allows to flush one or more indices through an API. The
-flush process of an index basically frees memory from the index by
-flushing data to the index storage and clearing the internal
-<<index-modules-translog,transaction log>>. By
-default, Elasticsearch uses memory heuristics in order to automatically
-trigger flush operations as required in order to clear memory.
+flush process of an index makes sure that any data that is currently only
+persisted in the <<index-modules-translog,transaction log>> is also perminantly
+persisted in Lucene. This reduces recovery times as that data doesn't need to be
+reindexed from the transaction logs after the Lucene indexed is opened. By
+default, Elasticsearch use heuristics in order to automatically
+trigger flushes as required and is rare for users to call the API directly.
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/indices/flush.asciidoc
+++ b/docs/reference/indices/flush.asciidoc
@@ -3,11 +3,11 @@
 
 The flush API allows to flush one or more indices through an API. The
 flush process of an index makes sure that any data that is currently only
-persisted in the <<index-modules-translog,transaction log>> is also perminantly
+persisted in the <<index-modules-translog,transaction log>> is also permanently
 persisted in Lucene. This reduces recovery times as that data doesn't need to be
 reindexed from the transaction logs after the Lucene indexed is opened. By
-default, Elasticsearch use heuristics in order to automatically
-trigger flushes as required and is rare for users to call the API directly.
+default, Elasticsearch uses heuristics in order to automatically
+trigger flushes as required. It is rare for users to need to call the API directly.
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
The semantics of the API changed considerably since the documentation was written.

The main change is to remove references to memory reduction (this is related to refresh).
Instead, flush refers to recovery times. I also removed the references to trimming the translog
as the translog may be required for other purposes (operation history for ops based recovery
and complement ongoing file based recoveries).

Closes #32869
