### PR TITLE
[CCR Monitoring] Only collect stats for specified indices

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ccr/CcrStatsCollector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ccr/CcrStatsCollector.java
@@ -72,7 +72,7 @@ public class CcrStatsCollector extends Collector {
             final ClusterState clusterState) throws Exception {
         try (ThreadContext.StoredContext ignore = stashWithOrigin(threadContext, MONITORING_ORIGIN)) {
             final CcrStatsAction.StatsRequest request = new CcrStatsAction.StatsRequest();
-            request.setIndices(Strings.EMPTY_ARRAY);
+            request.setIndices(getCollectionIndices());
             final CcrStatsAction.StatsResponses responses = ccrClient.stats(request).actionGet(getCollectionTimeout());
 
             final long timestamp = timestamp();

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ccr/CcrStatsCollector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ccr/CcrStatsCollector.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.monitoring.collector.ccr;
 
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -72,6 +73,7 @@ public class CcrStatsCollector extends Collector {
         try (ThreadContext.StoredContext ignore = stashWithOrigin(threadContext, MONITORING_ORIGIN)) {
             final CcrStatsAction.StatsRequest request = new CcrStatsAction.StatsRequest();
             request.setIndices(getCollectionIndices());
+            request.setIndicesOptions(IndicesOptions.lenientExpandOpen());
             final CcrStatsAction.StatsResponses responses = ccrClient.stats(request).actionGet(getCollectionTimeout());
 
             final long timestamp = timestamp();

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ccr/CcrStatsCollector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ccr/CcrStatsCollector.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.monitoring.collector.ccr;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;


### PR DESCRIPTION
Follow up to #33617. Relates to #30086.

As with all other per-index Monitoring collectors, the `CcrStatsCollector` should only collect stats for the indices the user wants to monitor. This list is controlled by the `xpack.monitoring.collection.indices` setting and defaults to all indices.