### PR TITLE
MINOR: Remove Dead Code in SearchScript

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/SearchScript.java
+++ b/server/src/main/java/org/elasticsearch/script/SearchScript.java
@@ -46,12 +46,6 @@ public abstract class SearchScript implements ScorerAware, ExecutableScript {
     /** The generic runtime parameters for the script. */
     private final Map<String, Object> params;
 
-    /** A lookup for the index this script will operate on. */
-    private final SearchLookup lookup;
-
-    /** A leaf lookup for the bound segment this script will operate on. */
-    private final LeafReaderContext leafContext;
-
     /** A leaf lookup for the bound segment this script will operate on. */
     private final LeafSearchLookup leafLookup;
 
@@ -60,8 +54,6 @@ public abstract class SearchScript implements ScorerAware, ExecutableScript {
 
     public SearchScript(Map<String, Object> params, SearchLookup lookup, LeafReaderContext leafContext) {
         this.params = params;
-        this.lookup = lookup;
-        this.leafContext = leafContext;
         // TODO: remove leniency when painless does not implement SearchScript for executable script cases
         this.leafLookup = leafContext == null ? null : lookup.getLeafSearchLookup(leafContext);
     }
@@ -74,11 +66,6 @@ public abstract class SearchScript implements ScorerAware, ExecutableScript {
     /** The leaf lookup for the Lucene segment this script was created for. */
     protected final LeafSearchLookup getLeafLookup() {
         return leafLookup;
-    }
-
-    /** The leaf context for the Lucene segment this script was created for. */
-    protected final LeafReaderContext getLeafContext() {
-        return leafContext;
     }
 
     /** The doc lookup for the Lucene segment this script was created for. */


### PR DESCRIPTION
* `lookup` is not used anywhere
* `getLeafContext` is not used anywhere
