### PR TITLE
Addressing forecast IT deleteForecast test failure (#33561)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteForecastAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteForecastAction.java
@@ -211,6 +211,7 @@ public class TransportDeleteForecastAction extends HandledTransportAction<Delete
 
         QueryBuilder query = QueryBuilders.boolQuery().filter(innerBoolQuery);
         request.setQuery(query);
+        request.setRefresh(true);
         return request;
     }
 }


### PR DESCRIPTION
This particular test failure is tricky to reproduce. I have added an index refresh after we delete the forecast docs to hopefully mitigate the bug. 

Since I cannot reproduce it, I cannot confirm the fix. @droberts195 let me know what you think. 