### PR TITLE
Fixed a grammatical mistake: 'a HTTP ...' -> 'an HTTP ...'

### DIFF
--- a/docs/java-rest/low-level/configuration.asciidoc
+++ b/docs/java-rest/low-level/configuration.asciidoc
@@ -54,7 +54,7 @@ include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-config-basi
 --------------------------------------------------
 
 Preemptive Authentication can be disabled, which means that every request will be sent without
-authorization headers to see if it is accepted and, upon receiving HTTP 401 response, it will
+authorization headers to see if it is accepted and, upon receiving an HTTP 401 response, it will
 resend the exact same request with the basic authentication header. If you wish to do this, then
 you can do so by disabling it via the `HttpAsyncClientBuilder`:
 

--- a/docs/java-rest/low-level/configuration.asciidoc
+++ b/docs/java-rest/low-level/configuration.asciidoc
@@ -54,7 +54,7 @@ include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-config-basi
 --------------------------------------------------
 
 Preemptive Authentication can be disabled, which means that every request will be sent without
-authorization headers to see if it is accepted and, upon receiving a HTTP 401 response, it will
+authorization headers to see if it is accepted and, upon receiving HTTP 401 response, it will
 resend the exact same request with the basic authentication header. If you wish to do this, then
 you can do so by disabling it via the `HttpAsyncClientBuilder`:
 

--- a/docs/plugins/plugin-script.asciidoc
+++ b/docs/plugins/plugin-script.asciidoc
@@ -88,7 +88,7 @@ must not be contained in the `plugins` directory for the node that you are
 installing the plugin to or installation will fail.
 
 HTTP::
-To install a plugin from a HTTP URL:
+To install a plugin from an HTTP URL:
 +
 [source,shell]
 -----------------------------------

--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -96,7 +96,7 @@ and stack traces in response output. Note: When set to `false` and the `error_tr
 parameter is specified, an error will be returned; when `error_trace` is not specified, a
 simple message will be returned. Defaults to `true`
 
-|`http.pipelining.max_events` |The maximum number of events to be queued up in memory before a HTTP connection is closed, defaults to `10000`.
+|`http.pipelining.max_events` |The maximum number of events to be queued up in memory before an HTTP connection is closed, defaults to `10000`.
 
 |`http.max_warning_header_count` |The maximum number of warning headers in
  client HTTP responses, defaults to unbounded.

--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -60,7 +60,7 @@ The maximum period of inactivity between two data packets, before the
 request is aborted.
 
 `xpack.http.max_response_size`::
-Specifies the maximum size a HTTP response is allowed to have, defaults to
+Specifies the maximum size an HTTP response is allowed to have, defaults to
 `10mb`, the maximum configurable value is `50mb`.
 
 [[ssl-notification-settings]]

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -78,7 +78,7 @@ The roles to associate with the anonymous user. Required.
 When `true`, an HTTP 403 response is returned if the anonymous user
 does not have the appropriate permissions for the requested action. The
 user is not prompted to provide credentials to access the requested
-resource. When set to `false`, HTTP 401 is returned and the user
+resource. When set to `false`, an HTTP 401 response is returned and the user
 can provide credentials with the appropriate permissions to gain
 access. Defaults to `true`.
 

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -78,7 +78,7 @@ The roles to associate with the anonymous user. Required.
 When `true`, an HTTP 403 response is returned if the anonymous user
 does not have the appropriate permissions for the requested action. The
 user is not prompted to provide credentials to access the requested
-resource. When set to `false`, a HTTP 401 is returned and the user
+resource. When set to `false`, HTTP 401 is returned and the user
 can provide credentials with the appropriate permissions to gain
 access. Defaults to `true`.
 

--- a/docs/reference/setup/install/windows.asciidoc
+++ b/docs/reference/setup/install/windows.asciidoc
@@ -69,7 +69,7 @@ name, node name and roles to be set, in addition to memory and network settings:
 [[msi-installer-configuration]]
 image::images/msi_installer/msi_installer_configuration.png[]
 
-A list of common plugins that can be downloaded and installed as part of the installation, with the option to configure a HTTPS proxy through which to download these plugins.
+A list of common plugins that can be downloaded and installed as part of the installation, with the option to configure an HTTPS proxy through which to download these plugins.
 
 TIP: Ensure the installation machine has access to the internet and that any corporate firewalls in place are configured to allow downloads from `artifacts.elastic.co`:
 

--- a/docs/ruby/client.asciidoc
+++ b/docs/ruby/client.asciidoc
@@ -84,7 +84,7 @@ client.search index: 'my-index', body: { query: { match: { title: 'test' } } }
 The `elasticsearch` gem combines two separate Rubygems:
 
 * https://github.com/elastic/elasticsearch-ruby/tree/master/elasticsearch-transport[`elasticsearch-transport`]
-provides a HTTP Ruby client for connecting to the Elasticsearch cluster,
+provides an HTTP Ruby client for connecting to the Elasticsearch cluster,
 
 * https://github.com/elastic/elasticsearch-ruby/tree/master/elasticsearch-api[`elasticsearch-api`]
 provides a Ruby API for the Elasticsearch RESTful API.
@@ -94,7 +94,7 @@ Please see their respective documentation for configuration options and technica
 Notably, the documentation and comprehensive examples for all the API methods is contained in the source,
 and available online at http://rubydoc.info/gems/elasticsearch-api/Elasticsearch/API/Actions[Rubydoc].
 
-Keep in mind, that for optimal performance, you should use a HTTP library which supports
+Keep in mind, that for optimal performance, you should use an HTTP library which supports
 persistent ("keep-alive") HTTP connections.
 
 

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4CorsTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4CorsTests.java
@@ -46,7 +46,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class Netty4CorsTests extends ESTestCase {
 
     public void testCorsEnabledWithoutAllowOrigins() {
-        // Set up a HTTP transport with only the CORS enabled setting
+        // Set up an HTTP transport with only the CORS enabled setting
         Settings settings = Settings.builder()
             .put(HttpTransportSettings.SETTING_CORS_ENABLED.getKey(), true)
             .build();
@@ -57,7 +57,7 @@ public class Netty4CorsTests extends ESTestCase {
 
     public void testCorsEnabledWithAllowOrigins() {
         final String originValue = "remote-host";
-        // create a http transport with CORS enabled and allow origin configured
+        // create an HTTP transport with CORS enabled and allow origin configured
         Settings settings = Settings.builder()
             .put(SETTING_CORS_ENABLED.getKey(), true)
             .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), originValue)
@@ -72,7 +72,7 @@ public class Netty4CorsTests extends ESTestCase {
     public void testCorsAllowOriginWithSameHost() {
         String originValue = "remote-host";
         String host = "remote-host";
-        // create a http transport with CORS enabled
+        // create an HTTP transport with CORS enabled
         Settings settings = Settings.builder()
             .put(SETTING_CORS_ENABLED.getKey(), true)
             .build();

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4SizeHeaderFrameDecoderTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4SizeHeaderFrameDecoderTests.java
@@ -44,7 +44,7 @@ import java.util.Collections;
 import static org.hamcrest.Matchers.is;
 
 /**
- * This test checks, if a HTTP look-alike request (starting with a HTTP method and a space)
+ * This test checks, if an HTTP look-alike request (starting with an HTTP method and a space)
  * actually returns text response instead of just dropping the connection
  */
 public class Netty4SizeHeaderFrameDecoderTests extends ESTestCase {
@@ -91,7 +91,7 @@ public class Netty4SizeHeaderFrameDecoderTests extends ESTestCase {
             socket.getOutputStream().flush();
 
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8))) {
-                assertThat(reader.readLine(), is("This is not a HTTP port"));
+                assertThat(reader.readLine(), is("This is not an HTTP port"));
             }
         }
     }

--- a/plugins/transport-nio/src/test/java/org/elasticsearch/http/nio/HttpReadWriteHandlerTests.java
+++ b/plugins/transport-nio/src/test/java/org/elasticsearch/http/nio/HttpReadWriteHandlerTests.java
@@ -218,7 +218,7 @@ public class HttpReadWriteHandlerTests extends ESTestCase {
     }
 
     public void testCorsEnabledWithoutAllowOrigins() throws IOException {
-        // Set up a HTTP transport with only the CORS enabled setting
+        // Set up an HTTP transport with only the CORS enabled setting
         Settings settings = Settings.builder()
             .put(HttpTransportSettings.SETTING_CORS_ENABLED.getKey(), true)
             .build();
@@ -233,7 +233,7 @@ public class HttpReadWriteHandlerTests extends ESTestCase {
 
     public void testCorsEnabledWithAllowOrigins() throws IOException {
         final String originValue = "remote-host";
-        // create a http transport with CORS enabled and allow origin configured
+        // create an HTTP transport with CORS enabled and allow origin configured
         Settings settings = Settings.builder()
             .put(SETTING_CORS_ENABLED.getKey(), true)
             .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), originValue)
@@ -252,7 +252,7 @@ public class HttpReadWriteHandlerTests extends ESTestCase {
     public void testCorsAllowOriginWithSameHost() throws IOException {
         String originValue = "remote-host";
         String host = "remote-host";
-        // create a http transport with CORS enabled
+        // create an HTTP transport with CORS enabled
         Settings settings = Settings.builder()
             .put(SETTING_CORS_ENABLED.getKey(), true)
             .build();

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/DetailedErrorsDisabledIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/DetailedErrorsDisabledIT.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 /**
- * Tests that when disabling detailed errors, a request with the error_trace parameter returns HTTP 400
+ * Tests that when disabling detailed errors, a request with the error_trace parameter returns an HTTP 400 response.
  */
 @ClusterScope(scope = Scope.TEST, supportsDedicatedMasters = false, numDataNodes = 1)
 public class DetailedErrorsDisabledIT extends HttpSmokeTestCase {

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/DetailedErrorsDisabledIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/DetailedErrorsDisabledIT.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 /**
- * Tests that when disabling detailed errors, a request with the error_trace parameter returns a HTTP 400
+ * Tests that when disabling detailed errors, a request with the error_trace parameter returns HTTP 400
  */
 @ClusterScope(scope = Scope.TEST, supportsDedicatedMasters = false, numDataNodes = 1)
 public class DetailedErrorsDisabledIT extends HttpSmokeTestCase {

--- a/server/src/main/java/org/elasticsearch/http/HttpChannel.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpChannel.java
@@ -27,7 +27,7 @@ import java.net.InetSocketAddress;
 public interface HttpChannel extends CloseableChannel {
 
     /**
-     * Sends a http response to the channel. The listener will be executed once the send process has been
+     * Sends an http response to the channel. The listener will be executed once the send process has been
      * completed.
      *
      * @param response to send to channel

--- a/server/src/main/java/org/elasticsearch/monitor/package-info.java
+++ b/server/src/main/java/org/elasticsearch/monitor/package-info.java
@@ -18,7 +18,7 @@
  */
 
 /**
- * Monitors the Elasticsearch process and the system on which it is running so that metrics can be exposed via a HTTP or transport APIs to
+ * Monitors the Elasticsearch process and the system on which it is running so that metrics can be exposed via an HTTP or transport APIs to
  * be logged and graphed.
  */
 package org.elasticsearch.monitor;

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -1087,7 +1087,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
      * @param bytesReference the bytes available to consume
      * @return the number of bytes consumed
      * @throws StreamCorruptedException if the message header format is not recognized
-     * @throws TcpTransport.HttpOnTransportException if the message header appears to be a HTTP message
+     * @throws TcpTransport.HttpOnTransportException if the message header appears to be an HTTP message
      * @throws IllegalArgumentException if the message length is greater that the maximum allowed frame size.
      *                                  This is dependent on the available memory.
      */
@@ -1109,7 +1109,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
      * @param networkBytes the will be read
      * @return the message decoded
      * @throws StreamCorruptedException if the message header format is not recognized
-     * @throws TcpTransport.HttpOnTransportException if the message header appears to be a HTTP message
+     * @throws TcpTransport.HttpOnTransportException if the message header appears to be an HTTP message
      * @throws IllegalArgumentException if the message length is greater that the maximum allowed frame size.
      *                                  This is dependent on the available memory.
      */
@@ -1136,7 +1136,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
      * @param networkBytes the will be read
      * @return the length of the message
      * @throws StreamCorruptedException if the message header format is not recognized
-     * @throws TcpTransport.HttpOnTransportException if the message header appears to be a HTTP message
+     * @throws TcpTransport.HttpOnTransportException if the message header appears to be an HTTP message
      * @throws IllegalArgumentException if the message length is greater that the maximum allowed frame size.
      *                                  This is dependent on the available memory.
      */
@@ -1151,7 +1151,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     private static int readHeaderBuffer(BytesReference headerBuffer) throws IOException {
         if (headerBuffer.get(0) != 'E' || headerBuffer.get(1) != 'S') {
             if (appearsToBeHTTP(headerBuffer)) {
-                throw new TcpTransport.HttpOnTransportException("This is not a HTTP port");
+                throw new TcpTransport.HttpOnTransportException("This is not an HTTP port");
             }
 
             throw new StreamCorruptedException("invalid internal transport message format, got ("

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -92,7 +92,7 @@ public class DefaultRestChannelTests extends ESTestCase {
     // TODO: Enable these Cors tests when the Cors logic lives in :server
 
 //    public void testCorsEnabledWithoutAllowOrigins() {
-//        // Set up a HTTP transport with only the CORS enabled setting
+//        // Set up an HTTP transport with only the CORS enabled setting
 //        Settings settings = Settings.builder()
 //            .put(HttpTransportSettings.SETTING_CORS_ENABLED.getKey(), true)
 //            .build();
@@ -103,7 +103,7 @@ public class DefaultRestChannelTests extends ESTestCase {
 //
 //    public void testCorsEnabledWithAllowOrigins() {
 //        final String originValue = "remote-host";
-//        // create a http transport with CORS enabled and allow origin configured
+//        // create an HTTP transport with CORS enabled and allow origin configured
 //        Settings settings = Settings.builder()
 //            .put(SETTING_CORS_ENABLED.getKey(), true)
 //            .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), originValue)
@@ -118,7 +118,7 @@ public class DefaultRestChannelTests extends ESTestCase {
 //    public void testCorsAllowOriginWithSameHost() {
 //        String originValue = "remote-host";
 //        String host = "remote-host";
-//        // create a http transport with CORS enabled
+//        // create an HTTP transport with CORS enabled
 //        Settings settings = Settings.builder()
 //            .put(SETTING_CORS_ENABLED.getKey(), true)
 //            .build();

--- a/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
@@ -429,7 +429,7 @@ public class TcpTransportTests extends ESTestCase {
                 fail("Expected exception");
             } catch (Exception ex) {
                 assertThat(ex, instanceOf(TcpTransport.HttpOnTransportException.class));
-                assertEquals("This is not a HTTP port", ex.getMessage());
+                assertEquals("This is not an HTTP port", ex.getMessage());
             }
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/fixture/AbstractHttpFixture.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/fixture/AbstractHttpFixture.java
@@ -157,7 +157,7 @@ public abstract class AbstractHttpFixture {
     }
 
     /**
-     * Represents a HTTP Response.
+     * Represents an HTTP Response.
      */
     protected static class Response {
 
@@ -203,7 +203,7 @@ public abstract class AbstractHttpFixture {
     }
 
     /**
-     * Represents a HTTP Request.
+     * Represents an HTTP Request.
      */
     protected static class Request {
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -161,7 +161,7 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     /**
-     * Construct a HttpHost from the given host and port
+     * Construct an HttpHost from the given host and port
      */
     protected HttpHost buildHttpHost(String host, int port) {
         return new HttpHost(host, port, getProtocol());

--- a/x-pack/docs/en/rest-api/watcher/execute-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/execute-watch.asciidoc
@@ -57,7 +57,7 @@ This API supports the following fields:
 
 | `ignore_condition`  | no       | false    | When set to `true`, the watch execution uses the
                                               {xpack-ref}/condition-always.html[Always Condition].
-                                              This can also be specified as a HTTP parameter.
+                                              This can also be specified as an HTTP parameter.
 
 | `alternative_input` | no       | null     | When present, the watch uses this object as a payload
                                               instead of executing its own input.
@@ -70,7 +70,7 @@ This API supports the following fields:
                                               execution result is persisted to the `.watcher-history`
                                               index for the current time. In addition, the status of the
                                               watch is updated, possibly throttling subsequent executions.
-                                              This can also be specified as a HTTP parameter.
+                                              This can also be specified as an HTTP parameter.
 
 | `watch`             | no       | null     | When present, this
                                               {xpack-ref}/how-watcher-works.html#watch-definition[watch] is used

--- a/x-pack/docs/en/watcher/customizing-watches.asciidoc
+++ b/x-pack/docs/en/watcher/customizing-watches.asciidoc
@@ -83,7 +83,7 @@ See <<input-search>> for more details.
 [[loading-http-data]]
 ==== Loading a Payload from a remote HTTP Service with HTTP Input
 
-Use the `http` input to issue a HTTP request and load the returned response as
+Use the `http` input to issue an HTTP request and load the returned response as
 the watch initial payload. This input expects the response body content type
 to either be JSON or YAML.
 

--- a/x-pack/docs/en/watcher/encrypting-data.asciidoc
+++ b/x-pack/docs/en/watcher/encrypting-data.asciidoc
@@ -6,8 +6,8 @@ information or details about your SMTP email service. You can encrypt this
 data by generating a key and adding some secure settings on each node in your
 cluster.
 
-Every `password` field that is used in your watch within a HTTP basic
-authentication block - for example within a webhook, a HTTP input or when using
+Every `password` field that is used in your watch within an HTTP basic
+authentication block - for example within a webhook, an HTTP input or when using
 the reporting email attachment - will not be stored as plain text anymore. Also
 be aware, that there is no way to configure your own fields in a watch to be
 encrypted.

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityHttpExceptionHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityHttpExceptionHandler.java
@@ -36,10 +36,10 @@ public final class SecurityHttpExceptionHandler implements BiConsumer<HttpChanne
 
         if (isNotSslRecordException(e)) {
             if (logger.isTraceEnabled()) {
-                logger.trace(new ParameterizedMessage("received plaintext http traffic on a https channel, closing connection {}",
+                logger.trace(new ParameterizedMessage("received plaintext http traffic on an https channel, closing connection {}",
                     channel), e);
             } else {
-                logger.warn("received plaintext http traffic on a https channel, closing connection {}", channel);
+                logger.warn("received plaintext http traffic on an https channel, closing connection {}", channel);
             }
             CloseableChannel.closeChannel(channel);
         } else if (isCloseDuringHandshakeException(e)) {

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
@@ -224,9 +224,9 @@ public class HttpClient extends AbstractComponent implements Closeable {
     }
 
     /**
-     * Creates a HTTP proxy from the system wide settings
+     * Creates an HTTP proxy from the system wide settings
      *
-     * @return A http proxy instance, if no settings are configured this will be a HttpProxy.NO_PROXY instance
+     * @return An HTTP proxy instance, if no settings are configured this will be an HttpProxy.NO_PROXY instance
      */
     private HttpProxy getProxyFromSettings() {
         String proxyHost = HttpSettings.PROXY_HOST.get(settings);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpClientTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpClientTests.java
@@ -513,7 +513,7 @@ public class HttpClientTests extends ESTestCase {
                 try (Socket socket = serverSocket.accept()) {
                     BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
                     in.readLine();
-                    socket.getOutputStream().write("This is not a HTTP response".getBytes(StandardCharsets.UTF_8));
+                    socket.getOutputStream().write("This is not an HTTP response".getBytes(StandardCharsets.UTF_8));
                     socket.getOutputStream().flush();
                 } catch (Exception e) {
                     hasExceptionHappened.set(e);

--- a/x-pack/qa/third-party/jira/build.gradle
+++ b/x-pack/qa/third-party/jira/build.gradle
@@ -59,7 +59,7 @@ def jiraIssues(projectKey) {
   return response.issues.findAll {it.key.startsWith(projectKey)}.collect {it.key}
 }
 
-/** Execute a HTTP request against the Jira server instance **/
+/** Execute an HTTP request against the Jira server instance **/
 def jiraHttpRequest(String endpoint, String method, int successCode) {
   HttpsURLConnection connection = null;
   try {


### PR DESCRIPTION
Fixed the mistake of 'a HTTP ...', as I have mentioned in #33728.

Closes #33728