### PR TITLE
Preserve cluster settings on full restart tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/upgrades/AbstractFullClusterRestartTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/upgrades/AbstractFullClusterRestartTestCase.java
@@ -57,4 +57,9 @@ public abstract class AbstractFullClusterRestartTestCase extends ESRestTestCase 
         return true;
     }
 
+    @Override
+    protected boolean preserveClusterSettings() {
+        return true;
+    }
+
 }


### PR DESCRIPTION
Today the full cluster restart tests do not preserve cluster settings on restart. This is a mistake because it is not an accurate reflection of reality, we do not expect users to clear cluster settings when they perform a full cluster restart. This commit makes it so that all full cluster restart tests preserve settings on upgrade.

Relates #33537, relates #33575, relates #33577 