### PR TITLE
Change "REST Verb" to "HTTP Verb"

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -478,7 +478,7 @@ If we study the above commands carefully, we can actually see a pattern of how w
 
 [source,js]
 --------------------------------------------------
-<REST Verb> /<Index>/<Type>/<ID>
+<HTTP Verb> /<Index>/<Type>/<ID>
 --------------------------------------------------
 // NOTCONSOLE
 


### PR DESCRIPTION
The verbs/methods are actually from HTTP and not from REST.

References: 
https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods 
https://tools.ietf.org/html/rfc2616.html#section-5.1.1
