### PR TITLE
[DOCS] fix typo in API call (missing a dot '.') for max_file_descriptors

### DIFF
--- a/docs/reference/setup/sysconfig/file-descriptors.asciidoc
+++ b/docs/reference/setup/sysconfig/file-descriptors.asciidoc
@@ -27,6 +27,6 @@ using the <<cluster-nodes-stats>> API, with:
 
 [source,js]
 --------------------------------------------------
-GET _nodes/stats/process?filter_path=**.max_file_descriptors
+GET _nodes/stats/process?filter_path=*.*.max_file_descriptors
 --------------------------------------------------
 // CONSOLE


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
