### PR TITLE
SQL: Move away internally from JDBCType to SQLType

### DIFF
--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcDatabaseMetaData.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcDatabaseMetaData.java
@@ -19,6 +19,7 @@ import java.sql.ResultSet;
 import java.sql.RowIdLifetime;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLType;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -1124,11 +1125,11 @@ class JdbcDatabaseMetaData implements DatabaseMetaData, JdbcWrapper {
             Object obj = cols[i];
             if (obj instanceof String) {
                 String name = obj.toString();
-                JDBCType type = JDBCType.VARCHAR;
+                SQLType type = JDBCType.VARCHAR;
                 if (i + 1 < cols.length) {
                     // check if the next item it's a type
-                    if (cols[i + 1] instanceof JDBCType) {
-                        type = (JDBCType) cols[i + 1];
+                    if (cols[i + 1] instanceof SQLType) {
+                        type = (SQLType) cols[i + 1];
                         i++;
                     }
                     // it's not, use the default and move on

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcParameterMetaData.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcParameterMetaData.java
@@ -54,7 +54,7 @@ class JdbcParameterMetaData implements ParameterMetaData, JdbcWrapper {
 
     @Override
     public String getParameterTypeName(int param) throws SQLException {
-        return paramInfo(param).type.name();
+        return paramInfo(param).type.getName();
     }
 
     @Override

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcResultSet.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcResultSet.java
@@ -25,6 +25,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.RowId;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLType;
 import java.sql.SQLWarning;
 import java.sql.SQLXML;
 import java.sql.Statement;
@@ -133,7 +134,7 @@ class JdbcResultSet implements ResultSet, JdbcWrapper {
 
     @Override
     public boolean getBoolean(int columnIndex) throws SQLException {
-        return column(columnIndex) != null ? getObject(columnIndex, Boolean.class) : false; 
+        return column(columnIndex) != null ? getObject(columnIndex, Boolean.class) : false;
     }
 
     @Override
@@ -245,7 +246,7 @@ class JdbcResultSet implements ResultSet, JdbcWrapper {
 
     private Long dateTime(int columnIndex) throws SQLException {
         Object val = column(columnIndex);
-        JDBCType type = cursor.columns().get(columnIndex - 1).type;
+        SQLType type = cursor.columns().get(columnIndex - 1).type;
         try {
             // TODO: the B6 appendix of the jdbc spec does mention CHAR, VARCHAR, LONGVARCHAR, DATE, TIMESTAMP as supported
             // jdbc types that should be handled by getDate and getTime methods. From all of those we support VARCHAR and
@@ -338,7 +339,7 @@ class JdbcResultSet implements ResultSet, JdbcWrapper {
             return null;
         }
 
-        JDBCType columnType = cursor.columns().get(columnIndex - 1).type;
+        SQLType columnType = cursor.columns().get(columnIndex - 1).type;
         
         return TypeConverter.convert(val, columnType, type);
     }

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcResultSetMetaData.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcResultSetMetaData.java
@@ -114,7 +114,7 @@ class JdbcResultSetMetaData implements ResultSetMetaData, JdbcWrapper {
 
     @Override
     public String getColumnTypeName(int column) throws SQLException {
-        return column(column).type.name();
+        return column(column).type.getName();
     }
 
     @Override

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/jdbc/PreparedQuery.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/jdbc/PreparedQuery.java
@@ -11,6 +11,7 @@ import org.elasticsearch.xpack.sql.type.DataType;
 
 import java.sql.JDBCType;
 import java.sql.SQLException;
+import java.sql.SQLType;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,10 +19,10 @@ import java.util.stream.Collectors;
 class PreparedQuery {
 
     static class ParamInfo {
-        JDBCType type;
+        SQLType type;
         Object value;
 
-        ParamInfo(Object value, JDBCType type) {
+        ParamInfo(Object value, SQLType type) {
             this.value = value;
             this.type = type;
         }
@@ -43,7 +44,7 @@ class PreparedQuery {
         return params[param - 1];
     }
 
-    void setParam(int param, Object value, JDBCType type) throws JdbcSQLException {
+    void setParam(int param, Object value, SQLType type) throws JdbcSQLException {
         if (param < 1 || param > params.length) {
             throw new JdbcSQLException("Invalid parameter index [" + param + "]");
         }

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/net/protocol/ColumnInfo.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/net/protocol/ColumnInfo.java
@@ -5,7 +5,7 @@
  */
 package org.elasticsearch.xpack.sql.jdbc.net.protocol;
 
-import java.sql.JDBCType;
+import java.sql.SQLType;
 import java.util.Objects;
 
 public class ColumnInfo {
@@ -15,9 +15,9 @@ public class ColumnInfo {
     public final String label;
     public final String name;
     public final int displaySize;
-    public final JDBCType type;
+    public final SQLType type;
 
-    public ColumnInfo(String name, JDBCType type, String table, String catalog, String schema, String label, int displaySize) {
+    public ColumnInfo(String name, SQLType type, String table, String catalog, String schema, String label, int displaySize) {
         if (name == null) {
             throw new IllegalArgumentException("[name] must not be null");
         }

--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcPreparedStatementTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcPreparedStatementTests.java
@@ -9,9 +9,9 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.sql.JDBCType;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLType;
 import java.sql.Struct;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -450,7 +450,7 @@ public class JdbcPreparedStatementTests extends ESTestCase {
         someCalendar.setTimeInMillis(randomLong());
 
         jps.setObject(1, someCalendar);
-        assertEquals(someCalendar.getTime(), (Date) value(jps));
+        assertEquals(someCalendar.getTime(), value(jps));
         assertEquals(TIMESTAMP, jdbcType(jps));
         assertTrue(value(jps) instanceof java.util.Date);
 
@@ -460,7 +460,7 @@ public class JdbcPreparedStatementTests extends ESTestCase {
 
         Calendar nonDefaultCal = randomCalendar();
         jps.setObject(1, nonDefaultCal);
-        assertEquals(nonDefaultCal.getTime(), (Date) value(jps));
+        assertEquals(nonDefaultCal.getTime(), value(jps));
         assertEquals(TIMESTAMP, jdbcType(jps));
     }
 
@@ -477,7 +477,7 @@ public class JdbcPreparedStatementTests extends ESTestCase {
         Date someDate = new Date(randomLong());
 
         jps.setObject(1, someDate);
-        assertEquals(someDate, (Date) value(jps));
+        assertEquals(someDate, value(jps));
         assertEquals(TIMESTAMP, jdbcType(jps));
         assertTrue(value(jps) instanceof java.util.Date);
 
@@ -530,7 +530,7 @@ public class JdbcPreparedStatementTests extends ESTestCase {
         assertTrue(value(jps) instanceof byte[]);
 
         jps.setObject(1, buffer, Types.VARBINARY);
-        assertEquals((byte[]) value(jps), buffer);
+        assertEquals(value(jps), buffer);
         assertEquals(VARBINARY, jdbcType(jps));
 
         SQLException sqle = expectThrows(SQLFeatureNotSupportedException.class, () -> jps.setObject(1, buffer, Types.VARCHAR));
@@ -555,7 +555,7 @@ public class JdbcPreparedStatementTests extends ESTestCase {
         return new JdbcPreparedStatement(null, JdbcConfiguration.create("jdbc:es://l:1", null, 0), "?");
     }
 
-    private JDBCType jdbcType(JdbcPreparedStatement jps) throws SQLException {
+    private SQLType jdbcType(JdbcPreparedStatement jps) throws SQLException {
         return jps.query.getParam(1).type;
     }
 

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryResponse.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryResponse.java
@@ -183,6 +183,7 @@ public class SqlQueryResponse extends ActionResponse implements ToXContentObject
         JDBCType jdbcType;
         int displaySize;
         if (in.readBoolean()) {
+            // FIXME: this needs changing to allow custom types
             jdbcType = JDBCType.valueOf(in.readVInt());
             displaySize = in.readVInt();
         } else {
@@ -207,8 +208,12 @@ public class SqlQueryResponse extends ActionResponse implements ToXContentObject
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         SqlQueryResponse that = (SqlQueryResponse) o;
         return Objects.equals(cursor, that.cursor) &&
                 Objects.equals(columns, that.columns) &&

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/type/DataType.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/type/DataType.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.sql.type;
 
 import java.sql.JDBCType;
+import java.sql.SQLType;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Locale;
@@ -43,7 +44,7 @@ public enum DataType {
     DATE(        JDBCType.TIMESTAMP, Timestamp.class, Long.BYTES,        24,                24);
     // @formatter:on
 
-    private static final Map<JDBCType, DataType> jdbcToEs;
+    private static final Map<SQLType, DataType> jdbcToEs;
 
     static {
         jdbcToEs = Arrays.stream(DataType.values())
@@ -59,7 +60,7 @@ public enum DataType {
     /**
      * Compatible JDBC type
      */
-    public final JDBCType jdbcType;
+    public final SQLType jdbcType;
 
     /**
      * Size of the type in bytes
@@ -102,7 +103,7 @@ public enum DataType {
 
     private final Class<?> javaClass;
 
-    DataType(JDBCType jdbcType, Class<?> javaClass, int size, int defaultPrecision, int displaySize, boolean isInteger, boolean isRational,
+    DataType(SQLType jdbcType, Class<?> javaClass, int size, int defaultPrecision, int displaySize, boolean isInteger, boolean isRational,
              boolean defaultDocValues) {
         this.esType = name().toLowerCase(Locale.ROOT);
         this.javaClass = javaClass;
@@ -115,7 +116,7 @@ public enum DataType {
         this.defaultDocValues = defaultDocValues;
     }
 
-    DataType(JDBCType jdbcType, Class<?> javaClass, int size, int defaultPrecision, int displaySize) {
+    DataType(SQLType jdbcType, Class<?> javaClass, int size, int defaultPrecision, int displaySize) {
         this(jdbcType, javaClass, size, defaultPrecision, displaySize, false, false, true);
     }
 
@@ -147,14 +148,14 @@ public enum DataType {
         return this != OBJECT && this != NESTED;
     }
 
-    public static DataType fromJdbcType(JDBCType jdbcType) {
+    public static DataType fromJdbcType(SQLType jdbcType) {
         if (jdbcToEs.containsKey(jdbcType) == false) {
             throw new IllegalArgumentException("Unsupported JDBC type [" + jdbcType + "]");
         }
         return jdbcToEs.get(jdbcType);
     }
     
-    public static Class<?> fromJdbcTypeToJava(JDBCType jdbcType) {
+    public static Class<?> fromJdbcTypeToJava(SQLType jdbcType) {
         if (jdbcToEs.containsKey(jdbcType) == false) {
             throw new IllegalArgumentException("Unsupported JDBC type [" + jdbcType + "]");
         }

--- a/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/ResultSetTestCase.java
+++ b/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/ResultSetTestCase.java
@@ -24,13 +24,13 @@ import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.JDBCType;
 import java.sql.NClob;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLType;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Arrays;
@@ -64,7 +64,7 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
     static final Set<String> fieldsNames = Stream.of("test_byte", "test_integer", "test_long", "test_short", "test_double",
             "test_float", "test_keyword")
             .collect(Collectors.toCollection(HashSet::new));
-    static final Map<Tuple<String,Object>,JDBCType> dateTimeTestingFields = new HashMap<Tuple<String,Object>,JDBCType>();
+    static final Map<Tuple<String, Object>, SQLType> dateTimeTestingFields = new HashMap<>();
     static final String SELECT_ALL_FIELDS = "SELECT test_boolean, test_byte, test_integer,"
             + "test_long, test_short, test_double, test_float, test_keyword, test_date FROM test";
     static final String SELECT_WILDCARD = "SELECT * FROM test";
@@ -193,17 +193,17 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
             assertEquals(format(Locale.ROOT, "Numeric %s out of range", Double.toString(floatNotByte)), sqle.getMessage());
             
             sqle = expectThrows(SQLException.class, () -> results.getByte("test_keyword"));
-            assertEquals(format(Locale.ROOT, "Unable to convert value [%.128s] of type [VARCHAR] to a Byte", randomString), 
+            assertEquals(format(Locale.ROOT, "Unable to convert value [%.128s] of type [VARCHAR] to a Byte", randomString),
                     sqle.getMessage());
             sqle = expectThrows(SQLException.class, () -> results.getObject("test_keyword", Byte.class));
-            assertEquals(format(Locale.ROOT, "Unable to convert value [%.128s] of type [VARCHAR] to a Byte", randomString), 
+            assertEquals(format(Locale.ROOT, "Unable to convert value [%.128s] of type [VARCHAR] to a Byte", randomString),
                     sqle.getMessage());
             
             sqle = expectThrows(SQLException.class, () -> results.getByte("test_date"));
-            assertEquals(format(Locale.ROOT, "Unable to convert value [%.128s] of type [TIMESTAMP] to a Byte", randomDate), 
+            assertEquals(format(Locale.ROOT, "Unable to convert value [%.128s] of type [TIMESTAMP] to a Byte", randomDate),
                     sqle.getMessage());
             sqle = expectThrows(SQLException.class, () -> results.getObject("test_date", Byte.class));
-            assertEquals(format(Locale.ROOT, "Unable to convert value [%.128s] of type [TIMESTAMP] to a Byte", randomDate), 
+            assertEquals(format(Locale.ROOT, "Unable to convert value [%.128s] of type [TIMESTAMP] to a Byte", randomDate),
                     sqle.getMessage());
         });
     }
@@ -249,7 +249,7 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
         doWithQuery(SELECT_WILDCARD, (results) -> {
             results.next();
             for(Entry<String, Number> e : map.entrySet()) {
-                short actual = (short) results.getObject(e.getKey(), Short.class);
+                short actual = results.getObject(e.getKey(), Short.class);
                 if (e.getValue() instanceof Double) {
                     assertEquals("For field " + e.getKey(), Math.round(e.getValue().doubleValue()), results.getShort(e.getKey()));
                     assertEquals("For field " + e.getKey(), Math.round(e.getValue().doubleValue()), actual);
@@ -590,7 +590,7 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
             results.next();
             for(Entry<String, Number> e : map.entrySet()) {
                 assertEquals("For field " + e.getKey(), e.getValue().doubleValue(), results.getDouble(e.getKey()), 0.0d);
-                assertEquals("For field " + e.getKey(), 
+                assertEquals("For field " + e.getKey(),
                         e.getValue().doubleValue(), results.getObject(e.getKey(), Double.class), 0.0d);
             }
         });
@@ -673,7 +673,7 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
             results.next();
             for(Entry<String, Number> e : map.entrySet()) {
                 assertEquals("For field " + e.getKey(), e.getValue().floatValue(), results.getFloat(e.getKey()), 0.0f);
-                assertEquals("For field " + e.getKey(), 
+                assertEquals("For field " + e.getKey(),
                         e.getValue().floatValue(), results.getObject(e.getKey(), Float.class), 0.0f);
             }
         });
@@ -746,7 +746,7 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
             builder.field("test_integer", randomValueOtherThan(0, () -> randomInt()));
             builder.field("test_long", randomValueOtherThan(0L, () -> randomLong()));
             builder.field("test_short", randomValueOtherThan((short) 0, () -> randomShort()));
-            builder.field("test_double", randomValueOtherThanMany(i -> i < 1.0d && i > -1.0d && i < Double.MAX_VALUE 
+            builder.field("test_double", randomValueOtherThanMany(i -> i < 1.0d && i > -1.0d && i < Double.MAX_VALUE
                     && i > Double.MIN_VALUE,
                     () -> randomDouble() * randomInt()));
             builder.field("test_float", randomValueOtherThanMany(i -> i < 1.0f && i > -1.0f && i < Float.MAX_VALUE && i > Float.MIN_VALUE,
@@ -820,9 +820,9 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
             
             assertEquals(results.getDate("test_date"), new java.sql.Date(connCalendar.getTimeInMillis()));
             assertEquals(results.getDate(9), new java.sql.Date(connCalendar.getTimeInMillis()));
-            assertEquals(results.getObject("test_date", java.sql.Date.class), 
+            assertEquals(results.getObject("test_date", java.sql.Date.class),
                     new java.sql.Date(randomLongDate - (randomLongDate % 86400000L)));
-            assertEquals(results.getObject(9, java.sql.Date.class), 
+            assertEquals(results.getObject(9, java.sql.Date.class),
                     new java.sql.Date(randomLongDate - (randomLongDate % 86400000L)));
 
             // bulk validation for all fields which are not of type date
@@ -889,9 +889,9 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
             
             assertEquals(results.getTime("test_date"), new java.sql.Time(c.getTimeInMillis()));
             assertEquals(results.getTime(9), new java.sql.Time(c.getTimeInMillis()));
-            assertEquals(results.getObject("test_date", java.sql.Time.class), 
+            assertEquals(results.getObject("test_date", java.sql.Time.class),
                     new java.sql.Time(randomLongDate % 86400000L));
-            assertEquals(results.getObject(9, java.sql.Time.class), 
+            assertEquals(results.getObject(9, java.sql.Time.class),
                     new java.sql.Time(randomLongDate % 86400000L));
             
             validateErrorsForDateTimeTestsWithoutCalendar(results::getTime);
@@ -1126,7 +1126,7 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
         assertThrowsUnsupportedAndExpectErrorMessage(() -> r.getRowId("test"), "RowId not supported");
         assertThrowsUnsupportedAndExpectErrorMessage(() -> r.getRowId(1), "RowId not supported");
         assertThrowsUnsupportedAndExpectErrorMessage(() -> r.getSQLXML("test"), "SQLXML not supported");
-        assertThrowsUnsupportedAndExpectErrorMessage(() -> r.getSQLXML(1), "SQLXML not supported");        
+        assertThrowsUnsupportedAndExpectErrorMessage(() -> r.getSQLXML(1), "SQLXML not supported");
         assertThrowsUnsupportedAndExpectErrorMessage(() -> r.getURL("test"), "URL not supported");
         assertThrowsUnsupportedAndExpectErrorMessage(() -> r.getURL(1), "URL not supported");
     }
@@ -1425,7 +1425,7 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
      * It returns a map containing the field name and its randomly generated value to be later used in checking the returned values.
      */
     private Map<String,Number> createTestDataForNumericValueTypes(Supplier<Number> randomGenerator) throws Exception, IOException {
-        Map<String,Number> map = new HashMap<String,Number>();
+        Map<String,Number> map = new HashMap<>();
         createIndex("test");
         updateMappingForNumericValuesTests("test");
     
@@ -1482,20 +1482,20 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
     
     private void validateErrorsForDateTimeTestsWithoutCalendar(CheckedFunction<String,Object,SQLException> method) {
         SQLException sqle;
-        for(Entry<Tuple<String,Object>,JDBCType> field : dateTimeTestingFields.entrySet()) {
+        for (Entry<Tuple<String, Object>, SQLType> field : dateTimeTestingFields.entrySet()) {
             sqle = expectThrows(SQLException.class, () -> method.apply(field.getKey().v1()));
             assertEquals(
-                    format(Locale.ROOT, "Unable to convert value [%.128s] of type [%s] to a Long", 
+                    format(Locale.ROOT, "Unable to convert value [%.128s] of type [%s] to a Long",
                             field.getKey().v2(), field.getValue()), sqle.getMessage());
         }
     }
     
     private void validateErrorsForDateTimeTestsWithCalendar(Calendar c, CheckedBiFunction<String,Calendar,Object,SQLException> method) {
         SQLException sqle;
-        for(Entry<Tuple<String,Object>,JDBCType> field : dateTimeTestingFields.entrySet()) {
+        for (Entry<Tuple<String, Object>, SQLType> field : dateTimeTestingFields.entrySet()) {
             sqle = expectThrows(SQLException.class, () -> method.apply(field.getKey().v1(), c));
             assertEquals(
-                    format(Locale.ROOT, "Unable to convert value [%.128s] of type [%s] to a Long", 
+                    format(Locale.ROOT, "Unable to convert value [%.128s] of type [%s] to a Long",
                             field.getKey().v2(), field.getValue()), sqle.getMessage());
         }
     }


### PR DESCRIPTION
This is a first step in allowing our own custom types (such as `Interval`) internally and within JDBC as we're moving away from a fixed enum to a pluggable interface (which is implemented by `JDBCType` as well).

Fix #33904