### PR TITLE
Fix field mapping updates with similarity

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -111,17 +111,6 @@ public abstract class MappedFieldType extends FieldType {
     public boolean equals(Object o) {
         if (!super.equals(o)) return false;
         MappedFieldType fieldType = (MappedFieldType) o;
-        // check similarity first because we need to check the name, and it might be null
-        // TODO: SimilarityProvider should have equals?
-        if (similarity == null || fieldType.similarity == null) {
-            if (similarity != fieldType.similarity) {
-                return false;
-            }
-        } else {
-            if (Objects.equals(similarity.name(), fieldType.similarity.name()) == false) {
-                return false;
-            }
-        }
 
         return boost == fieldType.boost &&
             docValues == fieldType.docValues &&
@@ -131,7 +120,8 @@ public abstract class MappedFieldType extends FieldType {
             Objects.equals(searchQuoteAnalyzer(), fieldType.searchQuoteAnalyzer()) &&
             Objects.equals(eagerGlobalOrdinals, fieldType.eagerGlobalOrdinals) &&
             Objects.equals(nullValue, fieldType.nullValue) &&
-            Objects.equals(nullValueAsString, fieldType.nullValueAsString);
+            Objects.equals(nullValueAsString, fieldType.nullValueAsString) &&
+            Objects.equals(similarity, fieldType.similarity);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityProvider.java
@@ -56,9 +56,10 @@ public final class SimilarityProvider {
         if (o == null || getClass() != o.getClass()) return false;
         SimilarityProvider that = (SimilarityProvider) o;
         /**
-         * We check name only because the <code>similarity</code> is
+         * We check <code>name</code> only because the <code>similarity</code> is
          * re-created for each new instance and they don't implement equals.
-         * This is safe though because each similarity name is unique within an index.
+         * This is not entirely correct though but we only use equality checks
+         * for similarities inside the same index and names are unique in this case.
          **/
         return Objects.equals(name, that.name);
     }
@@ -66,9 +67,10 @@ public final class SimilarityProvider {
     @Override
     public int hashCode() {
         /**
-         * We use name only because the <code>similarity</code> is
+         * We use <code>name</code> only because the <code>similarity</code> is
          * re-created for each new instance and they don't implement equals.
-         * This is safe though because each similarity name is unique within an index.
+         * This is not entirely correct though but we only use equality checks
+         * for similarities a single index and names are unique in this case.
          **/
         return Objects.hash(name);
     }

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityProvider.java
@@ -21,6 +21,8 @@ package org.elasticsearch.index.similarity;
 
 import org.apache.lucene.search.similarities.Similarity;
 
+import java.util.Objects;
+
 /**
  * Wrapper around a {@link Similarity} and its name.
  */
@@ -48,4 +50,26 @@ public final class SimilarityProvider {
         return similarity;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SimilarityProvider that = (SimilarityProvider) o;
+        /**
+         * We check name only because the <code>similarity</code> is
+         * re-created for each new instance and they don't implement equals.
+         * This is safe though because each similarity name is unique within an index.
+         **/
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        /**
+         * We use name only because the <code>similarity</code> is
+         * re-created for each new instance and they don't implement equals.
+         * This is safe though because each similarity name is unique within an index.
+         **/
+        return Objects.hash(name);
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
@@ -89,6 +89,17 @@ public abstract class FieldTypeTestCase extends ESTestCase {
                 other.setIndexAnalyzer(new NamedAnalyzer("foo", AnalyzerScope.INDEX, new StandardAnalyzer()));
             }
         },
+        // check that we can update if the analyzer is unchanged
+        new Modifier("analyzer", true) {
+            @Override
+            public void modify(MappedFieldType ft) {
+                ft.setIndexAnalyzer(new NamedAnalyzer("foo", AnalyzerScope.INDEX, new StandardAnalyzer()));
+            }
+            @Override
+            public void normalizeOther(MappedFieldType other) {
+                other.setIndexAnalyzer(new NamedAnalyzer("foo", AnalyzerScope.INDEX, new StandardAnalyzer()));
+            }
+        },
         new Modifier("search_analyzer", true) {
             @Override
             public void modify(MappedFieldType ft) {
@@ -135,6 +146,17 @@ public abstract class FieldTypeTestCase extends ESTestCase {
             @Override
             public void normalizeOther(MappedFieldType other) {
                 other.setSimilarity(new SimilarityProvider("bar", new BM25Similarity()));
+            }
+        },
+        // check that we can update if the similarity is unchanged
+        new Modifier("similarity", true) {
+            @Override
+            public void modify(MappedFieldType ft) {
+                ft.setSimilarity(new SimilarityProvider("foo", new BM25Similarity()));
+            }
+            @Override
+            public void normalizeOther(MappedFieldType other) {
+                other.setSimilarity(new SimilarityProvider("foo", new BM25Similarity()));
             }
         },
         new Modifier("eager_global_ordinals", true) {


### PR DESCRIPTION
This change fixes a bug introduced in 6.3 that prevents fields with an explicit
similarity to be updated. It also adds a test that checks this case for similarities
but also for analyzers since they could suffer from the same problem.

Closes #33611