### PR TITLE
Allow specifying shard changes batch sizes in bytes

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -35,7 +35,10 @@ import java.util.Locale;
 import java.util.Objects;
 
 public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXContentFragment {
+
     private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(ByteSizeValue.class));
+
+    public static final ByteSizeValue ZERO = new ByteSizeValue(0, ByteSizeUnit.BYTES);
 
     private final long size;
     private final ByteSizeUnit unit;

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -311,7 +311,7 @@ public class AutoFollowCoordinator implements ClusterStateApplier {
             request.setFollowerIndex(followIndexName);
             request.setMaxBatchOperationCount(pattern.getMaxBatchOperationCount());
             request.setMaxConcurrentReadBatches(pattern.getMaxConcurrentReadBatches());
-            request.setMaxOperationSizeInBytes(pattern.getMaxOperationSizeInBytes());
+            request.setMaxBatchSize(pattern.getMaxBatchSize());
             request.setMaxConcurrentWriteBatches(pattern.getMaxConcurrentWriteBatches());
             request.setMaxWriteBufferSize(pattern.getMaxWriteBufferSize());
             request.setMaxRetryDelay(pattern.getMaxRetryDelay());

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
@@ -409,7 +409,7 @@ public class ShardChangesAction extends Action<ShardChangesAction.Response> {
      * Returns at most maxOperationCount operations from the specified from sequence number. This method will never return operations above
      * the specified globalCheckpoint.
      *
-     * Also if the sum of collected operations' size is above the specified maxBatchSize then this method stops collecting more operations
+     * Also if the sum of collected operations' size is above the specified max batch size then this method stops collecting more operations
      * and returns what has been collected so far.
      */
     static Translog.Operation[] getOperations(IndexShard indexShard,

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
@@ -406,11 +406,11 @@ public class ShardChangesAction extends Action<ShardChangesAction.Response> {
     static final Translog.Operation[] EMPTY_OPERATIONS_ARRAY = new Translog.Operation[0];
 
     /**
-     * Returns at most maxOperationCount operations from the specified from sequence number.
-     * This method will never return operations above the specified globalCheckpoint.
+     * Returns at most maxOperationCount operations from the specified from sequence number. This method will never return operations above
+     * the specified globalCheckpoint.
      *
-     * Also if the sum of collected operations' size is above the specified maxBatchSize then this method
-     * stops collecting more operations and returns what has been collected so far.
+     * Also if the sum of collected operations' size is above the specified maxBatchSize then this method stops collecting more operations
+     * and returns what has been collected so far.
      */
     static Translog.Operation[] getOperations(IndexShard indexShard,
                                               long globalCheckpoint,

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
@@ -406,18 +406,28 @@ public class ShardChangesAction extends Action<ShardChangesAction.Response> {
     static final Translog.Operation[] EMPTY_OPERATIONS_ARRAY = new Translog.Operation[0];
 
     /**
-     * Returns at most maxOperationCount operations from the specified from sequence number. This method will never return operations above
-     * the specified globalCheckpoint.
+     * Returns at most the specified maximum number of operations from the specified from sequence number. This method will never return
+     * operations above the specified global checkpoint.
      *
-     * Also if the sum of collected operations' size is above the specified max batch size then this method stops collecting more operations
-     * and returns what has been collected so far.
+     * Also if the sum of collected operations size is above the specified maximum batch size then this method stops collecting more
+     * operations and returns what has been collected so far.
+     *
+     * @param indexShard the shard
+     * @param globalCheckpoint the global checkpoint
+     * @param fromSeqNo the starting sequence number
+     * @param maxOperationCount the maximum number of operations
+     * @param expectedHistoryUUID the expected history UUID for the shard
+     * @param maxBatchSize the maximum batch size
+     * @return the operations
+     * @throws IOException if an I/O exception occurs reading the operations
      */
-    static Translog.Operation[] getOperations(IndexShard indexShard,
-                                              long globalCheckpoint,
-                                              long fromSeqNo,
-                                              int maxOperationCount,
-                                              String expectedHistoryUUID,
-                                              ByteSizeValue maxBatchSize) throws IOException {
+    static Translog.Operation[] getOperations(
+            final IndexShard indexShard,
+            final long globalCheckpoint,
+            final long fromSeqNo,
+            final int maxOperationCount,
+            final String expectedHistoryUUID,
+            final ByteSizeValue maxBatchSize) throws IOException {
         if (indexShard.state() != IndexShardState.STARTED) {
             throw new IndexShardNotStartedException(indexShard.shardId(), indexShard.state());
         }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
@@ -203,7 +203,7 @@ public abstract class ShardFollowNodeTask extends AllocatedPersistentTask {
                 Translog.Operation op = buffer.remove();
                 ops.add(op);
                 sumEstimatedSize += op.estimateSize();
-                if (sumEstimatedSize > params.getMaxBatchSizeInBytes()) {
+                if (sumEstimatedSize > params.getMaxBatchSize().getBytes()) {
                     break;
                 }
             }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTask.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTask.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
@@ -45,7 +46,7 @@ public class ShardFollowTask implements XPackPlugin.XPackPersistentTaskParams {
     static final ParseField HEADERS = new ParseField("headers");
     public static final ParseField MAX_BATCH_OPERATION_COUNT = new ParseField("max_batch_operation_count");
     public static final ParseField MAX_CONCURRENT_READ_BATCHES = new ParseField("max_concurrent_read_batches");
-    public static final ParseField MAX_BATCH_SIZE_IN_BYTES = new ParseField("max_batch_size_in_bytes");
+    public static final ParseField MAX_BATCH_SIZE = new ParseField("max_batch_size");
     public static final ParseField MAX_CONCURRENT_WRITE_BATCHES = new ParseField("max_concurrent_write_batches");
     public static final ParseField MAX_WRITE_BUFFER_SIZE = new ParseField("max_write_buffer_size");
     public static final ParseField MAX_RETRY_DELAY = new ParseField("max_retry_delay");
@@ -55,7 +56,7 @@ public class ShardFollowTask implements XPackPlugin.XPackPersistentTaskParams {
     @SuppressWarnings("unchecked")
     private static ConstructingObjectParser<ShardFollowTask, Void> PARSER = new ConstructingObjectParser<>(NAME,
             (a) -> new ShardFollowTask((String) a[0], new ShardId((String) a[1], (String) a[2], (int) a[3]),
-                    new ShardId((String) a[4], (String) a[5], (int) a[6]), (int) a[7], (int) a[8], (long) a[9],
+                    new ShardId((String) a[4], (String) a[5], (int) a[6]), (int) a[7], (int) a[8], (ByteSizeValue) a[9],
                 (int) a[10], (int) a[11], (TimeValue) a[12], (TimeValue) a[13], (String) a[14], (Map<String, String>) a[15]));
 
     static {
@@ -68,7 +69,11 @@ public class ShardFollowTask implements XPackPlugin.XPackPersistentTaskParams {
         PARSER.declareInt(ConstructingObjectParser.constructorArg(), LEADER_SHARD_SHARDID_FIELD);
         PARSER.declareInt(ConstructingObjectParser.constructorArg(), MAX_BATCH_OPERATION_COUNT);
         PARSER.declareInt(ConstructingObjectParser.constructorArg(), MAX_CONCURRENT_READ_BATCHES);
-        PARSER.declareLong(ConstructingObjectParser.constructorArg(), MAX_BATCH_SIZE_IN_BYTES);
+        PARSER.declareField(
+                ConstructingObjectParser.constructorArg(),
+                (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), MAX_BATCH_SIZE.getPreferredName()),
+                MAX_BATCH_SIZE,
+                ObjectParser.ValueType.STRING);
         PARSER.declareInt(ConstructingObjectParser.constructorArg(), MAX_CONCURRENT_WRITE_BATCHES);
         PARSER.declareInt(ConstructingObjectParser.constructorArg(), MAX_WRITE_BUFFER_SIZE);
         PARSER.declareField(ConstructingObjectParser.constructorArg(),
@@ -86,7 +91,7 @@ public class ShardFollowTask implements XPackPlugin.XPackPersistentTaskParams {
     private final ShardId leaderShardId;
     private final int maxBatchOperationCount;
     private final int maxConcurrentReadBatches;
-    private final long maxBatchSizeInBytes;
+    private final ByteSizeValue maxBatchSize;
     private final int maxConcurrentWriteBatches;
     private final int maxWriteBufferSize;
     private final TimeValue maxRetryDelay;
@@ -100,7 +105,7 @@ public class ShardFollowTask implements XPackPlugin.XPackPersistentTaskParams {
             final ShardId leaderShardId,
             final int maxBatchOperationCount,
             final int maxConcurrentReadBatches,
-            final long maxBatchSizeInBytes,
+            final ByteSizeValue maxBatchSize,
             final int maxConcurrentWriteBatches,
             final int maxWriteBufferSize,
             final TimeValue maxRetryDelay,
@@ -112,7 +117,7 @@ public class ShardFollowTask implements XPackPlugin.XPackPersistentTaskParams {
         this.leaderShardId = leaderShardId;
         this.maxBatchOperationCount = maxBatchOperationCount;
         this.maxConcurrentReadBatches = maxConcurrentReadBatches;
-        this.maxBatchSizeInBytes = maxBatchSizeInBytes;
+        this.maxBatchSize = maxBatchSize;
         this.maxConcurrentWriteBatches = maxConcurrentWriteBatches;
         this.maxWriteBufferSize = maxWriteBufferSize;
         this.maxRetryDelay = maxRetryDelay;
@@ -127,7 +132,7 @@ public class ShardFollowTask implements XPackPlugin.XPackPersistentTaskParams {
         this.leaderShardId = ShardId.readShardId(in);
         this.maxBatchOperationCount = in.readVInt();
         this.maxConcurrentReadBatches = in.readVInt();
-        this.maxBatchSizeInBytes = in.readVLong();
+        this.maxBatchSize = new ByteSizeValue(in);
         this.maxConcurrentWriteBatches = in.readVInt();
         this.maxWriteBufferSize = in.readVInt();
         this.maxRetryDelay = in.readTimeValue();
@@ -164,8 +169,8 @@ public class ShardFollowTask implements XPackPlugin.XPackPersistentTaskParams {
         return maxWriteBufferSize;
     }
 
-    public long getMaxBatchSizeInBytes() {
-        return maxBatchSizeInBytes;
+    public ByteSizeValue getMaxBatchSize() {
+        return maxBatchSize;
     }
 
     public TimeValue getMaxRetryDelay() {
@@ -200,7 +205,7 @@ public class ShardFollowTask implements XPackPlugin.XPackPersistentTaskParams {
         leaderShardId.writeTo(out);
         out.writeVLong(maxBatchOperationCount);
         out.writeVInt(maxConcurrentReadBatches);
-        out.writeVLong(maxBatchSizeInBytes);
+        maxBatchSize.writeTo(out);
         out.writeVInt(maxConcurrentWriteBatches);
         out.writeVInt(maxWriteBufferSize);
         out.writeTimeValue(maxRetryDelay);
@@ -227,7 +232,7 @@ public class ShardFollowTask implements XPackPlugin.XPackPersistentTaskParams {
         builder.field(LEADER_SHARD_SHARDID_FIELD.getPreferredName(), leaderShardId.id());
         builder.field(MAX_BATCH_OPERATION_COUNT.getPreferredName(), maxBatchOperationCount);
         builder.field(MAX_CONCURRENT_READ_BATCHES.getPreferredName(), maxConcurrentReadBatches);
-        builder.field(MAX_BATCH_SIZE_IN_BYTES.getPreferredName(), maxBatchSizeInBytes);
+        builder.field(MAX_BATCH_SIZE.getPreferredName(), maxBatchSize.getStringRep());
         builder.field(MAX_CONCURRENT_WRITE_BATCHES.getPreferredName(), maxConcurrentWriteBatches);
         builder.field(MAX_WRITE_BUFFER_SIZE.getPreferredName(), maxWriteBufferSize);
         builder.field(MAX_RETRY_DELAY.getPreferredName(), maxRetryDelay.getStringRep());
@@ -248,7 +253,7 @@ public class ShardFollowTask implements XPackPlugin.XPackPersistentTaskParams {
                 maxBatchOperationCount == that.maxBatchOperationCount &&
                 maxConcurrentReadBatches == that.maxConcurrentReadBatches &&
                 maxConcurrentWriteBatches == that.maxConcurrentWriteBatches &&
-                maxBatchSizeInBytes == that.maxBatchSizeInBytes &&
+                maxBatchSize.equals(that.maxBatchSize) &&
                 maxWriteBufferSize == that.maxWriteBufferSize &&
                 Objects.equals(maxRetryDelay, that.maxRetryDelay) &&
                 Objects.equals(pollTimeout, that.pollTimeout) &&
@@ -259,19 +264,18 @@ public class ShardFollowTask implements XPackPlugin.XPackPersistentTaskParams {
     @Override
     public int hashCode() {
         return Objects.hash(
-            leaderClusterAlias,
-            followShardId,
-            leaderShardId,
-            maxBatchOperationCount,
-            maxConcurrentReadBatches,
-            maxConcurrentWriteBatches,
-            maxBatchSizeInBytes,
-            maxWriteBufferSize,
-            maxRetryDelay,
-            pollTimeout,
-            recordedLeaderIndexHistoryUUID,
-            headers
-        );
+                leaderClusterAlias,
+                followShardId,
+                leaderShardId,
+                maxBatchOperationCount,
+                maxConcurrentReadBatches,
+                maxConcurrentWriteBatches,
+                maxBatchSize,
+                maxWriteBufferSize,
+                maxRetryDelay,
+                pollTimeout,
+                recordedLeaderIndexHistoryUUID,
+                headers);
     }
 
     public String toString() {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -152,7 +152,7 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
                     new ShardChangesAction.Request(params.getLeaderShardId(), params.getRecordedLeaderIndexHistoryUUID());
                 request.setFromSeqNo(from);
                 request.setMaxOperationCount(maxOperationCount);
-                request.setMaxOperationSizeInBytes(params.getMaxBatchSizeInBytes());
+                request.setMaxBatchSize(params.getMaxBatchSize());
                 request.setPollTimeout(params.getPollTimeout());
                 leaderClient.execute(ShardChangesAction.INSTANCE, request, ActionListener.wrap(handler::accept, errorHandler));
             }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
@@ -167,7 +167,7 @@ public class TransportPutAutoFollowPatternAction extends
             request.getFollowIndexNamePattern(),
             request.getMaxBatchOperationCount(),
             request.getMaxConcurrentReadBatches(),
-            request.getMaxOperationSizeInBytes(),
+            request.getMaxBatchSize(),
             request.getMaxConcurrentWriteBatches(),
             request.getMaxWriteBufferSize(),
             request.getMaxRetryDelay(),

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -19,6 +19,8 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexSettings;
@@ -56,7 +58,7 @@ import java.util.stream.Collectors;
 
 public class TransportResumeFollowAction extends HandledTransportAction<ResumeFollowAction.Request, AcknowledgedResponse> {
 
-    static final long DEFAULT_MAX_BATCH_SIZE_IN_BYTES = Long.MAX_VALUE;
+    static final ByteSizeValue DEFAULT_MAX_BATCH_SIZE = new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES);
     private static final TimeValue DEFAULT_MAX_RETRY_DELAY = new TimeValue(500);
     private static final int DEFAULT_MAX_CONCURRENT_WRITE_BATCHES = 1;
     private static final int DEFAULT_MAX_WRITE_BUFFER_SIZE = 10240;
@@ -326,11 +328,11 @@ public class TransportResumeFollowAction extends HandledTransportAction<ResumeFo
             maxConcurrentReadBatches = DEFAULT_MAX_CONCURRENT_READ_BATCHES;
         }
 
-        long maxOperationSizeInBytes;
-        if (request.getMaxOperationSizeInBytes() != null) {
-            maxOperationSizeInBytes = request.getMaxOperationSizeInBytes();
+        ByteSizeValue maxBatchSize;
+        if (request.getMaxBatchSize() != null) {
+            maxBatchSize = request.getMaxBatchSize();
         } else {
-            maxOperationSizeInBytes = DEFAULT_MAX_BATCH_SIZE_IN_BYTES;
+            maxBatchSize = DEFAULT_MAX_BATCH_SIZE;
         }
 
         int maxConcurrentWriteBatches;
@@ -356,7 +358,7 @@ public class TransportResumeFollowAction extends HandledTransportAction<ResumeFo
             new ShardId(leaderIndexMetadata.getIndex(), shardId),
             maxBatchOperationCount,
             maxConcurrentReadBatches,
-            maxOperationSizeInBytes,
+            maxBatchSize,
             maxConcurrentWriteBatches,
             maxWriteBufferSize,
             maxRetryDelay,

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowMetadataTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowMetadataTests.java
@@ -6,6 +6,8 @@
 package org.elasticsearch.xpack.ccr;
 
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractSerializingTestCase;
@@ -43,7 +45,7 @@ public class AutoFollowMetadataTests extends AbstractSerializingTestCase<AutoFol
                 randomAlphaOfLength(4),
                 randomIntBetween(0, Integer.MAX_VALUE),
                 randomIntBetween(0, Integer.MAX_VALUE),
-                randomNonNegativeLong(),
+                new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES),
                 randomIntBetween(0, Integer.MAX_VALUE),
                 randomIntBetween(0, Integer.MAX_VALUE),
                 TimeValue.timeValueMillis(500),

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/ShardChangesIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/ShardChangesIT.java
@@ -30,6 +30,8 @@ import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -487,7 +489,7 @@ public class ShardChangesIT extends ESIntegTestCase {
         }
 
         PutFollowAction.Request followRequest = follow("index1", "index2");
-        followRequest.getFollowRequest().setMaxOperationSizeInBytes(1L);
+        followRequest.getFollowRequest().setMaxBatchSize(new ByteSizeValue(1, ByteSizeUnit.BYTES));
         client().execute(PutFollowAction.INSTANCE, followRequest).get();
 
         final Map<ShardId, Long> firstBatchNumDocsPerShard = new HashMap<>();

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowTests.java
@@ -9,6 +9,8 @@ import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsReques
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
@@ -134,7 +136,7 @@ public class AutoFollowTests extends ESSingleNodeTestCase {
             request.setMaxBatchOperationCount(randomIntBetween(0, Integer.MAX_VALUE));
         }
         if (randomBoolean()) {
-            request.setMaxOperationSizeInBytes(randomNonNegativeLong());
+            request.setMaxBatchSize(new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES));
         }
         if (randomBoolean()) {
             request.setMaxRetryDelay(TimeValue.timeValueMillis(500));
@@ -165,8 +167,8 @@ public class AutoFollowTests extends ESSingleNodeTestCase {
             if (request.getMaxBatchOperationCount() != null) {
                 assertThat(shardFollowTask.getMaxBatchOperationCount(), equalTo(request.getMaxBatchOperationCount()));
             }
-            if (request.getMaxOperationSizeInBytes() != null) {
-                assertThat(shardFollowTask.getMaxBatchSizeInBytes(), equalTo(request.getMaxOperationSizeInBytes()));
+            if (request.getMaxBatchSize() != null) {
+                assertThat(shardFollowTask.getMaxBatchSize(), equalTo(request.getMaxBatchSize()));
             }
             if (request.getMaxRetryDelay() != null) {
                 assertThat(shardFollowTask.getMaxRetryDelay(), equalTo(request.getMaxRetryDelay()));

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/FollowIndexRequestTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/FollowIndexRequestTests.java
@@ -6,6 +6,8 @@
 package org.elasticsearch.xpack.ccr.action;
 
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractStreamableXContentTestCase;
@@ -53,7 +55,7 @@ public class FollowIndexRequestTests extends AbstractStreamableXContentTestCase<
             request.setMaxConcurrentWriteBatches(randomIntBetween(1, Integer.MAX_VALUE));
         }
         if (randomBoolean()) {
-            request.setMaxOperationSizeInBytes(randomNonNegativeLong());
+            request.setMaxBatchSize(new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES));
         }
         if (randomBoolean()) {
             request.setMaxWriteBufferSize(randomIntBetween(1, Integer.MAX_VALUE));

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/GetAutoFollowPatternResponseTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/GetAutoFollowPatternResponseTests.java
@@ -5,6 +5,8 @@
  */
 package org.elasticsearch.xpack.ccr.action;
 
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.AbstractStreamableTestCase;
 import org.elasticsearch.xpack.core.ccr.AutoFollowMetadata.AutoFollowPattern;
@@ -31,7 +33,7 @@ public class GetAutoFollowPatternResponseTests extends AbstractStreamableTestCas
                 randomAlphaOfLength(4),
                 randomIntBetween(0, Integer.MAX_VALUE),
                 randomIntBetween(0, Integer.MAX_VALUE),
-                randomNonNegativeLong(),
+                new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES),
                 randomIntBetween(0, Integer.MAX_VALUE),
                 randomIntBetween(0, Integer.MAX_VALUE),
                 TimeValue.timeValueMillis(500),

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/PutAutoFollowPatternRequestTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/PutAutoFollowPatternRequestTests.java
@@ -6,6 +6,8 @@
 package org.elasticsearch.xpack.ccr.action;
 
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractStreamableXContentTestCase;
@@ -60,7 +62,7 @@ public class PutAutoFollowPatternRequestTests extends AbstractStreamableXContent
             request.setMaxConcurrentWriteBatches(randomIntBetween(0, Integer.MAX_VALUE));
         }
         if (randomBoolean()) {
-            request.setMaxOperationSizeInBytes(randomNonNegativeLong());
+            request.setMaxBatchSize(new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES));
         }
         if (randomBoolean()) {
             request.setMaxWriteBufferSize(randomIntBetween(0, Integer.MAX_VALUE));

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesActionTests.java
@@ -10,6 +10,8 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -61,8 +63,13 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
             int min = randomIntBetween(0, numWrites - 1);
             int max = randomIntBetween(min, numWrites - 1);
             int size = max - min + 1;
-            final Translog.Operation[] operations = ShardChangesAction.getOperations(indexShard,
-                indexShard.getGlobalCheckpoint(), min, size, indexShard.getHistoryUUID(), Long.MAX_VALUE);
+            final Translog.Operation[] operations = ShardChangesAction.getOperations(
+                    indexShard,
+                    indexShard.getGlobalCheckpoint(),
+                    min,
+                    size,
+                    indexShard.getHistoryUUID(),
+                    new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES));
             final List<Long> seenSeqNos = Arrays.stream(operations).map(Translog.Operation::seqNo).collect(Collectors.toList());
             final List<Long> expectedSeqNos = LongStream.rangeClosed(min, max).boxed().collect(Collectors.toList());
             assertThat(seenSeqNos, equalTo(expectedSeqNos));
@@ -78,7 +85,7 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
                             numWrites,
                             numWrites + 1,
                             indexShard.getHistoryUUID(),
-                            Long.MAX_VALUE));
+                            new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES)));
             final String message = String.format(
                     Locale.ROOT,
                     "not exposing operations from [%d] greater than the global checkpoint [%d]",
@@ -89,12 +96,12 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
 
         // get operations for a range some operations do not exist:
         Translog.Operation[] operations = ShardChangesAction.getOperations(indexShard, indexShard.getGlobalCheckpoint(),
-            numWrites  - 10, numWrites + 10, indexShard.getHistoryUUID(), Long.MAX_VALUE);
+            numWrites  - 10, numWrites + 10, indexShard.getHistoryUUID(), new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES));
         assertThat(operations.length, equalTo(10));
 
         // Unexpected history UUID:
         Exception e = expectThrows(IllegalStateException.class, () -> ShardChangesAction.getOperations(indexShard,
-            indexShard.getGlobalCheckpoint(), 0, 10, "different-history-uuid", Long.MAX_VALUE));
+            indexShard.getGlobalCheckpoint(), 0, 10, "different-history-uuid", new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES)));
         assertThat(e.getMessage(), equalTo("unexpected history uuid, expected [different-history-uuid], actual [" +
                 indexShard.getHistoryUUID() + "]"));
 
@@ -104,7 +111,7 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
             final int batchSize = randomIntBetween(0, Integer.MAX_VALUE);
             final IllegalArgumentException invalidRangeError = expectThrows(IllegalArgumentException.class,
                 () -> ShardChangesAction.getOperations(indexShard, indexShard.getGlobalCheckpoint(),
-                    fromSeqNo, batchSize, indexShard.getHistoryUUID(), Long.MAX_VALUE));
+                    fromSeqNo, batchSize, indexShard.getHistoryUUID(), new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES)));
             assertThat(invalidRangeError.getMessage(),
                 equalTo("Invalid range; from_seqno [" + fromSeqNo + "], to_seqno [" + (fromSeqNo + batchSize - 1) + "]"));
         }
@@ -116,7 +123,7 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
         ShardRouting shardRouting = TestShardRouting.newShardRouting("index", 0, "_node_id", true, ShardRoutingState.INITIALIZING);
         Mockito.when(indexShard.routingEntry()).thenReturn(shardRouting);
         expectThrows(IndexShardNotStartedException.class, () -> ShardChangesAction.getOperations(indexShard,
-            indexShard.getGlobalCheckpoint(), 0, 1, indexShard.getHistoryUUID(), Long.MAX_VALUE));
+            indexShard.getGlobalCheckpoint(), 0, 1, indexShard.getHistoryUUID(), new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES)));
     }
 
     public void testGetOperationsExceedByteLimit() throws Exception {
@@ -133,7 +140,7 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
 
         final IndexShard indexShard = indexService.getShard(0);
         final Translog.Operation[] operations = ShardChangesAction.getOperations(indexShard, indexShard.getGlobalCheckpoint(),
-            0, 12, indexShard.getHistoryUUID(), 256);
+            0, 12, indexShard.getHistoryUUID(), new ByteSizeValue(256, ByteSizeUnit.BYTES));
         assertThat(operations.length, equalTo(12));
         assertThat(operations[0].seqNo(), equalTo(0L));
         assertThat(operations[1].seqNo(), equalTo(1L));
@@ -160,7 +167,8 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
 
         final IndexShard indexShard = indexService.getShard(0);
         final Translog.Operation[] operations =
-            ShardChangesAction.getOperations(indexShard, indexShard.getGlobalCheckpoint(), 0, 1, indexShard.getHistoryUUID(), 0);
+            ShardChangesAction.getOperations(
+                    indexShard, indexShard.getGlobalCheckpoint(), 0, 1, indexShard.getHistoryUUID(), ByteSizeValue.ZERO);
         assertThat(operations.length, equalTo(1));
         assertThat(operations[0].seqNo(), equalTo(0L));
     }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskRandomTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskRandomTests.java
@@ -80,7 +80,7 @@ public class ShardFollowNodeTaskRandomTests extends ESTestCase {
             new ShardId("leader_index", "", 0),
             testRun.maxOperationCount,
             concurrency,
-            TransportResumeFollowAction.DEFAULT_MAX_BATCH_SIZE_IN_BYTES,
+            TransportResumeFollowAction.DEFAULT_MAX_BATCH_SIZE,
             concurrency,
             10240,
             TimeValue.timeValueMillis(10),

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskTests.java
@@ -8,6 +8,8 @@ package org.elasticsearch.xpack.ccr.action;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
@@ -675,7 +677,7 @@ public class ShardFollowNodeTaskTests extends ESTestCase {
             new ShardId("leader_index", "", 0),
             maxBatchOperationCount,
             maxConcurrentReadBatches,
-            maxBatchSizeInBytes,
+            new ByteSizeValue(maxBatchSizeInBytes, ByteSizeUnit.BYTES),
             maxConcurrentWriteBatches,
             bufferWriteLimit,
             TimeValue.ZERO,

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
@@ -16,6 +16,8 @@ import org.elasticsearch.action.support.replication.TransportWriteAction;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.Engine.Operation.Origin;
@@ -211,7 +213,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
             new ShardId("leader_index", "", 0),
             between(1, 64),
             between(1, 8),
-            Long.MAX_VALUE,
+            new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
             between(1, 4), 10240,
             TimeValue.timeValueMillis(10),
             TimeValue.timeValueMillis(10),
@@ -275,7 +277,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
                                 return;
                             }
                             Translog.Operation[] ops = ShardChangesAction.getOperations(indexShard, seqNoStats.getGlobalCheckpoint(), from,
-                                maxOperationCount, params.getRecordedLeaderIndexHistoryUUID(), params.getMaxBatchSizeInBytes());
+                                maxOperationCount, params.getRecordedLeaderIndexHistoryUUID(), params.getMaxBatchSize());
                             // hard code mapping version; this is ok, as mapping updates are not tested here
                             final ShardChangesAction.Response response = new ShardChangesAction.Response(
                                 1L,

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskTests.java
@@ -6,6 +6,8 @@
 package org.elasticsearch.xpack.ccr.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.shard.ShardId;
@@ -29,7 +31,7 @@ public class ShardFollowTaskTests extends AbstractSerializingTestCase<ShardFollo
             new ShardId(randomAlphaOfLength(4), randomAlphaOfLength(4), randomInt(5)),
             randomIntBetween(1, Integer.MAX_VALUE),
             randomIntBetween(1, Integer.MAX_VALUE),
-            randomNonNegativeLong(),
+            new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES),
             randomIntBetween(1, Integer.MAX_VALUE),
             randomIntBetween(1, Integer.MAX_VALUE),
             TimeValue.parseTimeValue(randomTimeValue(), ""),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
@@ -178,7 +179,7 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
         public static final ParseField FOLLOW_PATTERN_FIELD = new ParseField("follow_index_pattern");
         public static final ParseField MAX_BATCH_OPERATION_COUNT = new ParseField("max_batch_operation_count");
         public static final ParseField MAX_CONCURRENT_READ_BATCHES = new ParseField("max_concurrent_read_batches");
-        public static final ParseField MAX_BATCH_SIZE_IN_BYTES = new ParseField("max_batch_size_in_bytes");
+        public static final ParseField MAX_BATCH_SIZE = new ParseField("max_batch_size");
         public static final ParseField MAX_CONCURRENT_WRITE_BATCHES = new ParseField("max_concurrent_write_batches");
         public static final ParseField MAX_WRITE_BUFFER_SIZE = new ParseField("max_write_buffer_size");
         public static final ParseField MAX_RETRY_DELAY = new ParseField("max_retry_delay");
@@ -188,14 +189,18 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
         private static final ConstructingObjectParser<AutoFollowPattern, Void> PARSER =
             new ConstructingObjectParser<>("auto_follow_pattern",
                 args -> new AutoFollowPattern((List<String>) args[0], (String) args[1], (Integer) args[2], (Integer) args[3],
-                    (Long) args[4], (Integer) args[5], (Integer) args[6], (TimeValue) args[7], (TimeValue) args[8]));
+                    (ByteSizeValue) args[4], (Integer) args[5], (Integer) args[6], (TimeValue) args[7], (TimeValue) args[8]));
 
         static {
             PARSER.declareStringArray(ConstructingObjectParser.constructorArg(), LEADER_PATTERNS_FIELD);
             PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), FOLLOW_PATTERN_FIELD);
             PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), MAX_BATCH_OPERATION_COUNT);
             PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), MAX_CONCURRENT_READ_BATCHES);
-            PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), MAX_BATCH_SIZE_IN_BYTES);
+            PARSER.declareField(
+                    ConstructingObjectParser.optionalConstructorArg(),
+                    (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), MAX_BATCH_SIZE.getPreferredName()),
+                    MAX_BATCH_SIZE,
+                    ObjectParser.ValueType.STRING);
             PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), MAX_CONCURRENT_WRITE_BATCHES);
             PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), MAX_WRITE_BUFFER_SIZE);
             PARSER.declareField(ConstructingObjectParser.optionalConstructorArg(),
@@ -210,7 +215,7 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
         private final String followIndexPattern;
         private final Integer maxBatchOperationCount;
         private final Integer maxConcurrentReadBatches;
-        private final Long maxOperationSizeInBytes;
+        private final ByteSizeValue maxBatchSize;
         private final Integer maxConcurrentWriteBatches;
         private final Integer maxWriteBufferSize;
         private final TimeValue maxRetryDelay;
@@ -220,7 +225,7 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
                                  String followIndexPattern,
                                  Integer maxBatchOperationCount,
                                  Integer maxConcurrentReadBatches,
-                                 Long maxOperationSizeInBytes,
+                                 ByteSizeValue maxBatchSize,
                                  Integer maxConcurrentWriteBatches,
                                  Integer maxWriteBufferSize,
                                  TimeValue maxRetryDelay,
@@ -229,7 +234,7 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
             this.followIndexPattern = followIndexPattern;
             this.maxBatchOperationCount = maxBatchOperationCount;
             this.maxConcurrentReadBatches = maxConcurrentReadBatches;
-            this.maxOperationSizeInBytes = maxOperationSizeInBytes;
+            this.maxBatchSize = maxBatchSize;
             this.maxConcurrentWriteBatches = maxConcurrentWriteBatches;
             this.maxWriteBufferSize = maxWriteBufferSize;
             this.maxRetryDelay = maxRetryDelay;
@@ -241,7 +246,7 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
             followIndexPattern = in.readOptionalString();
             maxBatchOperationCount = in.readOptionalVInt();
             maxConcurrentReadBatches = in.readOptionalVInt();
-            maxOperationSizeInBytes = in.readOptionalLong();
+            maxBatchSize = in.readOptionalWriteable(ByteSizeValue::new);
             maxConcurrentWriteBatches = in.readOptionalVInt();
             maxWriteBufferSize = in.readOptionalVInt();
             maxRetryDelay = in.readOptionalTimeValue();
@@ -272,8 +277,8 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
             return maxConcurrentReadBatches;
         }
 
-        public Long getMaxOperationSizeInBytes() {
-            return maxOperationSizeInBytes;
+        public ByteSizeValue getMaxBatchSize() {
+            return maxBatchSize;
         }
 
         public Integer getMaxConcurrentWriteBatches() {
@@ -298,7 +303,7 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
             out.writeOptionalString(followIndexPattern);
             out.writeOptionalVInt(maxBatchOperationCount);
             out.writeOptionalVInt(maxConcurrentReadBatches);
-            out.writeOptionalLong(maxOperationSizeInBytes);
+            out.writeOptionalWriteable(maxBatchSize);
             out.writeOptionalVInt(maxConcurrentWriteBatches);
             out.writeOptionalVInt(maxWriteBufferSize);
             out.writeOptionalTimeValue(maxRetryDelay);
@@ -317,8 +322,8 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
             if (maxConcurrentReadBatches != null) {
                 builder.field(MAX_CONCURRENT_READ_BATCHES.getPreferredName(), maxConcurrentReadBatches);
             }
-            if (maxOperationSizeInBytes != null) {
-                builder.field(MAX_BATCH_SIZE_IN_BYTES.getPreferredName(), maxOperationSizeInBytes);
+            if (maxBatchSize != null) {
+                builder.field(MAX_BATCH_SIZE.getPreferredName(), maxBatchSize.getStringRep());
             }
             if (maxConcurrentWriteBatches != null) {
                 builder.field(MAX_CONCURRENT_WRITE_BATCHES.getPreferredName(), maxConcurrentWriteBatches);
@@ -349,7 +354,7 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
                 Objects.equals(followIndexPattern, that.followIndexPattern) &&
                 Objects.equals(maxBatchOperationCount, that.maxBatchOperationCount) &&
                 Objects.equals(maxConcurrentReadBatches, that.maxConcurrentReadBatches) &&
-                Objects.equals(maxOperationSizeInBytes, that.maxOperationSizeInBytes) &&
+                Objects.equals(maxBatchSize, that.maxBatchSize) &&
                 Objects.equals(maxConcurrentWriteBatches, that.maxConcurrentWriteBatches) &&
                 Objects.equals(maxWriteBufferSize, that.maxWriteBufferSize) &&
                 Objects.equals(maxRetryDelay, that.maxRetryDelay) &&
@@ -363,7 +368,7 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
                 followIndexPattern,
                 maxBatchOperationCount,
                 maxConcurrentReadBatches,
-                maxOperationSizeInBytes,
+                    maxBatchSize,
                 maxConcurrentWriteBatches,
                 maxWriteBufferSize,
                 maxRetryDelay,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
@@ -351,29 +351,28 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
             if (o == null || getClass() != o.getClass()) return false;
             AutoFollowPattern that = (AutoFollowPattern) o;
             return Objects.equals(leaderIndexPatterns, that.leaderIndexPatterns) &&
-                Objects.equals(followIndexPattern, that.followIndexPattern) &&
-                Objects.equals(maxBatchOperationCount, that.maxBatchOperationCount) &&
-                Objects.equals(maxConcurrentReadBatches, that.maxConcurrentReadBatches) &&
-                Objects.equals(maxBatchSize, that.maxBatchSize) &&
-                Objects.equals(maxConcurrentWriteBatches, that.maxConcurrentWriteBatches) &&
-                Objects.equals(maxWriteBufferSize, that.maxWriteBufferSize) &&
-                Objects.equals(maxRetryDelay, that.maxRetryDelay) &&
-                Objects.equals(pollTimeout, that.pollTimeout);
+                    Objects.equals(followIndexPattern, that.followIndexPattern) &&
+                    Objects.equals(maxBatchOperationCount, that.maxBatchOperationCount) &&
+                    Objects.equals(maxConcurrentReadBatches, that.maxConcurrentReadBatches) &&
+                    Objects.equals(maxBatchSize, that.maxBatchSize) &&
+                    Objects.equals(maxConcurrentWriteBatches, that.maxConcurrentWriteBatches) &&
+                    Objects.equals(maxWriteBufferSize, that.maxWriteBufferSize) &&
+                    Objects.equals(maxRetryDelay, that.maxRetryDelay) &&
+                    Objects.equals(pollTimeout, that.pollTimeout);
         }
 
         @Override
         public int hashCode() {
             return Objects.hash(
-                leaderIndexPatterns,
-                followIndexPattern,
-                maxBatchOperationCount,
-                maxConcurrentReadBatches,
+                    leaderIndexPatterns,
+                    followIndexPattern,
+                    maxBatchOperationCount,
+                    maxConcurrentReadBatches,
                     maxBatchSize,
-                maxConcurrentWriteBatches,
-                maxWriteBufferSize,
-                maxRetryDelay,
-                pollTimeout
-            );
+                    maxConcurrentWriteBatches,
+                    maxWriteBufferSize,
+                    maxRetryDelay,
+                    pollTimeout);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/PutAutoFollowPatternAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/PutAutoFollowPatternAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -51,7 +52,11 @@ public class PutAutoFollowPatternAction extends Action<AcknowledgedResponse> {
             PARSER.declareString(Request::setFollowIndexNamePattern, AutoFollowPattern.FOLLOW_PATTERN_FIELD);
             PARSER.declareInt(Request::setMaxBatchOperationCount, AutoFollowPattern.MAX_BATCH_OPERATION_COUNT);
             PARSER.declareInt(Request::setMaxConcurrentReadBatches, AutoFollowPattern.MAX_CONCURRENT_READ_BATCHES);
-            PARSER.declareLong(Request::setMaxOperationSizeInBytes, AutoFollowPattern.MAX_BATCH_SIZE_IN_BYTES);
+            PARSER.declareField(
+                    Request::setMaxBatchSize,
+                    (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), AutoFollowPattern.MAX_BATCH_SIZE.getPreferredName()),
+                    AutoFollowPattern.MAX_BATCH_SIZE,
+                    ObjectParser.ValueType.STRING);
             PARSER.declareInt(Request::setMaxConcurrentWriteBatches, AutoFollowPattern.MAX_CONCURRENT_WRITE_BATCHES);
             PARSER.declareInt(Request::setMaxWriteBufferSize, AutoFollowPattern.MAX_WRITE_BUFFER_SIZE);
             PARSER.declareField(Request::setMaxRetryDelay,
@@ -82,7 +87,7 @@ public class PutAutoFollowPatternAction extends Action<AcknowledgedResponse> {
 
         private Integer maxBatchOperationCount;
         private Integer maxConcurrentReadBatches;
-        private Long maxOperationSizeInBytes;
+        private ByteSizeValue maxBatchSize;
         private Integer maxConcurrentWriteBatches;
         private Integer maxWriteBufferSize;
         private TimeValue maxRetryDelay;
@@ -155,12 +160,12 @@ public class PutAutoFollowPatternAction extends Action<AcknowledgedResponse> {
             this.maxConcurrentReadBatches = maxConcurrentReadBatches;
         }
 
-        public Long getMaxOperationSizeInBytes() {
-            return maxOperationSizeInBytes;
+        public ByteSizeValue getMaxBatchSize() {
+            return maxBatchSize;
         }
 
-        public void setMaxOperationSizeInBytes(Long maxOperationSizeInBytes) {
-            this.maxOperationSizeInBytes = maxOperationSizeInBytes;
+        public void setMaxBatchSize(ByteSizeValue maxBatchSize) {
+            this.maxBatchSize = maxBatchSize;
         }
 
         public Integer getMaxConcurrentWriteBatches() {
@@ -203,7 +208,7 @@ public class PutAutoFollowPatternAction extends Action<AcknowledgedResponse> {
             followIndexNamePattern = in.readOptionalString();
             maxBatchOperationCount = in.readOptionalVInt();
             maxConcurrentReadBatches = in.readOptionalVInt();
-            maxOperationSizeInBytes = in.readOptionalLong();
+            maxBatchSize = in.readOptionalWriteable(ByteSizeValue::new);
             maxConcurrentWriteBatches = in.readOptionalVInt();
             maxWriteBufferSize = in.readOptionalVInt();
             maxRetryDelay = in.readOptionalTimeValue();
@@ -218,7 +223,7 @@ public class PutAutoFollowPatternAction extends Action<AcknowledgedResponse> {
             out.writeOptionalString(followIndexNamePattern);
             out.writeOptionalVInt(maxBatchOperationCount);
             out.writeOptionalVInt(maxConcurrentReadBatches);
-            out.writeOptionalLong(maxOperationSizeInBytes);
+            out.writeOptionalWriteable(maxBatchSize);
             out.writeOptionalVInt(maxConcurrentWriteBatches);
             out.writeOptionalVInt(maxWriteBufferSize);
             out.writeOptionalTimeValue(maxRetryDelay);
@@ -237,8 +242,8 @@ public class PutAutoFollowPatternAction extends Action<AcknowledgedResponse> {
                 if (maxBatchOperationCount != null) {
                     builder.field(AutoFollowPattern.MAX_BATCH_OPERATION_COUNT.getPreferredName(), maxBatchOperationCount);
                 }
-                if (maxOperationSizeInBytes != null) {
-                    builder.field(AutoFollowPattern.MAX_BATCH_SIZE_IN_BYTES.getPreferredName(), maxOperationSizeInBytes);
+                if (maxBatchSize != null) {
+                    builder.field(AutoFollowPattern.MAX_BATCH_SIZE.getPreferredName(), maxBatchSize.getStringRep());
                 }
                 if (maxWriteBufferSize != null) {
                     builder.field(AutoFollowPattern.MAX_WRITE_BUFFER_SIZE.getPreferredName(), maxWriteBufferSize);
@@ -266,31 +271,30 @@ public class PutAutoFollowPatternAction extends Action<AcknowledgedResponse> {
             if (o == null || getClass() != o.getClass()) return false;
             Request request = (Request) o;
             return Objects.equals(leaderClusterAlias, request.leaderClusterAlias) &&
-                Objects.equals(leaderIndexPatterns, request.leaderIndexPatterns) &&
-                Objects.equals(followIndexNamePattern, request.followIndexNamePattern) &&
-                Objects.equals(maxBatchOperationCount, request.maxBatchOperationCount) &&
-                Objects.equals(maxConcurrentReadBatches, request.maxConcurrentReadBatches) &&
-                Objects.equals(maxOperationSizeInBytes, request.maxOperationSizeInBytes) &&
-                Objects.equals(maxConcurrentWriteBatches, request.maxConcurrentWriteBatches) &&
-                Objects.equals(maxWriteBufferSize, request.maxWriteBufferSize) &&
-                Objects.equals(maxRetryDelay, request.maxRetryDelay) &&
-                Objects.equals(pollTimeout, request.pollTimeout);
+                    Objects.equals(leaderIndexPatterns, request.leaderIndexPatterns) &&
+                    Objects.equals(followIndexNamePattern, request.followIndexNamePattern) &&
+                    Objects.equals(maxBatchOperationCount, request.maxBatchOperationCount) &&
+                    Objects.equals(maxConcurrentReadBatches, request.maxConcurrentReadBatches) &&
+                    Objects.equals(maxBatchSize, request.maxBatchSize) &&
+                    Objects.equals(maxConcurrentWriteBatches, request.maxConcurrentWriteBatches) &&
+                    Objects.equals(maxWriteBufferSize, request.maxWriteBufferSize) &&
+                    Objects.equals(maxRetryDelay, request.maxRetryDelay) &&
+                    Objects.equals(pollTimeout, request.pollTimeout);
         }
 
         @Override
         public int hashCode() {
             return Objects.hash(
-                leaderClusterAlias,
-                leaderIndexPatterns,
-                followIndexNamePattern,
-                maxBatchOperationCount,
-                maxConcurrentReadBatches,
-                maxOperationSizeInBytes,
-                maxConcurrentWriteBatches,
-                maxWriteBufferSize,
-                maxRetryDelay,
-                pollTimeout
-            );
+                    leaderClusterAlias,
+                    leaderIndexPatterns,
+                    followIndexNamePattern,
+                    maxBatchOperationCount,
+                    maxConcurrentReadBatches,
+                    maxBatchSize,
+                    maxConcurrentWriteBatches,
+                    maxWriteBufferSize,
+                    maxRetryDelay,
+                    pollTimeout);
         }
     }
 


### PR DESCRIPTION
This commit changes the shard changes requests from using a raw byte value to being able to be specified using bytes units (e.g., 4mb).