### PR TITLE
SQL: Fix ANTL4 Grammar ambiguities.

### DIFF
--- a/x-pack/plugin/sql/src/main/antlr/SqlBase.g4
+++ b/x-pack/plugin/sql/src/main/antlr/SqlBase.g4
@@ -218,11 +218,9 @@ primaryExpression
     : castExpression                                                                 #cast
     | extractExpression                                                              #extract
     | constant                                                                       #constantDefault
-    | ASTERISK                                                                       #star
     | (qualifiedName DOT)? ASTERISK                                                  #star
     | functionExpression                                                             #function
     | '(' query ')'                                                                  #subqueryExpression
-    | identifier                                                                     #columnReference
     | qualifiedName                                                                  #dereference
     | '(' expression ')'                                                             #parenthesizedExpression
     ;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
@@ -51,7 +51,6 @@ import org.elasticsearch.xpack.sql.parser.SqlBaseParser.ArithmeticUnaryContext;
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.BooleanLiteralContext;
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.CastExpressionContext;
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.CastTemplateContext;
-import org.elasticsearch.xpack.sql.parser.SqlBaseParser.ColumnReferenceContext;
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.ComparisonContext;
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.DateEscapedLiteralContext;
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.DecimalLiteralContext;
@@ -140,11 +139,6 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
     public Expression visitStar(StarContext ctx) {
         return new UnresolvedStar(source(ctx), ctx.qualifiedName() != null ?
                 new UnresolvedAttribute(source(ctx.qualifiedName()), visitQualifiedName(ctx.qualifiedName())) : null);
-    }
-
-    @Override
-    public Object visitColumnReference(ColumnReferenceContext ctx) {
-        return new UnresolvedAttribute(source(ctx), visitIdentifier(ctx.identifier()));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseBaseListener.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseBaseListener.java
@@ -724,18 +724,6 @@ class SqlBaseBaseListener implements SqlBaseListener {
    *
    * <p>The default implementation does nothing.</p>
    */
-  @Override public void enterColumnReference(SqlBaseParser.ColumnReferenceContext ctx) { }
-  /**
-   * {@inheritDoc}
-   *
-   * <p>The default implementation does nothing.</p>
-   */
-  @Override public void exitColumnReference(SqlBaseParser.ColumnReferenceContext ctx) { }
-  /**
-   * {@inheritDoc}
-   *
-   * <p>The default implementation does nothing.</p>
-   */
   @Override public void enterDereference(SqlBaseParser.DereferenceContext ctx) { }
   /**
    * {@inheritDoc}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseBaseVisitor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseBaseVisitor.java
@@ -430,13 +430,6 @@ class SqlBaseBaseVisitor<T> extends AbstractParseTreeVisitor<T> implements SqlBa
    * <p>The default implementation returns the result of calling
    * {@link #visitChildren} on {@code ctx}.</p>
    */
-  @Override public T visitColumnReference(SqlBaseParser.ColumnReferenceContext ctx) { return visitChildren(ctx); }
-  /**
-   * {@inheritDoc}
-   *
-   * <p>The default implementation returns the result of calling
-   * {@link #visitChildren} on {@code ctx}.</p>
-   */
   @Override public T visitDereference(SqlBaseParser.DereferenceContext ctx) { return visitChildren(ctx); }
   /**
    * {@inheritDoc}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseListener.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseListener.java
@@ -670,18 +670,6 @@ interface SqlBaseListener extends ParseTreeListener {
    */
   void exitSubqueryExpression(SqlBaseParser.SubqueryExpressionContext ctx);
   /**
-   * Enter a parse tree produced by the {@code columnReference}
-   * labeled alternative in {@link SqlBaseParser#primaryExpression}.
-   * @param ctx the parse tree
-   */
-  void enterColumnReference(SqlBaseParser.ColumnReferenceContext ctx);
-  /**
-   * Exit a parse tree produced by the {@code columnReference}
-   * labeled alternative in {@link SqlBaseParser#primaryExpression}.
-   * @param ctx the parse tree
-   */
-  void exitColumnReference(SqlBaseParser.ColumnReferenceContext ctx);
-  /**
    * Enter a parse tree produced by the {@code dereference}
    * labeled alternative in {@link SqlBaseParser#primaryExpression}.
    * @param ctx the parse tree

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseParser.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseParser.java
@@ -3929,25 +3929,6 @@ class SqlBaseParser extends Parser {
       else return visitor.visitChildren(this);
     }
   }
-  public static class ColumnReferenceContext extends PrimaryExpressionContext {
-    public IdentifierContext identifier() {
-      return getRuleContext(IdentifierContext.class,0);
-    }
-    public ColumnReferenceContext(PrimaryExpressionContext ctx) { copyFrom(ctx); }
-    @Override
-    public void enterRule(ParseTreeListener listener) {
-      if ( listener instanceof SqlBaseListener ) ((SqlBaseListener)listener).enterColumnReference(this);
-    }
-    @Override
-    public void exitRule(ParseTreeListener listener) {
-      if ( listener instanceof SqlBaseListener ) ((SqlBaseListener)listener).exitColumnReference(this);
-    }
-    @Override
-    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-      if ( visitor instanceof SqlBaseVisitor ) return ((SqlBaseVisitor<? extends T>)visitor).visitColumnReference(this);
-      else return visitor.visitChildren(this);
-    }
-  }
   public static class ExtractContext extends PrimaryExpressionContext {
     public ExtractExpressionContext extractExpression() {
       return getRuleContext(ExtractExpressionContext.class,0);
@@ -4051,7 +4032,7 @@ class SqlBaseParser extends Parser {
     enterRule(_localctx, 60, RULE_primaryExpression);
     int _la;
     try {
-      setState(577);
+      setState(575);
       _errHandler.sync(this);
       switch ( getInterpreter().adaptivePredict(_input,76,_ctx) ) {
       case 1:
@@ -4082,74 +4063,58 @@ class SqlBaseParser extends Parser {
         _localctx = new StarContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(559);
-        match(ASTERISK);
-        }
-        break;
-      case 5:
-        _localctx = new StarContext(_localctx);
-        enterOuterAlt(_localctx, 5);
-        {
-        setState(563);
+        setState(562);
         _la = _input.LA(1);
         if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANALYZE) | (1L << ANALYZED) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << DEBUG) | (1L << EXECUTABLE) | (1L << EXPLAIN) | (1L << FORMAT) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << MAPPED) | (1L << OPTIMIZED) | (1L << PARSED) | (1L << PHYSICAL) | (1L << PLAN) | (1L << RLIKE) | (1L << QUERY) | (1L << SCHEMAS) | (1L << SHOW) | (1L << SYS) | (1L << TABLES))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (TEXT - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
           {
-          setState(560);
+          setState(559);
           qualifiedName();
-          setState(561);
+          setState(560);
           match(DOT);
           }
         }
 
-        setState(565);
+        setState(564);
         match(ASTERISK);
         }
         break;
-      case 6:
+      case 5:
         _localctx = new FunctionContext(_localctx);
-        enterOuterAlt(_localctx, 6);
+        enterOuterAlt(_localctx, 5);
         {
-        setState(566);
+        setState(565);
         functionExpression();
         }
         break;
-      case 7:
+      case 6:
         _localctx = new SubqueryExpressionContext(_localctx);
-        enterOuterAlt(_localctx, 7);
+        enterOuterAlt(_localctx, 6);
         {
-        setState(567);
+        setState(566);
         match(T__0);
-        setState(568);
+        setState(567);
         query();
-        setState(569);
+        setState(568);
         match(T__1);
         }
         break;
-      case 8:
-        _localctx = new ColumnReferenceContext(_localctx);
-        enterOuterAlt(_localctx, 8);
-        {
-        setState(571);
-        identifier();
-        }
-        break;
-      case 9:
+      case 7:
         _localctx = new DereferenceContext(_localctx);
-        enterOuterAlt(_localctx, 9);
+        enterOuterAlt(_localctx, 7);
         {
-        setState(572);
+        setState(570);
         qualifiedName();
         }
         break;
-      case 10:
+      case 8:
         _localctx = new ParenthesizedExpressionContext(_localctx);
-        enterOuterAlt(_localctx, 10);
+        enterOuterAlt(_localctx, 8);
         {
-        setState(573);
+        setState(571);
         match(T__0);
-        setState(574);
+        setState(572);
         expression();
-        setState(575);
+        setState(573);
         match(T__1);
         }
         break;
@@ -4195,23 +4160,23 @@ class SqlBaseParser extends Parser {
     CastExpressionContext _localctx = new CastExpressionContext(_ctx, getState());
     enterRule(_localctx, 62, RULE_castExpression);
     try {
-      setState(584);
+      setState(582);
       switch (_input.LA(1)) {
       case CAST:
         enterOuterAlt(_localctx, 1);
         {
-        setState(579);
+        setState(577);
         castTemplate();
         }
         break;
       case FUNCTION_ESC:
         enterOuterAlt(_localctx, 2);
         {
-        setState(580);
+        setState(578);
         match(FUNCTION_ESC);
-        setState(581);
+        setState(579);
         castTemplate();
-        setState(582);
+        setState(580);
         match(ESC_END);
         }
         break;
@@ -4264,17 +4229,17 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(586);
+      setState(584);
       match(CAST);
-      setState(587);
+      setState(585);
       match(T__0);
-      setState(588);
+      setState(586);
       expression();
-      setState(589);
+      setState(587);
       match(AS);
-      setState(590);
+      setState(588);
       dataType();
-      setState(591);
+      setState(589);
       match(T__1);
       }
     }
@@ -4318,23 +4283,23 @@ class SqlBaseParser extends Parser {
     ExtractExpressionContext _localctx = new ExtractExpressionContext(_ctx, getState());
     enterRule(_localctx, 66, RULE_extractExpression);
     try {
-      setState(598);
+      setState(596);
       switch (_input.LA(1)) {
       case EXTRACT:
         enterOuterAlt(_localctx, 1);
         {
-        setState(593);
+        setState(591);
         extractTemplate();
         }
         break;
       case FUNCTION_ESC:
         enterOuterAlt(_localctx, 2);
         {
-        setState(594);
+        setState(592);
         match(FUNCTION_ESC);
-        setState(595);
+        setState(593);
         extractTemplate();
-        setState(596);
+        setState(594);
         match(ESC_END);
         }
         break;
@@ -4388,17 +4353,17 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(600);
+      setState(598);
       match(EXTRACT);
-      setState(601);
+      setState(599);
       match(T__0);
-      setState(602);
+      setState(600);
       ((ExtractTemplateContext)_localctx).field = identifier();
-      setState(603);
+      setState(601);
       match(FROM);
-      setState(604);
+      setState(602);
       valueExpression(0);
-      setState(605);
+      setState(603);
       match(T__1);
       }
     }
@@ -4441,7 +4406,7 @@ class SqlBaseParser extends Parser {
     FunctionExpressionContext _localctx = new FunctionExpressionContext(_ctx, getState());
     enterRule(_localctx, 70, RULE_functionExpression);
     try {
-      setState(612);
+      setState(610);
       switch (_input.LA(1)) {
       case ANALYZE:
       case ANALYZED:
@@ -4476,18 +4441,18 @@ class SqlBaseParser extends Parser {
       case BACKQUOTED_IDENTIFIER:
         enterOuterAlt(_localctx, 1);
         {
-        setState(607);
+        setState(605);
         functionTemplate();
         }
         break;
       case FUNCTION_ESC:
         enterOuterAlt(_localctx, 2);
         {
-        setState(608);
+        setState(606);
         match(FUNCTION_ESC);
-        setState(609);
+        setState(607);
         functionTemplate();
-        setState(610);
+        setState(608);
         match(ESC_END);
         }
         break;
@@ -4545,45 +4510,45 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(614);
+      setState(612);
       functionName();
-      setState(615);
+      setState(613);
       match(T__0);
-      setState(627);
+      setState(625);
       _la = _input.LA(1);
       if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__0) | (1L << ALL) | (1L << ANALYZE) | (1L << ANALYZED) | (1L << CAST) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << DEBUG) | (1L << DISTINCT) | (1L << EXECUTABLE) | (1L << EXISTS) | (1L << EXPLAIN) | (1L << EXTRACT) | (1L << FALSE) | (1L << FORMAT) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << LEFT) | (1L << MAPPED) | (1L << MATCH) | (1L << NOT) | (1L << NULL) | (1L << OPTIMIZED) | (1L << PARSED) | (1L << PHYSICAL) | (1L << PLAN) | (1L << RIGHT) | (1L << RLIKE) | (1L << QUERY) | (1L << SCHEMAS) | (1L << SHOW) | (1L << SYS) | (1L << TABLES))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (TEXT - 64)) | (1L << (TRUE - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (FUNCTION_ESC - 64)) | (1L << (DATE_ESC - 64)) | (1L << (TIME_ESC - 64)) | (1L << (TIMESTAMP_ESC - 64)) | (1L << (GUID_ESC - 64)) | (1L << (PLUS - 64)) | (1L << (MINUS - 64)) | (1L << (ASTERISK - 64)) | (1L << (PARAM - 64)) | (1L << (STRING - 64)) | (1L << (INTEGER_VALUE - 64)) | (1L << (DECIMAL_VALUE - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
         {
-        setState(617);
+        setState(615);
         _la = _input.LA(1);
         if (_la==ALL || _la==DISTINCT) {
           {
-          setState(616);
+          setState(614);
           setQuantifier();
           }
         }
 
-        setState(619);
+        setState(617);
         expression();
-        setState(624);
+        setState(622);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==T__2) {
           {
           {
-          setState(620);
+          setState(618);
           match(T__2);
-          setState(621);
+          setState(619);
           expression();
           }
           }
-          setState(626);
+          setState(624);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
       }
 
-      setState(629);
+      setState(627);
       match(T__1);
       }
     }
@@ -4627,19 +4592,19 @@ class SqlBaseParser extends Parser {
     FunctionNameContext _localctx = new FunctionNameContext(_ctx, getState());
     enterRule(_localctx, 74, RULE_functionName);
     try {
-      setState(634);
+      setState(632);
       switch (_input.LA(1)) {
       case LEFT:
         enterOuterAlt(_localctx, 1);
         {
-        setState(631);
+        setState(629);
         match(LEFT);
         }
         break;
       case RIGHT:
         enterOuterAlt(_localctx, 2);
         {
-        setState(632);
+        setState(630);
         match(RIGHT);
         }
         break;
@@ -4674,7 +4639,7 @@ class SqlBaseParser extends Parser {
       case BACKQUOTED_IDENTIFIER:
         enterOuterAlt(_localctx, 3);
         {
-        setState(633);
+        setState(631);
         identifier();
         }
         break;
@@ -4886,13 +4851,13 @@ class SqlBaseParser extends Parser {
     enterRule(_localctx, 76, RULE_constant);
     try {
       int _alt;
-      setState(661);
+      setState(659);
       switch (_input.LA(1)) {
       case NULL:
         _localctx = new NullLiteralContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(636);
+        setState(634);
         match(NULL);
         }
         break;
@@ -4903,7 +4868,7 @@ class SqlBaseParser extends Parser {
         _localctx = new NumericLiteralContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(637);
+        setState(635);
         number();
         }
         break;
@@ -4912,7 +4877,7 @@ class SqlBaseParser extends Parser {
         _localctx = new BooleanLiteralContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(638);
+        setState(636);
         booleanValue();
         }
         break;
@@ -4920,7 +4885,7 @@ class SqlBaseParser extends Parser {
         _localctx = new StringLiteralContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(640); 
+        setState(638); 
         _errHandler.sync(this);
         _alt = 1;
         do {
@@ -4928,7 +4893,7 @@ class SqlBaseParser extends Parser {
           case 1:
             {
             {
-            setState(639);
+            setState(637);
             match(STRING);
             }
             }
@@ -4936,7 +4901,7 @@ class SqlBaseParser extends Parser {
           default:
             throw new NoViableAltException(this);
           }
-          setState(642); 
+          setState(640); 
           _errHandler.sync(this);
           _alt = getInterpreter().adaptivePredict(_input,84,_ctx);
         } while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER );
@@ -4946,7 +4911,7 @@ class SqlBaseParser extends Parser {
         _localctx = new ParamLiteralContext(_localctx);
         enterOuterAlt(_localctx, 5);
         {
-        setState(644);
+        setState(642);
         match(PARAM);
         }
         break;
@@ -4954,11 +4919,11 @@ class SqlBaseParser extends Parser {
         _localctx = new DateEscapedLiteralContext(_localctx);
         enterOuterAlt(_localctx, 6);
         {
-        setState(645);
+        setState(643);
         match(DATE_ESC);
-        setState(646);
+        setState(644);
         string();
-        setState(647);
+        setState(645);
         match(ESC_END);
         }
         break;
@@ -4966,11 +4931,11 @@ class SqlBaseParser extends Parser {
         _localctx = new TimeEscapedLiteralContext(_localctx);
         enterOuterAlt(_localctx, 7);
         {
-        setState(649);
+        setState(647);
         match(TIME_ESC);
-        setState(650);
+        setState(648);
         string();
-        setState(651);
+        setState(649);
         match(ESC_END);
         }
         break;
@@ -4978,11 +4943,11 @@ class SqlBaseParser extends Parser {
         _localctx = new TimestampEscapedLiteralContext(_localctx);
         enterOuterAlt(_localctx, 8);
         {
-        setState(653);
+        setState(651);
         match(TIMESTAMP_ESC);
-        setState(654);
+        setState(652);
         string();
-        setState(655);
+        setState(653);
         match(ESC_END);
         }
         break;
@@ -4990,11 +4955,11 @@ class SqlBaseParser extends Parser {
         _localctx = new GuidEscapedLiteralContext(_localctx);
         enterOuterAlt(_localctx, 9);
         {
-        setState(657);
+        setState(655);
         match(GUID_ESC);
-        setState(658);
+        setState(656);
         string();
-        setState(659);
+        setState(657);
         match(ESC_END);
         }
         break;
@@ -5046,7 +5011,7 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(663);
+      setState(661);
       _la = _input.LA(1);
       if ( !(((((_la - 80)) & ~0x3f) == 0 && ((1L << (_la - 80)) & ((1L << (EQ - 80)) | (1L << (NEQ - 80)) | (1L << (LT - 80)) | (1L << (LTE - 80)) | (1L << (GT - 80)) | (1L << (GTE - 80)))) != 0)) ) {
       _errHandler.recoverInline(this);
@@ -5095,7 +5060,7 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(665);
+      setState(663);
       _la = _input.LA(1);
       if ( !(_la==FALSE || _la==TRUE) ) {
       _errHandler.recoverInline(this);
@@ -5153,7 +5118,7 @@ class SqlBaseParser extends Parser {
       _localctx = new PrimitiveDataTypeContext(_localctx);
       enterOuterAlt(_localctx, 1);
       {
-      setState(667);
+      setState(665);
       identifier();
       }
     }
@@ -5205,25 +5170,25 @@ class SqlBaseParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(674);
+      setState(672);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,86,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           {
           {
-          setState(669);
+          setState(667);
           identifier();
-          setState(670);
+          setState(668);
           match(DOT);
           }
           } 
         }
-        setState(676);
+        setState(674);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,86,_ctx);
       }
-      setState(677);
+      setState(675);
       identifier();
       }
     }
@@ -5268,13 +5233,13 @@ class SqlBaseParser extends Parser {
     IdentifierContext _localctx = new IdentifierContext(_ctx, getState());
     enterRule(_localctx, 86, RULE_identifier);
     try {
-      setState(681);
+      setState(679);
       switch (_input.LA(1)) {
       case QUOTED_IDENTIFIER:
       case BACKQUOTED_IDENTIFIER:
         enterOuterAlt(_localctx, 1);
         {
-        setState(679);
+        setState(677);
         quoteIdentifier();
         }
         break;
@@ -5307,7 +5272,7 @@ class SqlBaseParser extends Parser {
       case DIGIT_IDENTIFIER:
         enterOuterAlt(_localctx, 2);
         {
-        setState(680);
+        setState(678);
         unquoteIdentifier();
         }
         break;
@@ -5360,43 +5325,43 @@ class SqlBaseParser extends Parser {
     enterRule(_localctx, 88, RULE_tableIdentifier);
     int _la;
     try {
-      setState(695);
+      setState(693);
       _errHandler.sync(this);
       switch ( getInterpreter().adaptivePredict(_input,90,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(686);
+        setState(684);
         _la = _input.LA(1);
         if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANALYZE) | (1L << ANALYZED) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << DEBUG) | (1L << EXECUTABLE) | (1L << EXPLAIN) | (1L << FORMAT) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << MAPPED) | (1L << OPTIMIZED) | (1L << PARSED) | (1L << PHYSICAL) | (1L << PLAN) | (1L << RLIKE) | (1L << QUERY) | (1L << SCHEMAS) | (1L << SHOW) | (1L << SYS) | (1L << TABLES))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (TEXT - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
           {
-          setState(683);
+          setState(681);
           ((TableIdentifierContext)_localctx).catalog = identifier();
-          setState(684);
+          setState(682);
           match(T__3);
           }
         }
 
-        setState(688);
+        setState(686);
         match(TABLE_IDENTIFIER);
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(692);
+        setState(690);
         _errHandler.sync(this);
         switch ( getInterpreter().adaptivePredict(_input,89,_ctx) ) {
         case 1:
           {
-          setState(689);
+          setState(687);
           ((TableIdentifierContext)_localctx).catalog = identifier();
-          setState(690);
+          setState(688);
           match(T__3);
           }
           break;
         }
-        setState(694);
+        setState(692);
         ((TableIdentifierContext)_localctx).name = identifier();
         }
         break;
@@ -5463,13 +5428,13 @@ class SqlBaseParser extends Parser {
     QuoteIdentifierContext _localctx = new QuoteIdentifierContext(_ctx, getState());
     enterRule(_localctx, 90, RULE_quoteIdentifier);
     try {
-      setState(699);
+      setState(697);
       switch (_input.LA(1)) {
       case QUOTED_IDENTIFIER:
         _localctx = new QuotedIdentifierContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(697);
+        setState(695);
         match(QUOTED_IDENTIFIER);
         }
         break;
@@ -5477,7 +5442,7 @@ class SqlBaseParser extends Parser {
         _localctx = new BackQuotedIdentifierContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(698);
+        setState(696);
         match(BACKQUOTED_IDENTIFIER);
         }
         break;
@@ -5549,13 +5514,13 @@ class SqlBaseParser extends Parser {
     UnquoteIdentifierContext _localctx = new UnquoteIdentifierContext(_ctx, getState());
     enterRule(_localctx, 92, RULE_unquoteIdentifier);
     try {
-      setState(704);
+      setState(702);
       switch (_input.LA(1)) {
       case IDENTIFIER:
         _localctx = new UnquotedIdentifierContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(701);
+        setState(699);
         match(IDENTIFIER);
         }
         break;
@@ -5587,7 +5552,7 @@ class SqlBaseParser extends Parser {
         _localctx = new UnquotedIdentifierContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(702);
+        setState(700);
         nonReserved();
         }
         break;
@@ -5595,7 +5560,7 @@ class SqlBaseParser extends Parser {
         _localctx = new DigitIdentifierContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(703);
+        setState(701);
         match(DIGIT_IDENTIFIER);
         }
         break;
@@ -5669,18 +5634,18 @@ class SqlBaseParser extends Parser {
     enterRule(_localctx, 94, RULE_number);
     int _la;
     try {
-      setState(714);
+      setState(712);
       _errHandler.sync(this);
       switch ( getInterpreter().adaptivePredict(_input,95,_ctx) ) {
       case 1:
         _localctx = new DecimalLiteralContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(707);
+        setState(705);
         _la = _input.LA(1);
         if (_la==PLUS || _la==MINUS) {
           {
-          setState(706);
+          setState(704);
           _la = _input.LA(1);
           if ( !(_la==PLUS || _la==MINUS) ) {
           _errHandler.recoverInline(this);
@@ -5690,7 +5655,7 @@ class SqlBaseParser extends Parser {
           }
         }
 
-        setState(709);
+        setState(707);
         match(DECIMAL_VALUE);
         }
         break;
@@ -5698,11 +5663,11 @@ class SqlBaseParser extends Parser {
         _localctx = new IntegerLiteralContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(711);
+        setState(709);
         _la = _input.LA(1);
         if (_la==PLUS || _la==MINUS) {
           {
-          setState(710);
+          setState(708);
           _la = _input.LA(1);
           if ( !(_la==PLUS || _la==MINUS) ) {
           _errHandler.recoverInline(this);
@@ -5712,7 +5677,7 @@ class SqlBaseParser extends Parser {
           }
         }
 
-        setState(713);
+        setState(711);
         match(INTEGER_VALUE);
         }
         break;
@@ -5758,7 +5723,7 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(716);
+      setState(714);
       _la = _input.LA(1);
       if ( !(_la==PARAM || _la==STRING) ) {
       _errHandler.recoverInline(this);
@@ -5830,7 +5795,7 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(718);
+      setState(716);
       _la = _input.LA(1);
       if ( !(((((_la - 6)) & ~0x3f) == 0 && ((1L << (_la - 6)) & ((1L << (ANALYZE - 6)) | (1L << (ANALYZED - 6)) | (1L << (CATALOGS - 6)) | (1L << (COLUMNS - 6)) | (1L << (DEBUG - 6)) | (1L << (EXECUTABLE - 6)) | (1L << (EXPLAIN - 6)) | (1L << (FORMAT - 6)) | (1L << (FUNCTIONS - 6)) | (1L << (GRAPHVIZ - 6)) | (1L << (MAPPED - 6)) | (1L << (OPTIMIZED - 6)) | (1L << (PARSED - 6)) | (1L << (PHYSICAL - 6)) | (1L << (PLAN - 6)) | (1L << (RLIKE - 6)) | (1L << (QUERY - 6)) | (1L << (SCHEMAS - 6)) | (1L << (SHOW - 6)) | (1L << (SYS - 6)) | (1L << (TABLES - 6)) | (1L << (TEXT - 6)) | (1L << (TYPE - 6)) | (1L << (TYPES - 6)) | (1L << (VERIFY - 6)))) != 0)) ) {
       _errHandler.recoverInline(this);
@@ -5881,7 +5846,7 @@ class SqlBaseParser extends Parser {
   }
 
   public static final String _serializedATN =
-    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3l\u02d3\4\2\t\2\4"+
+    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3l\u02d1\4\2\t\2\4"+
     "\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t"+
     "\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
     "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
@@ -5925,71 +5890,71 @@ class SqlBaseParser extends Parser {
     "\n\33\3\34\3\34\3\34\3\35\3\35\5\35\u0210\n\35\3\36\3\36\3\36\3\36\3\36"+
     "\3\36\5\36\u0218\n\36\3\37\3\37\3\37\3\37\5\37\u021e\n\37\3\37\3\37\3"+
     "\37\3\37\3\37\3\37\3\37\3\37\3\37\3\37\7\37\u022a\n\37\f\37\16\37\u022d"+
-    "\13\37\3 \3 \3 \3 \3 \3 \3 \5 \u0236\n \3 \3 \3 \3 \3 \3 \3 \3 \3 \3 "+
-    "\3 \3 \5 \u0244\n \3!\3!\3!\3!\3!\5!\u024b\n!\3\"\3\"\3\"\3\"\3\"\3\""+
-    "\3\"\3#\3#\3#\3#\3#\5#\u0259\n#\3$\3$\3$\3$\3$\3$\3$\3%\3%\3%\3%\3%\5"+
-    "%\u0267\n%\3&\3&\3&\5&\u026c\n&\3&\3&\3&\7&\u0271\n&\f&\16&\u0274\13&"+
-    "\5&\u0276\n&\3&\3&\3\'\3\'\3\'\5\'\u027d\n\'\3(\3(\3(\3(\6(\u0283\n(\r"+
-    "(\16(\u0284\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\5(\u0298"+
-    "\n(\3)\3)\3*\3*\3+\3+\3,\3,\3,\7,\u02a3\n,\f,\16,\u02a6\13,\3,\3,\3-\3"+
-    "-\5-\u02ac\n-\3.\3.\3.\5.\u02b1\n.\3.\3.\3.\3.\5.\u02b7\n.\3.\5.\u02ba"+
-    "\n.\3/\3/\5/\u02be\n/\3\60\3\60\3\60\5\60\u02c3\n\60\3\61\5\61\u02c6\n"+
-    "\61\3\61\3\61\5\61\u02ca\n\61\3\61\5\61\u02cd\n\61\3\62\3\62\3\63\3\63"+
-    "\3\63\2\4.<\64\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64"+
-    "\668:<>@BDFHJLNPRTVXZ\\^`bd\2\20\b\2\7\7\t\t\31\31,,\62\62\66\66\4\2\""+
-    "\"BB\4\2\t\t\62\62\4\2\37\37%%\3\2\25\26\4\2\7\7aa\4\2\r\r\25\25\4\2\7"+
-    "\7\27\27\3\2XY\3\2Z\\\3\2RW\4\2\35\35CC\3\2_`\20\2\b\t\22\24\31\31\33"+
-    "\33\36\36!\",,\62\62\668:<>?ABDEGG\u032c\2f\3\2\2\2\4i\3\2\2\2\6\u00d0"+
-    "\3\2\2\2\b\u00db\3\2\2\2\n\u00df\3\2\2\2\f\u00f4\3\2\2\2\16\u00fb\3\2"+
-    "\2\2\20\u00fd\3\2\2\2\22\u0101\3\2\2\2\24\u011d\3\2\2\2\26\u0127\3\2\2"+
-    "\2\30\u0131\3\2\2\2\32\u0140\3\2\2\2\34\u0142\3\2\2\2\36\u0148\3\2\2\2"+
-    " \u014a\3\2\2\2\"\u0151\3\2\2\2$\u0163\3\2\2\2&\u0174\3\2\2\2(\u0184\3"+
-    "\2\2\2*\u019f\3\2\2\2,\u01a1\3\2\2\2.\u01c2\3\2\2\2\60\u01d3\3\2\2\2\62"+
-    "\u01d6\3\2\2\2\64\u0208\3\2\2\2\66\u020a\3\2\2\28\u020d\3\2\2\2:\u0217"+
-    "\3\2\2\2<\u021d\3\2\2\2>\u0243\3\2\2\2@\u024a\3\2\2\2B\u024c\3\2\2\2D"+
-    "\u0258\3\2\2\2F\u025a\3\2\2\2H\u0266\3\2\2\2J\u0268\3\2\2\2L\u027c\3\2"+
-    "\2\2N\u0297\3\2\2\2P\u0299\3\2\2\2R\u029b\3\2\2\2T\u029d\3\2\2\2V\u02a4"+
-    "\3\2\2\2X\u02ab\3\2\2\2Z\u02b9\3\2\2\2\\\u02bd\3\2\2\2^\u02c2\3\2\2\2"+
-    "`\u02cc\3\2\2\2b\u02ce\3\2\2\2d\u02d0\3\2\2\2fg\5\6\4\2gh\7\2\2\3h\3\3"+
-    "\2\2\2ij\5,\27\2jk\7\2\2\3k\5\3\2\2\2l\u00d1\5\b\5\2m{\7\33\2\2nw\7\3"+
-    "\2\2op\78\2\2pv\t\2\2\2qr\7\36\2\2rv\t\3\2\2st\7G\2\2tv\5R*\2uo\3\2\2"+
-    "\2uq\3\2\2\2us\3\2\2\2vy\3\2\2\2wu\3\2\2\2wx\3\2\2\2xz\3\2\2\2yw\3\2\2"+
-    "\2z|\7\4\2\2{n\3\2\2\2{|\3\2\2\2|}\3\2\2\2}\u00d1\5\6\4\2~\u008a\7\24"+
-    "\2\2\177\u0086\7\3\2\2\u0080\u0081\78\2\2\u0081\u0085\t\4\2\2\u0082\u0083"+
-    "\7\36\2\2\u0083\u0085\t\3\2\2\u0084\u0080\3\2\2\2\u0084\u0082\3\2\2\2"+
-    "\u0085\u0088\3\2\2\2\u0086\u0084\3\2\2\2\u0086\u0087\3\2\2\2\u0087\u0089"+
-    "\3\2\2\2\u0088\u0086\3\2\2\2\u0089\u008b\7\4\2\2\u008a\177\3\2\2\2\u008a"+
-    "\u008b\3\2\2\2\u008b\u008c\3\2\2\2\u008c\u00d1\5\6\4\2\u008d\u008e\7>"+
-    "\2\2\u008e\u0091\7A\2\2\u008f\u0092\5\66\34\2\u0090\u0092\5Z.\2\u0091"+
-    "\u008f\3\2\2\2\u0091\u0090\3\2\2\2\u0091\u0092\3\2\2\2\u0092\u00d1\3\2"+
-    "\2\2\u0093\u0094\7>\2\2\u0094\u0095\7\23\2\2\u0095\u0098\t\5\2\2\u0096"+
-    "\u0099\5\66\34\2\u0097\u0099\5Z.\2\u0098\u0096\3\2\2\2\u0098\u0097\3\2"+
-    "\2\2\u0099\u00d1\3\2\2\2\u009a\u009d\t\6\2\2\u009b\u009e\5\66\34\2\u009c"+
-    "\u009e\5Z.\2\u009d\u009b\3\2\2\2\u009d\u009c\3\2\2\2\u009e\u00d1\3\2\2"+
-    "\2\u009f\u00a0\7>\2\2\u00a0\u00a2\7!\2\2\u00a1\u00a3\5\66\34\2\u00a2\u00a1"+
-    "\3\2\2\2\u00a2\u00a3\3\2\2\2\u00a3\u00d1\3\2\2\2\u00a4\u00a5\7>\2\2\u00a5"+
-    "\u00d1\7<\2\2\u00a6\u00a7\7?\2\2\u00a7\u00d1\7\22\2\2\u00a8\u00a9\7?\2"+
-    "\2\u00a9\u00ac\7A\2\2\u00aa\u00ab\7\21\2\2\u00ab\u00ad\5\66\34\2\u00ac"+
-    "\u00aa\3\2\2\2\u00ac\u00ad\3\2\2\2\u00ad\u00b0\3\2\2\2\u00ae\u00b1\5\66"+
-    "\34\2\u00af\u00b1\5Z.\2\u00b0\u00ae\3\2\2\2\u00b0\u00af\3\2\2\2\u00b0"+
-    "\u00b1\3\2\2\2\u00b1\u00bb\3\2\2\2\u00b2\u00b3\7D\2\2\u00b3\u00b8\5b\62"+
-    "\2\u00b4\u00b5\7\5\2\2\u00b5\u00b7\5b\62\2\u00b6\u00b4\3\2\2\2\u00b7\u00ba"+
-    "\3\2\2\2\u00b8\u00b6\3\2\2\2\u00b8\u00b9\3\2\2\2\u00b9\u00bc\3\2\2\2\u00ba"+
-    "\u00b8\3\2\2\2\u00bb\u00b2\3\2\2\2\u00bb\u00bc\3\2\2\2\u00bc\u00d1\3\2"+
-    "\2\2\u00bd\u00be\7?\2\2\u00be\u00c1\7\23\2\2\u00bf\u00c0\7\21\2\2\u00c0"+
-    "\u00c2\5b\62\2\u00c1\u00bf\3\2\2\2\u00c1\u00c2\3\2\2\2\u00c2\u00c6\3\2"+
-    "\2\2\u00c3\u00c4\7@\2\2\u00c4\u00c7\5\66\34\2\u00c5\u00c7\5Z.\2\u00c6"+
-    "\u00c3\3\2\2\2\u00c6\u00c5\3\2\2\2\u00c6\u00c7\3\2\2\2\u00c7\u00c9\3\2"+
-    "\2\2\u00c8\u00ca\5\66\34\2\u00c9\u00c8\3\2\2\2\u00c9\u00ca\3\2\2\2\u00ca"+
-    "\u00d1\3\2\2\2\u00cb\u00cc\7?\2\2\u00cc\u00d1\7E\2\2\u00cd\u00ce\7?\2"+
-    "\2\u00ce\u00cf\7@\2\2\u00cf\u00d1\7E\2\2\u00d0l\3\2\2\2\u00d0m\3\2\2\2"+
-    "\u00d0~\3\2\2\2\u00d0\u008d\3\2\2\2\u00d0\u0093\3\2\2\2\u00d0\u009a\3"+
-    "\2\2\2\u00d0\u009f\3\2\2\2\u00d0\u00a4\3\2\2\2\u00d0\u00a6\3\2\2\2\u00d0"+
-    "\u00a8\3\2\2\2\u00d0\u00bd\3\2\2\2\u00d0\u00cb\3\2\2\2\u00d0\u00cd\3\2"+
-    "\2\2\u00d1\7\3\2\2\2\u00d2\u00d3\7I\2\2\u00d3\u00d8\5\34\17\2\u00d4\u00d5"+
-    "\7\5\2\2\u00d5\u00d7\5\34\17\2\u00d6\u00d4\3\2\2\2\u00d7\u00da\3\2\2\2"+
-    "\u00d8\u00d6\3\2\2\2\u00d8\u00d9\3\2\2\2\u00d9\u00dc\3\2\2\2\u00da\u00d8"+
-    "\3\2\2\2\u00db\u00d2\3\2\2\2\u00db\u00dc\3\2\2\2\u00dc\u00dd\3\2\2\2\u00dd"+
+    "\13\37\3 \3 \3 \3 \3 \3 \5 \u0235\n \3 \3 \3 \3 \3 \3 \3 \3 \3 \3 \3 "+
+    "\5 \u0242\n \3!\3!\3!\3!\3!\5!\u0249\n!\3\"\3\"\3\"\3\"\3\"\3\"\3\"\3"+
+    "#\3#\3#\3#\3#\5#\u0257\n#\3$\3$\3$\3$\3$\3$\3$\3%\3%\3%\3%\3%\5%\u0265"+
+    "\n%\3&\3&\3&\5&\u026a\n&\3&\3&\3&\7&\u026f\n&\f&\16&\u0272\13&\5&\u0274"+
+    "\n&\3&\3&\3\'\3\'\3\'\5\'\u027b\n\'\3(\3(\3(\3(\6(\u0281\n(\r(\16(\u0282"+
+    "\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\5(\u0296\n(\3)\3)"+
+    "\3*\3*\3+\3+\3,\3,\3,\7,\u02a1\n,\f,\16,\u02a4\13,\3,\3,\3-\3-\5-\u02aa"+
+    "\n-\3.\3.\3.\5.\u02af\n.\3.\3.\3.\3.\5.\u02b5\n.\3.\5.\u02b8\n.\3/\3/"+
+    "\5/\u02bc\n/\3\60\3\60\3\60\5\60\u02c1\n\60\3\61\5\61\u02c4\n\61\3\61"+
+    "\3\61\5\61\u02c8\n\61\3\61\5\61\u02cb\n\61\3\62\3\62\3\63\3\63\3\63\2"+
+    "\4.<\64\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64\668:"+
+    "<>@BDFHJLNPRTVXZ\\^`bd\2\20\b\2\7\7\t\t\31\31,,\62\62\66\66\4\2\"\"BB"+
+    "\4\2\t\t\62\62\4\2\37\37%%\3\2\25\26\4\2\7\7aa\4\2\r\r\25\25\4\2\7\7\27"+
+    "\27\3\2XY\3\2Z\\\3\2RW\4\2\35\35CC\3\2_`\20\2\b\t\22\24\31\31\33\33\36"+
+    "\36!\",,\62\62\668:<>?ABDEGG\u0328\2f\3\2\2\2\4i\3\2\2\2\6\u00d0\3\2\2"+
+    "\2\b\u00db\3\2\2\2\n\u00df\3\2\2\2\f\u00f4\3\2\2\2\16\u00fb\3\2\2\2\20"+
+    "\u00fd\3\2\2\2\22\u0101\3\2\2\2\24\u011d\3\2\2\2\26\u0127\3\2\2\2\30\u0131"+
+    "\3\2\2\2\32\u0140\3\2\2\2\34\u0142\3\2\2\2\36\u0148\3\2\2\2 \u014a\3\2"+
+    "\2\2\"\u0151\3\2\2\2$\u0163\3\2\2\2&\u0174\3\2\2\2(\u0184\3\2\2\2*\u019f"+
+    "\3\2\2\2,\u01a1\3\2\2\2.\u01c2\3\2\2\2\60\u01d3\3\2\2\2\62\u01d6\3\2\2"+
+    "\2\64\u0208\3\2\2\2\66\u020a\3\2\2\28\u020d\3\2\2\2:\u0217\3\2\2\2<\u021d"+
+    "\3\2\2\2>\u0241\3\2\2\2@\u0248\3\2\2\2B\u024a\3\2\2\2D\u0256\3\2\2\2F"+
+    "\u0258\3\2\2\2H\u0264\3\2\2\2J\u0266\3\2\2\2L\u027a\3\2\2\2N\u0295\3\2"+
+    "\2\2P\u0297\3\2\2\2R\u0299\3\2\2\2T\u029b\3\2\2\2V\u02a2\3\2\2\2X\u02a9"+
+    "\3\2\2\2Z\u02b7\3\2\2\2\\\u02bb\3\2\2\2^\u02c0\3\2\2\2`\u02ca\3\2\2\2"+
+    "b\u02cc\3\2\2\2d\u02ce\3\2\2\2fg\5\6\4\2gh\7\2\2\3h\3\3\2\2\2ij\5,\27"+
+    "\2jk\7\2\2\3k\5\3\2\2\2l\u00d1\5\b\5\2m{\7\33\2\2nw\7\3\2\2op\78\2\2p"+
+    "v\t\2\2\2qr\7\36\2\2rv\t\3\2\2st\7G\2\2tv\5R*\2uo\3\2\2\2uq\3\2\2\2us"+
+    "\3\2\2\2vy\3\2\2\2wu\3\2\2\2wx\3\2\2\2xz\3\2\2\2yw\3\2\2\2z|\7\4\2\2{"+
+    "n\3\2\2\2{|\3\2\2\2|}\3\2\2\2}\u00d1\5\6\4\2~\u008a\7\24\2\2\177\u0086"+
+    "\7\3\2\2\u0080\u0081\78\2\2\u0081\u0085\t\4\2\2\u0082\u0083\7\36\2\2\u0083"+
+    "\u0085\t\3\2\2\u0084\u0080\3\2\2\2\u0084\u0082\3\2\2\2\u0085\u0088\3\2"+
+    "\2\2\u0086\u0084\3\2\2\2\u0086\u0087\3\2\2\2\u0087\u0089\3\2\2\2\u0088"+
+    "\u0086\3\2\2\2\u0089\u008b\7\4\2\2\u008a\177\3\2\2\2\u008a\u008b\3\2\2"+
+    "\2\u008b\u008c\3\2\2\2\u008c\u00d1\5\6\4\2\u008d\u008e\7>\2\2\u008e\u0091"+
+    "\7A\2\2\u008f\u0092\5\66\34\2\u0090\u0092\5Z.\2\u0091\u008f\3\2\2\2\u0091"+
+    "\u0090\3\2\2\2\u0091\u0092\3\2\2\2\u0092\u00d1\3\2\2\2\u0093\u0094\7>"+
+    "\2\2\u0094\u0095\7\23\2\2\u0095\u0098\t\5\2\2\u0096\u0099\5\66\34\2\u0097"+
+    "\u0099\5Z.\2\u0098\u0096\3\2\2\2\u0098\u0097\3\2\2\2\u0099\u00d1\3\2\2"+
+    "\2\u009a\u009d\t\6\2\2\u009b\u009e\5\66\34\2\u009c\u009e\5Z.\2\u009d\u009b"+
+    "\3\2\2\2\u009d\u009c\3\2\2\2\u009e\u00d1\3\2\2\2\u009f\u00a0\7>\2\2\u00a0"+
+    "\u00a2\7!\2\2\u00a1\u00a3\5\66\34\2\u00a2\u00a1\3\2\2\2\u00a2\u00a3\3"+
+    "\2\2\2\u00a3\u00d1\3\2\2\2\u00a4\u00a5\7>\2\2\u00a5\u00d1\7<\2\2\u00a6"+
+    "\u00a7\7?\2\2\u00a7\u00d1\7\22\2\2\u00a8\u00a9\7?\2\2\u00a9\u00ac\7A\2"+
+    "\2\u00aa\u00ab\7\21\2\2\u00ab\u00ad\5\66\34\2\u00ac\u00aa\3\2\2\2\u00ac"+
+    "\u00ad\3\2\2\2\u00ad\u00b0\3\2\2\2\u00ae\u00b1\5\66\34\2\u00af\u00b1\5"+
+    "Z.\2\u00b0\u00ae\3\2\2\2\u00b0\u00af\3\2\2\2\u00b0\u00b1\3\2\2\2\u00b1"+
+    "\u00bb\3\2\2\2\u00b2\u00b3\7D\2\2\u00b3\u00b8\5b\62\2\u00b4\u00b5\7\5"+
+    "\2\2\u00b5\u00b7\5b\62\2\u00b6\u00b4\3\2\2\2\u00b7\u00ba\3\2\2\2\u00b8"+
+    "\u00b6\3\2\2\2\u00b8\u00b9\3\2\2\2\u00b9\u00bc\3\2\2\2\u00ba\u00b8\3\2"+
+    "\2\2\u00bb\u00b2\3\2\2\2\u00bb\u00bc\3\2\2\2\u00bc\u00d1\3\2\2\2\u00bd"+
+    "\u00be\7?\2\2\u00be\u00c1\7\23\2\2\u00bf\u00c0\7\21\2\2\u00c0\u00c2\5"+
+    "b\62\2\u00c1\u00bf\3\2\2\2\u00c1\u00c2\3\2\2\2\u00c2\u00c6\3\2\2\2\u00c3"+
+    "\u00c4\7@\2\2\u00c4\u00c7\5\66\34\2\u00c5\u00c7\5Z.\2\u00c6\u00c3\3\2"+
+    "\2\2\u00c6\u00c5\3\2\2\2\u00c6\u00c7\3\2\2\2\u00c7\u00c9\3\2\2\2\u00c8"+
+    "\u00ca\5\66\34\2\u00c9\u00c8\3\2\2\2\u00c9\u00ca\3\2\2\2\u00ca\u00d1\3"+
+    "\2\2\2\u00cb\u00cc\7?\2\2\u00cc\u00d1\7E\2\2\u00cd\u00ce\7?\2\2\u00ce"+
+    "\u00cf\7@\2\2\u00cf\u00d1\7E\2\2\u00d0l\3\2\2\2\u00d0m\3\2\2\2\u00d0~"+
+    "\3\2\2\2\u00d0\u008d\3\2\2\2\u00d0\u0093\3\2\2\2\u00d0\u009a\3\2\2\2\u00d0"+
+    "\u009f\3\2\2\2\u00d0\u00a4\3\2\2\2\u00d0\u00a6\3\2\2\2\u00d0\u00a8\3\2"+
+    "\2\2\u00d0\u00bd\3\2\2\2\u00d0\u00cb\3\2\2\2\u00d0\u00cd\3\2\2\2\u00d1"+
+    "\7\3\2\2\2\u00d2\u00d3\7I\2\2\u00d3\u00d8\5\34\17\2\u00d4\u00d5\7\5\2"+
+    "\2\u00d5\u00d7\5\34\17\2\u00d6\u00d4\3\2\2\2\u00d7\u00da\3\2\2\2\u00d8"+
+    "\u00d6\3\2\2\2\u00d8\u00d9\3\2\2\2\u00d9\u00dc\3\2\2\2\u00da\u00d8\3\2"+
+    "\2\2\u00db\u00d2\3\2\2\2\u00db\u00dc\3\2\2\2\u00dc\u00dd\3\2\2\2\u00dd"+
     "\u00de\5\n\6\2\u00de\t\3\2\2\2\u00df\u00ea\5\16\b\2\u00e0\u00e1\7\64\2"+
     "\2\u00e1\u00e2\7\17\2\2\u00e2\u00e7\5\20\t\2\u00e3\u00e4\7\5\2\2\u00e4"+
     "\u00e6\5\20\t\2\u00e5\u00e3\3\2\2\2\u00e6\u00e9\3\2\2\2\u00e7\u00e5\3"+
@@ -6102,69 +6067,68 @@ class SqlBaseParser extends Parser {
     "\37\5\u0225\u0226\f\3\2\2\u0226\u0227\5P)\2\u0227\u0228\5<\37\4\u0228"+
     "\u022a\3\2\2\2\u0229\u021f\3\2\2\2\u0229\u0222\3\2\2\2\u0229\u0225\3\2"+
     "\2\2\u022a\u022d\3\2\2\2\u022b\u0229\3\2\2\2\u022b\u022c\3\2\2\2\u022c"+
-    "=\3\2\2\2\u022d\u022b\3\2\2\2\u022e\u0244\5@!\2\u022f\u0244\5D#\2\u0230"+
-    "\u0244\5N(\2\u0231\u0244\7Z\2\2\u0232\u0233\5V,\2\u0233\u0234\7^\2\2\u0234"+
-    "\u0236\3\2\2\2\u0235\u0232\3\2\2\2\u0235\u0236\3\2\2\2\u0236\u0237\3\2"+
-    "\2\2\u0237\u0244\7Z\2\2\u0238\u0244\5H%\2\u0239\u023a\7\3\2\2\u023a\u023b"+
-    "\5\b\5\2\u023b\u023c\7\4\2\2\u023c\u0244\3\2\2\2\u023d\u0244\5X-\2\u023e"+
-    "\u0244\5V,\2\u023f\u0240\7\3\2\2\u0240\u0241\5,\27\2\u0241\u0242\7\4\2"+
-    "\2\u0242\u0244\3\2\2\2\u0243\u022e\3\2\2\2\u0243\u022f\3\2\2\2\u0243\u0230"+
-    "\3\2\2\2\u0243\u0231\3\2\2\2\u0243\u0235\3\2\2\2\u0243\u0238\3\2\2\2\u0243"+
-    "\u0239\3\2\2\2\u0243\u023d\3\2\2\2\u0243\u023e\3\2\2\2\u0243\u023f\3\2"+
-    "\2\2\u0244?\3\2\2\2\u0245\u024b\5B\"\2\u0246\u0247\7K\2\2\u0247\u0248"+
-    "\5B\"\2\u0248\u0249\7Q\2\2\u0249\u024b\3\2\2\2\u024a\u0245\3\2\2\2\u024a"+
-    "\u0246\3\2\2\2\u024bA\3\2\2\2\u024c\u024d\7\20\2\2\u024d\u024e\7\3\2\2"+
-    "\u024e\u024f\5,\27\2\u024f\u0250\7\f\2\2\u0250\u0251\5T+\2\u0251\u0252"+
-    "\7\4\2\2\u0252C\3\2\2\2\u0253\u0259\5F$\2\u0254\u0255\7K\2\2\u0255\u0256"+
-    "\5F$\2\u0256\u0257\7Q\2\2\u0257\u0259\3\2\2\2\u0258\u0253\3\2\2\2\u0258"+
-    "\u0254\3\2\2\2\u0259E\3\2\2\2\u025a\u025b\7\34\2\2\u025b\u025c\7\3\2\2"+
-    "\u025c\u025d\5X-\2\u025d\u025e\7\37\2\2\u025e\u025f\5<\37\2\u025f\u0260"+
-    "\7\4\2\2\u0260G\3\2\2\2\u0261\u0267\5J&\2\u0262\u0263\7K\2\2\u0263\u0264"+
-    "\5J&\2\u0264\u0265\7Q\2\2\u0265\u0267\3\2\2\2\u0266\u0261\3\2\2\2\u0266"+
-    "\u0262\3\2\2\2\u0267I\3\2\2\2\u0268\u0269\5L\'\2\u0269\u0275\7\3\2\2\u026a"+
-    "\u026c\5\36\20\2\u026b\u026a\3\2\2\2\u026b\u026c\3\2\2\2\u026c\u026d\3"+
-    "\2\2\2\u026d\u0272\5,\27\2\u026e\u026f\7\5\2\2\u026f\u0271\5,\27\2\u0270"+
-    "\u026e\3\2\2\2\u0271\u0274\3\2\2\2\u0272\u0270\3\2\2\2\u0272\u0273\3\2"+
-    "\2\2\u0273\u0276\3\2\2\2\u0274\u0272\3\2\2\2\u0275\u026b\3\2\2\2\u0275"+
-    "\u0276\3\2\2\2\u0276\u0277\3\2\2\2\u0277\u0278\7\4\2\2\u0278K\3\2\2\2"+
-    "\u0279\u027d\7)\2\2\u027a\u027d\79\2\2\u027b\u027d\5X-\2\u027c\u0279\3"+
-    "\2\2\2\u027c\u027a\3\2\2\2\u027c\u027b\3\2\2\2\u027dM\3\2\2\2\u027e\u0298"+
-    "\7\60\2\2\u027f\u0298\5`\61\2\u0280\u0298\5R*\2\u0281\u0283\7`\2\2\u0282"+
-    "\u0281\3\2\2\2\u0283\u0284\3\2\2\2\u0284\u0282\3\2\2\2\u0284\u0285\3\2"+
-    "\2\2\u0285\u0298\3\2\2\2\u0286\u0298\7_\2\2\u0287\u0288\7M\2\2\u0288\u0289"+
-    "\5b\62\2\u0289\u028a\7Q\2\2\u028a\u0298\3\2\2\2\u028b\u028c\7N\2\2\u028c"+
-    "\u028d\5b\62\2\u028d\u028e\7Q\2\2\u028e\u0298\3\2\2\2\u028f\u0290\7O\2"+
-    "\2\u0290\u0291\5b\62\2\u0291\u0292\7Q\2\2\u0292\u0298\3\2\2\2\u0293\u0294"+
-    "\7P\2\2\u0294\u0295\5b\62\2\u0295\u0296\7Q\2\2\u0296\u0298\3\2\2\2\u0297"+
-    "\u027e\3\2\2\2\u0297\u027f\3\2\2\2\u0297\u0280\3\2\2\2\u0297\u0282\3\2"+
-    "\2\2\u0297\u0286\3\2\2\2\u0297\u0287\3\2\2\2\u0297\u028b\3\2\2\2\u0297"+
-    "\u028f\3\2\2\2\u0297\u0293\3\2\2\2\u0298O\3\2\2\2\u0299\u029a\t\f\2\2"+
-    "\u029aQ\3\2\2\2\u029b\u029c\t\r\2\2\u029cS\3\2\2\2\u029d\u029e\5X-\2\u029e"+
-    "U\3\2\2\2\u029f\u02a0\5X-\2\u02a0\u02a1\7^\2\2\u02a1\u02a3\3\2\2\2\u02a2"+
-    "\u029f\3\2\2\2\u02a3\u02a6\3\2\2\2\u02a4\u02a2\3\2\2\2\u02a4\u02a5\3\2"+
-    "\2\2\u02a5\u02a7\3\2\2\2\u02a6\u02a4\3\2\2\2\u02a7\u02a8\5X-\2\u02a8W"+
-    "\3\2\2\2\u02a9\u02ac\5\\/\2\u02aa\u02ac\5^\60\2\u02ab\u02a9\3\2\2\2\u02ab"+
-    "\u02aa\3\2\2\2\u02acY\3\2\2\2\u02ad\u02ae\5X-\2\u02ae\u02af\7\6\2\2\u02af"+
-    "\u02b1\3\2\2\2\u02b0\u02ad\3\2\2\2\u02b0\u02b1\3\2\2\2\u02b1\u02b2\3\2"+
-    "\2\2\u02b2\u02ba\7e\2\2\u02b3\u02b4\5X-\2\u02b4\u02b5\7\6\2\2\u02b5\u02b7"+
-    "\3\2\2\2\u02b6\u02b3\3\2\2\2\u02b6\u02b7\3\2\2\2\u02b7\u02b8\3\2\2\2\u02b8"+
-    "\u02ba\5X-\2\u02b9\u02b0\3\2\2\2\u02b9\u02b6\3\2\2\2\u02ba[\3\2\2\2\u02bb"+
-    "\u02be\7f\2\2\u02bc\u02be\7g\2\2\u02bd\u02bb\3\2\2\2\u02bd\u02bc\3\2\2"+
-    "\2\u02be]\3\2\2\2\u02bf\u02c3\7c\2\2\u02c0\u02c3\5d\63\2\u02c1\u02c3\7"+
-    "d\2\2\u02c2\u02bf\3\2\2\2\u02c2\u02c0\3\2\2\2\u02c2\u02c1\3\2\2\2\u02c3"+
-    "_\3\2\2\2\u02c4\u02c6\t\n\2\2\u02c5\u02c4\3\2\2\2\u02c5\u02c6\3\2\2\2"+
-    "\u02c6\u02c7\3\2\2\2\u02c7\u02cd\7b\2\2\u02c8\u02ca\t\n\2\2\u02c9\u02c8"+
-    "\3\2\2\2\u02c9\u02ca\3\2\2\2\u02ca\u02cb\3\2\2\2\u02cb\u02cd\7a\2\2\u02cc"+
-    "\u02c5\3\2\2\2\u02cc\u02c9\3\2\2\2\u02cda\3\2\2\2\u02ce\u02cf\t\16\2\2"+
-    "\u02cfc\3\2\2\2\u02d0\u02d1\t\17\2\2\u02d1e\3\2\2\2buw{\u0084\u0086\u008a"+
+    "=\3\2\2\2\u022d\u022b\3\2\2\2\u022e\u0242\5@!\2\u022f\u0242\5D#\2\u0230"+
+    "\u0242\5N(\2\u0231\u0232\5V,\2\u0232\u0233\7^\2\2\u0233\u0235\3\2\2\2"+
+    "\u0234\u0231\3\2\2\2\u0234\u0235\3\2\2\2\u0235\u0236\3\2\2\2\u0236\u0242"+
+    "\7Z\2\2\u0237\u0242\5H%\2\u0238\u0239\7\3\2\2\u0239\u023a\5\b\5\2\u023a"+
+    "\u023b\7\4\2\2\u023b\u0242\3\2\2\2\u023c\u0242\5V,\2\u023d\u023e\7\3\2"+
+    "\2\u023e\u023f\5,\27\2\u023f\u0240\7\4\2\2\u0240\u0242\3\2\2\2\u0241\u022e"+
+    "\3\2\2\2\u0241\u022f\3\2\2\2\u0241\u0230\3\2\2\2\u0241\u0234\3\2\2\2\u0241"+
+    "\u0237\3\2\2\2\u0241\u0238\3\2\2\2\u0241\u023c\3\2\2\2\u0241\u023d\3\2"+
+    "\2\2\u0242?\3\2\2\2\u0243\u0249\5B\"\2\u0244\u0245\7K\2\2\u0245\u0246"+
+    "\5B\"\2\u0246\u0247\7Q\2\2\u0247\u0249\3\2\2\2\u0248\u0243\3\2\2\2\u0248"+
+    "\u0244\3\2\2\2\u0249A\3\2\2\2\u024a\u024b\7\20\2\2\u024b\u024c\7\3\2\2"+
+    "\u024c\u024d\5,\27\2\u024d\u024e\7\f\2\2\u024e\u024f\5T+\2\u024f\u0250"+
+    "\7\4\2\2\u0250C\3\2\2\2\u0251\u0257\5F$\2\u0252\u0253\7K\2\2\u0253\u0254"+
+    "\5F$\2\u0254\u0255\7Q\2\2\u0255\u0257\3\2\2\2\u0256\u0251\3\2\2\2\u0256"+
+    "\u0252\3\2\2\2\u0257E\3\2\2\2\u0258\u0259\7\34\2\2\u0259\u025a\7\3\2\2"+
+    "\u025a\u025b\5X-\2\u025b\u025c\7\37\2\2\u025c\u025d\5<\37\2\u025d\u025e"+
+    "\7\4\2\2\u025eG\3\2\2\2\u025f\u0265\5J&\2\u0260\u0261\7K\2\2\u0261\u0262"+
+    "\5J&\2\u0262\u0263\7Q\2\2\u0263\u0265\3\2\2\2\u0264\u025f\3\2\2\2\u0264"+
+    "\u0260\3\2\2\2\u0265I\3\2\2\2\u0266\u0267\5L\'\2\u0267\u0273\7\3\2\2\u0268"+
+    "\u026a\5\36\20\2\u0269\u0268\3\2\2\2\u0269\u026a\3\2\2\2\u026a\u026b\3"+
+    "\2\2\2\u026b\u0270\5,\27\2\u026c\u026d\7\5\2\2\u026d\u026f\5,\27\2\u026e"+
+    "\u026c\3\2\2\2\u026f\u0272\3\2\2\2\u0270\u026e\3\2\2\2\u0270\u0271\3\2"+
+    "\2\2\u0271\u0274\3\2\2\2\u0272\u0270\3\2\2\2\u0273\u0269\3\2\2\2\u0273"+
+    "\u0274\3\2\2\2\u0274\u0275\3\2\2\2\u0275\u0276\7\4\2\2\u0276K\3\2\2\2"+
+    "\u0277\u027b\7)\2\2\u0278\u027b\79\2\2\u0279\u027b\5X-\2\u027a\u0277\3"+
+    "\2\2\2\u027a\u0278\3\2\2\2\u027a\u0279\3\2\2\2\u027bM\3\2\2\2\u027c\u0296"+
+    "\7\60\2\2\u027d\u0296\5`\61\2\u027e\u0296\5R*\2\u027f\u0281\7`\2\2\u0280"+
+    "\u027f\3\2\2\2\u0281\u0282\3\2\2\2\u0282\u0280\3\2\2\2\u0282\u0283\3\2"+
+    "\2\2\u0283\u0296\3\2\2\2\u0284\u0296\7_\2\2\u0285\u0286\7M\2\2\u0286\u0287"+
+    "\5b\62\2\u0287\u0288\7Q\2\2\u0288\u0296\3\2\2\2\u0289\u028a\7N\2\2\u028a"+
+    "\u028b\5b\62\2\u028b\u028c\7Q\2\2\u028c\u0296\3\2\2\2\u028d\u028e\7O\2"+
+    "\2\u028e\u028f\5b\62\2\u028f\u0290\7Q\2\2\u0290\u0296\3\2\2\2\u0291\u0292"+
+    "\7P\2\2\u0292\u0293\5b\62\2\u0293\u0294\7Q\2\2\u0294\u0296\3\2\2\2\u0295"+
+    "\u027c\3\2\2\2\u0295\u027d\3\2\2\2\u0295\u027e\3\2\2\2\u0295\u0280\3\2"+
+    "\2\2\u0295\u0284\3\2\2\2\u0295\u0285\3\2\2\2\u0295\u0289\3\2\2\2\u0295"+
+    "\u028d\3\2\2\2\u0295\u0291\3\2\2\2\u0296O\3\2\2\2\u0297\u0298\t\f\2\2"+
+    "\u0298Q\3\2\2\2\u0299\u029a\t\r\2\2\u029aS\3\2\2\2\u029b\u029c\5X-\2\u029c"+
+    "U\3\2\2\2\u029d\u029e\5X-\2\u029e\u029f\7^\2\2\u029f\u02a1\3\2\2\2\u02a0"+
+    "\u029d\3\2\2\2\u02a1\u02a4\3\2\2\2\u02a2\u02a0\3\2\2\2\u02a2\u02a3\3\2"+
+    "\2\2\u02a3\u02a5\3\2\2\2\u02a4\u02a2\3\2\2\2\u02a5\u02a6\5X-\2\u02a6W"+
+    "\3\2\2\2\u02a7\u02aa\5\\/\2\u02a8\u02aa\5^\60\2\u02a9\u02a7\3\2\2\2\u02a9"+
+    "\u02a8\3\2\2\2\u02aaY\3\2\2\2\u02ab\u02ac\5X-\2\u02ac\u02ad\7\6\2\2\u02ad"+
+    "\u02af\3\2\2\2\u02ae\u02ab\3\2\2\2\u02ae\u02af\3\2\2\2\u02af\u02b0\3\2"+
+    "\2\2\u02b0\u02b8\7e\2\2\u02b1\u02b2\5X-\2\u02b2\u02b3\7\6\2\2\u02b3\u02b5"+
+    "\3\2\2\2\u02b4\u02b1\3\2\2\2\u02b4\u02b5\3\2\2\2\u02b5\u02b6\3\2\2\2\u02b6"+
+    "\u02b8\5X-\2\u02b7\u02ae\3\2\2\2\u02b7\u02b4\3\2\2\2\u02b8[\3\2\2\2\u02b9"+
+    "\u02bc\7f\2\2\u02ba\u02bc\7g\2\2\u02bb\u02b9\3\2\2\2\u02bb\u02ba\3\2\2"+
+    "\2\u02bc]\3\2\2\2\u02bd\u02c1\7c\2\2\u02be\u02c1\5d\63\2\u02bf\u02c1\7"+
+    "d\2\2\u02c0\u02bd\3\2\2\2\u02c0\u02be\3\2\2\2\u02c0\u02bf\3\2\2\2\u02c1"+
+    "_\3\2\2\2\u02c2\u02c4\t\n\2\2\u02c3\u02c2\3\2\2\2\u02c3\u02c4\3\2\2\2"+
+    "\u02c4\u02c5\3\2\2\2\u02c5\u02cb\7b\2\2\u02c6\u02c8\t\n\2\2\u02c7\u02c6"+
+    "\3\2\2\2\u02c7\u02c8\3\2\2\2\u02c8\u02c9\3\2\2\2\u02c9\u02cb\7a\2\2\u02ca"+
+    "\u02c3\3\2\2\2\u02ca\u02c7\3\2\2\2\u02cba\3\2\2\2\u02cc\u02cd\t\16\2\2"+
+    "\u02cdc\3\2\2\2\u02ce\u02cf\t\17\2\2\u02cfe\3\2\2\2buw{\u0084\u0086\u008a"+
     "\u0091\u0098\u009d\u00a2\u00ac\u00b0\u00b8\u00bb\u00c1\u00c6\u00c9\u00d0"+
     "\u00d8\u00db\u00e7\u00ea\u00ed\u00f4\u00fb\u00ff\u0103\u010a\u010e\u0112"+
     "\u0117\u011b\u0123\u0127\u012e\u0139\u013c\u0140\u014c\u014f\u0155\u015c"+
     "\u0163\u0166\u016a\u016e\u0172\u0174\u017f\u0184\u0188\u018b\u0191\u0194"+
     "\u019a\u019d\u019f\u01c2\u01ca\u01cc\u01d3\u01d8\u01db\u01e3\u01ec\u01f2"+
-    "\u01fa\u01ff\u0205\u0208\u020f\u0217\u021d\u0229\u022b\u0235\u0243\u024a"+
-    "\u0258\u0266\u026b\u0272\u0275\u027c\u0284\u0297\u02a4\u02ab\u02b0\u02b6"+
-    "\u02b9\u02bd\u02c2\u02c5\u02c9\u02cc";
+    "\u01fa\u01ff\u0205\u0208\u020f\u0217\u021d\u0229\u022b\u0234\u0241\u0248"+
+    "\u0256\u0264\u0269\u0270\u0273\u027a\u0282\u0295\u02a2\u02a9\u02ae\u02b4"+
+    "\u02b7\u02bb\u02c0\u02c3\u02c7\u02ca";
   public static final ATN _ATN =
     new ATNDeserializer().deserialize(_serializedATN.toCharArray());
   static {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseVisitor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseVisitor.java
@@ -401,13 +401,6 @@ interface SqlBaseVisitor<T> extends ParseTreeVisitor<T> {
    */
   T visitSubqueryExpression(SqlBaseParser.SubqueryExpressionContext ctx);
   /**
-   * Visit a parse tree produced by the {@code columnReference}
-   * labeled alternative in {@link SqlBaseParser#primaryExpression}.
-   * @param ctx the parse tree
-   * @return the visitor result
-   */
-  T visitColumnReference(SqlBaseParser.ColumnReferenceContext ctx);
-  /**
    * Visit a parse tree produced by the {@code dereference}
    * labeled alternative in {@link SqlBaseParser#primaryExpression}.
    * @param ctx the parse tree

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlParser.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlParser.java
@@ -128,7 +128,7 @@ public class SqlParser {
     private void debug(SqlBaseParser parser) {
         
         // when debugging, use the exact prediction mode (needed for diagnostics as well)
-        parser.getInterpreter().setPredictionMode(PredictionMode.SLL);
+        parser.getInterpreter().setPredictionMode(PredictionMode.LL_EXACT_AMBIG_DETECTION);
 
         parser.addParseListener(parser.new TraceListener());
 


### PR DESCRIPTION
Removed rules in the grammar that were superfluous, as they
are already "caught" other rules in the same context.

Fixes: #31885