### PR TITLE
suggest sysctl command for querying vm.max_map_count

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -81,8 +81,8 @@ The `vm.max_map_count` setting should be set permanently in /etc/sysctl.conf:
 
 [source,sh]
 --------------------------------------------
-$ grep vm.max_map_count /etc/sysctl.conf
-vm.max_map_count=262144
+$ sysctl vm.max_map_count
+vm.max_map_count = 262144
 ----------------------------------
 
 To apply the setting on a live system type: `sysctl -w vm.max_map_count=262144`


### PR DESCRIPTION
there might not be an override in /etc/sysctl.conf
