### PR TITLE
[Monitoring] Removing unused version.* fields

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDoc.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDoc.java
@@ -69,13 +69,6 @@ public class IndexStatsMonitoringDoc extends FilteredMonitoringDoc {
             builder.field("created", metaData.getCreationDate());
             builder.field("status", health.getStatus().name().toLowerCase(Locale.ROOT));
 
-            builder.startObject("version");
-            {
-                builder.field("created", metaData.getCreationVersion());
-                builder.field("upgraded", metaData.getUpgradedVersion());
-            }
-            builder.endObject();
-
             builder.startObject("shards");
             {
                 final int total = metaData.getTotalNumberOfShards();
@@ -128,8 +121,6 @@ public class IndexStatsMonitoringDoc extends FilteredMonitoringDoc {
                         "index_stats.uuid",
                         "index_stats.created",
                         "index_stats.status",
-                        "index_stats.version.created",
-                        "index_stats.version.upgraded",
                         "index_stats.shards.total",
                         "index_stats.shards.primaries",
                         "index_stats.shards.replicas",

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDocTests.java
@@ -290,10 +290,6 @@ public class IndexStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestC
                "\"uuid\":\"" + index.getUUID() + "\"," +
                "\"created\":" + metaData.getCreationDate() + "," +
                "\"status\":\"" + indexHealth.getStatus().name().toLowerCase(Locale.ROOT) + "\"," +
-               "\"version\":{" +
-                 "\"created\":\"" + metaData.getCreationVersion() + "\"," +
-                 "\"upgraded\":\"" + metaData.getUpgradedVersion() + "\"" +
-               "}," +
                "\"shards\":{" +
                  "\"total\":" + total + "," +
                  "\"primaries\":" + primaries + "," +

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
@@ -419,7 +419,7 @@ public class MonitoringIT extends ESSingleNodeTestCase {
 
         // particular field values checked in the index stats tests
         final Map<String, Object> indexStats = (Map<String, Object>) source.get(IndexStatsMonitoringDoc.TYPE);
-        assertEquals(8, indexStats.size());
+        assertEquals(7, indexStats.size());
         assertThat((String) indexStats.get("index"), not(isEmptyOrNullString()));
         assertThat((String) indexStats.get("uuid"), not(isEmptyOrNullString()));
         assertThat(indexStats.get("created"), notNullValue());

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
@@ -424,9 +424,6 @@ public class MonitoringIT extends ESSingleNodeTestCase {
         assertThat((String) indexStats.get("uuid"), not(isEmptyOrNullString()));
         assertThat(indexStats.get("created"), notNullValue());
         assertThat((String) indexStats.get("status"), not(isEmptyOrNullString()));
-        assertThat(indexStats.get("version"), notNullValue());
-        final Map<String, Object> version = (Map<String, Object>) indexStats.get("version");
-        assertEquals(2, version.size());
         assertThat(indexStats.get("shards"), notNullValue());
         final Map<String, Object> shards = (Map<String, Object>) indexStats.get("shards");
         assertEquals(11, shards.size());


### PR DESCRIPTION
Backport of #33584 and #33833.

This PR removes fields that are not actually used by the Monitoring UI. This will greatly simplify the eventual migration to using Metricbeat for monitoring Elasticsearch (see https://github.com/elastic/beats/pull/8260#discussion_r215885868 for more context and discussion around removing these fields from ES collection).