### PR TITLE
Fix rpm install on Fedora 28

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -37,7 +37,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.netflix.nebula:gradle-ospackage-plugin:3.4.0'
+    classpath 'com.netflix.nebula:gradle-ospackage-plugin:4.7.1'
   }
 }
 


### PR DESCRIPTION
Could not find a bug report, but the problem is gone the version we use in 6.x 
This affects 5.6 only, newer branches use already use version `4.7.1` of the plugin.

Fixes #34087