### PR TITLE
Fixes fast vector highlighter docs per issue #24318.

### DIFF
--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -79,6 +79,10 @@ This highlighter can be used on fields with `term_vector` set to
   for things like phrase matches being sorted above term matches when
   highlighting a Boosting Query that boosts phrase matches over term matches
 
+[WARNING]
+The `fvh` highlighter does not support span queries. If you need support for
+span queries, try an alternative highlighter, such as the `unified` highlighter.
+
 [[offsets-strategy]]
 ==== Offsets Strategy
 To create meaningful search snippets from the terms being queried,


### PR DESCRIPTION
The `fvh` highlighter does not support span queries. This fix updates
the docs to add a warning stating the lack of span query support for
`fvh`. Fixes #24318