### PR TITLE
[DOCS] Synchronize location of Breaking Changes

### DIFF
--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -29,8 +29,6 @@ include::setup/bootstrap-checks-xes.asciidoc[]
 :edit_url:
 include::upgrade.asciidoc[]
 
-include::migration/index.asciidoc[]
-
 include::api-conventions.asciidoc[]
 
 include::docs.asciidoc[]
@@ -75,6 +73,8 @@ include::testing.asciidoc[]
 include::glossary.asciidoc[]
 
 include::release-notes/highlights.asciidoc[]
+
+include::migration/index.asciidoc[]
 
 include::release-notes.asciidoc[]
 

--- a/docs/reference/migration/migrate_7_0.asciidoc
+++ b/docs/reference/migration/migrate_7_0.asciidoc
@@ -1,5 +1,8 @@
 [[breaking-changes-7.0]]
 == Breaking changes in 7.0
+++++
+<titleabbrev>7.0</titleabbrev>
+++++
 
 This section discusses the changes that you need to be aware of when migrating
 your application to Elasticsearch 7.0.

--- a/docs/reference/migration/migrate_7_0.asciidoc
+++ b/docs/reference/migration/migrate_7_0.asciidoc
@@ -6,25 +6,6 @@ your application to Elasticsearch 7.0.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
-[float]
-=== Indices created before 7.0
-
-Elasticsearch 7.0 can read indices created in version 6.0 or above.  An
-Elasticsearch 7.0 node will not start in the presence of indices created in a
-version of Elasticsearch before 6.0.
-
-[IMPORTANT]
-.Reindex indices from Elasticsearch 5.x or before
-=========================================
-
-Indices created in Elasticsearch 5.x or before will need to be reindexed with
-Elasticsearch 6.x in order to be readable by Elasticsearch 7.x.
-
-=========================================
-
-[float]
-=== Also see:
-
 * <<breaking_70_aggregations_changes>>
 * <<breaking_70_cluster_changes>>
 * <<breaking_70_indices_changes>>
@@ -40,6 +21,22 @@ Elasticsearch 6.x in order to be readable by Elasticsearch 7.x.
 * <<breaking_70_snapshotstats_changes>>
 * <<breaking_70_restclient_changes>>
 * <<breaking_70_low_level_restclient_changes>>
+
+[float]
+=== Indices created before 7.0
+
+Elasticsearch 7.0 can read indices created in version 6.0 or above.  An
+Elasticsearch 7.0 node will not start in the presence of indices created in a
+version of Elasticsearch before 6.0.
+
+[IMPORTANT]
+.Reindex indices from Elasticsearch 5.x or before
+=========================================
+
+Indices created in Elasticsearch 5.x or before will need to be reindexed with
+Elasticsearch 6.x in order to be readable by Elasticsearch 7.x.
+
+=========================================
 
 include::migrate_7_0/aggregations.asciidoc[]
 include::migrate_7_0/analysis.asciidoc[]

--- a/docs/reference/migration/migrate_7_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_7_0/aggregations.asciidoc
@@ -1,21 +1,26 @@
+[float]
 [[breaking_70_aggregations_changes]]
 === Aggregations changes
 
+[float]
 ==== Deprecated `global_ordinals_hash` and `global_ordinals_low_cardinality` execution hints for terms aggregations have been removed
 
 These `execution_hint` are removed and should be replaced by `global_ordinals`.
 
+[float]
 ==== `search.max_buckets` in the cluster setting
 
 The dynamic cluster setting named `search.max_buckets` now defaults
 to 10,000 (instead of unlimited in the previous version).
 Requests that try to return more than the limit will fail with an exception.
 
+[float]
 ==== `missing` option of the `composite` aggregation has been removed
 
 The `missing` option of the `composite` aggregation, deprecated in 6.x,
 has been removed. `missing_bucket` should be used instead.
 
+[float]
 ==== Replaced `params._agg` with `state` context variable in scripted metric aggregations
 
 The object used to share aggregation state between the scripts in a Scripted Metric

--- a/docs/reference/migration/migrate_7_0/analysis.asciidoc
+++ b/docs/reference/migration/migrate_7_0/analysis.asciidoc
@@ -1,12 +1,15 @@
+[float]
 [[breaking_70_analysis_changes]]
 === Analysis changes
 
+[float]
 ==== Limiting the number of tokens produced by _analyze
 
 To safeguard against out of memory errors, the number of tokens that can be produced
 using the `_analyze` endpoint has been limited to 10000. This default limit can be changed
 for a particular index with the index setting `index.analyze.max_token_count`.
 
+[float]
 ==== Limiting the length of an analyzed text during highlighting
 
 Highlighting a text that was indexed without offsets or term vectors,
@@ -16,6 +19,7 @@ To protect against this, the maximum number of characters that will be analyzed 
 limited to 1000000. This default limit can be changed
 for a particular index with the index setting `index.highlight.max_analyzed_offset`.
 
+[float]
 ==== `delimited_payload_filter` renaming
 
 The `delimited_payload_filter` was deprecated and renamed to `delimited_payload` in 6.2.
@@ -23,6 +27,7 @@ Using it in indices created before 7.0 will issue deprecation warnings. Using th
 name in new indices created in 7.0 will throw an error. Use the new name `delimited_payload`
 instead.
 
+[float]
 ==== `standard` filter has been removed
 
 The `standard` token filter has been removed because it doesn't change anything in the stream.

--- a/docs/reference/migration/migrate_7_0/api.asciidoc
+++ b/docs/reference/migration/migrate_7_0/api.asciidoc
@@ -96,6 +96,7 @@ depending on whether {security} is enabled. Previously a
 current user was not authorized for any alias. An empty response with
 status 200 - OK is now returned instead at all times.
 
+[float]
 ==== Put User API response no longer has `user` object
 
 The Put User API response was changed in 6.5.0 to add the `created` field

--- a/docs/reference/migration/migrate_7_0/api.asciidoc
+++ b/docs/reference/migration/migrate_7_0/api.asciidoc
@@ -1,6 +1,8 @@
+[float]
 [[breaking_70_api_changes]]
 === API changes
 
+[float]
 ==== Camel case and underscore parameters deprecated in 6.x have been removed
 A number of duplicate parameters deprecated in 6.x have been removed from
 Bulk request, Multi Get request, Term Vectors request, and More Like This Query
@@ -22,6 +24,7 @@ The following parameters starting with underscore have been removed:
 Instead of these removed parameters, use their non camel case equivalents without
 starting underscore, e.g. use `version_type` instead of `_version_type` or `versionType`.
 
+[float]
 ==== Thread pool info
 
 In previous versions of Elasticsearch, the thread pool info returned in the
@@ -48,10 +51,12 @@ aligns the output of the API with the configuration values for thread
 pools. Note that `core` and `max` will be populated for scaling thread pools,
 and `size` will be populated for fixed thread pools.
 
+[float]
 ==== The parameter `fields` deprecated in 6.x has been removed from Bulk request 
 and Update request. The Update API returns `400 - Bad request` if request contains 
 unknown parameters (instead of ignored in the previous version).
 
+[float]
 [[remove-suggest-metric]]
 ==== Remove support for `suggest` metric/index metric in indices stats and nodes stats APIs
 
@@ -66,6 +71,7 @@ In the past, `fields` could be provided either as a parameter, or as part of the
 body. Specifying `fields` in the request body as opposed to a parameter was deprecated
 in 6.4.0, and is now unsupported in 7.0.0.
 
+[float]
 ==== `copy_settings` is deprecated on shrink and split APIs
 
 Versions of Elasticsearch prior to 6.4.0 did not copy index settings on shrink
@@ -76,10 +82,12 @@ will be for such settings to be copied on such operations. To enable users in
 the only behavior in 8.0.0, this parameter is deprecated in 7.0.0 for removal in
 8.0.0.
 
+[float]
 ==== The deprecated stored script contexts have now been removed
 When putting stored scripts, support for storing them with the deprecated `template` context or without a context is
 now removed. Scripts must be stored using the `script` context as mentioned in the documentation.
 
+[float]
 ==== Get Aliases API limitations when {security} is enabled removed
 
 The behavior and response codes of the get aliases API no longer vary

--- a/docs/reference/migration/migrate_7_0/cluster.asciidoc
+++ b/docs/reference/migration/migrate_7_0/cluster.asciidoc
@@ -1,16 +1,20 @@
+[float]
 [[breaking_70_cluster_changes]]
 === Cluster changes
 
+[float]
 ==== `:` is no longer allowed in cluster name
 
 Due to cross-cluster search using `:` to separate a cluster and index name,
 cluster names may no longer contain `:`.
 
+[float]
 ==== New default for `wait_for_active_shards` parameter of the open index command
 
 The default value for the `wait_for_active_shards` parameter of the open index API
 is changed from 0 to 1, which means that the command will now by default wait for all
 primary shards of the opened index to be allocated.
 
+[float]
 ==== Shard preferences `_primary`, `_primary_first`, `_replica`, and `_replica_first` are removed
 These shard preferences are removed in favour of the `_prefer_nodes` and `_only_nodes` preferences.

--- a/docs/reference/migration/migrate_7_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_7_0/indices.asciidoc
@@ -1,17 +1,20 @@
+[float]
 [[breaking_70_indices_changes]]
 === Indices changes
 
+[float]
 ==== `:` is no longer allowed in index name
 
 Due to cross-cluster search using `:` to separate a cluster and index name,
 index names may no longer contain `:`.
 
+[float]
 ==== `index.unassigned.node_left.delayed_timeout` may no longer be negative
 
 Negative values were interpreted as zero in earlier versions but are no
 longer accepted.
 
-
+[float]
 ==== `_flush` and `_force_merge` will no longer refresh
 
 In previous versions issuing a `_flush` or `_force_merge` (with `flush=true`)
@@ -20,7 +23,7 @@ visible to searches and non-realtime GET operations. From now on these operation
 don't have this side-effect anymore. To make documents visible an explicit `_refresh`
 call is needed unless the index is refreshed by the internal scheduler.
 
-
+[float]
 ==== Limit to the difference between max_size and min_size in NGramTokenFilter and NGramTokenizer
 
 To safeguard against creating too many index terms, the difference between `max_ngram` and
@@ -29,7 +32,7 @@ limit can be changed with the index setting `index.max_ngram_diff`. Note that if
 exceeded a error is thrown only for new indices. For existing pre-7.0 indices, a deprecation
 warning is logged.
 
-
+[float]
 ==== Limit to the difference between max_size and min_size in ShingleTokenFilter
 
 To safeguard against creating too many tokens, the difference between `max_shingle_size` and
@@ -38,6 +41,7 @@ limit can be changed with the index setting `index.max_shingle_diff`. Note that 
 exceeded a error is thrown only for new indices. For existing pre-7.0 indices, a deprecation
 warning is logged.
 
+[float]
 ==== Document distribution changes
 
 Indices created with version `7.0.0` onwards will have an automatic `index.number_of_routing_shards`
@@ -46,6 +50,7 @@ shards the index has. In order to maintain the exact same distribution as a pre 
 `index.number_of_routing_shards` must be set to the `index.number_of_shards` at index creation time.
 Note: if the number of routing shards equals the number of shards `_split` operations are not supported.
 
+[float]
 ==== Skipped background refresh on search idle shards
 
 Shards belonging to an index that does not have an explicit
@@ -56,6 +61,7 @@ that access a search idle shard will be "parked" until the next refresh
 happens.  Indexing requests with `wait_for_refresh` will also trigger
 a background refresh.
 
+[float]
 ==== Remove deprecated url parameters for Clear Indices Cache API
 
 The following previously deprecated url parameter have been removed:
@@ -65,12 +71,14 @@ The following previously deprecated url parameter have been removed:
 * `request_cache` - use `request` instead
 * `field_data` - use `fielddata` instead
 
+[float]
 ==== `network.breaker.inflight_requests.overhead` increased to 2
 
 Previously the in flight requests circuit breaker considered only the raw byte representation.
 By bumping the value of `network.breaker.inflight_requests.overhead` from 1 to 2, this circuit
 breaker considers now also the memory overhead of representing the request as a structured object.
 
+[float]
 ==== Parent circuit breaker changes
 
 The parent circuit breaker defines a new setting `indices.breaker.total.use_real_memory` which is
@@ -79,6 +87,7 @@ heap memory instead of only considering the reserved memory by child circuit bre
 setting is `true`, the default parent breaker limit also changes from 70% to 95% of the JVM heap size.
 The previous behavior can be restored by setting `indices.breaker.total.use_real_memory` to `false`.
 
+[float]
 ==== `fix` value for `index.shard.check_on_startup` is removed
 
 Deprecated option value `fix` for setting `index.shard.check_on_startup` is not supported.

--- a/docs/reference/migration/migrate_7_0/java.asciidoc
+++ b/docs/reference/migration/migrate_7_0/java.asciidoc
@@ -22,6 +22,7 @@ appropriate request directly.
 * All classes present in `org.elasticsearch.search.aggregations.metrics.*` packages
 were moved to a single `org.elasticsearch.search.aggregations.metrics` package.
 
+[float]
 ==== `Retry.withBackoff` methods with `Settings` removed
 
 The variants of `Retry.withBackoff` that included `Settings` have been removed

--- a/docs/reference/migration/migrate_7_0/java.asciidoc
+++ b/docs/reference/migration/migrate_7_0/java.asciidoc
@@ -1,18 +1,22 @@
+[float]
 [[breaking_70_java_changes]]
 === Java API changes
 
+[float]
 ==== `isShardsAcked` deprecated in `6.2` has been removed
 
 `isShardsAcked` has been replaced by `isShardsAcknowledged` in
 `CreateIndexResponse`, `RolloverResponse` and
 `CreateIndexClusterStateUpdateResponse`.
 
+[float]
 ==== `prepareExecute` removed from the client api
 
 The `prepareExecute` method which created a request builder has been
 removed from the client api. Instead, construct a builder for the
 appropriate request directly.
 
+[float]
 ==== Some Aggregation classes have moved packages
 
 * All classes present in `org.elasticsearch.search.aggregations.metrics.*` packages

--- a/docs/reference/migration/migrate_7_0/low_level_restclient.asciidoc
+++ b/docs/reference/migration/migrate_7_0/low_level_restclient.asciidoc
@@ -1,6 +1,8 @@
+[float]
 [[breaking_70_low_level_restclient_changes]]
 === Low-level REST client changes
 
+[float]
 ==== Deprecated flavors of performRequest have been removed
 
 We deprecated the flavors of `performRequest` and `performRequestAsync` that
@@ -8,6 +10,7 @@ do not take `Request` objects in 6.4.0 in favor of the flavors that take
 `Request` objects because those methods can be extended without breaking
 backwards compatibility.
 
+[float]
 ==== Removed setHosts
 
 We deprecated `setHosts` in 6.4.0 in favor of `setNodes` because it supports

--- a/docs/reference/migration/migrate_7_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/mappings.asciidoc
@@ -1,36 +1,44 @@
+[float]
 [[breaking_70_mappings_changes]]
 === Mapping changes
 
+[float]
 ==== The `_all` meta field is removed
 
 The `_all` field deprecated in 6 have now been removed.
 
+[float]
 ==== The `_uid` meta field is removed
 
 This field used to index a composite key formed of the `_type` and the `_id`.
 Now that indices cannot have multiple types, this has been removed in favour
 of `_id`.
 
+[float]
 ==== The `_default_` mapping is no longer allowed
 
 The `_default_` mapping has been deprecated in 6.0 and is now no longer allowed
 in 7.0. Trying to configure a `_default_` mapping on 7.x indices will result in
 an error.
 
+[float]
 ==== `index_options` for numeric fields has been removed
 
 The `index_options` field for numeric  fields has been deprecated in 6 and has now been removed.
 
+[float]
 ==== Limiting the number of `nested` json objects
 
 To safeguard against out of memory errors, the number of nested json objects within a single
 document across all fields has been limited to 10000. This default limit can be changed with
 the index setting `index.mapping.nested_objects.limit`.
 
+[float]
 ==== The `update_all_types` option has been removed
 
 This option is useless now that all indices have at most one type.
 
+[float]
 ==== The `classic` similarity has been removed
 
 The `classic` similarity relied on coordination factors for scoring to be good
@@ -39,6 +47,7 @@ Lucene, which means that the `classic` similarity now produces scores of lower
 quality. It is advised to switch to `BM25` instead, which is widely accepted
 as a better alternative.
 
+[float]
 ==== Similarities fail when unsupported options are provided
 
 An error will now be thrown when unknown configuration options are provided

--- a/docs/reference/migration/migrate_7_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_7_0/packaging.asciidoc
@@ -1,6 +1,8 @@
+[float]
 [[breaking_70_packaging_changes]]
 === Packaging changes
 
+[float]
 [[systemd-service-file-config]]
 ==== systemd service file is no longer configuration
 
@@ -9,6 +11,7 @@ was previously marked as a configuration file in rpm and deb packages.
 Overrides to the systemd elasticsearch service should be made
 in `/etc/systemd/system/elasticsearch.service.d/override.conf`.
 
+[float]
 ==== tar package no longer includes windows specific files
 
 The tar package previously included files in the `bin` directory meant only

--- a/docs/reference/migration/migrate_7_0/plugins.asciidoc
+++ b/docs/reference/migration/migrate_7_0/plugins.asciidoc
@@ -1,6 +1,8 @@
+[float]
 [[breaking_70_plugins_changes]]
 === Plugins changes
 
+[float]
 ==== Azure Repository plugin
 
 * The legacy azure settings which where starting with `cloud.azure.storage.` prefix have been removed.
@@ -12,6 +14,7 @@ You must set it per azure client instead. Like `azure.client.default.timeout: 10
 
 See {plugins}/repository-azure-repository-settings.html#repository-azure-repository-settings[Azure Repository settings].
 
+[float]
 ==== Google Cloud Storage Repository plugin
 
 * The repository settings `application_name`, `connect_timeout` and `read_timeout` have been removed and
@@ -19,6 +22,7 @@ must now be specified in the client settings instead.
 
 See {plugins}/repository-gcs-client.html#repository-gcs-client[Google Cloud Storage Client Settings].
 
+[float]
 ==== Analysis Plugin changes
 
 * The misspelled helper method `requriesAnalysisSettings(AnalyzerProvider<T> provider)` has been

--- a/docs/reference/migration/migrate_7_0/plugins.asciidoc
+++ b/docs/reference/migration/migrate_7_0/plugins.asciidoc
@@ -28,6 +28,7 @@ See {plugins}/repository-gcs-client.html#repository-gcs-client[Google Cloud Stor
 * The misspelled helper method `requriesAnalysisSettings(AnalyzerProvider<T> provider)` has been
 renamed to `requiresAnalysisSettings`
 
+[float]
 ==== File-based discovery plugin
 
 * This plugin has been removed since its functionality is now part of

--- a/docs/reference/migration/migrate_7_0/restclient.asciidoc
+++ b/docs/reference/migration/migrate_7_0/restclient.asciidoc
@@ -1,6 +1,8 @@
+[float]
 [[breaking_70_restclient_changes]]
 === High-level REST client changes
 
+[float]
 ==== API methods accepting `Header` argument have been removed
 
 All API methods accepting headers as a `Header` varargs argument, deprecated
@@ -12,6 +14,7 @@ In case you are specifying headers
 e.g. `client.index(indexRequest, new Header("name" "value"))` becomes
 `client.index(indexRequest, RequestOptions.DEFAULT.toBuilder().addHeader("name", "value").build());`
 
+[float]
 ==== Cluster Health API default to `cluster` level
 
 The Cluster Health API used to default to `shards` level to ease migration

--- a/docs/reference/migration/migrate_7_0/scripting.asciidoc
+++ b/docs/reference/migration/migrate_7_0/scripting.asciidoc
@@ -1,6 +1,8 @@
+[float]
 [[breaking_70_scripting_changes]]
 === Scripting changes
 
+[float]
 ==== getDate() and getDates() removed
 
 Fields of type `long` and `date` had `getDate()` and `getDates()` methods
@@ -12,6 +14,7 @@ now been removed. Instead, use `.value` on `date` fields, or explicitly
 parse `long` fields into a date object using
 `Instance.ofEpochMillis(doc["myfield"].value)`.
 
+[float]
 ==== Script errors will return as `400` error codes
 
 Malformed scripts, either in search templates, ingest pipelines or search 

--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -1,6 +1,8 @@
+[float]
 [[breaking_70_search_changes]]
 === Search and Query DSL changes
 
+[float]
 ==== Changes to queries
 *   The default value for `transpositions` parameter of `fuzzy` query
     has been changed to `true`.
@@ -18,6 +20,7 @@
 *   Attempts to generate multi-term phrase queries against non-text fields
     with a custom analyzer will now throw an exception
 
+[float]
 ==== Adaptive replica selection enabled by default
 
 Adaptive replica selection has been enabled by default. If you wish to return to
@@ -35,6 +38,7 @@ PUT /_cluster/settings
 --------------------------------------------------
 // CONSOLE
 
+[float]
 ==== Search API returns `400` for invalid requests
 
 The Search API returns `400 - Bad request` while it would previously return
@@ -48,12 +52,14 @@ The Search API returns `400 - Bad request` while it would previously return
 *   number of filters in the adjacency matrix aggregation is too large
 *   script compilation errors
 
+[float]
 ==== Scroll queries cannot use the `request_cache` anymore
 
 Setting `request_cache:true` on a query that creates a scroll (`scroll=1m`)
 has been deprecated in 6 and will now return a `400 - Bad request`.
 Scroll queries are not meant to be cached.
 
+[float]
 ==== Scroll queries cannot use `rescore`  anymore
 Including a rescore clause on a query that creates a scroll (`scroll=1m`) has
 been deprecated in 6.5 and will now return a `400 - Bad request`.  Allowing
@@ -61,6 +67,7 @@ rescore on scroll queries would break the scroll sort.  In the 6.x line, the
 rescore clause was silently ignored (for scroll queries), and it was allowed in
 the 5.x line.
 
+[float]
 ==== Term Suggesters supported distance algorithms
 
 The following string distance algorithms were given additional names in 6.2 and
@@ -70,7 +77,7 @@ removed.
 * 	`levenstein` - replaced by `levenshtein`
 * 	`jarowinkler` - replaced by `jaro_winkler`
 
-
+[float]
 ==== Limiting the number of terms that can be used in a Terms Query request
 
 Executing a Terms Query with a lot of terms may degrade the cluster performance,
@@ -79,7 +86,7 @@ To safeguard against this, the maximum number of terms that can be used in a
 Terms Query request has been limited to 65536. This default maximum can be changed
 for a particular index with the index setting `index.max_terms_count`.
 
-
+[float]
 ==== Limiting the length of regex that can be used in a Regexp Query request
 
 Executing a Regexp Query with a long regex string may degrade search performance.
@@ -87,11 +94,13 @@ To safeguard against this, the maximum length of regex that can be used in a
 Regexp Query request has been limited to 1000. This default maximum can be changed
 for a particular index with the index setting `index.max_regex_length`.
 
+[float]
 ==== Invalid `_search` request body
 
 Search requests with extra content after the main object will no longer be accepted
 by the `_search` endpoint. A parsing exception will be thrown instead.
 
+[float]
 ==== Context Completion Suggester
 
 The ability to query and index context enabled suggestions without context,
@@ -102,12 +111,14 @@ considerably.
 For geo context the value of the `path` parameter is now validated against the mapping,
 and the context is only accepted if `path` points to a field with `geo_point` type.
 
+[float]
 ==== Semantics changed for `max_concurrent_shard_requests`
 
 `max_concurrent_shard_requests` used to limit the total number of concurrent shard
 requests a single high level search request can execute. In 7.0 this changed to be the
 max number of concurrent shard requests per node. The default is now `5`.
 
+[float]
 ==== `max_score` set to `null` when scores are not tracked
 
 `max_score` used to be set to `0` whenever scores are not tracked. `null` is now used

--- a/docs/reference/migration/migrate_7_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/settings.asciidoc
@@ -53,6 +53,7 @@ This setting has been removed, as disabling http pipelining support on the serve
 provided little value. The setting `http.pipelining.max_events` can still be used to
 limit the number of pipelined requests in-flight.
 
+[float]
 ==== Cross-cluster search settings renamed
 
 The cross-cluster search remote cluster connection infrastructure is also used

--- a/docs/reference/migration/migrate_7_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/settings.asciidoc
@@ -1,18 +1,21 @@
+[float]
 [[breaking_70_settings_changes]]
-
 === Settings changes
 
+[float]
 ==== The default for `node.name` is now the hostname
 
 `node.name` now defaults to the hostname at the time when Elasticsearch
 is started. Previously the default node name was the first eight characters
 of the node id. It can still be configured explicitly in `elasticsearch.yml`.
 
+[float]
 ==== Percolator
 
 * The deprecated `index.percolator.map_unmapped_fields_as_string` setting has been removed in favour of
   the `index.percolator.map_unmapped_fields_as_text` setting.
 
+[float]
 ==== Index thread pool
 
 * Internally, single-document index/delete/update requests are executed as bulk
@@ -21,6 +24,7 @@ of the node id. It can still be configured explicitly in `elasticsearch.yml`.
   longer needed and has been removed. As such, the  settings
   `thread_pool.index.size` and `thread_pool.index.queue_size` have been removed.
 
+[float]
 [[write-thread-pool-fallback]]
 ==== Write thread pool fallback
 
@@ -32,6 +36,7 @@ of the node id. It can still be configured explicitly in `elasticsearch.yml`.
   available to keep the display output in APIs as `bulk` instead of `write`.
   These fallback settings and this system property have been removed.
 
+[float]
 [[remove-http-enabled]]
 ==== Http enabled setting removed
 
@@ -39,6 +44,7 @@ of the node id. It can still be configured explicitly in `elasticsearch.yml`.
 use of the transport client. This setting has been removed, as the transport client
 will be removed in the future, thus requiring HTTP to always be enabled.
 
+[float]
 [[remove-http-pipelining-setting]]
 ==== Http pipelining setting removed
 

--- a/docs/reference/migration/migrate_7_0/snapshotstats.asciidoc
+++ b/docs/reference/migration/migrate_7_0/snapshotstats.asciidoc
@@ -1,3 +1,4 @@
+[float]
 [[breaking_70_snapshotstats_changes]]
 === Snapshot stats changes
 
@@ -7,6 +8,7 @@ Snapshot stats details are provided in a new structured way:
 * `incremental` section for those files that actually needed to be copied over as part of the incremental snapshotting.
 * In case of a snapshot that's still in progress, there's also a `processed` section for files that are in the process of being copied.
 
+[float]
 ==== Deprecated `number_of_files`, `processed_files`, `total_size_in_bytes` and `processed_size_in_bytes` snapshot stats properties have been removed
 
 * Properties `number_of_files` and `total_size_in_bytes` are removed and should be replaced by values of nested object `total`.


### PR DESCRIPTION
Related to https://github.com/elastic/docs/issues/382

This PR moves the "Breaking Changes" section nearer the "Release Notes" section, to synchronize the location of this information across the library.

It also merges all of the 7.0 breaking change pages into a single page. 