### PR TITLE
Test: Relax jarhell gradle test

### DIFF
--- a/buildSrc/src/test/java/org/elasticsearch/gradle/precommit/JarHellTaskIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/precommit/JarHellTaskIT.java
@@ -34,7 +34,7 @@ public class JarHellTaskIT extends GradleIntegrationTestCase {
         assertTaskFailed(result, ":jarHell");
         assertOutputContains(
             result.getOutput(),
-            "Exception in thread \"main\" java.lang.IllegalStateException: jar hell!",
+            "java.lang.IllegalStateException: jar hell!",
             "class: org.apache.logging.log4j.Logger"
         );
     }


### PR DESCRIPTION
Gradle can sometimes emit mixed log lines due to how we spawn things in
separate processes. This commit changes the jarhell integ test to only
look for the exception and message, instead of including the outer part
about the exception in thread main.

closes #33774