### PR TITLE
When parsing JSON fields, also create tokens prefixed with the field key.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -51,8 +51,10 @@ import static org.elasticsearch.index.mapper.TypeParsers.parseField;
  * of keys.
  *
  * Currently the mapper extracts all leaf values of the JSON object, converts them to their text
- * representations, and indexes each one as a keyword. As an example, given a json field called
- * 'json_field' and the following input
+ * representations, and indexes each one as a keyword. It creates both a prefixed version of the token
+ * to allow searches on particular key-value pairs, as well as a 'root' token that is not prefixed.
+ *
+ * As an example, given a json field called 'json_field' and the following input
  *
  * {
  *   "json_field: {
@@ -63,13 +65,18 @@ import static org.elasticsearch.index.mapper.TypeParsers.parseField;
  *   }
  * }
  *
- * the mapper will produce untokenized string fields with the values "some value" and "true".
+ * the mapper will produce untokenized string fields called "json_field" with values "some value" and "true",
+ * as well as string fields called "json_field._prefixed" with values "key\0some value" and "key2.key3\0true".
+ *
+ * Note that \0 is a reserved separator character, and cannot be used in the keys of the JSON object
+ * (see {@link JsonFieldParser#SEPARATOR}).
  */
 public final class JsonFieldMapper extends FieldMapper {
 
     public static final String CONTENT_TYPE = "json";
     public static final NamedAnalyzer WHITESPACE_ANALYZER = new NamedAnalyzer(
         "whitespace", AnalyzerScope.INDEX, new WhitespaceAnalyzer());
+    public static final String PREFIXED_FIELD_SUFFIX = "._prefixed";
 
     private static class Defaults {
         public static final MappedFieldType FIELD_TYPE = new JsonFieldType();

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -51,8 +51,8 @@ import static org.elasticsearch.index.mapper.TypeParsers.parseField;
  * of keys.
  *
  * Currently the mapper extracts all leaf values of the JSON object, converts them to their text
- * representations, and indexes each one as a keyword. It creates both a prefixed version of the token
- * to allow searches on particular key-value pairs, as well as a 'root' token that is not prefixed.
+ * representations, and indexes each one as a keyword. It creates both a 'keyed' version of the token
+ * to allow searches on particular key-value pairs, as well as a 'root' token without the key
  *
  * As an example, given a json field called 'json_field' and the following input
  *
@@ -66,7 +66,7 @@ import static org.elasticsearch.index.mapper.TypeParsers.parseField;
  * }
  *
  * the mapper will produce untokenized string fields called "json_field" with values "some value" and "true",
- * as well as string fields called "json_field._prefixed" with values "key\0some value" and "key2.key3\0true".
+ * as well as string fields called "json_field._keyed" with values "key\0some value" and "key2.key3\0true".
  *
  * Note that \0 is a reserved separator character, and cannot be used in the keys of the JSON object
  * (see {@link JsonFieldParser#SEPARATOR}).
@@ -76,7 +76,7 @@ public final class JsonFieldMapper extends FieldMapper {
     public static final String CONTENT_TYPE = "json";
     public static final NamedAnalyzer WHITESPACE_ANALYZER = new NamedAnalyzer(
         "whitespace", AnalyzerScope.INDEX, new WhitespaceAnalyzer());
-    public static final String PREFIXED_FIELD_SUFFIX = "._prefixed";
+    public static final String KEYED_FIELD_SUFFIX = "._keyed";
 
     private static class Defaults {
         public static final MappedFieldType FIELD_TYPE = new JsonFieldType();

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
@@ -39,7 +39,7 @@ public class JsonFieldParser {
     private final MappedFieldType fieldType;
     private final int ignoreAbove;
 
-    private final String fieldName;
+    private final String rootFieldName;
     private final String prefixedFieldName;
 
     JsonFieldParser(MappedFieldType fieldType,
@@ -47,7 +47,7 @@ public class JsonFieldParser {
         this.fieldType = fieldType;
         this.ignoreAbove = ignoreAbove;
 
-        this.fieldName = fieldType.name();
+        this.rootFieldName = fieldType.name();
         this.prefixedFieldName = fieldType.name() + JsonFieldMapper.PREFIXED_FIELD_SUFFIX;
     }
 
@@ -136,8 +136,8 @@ public class JsonFieldParser {
                 + " Offending key: [" + key + "].");
         }
         String prefixedValue = createPrefixedValue(key, value);
-        
-        fields.add(new Field(fieldName, new BytesRef(value), fieldType));
+
+        fields.add(new Field(rootFieldName, new BytesRef(value), fieldType));
         fields.add(new Field(prefixedFieldName, new BytesRef(prefixedValue), fieldType));
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
@@ -40,7 +40,7 @@ public class JsonFieldParser {
     private final int ignoreAbove;
 
     private final String rootFieldName;
-    private final String prefixedFieldName;
+    private final String keyedFieldName;
 
     JsonFieldParser(MappedFieldType fieldType,
                     int ignoreAbove) {
@@ -48,7 +48,7 @@ public class JsonFieldParser {
         this.ignoreAbove = ignoreAbove;
 
         this.rootFieldName = fieldType.name();
-        this.prefixedFieldName = fieldType.name() + JsonFieldMapper.PREFIXED_FIELD_SUFFIX;
+        this.keyedFieldName = fieldType.name() + JsonFieldMapper.KEYED_FIELD_SUFFIX;
     }
 
     public List<IndexableField> parse(XContentParser parser) throws IOException {
@@ -134,13 +134,13 @@ public class JsonFieldParser {
             throw new IllegalArgumentException("Keys in [json] fields cannot contain the reserved character \\0."
                 + " Offending key: [" + key + "].");
         }
-        String prefixedValue = createPrefixedValue(key, value);
+        String keyedValue = createKeyedValue(key, value);
 
         fields.add(new Field(rootFieldName, new BytesRef(value), fieldType));
-        fields.add(new Field(prefixedFieldName, new BytesRef(prefixedValue), fieldType));
+        fields.add(new Field(keyedFieldName, new BytesRef(keyedValue), fieldType));
     }
 
-    private static String createPrefixedValue(String key, String value) {
+    private static String createKeyedValue(String key, String value) {
         return key + SEPARATOR + value;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
@@ -114,6 +114,10 @@ public class JsonFieldParser {
             if (value != null) {
                 addField(path, currentName, value, fields);
             }
+        } else {
+            // Note that we throw an exception here just to be safe. We don't actually expect to reach
+            // this case, since XContentParser verifies that the input is well-formed as it parses.
+            throw new IllegalArgumentException("Encountered unexpected token [" + token.toString() + "].");
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
@@ -31,16 +31,24 @@ import java.util.List;
 
 /**
  * A helper class for {@link JsonFieldMapper} parses a JSON object
- * and produces an indexable field for each leaf value.
+ * and produces a pair of indexable fields for each leaf value.
  */
 public class JsonFieldParser {
+    private static final String SEPARATOR = "\0";
+
     private final MappedFieldType fieldType;
     private final int ignoreAbove;
+
+    private final String fieldName;
+    private final String prefixedFieldName;
 
     JsonFieldParser(MappedFieldType fieldType,
                     int ignoreAbove) {
         this.fieldType = fieldType;
         this.ignoreAbove = ignoreAbove;
+
+        this.fieldName = fieldType.name();
+        this.prefixedFieldName = fieldType.name() + JsonFieldMapper.PREFIXED_FIELD_SUFFIX;
     }
 
     public List<IndexableField> parse(XContentParser parser) throws IOException {
@@ -48,36 +56,92 @@ public class JsonFieldParser {
             parser.currentToken(),
             parser::getTokenLocation);
 
+        ContentPath path = new ContentPath();
         List<IndexableField> fields = new ArrayList<>();
-        int openObjects = 1;
 
+        parseObject(parser, path, fields);
+        return fields;
+    }
+
+    private void parseObject(XContentParser parser,
+                             ContentPath path,
+                             List<IndexableField> fields) throws IOException {
+        String currentName = null;
         while (true) {
-            if (openObjects == 0) {
-                return fields;
+            XContentParser.Token token = parser.nextToken();
+            if (token == XContentParser.Token.END_OBJECT) {
+                return;
             }
 
-            XContentParser.Token token = parser.nextToken();
-            assert token != null;
-
-            if (token == XContentParser.Token.START_OBJECT) {
-                openObjects++;
-            } else if (token == XContentParser.Token.END_OBJECT) {
-                openObjects--;
-            } else if (token.isValue()) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                assert currentName != null;
+                path.add(currentName);
+                parseObject(parser, path, fields);
+                path.remove();
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                assert currentName != null;
+                parseArray(parser, path, currentName, fields);
+            }  else if (token.isValue()) {
                 String value = parser.text();
-                addField(value, fields);
+                addField(path, currentName, value, fields);
             } else if (token == XContentParser.Token.VALUE_NULL) {
                 String value = fieldType.nullValueAsString();
                 if (value != null) {
-                    addField(value, fields);
+                    addField(path, currentName, value, fields);
                 }
             }
         }
     }
 
-    private void addField(String value, List<IndexableField> fields) {
-        if (value.length() <= ignoreAbove) {
-            fields.add(new Field(fieldType.name(), new BytesRef(value), fieldType));
+    private void parseArray(XContentParser parser,
+                             ContentPath path,
+                             String currentName,
+                             List<IndexableField> fields) throws IOException {
+        while (true) {
+            XContentParser.Token token = parser.nextToken();
+            if (token == XContentParser.Token.END_ARRAY) {
+                return;
+            }
+
+            if (token == XContentParser.Token.START_OBJECT) {
+                path.add(currentName);
+                parseObject(parser, path, fields);
+                path.remove();
+            } else if (token.isValue()) {
+                String value = parser.text();
+                addField(path, currentName, value, fields);
+            } else if (token == XContentParser.Token.VALUE_NULL) {
+                String value = fieldType.nullValueAsString();
+                if (value != null) {
+                    addField(path, currentName, value, fields);
+                }
+            }
         }
+    }
+
+    private void addField(ContentPath path,
+                          String currentName,
+                          String value,
+                          List<IndexableField> fields) {
+        if (value.length() > ignoreAbove) {
+            return;
+        }
+
+        assert currentName != null;
+        String key = path.pathAsText(currentName);
+        if (key.contains(SEPARATOR)) {
+            throw new IllegalArgumentException("Keys in [json] fields cannot contain the reserved character \\0."
+                + " Offending key: [" + key + "].");
+        }
+        String prefixedValue = createPrefixedValue(key, value);
+        
+        fields.add(new Field(fieldName, new BytesRef(value), fieldType));
+        fields.add(new Field(prefixedFieldName, new BytesRef(prefixedValue), fieldType));
+    }
+
+    private static String createPrefixedValue(String key, String value) {
+        return key + SEPARATOR + value;
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldMapperTests.java
@@ -86,13 +86,13 @@ public class JsonFieldMapperTests extends ESSingleNodeTestCase {
         assertFalse(fields[0].fieldType().stored());
         assertTrue(fields[0].fieldType().omitNorms());
 
-        IndexableField[] prefixedFields = parsedDoc.rootDoc().getFields("field._prefixed");
-        assertEquals(1, prefixedFields.length);
+        IndexableField[] keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
+        assertEquals(1, keyedFields.length);
 
-        assertEquals("field._prefixed", prefixedFields[0].name());
-        assertEquals(new BytesRef("key\0value"), prefixedFields[0].binaryValue());
-        assertFalse(prefixedFields[0].fieldType().stored());
-        assertTrue(prefixedFields[0].fieldType().omitNorms());
+        assertEquals("field._keyed", keyedFields[0].name());
+        assertEquals(new BytesRef("key\0value"), keyedFields[0].binaryValue());
+        assertFalse(keyedFields[0].fieldType().stored());
+        assertTrue(keyedFields[0].fieldType().omitNorms());
 
         IndexableField[] fieldNamesFields = parsedDoc.rootDoc().getFields(FieldNamesFieldMapper.NAME);
         assertEquals(1, fieldNamesFields.length);
@@ -256,11 +256,11 @@ public class JsonFieldMapperTests extends ESSingleNodeTestCase {
         assertEquals(new BytesRef("true"), fields[1].binaryValue());
         assertEquals(new BytesRef("false"), fields[2].binaryValue());
 
-        IndexableField[] prefixedFields = parsedDoc.rootDoc().getFields("field._prefixed");
-        assertEquals(3, prefixedFields.length);
-        assertEquals(new BytesRef("key1\0value"), prefixedFields[0].binaryValue());
-        assertEquals(new BytesRef("key2\0true"), prefixedFields[1].binaryValue());
-        assertEquals(new BytesRef("key3\0false"), prefixedFields[2].binaryValue());
+        IndexableField[] keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
+        assertEquals(3, keyedFields.length);
+        assertEquals(new BytesRef("key1\0value"), keyedFields[0].binaryValue());
+        assertEquals(new BytesRef("key2\0true"), keyedFields[1].binaryValue());
+        assertEquals(new BytesRef("key3\0false"), keyedFields[2].binaryValue());
     }
 
     public void testIgnoreAbove() throws IOException {
@@ -326,7 +326,7 @@ public class JsonFieldMapperTests extends ESSingleNodeTestCase {
         assertEquals(1, otherFields.length);
         assertEquals(new BytesRef("placeholder"), otherFields[0].binaryValue());
 
-        IndexableField[] prefixedOtherFields = parsedDoc.rootDoc().getFields("other_field._prefixed");
+        IndexableField[] prefixedOtherFields = parsedDoc.rootDoc().getFields("other_field._keyed");
         assertEquals(1, prefixedOtherFields.length);
         assertEquals(new BytesRef("key\0placeholder"), prefixedOtherFields[0].binaryValue());
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldParserTests.java
@@ -124,6 +124,38 @@ public class JsonFieldParserTests extends ESTestCase {
         assertEquals(new BytesRef("key\0false"), prefixedField2.binaryValue());
     }
 
+    public void testArrayOfArrays() throws Exception {
+        String input = "{ \"key\": [[true, \"value\"], 3] }";
+        XContentParser xContentParser = createXContentParser(input);
+
+        List<IndexableField> fields = parser.parse(xContentParser);
+        assertEquals(6, fields.size());
+
+        IndexableField field1 = fields.get(0);
+        assertEquals("field", field1.name());
+        assertEquals(new BytesRef("true"), field1.binaryValue());
+
+        IndexableField prefixedField1 = fields.get(1);
+        assertEquals("field._prefixed", prefixedField1.name());
+        assertEquals(new BytesRef("key\0true"), prefixedField1.binaryValue());
+
+        IndexableField field2 = fields.get(2);
+        assertEquals("field", field2.name());
+        assertEquals(new BytesRef("value"), field2.binaryValue());
+
+        IndexableField prefixedField2 = fields.get(3);
+        assertEquals("field._prefixed", prefixedField2.name());
+        assertEquals(new BytesRef("key\0value"), prefixedField2.binaryValue());
+
+        IndexableField field3 = fields.get(4);
+        assertEquals("field", field3.name());
+        assertEquals(new BytesRef("3"), field3.binaryValue());
+
+        IndexableField prefixedField3 = fields.get(5);
+        assertEquals("field._prefixed", prefixedField3.name());
+        assertEquals(new BytesRef("key" + "\0" + "3"), prefixedField3.binaryValue());
+    }
+
     public void testArraysOfObjects() throws Exception {
         String input = "{ \"key1\": [{ \"key2\": true }, false], \"key4\": \"other\" }";
         XContentParser xContentParser = createXContentParser(input);

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldParserTests.java
@@ -58,17 +58,17 @@ public class JsonFieldParserTests extends ESTestCase {
         assertEquals("field", field1.name());
         assertEquals(new BytesRef("value1"), field1.binaryValue());
 
-        IndexableField prefixedField1 = fields.get(1);
-        assertEquals("field._prefixed", prefixedField1.name());
-        assertEquals(new BytesRef("key1\0value1"), prefixedField1.binaryValue());
+        IndexableField keyedField1 = fields.get(1);
+        assertEquals("field._keyed", keyedField1.name());
+        assertEquals(new BytesRef("key1\0value1"), keyedField1.binaryValue());
 
         IndexableField field2 = fields.get(2);
         assertEquals("field", field2.name());
         assertEquals(new BytesRef("value2"), field2.binaryValue());
 
-        IndexableField prefixedField2 = fields.get(3);
-        assertEquals("field._prefixed", prefixedField2.name());
-        assertEquals(new BytesRef("key2\0value2"), prefixedField2.binaryValue());
+        IndexableField keyedField2 = fields.get(3);
+        assertEquals("field._keyed", keyedField2.name());
+        assertEquals(new BytesRef("key2\0value2"), keyedField2.binaryValue());
     }
 
     public void testNumericValues() throws Exception {
@@ -82,9 +82,9 @@ public class JsonFieldParserTests extends ESTestCase {
         assertEquals("field", field.name());
         assertEquals(new BytesRef("2.718"), field.binaryValue());
 
-        IndexableField prefixedField = fields.get(1);
-        assertEquals("field._prefixed", prefixedField.name());
-        assertEquals(new BytesRef("key" + '\0' + "2.718"), prefixedField.binaryValue());
+        IndexableField keyedField = fields.get(1);
+        assertEquals("field._keyed", keyedField.name());
+        assertEquals(new BytesRef("key" + '\0' + "2.718"), keyedField.binaryValue());
     }
 
     public void testBooleanValues() throws Exception {
@@ -98,9 +98,9 @@ public class JsonFieldParserTests extends ESTestCase {
         assertEquals("field", field.name());
         assertEquals(new BytesRef("false"), field.binaryValue());
 
-        IndexableField prefixedField = fields.get(1);
-        assertEquals("field._prefixed", prefixedField.name());
-        assertEquals(new BytesRef("key\0false"), prefixedField.binaryValue());
+        IndexableField keyedField = fields.get(1);
+        assertEquals("field._keyed", keyedField.name());
+        assertEquals(new BytesRef("key\0false"), keyedField.binaryValue());
     }
 
     public void testBasicArrays() throws Exception {
@@ -114,17 +114,17 @@ public class JsonFieldParserTests extends ESTestCase {
         assertEquals("field", field1.name());
         assertEquals(new BytesRef("true"), field1.binaryValue());
 
-        IndexableField prefixedField1 = fields.get(1);
-        assertEquals("field._prefixed", prefixedField1.name());
-        assertEquals(new BytesRef("key\0true"), prefixedField1.binaryValue());
+        IndexableField keyedField1 = fields.get(1);
+        assertEquals("field._keyed", keyedField1.name());
+        assertEquals(new BytesRef("key\0true"), keyedField1.binaryValue());
 
         IndexableField field2 = fields.get(2);
         assertEquals("field", field2.name());
         assertEquals(new BytesRef("false"), field2.binaryValue());
 
-        IndexableField prefixedField2 = fields.get(3);
-        assertEquals("field._prefixed", prefixedField2.name());
-        assertEquals(new BytesRef("key\0false"), prefixedField2.binaryValue());
+        IndexableField keyedField2 = fields.get(3);
+        assertEquals("field._keyed", keyedField2.name());
+        assertEquals(new BytesRef("key\0false"), keyedField2.binaryValue());
     }
 
     public void testArrayOfArrays() throws Exception {
@@ -138,25 +138,25 @@ public class JsonFieldParserTests extends ESTestCase {
         assertEquals("field", field1.name());
         assertEquals(new BytesRef("true"), field1.binaryValue());
 
-        IndexableField prefixedField1 = fields.get(1);
-        assertEquals("field._prefixed", prefixedField1.name());
-        assertEquals(new BytesRef("key\0true"), prefixedField1.binaryValue());
+        IndexableField keyedField1 = fields.get(1);
+        assertEquals("field._keyed", keyedField1.name());
+        assertEquals(new BytesRef("key\0true"), keyedField1.binaryValue());
 
         IndexableField field2 = fields.get(2);
         assertEquals("field", field2.name());
         assertEquals(new BytesRef("value"), field2.binaryValue());
 
-        IndexableField prefixedField2 = fields.get(3);
-        assertEquals("field._prefixed", prefixedField2.name());
-        assertEquals(new BytesRef("key\0value"), prefixedField2.binaryValue());
+        IndexableField keyedField2 = fields.get(3);
+        assertEquals("field._keyed", keyedField2.name());
+        assertEquals(new BytesRef("key\0value"), keyedField2.binaryValue());
 
         IndexableField field3 = fields.get(4);
         assertEquals("field", field3.name());
         assertEquals(new BytesRef("3"), field3.binaryValue());
 
-        IndexableField prefixedField3 = fields.get(5);
-        assertEquals("field._prefixed", prefixedField3.name());
-        assertEquals(new BytesRef("key" + "\0" + "3"), prefixedField3.binaryValue());
+        IndexableField keyedField3 = fields.get(5);
+        assertEquals("field._keyed", keyedField3.name());
+        assertEquals(new BytesRef("key" + "\0" + "3"), keyedField3.binaryValue());
     }
 
     public void testArraysOfObjects() throws Exception {
@@ -170,25 +170,25 @@ public class JsonFieldParserTests extends ESTestCase {
         assertEquals("field", field1.name());
         assertEquals(new BytesRef("true"), field1.binaryValue());
 
-        IndexableField prefixedField1 = fields.get(1);
-        assertEquals("field._prefixed", prefixedField1.name());
-        assertEquals(new BytesRef("key1.key2\0true"), prefixedField1.binaryValue());
+        IndexableField keyedField1 = fields.get(1);
+        assertEquals("field._keyed", keyedField1.name());
+        assertEquals(new BytesRef("key1.key2\0true"), keyedField1.binaryValue());
 
         IndexableField field2 = fields.get(2);
         assertEquals("field", field2.name());
         assertEquals(new BytesRef("false"), field2.binaryValue());
 
-        IndexableField prefixedField2 = fields.get(3);
-        assertEquals("field._prefixed", prefixedField2.name());
-        assertEquals(new BytesRef("key1\0false"), prefixedField2.binaryValue());
+        IndexableField keyedField2 = fields.get(3);
+        assertEquals("field._keyed", keyedField2.name());
+        assertEquals(new BytesRef("key1\0false"), keyedField2.binaryValue());
 
         IndexableField field3 = fields.get(4);
         assertEquals("field", field3.name());
         assertEquals(new BytesRef("other"), field3.binaryValue());
 
-        IndexableField prefixedField3 = fields.get(5);
-        assertEquals("field._prefixed", prefixedField3.name());
-        assertEquals(new BytesRef("key4\0other"), prefixedField3.binaryValue());
+        IndexableField keyedField3 = fields.get(5);
+        assertEquals("field._keyed", keyedField3.name());
+        assertEquals(new BytesRef("key4\0other"), keyedField3.binaryValue());
     }
 
     public void testNestedObjects() throws Exception {
@@ -203,17 +203,17 @@ public class JsonFieldParserTests extends ESTestCase {
         assertEquals("field", field1.name());
         assertEquals(new BytesRef("value"), field1.binaryValue());
 
-        IndexableField prefixedField1 = fields.get(1);
-        assertEquals("field._prefixed", prefixedField1.name());
-        assertEquals(new BytesRef("parent1.key\0value"), prefixedField1.binaryValue());
+        IndexableField keyedField1 = fields.get(1);
+        assertEquals("field._keyed", keyedField1.name());
+        assertEquals(new BytesRef("parent1.key\0value"), keyedField1.binaryValue());
 
         IndexableField field2 = fields.get(2);
         assertEquals("field", field2.name());
         assertEquals(new BytesRef("value"), field2.binaryValue());
 
-        IndexableField prefixedField2 = fields.get(3);
-        assertEquals("field._prefixed", prefixedField2.name());
-        assertEquals(new BytesRef("parent2.key\0value"), prefixedField2.binaryValue());
+        IndexableField keyedField2 = fields.get(3);
+        assertEquals("field._keyed", keyedField2.name());
+        assertEquals(new BytesRef("parent2.key\0value"), keyedField2.binaryValue());
     }
 
     public void testIgnoreAbove() throws Exception {
@@ -249,9 +249,9 @@ public class JsonFieldParserTests extends ESTestCase {
         assertEquals("field", field.name());
         assertEquals(new BytesRef("placeholder"), field.binaryValue());
 
-        IndexableField prefixedField = fields.get(1);
-        assertEquals("field._prefixed", prefixedField.name());
-        assertEquals(new BytesRef("key\0placeholder"), prefixedField.binaryValue());
+        IndexableField keyedField = fields.get(1);
+        assertEquals("field._keyed", keyedField.name());
+        assertEquals(new BytesRef("key\0placeholder"), keyedField.binaryValue());
     }
 
     public void testMalformedJson() throws Exception {


### PR DESCRIPTION
This PR updates the parsing for `json` fields to emit tokens prefixed by the field key, in addition to 'root' tokens containing the unprefixed value. 

As an example, given a `json` field called 'json_field' and the following input
```
{
  "json_field: {
    "key1": "some value",
    "key2": {
       "key3": true
    }
  }
}
 ```
the mapper will produce untokenized string fields with the values `some value`, `key\0some value`,  `true`, and `key2.key3\0true`.

An important note about this change: the behavior we want is for searches on the 'root' JSON field to only consider raw values, and not prefixed tokens. For example, given the JSON field `"headers": { "content-type": "application/json”"}`, it should not match the query `"prefix": { "headers": "content" } }` just because one of the indexed tokens is `content-type\0application/json`. I think this behavior would be confusing, and that we should try to keep the token prefixing as an internal implementation detail. To avoid this issue, I chose to add the prefixed tokens to a new lucene field called `<field name>._prefixed`. This won't affect how searches are done (the user will still query using the key `headers`, or `headers.content-type`).

Finally, this PR just updates the indexing process -- these prefixed tokens can’t be searched yet. The search side will be implemented in a subsequent PR (I’m just a fan of keeping PRs small!)