### PR TITLE
Completion types with multi-fields support

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/50_completion_with_multi_fields.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/50_completion_with_multi_fields.yml
@@ -1,0 +1,279 @@
+
+---
+"Search by suggestion and by keyword sub-field should work":
+
+  - do:
+      indices.create:
+        index: completion_with_sub_keyword
+        body:
+          mappings:
+            test:
+              "properties":
+                "suggest_1":
+                  "type" : "completion"
+                  "fields":
+                    "text_raw":
+                      "type"  : "keyword"
+
+  - do:
+      index:
+        index: completion_with_sub_keyword
+        type:  test
+        id:    1
+        body:
+          suggest_1: "bar"
+
+  - do:
+      index:
+        index: completion_with_sub_keyword
+        type:  test
+        id:    2
+        body:
+          suggest_1: "baz"
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index:   completion_with_sub_keyword
+        body:
+          suggest:
+            result:
+              text: "b"
+              completion:
+                field: suggest_1
+
+  - length: { suggest.result: 1  }
+  - length: { suggest.result.0.options: 2  }
+
+
+  - do:
+      search:
+        index:   completion_with_sub_keyword
+        body:
+          query:   { term: { suggest_1.text_raw: "bar" }}
+
+  - match: { hits.total: 1 }
+
+
+
+---
+"Search by suggestion on sub field should work":
+
+  - do:
+      indices.create:
+        index: completion_with_sub_completion
+        body:
+          mappings:
+            test:
+              "properties":
+                "suggest_1":
+                  "type": "completion"
+                  "fields":
+                    "suggest_2":
+                      "type": "completion"
+
+  - do:
+      index:
+        index: completion_with_sub_completion
+        type:  test
+        id:    1
+        body:
+          suggest_1: "bar"
+
+  - do:
+      index:
+        index: completion_with_sub_completion
+        type:  test
+        id:    2
+        body:
+          suggest_1: "baz"
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: completion_with_sub_completion
+        body:
+          suggest:
+            result:
+              text: "b"
+              completion:
+                field: suggest_1.suggest_2
+
+  - length: { suggest.result: 1  }
+  - length: { suggest.result.0.options: 2  }
+
+---
+"Search by suggestion on sub field with context should work":
+
+  - do:
+      indices.create:
+        index: completion_with_context
+        body:
+          mappings:
+            test:
+              "properties":
+                "suggest_1":
+                  "type": "completion"
+                  "contexts":
+                    -
+                      "name": "color"
+                      "type": "category"
+                  "fields":
+                    "suggest_2":
+                      "type": "completion"
+                      "contexts":
+                        -
+                          "name": "color"
+                          "type": "category"
+
+
+  - do:
+      index:
+        index: completion_with_context
+        type:  test
+        id:    1
+        body:
+          suggest_1:
+            input: "foo red"
+            contexts:
+              color: "red"
+
+  - do:
+      index:
+        index: completion_with_context
+        type:  test
+        id:    2
+        body:
+          suggest_1:
+            input: "foo blue"
+            contexts:
+              color: "blue"
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: completion_with_context
+        body:
+          suggest:
+            result:
+              prefix: "foo"
+              completion:
+                field: suggest_1.suggest_2
+                contexts:
+                  color: "red"
+
+  - length: { suggest.result: 1  }
+  - length: { suggest.result.0.options: 1  }
+  - match:  { suggest.result.0.options.0.text: "foo red" }
+
+
+---
+"Search by suggestion on sub field with weight should work":
+
+  - do:
+      indices.create:
+        index: completion_with_weight
+        body:
+          mappings:
+            test:
+              "properties":
+                "suggest_1":
+                  "type": "completion"
+                  "fields":
+                    "suggest_2":
+                      "type": "completion"
+
+  - do:
+      index:
+        index: completion_with_weight
+        type:  test
+        id:    1
+        body:
+          suggest_1:
+            input: "bar"
+            weight: 2
+
+  - do:
+      index:
+        index: completion_with_weight
+        type:  test
+        id:    2
+        body:
+          suggest_1:
+            input: "baz"
+            weight: 3
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: completion_with_weight
+        body:
+          suggest:
+            result:
+              text: "b"
+              completion:
+                field: suggest_1.suggest_2
+
+  - length: { suggest.result: 1  }
+  - length: { suggest.result.0.options: 2  }
+  - match:  { suggest.result.0.options.0.text: "baz" }
+  - match:  { suggest.result.0.options.1.text: "bar" }
+
+---
+"Search by suggestion on geofield-hash on sub field should work":
+
+  - do:
+      indices.create:
+        index: geofield_with_completion
+        body:
+          mappings:
+            test:
+              "properties":
+                "geofield":
+                  "type": "geo_point"
+                  "fields":
+                    "suggest_1":
+                      "type": "completion"
+
+  - do:
+      index:
+        index: geofield_with_completion
+        type:  test
+        id:    1
+        body:
+          geofield: "hgjhrwysvqw7"
+        #41.12,-72.34,12
+
+  - do:
+      index:
+        index: geofield_with_completion
+        type:  test
+        id:    1
+        body:
+          geofield: "hgm4psywmkn7"
+        #41.12,-71.34,12
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: geofield_with_completion
+        body:
+          suggest:
+            result:
+              prefix: "hgm"
+              completion:
+                field: geofield.suggest_1
+
+
+  - length: { suggest.result: 1  }
+  - length: { suggest.result.0.options: 1  }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/50_completion_with_multi_fields.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/50_completion_with_multi_fields.yml
@@ -2,6 +2,10 @@
 ---
 "Search by suggestion and by keyword sub-field should work":
 
+  - skip:
+      version: " - 6.99.99"
+      reason:  "Search by suggestion with multi-fields was introduced 7.0.0"
+
   - do:
       indices.create:
         index: completion_with_sub_keyword
@@ -61,6 +65,10 @@
 ---
 "Search by suggestion on sub field should work":
 
+  - skip:
+      version: " - 6.99.99"
+      reason:  "Search by suggestion with multi-fields was introduced 7.0.0"
+
   - do:
       indices.create:
         index: completion_with_sub_completion
@@ -108,6 +116,10 @@
 
 ---
 "Search by suggestion on sub field with context should work":
+
+  - skip:
+      version: " - 6.99.99"
+      reason:  "Search by suggestion with multi-fields was introduced 7.0.0"
 
   - do:
       indices.create:
@@ -176,6 +188,10 @@
 ---
 "Search by suggestion on sub field with weight should work":
 
+  - skip:
+      version: " - 6.99.99"
+      reason:  "Search by suggestion with multi-fields was introduced 7.0.0"
+
   - do:
       indices.create:
         index: completion_with_weight
@@ -229,6 +245,10 @@
 
 ---
 "Search by suggestion on geofield-hash on sub field should work":
+
+  - skip:
+      version: " - 6.99.99"
+      reason:  "Search by suggestion with multi-fields was introduced 7.0.0"
 
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -489,10 +489,10 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
         Map<String, CompletionInputMetaData> inputMap;
         if (isExternalValueOfClass(context, CompletionInputMetaData.class)) {
             CompletionInputMetaData inputAndMeta = (CompletionInputMetaData) context.externalValue();
-            inputMap = Collections.singletonMap(inputAndMeta.inputField, inputAndMeta);
+            inputMap = Collections.singletonMap(inputAndMeta.input, inputAndMeta);
         } else {
             String fieldName = context.externalValue().toString();
-            inputMap = Collections.singletonMap(fieldName, new CompletionInputMetaData(fieldName, Collections.<String, Set<CharSequence>>emptyMap(), 1));
+            inputMap = Collections.singletonMap(fieldName, new CompletionInputMetaData(fieldName, Collections.emptyMap(), 1));
         }
         return inputMap;
     }
@@ -510,7 +510,7 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
     private void parse(ParseContext parseContext, Token token, XContentParser parser, Map<String, CompletionInputMetaData> inputMap) throws IOException {
         String currentFieldName = null;
         if (token == Token.VALUE_STRING) {
-            inputMap.put(parser.text(), new CompletionInputMetaData(parser.text(), Collections.<String, Set<CharSequence>>emptyMap(), 1));
+            inputMap.put(parser.text(), new CompletionInputMetaData(parser.text(), Collections.emptyMap(), 1));
         } else if (token == Token.START_OBJECT) {
             Set<String> inputs = new HashSet<>();
             int weight = 1;
@@ -593,19 +593,19 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
     }
 
     static class CompletionInputMetaData {
-        public final String inputField;
+        public final String input;
         public final Map<String, Set<CharSequence>> contexts;
         public final int weight;
 
-        CompletionInputMetaData(String inputField, Map<String, Set<CharSequence>> contexts, int weight) {
-            this.inputField = inputField;
+        CompletionInputMetaData(String input, Map<String, Set<CharSequence>> contexts, int weight) {
+            this.input = input;
             this.contexts = contexts;
             this.weight = weight;
         }
 
         @Override
         public String toString() {
-            return inputField;
+            return input;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -501,7 +501,6 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
         return context.externalValue().getClass().equals(clazz);
     }
 
-
     /**
      * Acceptable inputs:
      *  "STRING" - interpreted as the field value (input)

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -204,7 +204,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().endObject()
             .endObject().endObject()
         );
-        System.out.println(mapping);
+
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
 
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -246,7 +246,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().endObject()
             .endObject().endObject()
         );
-        System.out.println(mapping);
+
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
 
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
@@ -294,7 +294,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().endObject()
             .endObject().endObject()
         );
-        System.out.println(mapping);
+
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
 
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.index.mapper;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Query;
@@ -36,7 +34,6 @@ import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.geo.GeoHashUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -53,13 +50,11 @@ import org.hamcrest.Matchers;
 import org.hamcrest.core.CombinableMatcher;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.hamcrest.Matchers.array;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -228,7 +223,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
 
         ParseContext.Document indexableFields = parsedDocument.rootDoc();
 
-        assertThat(indexableFields.getFields("keywordfield"), array(
+        assertThat(indexableFields.getFields("keywordfield"), arrayContainingInAnyOrder(
             keywordField("key1"),
             sortedSetDocValuesField("key1"),
             keywordField("key2"),
@@ -236,7 +231,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
             keywordField("key3"),
             sortedSetDocValuesField("key3")
         ));
-        assertThat(indexableFields.getFields("keywordfield.subsuggest"), array(
+        assertThat(indexableFields.getFields("keywordfield.subsuggest"), arrayContainingInAnyOrder(
             contextSuggestField("key1"),
             contextSuggestField("key2"),
             contextSuggestField("key3")
@@ -287,15 +282,15 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
             XContentType.JSON));
 
         ParseContext.Document indexableFields = parsedDocument.rootDoc();
-        //TODO how to assert about context?
-        assertThat(indexableFields.getFields("suggest"), array(
+        assertThat(indexableFields.getFields("suggest"), arrayContainingInAnyOrder(
             contextSuggestField("timmy"),
             contextSuggestField("starbucks")
         ));
-        assertThat(indexableFields.getFields("suggest.subsuggest"), array(
+        assertThat(indexableFields.getFields("suggest.subsuggest"), arrayContainingInAnyOrder(
             contextSuggestField("timmy"),
             contextSuggestField("starbucks")
         ));
+        //unable to assert about context, covered in a REST test
     }
 
     public void testCompletionWithContextAndSubCompletionIndexByPath() throws Exception {
@@ -337,14 +332,15 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
             XContentType.JSON));
 
         ParseContext.Document indexableFields = parsedDocument.rootDoc();
-        assertThat(indexableFields.getFields("suggest"), array(
+        assertThat(indexableFields.getFields("suggest"), arrayContainingInAnyOrder(
             contextSuggestField("timmy"),
             contextSuggestField("starbucks")
         ));
-        assertThat(indexableFields.getFields("suggest.subsuggest"), array(
+        assertThat(indexableFields.getFields("suggest.subsuggest"), arrayContainingInAnyOrder(
             contextSuggestField("timmy"),
             contextSuggestField("starbucks")
         ));
+        //unable to assert about context, covered in a REST test
     }
 
 
@@ -371,11 +367,11 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
             XContentType.JSON));
 
         ParseContext.Document indexableFields = parsedDocument.rootDoc();
-        //TODO how to assert about geofields?
         assertThat(indexableFields.getFields("geofield"), arrayWithSize(2));
-        assertThat(indexableFields.getFields("geofield.analyzed"), array(
+        assertThat(indexableFields.getFields("geofield.analyzed"), arrayContainingInAnyOrder(
             suggestField("drm3btev3e86")
         ));
+        //unable to assert about geofield content, covered in a REST test
     }
 
     public void testCompletionTypeWithSubCompletionFieldAndStringInsert() throws Exception {
@@ -401,10 +397,10 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
             XContentType.JSON));
 
         ParseContext.Document indexableFields = parsedDocument.rootDoc();
-        assertThat(indexableFields.getFields("suggest"), array(
+        assertThat(indexableFields.getFields("suggest"), arrayContainingInAnyOrder(
             suggestField("suggestion")
         ));
-        assertThat(indexableFields.getFields("suggest.subsuggest"), array(
+        assertThat(indexableFields.getFields("suggest.subsuggest"), arrayContainingInAnyOrder(
             suggestField("suggestion")
         ));
     }
@@ -435,18 +431,15 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
             XContentType.JSON));
 
         ParseContext.Document indexableFields = parsedDocument.rootDoc();
-        //TODO how to assert about weight?
-        assertThat(indexableFields.getFields("completion"), array(
+        assertThat(indexableFields.getFields("completion"), arrayContainingInAnyOrder(
             suggestField("New York"),
             suggestField("NY")
         ));
-        assertThat(indexableFields.getFields("completion.analyzed"), array(
+        assertThat(indexableFields.getFields("completion.analyzed"), arrayContainingInAnyOrder(
             suggestField("New York"),
             suggestField("NY")
         ));
-
-        assertSuggestFields(indexableFields.getFields("completion"), 2);
-        assertThat(indexableFields.getFields("completion.analyzed"), arrayWithSize(2));
+        //unable to assert about weight, covered in a REST test
     }
 
     public void testCompletionTypeWithSubKeywordFieldAndObjectInsert() throws Exception {
@@ -475,17 +468,17 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
             XContentType.JSON));
 
         ParseContext.Document indexableFields = parsedDocument.rootDoc();
-        //TODO how to assert about weight?
-        assertThat(indexableFields.getFields("completion"), array(
+        assertThat(indexableFields.getFields("completion"), arrayContainingInAnyOrder(
             suggestField("New York"),
             suggestField("NY")
         ));
-        assertThat(indexableFields.getFields("completion.analyzed"), array(
+        assertThat(indexableFields.getFields("completion.analyzed"), arrayContainingInAnyOrder(
             keywordField("New York"),
             sortedSetDocValuesField("New York"),
             keywordField("NY"),
             sortedSetDocValuesField("NY")
         ));
+        //unable to assert about weight, covered in a REST test
     }
 
     public void testCompletionTypeWithSubKeywordFieldAndStringInsert() throws Exception {
@@ -511,10 +504,10 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
             XContentType.JSON));
 
         ParseContext.Document indexableFields = parsedDocument.rootDoc();
-        assertThat(indexableFields.getFields("completion"), array(
+        assertThat(indexableFields.getFields("completion"), arrayContainingInAnyOrder(
             suggestField("suggestion")
         ));
-        assertThat(indexableFields.getFields("completion.analyzed"), array(
+        assertThat(indexableFields.getFields("completion.analyzed"), arrayContainingInAnyOrder(
             keywordField("suggestion"),
             sortedSetDocValuesField("suggestion")
         ));
@@ -537,7 +530,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                         .endObject()),
                 XContentType.JSON));
         IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
-        assertThat(fields, array(
+        assertThat(fields, arrayContainingInAnyOrder(
             suggestField("suggestion1"),
             suggestField("suggestion2")
         ));
@@ -563,7 +556,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                         .endObject()),
                 XContentType.JSON));
         IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
-        assertThat(fields, array(
+        assertThat(fields, arrayContainingInAnyOrder(
             suggestField("suggestion")
         ));
     }
@@ -588,7 +581,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                         .endObject()),
                 XContentType.JSON));
         IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
-        assertThat(fields, array(
+        assertThat(fields, arrayContainingInAnyOrder(
             suggestField("suggestion1"),
             suggestField("suggestion2"),
             suggestField("suggestion3")
@@ -665,7 +658,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                         .endObject()),
                 XContentType.JSON));
         IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
-        assertThat(fields, array(
+        assertThat(fields, arrayContainingInAnyOrder(
             suggestField("suggestion1"),
             suggestField("suggestion2"),
             suggestField("suggestion3")
@@ -702,7 +695,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                         .endObject()),
                 XContentType.JSON));
         IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
-        assertThat(fields, array(
+        assertThat(fields, arrayContainingInAnyOrder(
             suggestField("suggestion1"),
             suggestField("suggestion2"),
             suggestField("suggestion3"),
@@ -920,16 +913,4 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
             }
         };
     }
-
-    private Matcher<IndexableField> contextSuggestField(String value ,Matcher<IndexableField> contextMatcher) {
-        return Matchers.allOf(hasProperty(IndexableField::stringValue, equalTo(value)),
-            Matchers.instanceOf(ContextSuggestField.class),
-            contextMatcher
-        );
-    }
-
-    private Matcher<IndexableField> withContext(Map<String, Set<String>> contexts) {
-        return null;
-    }
-
 }


### PR DESCRIPTION
Mappings with completion type and multi-fields, were not able to index array or
object format on completion fields. Only string format was supproted.
This is fixed by providing multiField parser with externalValueContext with already parsed object

closes #15115

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
