### PR TITLE
Fix AutoQueueAdjustingExecutorBuilder settings validation

### DIFF
--- a/server/src/test/java/org/elasticsearch/threadpool/AutoQueueAdjustingExecutorBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/AutoQueueAdjustingExecutorBuilderTests.java
@@ -25,10 +25,10 @@ import static org.hamcrest.CoreMatchers.containsString;
 
 public class AutoQueueAdjustingExecutorBuilderTests extends ESThreadPoolTestCase {
 
-    public void testValidatingMinMaxSettings() throws Exception {
+    public void testValidatingMinMaxSettings() {
         Settings settings = Settings.builder()
-                .put("thread_pool.search.min_queue_size", randomIntBetween(30, 100))
-                .put("thread_pool.search.max_queue_size", randomIntBetween(1,25))
+                .put("thread_pool.test.min_queue_size", randomIntBetween(30, 100))
+                .put("thread_pool.test.max_queue_size", randomIntBetween(1,25))
                 .build();
         try {
             new AutoQueueAdjustingExecutorBuilder(settings, "test", 1, 15, 1, 100, 10);
@@ -36,6 +36,70 @@ public class AutoQueueAdjustingExecutorBuilderTests extends ESThreadPoolTestCase
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("Failed to parse value"));
         }
+
+        settings = Settings.builder()
+            .put("thread_pool.test.min_queue_size", 10)
+            .put("thread_pool.test.max_queue_size", 9)
+            .build();
+        try {
+            new AutoQueueAdjustingExecutorBuilder(settings, "test", 1, 15, 1, 100, 2000).getSettings(settings);
+            fail("should have thrown an exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Failed to parse value [10] for setting [thread_pool.test.min_queue_size] must be <= 9");
+        }
+
+        settings = Settings.builder()
+            .put("thread_pool.test.min_queue_size", 11)
+            .put("thread_pool.test.max_queue_size", 10)
+            .build();
+        try {
+            new AutoQueueAdjustingExecutorBuilder(settings, "test", 1, 15, 1, 100, 2000).getSettings(settings);
+            fail("should have thrown an exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Failed to parse value [11] for setting [thread_pool.test.min_queue_size] must be <= 10");
+        }
+
+        settings = Settings.builder()
+            .put("thread_pool.test.min_queue_size", 101)
+            .build();
+        try {
+            new AutoQueueAdjustingExecutorBuilder(settings, "test", 1, 15, 100, 100, 2000).getSettings(settings);
+            fail("should have thrown an exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Failed to parse value [101] for setting [thread_pool.test.min_queue_size] must be <= 100");
+        }
+
+        settings = Settings.builder()
+            .put("thread_pool.test.max_queue_size", 99)
+            .build();
+        try {
+            new AutoQueueAdjustingExecutorBuilder(settings, "test", 1, 15, 100, 100, 2000).getSettings(settings);
+            fail("should have thrown an exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Failed to parse value [100] for setting [thread_pool.test.min_queue_size] must be <= 99");
+        }
+    }
+
+    public void testSetLowerSettings() {
+        Settings settings = Settings.builder()
+            .put("thread_pool.test.min_queue_size", 10)
+            .put("thread_pool.test.max_queue_size", 10)
+            .build();
+        AutoQueueAdjustingExecutorBuilder test = new AutoQueueAdjustingExecutorBuilder(settings, "test", 1, 1000, 1000, 1000, 2000);
+        AutoQueueAdjustingExecutorBuilder.AutoExecutorSettings s = test.getSettings(settings);
+        assertEquals(10, s.maxQueueSize);
+        assertEquals(10, s.minQueueSize);
+    }
+
+    public void testSetHigherSettings() {
+        Settings settings = Settings.builder()
+            .put("thread_pool.test.min_queue_size", 2000)
+            .put("thread_pool.test.max_queue_size", 3000)
+            .build();
+        AutoQueueAdjustingExecutorBuilder test = new AutoQueueAdjustingExecutorBuilder(settings, "test", 1, 1000, 1000, 1000, 2000);
+        AutoQueueAdjustingExecutorBuilder.AutoExecutorSettings s = test.getSettings(settings);
+        assertEquals(3000, s.maxQueueSize);
+        assertEquals(2000, s.minQueueSize);
     }
 
 }


### PR DESCRIPTION
Settings validation in AutoQueueAdjustingExecutorBuilder always checked against
a default value which means that we never can change a max queue size that is lower
than the default. This change adds tests and fixes this validation.