### PR TITLE
Add validation unit tests for empty and malformed queries (#33095)

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
@@ -89,7 +89,7 @@ public class RestValidateQueryAction extends BaseRestHandler {
                     handleException(validateQueryRequest, finalBodyParsingException.getMessage(), channel);
                 }
             } else {
-                client.admin().indices().validateQuery(validateQueryRequest, new RestToXContentListener<>(channel));
+                validateQuery(client, validateQueryRequest, channel);
             }
         };
     }
@@ -106,5 +106,9 @@ public class RestValidateQueryAction extends BaseRestHandler {
         }
         builder.endObject();
         return new BytesRestResponse(OK, builder);
+    }
+
+    void validateQuery(NodeClient client, ValidateQueryRequest request, RestChannel channel) {
+        client.admin().indices().validateQuery(request, new RestToXContentListener<>(channel));
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
@@ -89,7 +89,7 @@ public class RestValidateQueryAction extends BaseRestHandler {
                     handleException(validateQueryRequest, finalBodyParsingException.getMessage(), channel);
                 }
             } else {
-                validateQuery(client, validateQueryRequest, channel);
+                client.admin().indices().validateQuery(validateQueryRequest, new RestToXContentListener<>(channel));
             }
         };
     }
@@ -106,9 +106,5 @@ public class RestValidateQueryAction extends BaseRestHandler {
         }
         builder.endObject();
         return new BytesRestResponse(OK, builder);
-    }
-
-    void validateQuery(NodeClient client, ValidateQueryRequest request, RestChannel channel) {
-        client.admin().indices().validateQuery(request, new RestToXContentListener<>(channel));
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryActionTests.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.rest.action.admin.indices;
+
+import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRequest;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestActions;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+
+import java.util.HashMap;
+
+public class RestValidateQueryActionTests extends ESTestCase {
+
+    public void testRestValidateQueryAction_emptyQuery() {
+        final String content = "{\"query\":{}}";
+
+        expectParsingException(content);
+    }
+
+    public void testRestValidateQueryAction_malformed() {
+        final String content = "{malformed_json}";
+
+        expectParsingException(content);
+    }
+
+    private void expectParsingException(String content) {
+        final RestRequest request = new FakeRestRequest
+            .Builder(xContentRegistry())
+            .withPath("index1/type1/_validate/query")
+            .withParams(new HashMap<>())
+            .withContent(new BytesArray(content), XContentType.JSON)
+            .build();
+
+        final ValidateQueryRequest validateQueryRequest = new ValidateQueryRequest("index1");
+
+        expectThrows(ParsingException.class,
+            () -> request.withContentOrSourceParamParserOrNull(parser -> validateQueryRequest.query(RestActions.getQueryContent(parser))));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryActionTests.java
@@ -37,7 +37,7 @@ public class RestValidateQueryActionTests extends ESTestCase {
         expectParsingException(content);
     }
 
-    public void testRestValidateQueryAction_malformed() {
+    public void testRestValidateQueryAction_malformedQuery() {
         final String content = "{malformed_json}";
 
         expectParsingException(content);

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryActionTests.java
@@ -18,42 +18,107 @@
  */
 package org.elasticsearch.rest.action.admin.indices;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRequest;
-import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestActions;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.search.AbstractSearchTestCase;
+import org.elasticsearch.test.rest.FakeRestChannel;
 import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.usage.UsageService;
+import org.junit.Before;
 
-import java.util.HashMap;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
-public class RestValidateQueryActionTests extends ESTestCase {
+public class RestValidateQueryActionTests extends AbstractSearchTestCase {
 
-    public void testRestValidateQueryAction_emptyQuery() {
+    private final Settings settings = Settings.EMPTY;
+    private final NodeClient client = mock(NodeClient.class);
+    private final UsageService usageService = new UsageService(settings);
+    private final RestController controller = new RestController(settings, emptySet(), null, client, null, usageService);
+    private final RestValidateQueryAction action = spy(new RestValidateQueryAction(settings, controller));
+
+    /**
+     * Configures {@link NodeClient} mock to disable {@link IndicesAdminClient#validateQuery(ValidateQueryRequest, ActionListener)} action.
+     * <p>
+     * This lower level of validation is out of the scope of this test.
+     *
+     * @throws Exception thrown if an error occurs
+     */
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        doNothing().when(action).validateQuery(eq(client), any(ValidateQueryRequest.class), any(RestChannel.class));
+    }
+
+    public void testRestValidateQueryAction_validQuery() throws Exception {
+        // GIVEN a valid query
+        final String content = "{\"query\":{\"bool\":{\"must\":{\"term\":{\"user\":\"kimchy\"}}}}}";
+
+        final RestRequest request = createRestRequest(content);
+        final FakeRestChannel channel = new FakeRestChannel(request, true, 0);
+
+        // WHEN
+        action.handleRequest(request, channel, client);
+
+        // THEN query is valid (i.e. not marked as invalid)
+        assertThat(channel.responses().get(), equalTo(0));
+        assertThat(channel.errors().get(), equalTo(0));
+        assertNull(channel.capturedResponse());
+    }
+
+    public void testRestValidateQueryAction_emptyQuery() throws Exception {
+        // GIVEN an empty (i.e. invalid) query wrapped into a valid JSON
         final String content = "{\"query\":{}}";
 
-        expectParsingException(content);
+        final RestRequest request = createRestRequest(content);
+        final FakeRestChannel channel = new FakeRestChannel(request, true, 0);
+
+        // WHEN
+        action.handleRequest(request, channel, client);
+
+        // THEN query is marked as invalid
+        assertThat(channel.responses().get(), equalTo(1));
+        assertThat(channel.errors().get(), equalTo(0));
+        assertThat(channel.capturedResponse().content().utf8ToString(), containsString("{\"valid\":false}"));
     }
 
-    public void testRestValidateQueryAction_malformedQuery() {
+    public void testRestValidateQueryAction_malformedQuery() throws Exception {
+        // GIVEN an invalid query due to a malformed JSON
         final String content = "{malformed_json}";
 
-        expectParsingException(content);
+        final RestRequest request = createRestRequest(content);
+        final FakeRestChannel channel = new FakeRestChannel(request, true, 0);
+
+        // WHEN
+        action.handleRequest(request, channel, client);
+
+        // THEN query is marked as invalid
+        assertThat(channel.responses().get(), equalTo(1));
+        assertThat(channel.errors().get(), equalTo(0));
+        assertThat(channel.capturedResponse().content().utf8ToString(), containsString("{\"valid\":false}"));
     }
 
-    private void expectParsingException(String content) {
-        final RestRequest request = new FakeRestRequest
-            .Builder(xContentRegistry())
+    private RestRequest createRestRequest(String content) {
+        return new FakeRestRequest.Builder(xContentRegistry())
             .withPath("index1/type1/_validate/query")
-            .withParams(new HashMap<>())
+            .withParams(emptyMap())
             .withContent(new BytesArray(content), XContentType.JSON)
             .build();
-
-        final ValidateQueryRequest validateQueryRequest = new ValidateQueryRequest("index1");
-
-        expectThrows(ParsingException.class,
-            () -> request.withContentOrSourceParamParserOrNull(parser -> validateQueryRequest.query(RestActions.getQueryContent(parser))));
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryActionTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.rest.FakeRestChannel;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.usage.UsageService;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -51,13 +52,12 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class RestValidateQueryActionTests extends AbstractSearchTestCase {
 
-    private static final Settings settings = Settings.EMPTY;
-    private static final TestThreadPool threadPool = new TestThreadPool(RestValidateQueryActionTests.class.getName());
-    private static final NodeClient client = new NodeClient(settings, threadPool);
+    private static ThreadPool threadPool = new TestThreadPool(RestValidateQueryActionTests.class.getName());
+    private static NodeClient client = new NodeClient(Settings.EMPTY, threadPool);
 
-    private static final UsageService usageService = new UsageService(settings);
-    private static final RestController controller = new RestController(settings, emptySet(), null, client, null, usageService);
-    private static final RestValidateQueryAction action = new RestValidateQueryAction(settings, controller);
+    private static UsageService usageService = new UsageService(Settings.EMPTY);
+    private static RestController controller = new RestController(Settings.EMPTY, emptySet(), null, client, null, usageService);
+    private static RestValidateQueryAction action = new RestValidateQueryAction(Settings.EMPTY, controller);
 
     /**
      * Configures {@link NodeClient} to stub {@link ValidateQueryAction} transport action.
@@ -82,8 +82,15 @@ public class RestValidateQueryActionTests extends AbstractSearchTestCase {
     }
 
     @AfterClass
-    public static void terminateTestThreadPool() throws InterruptedException {
+    public static void terminateThreadPool() throws InterruptedException {
         terminate(threadPool);
+
+        threadPool = null;
+        client = null;
+
+        usageService = null;
+        controller = null;
+        action = null;
     }
 
     public void testRestValidateQueryAction() throws Exception {

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryActionTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.test.rest.FakeRestChannel;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.usage.UsageService;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.util.Collections;
@@ -47,7 +48,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.spy;
 
 public class RestValidateQueryActionTests extends AbstractSearchTestCase {
 
@@ -55,9 +55,9 @@ public class RestValidateQueryActionTests extends AbstractSearchTestCase {
     private static final TestThreadPool threadPool = new TestThreadPool(RestValidateQueryActionTests.class.getName());
     private static final NodeClient client = new NodeClient(settings, threadPool);
 
-    private final UsageService usageService = new UsageService(settings);
-    private final RestController controller = new RestController(settings, emptySet(), null, client, null, usageService);
-    private final RestValidateQueryAction action = spy(new RestValidateQueryAction(settings, controller));
+    private static final UsageService usageService = new UsageService(settings);
+    private static final RestController controller = new RestController(settings, emptySet(), null, client, null, usageService);
+    private static final RestValidateQueryAction action = new RestValidateQueryAction(settings, controller);
 
     /**
      * Configures {@link NodeClient} to stub {@link ValidateQueryAction} transport action.
@@ -79,6 +79,11 @@ public class RestValidateQueryActionTests extends AbstractSearchTestCase {
         actions.put(ValidateQueryAction.INSTANCE, transportAction);
 
         client.initialize(actions, () -> "local", null);
+    }
+
+    @AfterClass
+    public static void terminateTestThreadPool() throws InterruptedException {
+        terminate(threadPool);
     }
 
     public void testRestValidateQueryAction() throws Exception {


### PR DESCRIPTION
This pull request adds unit tests to leverage REST query validation action logic. It checks for `ParsingException` when malformed or empty queries are sent.