### PR TITLE
[Docs] Clarify accessing Date methods in painless

### DIFF
--- a/docs/painless/painless-getting-started.asciidoc
+++ b/docs/painless/painless-getting-started.asciidoc
@@ -198,13 +198,11 @@ POST hockey/player/1/_update
 ==== Dates
 
 Date fields are exposed as
-`ReadableDateTime` or
-so they support methods like
-`getYear`,
-and `getDayOfWeek`.
-To get milliseconds since epoch call
-`getMillis`.
-For example, the following returns every hockey player's birth year:
+`ReadableDateTime`, so they support methods like `getYear`, `getDayOfWeek` 
+or e.g. getting milliseconds since epoch with `getMillis`. To use these
+in a script, leave out the `get` prefix and continue with lowercasing the
+rest of the method nane. For example, the following returns every hockey 
+player's birth year:
 
 [source,js]
 ----------------------------------------------------------------

--- a/docs/painless/painless-getting-started.asciidoc
+++ b/docs/painless/painless-getting-started.asciidoc
@@ -201,7 +201,7 @@ Date fields are exposed as
 `ReadableDateTime`, so they support methods like `getYear`, `getDayOfWeek` 
 or e.g. getting milliseconds since epoch with `getMillis`. To use these
 in a script, leave out the `get` prefix and continue with lowercasing the
-rest of the method nane. For example, the following returns every hockey 
+rest of the method name. For example, the following returns every hockey 
 player's birth year:
 
 [source,js]


### PR DESCRIPTION
I just tried to access the millis of a date field in painless and tried to use "getMillis" on the document value like `doc['event_date'].value.getMillis` because that is how I read the documentation. It turns out the way it works is `doc['event_date'].value.millis`. I might be missing something, but if not I think the docs are a bit misleading and could be corrected like suggested.