### PR TITLE
Ensure empty queries are returned as invalid (#33095)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -1268,22 +1268,31 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertThat(unknownSettingError.getDetailedMessage(), containsString("unknown setting [index.this-setting-does-not-exist]"));
     }
 
-    public void testValidateQueryWithNullQuery() throws IOException {
+    public void testValidateWithNullQuery() throws IOException {
         testValidateQuery(null);
     }
 
-    public void testValidateQueryWithEmptyQuery() throws IOException {
+    public void testValidateWithEmptySimpleQueryStringQuery() throws IOException {
         testValidateQuery(new SimpleQueryStringBuilder(""));
     }
 
-    public void testValidateQueryWithBlankQuery() throws IOException {
+    public void testValidateQueryWithBlankSimpleStringQuery() throws IOException {
         testValidateQuery(new SimpleQueryStringBuilder(" "));
     }
 
-    private void testValidateQuery(QueryBuilder builder) throws IOException {
+    public void testValidateWithBoolQuery() throws IOException {
+        QueryBuilder builder = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.queryStringQuery("*:*"))
+            .filter(QueryBuilders.termQuery("user", "kimchy"));
+
+        testValidateQuery(builder);
+    }
+
+    private void testValidateQuery(QueryBuilder query) throws IOException {
         String index = "some_index";
         createIndex(index, Settings.EMPTY);
-        ValidateQueryRequest request = new ValidateQueryRequest(index).query(builder);
+        ValidateQueryRequest request = new ValidateQueryRequest(index).query(query);
         request.explain(randomBoolean());
         ValidateQueryResponse response = execute(request, highLevelClient().indices()::validateQuery,
             highLevelClient().indices()::validateQueryAsync);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -86,6 +86,7 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.SimpleQueryStringBuilder;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
@@ -1267,13 +1268,21 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertThat(unknownSettingError.getDetailedMessage(), containsString("unknown setting [index.this-setting-does-not-exist]"));
     }
 
-    public void testValidateQuery() throws IOException{
+    public void testValidateQueryWithNullQuery() throws IOException {
+        testValidateQuery(null);
+    }
+
+    public void testValidateQueryWithEmptyQuery() throws IOException {
+        testValidateQuery(new SimpleQueryStringBuilder(""));
+    }
+
+    public void testValidateQueryWithBlankQuery() throws IOException {
+        testValidateQuery(new SimpleQueryStringBuilder(" "));
+    }
+
+    private void testValidateQuery(QueryBuilder builder) throws IOException {
         String index = "some_index";
         createIndex(index, Settings.EMPTY);
-        QueryBuilder builder = QueryBuilders
-            .boolQuery()
-            .must(QueryBuilders.queryStringQuery("*:*"))
-            .filter(QueryBuilders.termQuery("user", "kimchy"));
         ValidateQueryRequest request = new ValidateQueryRequest(index).query(builder);
         request.explain(randomBoolean());
         ValidateQueryResponse response = execute(request, highLevelClient().indices()::validateQuery,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
@@ -33,6 +33,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * A request to validate a specific query.
@@ -41,7 +42,9 @@ import java.util.Arrays;
  */
 public class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest> implements ToXContentObject {
 
-    private QueryBuilder query = new MatchAllQueryBuilder();
+    private final MatchAllQueryBuilder defaultQuery = new MatchAllQueryBuilder();
+
+    private QueryBuilder query = defaultQuery;
 
     private boolean explain;
     private boolean rewrite;
@@ -81,7 +84,7 @@ public class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest>
     }
 
     public ValidateQueryRequest query(QueryBuilder query) {
-        this.query = query;
+        this.query = Optional.ofNullable(query).orElse(defaultQuery);
         return this;
     }
 


### PR DESCRIPTION
Null queries were causing an `ActionRequestValidationException`. To work around this issue, null queries are reset to a "match all" query which was already the default value.

Empty and whitespaces-only queries were already passing the test suite. Specific test cases have just been added to ensure that.