### PR TITLE
Remove volatile from global checkpoint listeners

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/GlobalCheckpointListeners.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/GlobalCheckpointListeners.java
@@ -63,7 +63,7 @@ public class GlobalCheckpointListeners implements Closeable {
 
     // guarded by this
     private boolean closed;
-    private volatile Map<GlobalCheckpointListener, ScheduledFuture<?>> listeners;
+    private Map<GlobalCheckpointListener, ScheduledFuture<?>> listeners;
     private long lastKnownGlobalCheckpoint = UNASSIGNED_SEQ_NO;
 
     private final ShardId shardId;


### PR DESCRIPTION
This field does not need to be volatile because all accesses are done under a lock. This commit removes the unnecessary volatile modifier from this field.
