### PR TITLE
[DOCS] Note that User Cluster Metadata is not private

### DIFF
--- a/docs/reference/modules/cluster/misc.asciidoc
+++ b/docs/reference/modules/cluster/misc.asciidoc
@@ -43,11 +43,11 @@ PUT /_cluster/settings
 -------------------------------
 // CONSOLE
 
-NOTE: User-defined cluster metadata is not intended to store sensitive or
+IMPORTANT: User-defined cluster metadata is not intended to store sensitive or
 confidential information. Any information stored in user-defined cluster
 metadata will be viewable by anyone with access to the
 <<cluster-get-settings,Cluster Get Settings>> API, and is recorded in the
-Elasticsearch logs.
+{es} logs.
 
 [[cluster-max-tombstones]]
 ==== Index Tombstones

--- a/docs/reference/modules/cluster/misc.asciidoc
+++ b/docs/reference/modules/cluster/misc.asciidoc
@@ -43,6 +43,12 @@ PUT /_cluster/settings
 -------------------------------
 // CONSOLE
 
+NOTE: User-defined cluster metadata is not intended to store sensitive or
+confidential information. Any information stored in user-defined cluster
+metadata will be viewable by anyone with access to the
+<<cluster-get-settings,Cluster Get Settings>> API, and is recorded in the
+Elasticsearch logs.
+
 [[cluster-max-tombstones]]
 ==== Index Tombstones
 


### PR DESCRIPTION
As user-defined cluster metadata is accessible to anyone with access to
get the cluster settings, stored in the logs, and likely to be tracked
by monitoring solutions, it is useful to clarify in the documentation
that it should not be used to store secret information.

Per discussion in #34023