### PR TITLE
CORE: Disable Setting Type Validation

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -458,7 +458,7 @@ public class Setting<T> implements ToXContentObject {
      * @return the raw string representation of the setting value
      */
     String innerGetRaw(final Settings settings) {
-        return settings.get(getKey(), defaultValue.apply(settings), isListSetting());
+        return settings.get(getKey(), defaultValue.apply(settings));
     }
 
     /** Logs a deprecation warning if the setting is deprecated and used. */

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -180,6 +180,7 @@ public class SettingTests extends ESTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/33135")
     public void testValidateStringSetting() {
         Settings settings = Settings.builder().putList("foo.bar", Arrays.asList("bla-a", "bla-b")).build();
         Setting<String> stringSetting = Setting.simpleString("foo.bar", Property.NodeScope);


### PR DESCRIPTION
* Reverts setting type validation introduced in #33503
