### PR TITLE
Use the global doc id to generate random scores

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/search/function/RandomScoreFunction.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/function/RandomScoreFunction.java
@@ -70,7 +70,7 @@ public class RandomScoreFunction extends ScoreFunction {
             public double score(int docId, float subQueryScore) throws IOException {
                 int hash;
                 if (values == null) {
-                    hash = BitMixer.mix(docId, saltedSeed);
+                    hash = BitMixer.mix(ctx.docBase + docId, saltedSeed);
                 } else if (values.advanceExact(docId)) {
                     hash = StringHelper.murmurhash3_x86_32(values.nextValue(), saltedSeed);
                 } else {


### PR DESCRIPTION
This commit changes the random_score function to use the global docID of the document
rather than the segment docID to generate random scores. As a result documents that have
the same segment docID within the shard will generate different scores.