### PR TITLE
refactor CompositeValuesSourceParserHelper for reusage

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
@@ -193,11 +193,7 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
         builder.field(SIZE_FIELD_NAME.getPreferredName(), size);
         builder.startArray(SOURCES_FIELD_NAME.getPreferredName());
         for (CompositeValuesSourceBuilder<?> source: sources) {
-            builder.startObject();
-            builder.startObject(source.name());
-            source.toXContent(builder, params);
-            builder.endObject();
-            builder.endObject();
+            CompositeValuesSourceParserHelper.toXContent(source, builder, params);
         }
         builder.endArray();
         if (after != null) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceParserHelper.java
@@ -25,7 +25,9 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.AbstractObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.aggregations.support.ValueType;
 
@@ -33,7 +35,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
-class CompositeValuesSourceParserHelper {
+public class CompositeValuesSourceParserHelper {
     static <VB extends CompositeValuesSourceBuilder<VB>, T> void declareValuesSourceFields(AbstractObjectParser<VB, T> objectParser,
                                                                                            ValueType targetValueType) {
         objectParser.declareField(VB::field, XContentParser::text,
@@ -57,7 +59,7 @@ class CompositeValuesSourceParserHelper {
         objectParser.declareField(VB::order,  XContentParser::text, new ParseField("order"), ObjectParser.ValueType.STRING);
     }
 
-    static void writeTo(CompositeValuesSourceBuilder<?> builder, StreamOutput out) throws IOException {
+    public static void writeTo(CompositeValuesSourceBuilder<?> builder, StreamOutput out) throws IOException {
         final byte code;
         if (builder.getClass() == TermsValuesSourceBuilder.class) {
             code = 0;
@@ -72,7 +74,7 @@ class CompositeValuesSourceParserHelper {
         builder.writeTo(out);
     }
 
-    static CompositeValuesSourceBuilder<?> readFrom(StreamInput in) throws IOException {
+    public static CompositeValuesSourceBuilder<?> readFrom(StreamInput in) throws IOException {
         int code = in.readByte();
         switch(code) {
             case 0:
@@ -86,7 +88,7 @@ class CompositeValuesSourceParserHelper {
         }
     }
 
-    static CompositeValuesSourceBuilder<?> fromXContent(XContentParser parser) throws IOException {
+    public static CompositeValuesSourceBuilder<?> fromXContent(XContentParser parser) throws IOException {
         XContentParser.Token token = parser.currentToken();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser::getTokenLocation);
         token = parser.nextToken();
@@ -115,6 +117,16 @@ class CompositeValuesSourceParserHelper {
         }
         parser.nextToken();
         parser.nextToken();
+        return builder;
+    }
+
+    public static XContentBuilder toXContent(CompositeValuesSourceBuilder<?> source, XContentBuilder builder, Params params)
+            throws IOException {
+        builder.startObject();
+        builder.startObject(source.name());
+        source.toXContent(builder, params);
+        builder.endObject();
+        builder.endObject();
         return builder;
     }
 }


### PR DESCRIPTION
refactor CompositeValuesSourceParserHelper for reusage by making it public and moving toXContent in order to be able to reuse the functionality downstream