### PR TITLE
Remove leftover doc about format being updateable

### DIFF
--- a/docs/reference/mapping/params/format.asciidoc
+++ b/docs/reference/mapping/params/format.asciidoc
@@ -31,10 +31,6 @@ Many APIs which support date values also support <<date-math,date math>>
 expressions, such as `now-1m/d` -- the current time, minus one month, rounded
 down to the nearest day.
 
-TIP: The `format` setting can be updated on existing fields using the
-<<indices-put-mapping,PUT mapping API>>.
-
-
 [[custom-date-formats]]
 ==== Custom date formats
 


### PR DESCRIPTION
With this commit we remove a leftover in the docs about the `format`
field being updateable. This is not true since we removed support for
updates in #25285.

Closes #33986
Relates #25285
