### PR TITLE
keep IndexFormatToo(Old|New)Exception in corruption marker

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -185,7 +185,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         failIfCorrupted();
         try {
             return readSegmentsInfo(null, directory());
-        } catch (CorruptIndexException ex) {
+        } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
             markStoreCorrupted(ex);
             throw ex;
         }

--- a/server/src/test/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandTests.java
@@ -146,7 +146,6 @@ public class RemoveCorruptedShardDataCommandTests extends IndexShardTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/33916")
     public void testCorruptedIndex() throws Exception {
         final int numDocs = indexDocs(indexShard, true);
 
@@ -179,9 +178,9 @@ public class RemoveCorruptedShardDataCommandTests extends IndexShardTestCase {
             } else {
                 assertThat(e.getMessage(), containsString("aborted by user"));
             }
+        } finally {
+            logger.info("--> output:\n{}", t.getOutput());
         }
-
-        logger.info("--> output:\n{}", t.getOutput());
 
         if (corruptSegments == false) {
 


### PR DESCRIPTION
CorruptIndexException, IndexFormatTooOldException and IndexFormatTooNewException are handled in the similar way at Store#getMetadata. It is worth to do same in Store#readLastCommittedSegmentsInfo

Closes #33916