### PR TITLE
Support 'string'-style queries on metadata fields when reasonable.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredFieldMapper.java
@@ -85,7 +85,7 @@ public final class IgnoredFieldMapper extends MetadataFieldMapper {
         }
     }
 
-    public static final class IgnoredFieldType extends TermBasedFieldType {
+    public static final class IgnoredFieldType extends StringFieldType {
 
         public IgnoredFieldType() {
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -108,7 +108,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
         }
     }
 
-    static final class RoutingFieldType extends TermBasedFieldType {
+    static final class RoutingFieldType extends StringFieldType {
 
         RoutingFieldType() {
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredFieldTypeTests.java
@@ -21,7 +21,9 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 
@@ -30,6 +32,24 @@ public class IgnoredFieldTypeTests extends FieldTypeTestCase {
     @Override
     protected MappedFieldType createDefaultFieldType() {
         return new IgnoredFieldMapper.IgnoredFieldType();
+    }
+
+    public void testPrefixQuery() {
+        MappedFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+        ft.setIndexOptions(IndexOptions.DOCS);
+
+        Query expected = new PrefixQuery(new Term("field", new BytesRef("foo*")));
+        assertEquals(expected, ft.prefixQuery("foo*", null, null));
+    }
+
+    public void testRegexpQuery() {
+        MappedFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+        ft.setIndexOptions(IndexOptions.DOCS);
+
+        Query expected = new RegexpQuery(new Term("field", new BytesRef("foo?")));
+        assertEquals(expected, ft.regexpQuery("foo?", 0, 10, null, null));
     }
 
     public void testWildcardQuery() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredFieldTypeTests.java
@@ -19,6 +19,12 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.BytesRef;
+
 public class IgnoredFieldTypeTests extends FieldTypeTestCase {
 
     @Override
@@ -26,4 +32,12 @@ public class IgnoredFieldTypeTests extends FieldTypeTestCase {
         return new IgnoredFieldMapper.IgnoredFieldType();
     }
 
+    public void testWildcardQuery() {
+        MappedFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+        ft.setIndexOptions(IndexOptions.DOCS);
+
+        Query expected = new WildcardQuery(new Term("field", new BytesRef("foo*")));
+        assertEquals(expected, ft.wildcardQuery("foo*", null, null));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/RoutingFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RoutingFieldTypeTests.java
@@ -18,12 +18,24 @@
  */
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.RoutingFieldMapper;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.BytesRef;
 
 public class RoutingFieldTypeTests extends FieldTypeTestCase {
     @Override
     protected MappedFieldType createDefaultFieldType() {
         return new RoutingFieldMapper.RoutingFieldType();
+    }
+
+    public void testWildcardQuery() {
+        MappedFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+        ft.setIndexOptions(IndexOptions.DOCS);
+
+        Query expected = new WildcardQuery(new Term("field", new BytesRef("foo*")));
+        assertEquals(expected, ft.wildcardQuery("foo*", null, null));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/RoutingFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RoutingFieldTypeTests.java
@@ -20,7 +20,9 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 
@@ -28,6 +30,24 @@ public class RoutingFieldTypeTests extends FieldTypeTestCase {
     @Override
     protected MappedFieldType createDefaultFieldType() {
         return new RoutingFieldMapper.RoutingFieldType();
+    }
+
+    public void testPrefixQuery() {
+        MappedFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+        ft.setIndexOptions(IndexOptions.DOCS);
+
+        Query expected = new PrefixQuery(new Term("field", new BytesRef("foo*")));
+        assertEquals(expected, ft.prefixQuery("foo*", null, null));
+    }
+
+    public void testRegexpQuery() {
+        MappedFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+        ft.setIndexOptions(IndexOptions.DOCS);
+
+        Query expected = new RegexpQuery(new Term("field", new BytesRef("foo?")));
+        assertEquals(expected, ft.regexpQuery("foo?", 0, 10, null, null));
     }
 
     public void testWildcardQuery() {


### PR DESCRIPTION
This change has two components:
- Support `prefix` and `regexp` queries on `_index` fields for consistency, since we already support `wildcard` queries.
- Update `ignored` and `routing` field types to inherit from `StringFieldType`, which allows them to support 'string'-style queries like `prefix`, `regex`, and `wildcard`. We temporarily removed support for `wildcard` as part of the refactor in #34062, and this PR restores that support for compatibility, and also makes sure the other query types are implemented for consistency.

Note that we may eventually deprecate support for 'string'-style queries on `ignored` and `routing` fields, pending a separate discussion.