### PR TITLE
Add a release note about the more aggressive reclamation of deleted documents.

### DIFF
--- a/docs/reference/release-notes/6.5.asciidoc
+++ b/docs/reference/release-notes/6.5.asciidoc
@@ -78,9 +78,17 @@ location of the hosts file has moved from
 // [[feature-6.5.0]]
 // === New Features
 
-// [float]
-// [[enhancement-6.5.0]]
-// === Enhancements
+[float]
+[[enhancement-6.5.0]]
+=== Enhancements
+
+Merging::
+* The default merge policy (`tiered`) used to allow up to 50% of deleted
+documents per shard, possibly more in the case of a
+<<indices-forcemerge,force-merged index>>. This threshold is now 33%, meaning
+that deleted documents may only make an index up to about 50% larger than the
+same index without deleted document, versus 2x previously. Also this threshold
+now also applies to indices that have been force-merged in the past.
 
 // [float]
 // [[bug-6.5.0]]


### PR DESCRIPTION
The fact that Elasticsearch 6.5 will be based on Lucene 7.5 means that it will
benefit from improvements to merging, in particular more aggressive reclamation
of deleted documents.