### PR TITLE
Add script to cache dependencies

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -5,13 +5,13 @@ SCRIPT="$0"
 # SCRIPT might be an arbitrarily deep series of symbolic links; loop until we
 # have the concrete path
 while [ -h "$SCRIPT" ] ; do
-  ls=`ls -ld "$SCRIPT"`
+  ls=$(ls -ld "$SCRIPT")
   # Drop everything prior to ->
-  link=`expr "$ls" : '.*-> \(.*\)$'`
+  link=$(expr "$ls" : '.*-> \(.*\)$')
   if expr "$link" : '/.*' > /dev/null; then
     SCRIPT="$link"
   else
-    SCRIPT=`dirname "$SCRIPT"`/"$link"
+    SCRIPT=$(dirname "$SCRIPT")/"$link"
   fi
 done
 

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+SCRIPT="$0"
+
+# SCRIPT might be an arbitrarily deep series of symbolic links; loop until we
+# have the concrete path
+while [ -h "$SCRIPT" ] ; do
+  ls=`ls -ld "$SCRIPT"`
+  # Drop everything prior to ->
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    SCRIPT="$link"
+  else
+    SCRIPT=`dirname "$SCRIPT"`/"$link"
+  fi
+done
+
+source $(dirname "${SCRIPT}")/java-versions.properties
+JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA} ./gradlew resolveAllDependencies --parallel

--- a/build.gradle
+++ b/build.gradle
@@ -632,7 +632,7 @@ if (System.properties.get("build.compare") != null) {
 allprojects {
   task resolveAllDependencies {
     doLast {
-      configurations.all { if (it.isCanBeResolved()) it.resolve() }
+      configurations.findAll { it.isCanBeResolved() }.each { it.resolve() }
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -628,3 +628,11 @@ if (System.properties.get("build.compare") != null) {
     }
   }
 }
+
+allprojects {
+  task resolveAllDependencies {
+    doLast {
+      configurations.all { if (it.isCanBeResolved()) it.resolve() }
+    }
+  }
+}


### PR DESCRIPTION
With the introduction of immutable workers into our CI, we now have a problem where we would have to download dependencies on every single build. To this end our infrastructure team has introduced the possibility to download dependencies one time and then bake these into the base immutable worker image. For this, we introduce our version of this special script which runs a task that downloads all dependencies of all configurations. With this script, our infrastructure team will be rebuilding these images on an at-least daily basis. This helps us avoid having to download the dependencies for every single build.
