### PR TITLE
Fix Javadoc issues in 6.x for JDK11

### DIFF
--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AmazonS3Fixture.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AmazonS3Fixture.java
@@ -473,7 +473,7 @@ public class AmazonS3Fixture extends AbstractHttpFixture {
     }
 
     /**
-     * Retrieves the object name from all derives paths named {pathX} where 0 <= X < 10.
+     * Retrieves the object name from all derives paths named {pathX} where X is between 0 and 9 inclusive.
      *
      * This is the counterpart of {@link #objectsPaths(String)}
      */

--- a/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
@@ -976,7 +976,7 @@ public abstract class BaseXContentTestCase extends ESTestCase {
 
     /**
      * Test that the same map written multiple times do not trigger the self-reference check in
-     * {@link CollectionUtils#ensureNoSelfReferences(Object, String)} (Object)}
+     * {@link CollectionUtils#ensureNoSelfReferences(Object)} (Object)}
      */
     public void testRepeatedMapsAndNoSelfReferences() throws Exception {
         Map<String, Object> mapB = singletonMap("b", "B");

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
@@ -92,7 +92,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
     private final SeqNoFieldMapper.SequenceIDFields sequenceIDFields = SeqNoFieldMapper.SequenceIDFields.emptySeqID();
 
     /**
-     * For each provided field type, we also register an alias with name <field>-alias.
+     * For each provided field type, we also register an alias with name <code>field</code>-alias.
      */
     @Override
     protected Map<String, MappedFieldType> getFieldAliases(MappedFieldType... fieldTypes) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorTests.java
@@ -60,7 +60,7 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
     private static final String MAX_AGG_NAME = "maxAgg";
 
     /**
-     * For each provided field type, we also register an alias with name <field>-alias.
+     * For each provided field type, we also register an alias with name <code>field</code>-alias.
      */
     @Override
     protected Map<String, MappedFieldType> getFieldAliases(MappedFieldType... fieldTypes) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorTests.java
@@ -77,7 +77,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
     }
 
     /**
-     * For each provided field type, we also register an alias with name <field>-alias.
+     * For each provided field type, we also register an alias with name <code>field</code>-alias.
      */
     @Override
     protected Map<String, MappedFieldType> getFieldAliases(MappedFieldType... fieldTypes) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTextAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTextAggregatorTests.java
@@ -53,7 +53,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.signific
 public class SignificantTextAggregatorTests extends AggregatorTestCase {
 
     /**
-     * For each provided field type, we also register an alias with name <field>-alias.
+     * For each provided field type, we also register an alias with name <code>field</code>-alias.
      */
     @Override
     protected Map<String, MappedFieldType> getFieldAliases(MappedFieldType... fieldTypes) {

--- a/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/AbstractAdLdapRealmTestCase.java
+++ b/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/AbstractAdLdapRealmTestCase.java
@@ -318,8 +318,6 @@ public abstract class AbstractAdLdapRealmTestCase extends SecurityIntegTestCase 
 
     /**
      * Collects all the certificates that are normally trusted by the node ( contained in testnode.jks )
-     *
-     * @return
      */
     List<String> getNodeTrustedCertificates() {
         Path testnodeCert =


### PR DESCRIPTION
This commit fixes a handful of Javadoc issues in the 6.x branch that prevent a
successful build (of `precommit` and `assemble`) against JDK 11.
