### PR TITLE
Removing poor randomization for node name

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
@@ -347,7 +347,7 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
             roles.add(DiscoveryNode.Role.DATA);
             roles.add(DiscoveryNode.Role.MASTER);
             roles.add(DiscoveryNode.Role.INGEST);
-            nodesBuilder.add(new DiscoveryNode(randomAlphaOfLength(i+1),
+            nodesBuilder.add(new DiscoveryNode("ml-feature-set-given-ml-node-" + i,
                 new TransportAddress(TransportAddress.META_ADDRESS, 9100 + i),
                 attrs,
                 roles,
@@ -359,7 +359,7 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
             roles.add(DiscoveryNode.Role.DATA);
             roles.add(DiscoveryNode.Role.MASTER);
             roles.add(DiscoveryNode.Role.INGEST);
-            nodesBuilder.add(new DiscoveryNode(randomAlphaOfLength(i+1),
+            nodesBuilder.add(new DiscoveryNode("ml-feature-set-given-non-ml-node-" + i,
                 new TransportAddress(TransportAddress.META_ADDRESS, 9300 + i),
                 attrs,
                 roles,


### PR DESCRIPTION
Running with
```
./gradlew :x-pack:plugin:ml:test -Dtests.seed=B624F5D318CE943B -Dtests.class=org.elasticsearch.xpack.ml.MachineLearningFeatureSetTests -Dtests.method="testNodeCount" -Dtests.security.manager=true -Dtests.locale=es-EC -Dtests.timezone=America/Yakutat
```
Causes two nodes to both be called `b` 🤦‍♂️  
Gave them deterministic names for the given test scenario.