### PR TITLE
Improves doc values format deprecation message

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
@@ -153,10 +153,10 @@ setup:
       features: warnings
   - do:
       warnings:
-        - 'There are doc-value fields which are not using a format. The output will change in 7.0 when doc value fields get formatted based on mappings by default. It is recommended to pass [format=use_field_mapping] with a doc value field in order to opt in for the future behaviour and ease the migration to 7.0: [count, include.field1]'
+        - 'There are doc-value fields which are not using a format. The output will change in 7.0 when doc value fields get formatted based on mappings by default. It is recommended to pass [format=use_field_mapping] with a doc value field in order to opt in for the future behaviour and ease the migration to 7.0: [count, include.field1.keyword]'
       search:
         body:
-          docvalue_fields: [ "count", "include.field1" ]
+          docvalue_fields: [ "count", "include.field1.keyword" ]
   - match: { hits.hits.0.fields.count: [1] }
 
 ---

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
@@ -139,10 +139,24 @@ setup:
       features: warnings
   - do:
       warnings:
-        - 'Doc-value field [count] is not using a format. The output will change in 7.0 when doc value fields get formatted based on mappings by default. It is recommended to pass [format=use_field_mapping] with the doc value field in order to opt in for the future behaviour and ease the migration to 7.0.'
+        - 'There are doc-value field which are not using a format. The output will change in 7.0 when doc value fields get formatted based on mappings by default. It is recommended to pass [format=use_field_mapping] with a doc value field in order to opt in for the future behaviour and ease the migration to 7.0: [count]'
       search:
         body:
           docvalue_fields: [ "count" ]
+  - match: { hits.hits.0.fields.count: [1] }
+
+---
+"multiple docvalue_fields":
+  - skip:
+      version: " - 6.3.99"
+      reason: format option was added in 6.4
+      features: warnings
+  - do:
+      warnings:
+        - 'There are doc-value field which are not using a format. The output will change in 7.0 when doc value fields get formatted based on mappings by default. It is recommended to pass [format=use_field_mapping] with a doc value field in order to opt in for the future behaviour and ease the migration to 7.0: [count, include.field1]'
+      search:
+        body:
+          docvalue_fields: [ "count", "include.field1" ]
   - match: { hits.hits.0.fields.count: [1] }
 
 ---
@@ -153,7 +167,7 @@ setup:
       features: warnings
   - do:
       warnings:
-        - 'Doc-value field [count] is not using a format. The output will change in 7.0 when doc value fields get formatted based on mappings by default. It is recommended to pass [format=use_field_mapping] with the doc value field in order to opt in for the future behaviour and ease the migration to 7.0.'
+        - 'There are doc-value field which are not using a format. The output will change in 7.0 when doc value fields get formatted based on mappings by default. It is recommended to pass [format=use_field_mapping] with a doc value field in order to opt in for the future behaviour and ease the migration to 7.0: [count]'
       search:
         docvalue_fields: [ "count" ]
   - match: { hits.hits.0.fields.count: [1] }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
@@ -139,7 +139,7 @@ setup:
       features: warnings
   - do:
       warnings:
-        - 'There are doc-value field which are not using a format. The output will change in 7.0 when doc value fields get formatted based on mappings by default. It is recommended to pass [format=use_field_mapping] with a doc value field in order to opt in for the future behaviour and ease the migration to 7.0: [count]'
+        - 'There are doc-value fields which are not using a format. The output will change in 7.0 when doc value fields get formatted based on mappings by default. It is recommended to pass [format=use_field_mapping] with a doc value field in order to opt in for the future behaviour and ease the migration to 7.0: [count]'
       search:
         body:
           docvalue_fields: [ "count" ]
@@ -153,7 +153,7 @@ setup:
       features: warnings
   - do:
       warnings:
-        - 'There are doc-value field which are not using a format. The output will change in 7.0 when doc value fields get formatted based on mappings by default. It is recommended to pass [format=use_field_mapping] with a doc value field in order to opt in for the future behaviour and ease the migration to 7.0: [count, include.field1]'
+        - 'There are doc-value fields which are not using a format. The output will change in 7.0 when doc value fields get formatted based on mappings by default. It is recommended to pass [format=use_field_mapping] with a doc value field in order to opt in for the future behaviour and ease the migration to 7.0: [count, include.field1]'
       search:
         body:
           docvalue_fields: [ "count", "include.field1" ]
@@ -167,7 +167,7 @@ setup:
       features: warnings
   - do:
       warnings:
-        - 'There are doc-value field which are not using a format. The output will change in 7.0 when doc value fields get formatted based on mappings by default. It is recommended to pass [format=use_field_mapping] with a doc value field in order to opt in for the future behaviour and ease the migration to 7.0: [count]'
+        - 'There are doc-value fields which are not using a format. The output will change in 7.0 when doc value fields get formatted based on mappings by default. It is recommended to pass [format=use_field_mapping] with a doc value field in order to opt in for the future behaviour and ease the migration to 7.0: [count]'
       search:
         docvalue_fields: [ "count" ]
   - match: { hits.hits.0.fields.count: [1] }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/DocValueFieldsFetchSubPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/DocValueFieldsFetchSubPhase.java
@@ -161,7 +161,7 @@ public final class DocValueFieldsFetchSubPhase implements FetchSubPhase {
             DEPRECATION_LOGGER.deprecated("There are doc-value field which are not using a format. The output will "
                     + "change in 7.0 when doc value fields get formatted based on mappings by default. It is recommended to pass "
                     + "[format={}] with a doc value field in order to opt in for the future behaviour and ease the migration to "
-                    + "7.0: [{}]", DocValueFieldsContext.USE_DEFAULT_FORMAT, noFormatFields);
+                    + "7.0: {}", DocValueFieldsContext.USE_DEFAULT_FORMAT, noFormatFields);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/DocValueFieldsFetchSubPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/DocValueFieldsFetchSubPhase.java
@@ -81,7 +81,7 @@ public final class DocValueFieldsFetchSubPhase implements FetchSubPhase {
         List<String> noFormatFields = context.docValueFieldsContext().fields().stream().filter(f -> f.format == null).map(f -> f.field)
                 .collect(Collectors.toList());
         if (noFormatFields.isEmpty() == false) {
-            DEPRECATION_LOGGER.deprecated("There are doc-value field which are not using a format. The output will "
+            DEPRECATION_LOGGER.deprecated("There are doc-value fields which are not using a format. The output will "
                     + "change in 7.0 when doc value fields get formatted based on mappings by default. It is recommended to pass "
                     + "[format={}] with a doc value field in order to opt in for the future behaviour and ease the migration to "
                     + "7.0: {}", DocValueFieldsContext.USE_DEFAULT_FORMAT, noFormatFields);


### PR DESCRIPTION
This changes the deprecation message when doc values fields do not
supply a format form logging a deprecation warning for each offending
field individually to logging a single message which lists all
offending fields

Closes #33572