### PR TITLE
Add a simple JSON field mapper.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -77,6 +77,7 @@ public final class JsonFieldMapper extends FieldMapper {
         static {
             FIELD_TYPE.setTokenized(false);
             FIELD_TYPE.setOmitNorms(true);
+            FIELD_TYPE.setStored(false);
             FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
             FIELD_TYPE.freeze();
         }
@@ -120,12 +121,20 @@ public final class JsonFieldMapper extends FieldMapper {
             return builder;
         }
 
+        @Override
         public Builder addMultiField(Mapper.Builder mapperBuilder) {
             throw new UnsupportedOperationException("[fields] is not supported for [" + CONTENT_TYPE + "] fields.");
         }
 
+        @Override
         public Builder copyTo(CopyTo copyTo) {
             throw new UnsupportedOperationException("[copy_to] is not supported for [" + CONTENT_TYPE + "] fields.");
+        }
+
+        @Override
+        public Builder store(boolean store) {
+            throw new UnsupportedOperationException("[store] is not currently supported for [" +
+                CONTENT_TYPE + "] fields.");
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.search.NormsFieldExistsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryShardContext;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.index.mapper.TypeParsers.parseField;
+
+/**
+ * A field mapper that accepts a JSON object and flattens it into a single field. This data type
+ * can be a useful alternative to an 'object' mapping when the object has a large, unknown set
+ * of keys.
+ *
+ * Currently the mapper extracts all leaf values of the JSON object, converts them to their text
+ * representations, and indexes each one as a keyword. As an example, given a json field called
+ * 'json_field' and the following input
+ *
+ * {
+ *   "json_field: {
+ *     "key1": "some value",
+ *     "key2": {
+ *       "key3": true
+ *     }
+ *   }
+ * }
+ *
+ * the mapper will produce untokenized string fields with the values "some value" and "true".
+ */
+public final class JsonFieldMapper extends FieldMapper {
+
+    public static final String CONTENT_TYPE = "json";
+
+    private static class Defaults {
+        public static final MappedFieldType FIELD_TYPE = new JsonFieldType();
+
+        static {
+            FIELD_TYPE.setTokenized(false);
+            FIELD_TYPE.setOmitNorms(true);
+            FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
+            FIELD_TYPE.freeze();
+        }
+    }
+
+    public static class Builder extends FieldMapper.Builder<Builder, JsonFieldMapper> {
+
+        public Builder(String name) {
+            super(name, Defaults.FIELD_TYPE, Defaults.FIELD_TYPE);
+            builder = this;
+        }
+
+        @Override
+        public JsonFieldType fieldType() {
+            return (JsonFieldType) super.fieldType();
+        }
+
+        @Override
+        public Builder indexOptions(IndexOptions indexOptions) {
+            if (indexOptions.compareTo(IndexOptions.DOCS_AND_FREQS) > 0) {
+                throw new IllegalArgumentException("The [" + CONTENT_TYPE
+                    + "] field does not support positions, got [index_options]="
+                    + indexOptionToString(indexOptions));
+            }
+            return super.indexOptions(indexOptions);
+        }
+
+        public Builder addMultiField(Mapper.Builder mapperBuilder) {
+            throw new UnsupportedOperationException("[fields] is not supported for [" + CONTENT_TYPE + "] fields.");
+        }
+
+        public Builder copyTo(CopyTo copyTo) {
+            throw new UnsupportedOperationException("[copy_to] is not currently supported for ["
+                + CONTENT_TYPE + "] fields.");
+        }
+
+        @Override
+        public JsonFieldMapper build(BuilderContext context) {
+            setupFieldType(context);
+            return new JsonFieldMapper(name, fieldType, defaultFieldType, context.indexSettings());
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder<?,?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            JsonFieldMapper.Builder builder = new JsonFieldMapper.Builder(name);
+            parseField(builder, name, node, parserContext);
+            for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
+                Map.Entry<String, Object> entry = iterator.next();
+                String propName = entry.getKey();
+                Object propNode = entry.getValue();
+                if (propName.equals("norms")) {
+                    TypeParsers.parseNorms(builder, name, propNode);
+                    iterator.remove();
+                }
+            }
+            return builder;
+        }
+    }
+
+    public static final class JsonFieldType extends StringFieldType {
+
+        public JsonFieldType() {
+            setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
+            setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
+        }
+
+        private JsonFieldType(JsonFieldType ref) {
+            super(ref);
+        }
+
+        public JsonFieldType clone() {
+            return new JsonFieldType(this);
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            if (omitNorms()) {
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
+            } else {
+                return new NormsFieldExistsQuery(name());
+            }
+        }
+
+        @Override
+        public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions,
+                                boolean transpositions) {
+            throw new UnsupportedOperationException("[fuzzy] queries are not currently supported on [" +
+                CONTENT_TYPE + "] fields.");
+        }
+
+        @Override
+        public Query regexpQuery(String value, int flags, int maxDeterminizedStates,
+                                 MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+            throw new UnsupportedOperationException("[regexp] queries are not currently supported on [" +
+                CONTENT_TYPE + "] fields.");
+        }
+
+        @Override
+        public Object valueForDisplay(Object value) {
+            if (value == null) {
+                return null;
+            }
+            BytesRef binaryValue = (BytesRef) value;
+            return binaryValue.utf8ToString();
+        }
+    }
+
+    private final JsonFieldParser fieldParser;
+
+    private JsonFieldMapper(String simpleName,
+                            MappedFieldType fieldType,
+                            MappedFieldType defaultFieldType,
+                            Settings indexSettings) {
+        super(simpleName, fieldType, defaultFieldType, indexSettings, MultiFields.empty(), CopyTo.empty());
+        assert fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) <= 0;
+        this.fieldParser = new JsonFieldParser(fieldType);
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    protected JsonFieldMapper clone() {
+        return (JsonFieldMapper) super.clone();
+    }
+
+    @Override
+    public JsonFieldType fieldType() {
+        return (JsonFieldType) super.fieldType();
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException {
+        if (context.parser().currentToken() == XContentParser.Token.VALUE_NULL) {
+            return;
+        }
+
+        if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
+            fields.addAll(fieldParser.parse(context.parser()));
+            if (fieldType.omitNorms()) {
+                createFieldNamesField(context, fields);
+            }
+        } else {
+            context.parser().skipChildren();
+        }
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        super.doXContentBody(builder, includeDefaults, params);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -232,6 +232,14 @@ public final class JsonFieldMapper extends FieldMapper {
         }
 
         @Override
+        public Query wildcardQuery(String value,
+                                   MultiTermQuery.RewriteMethod method,
+                                   QueryShardContext context) {
+            throw new UnsupportedOperationException("[wildcard] queries are not currently supported on [" +
+                CONTENT_TYPE + "] fields.");
+        }
+
+        @Override
         public Object valueForDisplay(Object value) {
             if (value == null) {
                 return null;

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -125,8 +125,7 @@ public final class JsonFieldMapper extends FieldMapper {
         }
 
         public Builder copyTo(CopyTo copyTo) {
-            throw new UnsupportedOperationException("[copy_to] is not currently supported for ["
-                + CONTENT_TYPE + "] fields.");
+            throw new UnsupportedOperationException("[copy_to] is not supported for [" + CONTENT_TYPE + "] fields.");
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -142,6 +142,12 @@ public final class JsonFieldMapper extends FieldMapper {
                 } else if (propName.equals("norms")) {
                     TypeParsers.parseNorms(builder, name, propNode);
                     iterator.remove();
+                } else if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(propNode.toString());
+                    iterator.remove();
                 }
             }
             return builder;
@@ -256,6 +262,10 @@ public final class JsonFieldMapper extends FieldMapper {
     @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
+
+        if (includeDefaults || fieldType().nullValue() != null) {
+            builder.field("null_value", fieldType().nullValue());
+        }
 
         if (includeDefaults || ignoreAbove != Defaults.IGNORE_ABOVE) {
             builder.field("ignore_above", ignoreAbove);

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -24,7 +24,6 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.MultiTermQuery;
-import org.apache.lucene.search.NormsFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
@@ -153,9 +152,6 @@ public final class JsonFieldMapper extends FieldMapper {
                 if (propName.equals("ignore_above")) {
                     builder.ignoreAbove(XContentMapValues.nodeIntegerValue(propNode, -1));
                     iterator.remove();
-                } else if (propName.equals("norms")) {
-                    TypeParsers.parseNorms(builder, name, propNode);
-                    iterator.remove();
                 } else if (propName.equals("null_value")) {
                     if (propNode == null) {
                         throw new MapperParsingException("Property [null_value] cannot be null.");
@@ -219,11 +215,7 @@ public final class JsonFieldMapper extends FieldMapper {
 
         @Override
         public Query existsQuery(QueryShardContext context) {
-            if (omitNorms()) {
-                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
-            } else {
-                return new NormsFieldExistsQuery(name());
-            }
+            return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
         }
 
         @Override
@@ -294,9 +286,7 @@ public final class JsonFieldMapper extends FieldMapper {
 
         if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
             fields.addAll(fieldParser.parse(context.parser()));
-            if (fieldType.omitNorms()) {
-                createFieldNamesField(context, fields);
-            }
+            createFieldNamesField(context, fields);
         } else {
             context.parser().skipChildren();
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParserUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A helper class for {@link JsonFieldMapper} parses a JSON object
+ * and produces an indexable field for each leaf value.
+ */
+public class JsonFieldParser {
+    private final MappedFieldType fieldType;
+
+    JsonFieldParser(MappedFieldType fieldType) {
+        this.fieldType = fieldType;
+    }
+
+    public List<IndexableField> parse(XContentParser parser) throws IOException {
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT,
+            parser.currentToken(),
+            parser::getTokenLocation);
+
+        List<IndexableField> fields = new ArrayList<>();
+        int openObjects = 1;
+
+        while (true) {
+            if (openObjects == 0) {
+                return fields;
+            }
+
+            XContentParser.Token token = parser.nextToken();
+            assert token != null;
+
+            if (token == XContentParser.Token.START_OBJECT) {
+                openObjects++;
+            } else if (token == XContentParser.Token.END_OBJECT) {
+                openObjects--;
+            } else if (token.isValue()) {
+                String value = parser.text();
+                addField(value, fields);
+            }
+        }
+    }
+
+    private void addField(String value, List<IndexableField> fields) {
+        fields.add(new Field(fieldType.name(), new BytesRef(value), fieldType));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
@@ -35,9 +35,12 @@ import java.util.List;
  */
 public class JsonFieldParser {
     private final MappedFieldType fieldType;
+    private final int ignoreAbove;
 
-    JsonFieldParser(MappedFieldType fieldType) {
+    JsonFieldParser(MappedFieldType fieldType,
+                    int ignoreAbove) {
         this.fieldType = fieldType;
+        this.ignoreAbove = ignoreAbove;
     }
 
     public List<IndexableField> parse(XContentParser parser) throws IOException {
@@ -68,6 +71,8 @@ public class JsonFieldParser {
     }
 
     private void addField(String value, List<IndexableField> fields) {
-        fields.add(new Field(fieldType.name(), new BytesRef(value), fieldType));
+        if (value.length() <= ignoreAbove) {
+            fields.add(new Field(fieldType.name(), new BytesRef(value), fieldType));
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
@@ -66,6 +66,11 @@ public class JsonFieldParser {
             } else if (token.isValue()) {
                 String value = parser.text();
                 addField(value, fields);
+            } else if (token == XContentParser.Token.VALUE_NULL) {
+                String value = fieldType.nullValueAsString();
+                if (value != null) {
+                    addField(value, fields);
+                }
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -44,6 +44,7 @@ import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.IgnoredFieldMapper;
 import org.elasticsearch.index.mapper.IndexFieldMapper;
 import org.elasticsearch.index.mapper.IpFieldMapper;
+import org.elasticsearch.index.mapper.JsonFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
@@ -131,6 +132,7 @@ public class IndicesModule extends AbstractModule {
         mappers.put(ObjectMapper.NESTED_CONTENT_TYPE, new ObjectMapper.TypeParser());
         mappers.put(CompletionFieldMapper.CONTENT_TYPE, new CompletionFieldMapper.TypeParser());
         mappers.put(FieldAliasMapper.CONTENT_TYPE, new FieldAliasMapper.TypeParser());
+        mappers.put(JsonFieldMapper.CONTENT_TYPE, new JsonFieldMapper.TypeParser());
         mappers.put(GeoPointFieldMapper.CONTENT_TYPE, new GeoPointFieldMapper.TypeParser());
 
         if (ShapesAvailability.JTS_AVAILABLE && ShapesAvailability.SPATIAL4J_AVAILABLE) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldMapperTests.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+public class JsonFieldMapperTests extends ESSingleNodeTestCase {
+    private DocumentMapperParser parser;
+
+    @Before
+    public void setup() {
+        IndexService indexService = createIndex("test");
+        parser = indexService.mapperService().documentMapperParser();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(InternalSettingsPlugin.class);
+    }
+
+    public void testDefaults() throws Exception {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
+            .startObject("type")
+                .startObject("properties")
+                    .startObject("field")
+                        .field("type", "json")
+                    .endObject()
+                .endObject()
+            .endObject()
+        .endObject());
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        BytesReference doc = BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
+            .startObject("field")
+                .field("key1", "value")
+                .field("key2", true)
+            .endObject()
+        .endObject());
+
+        ParsedDocument parsedDoc = mapper.parse(SourceToParse.source("test", "type", "1", doc, XContentType.JSON));
+        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(2, fields.length);
+
+        IndexableField field1 = fields[0];
+        assertEquals("field", field1.name());
+        assertEquals(new BytesRef("value"), field1.binaryValue());
+        assertTrue(field1.fieldType().omitNorms());
+
+        IndexableField field2 = fields[1];
+        assertEquals("field", field2.name());
+        assertEquals(new BytesRef("true"), field2.binaryValue());
+        assertTrue(field2.fieldType().omitNorms());
+
+        IndexableField[] fieldNamesFields = parsedDoc.rootDoc().getFields(FieldNamesFieldMapper.NAME);
+        assertEquals(1, fieldNamesFields.length);
+
+        IndexableField fieldNamesField = fieldNamesFields[0];
+        assertEquals("field", fieldNamesField.stringValue());
+    }
+
+    public void testDisableIndex() throws Exception {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
+            .startObject("type")
+                .startObject("properties")
+                    .startObject("field")
+                        .field("type", "json")
+                        .field("index", false)
+                    .endObject()
+                .endObject()
+            .endObject()
+        .endObject());
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        BytesReference doc = BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
+            .startObject("field")
+                .field("key", "value")
+            .endObject()
+        .endObject());
+
+        ParsedDocument parsedDoc = mapper.parse(SourceToParse.source("test", "type", "1", doc, XContentType.JSON));
+        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(0, fields.length);
+    }
+
+    public void testEnableStore() throws Exception {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
+            .startObject("type")
+                .startObject("properties")
+                    .startObject("field")
+                        .field("type", "json")
+                        .field("index", false)
+                        .field("store", true)
+                    .endObject()
+                .endObject()
+            .endObject()
+        .endObject());
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        BytesReference doc = BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
+            .startObject("field")
+                .field("key", "value")
+            .endObject()
+        .endObject());
+
+        ParsedDocument parsedDoc = mapper.parse(SourceToParse.source("test", "type", "1", doc, XContentType.JSON));
+        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(1, fields.length);
+
+        IndexableField field = fields[0];
+        assertTrue(field.fieldType().stored());
+    }
+
+    public void testIndexOptions() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
+            .startObject("type")
+                .startObject("properties")
+                    .startObject("field")
+                        .field("type", "json")
+                        .field("index_options", "freqs")
+                    .endObject()
+                .endObject()
+            .endObject()
+        .endObject());
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        for (String indexOptions : Arrays.asList("positions", "offsets")) {
+            String invalidMapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
+                .startObject("type")
+                    .startObject("properties")
+                        .startObject("field")
+                            .field("type", "json")
+                            .field("index_options", indexOptions)
+                        .endObject()
+                    .endObject()
+                .endObject()
+            .endObject());
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                    () -> parser.parse("type", new CompressedXContent(invalidMapping)));
+            assertEquals("The [json] field does not support positions, got [index_options]=" + indexOptions, e.getMessage());
+        }
+    }
+
+    public void testEnableNorms() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties")
+                .startObject("field")
+                    .field("type", "json")
+                    .field("norms", true)
+                .endObject()
+            .endObject()
+        .endObject().endObject());
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        BytesReference doc = BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
+            .startObject("field")
+                .field("key", "value")
+            .endObject()
+        .endObject());
+        ParsedDocument parsedDoc = mapper.parse(SourceToParse.source("test", "type", "1", doc, XContentType.JSON));
+
+        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(1, fields.length);
+        assertFalse(fields[0].fieldType().omitNorms());
+
+        IndexableField[] fieldNamesFields = parsedDoc.rootDoc().getFields(FieldNamesFieldMapper.NAME);
+        assertEquals(0, fieldNamesFields.length);
+    }
+
+    public void testNullValue() throws Exception {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
+            .startObject("type")
+                .startObject("properties")
+                    .startObject("field")
+                        .field("type", "json")
+                    .endObject()
+                .endObject()
+            .endObject()
+        .endObject());
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        BytesReference doc = BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
+            .nullField("field")
+        .endObject());
+
+        ParsedDocument parsedDoc = mapper.parse(SourceToParse.source("test", "type", "1", doc, XContentType.JSON));
+        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(0, fields.length);
+    }
+
+    public void testMalformedJson() throws Exception {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
+            .startObject("type")
+                .startObject("properties")
+                    .startObject("field")
+                        .field("type", "json")
+                    .endObject()
+                .endObject()
+            .endObject()
+        .endObject());
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        BytesReference doc1 = BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
+            .field("field", "not a JSON object")
+        .endObject());
+
+        expectThrows(MapperParsingException.class, () -> mapper.parse(
+            SourceToParse.source("test", "type", "1", doc1, XContentType.JSON)));
+
+        BytesReference doc2 = new BytesArray("{ \"field\": { \"key\": \"value\" ");
+        expectThrows(MapperParsingException.class, () -> mapper.parse(
+            SourceToParse.source("test", "type", "1", doc2, XContentType.JSON)));
+    }
+
+    public void testFieldMultiplicity() throws Exception {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
+            .startObject("type")
+                .startObject("properties")
+                    .startObject("field")
+                        .field("type", "json")
+                    .endObject()
+                .endObject()
+            .endObject()
+        .endObject());
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        BytesReference doc = BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
+            .startArray("field")
+                .startObject()
+                    .field("key1", "value")
+                .endObject()
+                .startObject()
+                    .field("key2", true)
+                    .field("key3", false)
+                .endObject()
+            .endArray()
+        .endObject());
+
+        ParsedDocument parsedDoc = mapper.parse(SourceToParse.source("test", "type", "1", doc, XContentType.JSON));
+        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(3, fields.length);
+
+        IndexableField field1 = fields[0];
+        assertEquals("field", field1.name());
+        assertEquals(new BytesRef("value"), field1.binaryValue());
+
+        IndexableField field2 = fields[1];
+        assertEquals("field", field2.name());
+        assertEquals(new BytesRef("true"), field2.binaryValue());
+
+        IndexableField field3 = fields[2];
+        assertEquals("field", field3.name());
+        assertEquals(new BytesRef("false"), field3.binaryValue());
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldMapperTests.java
@@ -130,28 +130,14 @@ public class JsonFieldMapperTests extends ESSingleNodeTestCase {
                 .startObject("properties")
                     .startObject("field")
                         .field("type", "json")
-                        .field("index", false)
                         .field("store", true)
                     .endObject()
                 .endObject()
             .endObject()
         .endObject());
 
-        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
-        assertEquals(mapping, mapper.mappingSource().toString());
-
-        BytesReference doc = BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
-            .startObject("field")
-                .field("key", "value")
-            .endObject()
-        .endObject());
-
-        ParsedDocument parsedDoc = mapper.parse(SourceToParse.source("test", "type", "1", doc, XContentType.JSON));
-        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-
-        IndexableField field = fields[0];
-        assertTrue(field.fieldType().stored());
+        expectThrows(UnsupportedOperationException.class, () ->
+            parser.parse("type", new CompressedXContent(mapping)));
     }
 
     public void testIndexOptions() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldMapperTests.java
@@ -186,34 +186,6 @@ public class JsonFieldMapperTests extends ESSingleNodeTestCase {
         }
     }
 
-    public void testEnableNorms() throws IOException {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
-            .startObject("properties")
-                .startObject("field")
-                    .field("type", "json")
-                    .field("norms", true)
-                .endObject()
-            .endObject()
-        .endObject().endObject());
-
-        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
-        assertEquals(mapping, mapper.mappingSource().toString());
-
-        BytesReference doc = BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
-            .startObject("field")
-                .field("key", "value")
-            .endObject()
-        .endObject());
-        ParsedDocument parsedDoc = mapper.parse(SourceToParse.source("test", "type", "1", doc, XContentType.JSON));
-
-        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertFalse(fields[0].fieldType().omitNorms());
-
-        IndexableField[] fieldNamesFields = parsedDoc.rootDoc().getFields(FieldNamesFieldMapper.NAME);
-        assertEquals(0, fieldNamesFields.length);
-    }
-
     public void testNullField() throws Exception {
         String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
             .startObject("type")

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldParserTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class JsonFieldParserTests extends ESTestCase {
@@ -126,6 +125,28 @@ public class JsonFieldParserTests extends ESTestCase {
 
         List<IndexableField> fields = ignoreAboveParser.parse(xContentParser);
         assertEquals(0, fields.size());
+    }
+
+    public void testNullValues() throws Exception {
+        String input = "{ \"key\": null}";
+        XContentParser xContentParser = createXContentParser(input);
+
+        List<IndexableField> fields = parser.parse(xContentParser);
+        assertEquals(0, fields.size());
+
+        xContentParser = createXContentParser(input);
+
+        JsonFieldType fieldType = new JsonFieldType();
+        fieldType.setName("field");
+        fieldType.setNullValue("placeholder");
+        JsonFieldParser nullValueParser = new JsonFieldParser(fieldType, Integer.MAX_VALUE);
+
+        fields = nullValueParser.parse(xContentParser);
+        assertEquals(1, fields.size());
+
+        IndexableField field = fields.get(0);
+        assertEquals("field", field.name());
+        assertEquals(new BytesRef("placeholder"), field.binaryValue());
     }
 
     private XContentParser createXContentParser(String input) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldParserTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 public class JsonFieldParserTests extends ESTestCase {
@@ -39,7 +40,7 @@ public class JsonFieldParserTests extends ESTestCase {
 
         MappedFieldType fieldType = new JsonFieldType();
         fieldType.setName("field");
-        parser = new JsonFieldParser(fieldType);
+        parser = new JsonFieldParser(fieldType, Integer.MAX_VALUE);
     }
 
     public void testTextValues() throws Exception {
@@ -113,6 +114,18 @@ public class JsonFieldParserTests extends ESTestCase {
         IndexableField field2 = fields.get(1);
         assertEquals("field", field2.name());
         assertEquals(new BytesRef("value"), field2.binaryValue());
+    }
+
+    public void testIgnoreAbove() throws Exception {
+        String input = "{ \"key\": \"a longer field than usual\" }";
+        XContentParser xContentParser = createXContentParser(input);
+
+        JsonFieldType fieldType = new JsonFieldType();
+        fieldType.setName("field");
+        JsonFieldParser ignoreAboveParser = new JsonFieldParser(fieldType, 10);
+
+        List<IndexableField> fields = ignoreAboveParser.parse(xContentParser);
+        assertEquals(0, fields.size());
     }
 
     private XContentParser createXContentParser(String input) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldParserTests.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.mapper.JsonFieldMapper.JsonFieldType;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.List;
+
+public class JsonFieldParserTests extends ESTestCase {
+    private JsonFieldParser parser;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        MappedFieldType fieldType = new JsonFieldType();
+        fieldType.setName("field");
+        parser = new JsonFieldParser(fieldType);
+    }
+
+    public void testTextValues() throws Exception {
+        String input = "{ \"key1\": \"value1\", \"key2\": \"value2\" }";
+        XContentParser xContentParser = createXContentParser(input);
+
+        List<IndexableField> fields = parser.parse(xContentParser);
+        assertEquals(2, fields.size());
+
+        IndexableField field1 = fields.get(0);
+        assertEquals("field", field1.name());
+        assertEquals(new BytesRef("value1"), field1.binaryValue());
+
+        IndexableField field2 = fields.get(1);
+        assertEquals("field", field2.name());
+        assertEquals(new BytesRef("value2"), field2.binaryValue());
+    }
+
+    public void testNumericValues() throws Exception {
+        String input = "{ \"key\": 2.718 }";
+        XContentParser xContentParser = createXContentParser(input);
+
+        List<IndexableField> fields = parser.parse(xContentParser);
+        assertEquals(1, fields.size());
+
+        IndexableField field = fields.get(0);
+        assertEquals("field", field.name());
+        assertEquals(new BytesRef("2.718"), field.binaryValue());
+    }
+
+    public void testBooleanValues() throws Exception {
+        String input = "{ \"key\": false }";
+        XContentParser xContentParser = createXContentParser(input);
+
+        List<IndexableField> fields = parser.parse(xContentParser);
+        assertEquals(1, fields.size());
+
+        IndexableField field = fields.get(0);
+        assertEquals("field", field.name());
+        assertEquals(new BytesRef("false"), field.binaryValue());
+    }
+
+    public void testArrays() throws Exception {
+        String input = "{ \"key\": [true, false] }";
+        XContentParser xContentParser = createXContentParser(input);
+
+        List<IndexableField> fields = parser.parse(xContentParser);
+        assertEquals(2, fields.size());
+
+        IndexableField field1 = fields.get(0);
+        assertEquals("field", field1.name());
+        assertEquals(new BytesRef("true"), field1.binaryValue());
+
+        IndexableField field2 = fields.get(1);
+        assertEquals("field", field2.name());
+        assertEquals(new BytesRef("false"), field2.binaryValue());
+    }
+
+    public void testNestedObjects() throws Exception {
+        String input = "{ \"parent1\": { \"key\" : \"value\" }," +
+            "\"parent2\": { \"key\" : \"value\" }}";
+        XContentParser xContentParser = createXContentParser(input);
+
+        List<IndexableField> fields = parser.parse(xContentParser);
+        assertEquals(2, fields.size());
+
+        IndexableField field1 = fields.get(0);
+        assertEquals("field", field1.name());
+        assertEquals(new BytesRef("value"), field1.binaryValue());
+
+        IndexableField field2 = fields.get(1);
+        assertEquals("field", field2.name());
+        assertEquals(new BytesRef("value"), field2.binaryValue());
+    }
+
+    private XContentParser createXContentParser(String input) throws IOException {
+        XContentParser xContentParser = createParser(JsonXContent.jsonXContent, input);
+        xContentParser.nextToken();
+        return xContentParser;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldTypeTests.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.NormsFieldExistsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.index.mapper.JsonFieldMapper.JsonFieldType;
+
+public class JsonFieldTypeTests extends FieldTypeTestCase {
+
+    @Override
+    protected JsonFieldType createDefaultFieldType() {
+        return new JsonFieldType();
+    }
+
+    public void testValueForDisplay() {
+        JsonFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+
+        BytesRef indexedValue = ft.indexedValueForSearch("value");
+        assertEquals("value", ft.valueForDisplay(indexedValue));
+    }
+
+    public void testTermQuery() {
+        JsonFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+
+        Query expected = new TermQuery(new Term("field", "value"));
+        assertEquals(expected, ft.termQuery("value", null));
+
+        ft.setIndexOptions(IndexOptions.NONE);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> ft.termQuery("field", null));
+        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
+    }
+
+    public void testExistsQuery() {
+        JsonFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+        ft.setOmitNorms(true);
+
+        Query expected = new TermQuery(new Term(FieldNamesFieldMapper.NAME, new BytesRef("field")));
+        assertEquals(expected, ft.existsQuery(null));
+
+        ft.setOmitNorms(false);
+        expected = new NormsFieldExistsQuery("field");
+        assertEquals(expected, ft.existsQuery(null));
+    }
+
+    public void testFuzzyQuery() {
+        JsonFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+
+        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
+            () -> ft.fuzzyQuery("valuee", Fuzziness.fromEdits(2), 1, 50, true));
+        assertEquals("[fuzzy] queries are not currently supported on [json] fields.", e.getMessage());
+    }
+
+    public void testRegexpQuery() {
+        JsonFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+
+        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
+            () -> ft.regexpQuery("valu*", 0, 10, null, null));
+        assertEquals("[regexp] queries are not currently supported on [json] fields.", e.getMessage());
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldTypeTests.java
@@ -87,8 +87,17 @@ public class JsonFieldTypeTests extends FieldTypeTestCase {
         JsonFieldType ft = createDefaultFieldType();
         ft.setName("field");
 
-        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
+        UnsupportedOperationException e  = expectThrows(UnsupportedOperationException.class,
             () -> ft.regexpQuery("valu*", 0, 10, null, null));
         assertEquals("[regexp] queries are not currently supported on [json] fields.", e.getMessage());
+    }
+
+    public void testWildcardQuery() {
+        JsonFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+
+        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
+            () -> ft.wildcardQuery("valu*", null, null));
+        assertEquals("[wildcard] queries are not currently supported on [json] fields.", e.getMessage());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldTypeTests.java
@@ -20,7 +20,6 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.NormsFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
@@ -70,13 +69,8 @@ public class JsonFieldTypeTests extends FieldTypeTestCase {
     public void testExistsQuery() {
         JsonFieldType ft = createDefaultFieldType();
         ft.setName("field");
-        ft.setOmitNorms(true);
 
         Query expected = new TermQuery(new Term(FieldNamesFieldMapper.NAME, new BytesRef("field")));
-        assertEquals(expected, ft.existsQuery(null));
-
-        ft.setOmitNorms(false);
-        expected = new NormsFieldExistsQuery("field");
         assertEquals(expected, ft.existsQuery(null));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldTypeTests.java
@@ -26,8 +26,20 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.JsonFieldMapper.JsonFieldType;
+import org.junit.Before;
 
 public class JsonFieldTypeTests extends FieldTypeTestCase {
+
+    @Before
+    public void setupProperties() {
+        addModifier(new Modifier("split_queries_on_whitespace", true) {
+            @Override
+            public void modify(MappedFieldType type) {
+                JsonFieldType ft = (JsonFieldType) type;
+                ft.setSplitQueriesOnWhitespace(!ft.splitQueriesOnWhitespace());
+            }
+        });
+    }
 
     @Override
     protected JsonFieldType createDefaultFieldType() {


### PR DESCRIPTION
Currently the mapper extracts all leaf values of the JSON object, converts them to their text representations, and indexes each one as a keyword. I plan to add support for key-value pairs in a subsequent PR. As discussed in #33795, we've decided to try an approach where we tokenize the JSON outside of lucene analysis.

Because of the parallel between this data type and `keyword`, I included the relevant options `ignore_above`, `null_value`, and `split_queries_on_whitespace`.

Lastly, it would be great to get feedback on the naming: I settled on `json`, but am very happy for other suggestions. I wasn't a huge fan of names like `key_value`, `map`, or `dict`, because they might suggest the input should be a flat list of key-value pairs, as opposed to a general JSON blob. Certainly `object` would be a nice choice, but it conflicts with the existing type.