### PR TITLE
Fix remote cluster seeds fallback

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.SettingUpgrader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.common.util.set.Sets;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
@@ -31,17 +31,22 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.SettingUpgrader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.set.Sets;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -181,12 +186,36 @@ public abstract class RemoteClusterAware extends AbstractComponent {
      * {@link TransportAddress#META_ADDRESS} and their configured address will be used as the hostname for the generated discovery node.
      */
     protected static Map<String, Tuple<String, List<Supplier<DiscoveryNode>>>> buildRemoteClustersDynamicConfig(Settings settings) {
-        Stream<Setting<List<String>>> allConcreteSettings = REMOTE_CLUSTERS_SEEDS.getAllConcreteSettings(settings);
+        final Map<String, Tuple<String, List<Supplier<DiscoveryNode>>>> remoteSeeds =
+                buildRemoteClustersDynamicConfig(settings, REMOTE_CLUSTERS_SEEDS);
+        final Map<String, Tuple<String, List<Supplier<DiscoveryNode>>>> searchRemoteSeeds =
+                buildRemoteClustersDynamicConfig(settings, SEARCH_REMOTE_CLUSTERS_SEEDS);
+        // sort the intersection for predictable output order
+        final NavigableSet<String> intersection =
+                new TreeSet<>(Arrays.asList(
+                        searchRemoteSeeds.keySet().stream().filter(s -> remoteSeeds.keySet().contains(s)).sorted().toArray(String[]::new)));
+        if (intersection.isEmpty() == false) {
+            final String message = String.format(
+                    Locale.ROOT,
+                    "found duplicate remote cluster configurations for cluster alias%s [%s]",
+                    intersection.size() == 1 ? "" : "es",
+                    String.join(",", intersection));
+            throw new IllegalArgumentException(message);
+        }
+        return Stream
+                .concat(remoteSeeds.entrySet().stream(), searchRemoteSeeds.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private static Map<String, Tuple<String, List<Supplier<DiscoveryNode>>>> buildRemoteClustersDynamicConfig(
+            final Settings settings, final Setting.AffixSetting<List<String>> seedsSetting) {
+        final Stream<Setting<List<String>>> allConcreteSettings = seedsSetting.getAllConcreteSettings(settings);
         return allConcreteSettings.collect(
-                Collectors.toMap(REMOTE_CLUSTERS_SEEDS::getNamespace, concreteSetting -> {
-                    String clusterName = REMOTE_CLUSTERS_SEEDS.getNamespace(concreteSetting);
+                Collectors.toMap(seedsSetting::getNamespace, concreteSetting -> {
+                    String clusterName = seedsSetting.getNamespace(concreteSetting);
                     List<String> addresses = concreteSetting.get(settings);
-                    final boolean proxyMode = REMOTE_CLUSTERS_PROXY.getConcreteSettingForNamespace(clusterName).exists(settings);
+                    final boolean proxyMode =
+                            REMOTE_CLUSTERS_PROXY.getConcreteSettingForNamespace(clusterName).existsOrFallbackExists(settings);
                     List<Supplier<DiscoveryNode>> nodes = new ArrayList<>(addresses.size());
                     for (String address : addresses) {
                         nodes.add(() -> buildSeedNode(clusterName, address, proxyMode));


### PR DESCRIPTION
Recently we introduced the settings `cluster.remote` to take the place of `search.remote` for configuring remote cluster connections. We made this change due to the fact that we have generalized the remote cluster infrastructure to also be used within cross-cluster replication and not only cross-cluster search. For backwards compatibility, when we made this change, we allowed that `cluster.remote` would fallback to `search.remote`. Alas, the initial change for this contained a bug for handling the `proxy` and `seeds` settings. The bug for the `seeds` settings arose because we were manually iterating over the concrete settings only for `cluster.remote` seeds but not for `search.remote` seeds. This commit addresses this by iterating over both `cluster.remote` seeds and `search.remote` seeds. Additionally, when checking for existence of proxy settings, we have to not only check `cluster.remote` proxy settings, but also fallback to `search.remote` proxy settings. This commit addresses both issues, and adds tests for these situations.

Relates #33413 