### PR TITLE
TESTS: Enable DEBUG Logging in Flaky Test

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -53,6 +53,7 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.mocksocket.MockServerSocket;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.test.transport.StubbableTransport;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -834,6 +835,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
         }
     }
 
+    @TestLogging("_root:DEBUG, org.elasticsearch.transport:TRACE")
     public void testCloseWhileConcurrentlyConnecting() throws IOException, InterruptedException, BrokenBarrierException {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT);


### PR DESCRIPTION
* This should surface what errors are thrown on CI
and in org.elasticsearch.transport.RemoteClusterConnection.ConnectHandler#collectRemoteNodes
(the sequence of caught error in the last catch block (https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java#L544) and moving on to the next seed node seems to be the only path by which the error logged in #33756  (`RuntimeException` without message from a successful connect callback and then subsequent cancellation because closed exception on the same listener) could come about)
* Relates #33756

------------------------------------------

Can't reproduce the issue in #33756 at all locally (tried 100k+ runs on OSX, Ubuntu and CentOS), but I think this should make it relatively straightforward to track this down.