### PR TITLE
Ensure realtime `_get` and `_termvectors` don't run on the network thread

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
@@ -81,7 +81,7 @@ public class TransportGetAction extends TransportSingleShardAction<GetRequest, G
         IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
         IndexShard indexShard = indexService.getShard(shardId.id());
         if (request.realtime()) { // we are not tied to a refresh cycle here anyway
-            listener.onResponse(shardOperation(request, shardId));
+            super.asyncShardOperation(request, shardId, listener);
         } else {
             indexShard.awaitShardSearchActive(b -> {
                 try {

--- a/server/src/main/java/org/elasticsearch/action/termvectors/TransportTermVectorsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TransportTermVectorsAction.java
@@ -90,7 +90,7 @@ public class TransportTermVectorsAction extends TransportSingleShardAction<TermV
         IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
         IndexShard indexShard = indexService.getShard(shardId.id());
         if (request.realtime()) { // it's a realtime request which is not subject to refresh cycles
-            listener.onResponse(shardOperation(request, shardId));
+            super.asyncShardOperation(request, shardId, listener);
         } else {
             indexShard.awaitShardSearchActive(b -> {
                 try {


### PR DESCRIPTION
The change in #27500 introduces this regression that causes `_get` and `_term_vector`
actions to run on the network thread if the realtime flag is set.
This fixes the issue by delegating to the super method forking on the corresponding threadpool.

Relates to #27500

This code is not released yet.