### PR TITLE
Checkstyle: Package declarations

### DIFF
--- a/buildSrc/src/main/resources/checkstyle.xml
+++ b/buildSrc/src/main/resources/checkstyle.xml
@@ -62,7 +62,13 @@
     -->
     <module name="ModifierOrder" />
 
+    <!-- Checks that we don't include modifier where they are implied. For
+      example, this does not allow interface methods to be declared public
+      because they are *always* public. -->
     <module name="RedundantModifier" />
+    <!-- Checks that all java files have a package declaration and that it
+      lines up with the directory structure. -->
+    <module name="PackageDeclaration"/>
 
     <!-- We don't use Java's builtin serialization and we suppress all warning
       about it. The flip side of that coin is that we shouldn't _try_ to use

--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -17,6 +17,10 @@
   <!-- the constructors on some local classes in these tests must be public-->
   <suppress files="server[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]plugins[/\\]PluginsServiceTests.java" checks="RedundantModifier" />
 
+  <!-- Intentionally doesn't have a package declaration to test logging
+    configuration of classes that aren't in packages. -->
+  <suppress files="test[/\\]framework[/\\]src[/\\]test[/\\]java[/\\]Dummy.java" checks="PackageDeclaration" />
+
   <!-- Hopefully temporary suppression of LineLength on files that don't pass it. We should remove these when we the
     files start to pass. -->
   <suppress files="client[/\\]rest[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]HeapBufferedAsyncResponseConsumerTests.java" checks="LineLength" />


### PR DESCRIPTION
Make sure that all java files have a package declaration and that all of
the package declarations line up with the directory structure. This
would have caught the bug that I caused in
190ea9a6def9082348d983b16420ef02607d4c17 and fixed in
b6d68bd805f1858a0210e381402236dea1d42509.
