### PR TITLE
Fix heading in composite-aggregation.asciidoc

### DIFF
--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -348,7 +348,7 @@ GET /_search
 \... will sort the composite bucket in descending order when comparing values from the `date_histogram` source
 and in ascending order when comparing values from the `terms` source.
 
-====== Missing bucket
+*Missing bucket*
 
 By default documents without a value for a given source are ignored.
 It is possible to include them in the response by setting `missing_bucket` to

--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -348,7 +348,7 @@ GET /_search
 \... will sort the composite bucket in descending order when comparing values from the `date_histogram` source
 and in ascending order when comparing values from the `terms` source.
 
-*Missing bucket*
+==== Missing bucket
 
 By default documents without a value for a given source are ignored.
 It is possible to include them in the response by setting `missing_bucket` to


### PR DESCRIPTION
The heading for the "Missing buckets" in the "Order" section is too deep.