### PR TITLE
Resync fails to notify on unavaiable exceptions

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -22,7 +22,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.action.support.replication.ReplicationOperation;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
@@ -171,12 +170,7 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
 
                 @Override
                 public void handleException(TransportException exp) {
-                    final Throwable cause = exp.unwrapCause();
-                    if (TransportActions.isShardNotAvailableException(cause)) {
-                        logger.trace("primary became unavailable during resync, ignoring", exp);
-                    } else {
-                        listener.onFailure(exp);
-                    }
+                    listener.onFailure(exp);
                 }
             });
     }

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -322,7 +322,6 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
      * This test ensures that when an index deletion takes place while a node is offline, when that
      * node rejoins the cluster, it deletes the index locally instead of importing it as a dangling index.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/33613")
     public void testIndexDeletionWhenNodeRejoins() throws Exception {
         final String indexName = "test-index-del-on-node-rejoin-idx";
         final int numNodes = 2;


### PR DESCRIPTION
We fail to notify the resync listener if the resync replication hits a
shard unavailable exception. Moreover, we no longer need to swallow
these unavailable exceptions.

Relates #31179
Closes #33613