### PR TITLE
SQL: Return correct catalog separator in JDBC

### DIFF
--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcDatabaseMetaData.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcDatabaseMetaData.java
@@ -368,7 +368,7 @@ class JdbcDatabaseMetaData implements DatabaseMetaData, JdbcWrapper {
 
     @Override
     public String getCatalogSeparator() throws SQLException {
-        return ".";
+        return ":";
     }
 
     @Override

--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcDatabaseMetaDataTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcDatabaseMetaDataTests.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.jdbc.jdbc;
+
+import org.elasticsearch.test.ESTestCase;
+
+public class JdbcDatabaseMetaDataTests extends ESTestCase {
+
+    private JdbcDatabaseMetaData md = new JdbcDatabaseMetaData(null);
+
+    public void testSeparators() throws Exception {
+        assertEquals(":", md.getCatalogSeparator());
+        assertEquals("\"", md.getIdentifierQuoteString());
+        assertEquals("\\", md.getSearchStringEscape());
+        
+    }
+}


### PR DESCRIPTION
Return `:` instead of `.` (which leads to syntax errors).

Fix #33654