### PR TITLE
[CCR] Delay auto follow license check

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -70,12 +70,6 @@ public class AutoFollowCoordinator implements ClusterStateApplier {
     }
 
     private void doAutoFollow() {
-        if (ccrLicenseChecker.isCcrAllowed() == false) {
-            // TODO: set non-compliant status on auto-follow coordination that can be viewed via a stats API
-            LOGGER.warn("skipping auto-follower coordination", LicenseUtils.newComplianceException("ccr"));
-            threadPool.schedule(pollInterval, ThreadPool.Names.SAME, this::doAutoFollow);
-            return;
-        }
         if (localNodeMaster == false) {
             return;
         }
@@ -87,6 +81,13 @@ public class AutoFollowCoordinator implements ClusterStateApplier {
         }
 
         if (autoFollowMetadata.getPatterns().isEmpty()) {
+            threadPool.schedule(pollInterval, ThreadPool.Names.SAME, this::doAutoFollow);
+            return;
+        }
+
+        if (ccrLicenseChecker.isCcrAllowed() == false) {
+            // TODO: set non-compliant status on auto-follow coordination that can be viewed via a stats API
+            LOGGER.warn("skipping auto-follower coordination", LicenseUtils.newComplianceException("ccr"));
             threadPool.schedule(pollInterval, ThreadPool.Names.SAME, this::doAutoFollow);
             return;
         }


### PR DESCRIPTION
so that we're sure that there are auto follow patterns configured

Otherwise we log many warnings in case someone is running with basic or gold
license and has not used the ccr feature:

```
[elasticsearch] [2018-09-10T09:58:12,633][INFO ][o.e.n.Node               ] [node-0] started
[elasticsearch] [2018-09-10T09:58:12,704][INFO ][o.e.g.GatewayService     ] [node-0] recovered [0] indices into cluster_state
[elasticsearch] [2018-09-10T09:58:12,790][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node-0] adding template [.watches] for index patterns [.watches*]
[elasticsearch] [2018-09-10T09:58:12,847][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node-0] adding template [.watch-history-9] for index patterns [.watcher-history-9*]
[elasticsearch] [2018-09-10T09:58:12,877][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node-0] adding template [.triggered_watches] for index patterns [.triggered_watches*]
[elasticsearch] [2018-09-10T09:58:12,922][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node-0] adding template [.monitoring-logstash] for index patterns [.monitoring-logstash-6-*]
[elasticsearch] [2018-09-10T09:58:12,969][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node-0] adding template [.monitoring-es] for index patterns [.monitoring-es-6-*]
[elasticsearch] [2018-09-10T09:58:13,007][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node-0] adding template [.monitoring-alerts] for index patterns [.monitoring-alerts-6]
[elasticsearch] [2018-09-10T09:58:13,049][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node-0] adding template [.monitoring-beats] for index patterns [.monitoring-beats-6-*]
[elasticsearch] [2018-09-10T09:58:13,089][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node-0] adding template [.monitoring-kibana] for index patterns [.monitoring-kibana-6-*]
[elasticsearch] [2018-09-10T09:58:13,191][INFO ][o.e.l.LicenseService     ] [node-0] license [26b3e83d-2d85-4a69-95a4-fb8c554764a5] mode [basic] - valid
[elasticsearch] [2018-09-10T09:58:15,111][WARN ][o.e.x.c.a.AutoFollowCoordinator] [node-0] skipping auto-follower coordination
[elasticsearch] org.elasticsearch.ElasticsearchSecurityException: current license is non-compliant for [ccr]
[elasticsearch]         at org.elasticsearch.license.LicenseUtils.newComplianceException(LicenseUtils.java:27) ~[x-pack-core-7.0.0-alpha1-SNAPSHOT.jar:7.0.0-alpha1-SNAPSHOT]
[elasticsearch]         at org.elasticsearch.xpack.ccr.action.AutoFollowCoordinator.doAutoFollow(AutoFollowCoordinator.java:75) [x-pack-ccr-7.0.0-alpha1-SNAPSHOT.jar:7.0.0-alpha1-SNAPSHOT]
[elasticsearch]         at org.elasticsearch.threadpool.ThreadPool$LoggingRunnable.run(ThreadPool.java:445) [elasticsearch-7.0.0-alpha1-SNAPSHOT.jar:7.0.0-alpha1-SNAPSHOT]
[elasticsearch]         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:514) [?:?]
[elasticsearch]         at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
[elasticsearch]         at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
[elasticsearch]         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1135) [?:?]
[elasticsearch]         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
[elasticsearch]         at java.lang.Thread.run(Thread.java:844) [?:?]
[elasticsearch] [2018-09-10T09:58:17,619][WARN ][o.e.x.c.a.AutoFollowCoordinator] [node-0] skipping auto-follower coordination
[elasticsearch] org.elasticsearch.ElasticsearchSecurityException: current license is non-compliant for [ccr]
[elasticsearch]         at org.elasticsearch.license.LicenseUtils.newComplianceException(LicenseUtils.java:27) ~[x-pack-core-7.0.0-alpha1-SNAPSHOT.jar:7.0.0-alpha1-SNAPSHOT]
[elasticsearch]         at org.elasticsearch.xpack.ccr.action.AutoFollowCoordinator.doAutoFollow(AutoFollowCoordinator.java:75) [x-pack-ccr-7.0.0-alpha1-SNAPSHOT.jar:7.0.0-alpha1-SNAPSHOT]
[elasticsearch]         at org.elasticsearch.threadpool.ThreadPool$LoggingRunnable.run(ThreadPool.java:445) [elasticsearch-7.0.0-alpha1-SNAPSHOT.jar:7.0.0-alpha1-SNAPSHOT]
[elasticsearch]         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:514) [?:?]
[elasticsearch]         at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
[elasticsearch]         at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
[elasticsearch]         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1135) [?:?]
[elasticsearch]         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
[elasticsearch]         at java.lang.Thread.run(Thread.java:844) [?:?]
[elasticsearch] [2018-09-10T09:58:20,121][WARN ][o.e.x.c.a.AutoFollowCoordinator] [node-0] skipping auto-follower coordination
[elasticsearch] org.elasticsearch.ElasticsearchSecurityException: current license is non-compliant for [ccr]
[elasticsearch]         at org.elasticsearch.license.LicenseUtils.newComplianceException(LicenseUtils.java:27) ~[x-pack-core-7.0.0-alpha1-SNAPSHOT.jar:7.0.0-alpha1-SNAPSHOT]
[elasticsearch]         at org.elasticsearch.xpack.ccr.action.AutoFollowCoordinator.doAutoFollow(AutoFollowCoordinator.java:75) [x-pack-ccr-7.0.0-alpha1-SNAPSHOT.jar:7.0.0-alpha1-SNAPSHOT]
[elasticsearch]         at org.elasticsearch.threadpool.ThreadPool$LoggingRunnable.run(ThreadPool.java:445) [elasticsearch-7.0.0-alpha1-SNAPSHOT.jar:7.0.0-alpha1-SNAPSHOT]
[elasticsearch]         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:514) [?:?]
[elasticsearch]         at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
[elasticsearch]         at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
[elasticsearch]         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1135) [?:?]
[elasticsearch]         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
[elasticsearch]         at java.lang.Thread.run(Thread.java:844) [?:?]
```