### PR TITLE
[DOCS] Adds missing built-in user information

### DIFF
--- a/docs/reference/setup/install/windows.asciidoc
+++ b/docs/reference/setup/install/windows.asciidoc
@@ -295,8 +295,9 @@ as _properties_ within Windows Installer documentation) that can be passed to `m
 
 `SKIPSETTINGPASSWORDS`::
 
-  When installing with a `Trial` license and X-Pack Security enabled, whether the
-  installation should skip setting up the built-in users `elastic`, `kibana` and `logstash_system`.
+  When installing with a `Trial` license and {security} enabled, whether the
+  installation should skip setting up the built-in users `elastic`, `kibana`, 
+  `logstash_system`, `apm_system`, and `beats_system`.
   Defaults to `false`
 
 `ELASTICUSERPASSWORD`::


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/32515

This PR adds information about the beats_system and apm_system built-in users to https://www.elastic.co/guide/en/elasticsearch/reference/master/windows.html