### PR TITLE
[Zen2] Logging improvements in CoordinatorTests

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
@@ -167,11 +167,15 @@ public class CoordinationState extends AbstractComponent {
         logger.debug("handleStartJoin: leaving term [{}] due to {}", getCurrentTerm(), startJoinRequest);
 
         if (joinVotes.isEmpty() == false) {
+            final String reason;
             if (electionWon == false) {
-                logger.debug("handleStartJoin: failed election, discarding {}", joinVotes);
-            } else if (startJoinRequest.getSourceNode().equals(localNode) == false) {
-                logger.debug("handleStartJoin: standing down as leader, discarding {}", joinVotes);
+                reason = "failed election";
+            } else if (startJoinRequest.getSourceNode().equals(localNode)) {
+                reason = "bumping term";
+            } else {
+                reason = "standing down as leader";
             }
+            logger.debug("handleStartJoin: discarding {}: {}", joinVotes, reason);
         }
 
         persistedState.setCurrentTerm(startJoinRequest.getTerm());
@@ -240,6 +244,7 @@ public class CoordinationState extends AbstractComponent {
             join.getSourceNode(), electionWon, lastAcceptedTerm, getLastAcceptedVersion());
 
         if (electionWon && prevElectionWon == false) {
+            logger.debug("handleJoin: election won in term [{}] with {}", getCurrentTerm(), joinVotes);
             lastPublishedVersion = getLastAcceptedVersion();
         }
         return added;

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.coordination.JoinHelper.InitialJoinAccumulator;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -99,7 +100,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         this.persistedStateSupplier = persistedStateSupplier;
         this.lastKnownLeader = Optional.empty();
         this.lastJoin = Optional.empty();
-        this.joinAccumulator = joinHelper.new CandidateJoinAccumulator();
+        this.joinAccumulator = new InitialJoinAccumulator();
         this.publishTimeout = PUBLISH_TIMEOUT_SETTING.get(settings);
         this.electionSchedulerFactory = new ElectionSchedulerFactory(settings, random, transportService.getThreadPool());
         this.preVoteCollector = new PreVoteCollector(settings, transportService, this::startElection, this::updateMaxTermSeen);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinTaskExecutor.java
@@ -170,8 +170,8 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
         ClusterState tmpState = ClusterState.builder(currentState).nodes(nodesBuilder).blocks(ClusterBlocks.builder()
             .blocks(currentState.blocks())
             .removeGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID)).build();
-        return ClusterState.builder(allocationService.deassociateDeadNodes(tmpState, false,
-            "removed dead nodes on election"));
+        logger.trace("becomeMasterAndTrimConflictingNodes: {}", tmpState.nodes());
+        return ClusterState.builder(allocationService.deassociateDeadNodes(tmpState, false, "removed dead nodes on election"));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1221,7 +1221,17 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
                 if (ThreadPool.Names.SAME.equals(executor)) {
                     processException(handler, rtx);
                 } else {
-                    threadPool.executor(handler.executor()).execute(() -> processException(handler, rtx));
+                    threadPool.executor(handler.executor()).execute(new Runnable() {
+                        @Override
+                        public void run() {
+                            processException(handler, rtx);
+                        }
+
+                        @Override
+                        public String toString() {
+                            return "delivery of exception response to [" + action + "][" + requestId + "]: " + exception;
+                        }
+                    });
                 }
             }
         }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -158,7 +158,7 @@ public class CoordinatorTests extends ESTestCase {
 
                 final String nodeId = clusterNode.getId();
                 assertThat(nodeId + " has the same term as the leader", clusterNode.coordinator.getCurrentTerm(), is(leaderTerm));
-                assertTrue("leader should have received a vote from " + nodeId,
+                assertTrue("leader " + leader.getId() + " should have received a vote from " + nodeId,
                     leader.coordinator.hasJoinVoteFrom(clusterNode.getLocalNode()));
 
                 assertThat(nodeId + " is a follower", clusterNode.coordinator.getMode(), is(FOLLOWER));

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -270,27 +270,22 @@ public class CoordinatorTests extends ESTestCase {
             }
 
             void submitValue(final long value) {
-                onNode(localNode, new Runnable() {
-                        @Override
-                        public void run() {
-                            masterService.submitStateUpdateTask("new value [" + value + "]", new ClusterStateUpdateTask() {
-                                @Override
-                                public ClusterState execute(ClusterState currentState) {
-                                    return setValue(currentState, value);
-                                }
-
-                                @Override
-                                public void onFailure(String source, Exception e) {
-                                    logger.debug(() -> new ParameterizedMessage("failed to publish: [{}]", source), e);
-                                }
-                            });
-                        }
+                onNode(localNode, () -> masterService.submitStateUpdateTask("new value [" + value + "]", new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) {
+                        return setValue(currentState, value);
+                    }
 
                     @Override
-                    public String toString() {
-                        return "submitStateUpdateTask: new value [" + value + "]";
+                    public void onFailure(String source, Exception e) {
+                        logger.debug(() -> new ParameterizedMessage("failed to publish: [{}]", source), e);
                     }
-                }).run();
+                })).run();
+            }
+
+            @Override
+            public String toString() {
+                return localNode.toString();
             }
         }
 


### PR DESCRIPTION
Today, we know that CoordinatorTests sometimes fail to stabilise due to an
election collision. This change improves the logging that occurs when an
election collision occurs so it will be easier to see if this is happening when
analysing a test failure. We also wrap the call to
masterService.submitStateUpdateTask() in a context that logs the node on which
it runs.

We also introduce the InitialJoinAccumulator instead of using a placeholder
CandidateJoinAccumulator at startup, which reduces the cases to consider in
CandidateJoinAccumulator.close() and tightens up the assertions we can make
here.
