### PR TITLE
Remove special-casing of Synonym filters in AnalysisRegistry

### DIFF
--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
@@ -276,6 +276,8 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
         filters.put("sorani_normalization", SoraniNormalizationFilterFactory::new);
         filters.put("stemmer_override", requiresAnalysisSettings(StemmerOverrideTokenFilterFactory::new));
         filters.put("stemmer", StemmerTokenFilterFactory::new);
+        filters.put("synonym", requiresAnalysisSettings(SynonymTokenFilterFactory::new));
+        filters.put("synonym_graph", requiresAnalysisSettings(SynonymGraphTokenFilterFactory::new));
         filters.put("trim", TrimTokenFilterFactory::new);
         filters.put("truncate", requiresAnalysisSettings(TruncateTokenFilterFactory::new));
         filters.put("unique", UniqueTokenFilterFactory::new);

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ESSolrSynonymParser.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ESSolrSynonymParser.java
@@ -17,23 +17,23 @@
  * under the License.
  */
 
-package org.elasticsearch.index.analysis;
+package org.elasticsearch.analysis.common;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.synonym.WordnetSynonymParser;
+import org.apache.lucene.analysis.synonym.SolrSynonymParser;
 import org.apache.lucene.util.CharsRef;
 import org.apache.lucene.util.CharsRefBuilder;
 
 import java.io.IOException;
 
-public class ESWordnetSynonymParser extends WordnetSynonymParser {
-    private static final Logger logger = LogManager.getLogger(ESWordnetSynonymParser.class);
+public class ESSolrSynonymParser extends SolrSynonymParser {
+    private static final Logger logger = LogManager.getLogger(ESSolrSynonymParser.class);
 
     private final boolean lenient;
 
-    public ESWordnetSynonymParser(boolean dedup, boolean expand, boolean lenient, Analyzer analyzer) {
+    public ESSolrSynonymParser(boolean dedup, boolean expand, boolean lenient, Analyzer analyzer) {
         super(dedup, expand, analyzer);
         this.lenient = lenient;
     }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ESWordnetSynonymParser.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ESWordnetSynonymParser.java
@@ -17,23 +17,23 @@
  * under the License.
  */
 
-package org.elasticsearch.index.analysis;
+package org.elasticsearch.analysis.common;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.synonym.SolrSynonymParser;
+import org.apache.lucene.analysis.synonym.WordnetSynonymParser;
 import org.apache.lucene.util.CharsRef;
 import org.apache.lucene.util.CharsRefBuilder;
 
 import java.io.IOException;
 
-public class ESSolrSynonymParser extends SolrSynonymParser {
-    private static final Logger logger = LogManager.getLogger(ESSolrSynonymParser.class);
+public class ESWordnetSynonymParser extends WordnetSynonymParser {
+    private static final Logger logger = LogManager.getLogger(ESWordnetSynonymParser.class);
 
     private final boolean lenient;
 
-    public ESSolrSynonymParser(boolean dedup, boolean expand, boolean lenient, Analyzer analyzer) {
+    public ESWordnetSynonymParser(boolean dedup, boolean expand, boolean lenient, Analyzer analyzer) {
         super(dedup, expand, analyzer);
         this.lenient = lenient;
     }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymGraphTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymGraphTokenFilterFactory.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.index.analysis;
+package org.elasticsearch.analysis.common;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
@@ -26,16 +26,18 @@ import org.apache.lucene.analysis.synonym.SynonymMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.analysis.CharFilterFactory;
+import org.elasticsearch.index.analysis.TokenFilterFactory;
+import org.elasticsearch.index.analysis.TokenizerFactory;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.function.Function;
 
 public class SynonymGraphTokenFilterFactory extends SynonymTokenFilterFactory {
 
-    public SynonymGraphTokenFilterFactory(IndexSettings indexSettings, Environment env, AnalysisRegistry analysisRegistry,
-                                     String name, Settings settings) throws IOException {
-        super(indexSettings, env, analysisRegistry, name, settings);
+    public SynonymGraphTokenFilterFactory(IndexSettings indexSettings, Environment env,
+                                     String name, Settings settings) {
+        super(indexSettings, env, name, settings);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.index.analysis;
+package org.elasticsearch.analysis.common;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
@@ -26,6 +26,14 @@ import org.apache.lucene.analysis.synonym.SynonymMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.analysis.AbstractTokenFilterFactory;
+import org.elasticsearch.index.analysis.Analysis;
+import org.elasticsearch.index.analysis.CharFilterFactory;
+import org.elasticsearch.index.analysis.CustomAnalyzer;
+import org.elasticsearch.index.analysis.ESSolrSynonymParser;
+import org.elasticsearch.index.analysis.ESWordnetSynonymParser;
+import org.elasticsearch.index.analysis.TokenFilterFactory;
+import org.elasticsearch.index.analysis.TokenizerFactory;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -41,8 +49,8 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
     protected final Settings settings;
     protected final Environment environment;
 
-    public SynonymTokenFilterFactory(IndexSettings indexSettings, Environment env, AnalysisRegistry analysisRegistry,
-                                      String name, Settings settings) throws IOException {
+    public SynonymTokenFilterFactory(IndexSettings indexSettings, Environment env,
+                                      String name, Settings settings) {
         super(indexSettings, name, settings);
         this.settings = settings;
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
@@ -30,12 +30,9 @@ import org.elasticsearch.index.analysis.AbstractTokenFilterFactory;
 import org.elasticsearch.index.analysis.Analysis;
 import org.elasticsearch.index.analysis.CharFilterFactory;
 import org.elasticsearch.index.analysis.CustomAnalyzer;
-import org.elasticsearch.index.analysis.ESSolrSynonymParser;
-import org.elasticsearch.index.analysis.ESWordnetSynonymParser;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
 
-import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.List;

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/CommonAnalysisFactoryTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/CommonAnalysisFactoryTests.java
@@ -25,7 +25,6 @@ import org.apache.lucene.analysis.miscellaneous.LimitTokenCountFilterFactory;
 import org.apache.lucene.analysis.reverse.ReverseStringFilterFactory;
 import org.apache.lucene.analysis.snowball.SnowballPorterFilterFactory;
 import org.elasticsearch.index.analysis.SoraniNormalizationFilterFactory;
-import org.elasticsearch.index.analysis.SynonymTokenFilterFactory;
 import org.elasticsearch.indices.analysis.AnalysisFactoryTestCase;
 
 import java.util.List;

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/ESSolrSynonymParserTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/ESSolrSynonymParserTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.index.analysis;
+package org.elasticsearch.analysis.common;
 
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.StopFilter;
@@ -35,16 +35,13 @@ import java.text.ParseException;
 
 import static org.hamcrest.Matchers.containsString;
 
-public class ESWordnetSynonymParserTests extends ESTokenStreamTestCase {
+public class ESSolrSynonymParserTests extends ESTokenStreamTestCase {
 
     public void testLenientParser() throws IOException, ParseException {
-        ESWordnetSynonymParser parser = new ESWordnetSynonymParser(true, false, true, new StandardAnalyzer());
+        ESSolrSynonymParser parser = new ESSolrSynonymParser(true, false, true, new StandardAnalyzer());
         String rules =
-            "s(100000001,1,'&',a,1,0).\n" +
-            "s(100000001,2,'and',a,1,0).\n" +
-            "s(100000002,1,'come',v,1,0).\n" +
-            "s(100000002,2,'advance',v,1,0).\n" +
-            "s(100000002,3,'approach',v,1,0).";
+            "&,and\n" +
+            "come,advance,approach\n";
         StringReader rulesReader = new StringReader(rules);
         parser.parse(rulesReader);
         SynonymMap synonymMap = parser.build();
@@ -57,12 +54,9 @@ public class ESWordnetSynonymParserTests extends ESTokenStreamTestCase {
     public void testLenientParserWithSomeIncorrectLines() throws IOException, ParseException {
         CharArraySet stopSet = new CharArraySet(1, true);
         stopSet.add("bar");
-        ESWordnetSynonymParser parser =
-            new ESWordnetSynonymParser(true, false, true, new StandardAnalyzer(stopSet));
-        String rules =
-            "s(100000001,1,'foo',v,1,0).\n" +
-            "s(100000001,2,'bar',v,1,0).\n" +
-            "s(100000001,3,'baz',v,1,0).";
+        ESSolrSynonymParser parser =
+            new ESSolrSynonymParser(true, false, true, new StandardAnalyzer(stopSet));
+        String rules = "foo,bar,baz";
         StringReader rulesReader = new StringReader(rules);
         parser.parse(rulesReader);
         SynonymMap synonymMap = parser.build();
@@ -73,16 +67,12 @@ public class ESWordnetSynonymParserTests extends ESTokenStreamTestCase {
     }
 
     public void testNonLenientParser() {
-        ESWordnetSynonymParser parser = new ESWordnetSynonymParser(true, false, false, new StandardAnalyzer());
+        ESSolrSynonymParser parser = new ESSolrSynonymParser(true, false, false, new StandardAnalyzer());
         String rules =
-            "s(100000001,1,'&',a,1,0).\n" +
-            "s(100000001,2,'and',a,1,0).\n" +
-            "s(100000002,1,'come',v,1,0).\n" +
-            "s(100000002,2,'advance',v,1,0).\n" +
-            "s(100000002,3,'approach',v,1,0).";
+            "&,and=>and\n" +
+            "come,advance,approach\n";
         StringReader rulesReader = new StringReader(rules);
         ParseException ex = expectThrows(ParseException.class, () -> parser.parse(rulesReader));
         assertThat(ex.getMessage(), containsString("Invalid synonym rule at line 1"));
     }
-
 }

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/ESWordnetSynonymParserTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/ESWordnetSynonymParserTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.index.analysis;
+package org.elasticsearch.analysis.common;
 
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.StopFilter;
@@ -35,13 +35,16 @@ import java.text.ParseException;
 
 import static org.hamcrest.Matchers.containsString;
 
-public class ESSolrSynonymParserTests extends ESTokenStreamTestCase {
+public class ESWordnetSynonymParserTests extends ESTokenStreamTestCase {
 
     public void testLenientParser() throws IOException, ParseException {
-        ESSolrSynonymParser parser = new ESSolrSynonymParser(true, false, true, new StandardAnalyzer());
+        ESWordnetSynonymParser parser = new ESWordnetSynonymParser(true, false, true, new StandardAnalyzer());
         String rules =
-            "&,and\n" +
-            "come,advance,approach\n";
+            "s(100000001,1,'&',a,1,0).\n" +
+            "s(100000001,2,'and',a,1,0).\n" +
+            "s(100000002,1,'come',v,1,0).\n" +
+            "s(100000002,2,'advance',v,1,0).\n" +
+            "s(100000002,3,'approach',v,1,0).";
         StringReader rulesReader = new StringReader(rules);
         parser.parse(rulesReader);
         SynonymMap synonymMap = parser.build();
@@ -54,9 +57,12 @@ public class ESSolrSynonymParserTests extends ESTokenStreamTestCase {
     public void testLenientParserWithSomeIncorrectLines() throws IOException, ParseException {
         CharArraySet stopSet = new CharArraySet(1, true);
         stopSet.add("bar");
-        ESSolrSynonymParser parser =
-            new ESSolrSynonymParser(true, false, true, new StandardAnalyzer(stopSet));
-        String rules = "foo,bar,baz";
+        ESWordnetSynonymParser parser =
+            new ESWordnetSynonymParser(true, false, true, new StandardAnalyzer(stopSet));
+        String rules =
+            "s(100000001,1,'foo',v,1,0).\n" +
+            "s(100000001,2,'bar',v,1,0).\n" +
+            "s(100000001,3,'baz',v,1,0).";
         StringReader rulesReader = new StringReader(rules);
         parser.parse(rulesReader);
         SynonymMap synonymMap = parser.build();
@@ -67,12 +73,16 @@ public class ESSolrSynonymParserTests extends ESTokenStreamTestCase {
     }
 
     public void testNonLenientParser() {
-        ESSolrSynonymParser parser = new ESSolrSynonymParser(true, false, false, new StandardAnalyzer());
+        ESWordnetSynonymParser parser = new ESWordnetSynonymParser(true, false, false, new StandardAnalyzer());
         String rules =
-            "&,and=>and\n" +
-            "come,advance,approach\n";
+            "s(100000001,1,'&',a,1,0).\n" +
+            "s(100000001,2,'and',a,1,0).\n" +
+            "s(100000002,1,'come',v,1,0).\n" +
+            "s(100000002,2,'advance',v,1,0).\n" +
+            "s(100000002,3,'approach',v,1,0).";
         StringReader rulesReader = new StringReader(rules);
         ParseException ex = expectThrows(ParseException.class, () -> parser.parse(rulesReader));
         assertThat(ex.getMessage(), containsString("Invalid synonym rule at line 1"));
     }
+
 }

--- a/modules/analysis-common/src/test/resources/rest-api-spec/test/analysis-common/40_token_filters.yml
+++ b/modules/analysis-common/src/test/resources/rest-api-spec/test/analysis-common/40_token_filters.yml
@@ -224,6 +224,68 @@
     - match:  { tokens.1.token: Bar! }
 
 ---
+"synonym":
+    - do:
+        indices.create:
+          index: test
+          body:
+            settings:
+              analysis:
+                filter:
+                  my_synonym:
+                    type: synonym
+                    synonyms: ["car,auto"]
+
+    - do:
+        indices.analyze:
+          index: test
+          body:
+            text: what car magazine
+            tokenizer: whitespace
+            filter: [ my_synonym ]
+    - length: { tokens: 4 }
+    - match:  { tokens.0.token: what }
+    - match:  { tokens.0.position: 0 }
+    - match:  { tokens.1.token: car }
+    - match:  { tokens.1.position: 1 }
+    - match:  { tokens.2.token: auto }
+    - match:  { tokens.2.position: 1 }
+    - match:  { tokens.3.token: magazine }
+    - match:  { tokens.3.position: 2 }
+
+---
+"synonym_graph":
+    - do:
+        indices.create:
+          index: test
+          body:
+            settings:
+              analysis:
+                filter:
+                  my_graph_synonym:
+                    type: synonym_graph
+                    synonyms: [ "guinea pig,cavy" ]
+
+    - do:
+        indices.analyze:
+          index: test
+          body:
+            text: my guinea pig snores
+            tokenizer: whitespace
+            filter: [ my_graph_synonym ]
+    - length: { tokens: 5 }
+    - match:  { tokens.0.token: my }
+    - match:  { tokens.1.token: cavy }
+    - match:  { tokens.1.position: 1 }
+    - match:  { tokens.1.positionLength: 2 }
+    - match:  { tokens.2.token: guinea }
+    - match:  { tokens.2.position: 1 }
+    - match:  { tokens.3.token: pig }
+    - match:  { tokens.3.position: 2 }
+    - match:  { tokens.4.token: snores }
+    - match:  { tokens.4.position: 3 }
+
+---
 "synonym_graph and flatten_graph":
     - do:
         indices.create:

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.analysis.MockSynonymAnalyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.document.FieldType;
@@ -55,6 +56,7 @@ import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.TextFieldMapper.TextFieldType;
 import org.elasticsearch.index.query.MatchPhraseQueryBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.search.MatchQuery;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -82,10 +84,6 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
     @Before
     public void setup() {
         Settings settings = Settings.builder()
-            .put("index.analysis.filter.mySynonyms.type", "synonym")
-            .putList("index.analysis.filter.mySynonyms.synonyms", Collections.singletonList("car, auto"))
-            .put("index.analysis.analyzer.synonym.tokenizer", "standard")
-            .put("index.analysis.analyzer.synonym.filter", "mySynonyms")
             // Stop filter remains in server as it is part of lucene-core
             .put("index.analysis.analyzer.my_stop_analyzer.tokenizer", "standard")
             .put("index.analysis.analyzer.my_stop_analyzer.filter", "stop")
@@ -739,7 +737,7 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
             .endObject()
             .startObject("synfield")
             .field("type", "text")
-            .field("analyzer", "synonym")
+            .field("analyzer", "standard")  // will be replaced with MockSynonymAnalyzer
             .field("index_phrases", true)
             .endObject()
             .endObject()
@@ -766,11 +764,13 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(q5,
             is(new PhraseQuery.Builder().add(new Term("field", "sparkle")).add(new Term("field", "stopword"), 2).build()));
 
-        Query q6 = new MatchPhraseQueryBuilder("synfield", "motor car").toQuery(queryShardContext);
+        MatchQuery matchQuery = new MatchQuery(queryShardContext);
+        matchQuery.setAnalyzer(new MockSynonymAnalyzer());
+        Query q6 = matchQuery.parse(MatchQuery.Type.PHRASE, "synfield", "motor dogs");
         assertThat(q6, is(new MultiPhraseQuery.Builder()
             .add(new Term[]{
-                new Term("synfield._index_phrase", "motor car"),
-                new Term("synfield._index_phrase", "motor auto")})
+                new Term("synfield._index_phrase", "motor dogs"),
+                new Term("synfield._index_phrase", "motor dog")})
             .build()));
 
         ParsedDocument doc = mapper.parse(SourceToParse.source("test", "type", "1", BytesReference

--- a/test/framework/src/main/java/org/elasticsearch/indices/analysis/AnalysisFactoryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/analysis/AnalysisFactoryTestCase.java
@@ -31,8 +31,6 @@ import org.elasticsearch.index.analysis.PreConfiguredTokenizer;
 import org.elasticsearch.index.analysis.ShingleTokenFilterFactory;
 import org.elasticsearch.index.analysis.StandardTokenizerFactory;
 import org.elasticsearch.index.analysis.StopTokenFilterFactory;
-import org.elasticsearch.index.analysis.SynonymGraphTokenFilterFactory;
-import org.elasticsearch.index.analysis.SynonymTokenFilterFactory;
 import org.elasticsearch.plugins.AnalysisPlugin;
 import org.elasticsearch.test.ESTestCase;
 
@@ -169,8 +167,8 @@ public abstract class AnalysisFactoryTestCase extends ESTestCase {
         .put("stemmeroverride",           MovedToAnalysisCommon.class)
         .put("stop",                      StopTokenFilterFactory.class)
         .put("swedishlightstem",          MovedToAnalysisCommon.class)
-        .put("synonym",                   SynonymTokenFilterFactory.class)
-        .put("synonymgraph",              SynonymGraphTokenFilterFactory.class)
+        .put("synonym",                   MovedToAnalysisCommon.class)
+        .put("synonymgraph",              MovedToAnalysisCommon.class)
         .put("trim",                      MovedToAnalysisCommon.class)
         .put("truncate",                  MovedToAnalysisCommon.class)
         .put("turkishlowercase",          MovedToAnalysisCommon.class)


### PR DESCRIPTION
The synonym filters no longer need access to the AnalysisRegistry in their
constructors, so we can remove the special-case code and move them to the
common analysis module