### PR TITLE
Add note about how the body is referenced

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
@@ -316,6 +316,8 @@ Supports also regular expressions with flag X for more readability (accepts whit
                    \d+    \s+  \d{2}:\d{2}:\d{2}  \s+  \d+    \s+  \n  $/
 ....
 
+**Note:** `$body` is used mainly for cat apis, to refer to the last obtained response body as a string, while `''` refers to the parsed representation of the string (parsed into a Map by the java runner for instance).
+
 === `lt` and `gt`
 
 Compares two numeric values, eg:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
@@ -316,7 +316,7 @@ Supports also regular expressions with flag X for more readability (accepts whit
                    \d+    \s+  \d{2}:\d{2}:\d{2}  \s+  \d+    \s+  \n  $/
 ....
 
-**Note:** `$body` is used mainly for cat apis, to refer to the last obtained response body as a string, while `''` refers to the parsed representation of the string (parsed into a Map by the java runner for instance).
+**Note:** `$body` is used to refer to the last obtained response body as a string, while `''` refers to the parsed representation (parsed into a Map by the Java runner for instance). Having the raw string response is for example useful when testing cat APIs.
 
 === `lt` and `gt`
 


### PR DESCRIPTION
Hi all!
In some test, such as [`get_source/10_basic.yml`](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/10_basic.yml#L16) the body is referenced as an empty string instead of `$body`. This pr adds a note to warn the developers about this behavior.

https://github.com/elastic/elasticsearch/blob/3a5b8a71b4f7d5473a7bfbce2f2eb5a6bfefdc17/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/10_basic.yml#L10-L17