### PR TITLE
[ML] Return missing job error when .ml-config is does not exist

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -120,7 +120,7 @@ public class JobManager extends AbstractComponent {
     }
 
     public void jobExists(String jobId, ActionListener<Boolean> listener) {
-        jobConfigProvider.checkJobExists(jobId, listener);
+        jobConfigProvider.jobExists(jobId, true, listener);
     }
 
     /**
@@ -281,7 +281,16 @@ public class JobManager extends AbstractComponent {
                 actionListener::onFailure
         );
 
-        jobResultsProvider.checkForLeftOverDocuments(job, checkForLeftOverDocs);
+        jobConfigProvider.jobExists(job.getId(), false, ActionListener.wrap(
+                jobExists -> {
+                    if (jobExists) {
+                        actionListener.onFailure(ExceptionsHelper.jobAlreadyExists(job.getId()));
+                    } else {
+                        jobResultsProvider.checkForLeftOverDocuments(job, checkForLeftOverDocs);
+                    }
+                },
+                actionListener::onFailure
+        ));
     }
 
     public void updateJob(UpdateJobAction.Request request, ActionListener<PutJobAction.Response> actionListener) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
@@ -108,6 +108,15 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
         assertEquals(DocWriteResponse.Result.DELETED, deleteResponseHolder.get().getResult());
     }
 
+    public void testGetDatafeedConfig_missing() throws InterruptedException {
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+        AtomicReference<DatafeedConfig.Builder> configBuilderHolder = new AtomicReference<>();
+        blockingCall(actionListener -> datafeedConfigProvider.getDatafeedConfig("missing", actionListener),
+                configBuilderHolder, exceptionHolder);
+        assertNull(configBuilderHolder.get());
+        assertEquals(ResourceNotFoundException.class, exceptionHolder.get().getClass());
+    }
+
     public void testMultipleCreateAndDeletes() throws InterruptedException {
         String datafeedId = "df2";
 
@@ -127,7 +136,7 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
                 indexResponseHolder, exceptionHolder);
         assertNull(indexResponseHolder.get());
         assertThat(exceptionHolder.get(), instanceOf(ResourceAlreadyExistsException.class));
-        assertEquals("A datafeed with Id [df2] already exists", exceptionHolder.get().getMessage());
+        assertEquals("A datafeed with id [df2] already exists", exceptionHolder.get().getMessage());
 
         // delete
         exceptionHolder.set(null);
@@ -142,7 +151,7 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
         blockingCall(actionListener -> datafeedConfigProvider.deleteDatafeedConfig(datafeedId, actionListener),
                 deleteResponseHolder, exceptionHolder);
         assertNull(deleteResponseHolder.get());
-        assertThat(exceptionHolder.get(), instanceOf(ResourceNotFoundException.class));
+        assertEquals(ResourceNotFoundException.class, exceptionHolder.get().getClass());
     }
 
     public void testUpdateWhenApplyingTheUpdateThrows() throws Exception {
@@ -202,7 +211,7 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
 
         assertNull(datafeedIdsHolder.get());
         assertNotNull(exceptionHolder.get());
-        assertThat(exceptionHolder.get(), IsInstanceOf.instanceOf(ResourceNotFoundException.class));
+        assertEquals(ResourceNotFoundException.class, exceptionHolder.get().getClass());
         assertThat(exceptionHolder.get().getMessage(), containsString("No datafeed with id [*] exists"));
 
         exceptionHolder.set(null);
@@ -217,7 +226,7 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
 
         assertNull(datafeedsHolder.get());
         assertNotNull(exceptionHolder.get());
-        assertThat(exceptionHolder.get(), IsInstanceOf.instanceOf(ResourceNotFoundException.class));
+        assertEquals(ResourceNotFoundException.class, exceptionHolder.get().getClass());
         assertThat(exceptionHolder.get().getMessage(), containsString("No datafeed with id [*] exists"));
 
         exceptionHolder.set(null);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobConfigProviderIT.java
@@ -68,18 +68,25 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
 
         assertNull(jobHolder.get());
         assertNotNull(exceptionHolder.get());
-        assertThat(exceptionHolder.get(), instanceOf(ResourceNotFoundException.class));
+        assertEquals(ResourceNotFoundException.class, exceptionHolder.get().getClass());
     }
 
     public void testCheckJobExists() throws InterruptedException {
         AtomicReference<Boolean> jobExistsHolder = new AtomicReference<>();
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
 
-        blockingCall(actionListener -> jobConfigProvider.checkJobExists("missing", actionListener), jobExistsHolder, exceptionHolder);
+        boolean throwIfMissing = randomBoolean();
+        blockingCall(actionListener ->
+                jobConfigProvider.jobExists("missing", throwIfMissing, actionListener), jobExistsHolder, exceptionHolder);
 
-        assertNull(jobExistsHolder.get());
-        assertNotNull(exceptionHolder.get());
-        assertThat(exceptionHolder.get(), instanceOf(ResourceNotFoundException.class));
+        if (throwIfMissing) {
+            assertNull(jobExistsHolder.get());
+            assertNotNull(exceptionHolder.get());
+            assertEquals(ResourceNotFoundException.class, exceptionHolder.get().getClass());
+        } else {
+            assertFalse(jobExistsHolder.get());
+            assertNull(exceptionHolder.get());
+        }
 
         AtomicReference<IndexResponse> indexResponseHolder = new AtomicReference<>();
 
@@ -88,7 +95,8 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
         blockingCall(actionListener -> jobConfigProvider.putJob(job, actionListener), indexResponseHolder, exceptionHolder);
 
         exceptionHolder.set(null);
-        blockingCall(actionListener -> jobConfigProvider.checkJobExists("existing-job", actionListener), jobExistsHolder, exceptionHolder);
+        blockingCall(actionListener ->
+                jobConfigProvider.jobExists("existing-job", throwIfMissing, actionListener), jobExistsHolder, exceptionHolder);
         assertNull(exceptionHolder.get());
         assertNotNull(jobExistsHolder.get());
         assertTrue(jobExistsHolder.get());
@@ -159,7 +167,7 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
         getJobResponseHolder.set(null);
         blockingCall(actionListener -> jobConfigProvider.getJob(jobId, actionListener), getJobResponseHolder, exceptionHolder);
         assertNull(getJobResponseHolder.get());
-        assertThat(exceptionHolder.get(), instanceOf(ResourceNotFoundException.class));
+        assertEquals(ResourceNotFoundException.class, exceptionHolder.get().getClass());
 
         // Delete deleted job
         deleteJobResponseHolder.set(null);
@@ -167,7 +175,7 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
         blockingCall(actionListener -> jobConfigProvider.deleteJob(jobId, actionListener),
                 deleteJobResponseHolder, exceptionHolder);
         assertNull(deleteJobResponseHolder.get());
-        assertThat(exceptionHolder.get(), instanceOf(ResourceNotFoundException.class));
+        assertEquals(ResourceNotFoundException.class, exceptionHolder.get().getClass());
     }
 
     public void testGetJobs() throws Exception {
@@ -263,7 +271,7 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
 
         assertNull(jobIdsHolder.get());
         assertNotNull(exceptionHolder.get());
-        assertThat(exceptionHolder.get(), instanceOf(ResourceNotFoundException.class));
+        assertEquals(ResourceNotFoundException.class, exceptionHolder.get().getClass());
         assertThat(exceptionHolder.get().getMessage(), containsString("No known job with id"));
 
         exceptionHolder.set(null);
@@ -278,7 +286,7 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
 
         assertNull(jobsHolder.get());
         assertNotNull(exceptionHolder.get());
-        assertThat(exceptionHolder.get(), instanceOf(ResourceNotFoundException.class));
+        assertEquals(ResourceNotFoundException.class, exceptionHolder.get().getClass());
         assertThat(exceptionHolder.get().getMessage(), containsString("No known job with id"));
 
         exceptionHolder.set(null);
@@ -315,7 +323,7 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
                 jobIdsHolder, exceptionHolder);
         assertNull(jobIdsHolder.get());
         assertNotNull(exceptionHolder.get());
-        assertThat(exceptionHolder.get(), instanceOf(ResourceNotFoundException.class));
+        assertEquals(ResourceNotFoundException.class, exceptionHolder.get().getClass());
         assertThat(exceptionHolder.get().getMessage(), equalTo("No known job with id 'missing1,missing2'"));
 
         // Job builders
@@ -344,7 +352,7 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
                 jobsHolder, exceptionHolder);
         assertNull(jobsHolder.get());
         assertNotNull(exceptionHolder.get());
-        assertThat(exceptionHolder.get(), instanceOf(ResourceNotFoundException.class));
+        assertEquals(ResourceNotFoundException.class, exceptionHolder.get().getClass());
         assertThat(exceptionHolder.get().getMessage(), equalTo("No known job with id 'missing1,missing2'"));
     }
 


### PR DESCRIPTION
Jindex feature branch.

Fixes a couple of cases where the wrong error is returned:
1. When creating a job that already exists the first check was for left over documents so you got an error about existing state docs rather than the job id is used error.
2. Before the `.ml-config` index is created Get requests throw an IndexNotFoundException when we want a missing job/datafeed error. GetRequests do not have an lenient ignore missing index option so the error has to be caught and translated. The other option is to ensure the index exists when the node starts but this is counter to the use of index templates and a more complicated solution

For #32905