### PR TITLE
[Docs] remove double words

### DIFF
--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -19,7 +19,7 @@ are tests even if they don't have `// CONSOLE` but usually `// TEST` is used
 for its modifiers:
   * `// TEST[s/foo/bar/]`: Replace `foo` with `bar` in the generated test. This
   should be used sparingly because it makes the snippet "lie". Sometimes,
-  though, you can use it to make the snippet more clear. Keep in mind the that
+  though, you can use it to make the snippet more clear. Keep in mind that
   if there are multiple substitutions then they are applied in the order that
   they are defined.
   * `// TEST[catch:foo]`: Used to expect errors in the requests. Replace `foo`

--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -19,9 +19,9 @@ are tests even if they don't have `// CONSOLE` but usually `// TEST` is used
 for its modifiers:
   * `// TEST[s/foo/bar/]`: Replace `foo` with `bar` in the generated test. This
   should be used sparingly because it makes the snippet "lie". Sometimes,
-  though, you can use it to make the snippet more clear more clear. Keep in
-  mind the that if there are multiple substitutions then they are applied in
-  the order that they are defined.
+  though, you can use it to make the snippet more clear. Keep in mind the that
+  if there are multiple substitutions then they are applied in the order that
+  they are defined.
   * `// TEST[catch:foo]`: Used to expect errors in the requests. Replace `foo`
   with `request` to expect a 400 error, for example. If the snippet contains
   multiple requests then only the last request will expect the error.


### PR DESCRIPTION
removes double wording

Note: Afaik internal docs, not published outside of github