### PR TITLE
[Docs] Updating URL for Openstack Swift plugin

### DIFF
--- a/docs/plugins/repository.asciidoc
+++ b/docs/plugins/repository.asciidoc
@@ -32,7 +32,7 @@ The GCS repository plugin adds support for using Google Cloud Storage service as
 
 The following plugin has been contributed by our community:
 
-* https://github.com/wikimedia/search-repository-swift[Openstack Swift] (by Wikimedia Foundation)
+* https://github.com/BigDataBoutique/elasticsearch-repository-swift[Openstack Swift] (by Wikimedia Foundation and BigData Boutique)
 
 
 include::repository-azure.asciidoc[]


### PR DESCRIPTION
The repository plugin for Openstack Swift was developed originally by Wikimedia foundation but is now retired. We took over it and now have a 6.x compatible version with tests. We are still testing but the up-to-date version is in our fork.
