### PR TITLE
Docs: Wrap expert script example to fit in docs

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -42,11 +42,6 @@
   <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]StoredScriptsDocumentationIT.java" id="SnippetLength" />
   <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]TasksClientDocumentationIT.java" id="SnippetLength" />
   <suppress files="client[/\\]rest-high-level[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]WatcherDocumentationIT.java" id="SnippetLength" />
-  <!--
-    This one is in plugins/examples/script-expert-scoring but we need to
-    suppress it like this because we build that project twice, once in for
-    real and once as a test for our build system. -->
-  <suppress files="src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]example[/\\]expertscript[/\\]ExpertScriptPlugin.java" id="SnippetLength" />
   <suppress files="modules[/\\]reindex[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]client[/\\]documentation[/\\]ReindexDocumentationIT.jav" id="SnippetLength" />
 
   <!-- Hopefully temporary suppression of LineLength on files that don't pass it. We should remove these when we the

--- a/plugins/examples/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java
+++ b/plugins/examples/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java
@@ -31,8 +31,10 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.ScoreScript;
+import org.elasticsearch.script.ScoreScript.LeafFactory;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
+import org.elasticsearch.search.lookup.SearchLookup;
 
 /**
  * An example script plugin that adds a {@link ScriptEngine} implementing expert scoring.
@@ -53,80 +55,105 @@ public class ExpertScriptPlugin extends Plugin implements ScriptPlugin {
         }
 
         @Override
-        public <T> T compile(String scriptName, String scriptSource, ScriptContext<T> context, Map<String, String> params) {
+        public <T> T compile(String scriptName, String scriptSource,
+                ScriptContext<T> context, Map<String, String> params) {
             if (context.equals(ScoreScript.CONTEXT) == false) {
-                throw new IllegalArgumentException(getType() + " scripts cannot be used for context [" + context.name + "]");
+                throw new IllegalArgumentException(getType()
+                        + " scripts cannot be used for context ["
+                        + context.name + "]");
             }
             // we use the script "source" as the script identifier
             if ("pure_df".equals(scriptSource)) {
-                ScoreScript.Factory factory = (p, lookup) -> new ScoreScript.LeafFactory() {
-                    final String field;
-                    final String term;
-                    {
-                        if (p.containsKey("field") == false) {
-                            throw new IllegalArgumentException("Missing parameter [field]");
-                        }
-                        if (p.containsKey("term") == false) {
-                            throw new IllegalArgumentException("Missing parameter [term]");
-                        }
-                        field = p.get("field").toString();
-                        term = p.get("term").toString();
-                    }
-
-                    @Override
-                    public ScoreScript newInstance(LeafReaderContext context) throws IOException {
-                        PostingsEnum postings = context.reader().postings(new Term(field, term));
-                        if (postings == null) {
-                            // the field and/or term don't exist in this segment, so always return 0
-                            return new ScoreScript(p, lookup, context) {
-                                @Override
-                                public double execute() {
-                                    return 0.0d;
-                                }
-                            };
-                        }
-                        return new ScoreScript(p, lookup, context) {
-                            int currentDocid = -1;
-                            @Override
-                            public void setDocument(int docid) {
-                                // advance has undefined behavior calling with a docid <= its current docid
-                                if (postings.docID() < docid) {
-                                    try {
-                                        postings.advance(docid);
-                                    } catch (IOException e) {
-                                        throw new UncheckedIOException(e);
-                                    }
-                                }
-                                currentDocid = docid;
-                            }
-                            @Override
-                            public double execute() {
-                                if (postings.docID() != currentDocid) {
-                                    // advance moved past the current doc, so this doc has no occurrences of the term
-                                    return 0.0d;
-                                }
-                                try {
-                                    return postings.freq();
-                                } catch (IOException e) {
-                                    throw new UncheckedIOException(e);
-                                }
-                            }
-                        };
-                    }
-
-                    @Override
-                    public boolean needs_score() {
-                        return false;
-                    }
-                };
+                ScoreScript.Factory factory = PureDfLeafFactory::new;
                 return context.factoryClazz.cast(factory);
             }
-            throw new IllegalArgumentException("Unknown script name " + scriptSource);
+            throw new IllegalArgumentException("Unknown script name "
+                    + scriptSource);
         }
 
         @Override
         public void close() {
             // optionally close resources
+        }
+
+        private static class PureDfLeafFactory implements LeafFactory {
+            private final Map<String, Object> params;
+            private final SearchLookup lookup;
+            private final String field;
+            private final String term;
+
+            private PureDfLeafFactory(
+                        Map<String, Object> params, SearchLookup lookup) {
+                if (params.containsKey("field") == false) {
+                    throw new IllegalArgumentException(
+                            "Missing parameter [field]");
+                }
+                if (params.containsKey("term") == false) {
+                    throw new IllegalArgumentException(
+                            "Missing parameter [term]");
+                }
+                this.params = params;
+                this.lookup = lookup;
+                field = params.get("field").toString();
+                term = params.get("term").toString();
+            }
+
+            @Override
+            public boolean needs_score() {
+                return false;  // Return true if the script needs the score
+            }
+
+            @Override
+            public ScoreScript newInstance(LeafReaderContext context)
+                    throws IOException {
+                PostingsEnum postings = context.reader().postings(
+                        new Term(field, term));
+                if (postings == null) {
+                    /*
+                     * the field and/or term don't exist in this segment,
+                     * so always return 0
+                     */
+                    return new ScoreScript(params, lookup, context) {
+                        @Override
+                        public double execute() {
+                            return 0.0d;
+                        }
+                    };
+                }
+                return new ScoreScript(params, lookup, context) {
+                    int currentDocid = -1;
+                    @Override
+                    public void setDocument(int docid) {
+                        /*
+                         * advance has undefined behavior calling with
+                         * a docid <= its current docid
+                         */
+                        if (postings.docID() < docid) {
+                            try {
+                                postings.advance(docid);
+                            } catch (IOException e) {
+                                throw new UncheckedIOException(e);
+                            }
+                        }
+                        currentDocid = docid;
+                    }
+                    @Override
+                    public double execute() {
+                        if (postings.docID() != currentDocid) {
+                            /*
+                             * advance moved past the current doc, so this doc
+                             * has no occurrences of the term
+                             */
+                            return 0.0d;
+                        }
+                        try {
+                            return postings.freq();
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    }
+                };
+            }
         }
     }
     // end::expert_engine


### PR DESCRIPTION
This slightly reworks the expert script plugin example so it fits on the
page when the docs are rendered. The box in which it is rendered is not
very wide so it took a bit of twisting to make it readable.
