### PR TITLE
Enable not wiping cluster settings after REST test

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -237,6 +237,16 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     /**
+     * Controls whether or not to preserve cluster settings upon completion of the test. The default implementation is to remove all cluster
+     * settings.
+     *
+     * @return true if cluster settings should be preserved and otherwise false
+     */
+    protected boolean preserveClusterSettings() {
+        return false;
+    }
+
+    /**
      * Returns whether to preserve the repositories on completion of this test.
      * Defaults to not preserving repos. See also
      * {@link #preserveSnapshotsUponCompletion()}.
@@ -295,7 +305,11 @@ public abstract class ESRestTestCase extends ESTestCase {
         }
 
         wipeSnapshots();
-        wipeClusterSettings();
+
+        // wipe cluster settings
+        if (preserveClusterSettings() == false) {
+            wipeClusterSettings();
+        }
     }
 
     /**


### PR DESCRIPTION
In some cases we want to skip wiping cluster settings after a REST test. For example, one use-case would be in the full cluster restart tests where want to test cluster settings before and after a full cluster restart. If we wipe the cluster settings before the restart, then it would not be possible to assert on them after the restart.

