### PR TITLE
[DOCS] Moves reserved keywords under SQL section

### DIFF
--- a/docs/reference/sql/appendix/syntax-reserved.asciidoc
+++ b/docs/reference/sql/appendix/syntax-reserved.asciidoc
@@ -1,8 +1,7 @@
 [role="xpack"]
 [testenv="basic"]
-[appendix]
 [[sql-syntax-reserved]]
-= Reserved keywords
+== Reserved keywords
 
 Table with reserved keywords that need to be quoted. Also provide an example to make it more obvious.
 


### PR DESCRIPTION
The SQL reserved keywords page appears in a strange place in the Elasticsearch Reference:

![image](https://user-images.githubusercontent.com/26471269/46174085-eafc8e80-c25c-11e8-8b72-d6c8fb163f7e.png)

This PR moves it under the "SQL access" section:

![image](https://user-images.githubusercontent.com/26471269/46174331-986fa200-c25d-11e8-933d-f672ee43f72d.png)
