### PR TITLE
[DOCS] Synchronizes captialization in top-level titles

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -1,5 +1,5 @@
 [[api-conventions]]
-= API Conventions
+= API conventions
 
 [partintro]
 --

--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -1,5 +1,5 @@
 [[getting-started]]
-= Getting Started
+= Getting started
 
 [partintro]
 --

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -1,6 +1,6 @@
 
 [[index-modules]]
-= Index Modules
+= Index modules
 
 [partintro]
 --

--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -1,5 +1,5 @@
 [[ingest]]
-= Ingest Node
+= Ingest node
 
 [partintro]
 --

--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -1,5 +1,5 @@
 [[es-release-notes]]
-= Release Notes
+= Release notes
 
 [partintro]
 --

--- a/docs/reference/release-notes/7.0.0-alpha1.asciidoc
+++ b/docs/reference/release-notes/7.0.0-alpha1.asciidoc
@@ -1,5 +1,5 @@
 [[release-notes-7.0.0-alpha1]]
-== 7.0.0-alpha1 Release Notes
+== 7.0.0-alpha1 release notes
 
 The changes listed below have been released for the first time in Elasticsearch 7.0.0-alpha1.
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -1,7 +1,7 @@
 [[release-highlights]]
-= {es} Release Highlights
+= {es} Release highlights
 ++++
-<titleabbrev>Release Highlights</titleabbrev>
+<titleabbrev>Release highlights</titleabbrev>
 ++++
 
 [partintro]

--- a/docs/reference/sql/appendix/syntax-reserved.asciidoc
+++ b/docs/reference/sql/appendix/syntax-reserved.asciidoc
@@ -2,7 +2,7 @@
 [testenv="basic"]
 [appendix]
 [[sql-syntax-reserved]]
-= Reserved Keywords
+= Reserved keywords
 
 Table with reserved keywords that need to be quoted. Also provide an example to make it more obvious.
 

--- a/docs/reference/sql/index.asciidoc
+++ b/docs/reference/sql/index.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="basic"]
 [[xpack-sql]]
-= SQL Access
+= SQL access
 
 :sql-tests: {xes-repo-dir}/../../qa/sql
 :sql-specs: {sql-tests}/src/main/resources

--- a/x-pack/docs/en/watcher/index.asciidoc
+++ b/x-pack/docs/en/watcher/index.asciidoc
@@ -1,5 +1,5 @@
 [[xpack-alerting]]
-= Alerting on Cluster and Index Events
+= Alerting on cluster and index events
 
 [partintro]
 --


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/33588#issuecomment-420086577, I've updated the top-level titles to sentence case for use in the Stack Overview and the Elasticsearch Reference. 