### PR TITLE
Remove superfluous semicolon from imports

### DIFF
--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/EvalQueryQuality.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/EvalQueryQuality.java
@@ -33,7 +33,7 @@ import org.elasticsearch.index.rankeval.RatedDocument.DocumentKey;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;;
+import java.util.Objects;
 
 /**
  * Result of the evaluation metric calculation on one particular query alone.

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestTests.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 public class ClusterUpdateSettingsRequestTests extends ESTestCase {
 

--- a/server/src/test/java/org/elasticsearch/search/profile/SearchProfileShardResultsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/SearchProfileShardResultsTests.java
@@ -40,7 +40,7 @@ import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureFieldName;
 import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 
 public class SearchProfileShardResultsTests  extends ESTestCase {
 

--- a/test/framework/src/test/java/org/elasticsearch/test/XContentTestUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/XContentTestUtilsTests.java
@@ -40,7 +40,7 @@ import java.util.function.Predicate;
 import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.instanceOf;;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class XContentTestUtilsTests extends ESTestCase {
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/util/LikeConversionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/util/LikeConversionTests.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.sql.util;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.elasticsearch.xpack.sql.util.StringUtils.likeToJavaPattern;
-import static org.elasticsearch.xpack.sql.util.StringUtils.likeToLuceneWildcard;;
+import static org.elasticsearch.xpack.sql.util.StringUtils.likeToLuceneWildcard;
 
 public class LikeConversionTests extends ESTestCase {
 


### PR DESCRIPTION
In the case where the double semicolon is in the middle of the import block,
this cause my local Eclipse IDE to complain with an error, but its also nice to
just clean this up in other places that at quick grep uncovered.

No need for review, just opening to get a complete CI run.