### PR TITLE
Make the high-level REST client skip types for document deletion.

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/DeleteRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/DeleteRequest.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.client.security.RefreshPolicy;
+import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.VersionType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A request to delete a document.
+ */
+public class DeleteRequest implements Validatable {
+
+    private final String index, id;
+
+    private String routing;
+    private long version = Versions.MATCH_ANY;
+    private VersionType versionType = VersionType.INTERNAL;
+    private TimeValue timeout;
+    private RefreshPolicy refreshPolicy = RefreshPolicy.NONE;
+    private ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT;
+
+    /**
+     * Create a request to delete the given {@code id} in {@code index}.
+     */
+    public DeleteRequest(String index, String id) {
+        this.index = Objects.requireNonNull(index);
+        this.id = Objects.requireNonNull(id);
+    }
+
+    @Override
+    public Optional<ValidationException> validate() {
+        List<String> validationErrors = new ArrayList<>();
+        if (versionType.validateVersionForWrites(version) == false) {
+            validationErrors.add("illegal version value [" + version + "] for version type [" + versionType.name() + "]");
+        }
+        if (versionType == VersionType.FORCE) {
+            validationErrors.add("version type [force] may no longer be used");
+        }
+        if (validationErrors.isEmpty()) {
+            return Optional.empty();
+        } else {
+            ValidationException ex = new ValidationException();
+            for (String error : validationErrors) {
+                ex.addValidationError(error);
+            }
+            return Optional.of(ex);
+        }
+    }
+
+    /**
+     * Return the name of the index that has the document to delete.
+     */
+    public String getIndex() {
+        return index;
+    }
+
+    /**
+     * Return the id of the document to delete.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Set the routing value.
+     * @see #getRouting()
+     */
+    public DeleteRequest setRouting(String routing) {
+        if (routing != null && routing.length() == 0) {
+            this.routing = null;
+        } else {
+            this.routing = routing;
+        }
+        return this;
+    }
+
+    /**
+     * Return the routing value, ie. the value whose hash is used to find ou
+     * which shard has the document to delete. {@code null} values mean that
+     * the {@link #getId()} should be used.
+     */
+    public String getRouting() {
+        return this.routing;
+    }
+
+    /**
+     * Set the expected version of the document to delete. If the document
+     * has a different version then the delete request will fail.
+     */
+    public DeleteRequest setVersion(long version) {
+        this.version = version;
+        return this;
+    }
+
+    /**
+     * Return the expected version of the document to delete.
+     */
+    public long getVersion() {
+        return this.version;
+    }
+
+    /**
+     * Sets the type of versioning to use.
+     */
+    public DeleteRequest setVersionType(VersionType versionType) {
+        this.versionType = Objects.requireNonNull(versionType);
+        return this;
+    }
+
+    /**
+     * Return the type of versioning to use.
+     */
+    public VersionType getVersionType() {
+        return this.versionType;
+    }
+
+    /** Return the timeout of this delete request. */
+    public TimeValue getTimeout() {
+        return timeout;
+    }
+
+    /**
+     * Set the timeout of this delete request.
+     */
+    public DeleteRequest setTimeout(TimeValue timeout) {
+        this.timeout = timeout;
+        return this;
+    }
+
+    /**
+     * Set the timeout of this delete request.
+     */
+    public DeleteRequest setTimeout(String timeout) {
+        return setTimeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout"));
+    }
+
+    /**
+     * Return the refresh policy for this delete request.
+     */
+    public RefreshPolicy getRefreshPolicy() {
+        return refreshPolicy;
+    }
+
+    /**
+     * Set the refresh policy for this delete request and return {@code this}.
+     */
+    public DeleteRequest setRefreshPolicy(RefreshPolicy refreshPolicy) {
+        this.refreshPolicy = refreshPolicy;
+        return this;
+    }
+
+    /**
+     * How many shards should be active.
+     * @see {@link DeleteRequest#setWaitForActiveShards(ActiveShardCount)}.
+     */
+    public ActiveShardCount getWaitForActiveShards() {
+        return waitForActiveShards;
+    }
+
+    /**
+     * Sets the number of shard copies that must be active before proceeding with the replication
+     * operation. Defaults to {@link ActiveShardCount#DEFAULT}, which requires one shard copy
+     * (the primary) to be active. Set this value to {@link ActiveShardCount#ALL} to
+     * wait for all shards (primary and all replicas) to be active. Otherwise, use
+     * {@link ActiveShardCount#from(int)} to set this value to any non-negative integer, up to the
+     * total number of shard copies (number of replicas + 1).
+     */
+    public DeleteRequest setWaitForActiveShards(ActiveShardCount waitForActiveShards) {
+        this.waitForActiveShards = Objects.requireNonNull(waitForActiveShards);
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index, id, routing, version, versionType, timeout, refreshPolicy, waitForActiveShards);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        DeleteRequest that = (DeleteRequest) obj;
+        return Objects.equals(index, that.index) &&
+                Objects.equals(id, that.id) &&
+                Objects.equals(routing, that.routing) &&
+                version == that.version &&
+                versionType == that.versionType &&
+                Objects.equals(timeout, that.timeout) &&
+                refreshPolicy == that.refreshPolicy &&
+                Objects.equals(waitForActiveShards, that.waitForActiveShards);
+    }
+
+    @Override
+    public String toString() {
+        return "delete {[" + index + "][" + id + "]}";
+    }
+
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/DeleteRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/DeleteRequest.java
@@ -196,27 +196,6 @@ public class DeleteRequest implements Validatable {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(index, id, routing, version, versionType, timeout, refreshPolicy, waitForActiveShards);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        DeleteRequest that = (DeleteRequest) obj;
-        return Objects.equals(index, that.index) &&
-                Objects.equals(id, that.id) &&
-                Objects.equals(routing, that.routing) &&
-                version == that.version &&
-                versionType == that.versionType &&
-                Objects.equals(timeout, that.timeout) &&
-                refreshPolicy == that.refreshPolicy &&
-                Objects.equals(waitForActiveShards, that.waitForActiveShards);
-    }
-
-    @Override
     public String toString() {
         return "delete {[" + index + "][" + id + "]}";
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/DeleteRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/DeleteRequest.java
@@ -176,7 +176,7 @@ public class DeleteRequest implements Validatable {
 
     /**
      * How many shards should be active.
-     * @see {@link DeleteRequest#setWaitForActiveShards(ActiveShardCount)}.
+     * @see DeleteRequest#setWaitForActiveShards(ActiveShardCount)
      */
     public ActiveShardCount getWaitForActiveShards() {
         return waitForActiveShards;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/DeleteResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/DeleteResponse.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.elasticsearch.action.DocWriteResponse.Result;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser.ValueType;
+import org.elasticsearch.common.xcontent.XContentParseException;
+import org.elasticsearch.index.seqno.SequenceNumbers;
+
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+
+/**
+ * An object representing a response to the deletion of a document.
+ * @see DeleteRequest
+ */
+public final class DeleteResponse {
+
+    static final ConstructingObjectParser<DeleteResponse, Void> PARSER = new ConstructingObjectParser<>("delete_response",
+            a -> new DeleteResponse((String) a[0], (String) a[1], (Result) a[2], (ShardInfo) a[3], (Long) a[4], (Long) a[5], (Long) a[6]));
+    static {
+        PARSER.declareString(constructorArg(), new ParseField("_index"));
+        PARSER.declareString(constructorArg(), new ParseField("_id"));
+        PARSER.declareField(constructorArg(), (parser, c) -> {
+            switch (parser.text()) {
+            case "deleted":
+                return Result.DELETED;
+            case "not_found":
+                return Result.NOT_FOUND;
+            default:
+                throw new XContentParseException(parser.getTokenLocation(), "Unexpected _result value: [" + parser.text() + "]");
+            }
+        }, new ParseField("result"), ValueType.STRING);
+        PARSER.declareObject(constructorArg(), ShardInfo.PARSER, new ParseField(ShardInfo.SHARDS_FIELD));
+        PARSER.declareLong(constructorArg(), new ParseField("_version"));
+        PARSER.declareLong(constructorArg(), new ParseField("_primary_term"));
+        PARSER.declareLong(constructorArg(), new ParseField("_seq_no"));
+    }
+
+    private final String index, id;
+    private final Result result;
+    private final long version;
+    private final long primaryTerm;
+    private final long seqNo;
+    private final ShardInfo shardInfo;
+
+    private DeleteResponse(String index, String id, Result result, ShardInfo shardInfo,
+            long version, long primaryTerm, long seqNo) {
+        this.index = Objects.requireNonNull(index, "_index may not be null");
+        this.id = Objects.requireNonNull(id, "_id may not be null");
+        this.result = Objects.requireNonNull(result, "_result may not be null");
+        this.shardInfo = Objects.requireNonNull(shardInfo, "_shards may not be null");
+        this.version = version;
+        this.primaryTerm = primaryTerm;
+        this.seqNo = seqNo;
+    }
+
+    /**
+     * Return whether the document has been deleted or whether it already did not exist.
+     */
+    public Result getResult() {
+        return result;
+    }
+
+    /**
+     * Return the index that the deleted document belonged to.
+     */
+    public String getIndex() {
+        return index;
+    }
+
+    /**
+     * Return the id of the deleted document.
+     */
+    public String getId() {
+        return this.id;
+    }
+
+    /**
+     * Returns the current version of the deleted document or {@link Versions#MATCH_ANY} if the document didn't exist.
+     */
+    public long getVersion() {
+        return version;
+    }
+
+    /**
+     * Returns the sequence number assigned for this change. Returns {@link SequenceNumbers#UNASSIGNED_SEQ_NO}
+     * if the document didn't exist.
+     */
+    public long getSeqNo() {
+        return seqNo;
+    }
+
+    /**
+     * Return the primary term of the deleted document.
+     */
+    public long getPrimaryTerm() {
+        return primaryTerm;
+    }
+
+    /**
+     * Return information about how many shards processed the request and potential failures.
+     */
+    public ShardInfo getShardInfo() {
+        return shardInfo;
+    }
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -35,7 +35,6 @@ import org.elasticsearch.action.admin.cluster.storedscripts.GetStoredScriptReque
 import org.elasticsearch.action.admin.cluster.storedscripts.PutStoredScriptRequest;
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
-import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.explain.ExplainRequest;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.get.GetRequest;
@@ -94,16 +93,17 @@ final class RequestConverters {
     }
 
     static Request delete(DeleteRequest deleteRequest) {
-        String endpoint = endpoint(deleteRequest.index(), deleteRequest.type(), deleteRequest.id());
+        String endpoint = endpoint(deleteRequest.getIndex(), "_doc", deleteRequest.getId());
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
 
         Params parameters = new Params(request);
-        parameters.withRouting(deleteRequest.routing());
-        parameters.withTimeout(deleteRequest.timeout());
-        parameters.withVersion(deleteRequest.version());
-        parameters.withVersionType(deleteRequest.versionType());
+        parameters.withDisabledTypes();
+        parameters.withRouting(deleteRequest.getRouting());
+        parameters.withTimeout(deleteRequest.getTimeout());
+        parameters.withVersion(deleteRequest.getVersion());
+        parameters.withVersionType(deleteRequest.getVersionType());
         parameters.withRefreshPolicy(deleteRequest.getRefreshPolicy());
-        parameters.withWaitForActiveShards(deleteRequest.waitForActiveShards());
+        parameters.withWaitForActiveShards(deleteRequest.getWaitForActiveShards());
         return request;
     }
 
@@ -922,6 +922,10 @@ final class RequestConverters {
                 return putParam("wait_for_events", waitForEvents.name().toLowerCase(Locale.ROOT));
             }
             return this;
+        }
+
+        Params withDisabledTypes() {
+            return putParam("include_type_name", "false");
         }
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -32,8 +32,6 @@ import org.elasticsearch.action.admin.cluster.storedscripts.GetStoredScriptRespo
 import org.elasticsearch.action.admin.cluster.storedscripts.PutStoredScriptRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.delete.DeleteRequest;
-import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.explain.ExplainRequest;
 import org.elasticsearch.action.explain.ExplainResponse;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
@@ -718,14 +716,14 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Deletes a document by id using the Delete API.
      * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html">Delete API on elastic.co</a>
-     * @param deleteRequest the reuqest
+     * @param deleteRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
      * @throws IOException in case there is a problem sending the request or parsing back the response
      */
     public final DeleteResponse delete(DeleteRequest deleteRequest, RequestOptions options) throws IOException {
-        return performRequestAndParseEntity(deleteRequest, RequestConverters::delete, options, DeleteResponse::fromXContent,
-                singleton(404));
+        return performRequestAndParseEntity(deleteRequest, RequestConverters::delete, options,
+                p -> DeleteResponse.PARSER.parse(p, null), Collections.singleton(404));
     }
 
     /**
@@ -736,8 +734,8 @@ public class RestHighLevelClient implements Closeable {
      * @param listener the listener to be notified upon request completion
      */
     public final void deleteAsync(DeleteRequest deleteRequest, RequestOptions options, ActionListener<DeleteResponse> listener) {
-        performRequestAsyncAndParseEntity(deleteRequest, RequestConverters::delete, options, DeleteResponse::fromXContent, listener,
-            Collections.singleton(404));
+        performRequestAsyncAndParseEntity(deleteRequest, RequestConverters::delete, options,
+                p -> DeleteResponse.PARSER.parse(p, null), listener, Collections.singleton(404));
     }
 
     /**

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ShardInfo.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ShardInfo.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.elasticsearch.action.support.replication.ReplicationResponse;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+/**
+ * Encapsulates the number of total successful and failed shard copies
+ */
+public final class ShardInfo {
+
+    public static final String SHARDS_FIELD = "_shards";
+    private static final String TOTAL_FIELD = "total";
+    private static final String SUCCESSFUL_FIELD = "successful";
+    private static final String FAILED_FIELD = "failed";
+    private static final String FAILURES = "failures";
+
+    static final ConstructingObjectParser<ShardInfo, Void> PARSER =
+        new ConstructingObjectParser<>(
+            "_shards",
+            a -> {
+                List<ReplicationResponse.ShardInfo.Failure> failures;
+                if (a[3] == null) {
+                    failures = Collections.emptyList();
+                } else {
+                    failures = Collections.unmodifiableList(Arrays.asList((ReplicationResponse.ShardInfo.Failure[]) a[3]));
+                }
+                return new ShardInfo((Integer) a[0], (Integer) a[1], (Integer) a[2], failures);
+            }
+        );
+    static {
+        PARSER.declareInt(constructorArg(), new ParseField(TOTAL_FIELD));
+        PARSER.declareInt(constructorArg(), new ParseField(SUCCESSFUL_FIELD));
+        PARSER.declareInt(constructorArg(), new ParseField(FAILED_FIELD));
+        PARSER.declareObjectArray(optionalConstructorArg(),
+                (p, c) -> ReplicationResponse.ShardInfo.Failure.fromXContent(p), new ParseField(FAILURES));
+    }
+
+    private final int total;
+    private final int successful;
+    private final int failed;
+    private final List<ReplicationResponse.ShardInfo.Failure> failures; // TODO: don't reuse server classes
+
+    private ShardInfo(int total, int successful, int failed, List<ReplicationResponse.ShardInfo.Failure> failures) {
+        this.total = total;
+        this.successful = successful;
+        this.failed = failed;
+        this.failures = failures;
+    }
+
+    /**
+     * Return the total number of shards.
+     */
+    public int getTotal() {
+        return total;
+    }
+
+    /**
+     * Return the number of successful shards.
+     */
+    public int getSuccessful() {
+        return successful;
+    }
+
+    /**
+     * Return the number of failed shards.
+     */
+    public int getFailed() {
+        return failed;
+    }
+
+    /**
+     * Return shard failures.
+     */
+    public List<ReplicationResponse.ShardInfo.Failure> getFailures() {
+        return failures;
+    }
+
+    @Override
+    public int hashCode() {
+        int h = failed;
+        h = 31 * h + successful;
+        h = 31 * h + total;
+        h = 31 * h + failures.hashCode();
+        return h;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ShardInfo that = (ShardInfo) obj;
+        return failed == that.failed &&
+                successful == that.successful &&
+                total == that.total &&
+                failures.equals(that.failures);
+    }
+
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/DeleteRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/DeleteRequestTests.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.index.VersionType;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Collections;
+import java.util.Optional;
+
+public class DeleteRequestTests extends ESTestCase {
+
+    public void testValidateDefaults() {
+        DeleteRequest request = new DeleteRequest("index", "id");
+        assertEquals(Optional.empty(), request.validate());
+    }
+
+    public void testValidateVersion() {
+        DeleteRequest request = new DeleteRequest("index", "id")
+                .setVersion(4L);
+        assertEquals(Optional.empty(), request.validate());
+
+        request.setVersion(Versions.NOT_FOUND);
+        Optional<ValidationException> exception = request.validate();
+        assertTrue(exception.isPresent());
+        assertEquals(
+                Collections.singletonList("illegal version value [-1] for version type [INTERNAL]"),
+                exception.get().validationErrors());
+    }
+
+    public void testValidateVersionType() {
+        DeleteRequest request = new DeleteRequest("index", "id")
+                .setVersionType(VersionType.EXTERNAL)
+                .setVersion(3L);
+        assertEquals(Optional.empty(), request.validate());
+
+        request.setVersionType(VersionType.FORCE);
+        Optional<ValidationException> exception = request.validate();
+        assertTrue(exception.isPresent());
+        assertEquals(
+                Collections.singletonList("version type [force] may no longer be used"),
+                exception.get().validationErrors());
+    }
+
+    public void testEmptyRoutingIsTranslatedToNull() {
+        DeleteRequest request = new DeleteRequest("index", "id");
+        assertNull(request.getRouting());
+        request.setRouting("");
+        assertNull(request.getRouting());
+        request.setRouting("a");
+        assertEquals("a", request.getRouting());
+    }
+
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/DeleteResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/DeleteResponseTests.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.elasticsearch.action.DocWriteResponse.Result;
+import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.seqno.SequenceNumbers;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public class DeleteResponseTests extends ESTestCase {
+
+    public void testParseSuccess() throws IOException {
+        String responseString = "{\n" +
+                "    \"_shards\" : {\n" +
+                "        \"total\" : 2,\n" +
+                "        \"failed\" : 0,\n" +
+                "        \"successful\" : 2\n" +
+                "    },\n" +
+                "    \"_index\" : \"twitter\",\n" +
+                "    \"_id\" : \"1\",\n" +
+                "    \"_version\" : 2,\n" +
+                "    \"_primary_term\": 1,\n" +
+                "    \"_seq_no\": 5,\n" +
+                "    \"result\": \"deleted\"\n" +
+                "}";
+        try (XContentParser parser = XContentType.JSON.xContent().createParser(new NamedXContentRegistry(Collections.emptyList()),
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, responseString)) {
+            DeleteResponse response = DeleteResponse.PARSER.parse(parser, null);
+            assertEquals(2, response.getShardInfo().getTotal());
+            assertEquals(2, response.getShardInfo().getSuccessful());
+            assertEquals(0, response.getShardInfo().getFailed());
+            assertEquals("twitter", response.getIndex());
+            assertEquals("1", response.getId());
+            assertEquals(2L, response.getVersion());
+            assertEquals(1L, response.getPrimaryTerm());
+            assertEquals(5L, response.getSeqNo());
+            assertEquals(Result.DELETED, response.getResult());
+            assertFalse(response.isForcedRefresh());
+        }
+    }
+
+    public void testParseForcedRefresh() throws IOException {
+        String responseString = "{\n" +
+                "    \"_shards\" : {\n" +
+                "        \"total\" : 2,\n" +
+                "        \"failed\" : 0,\n" +
+                "        \"successful\" : 2\n" +
+                "    },\n" +
+                "    \"_index\" : \"twitter\",\n" +
+                "    \"_id\" : \"1\",\n" +
+                "    \"_version\" : 2,\n" +
+                "    \"_primary_term\": 1,\n" +
+                "    \"_seq_no\": 5,\n" +
+                "    \"result\": \"deleted\",\n" +
+                "    \"forced_refresh\": true\n" +
+                "}";
+        try (XContentParser parser = XContentType.JSON.xContent().createParser(new NamedXContentRegistry(Collections.emptyList()),
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, responseString)) {
+            DeleteResponse response = DeleteResponse.PARSER.parse(parser, null);
+            assertEquals(2, response.getShardInfo().getTotal());
+            assertEquals(2, response.getShardInfo().getSuccessful());
+            assertEquals(0, response.getShardInfo().getFailed());
+            assertEquals("twitter", response.getIndex());
+            assertEquals("1", response.getId());
+            assertEquals(2L, response.getVersion());
+            assertEquals(1L, response.getPrimaryTerm());
+            assertEquals(5L, response.getSeqNo());
+            assertEquals(Result.DELETED, response.getResult());
+            assertTrue(response.isForcedRefresh());
+        }
+    }
+
+    public void testParseNotFound() throws IOException {
+        String responseString = "{\n" +
+                "    \"_shards\" : {\n" +
+                "        \"total\" : 2,\n" +
+                "        \"failed\" : 0,\n" +
+                "        \"successful\" : 2\n" +
+                "    },\n" +
+                "    \"_index\" : \"twitter\",\n" +
+                "    \"_id\" : \"1\",\n" +
+                "    \"_version\" : -1,\n" +
+                "    \"result\": \"not_found\"\n" +
+                "}";
+        try (XContentParser parser = XContentType.JSON.xContent().createParser(new NamedXContentRegistry(Collections.emptyList()),
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, responseString)) {
+            DeleteResponse response = DeleteResponse.PARSER.parse(parser, null);
+            assertEquals(2, response.getShardInfo().getTotal());
+            assertEquals(2, response.getShardInfo().getSuccessful());
+            assertEquals(0, response.getShardInfo().getFailed());
+            assertEquals("twitter", response.getIndex());
+            assertEquals("1", response.getId());
+            assertEquals(Versions.NOT_FOUND, response.getVersion());
+            assertEquals(0L, response.getPrimaryTerm());
+            assertEquals(SequenceNumbers.UNASSIGNED_SEQ_NO, response.getSeqNo());
+            assertEquals(Result.NOT_FOUND, response.getResult());
+            assertFalse(response.isForcedRefresh());
+        }
+    }
+
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MigrationDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MigrationDocumentationIT.java
@@ -20,11 +20,12 @@
 package org.elasticsearch.client.documentation;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.delete.DeleteRequest;
-import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.DocWriteResponse.Result;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.client.DeleteRequest;
+import org.elasticsearch.client.DeleteResponse;
 import org.elasticsearch.client.ESRestHighLevelClientTestCase;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
@@ -82,7 +83,7 @@ public class MigrationDocumentationIT extends ESRestHighLevelClientTestCase {
         RestHighLevelClient client = highLevelClient();
         {
             //tag::migration-request-ctor
-            IndexRequest request = new IndexRequest("index", "doc", "id"); // <1>
+            IndexRequest request = new IndexRequest("index", "_doc", "id"); // <1>
             request.source("{\"field\":\"value\"}", XContentType.JSON);
             //end::migration-request-ctor
 
@@ -93,7 +94,7 @@ public class MigrationDocumentationIT extends ESRestHighLevelClientTestCase {
         }
         {
             //tag::migration-request-async-execution
-            DeleteRequest request = new DeleteRequest("index", "doc", "id"); // <1>
+            DeleteRequest request = new DeleteRequest("index", "id"); // <1>
             client.deleteAsync(request, RequestOptions.DEFAULT, new ActionListener<DeleteResponse>() { // <2>
                 @Override
                 public void onResponse(DeleteResponse deleteResponse) {
@@ -106,14 +107,14 @@ public class MigrationDocumentationIT extends ESRestHighLevelClientTestCase {
                 }
             });
             //end::migration-request-async-execution
-            assertBusy(() -> assertFalse(client.exists(new GetRequest("index", "doc", "id"), RequestOptions.DEFAULT)));
+            assertBusy(() -> assertFalse(client.exists(new GetRequest("index", "_doc", "id"), RequestOptions.DEFAULT)));
         }
         {
             //tag::migration-request-sync-execution
-            DeleteRequest request = new DeleteRequest("index", "doc", "id");
+            DeleteRequest request = new DeleteRequest("index", "id");
             DeleteResponse response = client.delete(request, RequestOptions.DEFAULT); // <1>
             //end::migration-request-sync-execution
-            assertEquals(RestStatus.NOT_FOUND, response.status());
+            assertEquals(Result.NOT_FOUND, response.getResult());
         }
     }
 }

--- a/docs/java-rest/high-level/document/delete.asciidoc
+++ b/docs/java-rest/high-level/document/delete.asciidoc
@@ -11,8 +11,7 @@ A `DeleteRequest` requires the following arguments:
 include-tagged::{doc-tests}/CRUDDocumentationIT.java[delete-request]
 --------------------------------------------------
 <1> Index
-<2> Type
-<3> Document id
+<2> Document id
 
 ==== Optional arguments
 The following arguments can optionally be provided:
@@ -34,8 +33,7 @@ include-tagged::{doc-tests}/CRUDDocumentationIT.java[delete-request-timeout]
 --------------------------------------------------
 include-tagged::{doc-tests}/CRUDDocumentationIT.java[delete-request-refresh]
 --------------------------------------------------
-<1> Refresh policy as a `WriteRequest.RefreshPolicy` instance
-<2> Refresh policy as a `String`
+<1> Refresh policy
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/reference/migration/migrate_7_0/java.asciidoc
+++ b/docs/reference/migration/migrate_7_0/java.asciidoc
@@ -22,3 +22,9 @@ were moved to a single `org.elasticsearch.search.aggregations.metrics` package.
 
 The variants of `Retry.withBackoff` that included `Settings` have been removed
 because `Settings` is no longer needed.
+
+==== DeleteRequest, DeleteResponse
+// Modify this statement once all document APIs have been migrated
+`DeleteRequest` and `DeleteResponse` moved to the `org.elasticsearch.client` package
+and do not reference types anymore. Under the hood, the high-level REST client
+uses the new <<removal-of-types,typeless APIs>>.


### PR DESCRIPTION
I'm starting with delete since it is a bit simpler than other APIs, but we
should eventually do the same with all other APIs that are being replaced with
a typeless version (get, put_mapping, search, etc.).

Relates #15613
