### PR TITLE
Remove no-op test

### DIFF
--- a/x-pack/qa/kerberos-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationIT.java
+++ b/x-pack/qa/kerberos-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationIT.java
@@ -103,10 +103,6 @@ public class KerberosAuthenticationIT extends ESRestTestCase {
         executeRequestAndVerifyResponse(userPrincipalName, callbackHandler);
     }
 
-    public void testSoDoesNotFailWithNoTests() {
-        // intentionally empty - this is just needed to ensure the build does not fail because we mute its only test.
-    }
-
     @Override
     @SuppressForbidden(reason = "SPNEGO relies on hostnames and we need to ensure host isn't a IP address")
     protected HttpHost buildHttpHost(String host, int port) {


### PR DESCRIPTION
This test was introduced when muting some other tests in #32498, but not
removed when the tests were unmuted in #32514.