### PR TITLE
Use serializable exception in GCP listeners

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/shard/GlobalCheckpointListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/GlobalCheckpointListenersTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.shard;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -42,7 +43,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -512,10 +512,11 @@ public class GlobalCheckpointListenersTests extends ESTestCase {
                     try {
                         notified.set(true);
                         assertThat(g, equalTo(UNASSIGNED_SEQ_NO));
-                        assertThat(e, instanceOf(TimeoutException.class));
+                        assertThat(e, instanceOf(ElasticsearchTimeoutException.class));
                         assertThat(e, hasToString(containsString(timeout.getStringRep())));
                         final ArgumentCaptor<String> message = ArgumentCaptor.forClass(String.class);
-                        final ArgumentCaptor<TimeoutException> t = ArgumentCaptor.forClass(TimeoutException.class);
+                        final ArgumentCaptor<ElasticsearchTimeoutException> t =
+                                ArgumentCaptor.forClass(ElasticsearchTimeoutException.class);
                         verify(mockLogger).trace(message.capture(), t.capture());
                         assertThat(message.getValue(), equalTo("global checkpoint listener timed out"));
                         assertThat(t.getValue(), hasToString(containsString(timeout.getStringRep())));
@@ -547,7 +548,7 @@ public class GlobalCheckpointListenersTests extends ESTestCase {
                     try {
                         notified.set(true);
                         assertThat(g, equalTo(UNASSIGNED_SEQ_NO));
-                        assertThat(e, instanceOf(TimeoutException.class));
+                        assertThat(e, instanceOf(ElasticsearchTimeoutException.class));
                     } finally {
                         latch.countDown();
                     }

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.index.shard;
 
 import org.apache.lucene.store.LockObtainFailedException;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -89,7 +90,6 @@ import java.util.Locale;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -798,7 +798,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
                         notified.set(true);
                         assertThat(g, equalTo(UNASSIGNED_SEQ_NO));
                         assertNotNull(e);
-                        assertThat(e, instanceOf(TimeoutException.class));
+                        assertThat(e, instanceOf(ElasticsearchTimeoutException.class));
                         assertThat(e.getMessage(), equalTo(timeout.getStringRep()));
                     } finally {
                         latch.countDown();


### PR DESCRIPTION
We used TimeoutException here but that's not serializable. This commit switches to a serializable exception so that we can test for the exception type on the remote side.

Relates #33620