### PR TITLE
Add index status to cluster state API response (under metadata metric)

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStateAction.java
@@ -81,7 +81,8 @@ public class RestClusterStateAction extends BaseRestHandler {
             /*
              * there is no distinction in Java api between routing_table and routing_nodes, it's the same info set over the wire, one single
              * flag to ask for it.
-             * We ask for the routing table if metadata is requested because metadata includes index status, which requires the routing table.
+             * We ask for the routing table if metadata is requested because metadata includes index status, which requires the routing
+             * table.
              */
             clusterStateRequest.routingTable(
                     metrics.contains(ClusterState.Metric.ROUTING_TABLE) || metrics.contains(ClusterState.Metric.ROUTING_NODES)

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStateAction.java
@@ -80,10 +80,12 @@ public class RestClusterStateAction extends BaseRestHandler {
             clusterStateRequest.nodes(metrics.contains(ClusterState.Metric.NODES) || metrics.contains(ClusterState.Metric.MASTER_NODE));
             /*
              * there is no distinction in Java api between routing_table and routing_nodes, it's the same info set over the wire, one single
-             * flag to ask for it
+             * flag to ask for it.
+             * We ask for the routing table if metadata is requested because metadata includes index status, which requires the routing table.
              */
             clusterStateRequest.routingTable(
-                    metrics.contains(ClusterState.Metric.ROUTING_TABLE) || metrics.contains(ClusterState.Metric.ROUTING_NODES));
+                    metrics.contains(ClusterState.Metric.ROUTING_TABLE) || metrics.contains(ClusterState.Metric.ROUTING_NODES)
+                    || metrics.contains(ClusterState.Metric.METADATA));
             clusterStateRequest.metaData(metrics.contains(ClusterState.Metric.METADATA));
             clusterStateRequest.blocks(metrics.contains(ClusterState.Metric.BLOCKS));
             clusterStateRequest.customs(metrics.contains(ClusterState.Metric.CUSTOMS));


### PR DESCRIPTION
Currently, Elasticsearch Monitoring (the X-Pack feature) happens as a result of a handful of collectors running inside Elasticsearch. One such collector is the [IndexStatsCollector](https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollector.java) which collects metrics about each index in the cluster. One of the metrics it collects is the [index status](https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDoc.java#L70): green, yellow, or red.

Longer term we want to externalize this collection process to an agent like Metricbeat, which could call Elasticsearch REST APIs to perform the collection. When building the equivalent of the [IndexStatsCollector in Metricbeat](https://github.com/elastic/beats/pull/8260), we ran into an issue with collecting the index status. Metricbeat calls the Cluster State REST API, which currently does not report index status. This means Metricbeat would have to compute the index status by inspecting the shards under the `routing_table` metric in the Cluster State REST API response, by doing something like this:

https://github.com/ycombinator/beats/blob/e33c0acb608011c56db8d4429ecbf3c9d7053e07/metricbeat/module/elasticsearch/index/data_xpack.go#L194-L237

Having Metricbeat compute index status this way seems a bit flimsy. It should be something that's opaque to Metricbeat (or any client for that matter). Ideally Elasticsearch would compute this field and return it as part of the Cluster State REST API response. That is what this PR attempts to do.