### PR TITLE
[DOCS] Moves security reference to docs folder

### DIFF
--- a/docs/reference/security/reference/files.asciidoc
+++ b/docs/reference/security/reference/files.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[security-files]]
 === Security Files
 

--- a/x-pack/docs/en/security/reference.asciidoc
+++ b/x-pack/docs/en/security/reference.asciidoc
@@ -7,5 +7,5 @@
 * {ref}/security-api.html[Security API]
 * {ref}/xpack-commands.html[Security Commands]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/reference/files.asciidoc
-include::reference/files.asciidoc[]
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/reference/files.asciidoc
+include::{es-repo-dir}/security/reference/files.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/30665 

This PR moves the reference content from x-pack/docs/security to docs/reference/security.

NOTE: There is no code snippet testing in this content, so no changes are required to the gradle checks. 