### PR TITLE
Allow resolving of cluster names to be strict

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ClusterNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ClusterNameExpressionResolver.java
@@ -45,17 +45,26 @@ public final class ClusterNameExpressionResolver extends AbstractComponent {
      * Resolves the provided cluster expression to matching cluster names. This method only
      * supports exact or wildcard matches.
      *
-     * @param remoteClusters    the aliases for remote clusters
-     * @param clusterExpression the expressions that can be resolved to cluster names.
+     * @param remoteClusters            the aliases for remote clusters
+     * @param clusterExpression         the expressions that can be resolved to cluster names.
+     * @param expandExpressions         Whether expressions with wildcards are expanded
+     * @param ignoreNoneExistingAliases Whether none existing aliases are ignored
      * @return the resolved cluster aliases.
      */
-    public List<String> resolveClusterNames(Set<String> remoteClusters, String clusterExpression) {
+    public List<String> resolveClusterNames(Set<String> remoteClusters,
+                                            String clusterExpression,
+                                            boolean expandExpressions,
+                                            boolean ignoreNoneExistingAliases) {
         if (remoteClusters.contains(clusterExpression)) {
             return Collections.singletonList(clusterExpression);
-        } else if (Regex.isSimpleMatchPattern(clusterExpression)) {
+        } else if (expandExpressions && Regex.isSimpleMatchPattern(clusterExpression)) {
             return wildcardResolver.resolve(remoteClusters, clusterExpression);
         } else {
-            return Collections.emptyList();
+            if (ignoreNoneExistingAliases) {
+                return Collections.emptyList();
+            } else {
+                throw new IllegalArgumentException("unknown cluster expression [" + clusterExpression + "]");
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
@@ -216,19 +216,24 @@ public abstract class RemoteClusterAware extends AbstractComponent {
      * indices per cluster are collected as a list in the returned map keyed by the cluster alias. Local indices are grouped under
      * {@link #LOCAL_CLUSTER_GROUP_KEY}. The returned map is mutable.
      *
-     * @param requestIndices the indices in the search request to filter
-     * @param indexExists a predicate that can test if a certain index or alias exists in the local cluster
-     *
+     * @param requestIndices            the indices in the search request to filter
+     * @param indexExists               a predicate that can test if a certain index or alias exists in the local cluster
+     * @param expandExpressions         Whether expressions with wildcards are expanded
+     * @param ignoreNoneExistingAliases Whether none existing aliases are ignored
      * @return a map of grouped remote and local indices
      */
-    public Map<String, List<String>> groupClusterIndices(String[] requestIndices, Predicate<String> indexExists) {
+    public Map<String, List<String>> groupClusterIndices(String[] requestIndices,
+                                                         Predicate<String> indexExists,
+                                                         boolean expandExpressions,
+                                                         boolean ignoreNoneExistingAliases) {
         Map<String, List<String>> perClusterIndices = new HashMap<>();
         Set<String> remoteClusterNames = getRemoteClusterNames();
         for (String index : requestIndices) {
             int i = index.indexOf(RemoteClusterService.REMOTE_CLUSTER_INDEX_SEPARATOR);
             if (i >= 0) {
                 String remoteClusterName = index.substring(0, i);
-                List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusterNames, remoteClusterName);
+                List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusterNames, remoteClusterName,
+                    expandExpressions, ignoreNoneExistingAliases);
                 if (clusters.isEmpty() == false) {
                     if (indexExists.test(index)) {
                         // we use : as a separator for remote clusters. might conflict if there is an index that is actually named

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -261,7 +261,7 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
     public Map<String, OriginalIndices> groupIndices(IndicesOptions indicesOptions, String[] indices, Predicate<String> indexExists) {
         Map<String, OriginalIndices> originalIndicesMap = new HashMap<>();
         if (isCrossClusterSearchEnabled()) {
-            final Map<String, List<String>> groupedIndices = groupClusterIndices(indices, indexExists);
+            final Map<String, List<String>> groupedIndices = groupClusterIndices(indices, indexExists, true, true);
             if (groupedIndices.isEmpty()) {
                 //search on _all in the local cluster if neither local indices nor remote indices were specified
                 originalIndicesMap.put(LOCAL_CLUSTER_GROUP_KEY, new OriginalIndices(Strings.EMPTY_ARRAY, indicesOptions));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ClusterNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ClusterNameExpressionResolverTests.java
@@ -39,37 +39,37 @@ public class ClusterNameExpressionResolverTests extends ESTestCase {
     }
 
     public void testExactMatch() {
-        List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusters, "totallyDifferent");
+        List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusters, "totallyDifferent", true, true);
         assertEquals(new HashSet<>(Arrays.asList("totallyDifferent")), new HashSet<>(clusters));
     }
 
     public void testNoWildCardNoMatch() {
-        List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusters, "totallyDifferent2");
+        List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusters, "totallyDifferent2", true, true);
         assertTrue(clusters.isEmpty());
     }
 
     public void testWildCardNoMatch() {
-        List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusters, "totally*2");
+        List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusters, "totally*2", true, true);
         assertTrue(clusters.isEmpty());
     }
 
     public void testSimpleWildCard() {
-        List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusters, "*");
+        List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusters, "*", true, true);
         assertEquals(new HashSet<>(Arrays.asList("cluster1", "cluster2", "totallyDifferent")), new HashSet<>(clusters));
     }
 
     public void testSuffixWildCard() {
-        List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusters, "cluster*");
+        List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusters, "cluster*", true, true);
         assertEquals(new HashSet<>(Arrays.asList("cluster1", "cluster2")), new HashSet<>(clusters));
     }
 
     public void testPrefixWildCard() {
-        List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusters, "*Different");
+        List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusters, "*Different", true, true);
         assertEquals(new HashSet<>(Arrays.asList("totallyDifferent")), new HashSet<>(clusters));
     }
 
     public void testMiddleWildCard() {
-        List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusters, "clu*1");
+        List<String> clusters = clusterNameResolver.resolveClusterNames(remoteClusters, "clu*1", true, true);
         assertEquals(new HashSet<>(Arrays.asList("cluster1")), new HashSet<>(clusters));
     }
 }

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -178,7 +178,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
                     assertFalse(service.isRemoteClusterRegistered("foo"));
                     Map<String, List<String>> perClusterIndices = service.groupClusterIndices(new String[]{"foo:bar", "cluster_1:bar",
                         "cluster_2:foo:bar", "cluster_1:test", "cluster_2:foo*", "foo", "cluster*:baz", "*:boo", "no*match:boo"},
-                        i -> false);
+                        i -> false, true, true);
                     List<String> localIndices = perClusterIndices.remove(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
                     assertNotNull(localIndices);
                     assertEquals(Arrays.asList("foo:bar", "foo", "no*match:boo"), localIndices);
@@ -188,7 +188,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
 
                     IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () ->
                         service.groupClusterIndices(new String[]{"foo:bar", "cluster_1:bar",
-                            "cluster_2:foo:bar", "cluster_1:test", "cluster_2:foo*", "foo"}, "cluster_1:bar"::equals));
+                            "cluster_2:foo:bar", "cluster_1:test", "cluster_2:foo*", "foo"}, "cluster_1:bar"::equals, true, true));
 
                     assertEquals("Can not filter indices; index cluster_1:bar exists but there is also a remote cluster named:" +
                             " cluster_1", iae.getMessage());
@@ -235,7 +235,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
                     {
                         IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () ->
                             service.groupClusterIndices(new String[]{"foo:bar", "cluster_1:bar",
-                                "cluster_2:foo:bar", "cluster_1:test", "cluster_2:foo*", "foo"}, "cluster_1:bar"::equals));
+                                "cluster_2:foo:bar", "cluster_1:test", "cluster_2:foo*", "foo"}, "cluster_1:bar"::equals, true, true));
                         assertEquals("Can not filter indices; index cluster_1:bar exists but there is also a remote cluster named:" +
                             " cluster_1", iae.getMessage());
                     }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportCreateAndFollowIndexAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportCreateAndFollowIndexAction.java
@@ -102,7 +102,7 @@ public final class TransportCreateAndFollowIndexAction
             return;
         }
         final String[] indices = new String[]{request.getFollowRequest().getLeaderIndex()};
-        final Map<String, List<String>> remoteClusterIndices = remoteClusterService.groupClusterIndices(indices, s -> false);
+        final Map<String, List<String>> remoteClusterIndices = remoteClusterService.groupClusterIndices(indices, s -> false, false, false);
         if (remoteClusterIndices.containsKey(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY)) {
             createFollowerIndexAndFollowLocalIndex(request, state, listener);
         } else {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportFollowIndexAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportFollowIndexAction.java
@@ -102,7 +102,7 @@ public class TransportFollowIndexAction extends HandledTransportAction<FollowInd
             return;
         }
         final String[] indices = new String[]{request.getLeaderIndex()};
-        final Map<String, List<String>> remoteClusterIndices = remoteClusterService.groupClusterIndices(indices, s -> false);
+        final Map<String, List<String>> remoteClusterIndices = remoteClusterService.groupClusterIndices(indices, s -> false, false, false);
         if (remoteClusterIndices.containsKey(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY)) {
             followLocalIndex(request, listener);
         } else {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -437,7 +437,7 @@ class IndicesAndAliasesResolver {
         }
 
         ResolvedIndices splitLocalAndRemoteIndexNames(String... indices) {
-            final Map<String, List<String>> map = super.groupClusterIndices(indices, exists -> false);
+            final Map<String, List<String>> map = super.groupClusterIndices(indices, exists -> false, true, true);
             final List<String> local = map.remove(LOCAL_CLUSTER_GROUP_KEY);
             final List<String> remote = map.entrySet().stream()
                     .flatMap(e -> e.getValue().stream().map(v -> e.getKey() + REMOTE_CLUSTER_INDEX_SEPARATOR + v))


### PR DESCRIPTION
Added two parameters to `RemoteClusterAware#groupClusterIndices(...)` and
`ClusterNamesExpressionResolver#resolveClusterNames(...)` to allow callers
to resolve cluster name in a strict way.

In case of CCR it desired to fail with an error in case the cluster
name has not been configured, instead of ignoring it and assuming that
the user referred to the local cluster, which is what happens today.
Also supplying wildcards in cluster names is not desired.

So I think adding two parameters that control this should work and in
case of CCS the behavior would then remain the same.