### PR TITLE
Removing unused ML parameters

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -168,7 +168,6 @@ import org.elasticsearch.xpack.ml.job.categorization.MlClassicTokenizerFactory;
 import org.elasticsearch.xpack.ml.job.persistence.JobDataCountsPersister;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
-import org.elasticsearch.xpack.ml.job.process.DataCountsReporter;
 import org.elasticsearch.xpack.ml.job.process.NativeController;
 import org.elasticsearch.xpack.ml.job.process.NativeControllerHolder;
 import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectBuilder;
@@ -293,10 +292,6 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                         AutodetectBuilder.DONT_PERSIST_MODEL_STATE_SETTING,
                         AutodetectBuilder.MAX_ANOMALY_RECORDS_SETTING,
                         AutodetectBuilder.MAX_ANOMALY_RECORDS_SETTING_DYNAMIC,
-                        DataCountsReporter.ACCEPTABLE_PERCENTAGE_DATE_PARSE_ERRORS_SETTING,
-                        DataCountsReporter.MAX_ACCEPTABLE_PERCENT_OF_DATE_PARSE_ERRORS_SETTING,
-                        DataCountsReporter.ACCEPTABLE_PERCENTAGE_OUT_OF_ORDER_ERRORS_SETTING,
-                        DataCountsReporter.MAX_ACCEPTABLE_PERCENT_OF_OUT_OF_ORDER_ERRORS_SETTING,
                         AutodetectProcessManager.MAX_RUNNING_JOBS_PER_NODE,
                         AutodetectProcessManager.MAX_OPEN_JOBS_PER_NODE,
                         AutodetectProcessManager.MIN_DISK_SPACE_OFF_HEAP));
@@ -405,7 +400,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME));
         AutodetectProcessManager autodetectProcessManager = new AutodetectProcessManager(env, settings, client, threadPool,
                 jobManager, jobResultsProvider, jobResultsPersister, jobDataCountsPersister, autodetectProcessFactory,
-                normalizerFactory, xContentRegistry, auditor, clusterService);
+                normalizerFactory, xContentRegistry, auditor);
         this.autodetectProcessManager.set(autodetectProcessManager);
         DatafeedJobBuilder datafeedJobBuilder = new DatafeedJobBuilder(client, jobResultsProvider, auditor, System::currentTimeMillis);
         DatafeedManager datafeedManager = new DatafeedManager(threadPool, client, clusterService, datafeedJobBuilder,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -9,7 +9,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
@@ -131,13 +130,12 @@ public class AutodetectProcessManager extends AbstractComponent {
     private final NamedXContentRegistry xContentRegistry;
 
     private final Auditor auditor;
-    private final ClusterService clusterService;
 
     public AutodetectProcessManager(Environment environment, Settings settings, Client client, ThreadPool threadPool,
                                     JobManager jobManager, JobResultsProvider jobResultsProvider, JobResultsPersister jobResultsPersister,
                                     JobDataCountsPersister jobDataCountsPersister,
                                     AutodetectProcessFactory autodetectProcessFactory, NormalizerFactory normalizerFactory,
-                                    NamedXContentRegistry xContentRegistry, Auditor auditor, ClusterService clusterService) {
+                                    NamedXContentRegistry xContentRegistry, Auditor auditor) {
         super(settings);
         this.environment = environment;
         this.client = client;
@@ -152,7 +150,6 @@ public class AutodetectProcessManager extends AbstractComponent {
         this.jobDataCountsPersister = jobDataCountsPersister;
         this.auditor = auditor;
         this.nativeStorageProvider = new NativeStorageProvider(environment, MIN_DISK_SPACE_OFF_HEAP.get(settings));
-        this.clusterService = clusterService;
     }
 
     public void onNodeStartup() {
@@ -499,8 +496,7 @@ public class AutodetectProcessManager extends AbstractComponent {
         DataCountsReporter dataCountsReporter = new DataCountsReporter(settings,
             job,
             autodetectParams.dataCounts(),
-            jobDataCountsPersister,
-            clusterService);
+            jobDataCountsPersister);
         ScoresUpdater scoresUpdater = new ScoresUpdater(job, jobResultsProvider,
                 new JobRenormalizedResultsPersister(job.getId(), settings, client), normalizerFactory);
         ExecutorService renormalizerExecutorService = threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/CountingInputStreamTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/CountingInputStreamTests.java
@@ -5,44 +5,18 @@
  */
 package org.elasticsearch.xpack.ml.job.process;
 
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.settings.ClusterSettings;
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
-import org.junit.Before;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.elasticsearch.mock.orig.Mockito.when;
-import static org.mockito.Mockito.mock;
 
 public class CountingInputStreamTests extends ESTestCase {
 
-    private ClusterService clusterService;
-
-    @Before
-    public void setUpMocks() {
-        Settings settings = Settings.builder().put(DataCountsReporter.MAX_ACCEPTABLE_PERCENT_OF_DATE_PARSE_ERRORS_SETTING.getKey(), 10)
-            .put(DataCountsReporter.MAX_ACCEPTABLE_PERCENT_OF_OUT_OF_ORDER_ERRORS_SETTING.getKey(), 10)
-            .build();
-        Set<Setting<?>> setOfSettings = new HashSet<>();
-        setOfSettings.add(DataCountsReporter.MAX_ACCEPTABLE_PERCENT_OF_DATE_PARSE_ERRORS_SETTING);
-        setOfSettings.add(DataCountsReporter.MAX_ACCEPTABLE_PERCENT_OF_OUT_OF_ORDER_ERRORS_SETTING);
-        ClusterSettings clusterSettings = new ClusterSettings(settings, setOfSettings);
-
-        clusterService = mock(ClusterService.class);
-        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
-    }
-
     public void testRead_OneByteAtATime() throws IOException {
 
-        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter(clusterService);
+        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter();
 
         final String TEXT = "123";
         InputStream source = new ByteArrayInputStream(TEXT.getBytes(StandardCharsets.UTF_8));
@@ -56,7 +30,7 @@ public class CountingInputStreamTests extends ESTestCase {
     public void testRead_WithBuffer() throws IOException {
         final String TEXT = "To the man who only has a hammer, everything he encounters begins to look like a nail.";
 
-        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter(clusterService);
+        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter();
 
         InputStream source = new ByteArrayInputStream(TEXT.getBytes(StandardCharsets.UTF_8));
 
@@ -70,7 +44,7 @@ public class CountingInputStreamTests extends ESTestCase {
     public void testRead_WithTinyBuffer() throws IOException {
         final String TEXT = "To the man who only has a hammer, everything he encounters begins to look like a nail.";
 
-        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter(clusterService);
+        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter();
 
         InputStream source = new ByteArrayInputStream(TEXT.getBytes(StandardCharsets.UTF_8));
 
@@ -83,7 +57,7 @@ public class CountingInputStreamTests extends ESTestCase {
 
     public void testRead_WithResets() throws IOException {
 
-        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter(clusterService);
+        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter();
 
         final String TEXT = "To the man who only has a hammer, everything he encounters begins to look like a nail.";
         InputStream source = new ByteArrayInputStream(TEXT.getBytes(StandardCharsets.UTF_8));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/DataCountsReporterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/DataCountsReporterTests.java
@@ -6,9 +6,6 @@
 package org.elasticsearch.xpack.ml.job.process;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.settings.ClusterSettings;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.env.Environment;
@@ -25,33 +22,24 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.mock.orig.Mockito.when;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 public class DataCountsReporterTests extends ESTestCase {
-    private static final int MAX_PERCENT_DATE_PARSE_ERRORS = 40;
-    private static final int MAX_PERCENT_OUT_OF_ORDER_ERRORS = 30;
 
     private Job job;
     private JobDataCountsPersister jobDataCountsPersister;
     private Settings settings;
     private TimeValue bucketSpan = TimeValue.timeValueSeconds(300);
-    private ClusterService clusterService;
 
     @Before
     public void setUpMocks() {
         settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
-                .put(DataCountsReporter.MAX_ACCEPTABLE_PERCENT_OF_DATE_PARSE_ERRORS_SETTING.getKey(), MAX_PERCENT_DATE_PARSE_ERRORS)
-                .put(DataCountsReporter.MAX_ACCEPTABLE_PERCENT_OF_OUT_OF_ORDER_ERRORS_SETTING.getKey(), MAX_PERCENT_OUT_OF_ORDER_ERRORS)
                 .build();
 
         AnalysisConfig.Builder acBuilder = new AnalysisConfig.Builder(Arrays.asList(new Detector.Builder("metric", "field").build()));
@@ -59,14 +47,6 @@ public class DataCountsReporterTests extends ESTestCase {
         acBuilder.setLatency(TimeValue.ZERO);
         acBuilder.setDetectors(Arrays.asList(new Detector.Builder("metric", "field").build()));
 
-
-        Set<Setting<?>> setOfSettings = new HashSet<>();
-        setOfSettings.add(DataCountsReporter.MAX_ACCEPTABLE_PERCENT_OF_DATE_PARSE_ERRORS_SETTING);
-        setOfSettings.add(DataCountsReporter.MAX_ACCEPTABLE_PERCENT_OF_OUT_OF_ORDER_ERRORS_SETTING);
-        ClusterSettings clusterSettings = new ClusterSettings(settings, setOfSettings);
-
-        clusterService = mock(ClusterService.class);
-        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
         Job.Builder builder = new Job.Builder("sr");
         builder.setAnalysisConfig(acBuilder);
@@ -76,16 +56,9 @@ public class DataCountsReporterTests extends ESTestCase {
         jobDataCountsPersister = Mockito.mock(JobDataCountsPersister.class);
     }
 
-    public void testSettingAcceptablePercentages() throws IOException {
-        DataCountsReporter dataCountsReporter = new DataCountsReporter(settings, job, new DataCounts(job.getId()),
-                jobDataCountsPersister, clusterService);
-        assertEquals(dataCountsReporter.getAcceptablePercentDateParseErrors(), MAX_PERCENT_DATE_PARSE_ERRORS);
-        assertEquals(dataCountsReporter.getAcceptablePercentOutOfOrderErrors(), MAX_PERCENT_OUT_OF_ORDER_ERRORS);
-    }
-
     public void testSimpleConstructor() throws Exception {
         DataCountsReporter dataCountsReporter = new DataCountsReporter(settings, job, new DataCounts(job.getId()),
-                jobDataCountsPersister, clusterService);
+                jobDataCountsPersister);
         DataCounts stats = dataCountsReporter.incrementalStats();
         assertNotNull(stats);
         assertAllCountFieldsEqualZero(stats);
@@ -96,7 +69,7 @@ public class DataCountsReporterTests extends ESTestCase {
                 new Date(), new Date(), new Date(), new Date(), new Date());
 
         DataCountsReporter dataCountsReporter =
-                new DataCountsReporter(settings, job, counts, jobDataCountsPersister, clusterService);
+                new DataCountsReporter(settings, job, counts, jobDataCountsPersister);
         DataCounts stats = dataCountsReporter.incrementalStats();
         assertNotNull(stats);
         assertAllCountFieldsEqualZero(stats);
@@ -114,7 +87,7 @@ public class DataCountsReporterTests extends ESTestCase {
 
     public void testResetIncrementalCounts() throws Exception {
         DataCountsReporter dataCountsReporter = new DataCountsReporter(settings, job, new DataCounts(job.getId()),
-                jobDataCountsPersister, clusterService);
+                jobDataCountsPersister);
         DataCounts stats = dataCountsReporter.incrementalStats();
         assertNotNull(stats);
         assertAllCountFieldsEqualZero(stats);
@@ -167,7 +140,7 @@ public class DataCountsReporterTests extends ESTestCase {
 
     public void testReportLatestTimeIncrementalStats() throws IOException {
         DataCountsReporter dataCountsReporter = new DataCountsReporter(settings, job, new DataCounts(job.getId()),
-                jobDataCountsPersister, clusterService);
+                jobDataCountsPersister);
         dataCountsReporter.startNewIncrementalCount();
         dataCountsReporter.reportLatestTimeIncrementalStats(5001L);
         assertEquals(5001L, dataCountsReporter.incrementalStats().getLatestRecordTimeStamp().getTime());
@@ -175,7 +148,7 @@ public class DataCountsReporterTests extends ESTestCase {
 
     public void testReportRecordsWritten() {
         DataCountsReporter dataCountsReporter = new DataCountsReporter(settings, job, new DataCounts(job.getId()),
-                jobDataCountsPersister, clusterService);
+                jobDataCountsPersister);
         dataCountsReporter.setAnalysedFieldsPerRecord(3);
 
         dataCountsReporter.reportRecordWritten(5, 2000);
@@ -199,7 +172,7 @@ public class DataCountsReporterTests extends ESTestCase {
     }
 
     public void testReportRecordsWritten_Given9999Records() {
-        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter(clusterService);
+        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter();
         dataCountsReporter.setAnalysedFieldsPerRecord(3);
 
         for (int i = 1; i <= 9999; i++) {
@@ -216,7 +189,7 @@ public class DataCountsReporterTests extends ESTestCase {
     }
 
     public void testReportRecordsWritten_Given30000Records() {
-        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter(clusterService);
+        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter();
         dataCountsReporter.setAnalysedFieldsPerRecord(3);
 
         for (int i = 1; i <= 30001; i++) {
@@ -233,7 +206,7 @@ public class DataCountsReporterTests extends ESTestCase {
     }
 
     public void testReportRecordsWritten_Given100_000Records() {
-        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter(clusterService);
+        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter();
         dataCountsReporter.setAnalysedFieldsPerRecord(3);
 
         for (int i = 1; i <= 100000; i++) {
@@ -250,7 +223,7 @@ public class DataCountsReporterTests extends ESTestCase {
     }
 
     public void testReportRecordsWritten_Given1_000_000Records() {
-        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter(clusterService);
+        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter();
         dataCountsReporter.setAnalysedFieldsPerRecord(3);
 
         for (int i = 1; i <= 1_000_000; i++) {
@@ -267,7 +240,7 @@ public class DataCountsReporterTests extends ESTestCase {
     }
 
     public void testReportRecordsWritten_Given2_000_000Records() {
-        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter(clusterService);
+        DummyDataCountsReporter dataCountsReporter = new DummyDataCountsReporter();
         dataCountsReporter.setAnalysedFieldsPerRecord(3);
 
         for (int i = 1; i <= 2_000_000; i++) {
@@ -286,7 +259,7 @@ public class DataCountsReporterTests extends ESTestCase {
 
     public void testFinishReporting() {
         DataCountsReporter dataCountsReporter = new DataCountsReporter(settings, job, new DataCounts(job.getId()),
-                jobDataCountsPersister, clusterService);
+                jobDataCountsPersister);
 
         dataCountsReporter.setAnalysedFieldsPerRecord(3);
         Date now = new Date();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/DummyDataCountsReporter.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/DummyDataCountsReporter.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.ml.job.process;
 
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
@@ -27,9 +26,9 @@ class DummyDataCountsReporter extends DataCountsReporter {
 
     int logStatusCallCount = 0;
 
-    DummyDataCountsReporter(ClusterService clusterService) {
+    DummyDataCountsReporter() {
         super(Settings.EMPTY, createJob(), new DataCounts("DummyJobId"),
-                mock(JobDataCountsPersister.class), clusterService);
+                mock(JobDataCountsPersister.class));
     }
 
     /**


### PR DESCRIPTION
There are two unused parameters currently in the ML code `ACCEPTABLE_PERCENTAGE_DATE_PARSE_ERRORS_SETTING` and `ACCEPTABLE_PERCENTAGE_OUT_OF_ORDER_ERRORS_SETTING`. Recently, versions that support dynamic updating were added and are no longer necessary either.

