### PR TITLE
CCR: Make AutoFollowMetadata immutable

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
@@ -135,12 +135,13 @@ public class TransportPutAutoFollowPatternAction extends
         }
 
         AutoFollowPattern previousPattern = patterns.get(request.getLeaderClusterAlias());
-        List<String> followedIndexUUIDs = followedLeaderIndices.get(request.getLeaderClusterAlias());
-        if (followedIndexUUIDs == null) {
+        final List<String> followedIndexUUIDs;
+        if (followedLeaderIndices.containsKey(request.getLeaderClusterAlias())) {
+            followedIndexUUIDs = new ArrayList<>(followedLeaderIndices.get(request.getLeaderClusterAlias()));
+        } else {
             followedIndexUUIDs = new ArrayList<>();
-            followedLeaderIndices.put(request.getLeaderClusterAlias(), followedIndexUUIDs);
         }
-
+        followedLeaderIndices.put(request.getLeaderClusterAlias(), followedIndexUUIDs);
         // Mark existing leader indices as already auto followed:
         if (previousPattern != null) {
             markExistingIndicesAsAutoFollowedForNewPatterns(request.getLeaderIndexPatterns(), leaderClusterState.metaData(),

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinatorTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinatorTests.java
@@ -85,7 +85,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
             void getLeaderClusterState(Map<String, String> headers,
                                        String leaderClusterAlias,
                                        BiConsumer<ClusterState, Exception> handler) {
-                assertThat(headers, sameInstance(autoFollowHeaders.get("remote")));
+                assertThat(headers, equalTo(autoFollowHeaders.get("remote")));
                 handler.accept(leaderState, null);
             }
 
@@ -94,7 +94,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
                                  FollowIndexAction.Request followRequest,
                                  Runnable successHandler,
                                  Consumer<Exception> failureHandler) {
-                assertThat(headers, sameInstance(autoFollowHeaders.get("remote")));
+                assertThat(headers, equalTo(autoFollowHeaders.get("remote")));
                 assertThat(followRequest.getLeaderIndex(), equalTo("remote:logs-20190101"));
                 assertThat(followRequest.getFollowerIndex(), equalTo("logs-20190101"));
                 successHandler.run();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Custom metadata that contains auto follow patterns and what leader indices an auto follow pattern has already followed.
@@ -80,16 +81,10 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
                               Map<String, List<String>> followedLeaderIndexUUIDs,
                               Map<String, Map<String, String>> headers) {
         this.patterns = Collections.unmodifiableMap(patterns);
-        final Map<String, List<String>> mutableIndexUUIDs = new HashMap<>(followedLeaderIndexUUIDs.size());
-        for (Map.Entry<String, List<String>> entry : followedLeaderIndexUUIDs.entrySet()) {
-            mutableIndexUUIDs.put(entry.getKey(), Collections.unmodifiableList(entry.getValue()));
-        }
-        this.followedLeaderIndexUUIDs = Collections.unmodifiableMap(mutableIndexUUIDs);
-        final Map<String, Map<String, String>> mutableHeaders = new HashMap<>(headers.size());
-        for (Map.Entry<String, Map<String, String>> entry : headers.entrySet()) {
-            mutableHeaders.put(entry.getKey(), Collections.unmodifiableMap(entry.getValue()));
-        }
-        this.headers = Collections.unmodifiableMap(mutableHeaders);
+        this.followedLeaderIndexUUIDs = Collections.unmodifiableMap(followedLeaderIndexUUIDs.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> Collections.unmodifiableList(e.getValue()))));
+        this.headers = Collections.unmodifiableMap(headers.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> Collections.unmodifiableMap(e.getValue()))));
     }
 
     public AutoFollowMetadata(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
@@ -79,16 +79,25 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
     public AutoFollowMetadata(Map<String, AutoFollowPattern> patterns,
                               Map<String, List<String>> followedLeaderIndexUUIDs,
                               Map<String, Map<String, String>> headers) {
-        this.patterns = patterns;
-        this.followedLeaderIndexUUIDs = followedLeaderIndexUUIDs;
-        this.headers = Collections.unmodifiableMap(headers);
+        this.patterns = Collections.unmodifiableMap(patterns);
+        final Map<String, List<String>> mutableIndexUUIDs = new HashMap<>(followedLeaderIndexUUIDs.size());
+        for (Map.Entry<String, List<String>> entry : followedLeaderIndexUUIDs.entrySet()) {
+            mutableIndexUUIDs.put(entry.getKey(), Collections.unmodifiableList(entry.getValue()));
+        }
+        this.followedLeaderIndexUUIDs = Collections.unmodifiableMap(mutableIndexUUIDs);
+        final Map<String, Map<String, String>> mutableHeaders = new HashMap<>(headers.size());
+        for (Map.Entry<String, Map<String, String>> entry : headers.entrySet()) {
+            mutableHeaders.put(entry.getKey(), Collections.unmodifiableMap(entry.getValue()));
+        }
+        this.headers = Collections.unmodifiableMap(mutableHeaders);
     }
 
     public AutoFollowMetadata(StreamInput in) throws IOException {
-        patterns = in.readMap(StreamInput::readString, AutoFollowPattern::new);
-        followedLeaderIndexUUIDs = in.readMapOfLists(StreamInput::readString, StreamInput::readString);
-        headers = Collections.unmodifiableMap(in.readMap(StreamInput::readString,
-            valIn -> Collections.unmodifiableMap(valIn.readMap(StreamInput::readString, StreamInput::readString))));
+        this(
+            in.readMap(StreamInput::readString, AutoFollowPattern::new),
+            in.readMapOfLists(StreamInput::readString, StreamInput::readString),
+            in.readMap(StreamInput::readString, valIn -> valIn.readMap(StreamInput::readString, StreamInput::readString))
+        );
     }
 
     public Map<String, AutoFollowPattern> getPatterns() {


### PR DESCRIPTION
We should make AutoFollowMetadata immutable to avoid being inconsistent when one thread modifies it while other reads it.


CI: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+multijob-unix-compatibility/os=fedora/16/console

```
ERROR   6.76s J1 | AutoFollowTests.testAutoFollowManyIndices <<< FAILURES!
   > Throwable #1: java.util.ConcurrentModificationException
   > 	at __randomizedtesting.SeedInfo.seed([660C1616F2D0A0E7:4E3E396B9B410590]:0)
   > 	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:909)
   > 	at java.util.ArrayList$Itr.next(ArrayList.java:859)
   > 	at org.elasticsearch.common.io.stream.StreamOutput.lambda$writeMapOfLists$1(StreamOutput.java:538)
   > 	at org.elasticsearch.common.io.stream.StreamOutput.writeMap(StreamOutput.java:559)
   > 	at org.elasticsearch.common.io.stream.StreamOutput.writeMapOfLists(StreamOutput.java:536)
   > 	at org.elasticsearch.xpack.core.ccr.AutoFollowMetadata.writeTo(AutoFollowMetadata.java:125)
   > 	at org.elasticsearch.common.io.stream.StreamOutput.writeNamedWriteable(StreamOutput.java:947)
   > 	at org.elasticsearch.cluster.metadata.MetaData.writeTo(MetaData.java:879)
   > 	at org.elasticsearch.cluster.ClusterState.writeTo(ClusterState.java:744)
```