### PR TITLE
[ML] Leniently parse ml persistent task parameters

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/OpenJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/OpenJobAction.java
@@ -134,7 +134,7 @@ public class OpenJobAction extends Action<AcknowledgedResponse> {
         public static final ParseField IGNORE_DOWNTIME = new ParseField("ignore_downtime");
 
         public static final ParseField TIMEOUT = new ParseField("timeout");
-        public static ObjectParser<JobParams, Void> PARSER = new ObjectParser<>(TASK_NAME, JobParams::new);
+        public static ObjectParser<JobParams, Void> PARSER = new ObjectParser<>(TASK_NAME, true, JobParams::new);
 
         static {
             PARSER.declareString(JobParams::setJobId, Job.ID);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
@@ -141,7 +141,7 @@ public class StartDatafeedAction extends Action<AcknowledgedResponse> {
 
     public static class DatafeedParams implements XPackPlugin.XPackPersistentTaskParams {
 
-        public static ObjectParser<DatafeedParams, Void> PARSER = new ObjectParser<>(TASK_NAME, DatafeedParams::new);
+        public static ObjectParser<DatafeedParams, Void> PARSER = new ObjectParser<>(TASK_NAME, true, DatafeedParams::new);
 
         static {
             PARSER.declareString((params, datafeedId) -> params.datafeedId = datafeedId, DatafeedConfig.ID);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DatafeedParamsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DatafeedParamsTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+import java.io.IOException;
+
+public class DatafeedParamsTests extends AbstractSerializingTestCase<StartDatafeedAction.DatafeedParams> {
+    @Override
+    protected StartDatafeedAction.DatafeedParams doParseInstance(XContentParser parser) throws IOException {
+        return StartDatafeedAction.DatafeedParams.parseRequest(null, parser);
+    }
+
+    public static StartDatafeedAction.DatafeedParams createDatafeedParams() {
+        StartDatafeedAction.DatafeedParams params =
+                new StartDatafeedAction.DatafeedParams(randomAlphaOfLength(10), randomNonNegativeLong());
+        if (randomBoolean()) {
+            params.setEndTime(randomNonNegativeLong());
+        }
+        if (randomBoolean()) {
+            params.setTimeout(TimeValue.timeValueMillis(randomNonNegativeLong()));
+        }
+        return params;
+    }
+
+    @Override
+    protected StartDatafeedAction.DatafeedParams createTestInstance() {
+        return createDatafeedParams();
+    }
+
+    @Override
+    protected Writeable.Reader<StartDatafeedAction.DatafeedParams> instanceReader() {
+        return StartDatafeedAction.DatafeedParams::new;
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return true;
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/JobParamsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/JobParamsTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+import java.io.IOException;
+
+public class JobParamsTests extends AbstractSerializingTestCase<OpenJobAction.JobParams> {
+
+    @Override
+    protected OpenJobAction.JobParams doParseInstance(XContentParser parser) throws IOException {
+        return OpenJobAction.JobParams.parseRequest(null, parser);
+    }
+
+    public static OpenJobAction.JobParams createJobParams() {
+        OpenJobAction.JobParams params = new OpenJobAction.JobParams(randomAlphaOfLengthBetween(1, 20));
+        if (randomBoolean()) {
+            params.setTimeout(TimeValue.timeValueMillis(randomNonNegativeLong()));
+        }
+        return params;
+    }
+
+    @Override
+    protected OpenJobAction.JobParams createTestInstance() {
+        return createJobParams();
+    }
+
+    @Override
+    protected Writeable.Reader<OpenJobAction.JobParams> instanceReader() {
+        return OpenJobAction.JobParams::new;
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return true;
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/OpenJobActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/OpenJobActionRequestTests.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractStreamableXContentTestCase;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction.Request;
@@ -14,11 +13,7 @@ public class OpenJobActionRequestTests extends AbstractStreamableXContentTestCas
 
     @Override
     protected Request createTestInstance() {
-        OpenJobAction.JobParams params = new OpenJobAction.JobParams(randomAlphaOfLengthBetween(1, 20));
-        if (randomBoolean()) {
-            params.setTimeout(TimeValue.timeValueMillis(randomNonNegativeLong()));
-        }
-        return new Request(params);
+        return new Request(JobParamsTests.createJobParams());
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedActionRequestTests.java
@@ -6,10 +6,8 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractStreamableXContentTestCase;
-import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction.DatafeedParams;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction.Request;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -18,14 +16,7 @@ public class StartDatafeedActionRequestTests extends AbstractStreamableXContentT
 
     @Override
     protected Request createTestInstance() {
-        DatafeedParams params = new DatafeedParams(randomAlphaOfLength(10), randomNonNegativeLong());
-        if (randomBoolean()) {
-            params.setEndTime(randomNonNegativeLong());
-        }
-        if (randomBoolean()) {
-            params.setTimeout(TimeValue.timeValueMillis(randomNonNegativeLong()));
-        }
-        return new Request(params);
+        return new Request(DatafeedParamsTests.createDatafeedParams());
     }
 
     @Override


### PR DESCRIPTION
Ignore unknown fields when parsing the job and datafeed persistent task parameters.

This is required for migrating the ml configuration work #32905 where additional fields will be added to the task parameters (as the config won't be available in the cluster state) and those fields need to be safely parsed during a rolling upgrade to 7.0