### PR TITLE
Update geolite2 database in ingest geoip plugin

### DIFF
--- a/plugins/ingest-geoip/build.gradle
+++ b/plugins/ingest-geoip/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   compile("com.fasterxml.jackson.core:jackson-databind:${versions.jackson}")
   compile('com.maxmind.db:maxmind-db:1.2.2')
 
-  testCompile 'org.elasticsearch:geolite2-databases:20180303'
+  testCompile 'org.elasticsearch:geolite2-databases:20180911'
 }
 
 task copyDefaultGeoIp2DatabaseFiles(type: Copy) {

--- a/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -134,8 +134,8 @@ public class GeoIpProcessorTests extends ESTestCase {
         assertThat(geoData.get("city_name"), equalTo("Hollywood"));
         assertThat(geoData.get("timezone"), equalTo("America/New_York"));
         Map<String, Object> location = new HashMap<>();
-        location.put("lat", 26.0252d);
-        location.put("lon", -80.296d);
+        location.put("lat", 25.9825d);
+        location.put("lon", -80.3434d);
         assertThat(geoData.get("location"), equalTo(location));
     }
 
@@ -197,7 +197,7 @@ public class GeoIpProcessorTests extends ESTestCase {
     }
 
     public void testAsn() throws Exception {
-        String ip = "82.170.213.79";
+        String ip = "82.171.64.0";
         InputStream database = getDatabaseFileInputStream("/GeoLite2-ASN.mmdb");
         GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), "source_field",
             new DatabaseReader.Builder(database).build(), "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false,
@@ -213,7 +213,7 @@ public class GeoIpProcessorTests extends ESTestCase {
         Map<String, Object> geoData = (Map<String, Object>) ingestDocument.getSourceAndMetadata().get("target_field");
         assertThat(geoData.size(), equalTo(3));
         assertThat(geoData.get("ip"), equalTo(ip));
-        assertThat(geoData.get("asn"), equalTo(5615));
+        assertThat(geoData.get("asn"), equalTo(1136));
         assertThat(geoData.get("organization_name"), equalTo("KPN B.V."));
     }
 

--- a/plugins/ingest-geoip/src/test/resources/rest-api-spec/test/ingest_geoip/20_geoip_processor.yml
+++ b/plugins/ingest-geoip/src/test/resources/rest-api-spec/test/ingest_geoip/20_geoip_processor.yml
@@ -33,8 +33,8 @@
   - length: { _source.geoip: 6 }
   - match: { _source.geoip.city_name: "Minneapolis" }
   - match: { _source.geoip.country_iso_code: "US" }
-  - match: { _source.geoip.location.lon: -93.2166 }
-  - match: { _source.geoip.location.lat: 44.9759 }
+  - match: { _source.geoip.location.lon: -93.2323 }
+  - match: { _source.geoip.location.lat: 44.9733 }
   - match: { _source.geoip.region_iso_code: "US-MN" }
   - match: { _source.geoip.region_name: "Minnesota" }
   - match: { _source.geoip.continent_name: "North America" }
@@ -80,8 +80,8 @@
   - match: { _source.geoip.city_name: "Minneapolis" }
   - match: { _source.geoip.country_iso_code: "US" }
   - match: { _source.geoip.ip: "128.101.101.101" }
-  - match: { _source.geoip.location.lon: -93.2166 }
-  - match: { _source.geoip.location.lat: 44.9759 }
+  - match: { _source.geoip.location.lon: -93.2323 }
+  - match: { _source.geoip.location.lat: 44.9733 }
   - match: { _source.geoip.timezone: "America/Chicago" }
   - match: { _source.geoip.country_name: "United States" }
   - match: { _source.geoip.region_iso_code: "US-MN" }
@@ -193,8 +193,8 @@
   - length: { _source.geoip: 6 }
   - match: { _source.geoip.city_name: "Minneapolis" }
   - match: { _source.geoip.country_iso_code: "US" }
-  - match: { _source.geoip.location.lon: -93.2166 }
-  - match: { _source.geoip.location.lat: 44.9759 }
+  - match: { _source.geoip.location.lon: -93.2323 }
+  - match: { _source.geoip.location.lat: 44.9733 }
   - match: { _source.geoip.region_iso_code: "US-MN" }
   - match: { _source.geoip.region_name: "Minnesota" }
   - match: { _source.geoip.continent_name: "North America" }
@@ -224,15 +224,15 @@
         type: test
         id: 1
         pipeline: "my_pipeline"
-        body: {field1: "82.170.213.79"}
+        body: {field1: "82.171.64.0"}
 
   - do:
       get:
         index: test
         type: test
         id: 1
-  - match: { _source.field1: "82.170.213.79" }
+  - match: { _source.field1: "82.171.64.0" }
   - length: { _source.geoip: 3 }
-  - match: { _source.geoip.ip: "82.170.213.79" }
-  - match: { _source.geoip.asn: 5615 }
+  - match: { _source.geoip.ip: "82.171.64.0" }
+  - match: { _source.geoip.asn: 1136 }
   - match: { _source.geoip.organization_name: "KPN B.V." }


### PR DESCRIPTION
There have been several country subdivision changes since last time the GeoLite2 databases were updated. For examples, [China's subdivisions have new codes](https://www.iso.org/obp/ui/#iso:code:3166:CN) and [Norway has merged two counties into one](https://en.wikipedia.org/wiki/Tr%C3%B8ndelag). 

Additionally, we are adding `region_iso_codes` to documents [starting with the 6.5 release of the Ingest GeoIP Plugin](https://github.com/elastic/elasticsearch/pull/31669). These codes are used in Kibana region maps as a Join Field for region boundaries we create in the [Elastic Maps Service](http://maps.elastic.co/#file/China%20Provinces). So it would be great to bundle the latest GeoLite databases with Elasticsearch 6.5. 

The [geolite2-databases repo has already been updated and deployed](https://github.com/elastic/geolite2-databases/pull/2). This PR just updates the dependency and corresponding database tests.
