### PR TITLE
Watcher: Reenable watcher stats REST tests

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/watcher/usage/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/watcher/usage/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 "Test watcher usage stats output":
-  - skip:
-      version: "all"
-      reason: AwaitsFix at https://github.com/elastic/elasticsearch/issues/33326
   - do:
       catch: missing
       xpack.watcher.delete_watch:


### PR DESCRIPTION
Due to a bug, that was fixed in #33360 and commit
1de2a925ce8bf30d53ad71dfcd6e33ebbf7827c6 the initial adding of a watch
could get lost.

Closes #33326
