### PR TITLE
[DOCS] Fix typo in doc syntax for deprecation warning

### DIFF
--- a/docs/reference/search/suggesters/context-suggest.asciidoc
+++ b/docs/reference/search/suggesters/context-suggest.asciidoc
@@ -13,8 +13,8 @@ Every context mapping has a unique name and a type. There are two types: `catego
 and `geo`. Context mappings are configured under the `contexts` parameter in
 the field mapping.
 
-NOTE: deprecated[6.4.0, Indexing and querying without context on a context enabled completion
-field is deprecated and will be removed in the next major release.
+deprecated[6.4.0, Indexing and querying without context on a context enabled completion
+field is deprecated and will be removed in the next major release.]
 
 The following defines types, each with two context mappings for a completion
 field:


### PR DESCRIPTION
There is a syntax error that causes a rendering error in the reference documentation for the Context Suggester.

It currently looks like this:
<img width="771" alt="screen shot 2018-09-13 at 11 16 42 pm" src="https://user-images.githubusercontent.com/1522844/45533111-636a4680-b7ab-11e8-8199-302c9a73ed91.png">

It should look more like this:
<img width="771" alt="screen shot 2018-09-13 at 11 19 09 pm" src="https://user-images.githubusercontent.com/1522844/45533131-73822600-b7ab-11e8-8eb7-33e97e277f30.png">

I'm not super familiar with our documentation setup, but I believe this should fix the issue.