### PR TITLE
API: Drop deprecated methods from Retry

### DIFF
--- a/docs/reference/migration/migrate_7_0/java.asciidoc
+++ b/docs/reference/migration/migrate_7_0/java.asciidoc
@@ -18,3 +18,7 @@ appropriate request directly.
 * All classes present in `org.elasticsearch.search.aggregations.metrics.*` packages
 were moved to a single `org.elasticsearch.search.aggregations.metrics` package.
 
+==== `Retry.withBackoff` methods with `Settings` removed
+
+The variants of `Retry.withBackoff` that included `Settings` have been removed
+because `Settings` is no longer needed.

--- a/server/src/main/java/org/elasticsearch/action/bulk/Retry.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/Retry.java
@@ -22,7 +22,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.rest.RestStatus;
@@ -62,21 +61,6 @@ public class Retry {
     }
 
     /**
-     * Invokes #accept(BulkRequest, ActionListener). Backs off on the provided exception and delegates results to the
-     * provided listener. Retries will be scheduled using the class's thread pool.
-     * @param consumer The consumer to which apply the request and listener
-     * @param bulkRequest The bulk request that should be executed.
-     * @param listener A listener that is invoked when the bulk request finishes or completes with an exception. The listener is not
-     * @param settings settings
-     * @deprecated Prefer {@link #withBackoff(BiConsumer, BulkRequest, ActionListener)}. The {@link Settings} isn't used.
-     */
-    @Deprecated
-    public void withBackoff(BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer, BulkRequest bulkRequest,
-                            ActionListener<BulkResponse> listener, Settings settings) {
-        withBackoff(consumer, bulkRequest, listener);
-    }
-
-    /**
      * Invokes #accept(BulkRequest, ActionListener). Backs off on the provided exception. Retries will be scheduled using
      * the class's thread pool.
      *
@@ -89,22 +73,6 @@ public class Retry {
         PlainActionFuture<BulkResponse> future = PlainActionFuture.newFuture();
         withBackoff(consumer, bulkRequest, future);
         return future;
-    }
-
-    /**
-     * Invokes #accept(BulkRequest, ActionListener). Backs off on the provided exception. Retries will be scheduled using
-     * the class's thread pool.
-     *
-     * @param consumer The consumer to which apply the request and listener
-     * @param bulkRequest The bulk request that should be executed.
-     * @param settings settings
-     * @return a future representing the bulk response returned by the client.
-     * @deprecated prefer {@link #withBackoff(BiConsumer, BulkRequest)}. The {@link Settings} isn't used.
-     */
-    @Deprecated
-    public PlainActionFuture<BulkResponse> withBackoff(BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer,
-                                                       BulkRequest bulkRequest, Settings settings) {
-        return withBackoff(consumer, bulkRequest);
     }
 
     static class RetryHandler implements ActionListener<BulkResponse> {


### PR DESCRIPTION
We deprecated the `Retry.withBackoff` flavors with `Settings` in 6.5
because they were no longer needed. This drops them form 7.0.
