### PR TITLE
Checkstyle: Catch wide snippets

### DIFF
--- a/buildSrc/src/main/resources/checkstyle.xml
+++ b/buildSrc/src/main/resources/checkstyle.xml
@@ -12,9 +12,23 @@
 
   <!-- Checks Java files and forbids empty Javadoc comments -->
   <module name="RegexpMultiline">
+    <property name="id" value="EmptyJavadoc"/>
     <property name="format" value="\/\*[\s\*]*\*\/"/>
     <property name="fileExtensions" value="java"/>
     <property name="message" value="Empty javadoc comments are forbidden"/>
+  </module>
+
+  <!-- 
+    We include snippets that are wrapped in `// tag` and `// end` into the
+    docs, stripping the leading spaces. If the context is wider than 76
+    characters then it'll need to scroll. This fails the build if it sees
+    such snippets.
+  -->
+  <module name="RegexpMultiline">
+    <property name="id" value="SnippetLength"/>
+    <property name="format" value="^( *)\/\/\s*tag(.+)\s*\n(.*\n)*\1.{77,}\n(.*\n)*\1\/\/\s*end\2\s*$"/>
+    <property name="fileExtensions" value="java"/>
+    <property name="message" value="Code snippets longer than 76 characters get cut off when rendered in the docs"/>
   </module>
 
   <module name="TreeWalker">

--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -42,7 +42,11 @@
   <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]StoredScriptsDocumentationIT.java" id="SnippetLength" />
   <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]TasksClientDocumentationIT.java" id="SnippetLength" />
   <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]WatcherDocumentationIT.java" id="SnippetLength" />
-  <suppress files="plugins[/\\]examples[/\\]script-expert-scoring[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]example[/\\]expertscript[/\\]ExpertScriptPlugin.java" id="SnippetLength" />
+  <!--
+    This one is in plugins/examples/script-expert-scoring but we need to
+    suppress it like this because we build that project twice, once in for
+    real and once as a test for our build system. -->
+  <suppress files="src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]example[/\\]expertscript[/\\]ExpertScriptPlugin.java" id="SnippetLength" />
   <suppress files="modules[/\\]reindex[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]ReindexDocumentationIT.jav" id="SnippetLength" />
 
   <!-- Hopefully temporary suppression of LineLength on files that don't pass it. We should remove these when we the

--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -21,6 +21,30 @@
     configuration of classes that aren't in packages. -->
   <suppress files="test[/\\]framework[/\\]src[/\\]test[/\\]java[/\\]Dummy.java" checks="PackageDeclaration" />
 
+  <!--
+    Truly temporary suppressions suppression of snippets included in
+    documentation that are so wide that they scroll.
+  -->
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]CRUDDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]ClusterClientDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]GraphDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]IndicesClientDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]IngestClientDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]LicensingDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]MigrationDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]MigrationClientDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]MiscellaneousDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]MlClientDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]RollupDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]SearchDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]SecurityDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]SnapshotClientDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]StoredScriptsDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]TasksClientDocumentationIT.java" id="SnippetLength" />
+  <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]WatcherDocumentationIT.java" id="SnippetLength" />
+  <suppress files="plugins[/\\]examples[/\\]script-expert-scoring[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]example[/\\]expertscript[/\\]ExpertScriptPlugin.java" id="SnippetLength" />
+  <suppress files="modules[/\\]reindex[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]ReindexDocumentationIT.jav" id="SnippetLength" />
+
   <!-- Hopefully temporary suppression of LineLength on files that don't pass it. We should remove these when we the
     files start to pass. -->
   <suppress files="client[/\\]rest[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]HeapBufferedAsyncResponseConsumerTests.java" checks="LineLength" />

--- a/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
@@ -45,6 +45,7 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
@@ -93,8 +94,8 @@ public class RestClientDocumentation {
 
         //tag::rest-client-init
         RestClient restClient = RestClient.builder(
-                new HttpHost("localhost", 9200, "http"),
-                new HttpHost("localhost", 9201, "http")).build();
+            new HttpHost("localhost", 9200, "http"),
+            new HttpHost("localhost", 9201, "http")).build();
         //end::rest-client-init
 
         //tag::rest-client-close
@@ -103,26 +104,30 @@ public class RestClientDocumentation {
 
         {
             //tag::rest-client-init-default-headers
-            RestClientBuilder builder = RestClient.builder(new HttpHost("localhost", 9200, "http"));
+            RestClientBuilder builder = RestClient.builder(
+                new HttpHost("localhost", 9200, "http"));
             Header[] defaultHeaders = new Header[]{new BasicHeader("header", "value")};
             builder.setDefaultHeaders(defaultHeaders); // <1>
             //end::rest-client-init-default-headers
         }
         {
             //tag::rest-client-init-max-retry-timeout
-            RestClientBuilder builder = RestClient.builder(new HttpHost("localhost", 9200, "http"));
+            RestClientBuilder builder = RestClient.builder(
+                new HttpHost("localhost", 9200, "http"));
             builder.setMaxRetryTimeoutMillis(10000); // <1>
             //end::rest-client-init-max-retry-timeout
         }
         {
             //tag::rest-client-init-node-selector
-            RestClientBuilder builder = RestClient.builder(new HttpHost("localhost", 9200, "http"));
+            RestClientBuilder builder = RestClient.builder(
+                new HttpHost("localhost", 9200, "http"));
             builder.setNodeSelector(NodeSelector.SKIP_DEDICATED_MASTERS); // <1>
             //end::rest-client-init-node-selector
         }
         {
             //tag::rest-client-init-allocation-aware-selector
-            RestClientBuilder builder = RestClient.builder(new HttpHost("localhost", 9200, "http"));
+            RestClientBuilder builder = RestClient.builder(
+                    new HttpHost("localhost", 9200, "http"));
             builder.setNodeSelector(new NodeSelector() { // <1>
                 @Override
                 public void select(Iterable<Node> nodes) {
@@ -155,7 +160,8 @@ public class RestClientDocumentation {
         }
         {
             //tag::rest-client-init-failure-listener
-            RestClientBuilder builder = RestClient.builder(new HttpHost("localhost", 9200, "http"));
+            RestClientBuilder builder = RestClient.builder(
+                    new HttpHost("localhost", 9200, "http"));
             builder.setFailureListener(new RestClient.FailureListener() {
                 @Override
                 public void onFailure(Node node) {
@@ -166,24 +172,30 @@ public class RestClientDocumentation {
         }
         {
             //tag::rest-client-init-request-config-callback
-            RestClientBuilder builder = RestClient.builder(new HttpHost("localhost", 9200, "http"));
-            builder.setRequestConfigCallback(new RestClientBuilder.RequestConfigCallback() {
-                @Override
-                public RequestConfig.Builder customizeRequestConfig(RequestConfig.Builder requestConfigBuilder) {
-                    return requestConfigBuilder.setSocketTimeout(10000); // <1>
-                }
-            });
+            RestClientBuilder builder = RestClient.builder(
+                    new HttpHost("localhost", 9200, "http"));
+            builder.setRequestConfigCallback(
+                new RestClientBuilder.RequestConfigCallback() {
+                    @Override
+                    public RequestConfig.Builder customizeRequestConfig(
+                            RequestConfig.Builder requestConfigBuilder) {
+                        return requestConfigBuilder.setSocketTimeout(10000); // <1>
+                    }
+                });
             //end::rest-client-init-request-config-callback
         }
         {
             //tag::rest-client-init-client-config-callback
-            RestClientBuilder builder = RestClient.builder(new HttpHost("localhost", 9200, "http"));
-            builder.setHttpClientConfigCallback(new RestClientBuilder.HttpClientConfigCallback() {
-                @Override
-                public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
-                    return httpClientBuilder.setProxy(new HttpHost("proxy", 9000, "http"));  // <1>
-                }
-            });
+            RestClientBuilder builder = RestClient.builder(
+                new HttpHost("localhost", 9200, "http"));
+            builder.setHttpClientConfigCallback(new HttpClientConfigCallback() {
+                    @Override
+                    public HttpAsyncClientBuilder customizeHttpClient(
+                            HttpAsyncClientBuilder httpClientBuilder) {
+                        return httpClientBuilder.setProxy(
+                            new HttpHost("proxy", 9000, "http"));  // <1>
+                    }
+                });
             //end::rest-client-init-client-config-callback
         }
 
@@ -281,58 +293,74 @@ public class RestClientDocumentation {
     public void testCommonConfiguration() throws Exception {
         {
             //tag::rest-client-config-timeouts
-            RestClientBuilder builder = RestClient.builder(new HttpHost("localhost", 9200))
-                    .setRequestConfigCallback(new RestClientBuilder.RequestConfigCallback() {
+            RestClientBuilder builder = RestClient.builder(
+                new HttpHost("localhost", 9200))
+                .setRequestConfigCallback(
+                    new RestClientBuilder.RequestConfigCallback() {
                         @Override
-                        public RequestConfig.Builder customizeRequestConfig(RequestConfig.Builder requestConfigBuilder) {
-                            return requestConfigBuilder.setConnectTimeout(5000)
-                                    .setSocketTimeout(60000);
+                        public RequestConfig.Builder customizeRequestConfig(
+                                RequestConfig.Builder requestConfigBuilder) {
+                            return requestConfigBuilder
+                                .setConnectTimeout(5000)
+                                .setSocketTimeout(60000);
                         }
                     })
-                    .setMaxRetryTimeoutMillis(60000);
+                .setMaxRetryTimeoutMillis(60000);
             //end::rest-client-config-timeouts
         }
         {
             //tag::rest-client-config-threads
-            RestClientBuilder builder = RestClient.builder(new HttpHost("localhost", 9200))
-                    .setHttpClientConfigCallback(new RestClientBuilder.HttpClientConfigCallback() {
-                        @Override
-                        public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
-                            return httpClientBuilder.setDefaultIOReactorConfig(
-                                    IOReactorConfig.custom().setIoThreadCount(1).build());
-                        }
-                    });
+            RestClientBuilder builder = RestClient.builder(
+                new HttpHost("localhost", 9200))
+                .setHttpClientConfigCallback(new HttpClientConfigCallback() {
+                    @Override
+                    public HttpAsyncClientBuilder customizeHttpClient(
+                            HttpAsyncClientBuilder httpClientBuilder) {
+                        return httpClientBuilder.setDefaultIOReactorConfig(
+                            IOReactorConfig.custom()
+                                .setIoThreadCount(1)
+                                .build());
+                    }
+                });
             //end::rest-client-config-threads
         }
         {
             //tag::rest-client-config-basic-auth
-            final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            final CredentialsProvider credentialsProvider =
+                new BasicCredentialsProvider();
             credentialsProvider.setCredentials(AuthScope.ANY,
-                    new UsernamePasswordCredentials("user", "password"));
+                new UsernamePasswordCredentials("user", "password"));
 
-            RestClientBuilder builder = RestClient.builder(new HttpHost("localhost", 9200))
-                    .setHttpClientConfigCallback(new RestClientBuilder.HttpClientConfigCallback() {
-                        @Override
-                        public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
-                            return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
-                        }
-                    });
+            RestClientBuilder builder = RestClient.builder(
+                new HttpHost("localhost", 9200))
+                .setHttpClientConfigCallback(new HttpClientConfigCallback() {
+                    @Override
+                    public HttpAsyncClientBuilder customizeHttpClient(
+                            HttpAsyncClientBuilder httpClientBuilder) {
+                        return httpClientBuilder
+                            .setDefaultCredentialsProvider(credentialsProvider);
+                    }
+                });
             //end::rest-client-config-basic-auth
         }
         {
             //tag::rest-client-config-disable-preemptive-auth
-            final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            final CredentialsProvider credentialsProvider =
+                new BasicCredentialsProvider();
             credentialsProvider.setCredentials(AuthScope.ANY,
-                    new UsernamePasswordCredentials("user", "password"));
+                new UsernamePasswordCredentials("user", "password"));
 
-            RestClientBuilder builder = RestClient.builder(new HttpHost("localhost", 9200))
-                    .setHttpClientConfigCallback(new RestClientBuilder.HttpClientConfigCallback() {
-                        @Override
-                        public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
-                            httpClientBuilder.disableAuthCaching(); // <1>
-                            return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
-                        }
-                    });
+            RestClientBuilder builder = RestClient.builder(
+                new HttpHost("localhost", 9200))
+                .setHttpClientConfigCallback(new HttpClientConfigCallback() {
+                    @Override
+                    public HttpAsyncClientBuilder customizeHttpClient(
+                            HttpAsyncClientBuilder httpClientBuilder) {
+                        httpClientBuilder.disableAuthCaching(); // <1>
+                        return httpClientBuilder
+                            .setDefaultCredentialsProvider(credentialsProvider);
+                    }
+                });
             //end::rest-client-config-disable-preemptive-auth
         }
         {
@@ -343,15 +371,18 @@ public class RestClientDocumentation {
             try (InputStream is = Files.newInputStream(keyStorePath)) {
                 truststore.load(is, keyStorePass.toCharArray());
             }
-            SSLContextBuilder sslBuilder = SSLContexts.custom().loadTrustMaterial(truststore, null);
+            SSLContextBuilder sslBuilder = SSLContexts.custom()
+                .loadTrustMaterial(truststore, null);
             final SSLContext sslContext = sslBuilder.build();
-            RestClientBuilder builder = RestClient.builder(new HttpHost("localhost", 9200, "https"))
-                    .setHttpClientConfigCallback(new RestClientBuilder.HttpClientConfigCallback() {
-                        @Override
-                        public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
-                            return httpClientBuilder.setSSLContext(sslContext);
-                        }
-                    });
+            RestClientBuilder builder = RestClient.builder(
+                new HttpHost("localhost", 9200, "https"))
+                .setHttpClientConfigCallback(new HttpClientConfigCallback() {
+                    @Override
+                    public HttpAsyncClientBuilder customizeHttpClient(
+                            HttpAsyncClientBuilder httpClientBuilder) {
+                        return httpClientBuilder.setSSLContext(sslContext);
+                    }
+                });
             //end::rest-client-config-encrypted-communication
         }
     }

--- a/client/sniffer/src/test/java/org/elasticsearch/client/sniff/documentation/SnifferDocumentation.java
+++ b/client/sniffer/src/test/java/org/elasticsearch/client/sniff/documentation/SnifferDocumentation.java
@@ -56,8 +56,8 @@ public class SnifferDocumentation {
         {
             //tag::sniffer-init
             RestClient restClient = RestClient.builder(
-                    new HttpHost("localhost", 9200, "http"))
-                    .build();
+                new HttpHost("localhost", 9200, "http"))
+                .build();
             Sniffer sniffer = Sniffer.builder(restClient).build();
             //end::sniffer-init
 
@@ -69,21 +69,23 @@ public class SnifferDocumentation {
         {
             //tag::sniffer-interval
             RestClient restClient = RestClient.builder(
-                    new HttpHost("localhost", 9200, "http"))
-                    .build();
+                new HttpHost("localhost", 9200, "http"))
+                .build();
             Sniffer sniffer = Sniffer.builder(restClient)
-                    .setSniffIntervalMillis(60000).build();
+                .setSniffIntervalMillis(60000).build();
             //end::sniffer-interval
         }
         {
             //tag::sniff-on-failure
-            SniffOnFailureListener sniffOnFailureListener = new SniffOnFailureListener();
-            RestClient restClient = RestClient.builder(new HttpHost("localhost", 9200))
-                    .setFailureListener(sniffOnFailureListener) // <1>
-                    .build();
+            SniffOnFailureListener sniffOnFailureListener =
+                new SniffOnFailureListener();
+            RestClient restClient = RestClient.builder(
+                new HttpHost("localhost", 9200))
+                .setFailureListener(sniffOnFailureListener) // <1>
+                .build();
             Sniffer sniffer = Sniffer.builder(restClient)
-                    .setSniffAfterFailureDelayMillis(30000) // <2>
-                    .build();
+                .setSniffAfterFailureDelayMillis(30000) // <2>
+                .build();
             sniffOnFailureListener.setSniffer(sniffer); // <3>
             //end::sniff-on-failure
         }
@@ -103,29 +105,29 @@ public class SnifferDocumentation {
         {
             //tag::sniff-request-timeout
             RestClient restClient = RestClient.builder(
-                    new HttpHost("localhost", 9200, "http"))
-                    .build();
+                new HttpHost("localhost", 9200, "http"))
+                .build();
             NodesSniffer nodesSniffer = new ElasticsearchNodesSniffer(
-                    restClient,
-                    TimeUnit.SECONDS.toMillis(5),
-                    ElasticsearchNodesSniffer.Scheme.HTTP);
+                restClient,
+                TimeUnit.SECONDS.toMillis(5),
+                ElasticsearchNodesSniffer.Scheme.HTTP);
             Sniffer sniffer = Sniffer.builder(restClient)
-                    .setNodesSniffer(nodesSniffer).build();
+                .setNodesSniffer(nodesSniffer).build();
             //end::sniff-request-timeout
         }
         {
             //tag::custom-nodes-sniffer
             RestClient restClient = RestClient.builder(
-                    new HttpHost("localhost", 9200, "http"))
-                    .build();
+                new HttpHost("localhost", 9200, "http"))
+                .build();
             NodesSniffer nodesSniffer = new NodesSniffer() {
-                @Override
-                public List<Node> sniff() throws IOException {
-                    return null; // <1>
-                }
-            };
+                    @Override
+                    public List<Node> sniff() throws IOException {
+                        return null; // <1>
+                    }
+                };
             Sniffer sniffer = Sniffer.builder(restClient)
-                    .setNodesSniffer(nodesSniffer).build();
+                .setNodesSniffer(nodesSniffer).build();
             //end::custom-nodes-sniffer
         }
     }

--- a/docs/java-rest/low-level/configuration.asciidoc
+++ b/docs/java-rest/low-level/configuration.asciidoc
@@ -1,3 +1,4 @@
+[[java-rest-low-config]]
 == Common configuration
 
 As explained in <<java-rest-low-usage-initialization>>, the `RestClientBuilder`

--- a/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/JdbcIntegrationTestCase.java
+++ b/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/JdbcIntegrationTestCase.java
@@ -61,7 +61,8 @@ public abstract class JdbcIntegrationTestCase extends ESRestTestCase {
         // tag::connect-dm
         String address = "jdbc:es://" + elasticsearchAddress;     // <1>
         Properties connectionProperties = connectionProperties(); // <2>
-        Connection connection = DriverManager.getConnection(address, connectionProperties);
+        Connection connection =
+            DriverManager.getConnection(address, connectionProperties);
         // end::connect-dm
         assertNotNull("The timezone should be specified", connectionProperties.getProperty(JdbcConfiguration.TIME_ZONE));
         return connection;

--- a/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/SimpleExampleTestCase.java
+++ b/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/SimpleExampleTestCase.java
@@ -22,10 +22,10 @@ public class SimpleExampleTestCase extends JdbcIntegrationTestCase {
             // tag::simple_example
             try (Statement statement = connection.createStatement();
                     ResultSet results = statement.executeQuery(
-                          "  SELECT name, page_count"
-                        + "    FROM library"
-                        + "ORDER BY page_count DESC"
-                        + "   LIMIT 1")) {
+                          "   SELECT name, page_count"
+                        + "     FROM library"
+                        + " ORDER BY page_count DESC"
+                        + "    LIMIT 1")) {
                 assertTrue(results.next());
                 assertEquals("Don Quixote", results.getString(1));
                 assertEquals(1072, results.getInt(2));

--- a/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/SimpleExampleTestCase.java
+++ b/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/SimpleExampleTestCase.java
@@ -10,6 +10,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import static org.hamcrest.Matchers.containsString;
+
 public class SimpleExampleTestCase extends JdbcIntegrationTestCase {
     public void testSimpleExample() throws Exception {
         index("library", builder -> {
@@ -20,13 +22,17 @@ public class SimpleExampleTestCase extends JdbcIntegrationTestCase {
             // tag::simple_example
             try (Statement statement = connection.createStatement();
                     ResultSet results = statement.executeQuery(
-                        "SELECT name, page_count FROM library ORDER BY page_count DESC LIMIT 1")) {
+                          "  SELECT name, page_count"
+                        + "    FROM library"
+                        + "ORDER BY page_count DESC"
+                        + "   LIMIT 1")) {
                 assertTrue(results.next());
                 assertEquals("Don Quixote", results.getString(1));
                 assertEquals(1072, results.getInt(2));
-                SQLException e = expectThrows(SQLException.class, () -> results.getInt(1));
-                assertTrue(e.getMessage(), 
-                        e.getMessage().contains("Unable to convert value [Don Quixote] of type [VARCHAR] to an Integer"));
+                SQLException e = expectThrows(SQLException.class, () ->
+                    results.getInt(1));
+                assertThat(e.getMessage(), containsString("Unable to convert "
+                    + "value [Don Quixote] of type [VARCHAR] to an Integer"));
                 assertFalse(results.next());
             }
             // end::simple_example


### PR DESCRIPTION
We use wrap code in `// tag` and `//end` to include it in our docs. Our
current docs style wraps code snippets in a box that is only wide enough
for 76 characters and adds a horizontal scroll bar for wider snippets
which makes the snippet much harder to read. This adds a checkstyle check
that looks for java code that is included in the docs and is wider than
that 76 characters so all snippets fit into the box. It solves many of
the failures that this catches but suppresses many more. I will clean
those up in a follow up change.
