### PR TITLE
[DOCS] clarify the meaning of 'type' parameter for custom analyzer

### DIFF
--- a/docs/reference/analysis/analyzers/custom-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/custom-analyzer.asciidoc
@@ -59,7 +59,7 @@ PUT my_index
     "analysis": {
       "analyzer": {
         "my_custom_analyzer": {
-          "type":      "custom",
+          "type":      "custom", <1>
           "tokenizer": "standard",
           "char_filter": [
             "html_strip"
@@ -81,6 +81,11 @@ POST my_index/_analyze
 }
 --------------------------------
 // CONSOLE
+
+<1> Setting `type` to `custom` tells Elasticsearch that we are defining a custom analyzer.
+    Compare this to how <<configuring-analyzers,built-in analyzers can be configured>>:
+    `type` will be set to the name of the built-in analyzer, like
+    <<analysis-standard-analyzer,`standard`>> or <<analysis-simple-analyzer,`simple`>>.
 
 /////////////////////
 


### PR DESCRIPTION
Hello dear sirs,

This pull request is to improve the docs on the meaning of `type` parameter on the custom analyzer doc page. It closes #33456.

The `./gradlew :docs:check` finished successfully.

I also tried to run doc build scripts from [elastic/docs](https://github.com/elastic/docs) but didn't succeed (there were errors I could not figure how to solve).

Please tell me if this is useful anyhow, and I am open for suggestions.

Thank you!
