### PR TITLE
When creating wildcard queries, use MatchNoDocsQuery when the field type doesn't exist.

### DIFF
--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -33,6 +33,7 @@ import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
@@ -167,7 +168,9 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query wildcardQuery(String value, QueryShardContext context) {
+        public Query wildcardQuery(String value,
+                                   @Nullable MultiTermQuery.RewriteMethod method,
+                                   QueryShardContext context) {
             throw new UnsupportedOperationException("[wildcard] queries are not supported on [" + CONTENT_TYPE + "] fields.");
         }
 

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/CollationFieldTypeTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/CollationFieldTypeTests.java
@@ -126,7 +126,7 @@ public class CollationFieldTypeTests extends FieldTypeTestCase {
         ft.setName("field");
         ft.setIndexOptions(IndexOptions.DOCS);
         expectThrows(UnsupportedOperationException.class,
-            () -> ft.wildcardQuery("foo*", null));
+            () -> ft.wildcardQuery("foo*", null, null));
     }
 
     public void testRangeQuery() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Nullable;
@@ -151,7 +152,9 @@ public class IndexFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public Query wildcardQuery(String value, QueryShardContext context) {
+        public Query wildcardQuery(String value,
+                                   @Nullable MultiTermQuery.RewriteMethod method,
+                                   QueryShardContext context) {
             if (isSameIndex(value, context.getFullyQualifiedIndex().getName())) {
                 return Queries.newMatchAllQuery();
             } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -345,7 +345,9 @@ public abstract class MappedFieldType extends FieldType {
         throw new QueryShardException(context, "Can only use prefix queries on keyword and text fields - not on [" + name + "] which is of type [" + typeName() + "]");
     }
 
-    public Query wildcardQuery(String value, QueryShardContext context) {
+    public Query wildcardQuery(String value,
+                               @Nullable MultiTermQuery.RewriteMethod method,
+                               QueryShardContext context) {
         throw new QueryShardException(context, "Can only use wildcard queries on keyword and text fields - not on [" + name + "] which is of type [" + typeName() + "]");
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
@@ -19,23 +19,24 @@
 
 package org.elasticsearch.index.mapper;
 
-import java.util.List;
-
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
-import org.apache.lucene.search.TermInSetQuery;
-import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RegexpQuery;
+import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.support.QueryParsers;
+
+import java.util.List;
 
 /** Base class for {@link MappedFieldType} implementations that use the same
  * representation for internal index terms as the external representation so
@@ -78,13 +79,16 @@ public abstract class StringFieldType extends TermBasedFieldType {
     }
 
     @Override
-    public Query wildcardQuery(String value, QueryShardContext context) {
+    public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, QueryShardContext context) {
         Query termQuery = termQuery(value, context);
         if (termQuery instanceof MatchNoDocsQuery || termQuery instanceof MatchAllDocsQuery) {
             return termQuery;
         }
         Term term = MappedFieldType.extractTerm(termQuery);
-        return new WildcardQuery(term);
+
+        WildcardQuery query = new WildcardQuery(term);
+        QueryParsers.setRewriteMethod(query, method);
+        return query;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.index.Term;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
@@ -70,13 +69,19 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
 
     @Override
     protected void doAssertLuceneQuery(WildcardQueryBuilder queryBuilder, Query query, SearchContext context) throws IOException {
-        assertThat(query, instanceOf(WildcardQuery.class));
-        WildcardQuery wildcardQuery = (WildcardQuery) query;
-
         String expectedFieldName = expectedFieldName(queryBuilder.fieldName());
-        assertThat(wildcardQuery.getField(), equalTo(expectedFieldName));
-        assertThat(wildcardQuery.getTerm().field(), equalTo(expectedFieldName));
-        assertThat(wildcardQuery.getTerm().text(), equalTo(queryBuilder.value()));
+
+        if (expectedFieldName.equals(STRING_FIELD_NAME)) {
+            assertThat(query, instanceOf(WildcardQuery.class));
+            WildcardQuery wildcardQuery = (WildcardQuery) query;
+
+            assertThat(wildcardQuery.getField(), equalTo(expectedFieldName));
+            assertThat(wildcardQuery.getTerm().field(), equalTo(expectedFieldName));
+            assertThat(wildcardQuery.getTerm().text(), equalTo(queryBuilder.value()));
+        } else {
+            Query expected = new MatchNoDocsQuery("unknown field [" + expectedFieldName + "]");
+            assertEquals(expected, query);
+        }
     }
 
     public void testIllegalArguments() {
@@ -92,7 +97,7 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
     public void testEmptyValue() throws IOException {
         QueryShardContext context = createShardContext();
         context.setAllowUnmappedFields(true);
-        WildcardQueryBuilder wildcardQueryBuilder = new WildcardQueryBuilder("doc", "");
+        WildcardQueryBuilder wildcardQueryBuilder = new WildcardQueryBuilder(STRING_FIELD_NAME, "");
         assertEquals(wildcardQueryBuilder.toQuery(context).getClass(), WildcardQuery.class);
     }
 
@@ -128,16 +133,6 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
                 "}";
         e = expectThrows(ParsingException.class, () -> parseQuery(shortJson));
         assertEquals("[wildcard] query doesn't support multiple fields, found [user1] and [user2]", e.getMessage());
-    }
-
-    public void testWithMetaDataField() throws IOException {
-        QueryShardContext context = createShardContext();
-        for (String field : new String[]{"field1", "field2"}) {
-            WildcardQueryBuilder wildcardQueryBuilder = new WildcardQueryBuilder(field, "toto");
-            Query query = wildcardQueryBuilder.toQuery(context);
-            Query expected = new WildcardQuery(new Term(field, "toto"));
-            assertEquals(expected, query);
-        }
     }
 
     public void testIndexWildcard() throws IOException {


### PR DESCRIPTION
Follow-up from #34062.