### PR TITLE
In MatchQuery, remove a check for fragile search analyzers.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -257,10 +257,10 @@ public class    MatchQuery {
         assert analyzer != null;
 
         /*
-         * For untokenized fields that use a keyword analyzer, we know that further
-         * analysis isn't needed and can immediately return a term query.
+         * If a keyword analyzer is used, we know that further analysis isn't
+         * needed and can immediately return a term query.
          */
-        if (fieldType.tokenized() == false && analyzer == Lucene.KEYWORD_ANALYZER) {
+        if (analyzer == Lucene.KEYWORD_ANALYZER) {
             return blendTermQuery(new Term(fieldName, value.toString()), fieldType);
         }
 

--- a/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -48,10 +48,10 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.MultiPhrasePrefixQuery;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.unit.Fuzziness;
-import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.support.QueryParsers;
@@ -253,22 +253,17 @@ public class    MatchQuery {
         }
         final String field = fieldType.name();
 
+        Analyzer analyzer = getAnalyzer(fieldType, type == Type.PHRASE);
+        assert analyzer != null;
+
         /*
-         * If the user forced an analyzer we really don't care if they are
-         * searching a type that wants term queries to be used with query string
-         * because the QueryBuilder will take care of it. If they haven't forced
-         * an analyzer then types like NumberFieldType that want terms with
-         * query string will blow up because their analyzer isn't capable of
-         * passing through QueryBuilder.
+         * For untokenized fields that use a keyword analyzer, we know that further
+         * analysis isn't needed and can immediately return a term query.
          */
-        boolean noForcedAnalyzer = this.analyzer == null;
-        if (fieldType.tokenized() == false && noForcedAnalyzer &&
-                fieldType instanceof KeywordFieldMapper.KeywordFieldType == false) {
+        if (fieldType.tokenized() == false && analyzer == Lucene.KEYWORD_ANALYZER) {
             return blendTermQuery(new Term(fieldName, value.toString()), fieldType);
         }
 
-        Analyzer analyzer = getAnalyzer(fieldType, type == Type.PHRASE);
-        assert analyzer != null;
         MatchQueryBuilder builder = new MatchQueryBuilder(analyzer, fieldType);
         builder.setEnablePositionIncrements(this.enablePositionIncrements);
         if (hasPositions(fieldType)) {


### PR DESCRIPTION
As far as I can tell this guard against fragile analyzers is no longer relevant, since we stopped setting special analyzers on numeric fields (https://github.com/elastic/elasticsearch/commit/3bf6f4076c9294a4b6b1e8bc08b671ef6ad74380). Instead of removing the guard completely, I opted to keep a check for untokenized + unnormalized fields to avoid going through the analysis process unnecessarily.

My motivation for simplifying this check is that I'd like to add support for `split_queries_on_whitespace` to the new 'queryable object' fields. As it stands, I would have to add a dedicated `instanceof` check for the new mapper type, which I'd like to avoid.

@jimczi and @nik9000 it would be great to get your thoughts on this! I am not 100% clear on the historical context, and may be missing an important detail.