### PR TITLE
Scripting: Use ParameterMap for deprecated ctx var in update scripts

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollActionScriptTestCase.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollActionScriptTestCase.java
@@ -56,13 +56,12 @@ public abstract class AbstractAsyncBulkByScrollActionScriptTestCase<
     protected <T extends ActionRequest> T applyScript(Consumer<Map<String, Object>> scriptBody) {
         IndexRequest index = new IndexRequest("index", "type", "1").source(singletonMap("foo", "bar"));
         ScrollableHitSource.Hit doc = new ScrollableHitSource.BasicHit("test", "type", "id", 0);
-        UpdateScript updateScript = new UpdateScript(Collections.emptyMap()) {
+        UpdateScript.Factory factory = (params, ctx) -> new UpdateScript(Collections.emptyMap(), ctx) {
             @Override
-            public void execute(Map<String, Object> ctx) {
+            public void execute() {
                 scriptBody.accept(ctx);
             }
-        };
-        UpdateScript.Factory factory = params -> updateScript;
+        };;
         ExecutableScript simpleExecutableScript = new SimpleExecutableScript(scriptBody);
         when(scriptService.compile(any(), eq(ExecutableScript.CONTEXT))).thenReturn(params -> simpleExecutableScript);
         when(scriptService.compile(any(), eq(UpdateScript.CONTEXT))).thenReturn(factory);

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -19,11 +19,6 @@
 
 package org.elasticsearch.action.update;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.LongSupplier;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.DocWriteResponse;
@@ -52,16 +47,16 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.UpdateScript;
 import org.elasticsearch.search.lookup.SourceLookup;
 
-import static org.elasticsearch.common.Booleans.parseBoolean;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.LongSupplier;
 
 /**
  * Helper for translating an update request to an index, delete request or update response.
  */
 public class UpdateHelper extends AbstractComponent {
-
-    /** Whether scripts should add the ctx variable to the params map. */
-    private static final boolean CTX_IN_PARAMS =
-        parseBoolean(System.getProperty("es.scripting.update.ctx_in_params"), true);
 
     private final ScriptService scriptService;
 
@@ -286,17 +281,8 @@ public class UpdateHelper extends AbstractComponent {
         try {
             if (scriptService != null) {
                 UpdateScript.Factory factory = scriptService.compile(script, UpdateScript.CONTEXT);
-                final Map<String, Object> params;
-                if (CTX_IN_PARAMS) {
-                    params = new HashMap<>(script.getParams());
-                    params.put(ContextFields.CTX, ctx);
-                    deprecationLogger.deprecated("Using `ctx` via `params.ctx` is deprecated. " +
-                        "Use -Des.scripting.update.ctx_in_params=false to enforce non-deprecated usage.");
-                } else {
-                    params = script.getParams();
-                }
-                UpdateScript executableScript = factory.newInstance(params);
-                executableScript.execute(ctx);
+                UpdateScript executableScript = factory.newInstance(script.getParams(), ctx);
+                executableScript.execute();
             }
         } catch (Exception e) {
             throw new IllegalArgumentException("failed to execute script", e);

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -117,9 +117,9 @@ public class MockScriptEngine implements ScriptEngine {
             };
             return context.factoryClazz.cast(factory);
         } else if (context.instanceClazz.equals(UpdateScript.class)) {
-            UpdateScript.Factory factory = parameters -> new UpdateScript(parameters) {
+            UpdateScript.Factory factory = (parameters, ctx) -> new UpdateScript(parameters, ctx) {
                 @Override
-                public void execute(Map<String, Object> ctx) {
+                public void execute() {
                     final Map<String, Object> vars = new HashMap<>();
                     vars.put("ctx", ctx);
                     vars.put("params", parameters);


### PR DESCRIPTION
This commit removes the sysprop controlling whether ctx is in params for
update scripts and replaces it with use of the new ParameterMap, which
outputs a deprecation warning whenever params.ctx is used.