### PR TITLE
Integrate LeaderChecker with Coordinator

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -278,10 +278,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         closePrevotingAndElectionScheduler();
         preVoteCollector.update(getPreVoteResponse(), getLocalNode());
 
-        if (leaderCheckScheduler != null) {
-            leaderCheckScheduler.close();
-            leaderCheckScheduler = null;
-        }
+        assert leaderCheckScheduler == null : leaderCheckScheduler;
     }
 
     void becomeFollower(String method, DiscoveryNode leaderNode) {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -78,10 +78,13 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     private final UnicastConfiguredHostsResolver configuredHostsResolver;
     private final TimeValue publishTimeout;
     private final PublicationTransportHandler publicationHandler;
+    private final LeaderChecker leaderChecker;
     @Nullable
     private Releasable electionScheduler;
     @Nullable
     private Releasable prevotingRound;
+    @Nullable
+    private Releasable leaderCheckScheduler;
     private AtomicLong maxTermSeen = new AtomicLong();
 
     private Mode mode;
@@ -108,6 +111,19 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         this.peerFinder = new CoordinatorPeerFinder(settings, transportService,
             new HandshakingTransportAddressConnector(settings, transportService), configuredHostsResolver);
         this.publicationHandler = new PublicationTransportHandler(transportService, this::handlePublishRequest, this::handleApplyCommit);
+        this.leaderChecker = new LeaderChecker(settings, transportService, new Runnable() {
+            @Override
+            public void run() {
+                synchronized (mutex) {
+                    becomeCandidate("onLeaderFailure");
+                }
+            }
+
+            @Override
+            public String toString() {
+                return "notification of leader failure";
+            }
+        });
 
         masterService.setClusterStateSupplier(this::getStateForMasterService);
     }
@@ -233,6 +249,12 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
             joinAccumulator = joinHelper.new CandidateJoinAccumulator();
 
             peerFinder.activate(coordinationState.get().getLastAcceptedState().nodes());
+            leaderChecker.setCurrentNodes(DiscoveryNodes.EMPTY_NODES);
+
+            if (leaderCheckScheduler != null) {
+                leaderCheckScheduler.close();
+                leaderCheckScheduler = null;
+            }
         }
 
         preVoteCollector.update(getPreVoteResponse(), null);
@@ -251,6 +273,11 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         peerFinder.deactivate(getLocalNode());
         closePrevotingAndElectionScheduler();
         preVoteCollector.update(getPreVoteResponse(), getLocalNode());
+
+        if (leaderCheckScheduler != null) {
+            leaderCheckScheduler.close();
+            leaderCheckScheduler = null;
+        }
     }
 
     void becomeFollower(String method, DiscoveryNode leaderNode) {
@@ -261,6 +288,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
             mode = Mode.FOLLOWER;
             joinAccumulator.close(mode);
             joinAccumulator = new JoinHelper.FollowerJoinAccumulator();
+            leaderChecker.setCurrentNodes(DiscoveryNodes.EMPTY_NODES);
         }
 
         lastKnownLeader = Optional.of(leaderNode);
@@ -268,6 +296,11 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         closePrevotingAndElectionScheduler();
         cancelActivePublication();
         preVoteCollector.update(getPreVoteResponse(), leaderNode);
+
+        if (leaderCheckScheduler != null) {
+            leaderCheckScheduler.close();
+        }
+        leaderCheckScheduler = leaderChecker.startLeaderChecker(leaderNode);
     }
 
     private PreVoteResponse getPreVoteResponse() {
@@ -339,6 +372,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 assert getStateForMasterService().nodes().getMasterNodeId() != null
                     || getStateForMasterService().term() != getCurrentTerm() :
                     getStateForMasterService();
+                assert leaderCheckScheduler == null : leaderCheckScheduler;
             } else if (mode == Mode.FOLLOWER) {
                 assert coordinationState.get().electionWon() == false : getLocalNode() + " is FOLLOWER so electionWon() should be false";
                 assert lastKnownLeader.isPresent() && (lastKnownLeader.get().equals(getLocalNode()) == false);
@@ -347,12 +381,16 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 assert electionScheduler == null : electionScheduler;
                 assert prevotingRound == null : prevotingRound;
                 assert getStateForMasterService().nodes().getMasterNodeId() == null : getStateForMasterService();
+                assert leaderChecker.currentNodeIsMaster() == false;
+                assert leaderCheckScheduler != null;
             } else {
                 assert mode == Mode.CANDIDATE;
                 assert joinAccumulator instanceof JoinHelper.CandidateJoinAccumulator;
                 assert peerFinderLeader.isPresent() == false : peerFinderLeader;
                 assert prevotingRound == null || electionScheduler != null;
                 assert getStateForMasterService().nodes().getMasterNodeId() == null : getStateForMasterService();
+                assert leaderChecker.currentNodeIsMaster() == false;
+                assert leaderCheckScheduler == null : leaderCheckScheduler;
             }
         }
     }
@@ -577,6 +615,8 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                         return "scheduled timeout for " + publication;
                     }
                 });
+
+                leaderChecker.setCurrentNodes(publishRequest.getAcceptedState().nodes());
                 publication.start(Collections.emptySet()); // TODO start failure detector and put faultyNodes here
             }
         } catch (Exception e) {

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -1105,6 +1105,9 @@ public class TransportReplicationActionTests extends ESTestCase {
     }
 
     static class TestResponse extends ReplicationResponse {
+        TestResponse() {
+            setShardInfo(new ShardInfo());
+        }
     }
 
     private class TestAction extends TransportReplicationAction<Request, Request, TestResponse> {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -41,6 +41,7 @@ import org.elasticsearch.discovery.zen.UnicastHostsProvider.HostsResolver;
 import org.elasticsearch.indices.cluster.FakeThreadPoolMasterService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.disruption.DisruptableMockTransport;
+import org.elasticsearch.test.disruption.DisruptableMockTransport.ConnectionStatus;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.transport.TransportService;
 import org.hamcrest.Matcher;
@@ -59,7 +60,11 @@ import static java.util.Collections.emptySet;
 import static org.elasticsearch.cluster.coordination.CoordinationStateTests.clusterState;
 import static org.elasticsearch.cluster.coordination.CoordinationStateTests.setValue;
 import static org.elasticsearch.cluster.coordination.CoordinationStateTests.value;
+import static org.elasticsearch.cluster.coordination.Coordinator.Mode.CANDIDATE;
 import static org.elasticsearch.cluster.coordination.Coordinator.Mode.FOLLOWER;
+import static org.elasticsearch.cluster.coordination.LeaderChecker.LEADER_CHECK_INTERVAL_SETTING;
+import static org.elasticsearch.cluster.coordination.LeaderChecker.LEADER_CHECK_RETRY_COUNT_SETTING;
+import static org.elasticsearch.cluster.coordination.LeaderChecker.LEADER_CHECK_TIMEOUT_SETTING;
 import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
 import static org.elasticsearch.transport.TransportService.HANDSHAKE_ACTION_NAME;
 import static org.elasticsearch.transport.TransportService.NOOP_TRANSPORT_INTERCEPTOR;
@@ -68,7 +73,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
-@TestLogging("org.elasticsearch.cluster.coordination:TRACE,org.elasticsearch.cluster.discovery:TRACE")
+@TestLogging("org.elasticsearch.cluster.coordination:TRACE,org.elasticsearch.discovery:TRACE")
 public class CoordinatorTests extends ESTestCase {
 
     public void testCanUpdateClusterStateAfterStabilisation() {
@@ -101,6 +106,40 @@ public class CoordinatorTests extends ESTestCase {
         assertEquals(currentTerm, newTerm);
     }
 
+    public void testLeaderDisconnectionDetectedQuickly() {
+        final Cluster cluster = new Cluster(randomIntBetween(3, 5));
+        cluster.stabilise();
+
+        final ClusterNode originalLeader = cluster.getAnyLeader();
+        logger.info("--> disconnecting leader {}", originalLeader);
+        originalLeader.disconnect();
+
+        synchronized (originalLeader.coordinator.mutex) {
+            originalLeader.coordinator.becomeCandidate("simulated failure detection"); // TODO remove once follower checker is integrated
+        }
+
+        cluster.stabilise();
+        assertThat(cluster.getAnyLeader().getId(), not(equalTo(originalLeader.getId())));
+    }
+
+    public void testUnresponsiveLeaderDetectedEventually() {
+        final Cluster cluster = new Cluster(randomIntBetween(3, 5));
+        cluster.stabilise();
+
+        final ClusterNode originalLeader = cluster.getAnyLeader();
+        logger.info("--> partitioning leader {}", originalLeader);
+        originalLeader.partition();
+
+        synchronized (originalLeader.coordinator.mutex) {
+            originalLeader.coordinator.becomeCandidate("simulated failure detection"); // TODO remove once follower checker is integrated
+        }
+
+        cluster.stabilise(Cluster.DEFAULT_STABILISATION_TIME
+            + (LEADER_CHECK_INTERVAL_SETTING.get(Settings.EMPTY).millis() + LEADER_CHECK_TIMEOUT_SETTING.get(Settings.EMPTY).millis())
+            * LEADER_CHECK_RETRY_COUNT_SETTING.get(Settings.EMPTY));
+        assertThat(cluster.getAnyLeader().getId(), not(equalTo(originalLeader.getId())));
+    }
+
     private static String nodeIdFromIndex(int nodeIndex) {
         return "node" + nodeIndex;
     }
@@ -114,6 +153,9 @@ public class CoordinatorTests extends ESTestCase {
             // TODO does ThreadPool need a node name any more?
             Settings.builder().put(NODE_NAME_SETTING.getKey(), "deterministic-task-queue").build());
         private final VotingConfiguration initialConfiguration;
+
+        private final Set<String> disconnectedNodes = new HashSet<>();
+        private final Set<String> partitionedNodes = new HashSet<>();
 
         Cluster(int initialNodeCount) {
             logger.info("--> creating cluster of {} nodes", initialNodeCount);
@@ -142,8 +184,12 @@ public class CoordinatorTests extends ESTestCase {
         }
 
         void stabilise() {
+            stabilise(DEFAULT_STABILISATION_TIME);
+        }
+
+        void stabilise(long stabilisationTime) {
             final long stabilisationStartTime = deterministicTaskQueue.getCurrentTimeMillis();
-            while (deterministicTaskQueue.getCurrentTimeMillis() < stabilisationStartTime + DEFAULT_STABILISATION_TIME) {
+            while (deterministicTaskQueue.getCurrentTimeMillis() < stabilisationStartTime + stabilisationTime) {
 
                 while (deterministicTaskQueue.hasRunnableTasks()) {
                     try {
@@ -182,16 +228,21 @@ public class CoordinatorTests extends ESTestCase {
                 }
 
                 final String nodeId = clusterNode.getId();
-                assertThat(nodeId + " has the same term as the leader", clusterNode.coordinator.getCurrentTerm(), is(leaderTerm));
-                // TODO assert that all nodes have actually voted for the leader in this term
 
-                assertThat(nodeId + " is a follower", clusterNode.coordinator.getMode(), is(FOLLOWER));
-                assertThat(nodeId + " is at the same accepted version as the leader",
-                    Optional.of(clusterNode.coordinator.getLastAcceptedState().getVersion()), isPresentAndEqualToLeaderVersion);
-                assertThat(nodeId + " is at the same committed version as the leader",
-                    clusterNode.coordinator.getLastCommittedState().map(ClusterState::getVersion), isPresentAndEqualToLeaderVersion);
-                assertThat(clusterNode.coordinator.getLastCommittedState().map(ClusterState::getNodes).map(dn -> dn.nodeExists(nodeId)),
-                    equalTo(Optional.of(true)));
+                if (disconnectedNodes.contains(nodeId) || partitionedNodes.contains(nodeId)) {
+                    assertThat(nodeId + " is a candidate", clusterNode.coordinator.getMode(), is(CANDIDATE));
+                } else {
+                    assertThat(nodeId + " has the same term as the leader", clusterNode.coordinator.getCurrentTerm(), is(leaderTerm));
+                    // TODO assert that all nodes have actually voted for the leader in this term
+
+                    assertThat(nodeId + " is a follower", clusterNode.coordinator.getMode(), is(FOLLOWER));
+                    assertThat(nodeId + " is at the same accepted version as the leader",
+                        Optional.of(clusterNode.coordinator.getLastAcceptedState().getVersion()), isPresentAndEqualToLeaderVersion);
+                    assertThat(nodeId + " is at the same committed version as the leader",
+                        clusterNode.coordinator.getLastCommittedState().map(ClusterState::getVersion), isPresentAndEqualToLeaderVersion);
+                    assertThat(clusterNode.coordinator.getLastCommittedState().map(ClusterState::getNodes).map(dn -> dn.nodeExists(nodeId)),
+                        equalTo(Optional.of(true)));
+                }
             }
 
             assertThat(leader.coordinator.getLastCommittedState().map(ClusterState::getNodes).map(DiscoveryNodes::getSize),
@@ -202,6 +253,18 @@ public class CoordinatorTests extends ESTestCase {
             List<ClusterNode> allLeaders = clusterNodes.stream().filter(ClusterNode::isLeader).collect(Collectors.toList());
             assertThat(allLeaders, not(empty()));
             return randomFrom(allLeaders);
+        }
+
+        private ConnectionStatus getConnectionStatus(DiscoveryNode sender, DiscoveryNode destination) {
+            ConnectionStatus connectionStatus;
+            if (partitionedNodes.contains(sender.getId()) || partitionedNodes.contains(destination.getId())) {
+                connectionStatus = ConnectionStatus.BLACK_HOLE;
+            } else if (disconnectedNodes.contains(sender.getId()) || disconnectedNodes.contains(destination.getId())) {
+                connectionStatus = ConnectionStatus.DISCONNECTED;
+            } else {
+                connectionStatus = ConnectionStatus.CONNECTED;
+            }
+            return connectionStatus;
         }
 
         class ClusterNode extends AbstractComponent {
@@ -241,7 +304,7 @@ public class CoordinatorTests extends ESTestCase {
 
                     @Override
                     protected ConnectionStatus getConnectionStatus(DiscoveryNode sender, DiscoveryNode destination) {
-                        return ConnectionStatus.CONNECTED;
+                        return Cluster.this.getConnectionStatus(sender, destination);
                     }
 
                     @Override
@@ -290,7 +353,7 @@ public class CoordinatorTests extends ESTestCase {
                 return localNode.getId();
             }
 
-            public DiscoveryNode getLocalNode() {
+            DiscoveryNode getLocalNode() {
                 return localNode;
             }
 
@@ -315,6 +378,14 @@ public class CoordinatorTests extends ESTestCase {
             @Override
             public String toString() {
                 return localNode.toString();
+            }
+
+            void disconnect() {
+                disconnectedNodes.add(localNode.getId());
+            }
+
+            void partition() {
+                partitionedNodes.add(localNode.getId());
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -155,7 +155,7 @@ public class CoordinatorTests extends ESTestCase {
         private final VotingConfiguration initialConfiguration;
 
         private final Set<String> disconnectedNodes = new HashSet<>();
-        private final Set<String> partitionedNodes = new HashSet<>();
+        private final Set<String> blackholedNodes = new HashSet<>();
 
         Cluster(int initialNodeCount) {
             logger.info("--> creating cluster of {} nodes", initialNodeCount);
@@ -229,7 +229,7 @@ public class CoordinatorTests extends ESTestCase {
 
                 final String nodeId = clusterNode.getId();
 
-                if (disconnectedNodes.contains(nodeId) || partitionedNodes.contains(nodeId)) {
+                if (disconnectedNodes.contains(nodeId) || blackholedNodes.contains(nodeId)) {
                     assertThat(nodeId + " is a candidate", clusterNode.coordinator.getMode(), is(CANDIDATE));
                 } else {
                     assertThat(nodeId + " has the same term as the leader", clusterNode.coordinator.getCurrentTerm(), is(leaderTerm));
@@ -257,7 +257,7 @@ public class CoordinatorTests extends ESTestCase {
 
         private ConnectionStatus getConnectionStatus(DiscoveryNode sender, DiscoveryNode destination) {
             ConnectionStatus connectionStatus;
-            if (partitionedNodes.contains(sender.getId()) || partitionedNodes.contains(destination.getId())) {
+            if (blackholedNodes.contains(sender.getId()) || blackholedNodes.contains(destination.getId())) {
                 connectionStatus = ConnectionStatus.BLACK_HOLE;
             } else if (disconnectedNodes.contains(sender.getId()) || disconnectedNodes.contains(destination.getId())) {
                 connectionStatus = ConnectionStatus.DISCONNECTED;
@@ -396,7 +396,7 @@ public class CoordinatorTests extends ESTestCase {
             }
 
             void partition() {
-                partitionedNodes.add(localNode.getId());
+                blackholedNodes.add(localNode.getId());
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -330,8 +330,8 @@ public class CoordinatorTests extends ESTestCase {
 
                     @Override
                     protected void onBlackholedDuringSend(long requestId, String action, DiscoveryNode destination) {
-                        logger.trace("dropping {}", getRequestDescription(requestId, action, destination));
                         if (action.equals(HANDSHAKE_ACTION_NAME)) {
+                            logger.trace("ignoring blackhole and delivering {}", getRequestDescription(requestId, action, destination));
                             // handshakes always have a timeout, and are sent in a blocking fashion, so we must respond with an exception.
                             sendFromTo(destination, getLocalNode(), action, getDisconnectException(requestId, action, destination));
                         } else {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
@@ -294,7 +294,7 @@ public class LeaderCheckerTests extends ESTestCase {
             = DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).masterNodeId(localNode.getId()).build();
 
         {
-            leaderChecker.setLastPublishedDiscoveryNodes(discoveryNodes);
+            leaderChecker.setCurrentNodes(discoveryNodes);
 
             final CapturingTransportResponseHandler handler = new CapturingTransportResponseHandler();
             transportService.sendRequest(localNode, LEADER_CHECK_ACTION_NAME, new LeaderCheckRequest(otherNode), handler);
@@ -307,7 +307,7 @@ public class LeaderCheckerTests extends ESTestCase {
         }
 
         {
-            leaderChecker.setLastPublishedDiscoveryNodes(DiscoveryNodes.builder(discoveryNodes).add(otherNode).build());
+            leaderChecker.setCurrentNodes(DiscoveryNodes.builder(discoveryNodes).add(otherNode).build());
 
             final CapturingTransportResponseHandler handler = new CapturingTransportResponseHandler();
             transportService.sendRequest(localNode, LEADER_CHECK_ACTION_NAME, new LeaderCheckRequest(otherNode), handler);
@@ -318,7 +318,7 @@ public class LeaderCheckerTests extends ESTestCase {
         }
 
         {
-            leaderChecker.setLastPublishedDiscoveryNodes(DiscoveryNodes.builder(discoveryNodes).add(otherNode).masterNodeId(null).build());
+            leaderChecker.setCurrentNodes(DiscoveryNodes.builder(discoveryNodes).add(otherNode).masterNodeId(null).build());
 
             final CapturingTransportResponseHandler handler = new CapturingTransportResponseHandler();
             transportService.sendRequest(localNode, LEADER_CHECK_ACTION_NAME, new LeaderCheckRequest(otherNode), handler);

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/DisruptableMockTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/DisruptableMockTransport.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.util.Optional;
 
 import static org.elasticsearch.test.ESTestCase.copyWriteable;
-import static org.elasticsearch.transport.TransportService.HANDSHAKE_ACTION_NAME;
 
 public abstract class DisruptableMockTransport extends MockTransport {
     private final Logger logger;
@@ -52,7 +51,7 @@ public abstract class DisruptableMockTransport extends MockTransport {
 
     protected abstract void handle(DiscoveryNode sender, DiscoveryNode destination, String action, Runnable doDelivery);
 
-    private void sendFromTo(DiscoveryNode sender, DiscoveryNode destination, String action, Runnable doDelivery) {
+    protected final void sendFromTo(DiscoveryNode sender, DiscoveryNode destination, String action, Runnable doDelivery) {
         handle(sender, destination, action, new Runnable() {
             @Override
             public void run() {
@@ -75,10 +74,33 @@ public abstract class DisruptableMockTransport extends MockTransport {
 
         assert destination.equals(getLocalNode()) == false : "non-local message from " + getLocalNode() + " to itself";
 
-        final String requestDescription = new ParameterizedMessage("[{}][{}] from {} to {}",
-            action, requestId, getLocalNode(), destination).getFormattedMessage();
+        sendFromTo(getLocalNode(), destination, action, new Runnable() {
+            @Override
+            public void run() {
+                switch (getConnectionStatus(getLocalNode(), destination)) {
+                    case BLACK_HOLE:
+                        onBlackholedDuringSend(requestId, action, destination);
+                        break;
 
-        final Runnable returnConnectException = new Runnable() {
+                    case DISCONNECTED:
+                        onDisconnectedDuringSend(requestId, action, destination);
+                        break;
+
+                    case CONNECTED:
+                        onConnectedDuringSend(requestId, action, request, destination);
+                        break;
+                }
+            }
+
+            @Override
+            public String toString() {
+                return getRequestDescription(requestId, action, destination);
+            }
+        });
+    }
+
+    protected Runnable getDisconnectException(long requestId, String action, DiscoveryNode destination) {
+        return new Runnable() {
             @Override
             public void run() {
                 handleError(requestId, new ConnectTransportException(destination, "disconnected"));
@@ -86,116 +108,107 @@ public abstract class DisruptableMockTransport extends MockTransport {
 
             @Override
             public String toString() {
-                return "disconnection response to " + requestDescription;
+                return "disconnection response to " + getRequestDescription(requestId, action, destination);
+            }
+        };
+    }
+
+    protected String getRequestDescription(long requestId, String action, DiscoveryNode destination) {
+        return new ParameterizedMessage("[{}][{}] from {} to {}",
+            action, requestId, getLocalNode(), destination).getFormattedMessage();
+    }
+
+    protected void onBlackholedDuringSend(long requestId, String action, DiscoveryNode destination) {
+        logger.trace("dropping {}", getRequestDescription(requestId, action, destination));
+    }
+
+    protected void onDisconnectedDuringSend(long requestId, String action, DiscoveryNode destination) {
+        sendFromTo(destination, getLocalNode(), action, getDisconnectException(requestId, action, destination));
+    }
+
+    protected void onConnectedDuringSend(long requestId, String action, TransportRequest request, DiscoveryNode destination) {
+        Optional<DisruptableMockTransport> destinationTransport = getDisruptedCapturingTransport(destination, action);
+        assert destinationTransport.isPresent();
+
+        final RequestHandlerRegistry<TransportRequest> requestHandler =
+            destinationTransport.get().getRequestHandler(action);
+
+        final String requestDescription = getRequestDescription(requestId, action, destination);
+
+        final TransportChannel transportChannel = new TransportChannel() {
+            @Override
+            public String getProfileName() {
+                return "default";
+            }
+
+            @Override
+            public String getChannelType() {
+                return "disruptable-mock-transport-channel";
+            }
+
+            @Override
+            public void sendResponse(final TransportResponse response) {
+                sendFromTo(destination, getLocalNode(), action, new Runnable() {
+                    @Override
+                    public void run() {
+                        if (getConnectionStatus(destination, getLocalNode()) != ConnectionStatus.CONNECTED) {
+                            logger.trace("dropping response to {}: channel is not CONNECTED",
+                                requestDescription);
+                        } else {
+                            handleResponse(requestId, response);
+                        }
+                    }
+
+                    @Override
+                    public String toString() {
+                        return "response to " + requestDescription;
+                    }
+                });
+            }
+
+            @Override
+            public void sendResponse(TransportResponse response,
+                                     TransportResponseOptions options) {
+                sendResponse(response);
+            }
+
+            @Override
+            public void sendResponse(Exception exception) {
+                sendFromTo(destination, getLocalNode(), action, new Runnable() {
+                    @Override
+                    public void run() {
+                        if (getConnectionStatus(destination, getLocalNode()) != ConnectionStatus.CONNECTED) {
+                            logger.trace("dropping response to {}: channel is not CONNECTED",
+                                requestDescription);
+                        } else {
+                            handleRemoteError(requestId, exception);
+                        }
+                    }
+
+                    @Override
+                    public String toString() {
+                        return "error response to " + requestDescription;
+                    }
+                });
             }
         };
 
-        sendFromTo(getLocalNode(), destination, action, new Runnable() {
-            @Override
-            public void run() {
-                switch (getConnectionStatus(getLocalNode(), destination)) {
-                    case BLACK_HOLE:
-                        if (action.equals(HANDSHAKE_ACTION_NAME)) {
-                            // handshakes always have a timeout, and are sent in a blocking fashion, so we must respond with an exception.
-                            sendFromTo(destination, getLocalNode(), action, returnConnectException);
-                        } else {
-                            logger.trace("dropping {}", requestDescription);
-                        }
-                        break;
+        final TransportRequest copiedRequest;
+        try {
+            copiedRequest = copyWriteable(request, writeableRegistry(), requestHandler::newRequest);
+        } catch (IOException e) {
+            throw new AssertionError("exception de/serializing request", e);
+        }
 
-                    case DISCONNECTED:
-                        sendFromTo(destination, getLocalNode(), action, returnConnectException);
-                        break;
-
-                    case CONNECTED:
-                        Optional<DisruptableMockTransport> destinationTransport = getDisruptedCapturingTransport(destination, action);
-                        assert destinationTransport.isPresent();
-
-                        final RequestHandlerRegistry<TransportRequest> requestHandler =
-                            destinationTransport.get().getRequestHandler(action);
-
-                        final TransportChannel transportChannel = new TransportChannel() {
-                            @Override
-                            public String getProfileName() {
-                                return "default";
-                            }
-
-                            @Override
-                            public String getChannelType() {
-                                return "disruptable-mock-transport-channel";
-                            }
-
-                            @Override
-                            public void sendResponse(final TransportResponse response) {
-                                sendFromTo(destination, getLocalNode(), action, new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        if (getConnectionStatus(destination, getLocalNode()) != ConnectionStatus.CONNECTED) {
-                                            logger.trace("dropping response to {}: channel is not CONNECTED",
-                                                requestDescription);
-                                        } else {
-                                            handleResponse(requestId, response);
-                                        }
-                                    }
-
-                                    @Override
-                                    public String toString() {
-                                        return "response to " + requestDescription;
-                                    }
-                                });
-                            }
-
-                            @Override
-                            public void sendResponse(TransportResponse response,
-                                                     TransportResponseOptions options) {
-                                sendResponse(response);
-                            }
-
-                            @Override
-                            public void sendResponse(Exception exception) {
-                                sendFromTo(destination, getLocalNode(), action, new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        if (getConnectionStatus(destination, getLocalNode()) != ConnectionStatus.CONNECTED) {
-                                            logger.trace("dropping response to {}: channel is not CONNECTED",
-                                                requestDescription);
-                                        } else {
-                                            handleRemoteError(requestId, exception);
-                                        }
-                                    }
-
-                                    @Override
-                                    public String toString() {
-                                        return "error response to " + requestDescription;
-                                    }
-                                });
-                            }
-                        };
-
-                        final TransportRequest copiedRequest;
-                        try {
-                            copiedRequest = copyWriteable(request, writeableRegistry(), requestHandler::newRequest);
-                        } catch (IOException e) {
-                            throw new AssertionError("exception de/serializing request", e);
-                        }
-
-                        try {
-                            requestHandler.processMessageReceived(copiedRequest, transportChannel);
-                        } catch (Exception e) {
-                            try {
-                                transportChannel.sendResponse(e);
-                            } catch (Exception ee) {
-                                logger.warn("failed to send failure", e);
-                            }
-                        }
-                }
+        try {
+            requestHandler.processMessageReceived(copiedRequest, transportChannel);
+        } catch (Exception e) {
+            try {
+                transportChannel.sendResponse(e);
+            } catch (Exception ee) {
+                logger.warn("failed to send failure", e);
             }
-
-            @Override
-            public String toString() {
-                return requestDescription;
-            }
-        });
+        }
     }
 
     private NamedWriteableRegistry writeableRegistry() {


### PR DESCRIPTION
This change ensures that follower nodes periodically check that their leader is
healthy, and that they elect a new leader if not.