### PR TITLE
Change CCR stats endpoint to be index-centric

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestCcrStatsAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestCcrStatsAction.java
@@ -22,7 +22,7 @@ public class RestCcrStatsAction extends BaseRestHandler {
     public RestCcrStatsAction(final Settings settings, final RestController controller) {
         super(settings);
         controller.registerHandler(RestRequest.Method.GET, "/_ccr/stats", this);
-        controller.registerHandler(RestRequest.Method.GET, "/_ccr/stats/{index}", this);
+        controller.registerHandler(RestRequest.Method.GET, "/{index}/_ccr/stats", this);
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.stats.json
@@ -4,7 +4,7 @@
     "methods": [ "GET" ],
     "url": {
       "path": "/_ccr/stats",
-      "paths": [ "/_ccr/stats", "/_ccr/stats/{index}" ],
+      "paths": [ "/_ccr/stats", "/{index}/_ccr/stats" ],
       "parts": {
         "index": {
           "type": "list",


### PR DESCRIPTION
This commit modifies the CCR stats endpoint for indices to be /{index}/_ccr/stats. This makes this endpoint consistent with other index-centric endpoints like indices stats.

Relates #32350
