### PR TITLE
[Zen2] Fix CoordinatorTests

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -410,7 +410,6 @@
   <suppress files="server[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]action[/\\]search[/\\]SearchRequestBuilderTests.java" checks="LineLength" />
   <suppress files="server[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]action[/\\]support[/\\]WaitActiveShardCountIT.java" checks="LineLength" />
   <suppress files="server[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]action[/\\]support[/\\]broadcast[/\\]node[/\\]TransportBroadcastByNodeActionTests.java" checks="LineLength" />
-  <suppress files="server[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]action[/\\]support[/\\]master[/\\]TransportMasterNodeActionTests.java" checks="LineLength" />
   <suppress files="server[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]action[/\\]support[/\\]replication[/\\]BroadcastReplicationTests.java" checks="LineLength" />
   <suppress files="server[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]action[/\\]support[/\\]single[/\\]instance[/\\]TransportInstanceSingleOperationActionTests.java" checks="LineLength" />
   <suppress files="server[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]action[/\\]termvectors[/\\]AbstractTermVectorsTestCase.java" checks="LineLength" />

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -1086,6 +1086,19 @@ public abstract class TransportReplicationAction<
             return globalCheckpoint;
         }
 
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ReplicaResponse that = (ReplicaResponse) o;
+            return localCheckpoint == that.localCheckpoint &&
+                globalCheckpoint == that.globalCheckpoint;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(localCheckpoint, globalCheckpoint);
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -122,6 +122,10 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     }
 
     PublishWithJoinResponse handlePublishRequest(PublishRequest publishRequest) {
+        // overwrite local node
+        publishRequest = new PublishRequest(ClusterState.builder(publishRequest.getAcceptedState()).nodes(
+            DiscoveryNodes.builder(publishRequest.getAcceptedState().nodes()).localNodeId(getLocalNode().getId()).build()).build());
+
         synchronized (mutex) {
             final DiscoveryNode sourceNode = publishRequest.getAcceptedState().nodes().getMasterNode();
             logger.trace("handlePublishRequest: handling [{}] from [{}]", publishRequest, sourceNode);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -122,9 +122,8 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     }
 
     PublishWithJoinResponse handlePublishRequest(PublishRequest publishRequest) {
-        // overwrite local node
-        publishRequest = new PublishRequest(ClusterState.builder(publishRequest.getAcceptedState()).nodes(
-            DiscoveryNodes.builder(publishRequest.getAcceptedState().nodes()).localNodeId(getLocalNode().getId()).build()).build());
+        assert publishRequest.getAcceptedState().nodes().getLocalNode().equals(getLocalNode()) :
+            publishRequest.getAcceptedState().nodes().getLocalNode() + " != " + getLocalNode();
 
         synchronized (mutex) {
             final DiscoveryNode sourceNode = publishRequest.getAcceptedState().nodes().getMasterNode();

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -564,7 +564,9 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 transportService.getThreadPool().schedule(publishTimeout, Names.GENERIC, new Runnable() {
                     @Override
                     public void run() {
-                        publication.onTimeout();
+                        synchronized (mutex) {
+                            publication.onTimeout();
+                        }
                     }
 
                     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -257,6 +257,11 @@ public class FollowersChecker extends AbstractComponent {
                 TransportRequestOptions.builder().withTimeout(followerCheckTimeout).withType(Type.PING).build(),
                 new TransportResponseHandler<Empty>() {
                     @Override
+                    public Empty read(StreamInput in) {
+                        return Empty.INSTANCE;
+                    }
+
+                    @Override
                     public void handleResponse(Empty response) {
                         if (running() == false) {
                             logger.trace("{} no longer running", FollowerChecker.this);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -40,6 +40,7 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -251,7 +252,7 @@ public class JoinHelper extends AbstractComponent {
             assert closed == false : "CandidateJoinAccumulator closed";
             closed = true;
             if (newMode == Mode.LEADER) {
-                final Map<JoinTaskExecutor.Task, ClusterStateTaskListener> pendingAsTasks = new HashMap<>();
+                final Map<JoinTaskExecutor.Task, ClusterStateTaskListener> pendingAsTasks = new LinkedHashMap<>();
                 joinRequestAccumulator.forEach((key, value) -> {
                     final JoinTaskExecutor.Task task = new JoinTaskExecutor.Task(key, "elect leader");
                     pendingAsTasks.put(task, new JoinTaskListener(task, value));

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
@@ -167,6 +167,12 @@ public class LeaderChecker extends AbstractComponent {
                 TransportRequestOptions.builder().withTimeout(leaderCheckTimeout).withType(Type.PING).build(),
 
                 new TransportResponseHandler<TransportResponse.Empty>() {
+
+                    @Override
+                    public Empty read(StreamInput in) {
+                        return Empty.INSTANCE;
+                    }
+
                     @Override
                     public void handleResponse(Empty response) {
                         if (isClosed.get()) {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PreVoteCollector.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PreVoteCollector.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool.Names;
@@ -33,6 +34,7 @@ import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
+import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.LongConsumer;
@@ -127,6 +129,11 @@ public class PreVoteCollector extends AbstractComponent {
             logger.debug("{} requesting pre-votes from {}", this, broadcastNodes);
             broadcastNodes.forEach(n -> transportService.sendRequest(n, REQUEST_PRE_VOTE_ACTION_NAME, preVoteRequest,
                 new TransportResponseHandler<PreVoteResponse>() {
+                    @Override
+                    public PreVoteResponse read(StreamInput in) throws IOException {
+                        return new PreVoteResponse(in);
+                    }
+
                     @Override
                     public void handleResponse(PreVoteResponse response) {
                         handlePreVoteResponse(response, n);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Publication.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Publication.java
@@ -70,6 +70,10 @@ public abstract class Publication extends AbstractComponent {
     }
 
     public void onTimeout() {
+        if (isCompleted) {
+            return;
+        }
+
         assert timedOut == false;
         timedOut = true;
         if (applyCommitRequest.isPresent() == false) {

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/CapturingTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/CapturingTransport.java
@@ -111,7 +111,6 @@ public class CapturingTransport extends MockTransport implements Transport {
 
     @Override
     protected void onSendRequest(long requestId, String action, TransportRequest request, DiscoveryNode node) {
-        super.onSendRequest(requestId, action, request, node);
         capturedRequests.add(new CapturingTransport.CapturedRequest(node, requestId, action, request));
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.test.transport;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
@@ -91,7 +90,18 @@ public class MockTransport implements Transport, LifecycleComponent {
     public void handleResponse(final long requestId, final TransportResponse response) {
         final TransportResponseHandler transportResponseHandler = responseHandlers.onResponseReceived(requestId, listener);
         if (transportResponseHandler != null) {
-            transportResponseHandler.handleResponse(response);
+            final TransportResponse deliveredResponse;
+            if (rarely()) {
+                deliveredResponse = response;
+            } else {
+                try (BytesStreamOutput output = new BytesStreamOutput()) {
+                    response.writeTo(output);
+                    deliveredResponse = transportResponseHandler.read(output.bytes().streamInput());
+                } catch (IOException | UnsupportedOperationException e) {
+                    throw new AssertionError("failed to serialize/deserialize response " + response, e);
+                }
+            }
+            transportResponseHandler.handleResponse(deliveredResponse);
         }
     }
 
@@ -126,7 +136,7 @@ public class MockTransport implements Transport, LifecycleComponent {
                 output.writeException(t);
                 remoteException = new RemoteTransportException("remote failure", output.bytes().streamInput().readException());
             } catch (IOException ioException) {
-                throw new ElasticsearchException("failed to serialize/deserialize supplied exception " + t, ioException);
+                throw new AssertionError("failed to serialize/deserialize supplied exception " + t, ioException);
             }
         }
         this.handleError(requestId, remoteException);

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
@@ -181,7 +181,6 @@ public class MockTransport implements Transport, LifecycleComponent {
     }
 
     protected void onSendRequest(long requestId, String action, TransportRequest request, DiscoveryNode node) {
-
     }
 
     protected boolean nodeConnected(DiscoveryNode discoveryNode) {

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
@@ -91,15 +91,11 @@ public class MockTransport implements Transport, LifecycleComponent {
         final TransportResponseHandler transportResponseHandler = responseHandlers.onResponseReceived(requestId, listener);
         if (transportResponseHandler != null) {
             final TransportResponse deliveredResponse;
-            if (rarely()) {
-                deliveredResponse = response;
-            } else {
-                try (BytesStreamOutput output = new BytesStreamOutput()) {
-                    response.writeTo(output);
-                    deliveredResponse = transportResponseHandler.read(output.bytes().streamInput());
-                } catch (IOException | UnsupportedOperationException e) {
-                    throw new AssertionError("failed to serialize/deserialize response " + response, e);
-                }
+            try (BytesStreamOutput output = new BytesStreamOutput()) {
+                response.writeTo(output);
+                deliveredResponse = transportResponseHandler.read(output.bytes().streamInput());
+            } catch (IOException | UnsupportedOperationException e) {
+                throw new AssertionError("failed to serialize/deserialize response " + response, e);
             }
             transportResponseHandler.handleResponse(deliveredResponse);
         }

--- a/test/framework/src/test/java/org/elasticsearch/test/disruption/DisruptableMockTransportTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/disruption/DisruptableMockTransportTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.coordination.DeterministicTaskQueue;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
@@ -33,6 +34,7 @@ import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportResponse.Empty;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Before;
@@ -192,6 +194,11 @@ public class DisruptableMockTransportTests extends ESTestCase {
     private TransportResponseHandler<TransportResponse> responseHandlerShouldNotBeCalled() {
         return new TransportResponseHandler<TransportResponse>() {
             @Override
+            public TransportResponse read(StreamInput in) {
+                throw new AssertionError("should not be called");
+            }
+
+            @Override
             public void handleResponse(TransportResponse response) {
                 throw new AssertionError("should not be called");
             }
@@ -211,6 +218,11 @@ public class DisruptableMockTransportTests extends ESTestCase {
     private TransportResponseHandler<TransportResponse> responseHandlerShouldBeCalledNormally(Runnable onCalled) {
         return new TransportResponseHandler<TransportResponse>() {
             @Override
+            public TransportResponse read(StreamInput in) {
+                return Empty.INSTANCE;
+            }
+
+            @Override
             public void handleResponse(TransportResponse response) {
                 onCalled.run();
             }
@@ -229,6 +241,11 @@ public class DisruptableMockTransportTests extends ESTestCase {
 
     private TransportResponseHandler<TransportResponse> responseHandlerShouldBeCalledExceptionally(Consumer<TransportException> onCalled) {
         return new TransportResponseHandler<TransportResponse>() {
+            @Override
+            public TransportResponse read(StreamInput in) {
+                throw new AssertionError("should not be called");
+            }
+
             @Override
             public void handleResponse(TransportResponse response) {
                 throw new AssertionError("should not be called");


### PR DESCRIPTION
Today the `CoordinatorTests` are not very reliable if two elections are scheduled concurrently. Although we expect occasional failures due to this, in fact the failures are much more common than expected due to a handful of issues. This PR fixes these issues.