### PR TITLE
Fix potential NPE in `_cat/shards/` with partial CommonStats

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -32,16 +32,30 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.cache.query.QueryCacheStats;
 import org.elasticsearch.index.engine.CommitStats;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.engine.SegmentsStats;
+import org.elasticsearch.index.fielddata.FieldDataStats;
+import org.elasticsearch.index.flush.FlushStats;
+import org.elasticsearch.index.get.GetStats;
+import org.elasticsearch.index.merge.MergeStats;
+import org.elasticsearch.index.refresh.RefreshStats;
+import org.elasticsearch.index.search.stats.SearchStats;
+import org.elasticsearch.index.seqno.SeqNoStats;
+import org.elasticsearch.index.shard.DocsStats;
+import org.elasticsearch.index.store.StoreStats;
+import org.elasticsearch.index.warmer.WarmerStats;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.action.RestActionListener;
 import org.elasticsearch.rest.action.RestResponseListener;
+import org.elasticsearch.search.suggest.completion.CompletionStats;
 
 import java.time.Instant;
 import java.util.Locale;
+import java.util.function.Function;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -177,6 +191,14 @@ public class RestShardsAction extends AbstractCatAction {
         return table;
     }
 
+    private static <S, T> Object getOrNull(S stats, Function<S, T> accessor, Function<T, Object> func) {
+        if(stats != null) {
+            T t = accessor.apply(stats);
+            return func.apply(t);
+        }
+        return null;
+    }
+
     private Table buildTable(RestRequest request, ClusterStateResponse state, IndicesStatsResponse stats) {
         Table table = getTableWithHeader(request);
 
@@ -200,8 +222,8 @@ public class RestShardsAction extends AbstractCatAction {
                 table.addCell("r");
             }
             table.addCell(shard.state());
-            table.addCell(commonStats == null ? null : commonStats.getDocs().getCount());
-            table.addCell(commonStats == null ? null : commonStats.getStore().getSize());
+            table.addCell(getOrNull(commonStats, CommonStats::getDocs, DocsStats::getCount));
+            table.addCell(getOrNull(commonStats, CommonStats::getStore, StoreStats::getSize));
             if (shard.assignedToNode()) {
                 String ip = state.getState().nodes().get(shard.currentNodeId()).getHostAddress();
                 String nodeId = shard.currentNodeId();
@@ -248,69 +270,69 @@ public class RestShardsAction extends AbstractCatAction {
                 table.addCell(null);
             }
 
-            table.addCell(commonStats == null ? null : commonStats.getCompletion().getSize());
+            table.addCell(getOrNull(commonStats, CommonStats::getCompletion, CompletionStats::getSize));
 
-            table.addCell(commonStats == null ? null : commonStats.getFieldData().getMemorySize());
-            table.addCell(commonStats == null ? null : commonStats.getFieldData().getEvictions());
+            table.addCell(getOrNull(commonStats, CommonStats::getFieldData, FieldDataStats::getMemorySize));
+            table.addCell(getOrNull(commonStats, CommonStats::getFieldData, FieldDataStats::getEvictions));
 
-            table.addCell(commonStats == null ? null : commonStats.getQueryCache().getMemorySize());
-            table.addCell(commonStats == null ? null : commonStats.getQueryCache().getEvictions());
+            table.addCell(getOrNull(commonStats, CommonStats::getQueryCache, QueryCacheStats::getMemorySize));
+            table.addCell(getOrNull(commonStats, CommonStats::getQueryCache, QueryCacheStats::getEvictions));
 
-            table.addCell(commonStats == null ? null : commonStats.getFlush().getTotal());
-            table.addCell(commonStats == null ? null : commonStats.getFlush().getTotalTime());
+            table.addCell(getOrNull(commonStats, CommonStats::getFlush, FlushStats::getTotal));
+            table.addCell(getOrNull(commonStats, CommonStats::getFlush, FlushStats::getTotalTime));
 
-            table.addCell(commonStats == null ? null : commonStats.getGet().current());
-            table.addCell(commonStats == null ? null : commonStats.getGet().getTime());
-            table.addCell(commonStats == null ? null : commonStats.getGet().getCount());
-            table.addCell(commonStats == null ? null : commonStats.getGet().getExistsTime());
-            table.addCell(commonStats == null ? null : commonStats.getGet().getExistsCount());
-            table.addCell(commonStats == null ? null : commonStats.getGet().getMissingTime());
-            table.addCell(commonStats == null ? null : commonStats.getGet().getMissingCount());
+            table.addCell(getOrNull(commonStats, CommonStats::getGet, GetStats::current));
+            table.addCell(getOrNull(commonStats, CommonStats::getGet, GetStats::getTime));
+            table.addCell(getOrNull(commonStats, CommonStats::getGet, GetStats::getCount));
+            table.addCell(getOrNull(commonStats, CommonStats::getGet, GetStats::getExistsTime));
+            table.addCell(getOrNull(commonStats, CommonStats::getGet, GetStats::getExistsCount));
+            table.addCell(getOrNull(commonStats, CommonStats::getGet, GetStats::getMissingTime));
+            table.addCell(getOrNull(commonStats, CommonStats::getGet, GetStats::getMissingCount));
 
-            table.addCell(commonStats == null ? null : commonStats.getIndexing().getTotal().getDeleteCurrent());
-            table.addCell(commonStats == null ? null : commonStats.getIndexing().getTotal().getDeleteTime());
-            table.addCell(commonStats == null ? null : commonStats.getIndexing().getTotal().getDeleteCount());
-            table.addCell(commonStats == null ? null : commonStats.getIndexing().getTotal().getIndexCurrent());
-            table.addCell(commonStats == null ? null : commonStats.getIndexing().getTotal().getIndexTime());
-            table.addCell(commonStats == null ? null : commonStats.getIndexing().getTotal().getIndexCount());
-            table.addCell(commonStats == null ? null : commonStats.getIndexing().getTotal().getIndexFailedCount());
+            table.addCell(getOrNull(commonStats, CommonStats::getIndexing, i -> i.getTotal().getDeleteCurrent()));
+            table.addCell(getOrNull(commonStats, CommonStats::getIndexing, i -> i.getTotal().getDeleteTime()));
+            table.addCell(getOrNull(commonStats, CommonStats::getIndexing, i -> i.getTotal().getDeleteCount()));
+            table.addCell(getOrNull(commonStats, CommonStats::getIndexing, i -> i.getTotal().getIndexCurrent()));
+            table.addCell(getOrNull(commonStats, CommonStats::getIndexing, i -> i.getTotal().getIndexTime()));
+            table.addCell(getOrNull(commonStats, CommonStats::getIndexing, i -> i.getTotal().getIndexCount()));
+            table.addCell(getOrNull(commonStats, CommonStats::getIndexing, i -> i.getTotal().getIndexFailedCount()));
 
-            table.addCell(commonStats == null ? null : commonStats.getMerge().getCurrent());
-            table.addCell(commonStats == null ? null : commonStats.getMerge().getCurrentNumDocs());
-            table.addCell(commonStats == null ? null : commonStats.getMerge().getCurrentSize());
-            table.addCell(commonStats == null ? null : commonStats.getMerge().getTotal());
-            table.addCell(commonStats == null ? null : commonStats.getMerge().getTotalNumDocs());
-            table.addCell(commonStats == null ? null : commonStats.getMerge().getTotalSize());
-            table.addCell(commonStats == null ? null : commonStats.getMerge().getTotalTime());
+            table.addCell(getOrNull(commonStats, CommonStats::getMerge, MergeStats::getCurrent));
+            table.addCell(getOrNull(commonStats, CommonStats::getMerge, MergeStats::getCurrentNumDocs));
+            table.addCell(getOrNull(commonStats, CommonStats::getMerge, MergeStats::getCurrentSize));
+            table.addCell(getOrNull(commonStats, CommonStats::getMerge, MergeStats::getTotal));
+            table.addCell(getOrNull(commonStats, CommonStats::getMerge, MergeStats::getTotalNumDocs));
+            table.addCell(getOrNull(commonStats, CommonStats::getMerge, MergeStats::getTotalSize));
+            table.addCell(getOrNull(commonStats, CommonStats::getMerge, MergeStats::getTotalTime));
 
-            table.addCell(commonStats == null ? null : commonStats.getRefresh().getTotal());
-            table.addCell(commonStats == null ? null : commonStats.getRefresh().getTotalTime());
-            table.addCell(commonStats == null ? null : commonStats.getRefresh().getListeners());
+            table.addCell(getOrNull(commonStats, CommonStats::getRefresh, RefreshStats::getTotal));
+            table.addCell(getOrNull(commonStats, CommonStats::getRefresh, RefreshStats::getTotalTime));
+            table.addCell(getOrNull(commonStats, CommonStats::getRefresh, RefreshStats::getListeners));
 
-            table.addCell(commonStats == null ? null : commonStats.getSearch().getTotal().getFetchCurrent());
-            table.addCell(commonStats == null ? null : commonStats.getSearch().getTotal().getFetchTime());
-            table.addCell(commonStats == null ? null : commonStats.getSearch().getTotal().getFetchCount());
-            table.addCell(commonStats == null ? null : commonStats.getSearch().getOpenContexts());
-            table.addCell(commonStats == null ? null : commonStats.getSearch().getTotal().getQueryCurrent());
-            table.addCell(commonStats == null ? null : commonStats.getSearch().getTotal().getQueryTime());
-            table.addCell(commonStats == null ? null : commonStats.getSearch().getTotal().getQueryCount());
-            table.addCell(commonStats == null ? null : commonStats.getSearch().getTotal().getScrollCurrent());
-            table.addCell(commonStats == null ? null : commonStats.getSearch().getTotal().getScrollTime());
-            table.addCell(commonStats == null ? null : commonStats.getSearch().getTotal().getScrollCount());
+            table.addCell(getOrNull(commonStats, CommonStats::getSearch, i -> i.getTotal().getFetchCurrent()));
+            table.addCell(getOrNull(commonStats, CommonStats::getSearch, i -> i.getTotal().getFetchTime()));
+            table.addCell(getOrNull(commonStats, CommonStats::getSearch, i -> i.getTotal().getFetchCount()));
+            table.addCell(getOrNull(commonStats, CommonStats::getSearch, SearchStats::getOpenContexts));
+            table.addCell(getOrNull(commonStats, CommonStats::getSearch, i -> i.getTotal().getQueryCurrent()));
+            table.addCell(getOrNull(commonStats, CommonStats::getSearch, i -> i.getTotal().getQueryTime()));
+            table.addCell(getOrNull(commonStats, CommonStats::getSearch, i -> i.getTotal().getQueryCount()));
+            table.addCell(getOrNull(commonStats, CommonStats::getSearch, i -> i.getTotal().getScrollCurrent()));
+            table.addCell(getOrNull(commonStats, CommonStats::getSearch, i -> i.getTotal().getScrollTime()));
+            table.addCell(getOrNull(commonStats, CommonStats::getSearch, i -> i.getTotal().getScrollCount()));
 
-            table.addCell(commonStats == null ? null : commonStats.getSegments().getCount());
-            table.addCell(commonStats == null ? null : commonStats.getSegments().getMemory());
-            table.addCell(commonStats == null ? null : commonStats.getSegments().getIndexWriterMemory());
-            table.addCell(commonStats == null ? null : commonStats.getSegments().getVersionMapMemory());
-            table.addCell(commonStats == null ? null : commonStats.getSegments().getBitsetMemory());
+            table.addCell(getOrNull(commonStats, CommonStats::getSegments, SegmentsStats::getCount));
+            table.addCell(getOrNull(commonStats, CommonStats::getSegments, SegmentsStats::getMemory));
+            table.addCell(getOrNull(commonStats, CommonStats::getSegments, SegmentsStats::getIndexWriterMemory));
+            table.addCell(getOrNull(commonStats, CommonStats::getSegments, SegmentsStats::getVersionMapMemory));
+            table.addCell(getOrNull(commonStats, CommonStats::getSegments, SegmentsStats::getBitsetMemory));
 
-            table.addCell(shardStats == null || shardStats.getSeqNoStats() == null ? null : shardStats.getSeqNoStats().getMaxSeqNo());
-            table.addCell(shardStats == null || shardStats.getSeqNoStats() == null ? null : shardStats.getSeqNoStats().getLocalCheckpoint());
-            table.addCell(commitStats == null || shardStats.getSeqNoStats() == null ? null : shardStats.getSeqNoStats().getGlobalCheckpoint());
+            table.addCell(getOrNull(shardStats, ShardStats::getSeqNoStats, SeqNoStats::getMaxSeqNo));
+            table.addCell(getOrNull(shardStats, ShardStats::getSeqNoStats, SeqNoStats::getLocalCheckpoint));
+            table.addCell(getOrNull(shardStats, ShardStats::getSeqNoStats, SeqNoStats::getGlobalCheckpoint));
 
-            table.addCell(commonStats == null ? null : commonStats.getWarmer().current());
-            table.addCell(commonStats == null ? null : commonStats.getWarmer().total());
-            table.addCell(commonStats == null ? null : commonStats.getWarmer().totalTime());
+            table.addCell(getOrNull(commonStats, CommonStats::getWarmer, WarmerStats::current));
+            table.addCell(getOrNull(commonStats, CommonStats::getWarmer, WarmerStats::total));
+            table.addCell(getOrNull(commonStats, CommonStats::getWarmer, WarmerStats::totalTime));
 
             table.endRow();
         }


### PR DESCRIPTION
Today if we fetch common stats from a shard we might get a partial response
if the shard is closed while we fetch the stats. This causes hard to track and
reproduce NPEs. This change streamlines null checking to ensure we only render
stats we actually received.