### PR TITLE
Watcher: Ensure triggered watch deletion is sync

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/TriggeredWatchStore.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/TriggeredWatchStore.java
@@ -115,7 +115,7 @@ public class TriggeredWatchStore extends AbstractComponent {
     public void delete(Wid wid) {
         DeleteRequest request = new DeleteRequest(TriggeredWatchStoreField.INDEX_NAME, TriggeredWatchStoreField.DOC_TYPE, wid.value());
         try (ThreadContext.StoredContext ignore = stashWithOrigin(client.threadPool().getThreadContext(), WATCHER_ORIGIN)) {
-            client.delete(request); // FIXME shouldn't we wait before saying the delete was successful
+            client.delete(request).actionGet(defaultBulkTimeout);
         }
         logger.trace("successfully deleted triggered watch with id [{}]", wid);
     }


### PR DESCRIPTION
This checks for the response of a triggered watch deletion, as previous
versions accidentally did not properly wait for the future of a deletion
to come back. This could lead to early finishing of a watch, despite
this deletion still going on.

Reviewers note: This is not needed for master/6.x due to using the bulk processor there. Also I could not come up with a reliable test for this one. If you have ideas I am open to them.