### PR TITLE
[Zen2] Integrate FollowerChecker with Coordinator

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -451,7 +451,8 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 assert prevotingRound == null : prevotingRound;
                 assert becomingMaster || getStateForMasterService().nodes().getMasterNodeId() != null : getStateForMasterService();
                 assert leaderCheckScheduler == null : leaderCheckScheduler;
-                assert followersChecker.isActive() == (publicationInProgress() || becomingMaster == false);
+                assert followersChecker.isActive() == ((publicationInProgress() || becomingMaster == false)
+                    && getStateForMasterService().nodes().getSize() > 1);
             } else if (mode == Mode.FOLLOWER) {
                 assert coordinationState.get().electionWon() == false : getLocalNode() + " is FOLLOWER so electionWon() should be false";
                 assert lastKnownLeader.isPresent() && (lastKnownLeader.get().equals(getLocalNode()) == false);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -451,8 +451,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 assert prevotingRound == null : prevotingRound;
                 assert becomingMaster || getStateForMasterService().nodes().getMasterNodeId() != null : getStateForMasterService();
                 assert leaderCheckScheduler == null : leaderCheckScheduler;
-                assert followersChecker.isActive() == ((publicationInProgress() || becomingMaster == false)
-                    && getStateForMasterService().nodes().getSize() > 1);
+                assert followersChecker.isActive() == (publicationInProgress() || becomingMaster == false);
             } else if (mode == Mode.FOLLOWER) {
                 assert coordinationState.get().electionWon() == false : getLocalNode() + " is FOLLOWER so electionWon() should be false";
                 assert lastKnownLeader.isPresent() && (lastKnownLeader.get().equals(getLocalNode()) == false);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -451,6 +451,10 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                     || getStateForMasterService().term() != getCurrentTerm() :
                     getStateForMasterService();
                 assert leaderCheckScheduler == null : leaderCheckScheduler;
+
+                if (publicationInProgress() || getLastCommittedState().map(s -> s.term() == getCurrentTerm()).orElse(false)) {
+                    assert followersChecker.isActive();
+                }
             } else if (mode == Mode.FOLLOWER) {
                 assert coordinationState.get().electionWon() == false : getLocalNode() + " is FOLLOWER so electionWon() should be false";
                 assert lastKnownLeader.isPresent() && (lastKnownLeader.get().equals(getLocalNode()) == false);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -398,6 +398,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         return transportService.getLocalNode();
     }
 
+    // package-visible for testing
     boolean publicationInProgress() {
         synchronized (mutex) {
             return currentPublication.isPresent();

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -184,9 +184,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                     + getCurrentTerm() + "], rejecting " + followerCheckRequest);
             }
 
-            if (mode != Mode.FOLLOWER) {
-                becomeFollower("onFollowerCheckRequest", followerCheckRequest.getSender());
-            }
+            becomeFollower("onFollowerCheckRequest", followerCheckRequest.getSender());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -451,9 +451,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 assert prevotingRound == null : prevotingRound;
                 assert becomingMaster || getStateForMasterService().nodes().getMasterNodeId() != null : getStateForMasterService();
                 assert leaderCheckScheduler == null : leaderCheckScheduler;
-
                 assert followersChecker.isActive() == (publicationInProgress() || becomingMaster == false);
-
             } else if (mode == Mode.FOLLOWER) {
                 assert coordinationState.get().electionWon() == false : getLocalNode() + " is FOLLOWER so electionWon() should be false";
                 assert lastKnownLeader.isPresent() && (lastKnownLeader.get().equals(getLocalNode()) == false);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -319,7 +319,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 leaderCheckScheduler = null;
             }
 
-            followersChecker.setCurrentNodes(DiscoveryNodes.EMPTY_NODES);
+            followersChecker.clearCurrentNodes();
             followersChecker.updateFastResponseState(getCurrentTerm(), mode);
         }
 
@@ -370,7 +370,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
             leaderCheckScheduler = leaderChecker.startLeaderChecker(leaderNode);
         }
 
-        followersChecker.setCurrentNodes(DiscoveryNodes.EMPTY_NODES);
+        followersChecker.clearCurrentNodes();
         followersChecker.updateFastResponseState(getCurrentTerm(), mode);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -127,6 +127,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     }
 
     private static NodeRemovalClusterStateTaskExecutor getNodeRemovalExecutor(Settings settings, AllocationService allocationService, Logger logger) {
+        // TODO move NodeRemovalClusterStateTaskExecutor out of Zen since it's not Zen-specific
         return new NodeRemovalClusterStateTaskExecutor(allocationService, new ElectMasterService(settings) {
 
             @Override

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -398,6 +398,12 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         return transportService.getLocalNode();
     }
 
+    boolean publicationInProgress() {
+        synchronized (mutex) {
+            return currentPublication.isPresent();
+        }
+    }
+
     @Override
     protected void doStart() {
         CoordinationState.PersistedState persistedState = persistedStateSupplier.get();

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -128,7 +128,8 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         masterService.setClusterStateSupplier(this::getStateForMasterService);
     }
 
-    private static NodeRemovalClusterStateTaskExecutor getNodeRemovalExecutor(Settings settings, AllocationService allocationService, Logger logger) {
+    private static NodeRemovalClusterStateTaskExecutor getNodeRemovalExecutor(Settings settings, AllocationService allocationService,
+                                                                              Logger logger) {
         // TODO move NodeRemovalClusterStateTaskExecutor out of Zen since it's not Zen-specific
         return new NodeRemovalClusterStateTaskExecutor(allocationService, new ElectMasterService(settings) {
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -82,6 +82,7 @@ public class FollowersChecker extends AbstractComponent {
     private final Consumer<FollowerCheckRequest> handleRequestAndUpdateState;
 
     private final Object mutex = new Object(); // protects writes to this state; read access does not need sync
+    private volatile boolean active; // for assertions
     private final Map<DiscoveryNode, FollowerChecker> followerCheckers = newConcurrentMap();
     private final Set<DiscoveryNode> faultyNodes = new HashSet<>();
 
@@ -111,6 +112,8 @@ public class FollowersChecker extends AbstractComponent {
      */
     public void setCurrentNodes(DiscoveryNodes discoveryNodes) {
         synchronized (mutex) {
+            assert discoveryNodes.getSize() > 0;
+
             final Predicate<DiscoveryNode> isUnknownNode = n -> discoveryNodes.nodeExists(n) == false;
             followerCheckers.keySet().removeIf(isUnknownNode);
             faultyNodes.removeIf(isUnknownNode);
@@ -125,6 +128,19 @@ public class FollowersChecker extends AbstractComponent {
                     followerChecker.start();
                 }
             }
+
+            active = true;
+        }
+    }
+
+    /**
+     * Clear the set of known nodes, stopping all checks.
+     */
+    public void clearCurrentNodes() {
+        synchronized (mutex) {
+            followerCheckers.clear();
+            faultyNodes.clear();
+            active = false;
         }
     }
 
@@ -215,7 +231,7 @@ public class FollowersChecker extends AbstractComponent {
     // For assertions
     boolean isActive() {
         synchronized (mutex) {
-            return followerCheckers.isEmpty() == false || faultyNodes.isEmpty() == false;
+            return active;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -82,7 +82,6 @@ public class FollowersChecker extends AbstractComponent {
     private final Consumer<FollowerCheckRequest> handleRequestAndUpdateState;
 
     private final Object mutex = new Object(); // protects writes to this state; read access does not need sync
-    private volatile boolean active; // for assertions
     private final Map<DiscoveryNode, FollowerChecker> followerCheckers = newConcurrentMap();
     private final Set<DiscoveryNode> faultyNodes = new HashSet<>();
 
@@ -128,8 +127,6 @@ public class FollowersChecker extends AbstractComponent {
                     followerChecker.start();
                 }
             }
-
-            active = true;
         }
     }
 
@@ -140,7 +137,6 @@ public class FollowersChecker extends AbstractComponent {
         synchronized (mutex) {
             followerCheckers.clear();
             faultyNodes.clear();
-            active = false;
         }
     }
 
@@ -231,7 +227,7 @@ public class FollowersChecker extends AbstractComponent {
     // For assertions
     boolean isActive() {
         synchronized (mutex) {
-            return active;
+            return followerCheckers.isEmpty() == false || faultyNodes.isEmpty() == false;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -82,6 +82,7 @@ public class FollowersChecker extends AbstractComponent {
     private final Consumer<FollowerCheckRequest> handleRequestAndUpdateState;
 
     private final Object mutex = new Object(); // protects writes to this state; read access does not need sync
+    private volatile boolean active; // for assertions
     private final Map<DiscoveryNode, FollowerChecker> followerCheckers = newConcurrentMap();
     private final Set<DiscoveryNode> faultyNodes = new HashSet<>();
 
@@ -127,6 +128,8 @@ public class FollowersChecker extends AbstractComponent {
                     followerChecker.start();
                 }
             }
+
+            active = true;
         }
     }
 
@@ -137,6 +140,7 @@ public class FollowersChecker extends AbstractComponent {
         synchronized (mutex) {
             followerCheckers.clear();
             faultyNodes.clear();
+            active = false;
         }
     }
 
@@ -227,7 +231,7 @@ public class FollowersChecker extends AbstractComponent {
     // For assertions
     boolean isActive() {
         synchronized (mutex) {
-            return followerCheckers.isEmpty() == false || faultyNodes.isEmpty() == false;
+            return active;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -207,6 +207,18 @@ public class FollowersChecker extends AbstractComponent {
             '}';
     }
 
+    // For assertions
+    FastResponseState getFastResponseState() {
+        return fastResponseState;
+    }
+
+    // For assertions
+    boolean isActive() {
+        synchronized (mutex) {
+            return followerCheckers.isEmpty() == false || faultyNodes.isEmpty() == false;
+        }
+    }
+
     static class FastResponseState {
         final long term;
         final Mode mode;

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Publication.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Publication.java
@@ -22,6 +22,7 @@ package org.elasticsearch.cluster.coordination;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.ClusterStatePublisher.AckListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.component.AbstractComponent;
@@ -128,6 +129,11 @@ public abstract class Publication extends AbstractComponent {
             }
         }
         return isCompleted;
+    }
+
+    // For assertions
+    ClusterState publishedState() {
+        return publishRequest.getAcceptedState();
     }
 
     private void onPossibleCommitFailure() {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -163,7 +163,7 @@ public class CoordinatorTests extends ESTestCase {
         follower.partition();
 
         cluster.stabilise(
-            // wait for the new leader to notice that the follower is unresponsive
+            // wait for the leader to notice that the follower is unresponsive
             (FOLLOWER_CHECK_INTERVAL_SETTING.get(Settings.EMPTY).millis() + FOLLOWER_CHECK_TIMEOUT_SETTING.get(Settings.EMPTY).millis())
             * FOLLOWER_CHECK_RETRY_COUNT_SETTING.get(Settings.EMPTY));
         assertThat(cluster.getAnyLeader().getId(), equalTo(leader.getId()));
@@ -262,7 +262,6 @@ public class CoordinatorTests extends ESTestCase {
             assertThat(leader.coordinator.getLastCommittedState().map(ClusterState::getVersion), isPresentAndEqualToLeaderVersion);
             assertThat(leader.coordinator.getLastCommittedState().map(ClusterState::getNodes).map(dn -> dn.nodeExists(leader.getId())),
                 equalTo(Optional.of(true)));
-
 
             for (final ClusterNode clusterNode : clusterNodes) {
                 if (clusterNode == leader) {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -130,9 +130,9 @@ public class CoordinatorTests extends ESTestCase {
         logger.info("--> partitioning leader {}", originalLeader);
         originalLeader.partition();
 
-        cluster.stabilise(Cluster.DEFAULT_STABILISATION_TIME
+        cluster.stabilise(
             // first wait for all the followers to notice the leader has gone
-            + (LEADER_CHECK_INTERVAL_SETTING.get(Settings.EMPTY).millis() + LEADER_CHECK_TIMEOUT_SETTING.get(Settings.EMPTY).millis())
+            (LEADER_CHECK_INTERVAL_SETTING.get(Settings.EMPTY).millis() + LEADER_CHECK_TIMEOUT_SETTING.get(Settings.EMPTY).millis())
             * LEADER_CHECK_RETRY_COUNT_SETTING.get(Settings.EMPTY)
             // then wait for the new leader to notice that the old leader is unresponsive
             + (FOLLOWER_CHECK_INTERVAL_SETTING.get(Settings.EMPTY).millis() + FOLLOWER_CHECK_TIMEOUT_SETTING.get(Settings.EMPTY).millis())
@@ -150,6 +150,22 @@ public class CoordinatorTests extends ESTestCase {
         follower.disconnect();
 
         cluster.stabilise();
+        assertThat(cluster.getAnyLeader().getId(), equalTo(leader.getId()));
+    }
+
+    public void testUnresponsiveFollowerDetectedEventually() {
+        final Cluster cluster = new Cluster(randomIntBetween(3, 5));
+        cluster.stabilise();
+
+        final ClusterNode leader = cluster.getAnyLeader();
+        final ClusterNode follower = cluster.getAnyNodeExcept(leader);
+        logger.info("--> partitioning follower {}", follower);
+        follower.partition();
+
+        cluster.stabilise(
+            // wait for the new leader to notice that the follower is unresponsive
+            (FOLLOWER_CHECK_INTERVAL_SETTING.get(Settings.EMPTY).millis() + FOLLOWER_CHECK_TIMEOUT_SETTING.get(Settings.EMPTY).millis())
+            * FOLLOWER_CHECK_RETRY_COUNT_SETTING.get(Settings.EMPTY));
         assertThat(cluster.getAnyLeader().getId(), equalTo(leader.getId()));
     }
 
@@ -222,6 +238,10 @@ public class CoordinatorTests extends ESTestCase {
                 }
 
                 deterministicTaskQueue.advanceTime();
+            }
+
+            for (ClusterNode clusterNode : clusterNodes) {
+                assert clusterNode.coordinator.publicationInProgress() == false;
             }
 
             assertUniqueLeaderAndExpectedModes();

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
@@ -144,7 +144,7 @@ public class FollowersCheckerTests extends ESTestCase {
         assertThat(followersChecker.getFaultyNodes(), empty());
 
         checkedNodes.clear();
-        followersChecker.setCurrentNodes(discoveryNodesHolder[0] = DiscoveryNodes.EMPTY_NODES);
+        followersChecker.clearCurrentNodes();
         deterministicTaskQueue.runAllTasks(random());
         assertThat(checkedNodes, empty());
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
@@ -321,7 +321,8 @@ public class FollowersCheckerTests extends ESTestCase {
             rq -> copyWriteable(rq, writableRegistry(), FollowerCheckRequest::new),
             rq -> {
                 if (randomBoolean()) {
-                    return new FollowerCheckRequest(rq.getTerm(), new DiscoveryNode(randomAlphaOfLength(10), buildNewFakeTransportAddress(), Version.CURRENT));
+                    return new FollowerCheckRequest(rq.getTerm(),
+                        new DiscoveryNode(randomAlphaOfLength(10), buildNewFakeTransportAddress(), Version.CURRENT));
                 } else {
                     return new FollowerCheckRequest(randomNonNegativeLong(), rq.getSender());
                 }


### PR DESCRIPTION
This change ensures that the leader node periodically checks that its followers
are healthy, and that they are removed from the cluster if not.