### PR TITLE
Fix typo `NodeEnvironment#assertPathsDoNotExist`

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -488,7 +488,7 @@ public final class NodeEnvironment  implements Closeable {
     private static boolean assertPathsDoNotExist(final Path[] paths) {
         Set<Path> existingPaths = new HashSet<>();
         for (Path path : paths) {
-            if (FileSystemUtils.exists(paths)) {
+            if (FileSystemUtils.exists(path)) {
                 existingPaths.add(path);
             }
         }


### PR DESCRIPTION
* We want to check the individual paths here one by one to
get a better to interpret assertion message