### PR TITLE
Remove debug logging in full cluster restart tests

### DIFF
--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -53,9 +53,6 @@ for (Version version : bwcVersions.indexCompatible) {
     // some tests rely on the translog not being flushed
     setting 'indices.memory.shard_inactive_time', '20m'
 
-    // debug logging for testRecovery
-    setting 'logger.level', 'DEBUG'
-
     if (version.onOrAfter('5.3.0')) {
       setting 'http.content_type.required', 'true'
     }

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -75,9 +75,6 @@ for (Version version : bwcVersions.indexCompatible) {
     // some tests rely on the translog not being flushed
     setting 'indices.memory.shard_inactive_time', '20m'
 
-    // debug logging for testRecovery
-    setting 'logger.level', 'DEBUG'
-
     numNodes = 2
     dataDir = { nodeNum -> oldClusterTest.nodes[nodeNum].dataDir }
     cleanShared = false // We want to keep snapshots made by the old cluster!

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -155,9 +155,6 @@ subprojects {
       // some tests rely on the translog not being flushed
       setting 'indices.memory.shard_inactive_time', '20m'
 
-      // debug logging for testRecovery see https://github.com/elastic/x-pack-elasticsearch/issues/2691
-      setting 'logger.level', 'DEBUG'
-
       setting 'xpack.security.enabled', 'true'
       setting 'xpack.security.transport.ssl.enabled', 'true'
       setting 'xpack.ssl.keystore.path', 'testnode.jks'
@@ -200,9 +197,6 @@ subprojects {
       cleanShared = false // We want to keep snapshots made by the old cluster!
       setupCommand 'setupTestUser', 'bin/elasticsearch-users', 'useradd', 'test_user', '-p', 'x-pack-test-password', '-r', 'superuser'
       waitCondition = waitWithAuth
-
-      // debug logging for testRecovery see https://github.com/elastic/x-pack-elasticsearch/issues/2691
-      setting 'logger.level', 'DEBUG'
 
       // some tests rely on the translog not being flushed
       setting 'indices.memory.shard_inactive_time', '20m'


### PR DESCRIPTION
These logs are incredibly verbose, and it makes chasing normal failures burdensome. This commit removes the debug logging, which can be reenabled again if needed.
