### PR TITLE
MINOR: Drop Redundant Ctx. Check in ScriptService

### DIFF
--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/MoreExpressionTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/MoreExpressionTests.java
@@ -582,7 +582,7 @@ public class MoreExpressionTests extends ESIntegTestCase {
             String message = e.getMessage();
             assertThat(message + " should have contained failed to execute", message.contains("failed to execute"), equalTo(true));
             message = e.getCause().getMessage();
-            assertThat(message + " should have contained not supported", message.contains("not supported"), equalTo(true));
+            assertThat(message, equalTo("Failed to compile inline script [0] using lang [expression]"));
         }
     }
 

--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/StoredExpressionTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/StoredExpressionTests.java
@@ -61,7 +61,7 @@ public class StoredExpressionTests extends ESIntegTestCase {
             fail("update script should have been rejected");
         } catch(Exception e) {
             assertThat(e.getMessage(), containsString("failed to execute script"));
-            assertThat(e.getCause().getMessage(), containsString("scripts of type [stored], operation [update] and lang [expression] are not supported"));
+            assertThat(e.getCause().getMessage(), containsString("Failed to compile stored script [script1] using lang [expression]"));
         }
         try {
             client().prepareSearch()

--- a/server/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -281,15 +281,6 @@ public class ScriptService extends AbstractComponent implements Closeable, Clust
             options = source.getOptions();
         }
 
-        // TODO: fix this through some API or something, that's wrong
-        // special exception to prevent expressions from compiling as update or mapping scripts
-        boolean expression = "expression".equals(lang);
-        boolean notSupported = context.name.equals(UpdateScript.CONTEXT.name);
-        if (expression && notSupported) {
-            throw new UnsupportedOperationException("scripts of type [" + script.getType() + "]," +
-                " operation [" + context.name + "] and lang [" + lang + "] are not supported");
-        }
-
         ScriptEngine scriptEngine = getEngine(lang);
 
         if (isTypeEnabled(type) == false) {


### PR DESCRIPTION
* This check is completely redundant, the expression script
engine will throw anyway (and with a similar message) for
those contexts that it cannot compile. Moreover, the update context
is not the only context that is not suported by the expression engine
at this point so handling the update context separately here makes
no sense.

-------------------------------------

Just a random find :)