### PR TITLE
Add Gradle attributes to CI jobs

### DIFF
--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -7,4 +7,4 @@
 ES_BUILD_JAVA=java10
 ES_RUNTIME_JAVA=java8
 GRADLE_TASK=build
-GRADLE_ARGS=-Dtests.bwc.refspec=elastic/index-lifecycle-6.x
+GRADLE_EXTRA_ARGS=-Dtests.bwc.refspec=elastic/index-lifecycle-6.x

--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -6,5 +6,5 @@
 
 ES_BUILD_JAVA=java10
 ES_RUNTIME_JAVA=java8
-GRADLE_TASK="build"
-GRADLE_ARGS="-Dtests.bwc.refspec=elastic/index-lifecycle-6.x"
+GRADLE_TASK=build
+GRADLE_ARGS=-Dtests.bwc.refspec=elastic/index-lifecycle-6.x

--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -6,3 +6,5 @@
 
 ES_BUILD_JAVA=java10
 ES_RUNTIME_JAVA=java8
+GRADLE_TASK="build"
+GRADLE_ARGS="-Dtests.bwc.refspec=elastic/index-lifecycle-6.x"


### PR DESCRIPTION
CI already has a change to take these parameters into so we can host differences like these in the feature branches. 

`GRADLE_TASK="build"` will find it's way to master too.