### PR TITLE
[ML] Job in index: Datafeed node selector

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
@@ -97,7 +97,7 @@ public final class MlTasks {
      * Is there an ml anomaly detector job task for the job {@code jobId}?
      * @param jobId The job id
      * @param tasks Persistent tasks
-     * @return
+     * @return True if the job has a task
      */
     public static boolean taskExistsForJob(String jobId, PersistentTasksCustomMetaData tasks) {
         return openJobIds(tasks).contains(jobId);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
@@ -149,6 +150,8 @@ public class StartDatafeedAction
 
     public static class DatafeedParams implements XPackPlugin.XPackPersistentTaskParams {
 
+        public static final ParseField INDICES = new ParseField("indices");
+
         public static ObjectParser<DatafeedParams, Void> PARSER = new ObjectParser<>(MlTasks.DATAFEED_TASK_NAME, true, DatafeedParams::new);
         static {
             PARSER.declareString((params, datafeedId) -> params.datafeedId = datafeedId, DatafeedConfig.ID);
@@ -157,6 +160,8 @@ public class StartDatafeedAction
             PARSER.declareString(DatafeedParams::setEndTime, END_TIME);
             PARSER.declareString((params, val) ->
                     params.setTimeout(TimeValue.parseTimeValue(val, TIMEOUT.getPreferredName())), TIMEOUT);
+            PARSER.declareString(DatafeedParams::setJobId, Job.ID);
+            PARSER.declareStringArray(DatafeedParams::setDatafeedIndices, INDICES);
         }
 
         static long parseDateOrThrow(String date, ParseField paramName, LongSupplier now) {
@@ -288,6 +293,12 @@ public class StartDatafeedAction
                 builder.field(END_TIME.getPreferredName(), String.valueOf(endTime));
             }
             builder.field(TIMEOUT.getPreferredName(), timeout.getStringRep());
+            if (jobId != null) {
+                builder.field(Job.ID.getPreferredName(), jobId);
+            }
+            if (datafeedIndices.isEmpty() == false) {
+                builder.field(INDICES.getPreferredName(), datafeedIndices);
+            }
             builder.endObject();
             return builder;
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DatafeedParamsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DatafeedParamsTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 public class DatafeedParamsTests extends AbstractSerializingTestCase<StartDatafeedAction.DatafeedParams> {
     @Override
@@ -28,6 +29,13 @@ public class DatafeedParamsTests extends AbstractSerializingTestCase<StartDatafe
         if (randomBoolean()) {
             params.setTimeout(TimeValue.timeValueMillis(randomNonNegativeLong()));
         }
+        if (randomBoolean()) {
+            params.setJobId(randomAlphaOfLength(10));
+        }
+        if (randomBoolean()) {
+            params.setDatafeedIndices(Arrays.asList(randomAlphaOfLength(10), randomAlphaOfLength(10)));
+        }
+
         return params;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -411,7 +411,8 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 jobManager, jobResultsProvider, jobResultsPersister, jobDataCountsPersister, autodetectProcessFactory,
                 normalizerFactory, xContentRegistry, auditor);
         this.autodetectProcessManager.set(autodetectProcessManager);
-        DatafeedJobBuilder datafeedJobBuilder = new DatafeedJobBuilder(client, jobResultsProvider, auditor, System::currentTimeMillis);
+        DatafeedJobBuilder datafeedJobBuilder = new DatafeedJobBuilder(client, settings, xContentRegistry,
+                auditor, System::currentTimeMillis);
         DatafeedManager datafeedManager = new DatafeedManager(threadPool, client, clusterService, datafeedJobBuilder,
                 System::currentTimeMillis, auditor);
         this.datafeedManager.set(datafeedManager);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -162,6 +162,7 @@ import org.elasticsearch.xpack.ml.action.TransportValidateDetectorAction;
 import org.elasticsearch.xpack.ml.action.TransportValidateJobConfigAction;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedJobBuilder;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedManager;
+import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.job.JobManager;
 import org.elasticsearch.xpack.ml.job.UpdateJobProcessNotifier;
 import org.elasticsearch.xpack.ml.job.categorization.MlClassicTokenizer;
@@ -369,6 +370,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
         Auditor auditor = new Auditor(client, clusterService.nodeName());
         JobResultsProvider jobResultsProvider = new JobResultsProvider(client, settings);
         JobConfigProvider jobConfigProvider = new JobConfigProvider(client, settings);
+        DatafeedConfigProvider datafeedConfigProvider = new DatafeedConfigProvider(client, settings, xContentRegistry);
         UpdateJobProcessNotifier notifier = new UpdateJobProcessNotifier(settings, client, clusterService, threadPool);
         JobManager jobManager = new JobManager(env, settings, jobResultsProvider, clusterService, auditor, threadPool, client, notifier);
 
@@ -426,6 +428,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 mlLifeCycleService,
                 jobResultsProvider,
                 jobConfigProvider,
+                datafeedConfigProvider,
                 jobManager,
                 autodetectProcessManager,
                 new MlInitializationService(settings, threadPool, clusterService, client),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
@@ -88,7 +88,7 @@ public class MlAssignmentNotifier extends AbstractComponent implements ClusterSt
                 }
             } else if (MlTasks.DATAFEED_TASK_NAME.equals(currentTask.getTaskName())) {
                 StartDatafeedAction.DatafeedParams datafeedParams = (StartDatafeedAction.DatafeedParams) currentTask.getParams();
-                String jobId = datafeedParams.getJob() != null ? datafeedParams.getJob().getId() : null;
+                String jobId = datafeedParams.getJobId();
                 if (currentAssignment.getExecutorNode() == null) {
                     String msg = "No node found to start datafeed [" + datafeedParams.getDatafeedId() +"]. Reasons [" +
                             currentAssignment.getExplanation() + "]";

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -304,14 +304,14 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
         @Override
         public PersistentTasksCustomMetaData.Assignment getAssignment(StartDatafeedAction.DatafeedParams params,
                                                                       ClusterState clusterState) {
-            return new DatafeedNodeSelector(clusterState, resolver, params.getDatafeedId(), params.getDatafeedConfig()).selectNode();
+            return new DatafeedNodeSelector(clusterState, resolver, params.getDatafeedConfig()).selectNode();
         }
 
         @Override
         public void validate(StartDatafeedAction.DatafeedParams params, ClusterState clusterState) {
             PersistentTasksCustomMetaData tasks = clusterState.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
             TransportStartDatafeedAction.validate(params.getJob(), params.getDatafeedConfig(), tasks);
-            new DatafeedNodeSelector(clusterState, resolver, params.getDatafeedId(), params.getDatafeedConfig())
+            new DatafeedNodeSelector(clusterState, resolver, params.getDatafeedConfig())
                     .checkDatafeedTaskCanBeCreated();
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -321,7 +321,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
                                      final PersistentTaskState state) {
             DatafeedTask datafeedTask = (DatafeedTask) allocatedPersistentTask;
             datafeedTask.datafeedManager = datafeedManager;
-            datafeedManager.run(datafeedTask,
+            datafeedManager.run(datafeedTask, params.getJob(), params.getDatafeedConfig(),
                     (error) -> {
                         if (error != null) {
                             datafeedTask.markAsFailed(error);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -35,7 +35,6 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackField;
-import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
@@ -48,10 +47,13 @@ import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedManager;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedNodeSelector;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
+import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
+import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 /* This class extends from TransportMasterNodeAction for cluster state observing purposes.
@@ -67,34 +69,30 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
     private final Client client;
     private final XPackLicenseState licenseState;
     private final PersistentTasksService persistentTasksService;
+    private final JobConfigProvider jobConfigProvider;
+    private final DatafeedConfigProvider datafeedConfigProvider;
 
     @Inject
     public TransportStartDatafeedAction(Settings settings, TransportService transportService, ThreadPool threadPool,
                                         ClusterService clusterService, XPackLicenseState licenseState,
                                         PersistentTasksService persistentTasksService,
                                         ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
-                                        Client client) {
+                                        Client client, JobConfigProvider jobConfigProvider, DatafeedConfigProvider datafeedConfigProvider) {
         super(settings, StartDatafeedAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver,
                 StartDatafeedAction.Request::new);
         this.licenseState = licenseState;
         this.persistentTasksService = persistentTasksService;
         this.client = client;
+        this.jobConfigProvider = jobConfigProvider;
+        this.datafeedConfigProvider = datafeedConfigProvider;
     }
 
-    static void validate(String datafeedId, MlMetadata mlMetadata, PersistentTasksCustomMetaData tasks) {
-        DatafeedConfig datafeed = (mlMetadata == null) ? null : mlMetadata.getDatafeed(datafeedId);
-        if (datafeed == null) {
-            throw ExceptionsHelper.missingDatafeedException(datafeedId);
-        }
-        Job job = mlMetadata.getJobs().get(datafeed.getJobId());
-        if (job == null) {
-            throw ExceptionsHelper.missingJobException(datafeed.getJobId());
-        }
-        DatafeedJobValidator.validate(datafeed, job);
-        JobState jobState = MlTasks.getJobState(datafeed.getJobId(), tasks);
+    static void validate(Job job, DatafeedConfig datafeedConfig, PersistentTasksCustomMetaData tasks) {
+        DatafeedJobValidator.validate(datafeedConfig, job);
+        JobState jobState = MlTasks.getJobState(datafeedConfig.getJobId(), tasks);
         if (jobState.isAnyOf(JobState.OPENING, JobState.OPENED) == false) {
-            throw ExceptionsHelper.conflictStatusException("cannot start datafeed [" + datafeedId + "] because job [" + job.getId() +
-                    "] is " + jobState);
+            throw ExceptionsHelper.conflictStatusException("cannot start datafeed [" + datafeedConfig.getId() +
+                    "] because job [" + job.getId() + "] is " + jobState);
         }
     }
 
@@ -114,57 +112,83 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
     protected void masterOperation(StartDatafeedAction.Request request, ClusterState state,
                                    ActionListener<AcknowledgedResponse> listener) {
         StartDatafeedAction.DatafeedParams params = request.getParams();
-        if (licenseState.isMachineLearningAllowed()) {
-
-            ActionListener<PersistentTasksCustomMetaData.PersistentTask<StartDatafeedAction.DatafeedParams>> waitForTaskListener =
-                    new ActionListener<PersistentTasksCustomMetaData.PersistentTask<StartDatafeedAction.DatafeedParams>>() {
-                        @Override
-                        public void onResponse(PersistentTasksCustomMetaData.PersistentTask<StartDatafeedAction.DatafeedParams>
-                                                       persistentTask) {
-                            waitForDatafeedStarted(persistentTask.getId(), params, listener);
-                        }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            if (e instanceof ResourceAlreadyExistsException) {
-                                logger.debug("datafeed already started", e);
-                                e = new ElasticsearchStatusException("cannot start datafeed [" + params.getDatafeedId() +
-                                        "] because it has already been started", RestStatus.CONFLICT);
-                            }
-                            listener.onFailure(e);
-                        }
-                    };
-
-            // Verify data extractor factory can be created, then start persistent task
-            MlMetadata mlMetadata = MlMetadata.getMlMetadata(state);
-            PersistentTasksCustomMetaData tasks = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
-            validate(params.getDatafeedId(), mlMetadata, tasks);
-            DatafeedConfig datafeed = mlMetadata.getDatafeed(params.getDatafeedId());
-            Job job = mlMetadata.getJobs().get(datafeed.getJobId());
-
-            if (RemoteClusterLicenseChecker.containsRemoteIndex(datafeed.getIndices())) {
-                final RemoteClusterLicenseChecker remoteClusterLicenseChecker =
-                        new RemoteClusterLicenseChecker(client, XPackLicenseState::isMachineLearningAllowedForOperationMode);
-                remoteClusterLicenseChecker.checkRemoteClusterLicenses(
-                        RemoteClusterLicenseChecker.remoteClusterAliases(datafeed.getIndices()),
-                        ActionListener.wrap(
-                                response -> {
-                                    if (response.isSuccess() == false) {
-                                        listener.onFailure(createUnlicensedError(datafeed.getId(), response));
-                                    } else {
-                                        createDataExtractor(job, datafeed, params, waitForTaskListener);
-                                    }
-                                },
-                                e -> listener.onFailure(
-                                        createUnknownLicenseError(
-                                                datafeed.getId(), RemoteClusterLicenseChecker.remoteIndices(datafeed.getIndices()), e))
-                        ));
-            } else {
-                createDataExtractor(job, datafeed, params, waitForTaskListener);
-            }
-        } else {
+        if (licenseState.isMachineLearningAllowed() == false) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
+            return;
         }
+
+        PersistentTasksCustomMetaData tasks = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
+
+        ActionListener<PersistentTasksCustomMetaData.PersistentTask<StartDatafeedAction.DatafeedParams>> waitForTaskListener =
+                new ActionListener<PersistentTasksCustomMetaData.PersistentTask<StartDatafeedAction.DatafeedParams>>() {
+                    @Override
+                    public void onResponse(PersistentTasksCustomMetaData.PersistentTask<StartDatafeedAction.DatafeedParams>
+                                                   persistentTask) {
+                        waitForDatafeedStarted(persistentTask.getId(), params, listener);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        if (e instanceof ResourceAlreadyExistsException) {
+                            logger.debug("datafeed already started", e);
+                            e = new ElasticsearchStatusException("cannot start datafeed [" + params.getDatafeedId() +
+                                    "] because it has already been started", RestStatus.CONFLICT);
+                        }
+                        listener.onFailure(e);
+                    }
+                };
+
+        // Verify data extractor factory can be created, then start persistent task
+        Consumer<Boolean> createDataExtrator = ok -> {
+                if (RemoteClusterLicenseChecker.containsRemoteIndex(params.getDatafeedConfig().getIndices())) {
+                    final RemoteClusterLicenseChecker remoteClusterLicenseChecker =
+                            new RemoteClusterLicenseChecker(client, XPackLicenseState::isMachineLearningAllowedForOperationMode);
+                    remoteClusterLicenseChecker.checkRemoteClusterLicenses(
+                            RemoteClusterLicenseChecker.remoteClusterAliases(params.getDatafeedConfig().getIndices()),
+                            ActionListener.wrap(
+                                    response -> {
+                                        if (response.isSuccess() == false) {
+                                            listener.onFailure(createUnlicensedError(params.getDatafeedConfig().getId(), response));
+                                        } else {
+                                            createDataExtractor(params.getJob(), params.getDatafeedConfig(), params, waitForTaskListener);
+                                        }
+                                    },
+                                    e -> listener.onFailure(
+                                            createUnknownLicenseError(
+                                                    params.getDatafeedConfig().getId(),
+                                                    RemoteClusterLicenseChecker.remoteIndices(params.getDatafeedConfig().getIndices()), e))
+                            ));
+                } else {
+                    createDataExtractor(params.getJob(), params.getDatafeedConfig(), params, waitForTaskListener);
+                }
+            };
+
+        ActionListener<Job.Builder> jobListener = ActionListener.wrap(
+                jobBuilder -> {
+                    try {
+                        params.setJob(jobBuilder.build());
+                        validate(params.getJob(), params.getDatafeedConfig(), tasks);
+                        createDataExtrator.accept(Boolean.TRUE);
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
+                },
+                listener::onFailure
+        );
+
+        ActionListener<DatafeedConfig.Builder> datafeedListener = ActionListener.wrap(
+                datafeedConfig -> {
+                    try {
+                        params.setDatafeedConfig(datafeedConfig.build());
+                        jobConfigProvider.getJob(params.getDatafeedConfig().getJobId(), jobListener);
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
+                },
+                listener::onFailure
+        );
+
+        datafeedConfigProvider.getDatafeedConfig(params.getDatafeedId(), datafeedListener);
     }
 
     private void createDataExtractor(Job job, DatafeedConfig datafeed, StartDatafeedAction.DatafeedParams params,
@@ -280,14 +304,15 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
         @Override
         public PersistentTasksCustomMetaData.Assignment getAssignment(StartDatafeedAction.DatafeedParams params,
                                                                       ClusterState clusterState) {
-            return new DatafeedNodeSelector(clusterState, resolver, params.getDatafeedId()).selectNode();
+            return new DatafeedNodeSelector(clusterState, resolver, params.getDatafeedId(), params.getDatafeedConfig()).selectNode();
         }
 
         @Override
         public void validate(StartDatafeedAction.DatafeedParams params, ClusterState clusterState) {
             PersistentTasksCustomMetaData tasks = clusterState.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
-            TransportStartDatafeedAction.validate(params.getDatafeedId(), MlMetadata.getMlMetadata(clusterState), tasks);
-            new DatafeedNodeSelector(clusterState, resolver, params.getDatafeedId()).checkDatafeedTaskCanBeCreated();
+            TransportStartDatafeedAction.validate(params.getJob(), params.getDatafeedConfig(), tasks);
+            new DatafeedNodeSelector(clusterState, resolver, params.getDatafeedId(), params.getDatafeedConfig())
+                    .checkDatafeedTaskCanBeCreated();
         }
 
         @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
@@ -82,6 +82,10 @@ class DatafeedJob {
         return isIsolated;
     }
 
+    public String getJobId() {
+        return jobId;
+    }
+
     Long runLookBack(long startTime, Long endTime) throws Exception {
         lookbackStartTimeMs = skipToStartTime(startTime);
         Optional<Long> endMs = Optional.ofNullable(endTime);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
@@ -8,93 +8,150 @@ package org.elasticsearch.xpack.ml.datafeed;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ml.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.BucketsQueryBuilder;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
+import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 import org.elasticsearch.xpack.ml.notifications.Auditor;
 
 import java.util.Collections;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public class DatafeedJobBuilder {
 
     private final Client client;
-    private final JobResultsProvider jobResultsProvider;
+    private final Settings settings;
+    private final NamedXContentRegistry xContentRegistry;
     private final Auditor auditor;
     private final Supplier<Long> currentTimeSupplier;
 
-    public DatafeedJobBuilder(Client client, JobResultsProvider jobResultsProvider, Auditor auditor, Supplier<Long> currentTimeSupplier) {
+    public DatafeedJobBuilder(Client client, Settings settings, NamedXContentRegistry xContentRegistry,
+                              Auditor auditor, Supplier<Long> currentTimeSupplier) {
         this.client = client;
-        this.jobResultsProvider = Objects.requireNonNull(jobResultsProvider);
+        this.settings = Objects.requireNonNull(settings);
+        this.xContentRegistry = Objects.requireNonNull(xContentRegistry);
         this.auditor = Objects.requireNonNull(auditor);
         this.currentTimeSupplier = Objects.requireNonNull(currentTimeSupplier);
     }
 
-    void build(Job job, DatafeedConfig datafeed, ActionListener<DatafeedJob> listener) {
+    void build(String datafeedId, ActionListener<DatafeedJob> listener) {
+
+        JobResultsProvider jobResultsProvider = new JobResultsProvider(client, settings);
+        JobConfigProvider jobConfigProvider = new JobConfigProvider(client, settings);
+        DatafeedConfigProvider datafeedConfigProvider = new DatafeedConfigProvider(client, settings, xContentRegistry);
+
+        build(datafeedId, jobResultsProvider, jobConfigProvider, datafeedConfigProvider, listener);
+    }
+
+    /**
+     * For testing only.
+     * Use {@link #build(String, ActionListener)} instead
+     */
+    void build(String datafeedId, JobResultsProvider jobResultsProvider, JobConfigProvider jobConfigProvider,
+               DatafeedConfigProvider datafeedConfigProvider, ActionListener<DatafeedJob> listener) {
+
+        AtomicReference<Job> jobHolder = new AtomicReference<>();
+        AtomicReference<DatafeedConfig> datafeedConfigHolder = new AtomicReference<>();
 
         // Step 5. Build datafeed job object
         Consumer<Context> contextHanlder = context -> {
-            TimeValue frequency = getFrequencyOrDefault(datafeed, job);
-            TimeValue queryDelay = datafeed.getQueryDelay();
-            DatafeedJob datafeedJob = new DatafeedJob(job.getId(), buildDataDescription(job), frequency.millis(), queryDelay.millis(),
+            TimeValue frequency = getFrequencyOrDefault(datafeedConfigHolder.get(), jobHolder.get());
+            TimeValue queryDelay = datafeedConfigHolder.get().getQueryDelay();
+            DatafeedJob datafeedJob = new DatafeedJob(jobHolder.get().getId(), buildDataDescription(jobHolder.get()),
+                    frequency.millis(), queryDelay.millis(),
                     context.dataExtractorFactory, client, auditor, currentTimeSupplier,
                     context.latestFinalBucketEndMs, context.latestRecordTimeMs);
+
             listener.onResponse(datafeedJob);
         };
 
         final Context context = new Context();
 
-        // Step 4. Context building complete - invoke final listener
+        // Context building complete - invoke final listener
         ActionListener<DataExtractorFactory> dataExtractorFactoryHandler = ActionListener.wrap(
                 dataExtractorFactory -> {
                     context.dataExtractorFactory = dataExtractorFactory;
                     contextHanlder.accept(context);
                 }, e -> {
-                    auditor.error(job.getId(), e.getMessage());
+                    auditor.error(jobHolder.get().getId(), e.getMessage());
                     listener.onFailure(e);
                 }
         );
 
-        // Step 3. Create data extractor factory
+        // Create data extractor factory
         Consumer<DataCounts> dataCountsHandler = dataCounts -> {
             if (dataCounts.getLatestRecordTimeStamp() != null) {
                 context.latestRecordTimeMs = dataCounts.getLatestRecordTimeStamp().getTime();
             }
-            DataExtractorFactory.create(client, datafeed, job, dataExtractorFactoryHandler);
+            DataExtractorFactory.create(client, datafeedConfigHolder.get(), jobHolder.get(), dataExtractorFactoryHandler);
         };
 
-        // Step 2. Collect data counts
+        // Collect data counts
         Consumer<QueryPage<Bucket>> bucketsHandler = buckets -> {
             if (buckets.results().size() == 1) {
-                TimeValue bucketSpan = job.getAnalysisConfig().getBucketSpan();
+                TimeValue bucketSpan = jobHolder.get().getAnalysisConfig().getBucketSpan();
                 context.latestFinalBucketEndMs = buckets.results().get(0).getTimestamp().getTime() + bucketSpan.millis() - 1;
             }
-            jobResultsProvider.dataCounts(job.getId(), dataCountsHandler, listener::onFailure);
+            jobResultsProvider.dataCounts(jobHolder.get().getId(), dataCountsHandler, listener::onFailure);
         };
 
-        // Step 1. Collect latest bucket
-        BucketsQueryBuilder latestBucketQuery = new BucketsQueryBuilder()
-                .sortField(Result.TIMESTAMP.getPreferredName())
-                .sortDescending(true).size(1)
-                .includeInterim(false);
-        jobResultsProvider.bucketsViaInternalClient(job.getId(), latestBucketQuery, bucketsHandler, e -> {
-            if (e instanceof ResourceNotFoundException) {
-                QueryPage<Bucket> empty = new QueryPage<>(Collections.emptyList(), 0, Bucket.RESULT_TYPE_FIELD);
-                bucketsHandler.accept(empty);
-            } else {
-                listener.onFailure(e);
-            }
-        });
+        // Collect latest bucket
+        Consumer<String> jobIdConsumer = jobId -> {
+            BucketsQueryBuilder latestBucketQuery = new BucketsQueryBuilder()
+                    .sortField(Result.TIMESTAMP.getPreferredName())
+                    .sortDescending(true).size(1)
+                    .includeInterim(false);
+            jobResultsProvider.bucketsViaInternalClient(jobId, latestBucketQuery, bucketsHandler, e -> {
+                if (e instanceof ResourceNotFoundException) {
+                    QueryPage<Bucket> empty = new QueryPage<>(Collections.emptyList(), 0, Bucket.RESULT_TYPE_FIELD);
+                    bucketsHandler.accept(empty);
+                } else {
+                    listener.onFailure(e);
+                }
+            });
+        };
+
+        // Get the job config
+        ActionListener<Job.Builder> jobConfigListener = ActionListener.wrap(
+                jobBuilder -> {
+                    try {
+                        jobHolder.set(jobBuilder.build());
+                        jobIdConsumer.accept(jobHolder.get().getId());
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
+                },
+                listener::onFailure
+        );
+
+        // Get the datafeed config
+        ActionListener<DatafeedConfig.Builder> datafeedConfigListener = ActionListener.wrap(
+                configBuilder -> {
+                    try {
+                        datafeedConfigHolder.set(configBuilder.build());
+                        jobConfigProvider.getJob(datafeedConfigHolder.get().getJobId(), jobConfigListener);
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
+                },
+                listener::onFailure
+        );
+
+        datafeedConfigProvider.getDatafeedConfig(datafeedId, datafeedConfigListener);
     }
 
     private static TimeValue getFrequencyOrDefault(DatafeedConfig datafeed, Job job) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ml.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedJobValidator;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
@@ -125,11 +126,14 @@ public class DatafeedJobBuilder {
             });
         };
 
-        // Get the job config
+        // Get the job config and re-validate
+        // Re-validation is required as the config has been re-read since
+        // the previous validation
         ActionListener<Job.Builder> jobConfigListener = ActionListener.wrap(
                 jobBuilder -> {
                     try {
                         jobHolder.set(jobBuilder.build());
+                        DatafeedJobValidator.validate(datafeedConfigHolder.get(), jobHolder.get());
                         jobIdConsumer.accept(jobHolder.get().getId());
                     } catch (Exception e) {
                         listener.onFailure(e);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
@@ -25,9 +25,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
-import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
-import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.ml.MachineLearning;
@@ -76,11 +74,14 @@ public class DatafeedManager extends AbstractComponent {
         clusterService.addListener(taskRunner);
     }
 
-    public void run(TransportStartDatafeedAction.DatafeedTask task, Job job, DatafeedConfig datafeed, Consumer<Exception> taskHandler) {
+
+    public void run(TransportStartDatafeedAction.DatafeedTask task, Consumer<Exception> finishHandler) {
+        String datafeedId = task.getDatafeedId();
 
         ActionListener<DatafeedJob> datafeedJobHandler = ActionListener.wrap(
                 datafeedJob -> {
-                    Holder holder = new Holder(task, datafeed, datafeedJob, new ProblemTracker(auditor, job.getId()), taskHandler);
+                    Holder holder = new Holder(task, datafeedId, datafeedJob,
+                            new ProblemTracker(auditor, datafeedJob.getJobId()), finishHandler);
                     runningDatafeedsOnThisNode.put(task.getAllocationId(), holder);
                     task.updatePersistentTaskState(DatafeedState.STARTED, new ActionListener<PersistentTask<?>>() {
                         @Override
@@ -90,13 +91,13 @@ public class DatafeedManager extends AbstractComponent {
 
                         @Override
                         public void onFailure(Exception e) {
-                            taskHandler.accept(e);
+                            finishHandler.accept(e);
                         }
                     });
-                }, taskHandler::accept
+                }, finishHandler::accept
         );
 
-        datafeedJobBuilder.build(job, datafeed, datafeedJobHandler);
+        datafeedJobBuilder.build(datafeedId, datafeedJobHandler);
     }
 
     public void stopDatafeed(TransportStartDatafeedAction.DatafeedTask task, String reason, TimeValue timeout) {
@@ -151,7 +152,7 @@ public class DatafeedManager extends AbstractComponent {
 
             @Override
             public void onFailure(Exception e) {
-                logger.error("Failed lookback import for job [" + holder.datafeed.getJobId() + "]", e);
+                logger.error("Failed lookback import for job [" + holder.datafeedJob.getJobId() + "]", e);
                 holder.stop("general_lookback_failure", TimeValue.timeValueSeconds(20), e);
             }
 
@@ -181,17 +182,17 @@ public class DatafeedManager extends AbstractComponent {
                     } else {
                         // Notify that a lookback-only run found no data
                         String lookbackNoDataMsg = Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_LOOKBACK_NO_DATA);
-                        logger.warn("[{}] {}", holder.datafeed.getJobId(), lookbackNoDataMsg);
-                        auditor.warning(holder.datafeed.getJobId(), lookbackNoDataMsg);
+                        logger.warn("[{}] {}", holder.datafeedJob.getJobId(), lookbackNoDataMsg);
+                        auditor.warning(holder.datafeedJob.getJobId(), lookbackNoDataMsg);
                     }
                 } catch (Exception e) {
-                    logger.error("Failed lookback import for job [" + holder.datafeed.getJobId() + "]", e);
+                    logger.error("Failed lookback import for job [" + holder.datafeedJob.getJobId() + "]", e);
                     holder.stop("general_lookback_failure", TimeValue.timeValueSeconds(20), e);
                     return;
                 }
                 if (isolated == false) {
                     if (next != null) {
-                        doDatafeedRealtime(next, holder.datafeed.getJobId(), holder);
+                        doDatafeedRealtime(next, holder.datafeedJob.getJobId(), holder);
                     } else {
                         holder.stop("no_realtime", TimeValue.timeValueSeconds(20), null);
                         holder.problemTracker.finishReport();
@@ -269,29 +270,29 @@ public class DatafeedManager extends AbstractComponent {
 
         private final TransportStartDatafeedAction.DatafeedTask task;
         private final long allocationId;
-        private final DatafeedConfig datafeed;
+        private final String datafeedId;
         // To ensure that we wait until loopback / realtime search has completed before we stop the datafeed
         private final ReentrantLock datafeedJobLock = new ReentrantLock(true);
         private final DatafeedJob datafeedJob;
         private final boolean autoCloseJob;
         private final ProblemTracker problemTracker;
-        private final Consumer<Exception> handler;
+        private final Consumer<Exception> finishHandler;
         volatile Future<?> future;
         private volatile boolean isRelocating;
 
-        Holder(TransportStartDatafeedAction.DatafeedTask task, DatafeedConfig datafeed, DatafeedJob datafeedJob,
-               ProblemTracker problemTracker, Consumer<Exception> handler) {
+        Holder(TransportStartDatafeedAction.DatafeedTask task, String datafeedId, DatafeedJob datafeedJob,
+               ProblemTracker problemTracker, Consumer<Exception> finishHandler) {
             this.task = task;
             this.allocationId = task.getAllocationId();
-            this.datafeed = datafeed;
+            this.datafeedId = datafeedId;
             this.datafeedJob = datafeedJob;
             this.autoCloseJob = task.isLookbackOnly();
             this.problemTracker = problemTracker;
-            this.handler = handler;
+            this.finishHandler = finishHandler;
         }
 
         String getJobId() {
-            return datafeed.getJobId();
+            return datafeedJob.getJobId();
         }
 
         boolean isRunning() {
@@ -307,23 +308,23 @@ public class DatafeedManager extends AbstractComponent {
                 return;
             }
 
-            logger.info("[{}] attempt to stop datafeed [{}] for job [{}]", source, datafeed.getId(), datafeed.getJobId());
+            logger.info("[{}] attempt to stop datafeed [{}] for job [{}]", source, datafeedId, datafeedJob.getJobId());
             if (datafeedJob.stop()) {
                 boolean acquired = false;
                 try {
-                    logger.info("[{}] try lock [{}] to stop datafeed [{}] for job [{}]...", source, timeout, datafeed.getId(),
-                            datafeed.getJobId());
+                    logger.info("[{}] try lock [{}] to stop datafeed [{}] for job [{}]...", source, timeout, datafeedId,
+                            datafeedJob.getJobId());
                     acquired = datafeedJobLock.tryLock(timeout.millis(), TimeUnit.MILLISECONDS);
                 } catch (InterruptedException e1) {
                     Thread.currentThread().interrupt();
                 } finally {
-                    logger.info("[{}] stopping datafeed [{}] for job [{}], acquired [{}]...", source, datafeed.getId(),
-                            datafeed.getJobId(), acquired);
+                    logger.info("[{}] stopping datafeed [{}] for job [{}], acquired [{}]...", source, datafeedId,
+                            datafeedJob.getJobId(), acquired);
                     runningDatafeedsOnThisNode.remove(allocationId);
                     FutureUtils.cancel(future);
-                    auditor.info(datafeed.getJobId(), Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_STOPPED));
-                    handler.accept(e);
-                    logger.info("[{}] datafeed [{}] for job [{}] has been stopped{}", source, datafeed.getId(), datafeed.getJobId(),
+                    auditor.info(datafeedJob.getJobId(), Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_STOPPED));
+                    finishHandler.accept(e);
+                    logger.info("[{}] datafeed [{}] for job [{}] has been stopped{}", source, datafeedId, datafeedJob.getJobId(),
                             acquired ? "" : ", but there may be pending tasks as the timeout [" + timeout.getStringRep() + "] expired");
                     if (autoCloseJob) {
                         closeJob();
@@ -333,7 +334,7 @@ public class DatafeedManager extends AbstractComponent {
                     }
                 }
             } else {
-                logger.info("[{}] datafeed [{}] for job [{}] was already stopped", source, datafeed.getId(), datafeed.getJobId());
+                logger.info("[{}] datafeed [{}] for job [{}] was already stopped", source, datafeedId, datafeedJob.getJobId());
             }
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelector.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
-import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
@@ -29,14 +28,18 @@ public class DatafeedNodeSelector {
     private static final Logger LOGGER = Loggers.getLogger(DatafeedNodeSelector.class);
 
     private final DatafeedConfig datafeed;
+    private final String datafeedId;
     private final PersistentTasksCustomMetaData.PersistentTask<?> jobTask;
     private final ClusterState clusterState;
     private final IndexNameExpressionResolver resolver;
 
-    public DatafeedNodeSelector(ClusterState clusterState, IndexNameExpressionResolver resolver, String datafeedId) {
-        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
+    // TODO The datafeed config may be null because of streaming the
+    // DatafeedParams in a mixed cluster state
+    public DatafeedNodeSelector(ClusterState clusterState, IndexNameExpressionResolver resolver, String datafeedId,
+                                @Nullable DatafeedConfig datafeed) {
         PersistentTasksCustomMetaData tasks = clusterState.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
-        this.datafeed = mlMetadata.getDatafeed(datafeedId);
+        this.datafeed = datafeed;
+        this.datafeedId = datafeedId;
         this.jobTask = MlTasks.getJobTask(datafeed.getJobId(), tasks);
         this.clusterState = Objects.requireNonNull(clusterState);
         this.resolver = Objects.requireNonNull(resolver);
@@ -45,8 +48,7 @@ public class DatafeedNodeSelector {
     public void checkDatafeedTaskCanBeCreated() {
         AssignmentFailure assignmentFailure = checkAssignment();
         if (assignmentFailure != null && assignmentFailure.isCriticalForTaskCreation) {
-            String msg = "No node found to start datafeed [" + datafeed.getId() + "], allocation explanation [" + assignmentFailure.reason
-                    + "]";
+            String msg = "No node found to start datafeed [" + datafeedId + "], allocation explanation [" + assignmentFailure.reason + "]";
             LOGGER.debug(msg);
             throw ExceptionsHelper.conflictStatusException(msg);
         }
@@ -64,7 +66,7 @@ public class DatafeedNodeSelector {
     @Nullable
     private AssignmentFailure checkAssignment() {
         PriorityFailureCollector priorityFailureCollector = new PriorityFailureCollector();
-        priorityFailureCollector.add(verifyIndicesActive(datafeed));
+        priorityFailureCollector.add(verifyIndicesActive());
 
         JobTaskState jobTaskState = null;
         JobState jobState = JobState.CLOSED;
@@ -75,13 +77,14 @@ public class DatafeedNodeSelector {
 
         if (jobState.isAnyOf(JobState.OPENING, JobState.OPENED) == false) {
             // lets try again later when the job has been opened:
-            String reason = "cannot start datafeed [" + datafeed.getId() + "], because job's [" + datafeed.getJobId() +
+            String reason = "cannot start datafeed [" + datafeed.getId() + "], because the job's [" + datafeed.getJobId() +
                     "] state is [" + jobState +  "] while state [" + JobState.OPENED + "] is required";
             priorityFailureCollector.add(new AssignmentFailure(reason, true));
         }
 
         if (jobTaskState != null && jobTaskState.isStatusStale(jobTask)) {
-            String reason = "cannot start datafeed [" + datafeed.getId() + "], job [" + datafeed.getJobId() + "] state is stale";
+            String reason = "cannot start datafeed [" + datafeed.getId() + "], because the job's [" + datafeed.getJobId() +
+                    "] state is stale";
             priorityFailureCollector.add(new AssignmentFailure(reason, true));
         }
 
@@ -89,7 +92,7 @@ public class DatafeedNodeSelector {
     }
 
     @Nullable
-    private AssignmentFailure verifyIndicesActive(DatafeedConfig datafeed) {
+    private AssignmentFailure verifyIndicesActive() {
         List<String> indices = datafeed.getIndices();
         for (String index : indices) {
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlAssignmentNotifierTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlAssignmentNotifierTests.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class MlAssignmentNotifierTests extends ESTestCase {
 
-    public void testClusterChanged_info() throws Exception {
+    public void testClusterChanged_info() {
         Auditor auditor = mock(Auditor.class);
         ClusterService clusterService = mock(ClusterService.class);
         MlAssignmentNotifier notifier = new MlAssignmentNotifier(Settings.EMPTY, auditor, clusterService);
@@ -60,7 +60,7 @@ public class MlAssignmentNotifierTests extends ESTestCase {
         verifyNoMoreInteractions(auditor);
     }
 
-    public void testClusterChanged_warning() throws Exception {
+    public void testClusterChanged_warning() {
         Auditor auditor = mock(Auditor.class);
         ClusterService clusterService = mock(ClusterService.class);
         MlAssignmentNotifier notifier = new MlAssignmentNotifier(Settings.EMPTY, auditor, clusterService);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedActionTests.java
@@ -7,11 +7,9 @@
 package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
@@ -28,61 +26,33 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class TransportStartDatafeedActionTests extends ESTestCase {
 
-    public void testValidate_GivenDatafeedIsMissing() {
-        Job job = DatafeedManagerTests.createDatafeedJob().build(new Date());
-        MlMetadata mlMetadata = new MlMetadata.Builder()
-                .putJob(job, false)
-                .build();
-        Exception e = expectThrows(ResourceNotFoundException.class,
-                () -> TransportStartDatafeedAction.validate("some-datafeed", mlMetadata, null));
-        assertThat(e.getMessage(), equalTo("No datafeed with id [some-datafeed] exists"));
-    }
-
     public void testValidate_jobClosed() {
         Job job1 = DatafeedManagerTests.createDatafeedJob().build(new Date());
-        MlMetadata mlMetadata1 = new MlMetadata.Builder()
-                .putJob(job1, false)
-                .build();
         PersistentTasksCustomMetaData tasks = PersistentTasksCustomMetaData.builder().build();
         DatafeedConfig datafeedConfig1 = DatafeedManagerTests.createDatafeedConfig("foo-datafeed", "job_id").build();
-        MlMetadata mlMetadata2 = new MlMetadata.Builder(mlMetadata1)
-                .putDatafeed(datafeedConfig1, Collections.emptyMap())
-                .build();
         Exception e = expectThrows(ElasticsearchStatusException.class,
-                () -> TransportStartDatafeedAction.validate("foo-datafeed", mlMetadata2, tasks));
+                () -> TransportStartDatafeedAction.validate(job1, datafeedConfig1, tasks));
         assertThat(e.getMessage(), equalTo("cannot start datafeed [foo-datafeed] because job [job_id] is closed"));
     }
 
     public void testValidate_jobOpening() {
         Job job1 = DatafeedManagerTests.createDatafeedJob().build(new Date());
-        MlMetadata mlMetadata1 = new MlMetadata.Builder()
-                .putJob(job1, false)
-                .build();
         PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
         addJobTask("job_id", INITIAL_ASSIGNMENT.getExecutorNode(), null, tasksBuilder);
         PersistentTasksCustomMetaData tasks = tasksBuilder.build();
         DatafeedConfig datafeedConfig1 = DatafeedManagerTests.createDatafeedConfig("foo-datafeed", "job_id").build();
-        MlMetadata mlMetadata2 = new MlMetadata.Builder(mlMetadata1)
-                .putDatafeed(datafeedConfig1, Collections.emptyMap())
-                .build();
 
-        TransportStartDatafeedAction.validate("foo-datafeed", mlMetadata2, tasks);
+        TransportStartDatafeedAction.validate(job1, datafeedConfig1, tasks);
     }
 
     public void testValidate_jobOpened() {
         Job job1 = DatafeedManagerTests.createDatafeedJob().build(new Date());
-        MlMetadata mlMetadata1 = new MlMetadata.Builder()
-                .putJob(job1, false)
-                .build();
         PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
         addJobTask("job_id", INITIAL_ASSIGNMENT.getExecutorNode(), JobState.OPENED, tasksBuilder);
         PersistentTasksCustomMetaData tasks = tasksBuilder.build();
         DatafeedConfig datafeedConfig1 = DatafeedManagerTests.createDatafeedConfig("foo-datafeed", "job_id").build();
-        MlMetadata mlMetadata2 = new MlMetadata.Builder(mlMetadata1)
-                .putDatafeed(datafeedConfig1, Collections.emptyMap())
-                .build();
 
-        TransportStartDatafeedAction.validate("foo-datafeed", mlMetadata2, tasks);
+        TransportStartDatafeedAction.validate(job1, datafeedConfig1, tasks);
     }
 
     public static TransportStartDatafeedAction.DatafeedTask createDatafeedTask(long id, String type, String action,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
@@ -19,6 +19,8 @@ import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
+import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
+import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 import org.elasticsearch.xpack.ml.notifications.Auditor;
 import org.junit.Before;
@@ -32,6 +34,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -41,8 +44,10 @@ public class DatafeedJobBuilderTests extends ESTestCase {
 
     private Client client;
     private Auditor auditor;
-    private JobResultsProvider jobResultsProvider;
     private Consumer<Exception> taskHandler;
+    private JobResultsProvider jobResultsProvider;
+    private JobConfigProvider jobConfigProvider;
+    private DatafeedConfigProvider datafeedConfigProvider;
 
     private DatafeedJobBuilder datafeedJobBuilder;
 
@@ -54,10 +59,10 @@ public class DatafeedJobBuilderTests extends ESTestCase {
         when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         when(client.settings()).thenReturn(Settings.EMPTY);
         auditor = mock(Auditor.class);
-        jobResultsProvider = mock(JobResultsProvider.class);
         taskHandler = mock(Consumer.class);
-        datafeedJobBuilder = new DatafeedJobBuilder(client, jobResultsProvider, auditor, System::currentTimeMillis);
+        datafeedJobBuilder = new DatafeedJobBuilder(client, Settings.EMPTY, xContentRegistry(), auditor, System::currentTimeMillis);
 
+        jobResultsProvider = mock(JobResultsProvider.class);
         Mockito.doAnswer(invocationOnMock -> {
             String jobId = (String) invocationOnMock.getArguments()[0];
             @SuppressWarnings("unchecked")
@@ -72,6 +77,9 @@ public class DatafeedJobBuilderTests extends ESTestCase {
             consumer.accept(new ResourceNotFoundException("dummy"));
             return null;
         }).when(jobResultsProvider).bucketsViaInternalClient(any(), any(), any(), any());
+
+        jobConfigProvider = mock(JobConfigProvider.class);
+        datafeedConfigProvider = mock(DatafeedConfigProvider.class);
     }
 
     public void testBuild_GivenScrollDatafeedAndNewJob() throws Exception {
@@ -79,7 +87,8 @@ public class DatafeedJobBuilderTests extends ESTestCase {
         dataDescription.setTimeField("time");
         Job.Builder jobBuilder = DatafeedManagerTests.createDatafeedJob();
         jobBuilder.setDataDescription(dataDescription);
-        DatafeedConfig datafeed = DatafeedManagerTests.createDatafeedConfig("datafeed1", "foo").build();
+        jobBuilder.setCreateTime(new Date());
+        DatafeedConfig.Builder datafeed = DatafeedManagerTests.createDatafeedConfig("datafeed1", jobBuilder.getId());
 
         AtomicBoolean wasHandlerCalled = new AtomicBoolean(false);
         ActionListener<DatafeedJob> datafeedJobHandler = ActionListener.wrap(
@@ -91,7 +100,10 @@ public class DatafeedJobBuilderTests extends ESTestCase {
                 }, e -> fail()
         );
 
-        datafeedJobBuilder.build(jobBuilder.build(new Date()), datafeed, datafeedJobHandler);
+        givenJob(jobBuilder);
+        givenDatafeed(datafeed);
+
+        datafeedJobBuilder.build("datafeed1", jobResultsProvider, jobConfigProvider, datafeedConfigProvider, datafeedJobHandler);
 
         assertBusy(() -> wasHandlerCalled.get());
     }
@@ -101,7 +113,8 @@ public class DatafeedJobBuilderTests extends ESTestCase {
         dataDescription.setTimeField("time");
         Job.Builder jobBuilder = DatafeedManagerTests.createDatafeedJob();
         jobBuilder.setDataDescription(dataDescription);
-        DatafeedConfig datafeed = DatafeedManagerTests.createDatafeedConfig("datafeed1", "foo").build();
+        jobBuilder.setCreateTime(new Date());
+        DatafeedConfig.Builder datafeed = DatafeedManagerTests.createDatafeedConfig("datafeed1", jobBuilder.getId());
 
         givenLatestTimes(7_200_000L, 3_600_000L);
 
@@ -115,7 +128,10 @@ public class DatafeedJobBuilderTests extends ESTestCase {
                 }, e -> fail()
         );
 
-        datafeedJobBuilder.build(jobBuilder.build(new Date()), datafeed, datafeedJobHandler);
+        givenJob(jobBuilder);
+        givenDatafeed(datafeed);
+
+        datafeedJobBuilder.build("datafeed1", jobResultsProvider, jobConfigProvider, datafeedConfigProvider, datafeedJobHandler);
 
         assertBusy(() -> wasHandlerCalled.get());
     }
@@ -125,7 +141,8 @@ public class DatafeedJobBuilderTests extends ESTestCase {
         dataDescription.setTimeField("time");
         Job.Builder jobBuilder = DatafeedManagerTests.createDatafeedJob();
         jobBuilder.setDataDescription(dataDescription);
-        DatafeedConfig datafeed = DatafeedManagerTests.createDatafeedConfig("datafeed1", "foo").build();
+        jobBuilder.setCreateTime(new Date());
+        DatafeedConfig.Builder datafeed = DatafeedManagerTests.createDatafeedConfig("datafeed1", jobBuilder.getId());
 
         givenLatestTimes(3_800_000L, 3_600_000L);
 
@@ -139,7 +156,10 @@ public class DatafeedJobBuilderTests extends ESTestCase {
                 }, e -> fail()
         );
 
-        datafeedJobBuilder.build(jobBuilder.build(new Date()), datafeed, datafeedJobHandler);
+        givenJob(jobBuilder);
+        givenDatafeed(datafeed);
+
+        datafeedJobBuilder.build("datafeed1", jobResultsProvider, jobConfigProvider, datafeedConfigProvider, datafeedJobHandler);
 
         assertBusy(() -> wasHandlerCalled.get());
     }
@@ -149,7 +169,8 @@ public class DatafeedJobBuilderTests extends ESTestCase {
         dataDescription.setTimeField("time");
         Job.Builder jobBuilder = DatafeedManagerTests.createDatafeedJob();
         jobBuilder.setDataDescription(dataDescription);
-        DatafeedConfig datafeed = DatafeedManagerTests.createDatafeedConfig("datafeed1", "foo").build();
+        jobBuilder.setCreateTime(new Date());
+        DatafeedConfig.Builder datafeed = DatafeedManagerTests.createDatafeedConfig("datafeed1", jobBuilder.getId());
 
         Exception error = new RuntimeException("error");
         doAnswer(invocationOnMock -> {
@@ -159,9 +180,32 @@ public class DatafeedJobBuilderTests extends ESTestCase {
             return null;
         }).when(jobResultsProvider).bucketsViaInternalClient(any(), any(), any(), any());
 
-        datafeedJobBuilder.build(jobBuilder.build(new Date()), datafeed, ActionListener.wrap(datafeedJob -> fail(), taskHandler));
+
+        givenJob(jobBuilder);
+        givenDatafeed(datafeed);
+
+        datafeedJobBuilder.build("datafeed1", jobResultsProvider, jobConfigProvider, datafeedConfigProvider,
+                ActionListener.wrap(datafeedJob -> fail(), taskHandler));
 
         verify(taskHandler).accept(error);
+    }
+
+    private void givenJob(Job.Builder job) {
+        Mockito.doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<Job.Builder> handler = (ActionListener<Job.Builder>) invocationOnMock.getArguments()[1];
+            handler.onResponse(job);
+            return null;
+        }).when(jobConfigProvider).getJob(eq(job.getId()), any());
+    }
+
+    private void givenDatafeed(DatafeedConfig.Builder datafeed) {
+        Mockito.doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<DatafeedConfig.Builder> handler = (ActionListener<DatafeedConfig.Builder>) invocationOnMock.getArguments()[1];
+            handler.onResponse(datafeed);
+            return null;
+        }).when(datafeedConfigProvider).getDatafeedConfig(eq(datafeed.getId()), any());
     }
 
     private void givenLatestTimes(long latestRecordTimestamp, long latestBucketTimestamp) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
@@ -73,9 +73,10 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result =
+                new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices()).selectNode();
         assertEquals("node_id", result.getExecutorNode());
-        new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated();
+        new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices()).checkDatafeedTaskCanBeCreated();
     }
 
     public void testSelectNode_GivenJobIsOpening() {
@@ -88,9 +89,10 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result =
+                new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices()).selectNode();
         assertEquals("node_id", result.getExecutorNode());
-        new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated();
+        new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices()).checkDatafeedTaskCanBeCreated();
     }
 
     public void testNoJobTask() {
@@ -103,13 +105,15 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result =
+                new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices()).selectNode();
         assertNull(result.getExecutorNode());
         assertThat(result.getExplanation(), equalTo("cannot start datafeed [datafeed_id], because the job's [job_id] state is " +
                 "[closed] while state [opened] is required"));
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated());
+                () -> new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices())
+                        .checkDatafeedTaskCanBeCreated());
         assertThat(e.getMessage(), containsString("No node found to start datafeed [datafeed_id], allocation explanation "
                 + "[cannot start datafeed [datafeed_id], because the job's [job_id] state is [closed] while state [opened] is required]"));
     }
@@ -125,13 +129,15 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result =
+                new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices()).selectNode();
         assertNull(result.getExecutorNode());
         assertEquals("cannot start datafeed [datafeed_id], because the job's [job_id] state is [" + jobState +
                 "] while state [opened] is required", result.getExplanation());
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated());
+                () -> new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices())
+                        .checkDatafeedTaskCanBeCreated());
         assertThat(e.getMessage(), containsString("No node found to start datafeed [datafeed_id], allocation explanation "
                 + "[cannot start datafeed [datafeed_id], because the job's [job_id] state is [" + jobState
                 + "] while state [opened] is required]"));
@@ -152,12 +158,13 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0, states);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result =
+                new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices()).selectNode();
         assertNull(result.getExecutorNode());
         assertThat(result.getExplanation(), equalTo("cannot start datafeed [datafeed_id] because index [foo] " +
                 "does not have all primary shards active yet."));
 
-        new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated();
+        new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices()).checkDatafeedTaskCanBeCreated();
     }
 
     public void testShardNotAllActive() {
@@ -176,12 +183,13 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 2, 0, states);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result =
+                new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices()).selectNode();
         assertNull(result.getExecutorNode());
         assertThat(result.getExplanation(), equalTo("cannot start datafeed [datafeed_id] because index [foo] " +
                 "does not have all primary shards active yet."));
 
-        new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated();
+        new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices()).checkDatafeedTaskCanBeCreated();
     }
 
     public void testIndexDoesntExist() {
@@ -194,13 +202,15 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result =
+                new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices()).selectNode();
         assertNull(result.getExecutorNode());
         assertThat(result.getExplanation(), equalTo("cannot start datafeed [datafeed_id] because index [not_foo] " +
                 "does not exist, is closed, or is still initializing."));
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated());
+                () -> new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices())
+                        .checkDatafeedTaskCanBeCreated());
         assertThat(e.getMessage(), containsString("No node found to start datafeed [datafeed_id], allocation explanation "
                 + "[cannot start datafeed [datafeed_id] because index [not_foo] does not exist, is closed, or is still initializing.]"));
     }
@@ -215,7 +225,8 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result =
+                new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices()).selectNode();
         assertNotNull(result.getExecutorNode());
     }
 
@@ -232,13 +243,15 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result =
+                new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices()).selectNode();
         assertNull(result.getExecutorNode());
         assertEquals("cannot start datafeed [datafeed_id], because the job's [job_id] state is stale",
                 result.getExplanation());
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated());
+                () -> new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices())
+                        .checkDatafeedTaskCanBeCreated());
         assertThat(e.getMessage(), containsString("No node found to start datafeed [datafeed_id], allocation explanation "
                 + "[cannot start datafeed [datafeed_id], because the job's [job_id] state is stale]"));
 
@@ -246,9 +259,9 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
         addJobTask(job.getId(), "node_id1", JobState.OPENED, tasksBuilder);
         tasks = tasksBuilder.build();
         givenClusterState("foo", 1, 0);
-        result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
+        result = new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices()).selectNode();
         assertEquals("node_id1", result.getExecutorNode());
-        new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated();
+        new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices()).checkDatafeedTaskCanBeCreated();
     }
 
     public void testSelectNode_GivenJobOpeningAndIndexDoesNotExist() {
@@ -265,7 +278,8 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
         givenClusterState("foo", 1, 0);
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated());
+                () -> new DatafeedNodeSelector(clusterState, resolver, df.getId(), df.getJobId(), df.getIndices())
+                        .checkDatafeedTaskCanBeCreated());
         assertThat(e.getMessage(), containsString("No node found to start datafeed [datafeed_id], allocation explanation "
                 + "[cannot start datafeed [datafeed_id] because index [not_foo] does not exist, is closed, or is still initializing.]"));
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
@@ -73,9 +73,9 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
         assertEquals("node_id", result.getExecutorNode());
-        new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated();
+        new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated();
     }
 
     public void testSelectNode_GivenJobIsOpening() {
@@ -88,9 +88,9 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
         assertEquals("node_id", result.getExecutorNode());
-        new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated();
+        new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated();
     }
 
     public void testNoJobTask() {
@@ -103,13 +103,13 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
         assertNull(result.getExecutorNode());
         assertThat(result.getExplanation(), equalTo("cannot start datafeed [datafeed_id], because the job's [job_id] state is " +
                 "[closed] while state [opened] is required"));
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated());
+                () -> new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated());
         assertThat(e.getMessage(), containsString("No node found to start datafeed [datafeed_id], allocation explanation "
                 + "[cannot start datafeed [datafeed_id], because the job's [job_id] state is [closed] while state [opened] is required]"));
     }
@@ -125,13 +125,13 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
         assertNull(result.getExecutorNode());
         assertEquals("cannot start datafeed [datafeed_id], because the job's [job_id] state is [" + jobState +
                 "] while state [opened] is required", result.getExplanation());
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated());
+                () -> new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated());
         assertThat(e.getMessage(), containsString("No node found to start datafeed [datafeed_id], allocation explanation "
                 + "[cannot start datafeed [datafeed_id], because the job's [job_id] state is [" + jobState
                 + "] while state [opened] is required]"));
@@ -152,12 +152,12 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0, states);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
         assertNull(result.getExecutorNode());
         assertThat(result.getExplanation(), equalTo("cannot start datafeed [datafeed_id] because index [foo] " +
                 "does not have all primary shards active yet."));
 
-        new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated();
+        new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated();
     }
 
     public void testShardNotAllActive() {
@@ -176,12 +176,12 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 2, 0, states);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
         assertNull(result.getExecutorNode());
         assertThat(result.getExplanation(), equalTo("cannot start datafeed [datafeed_id] because index [foo] " +
                 "does not have all primary shards active yet."));
 
-        new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated();
+        new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated();
     }
 
     public void testIndexDoesntExist() {
@@ -194,13 +194,13 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
         assertNull(result.getExecutorNode());
         assertThat(result.getExplanation(), equalTo("cannot start datafeed [datafeed_id] because index [not_foo] " +
                 "does not exist, is closed, or is still initializing."));
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated());
+                () -> new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated());
         assertThat(e.getMessage(), containsString("No node found to start datafeed [datafeed_id], allocation explanation "
                 + "[cannot start datafeed [datafeed_id] because index [not_foo] does not exist, is closed, or is still initializing.]"));
     }
@@ -215,7 +215,7 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
         assertNotNull(result.getExecutorNode());
     }
 
@@ -232,13 +232,13 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
         assertNull(result.getExecutorNode());
         assertEquals("cannot start datafeed [datafeed_id], because the job's [job_id] state is stale",
                 result.getExplanation());
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated());
+                () -> new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated());
         assertThat(e.getMessage(), containsString("No node found to start datafeed [datafeed_id], allocation explanation "
                 + "[cannot start datafeed [datafeed_id], because the job's [job_id] state is stale]"));
 
@@ -246,9 +246,9 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
         addJobTask(job.getId(), "node_id1", JobState.OPENED, tasksBuilder);
         tasks = tasksBuilder.build();
         givenClusterState("foo", 1, 0);
-        result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
+        result = new DatafeedNodeSelector(clusterState, resolver, df).selectNode();
         assertEquals("node_id1", result.getExecutorNode());
-        new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated();
+        new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated();
     }
 
     public void testSelectNode_GivenJobOpeningAndIndexDoesNotExist() {
@@ -265,7 +265,7 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
         givenClusterState("foo", 1, 0);
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated());
+                () -> new DatafeedNodeSelector(clusterState, resolver, df).checkDatafeedTaskCanBeCreated());
         assertThat(e.getMessage(), containsString("No node found to start datafeed [datafeed_id], allocation explanation "
                 + "[cannot start datafeed [datafeed_id] because index [not_foo] does not exist, is closed, or is still initializing.]"));
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
@@ -26,13 +26,13 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
-import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.junit.Before;
 
 import java.net.InetAddress;
@@ -52,7 +52,6 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
     private IndexNameExpressionResolver resolver;
     private DiscoveryNodes nodes;
     private ClusterState clusterState;
-    private MlMetadata mlMetadata;
     private PersistentTasksCustomMetaData tasks;
 
     @Before
@@ -65,11 +64,8 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
     }
 
     public void testSelectNode_GivenJobIsOpened() {
-        MlMetadata.Builder mlMetadataBuilder = new MlMetadata.Builder();
         Job job = createScheduledJob("job_id").build(new Date());
-        mlMetadataBuilder.putJob(job, false);
-        mlMetadataBuilder.putDatafeed(createDatafeed("datafeed_id", job.getId(), Collections.singletonList("foo")), Collections.emptyMap());
-        mlMetadata = mlMetadataBuilder.build();
+        DatafeedConfig df = createDatafeed("datafeed_id", job.getId(), Collections.singletonList("foo"));
 
         PersistentTasksCustomMetaData.Builder tasksBuilder =  PersistentTasksCustomMetaData.builder();
         addJobTask(job.getId(), "node_id", JobState.OPENED, tasksBuilder);
@@ -77,17 +73,14 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
         assertEquals("node_id", result.getExecutorNode());
-        new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").checkDatafeedTaskCanBeCreated();
+        new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated();
     }
 
     public void testSelectNode_GivenJobIsOpening() {
-        MlMetadata.Builder mlMetadataBuilder = new MlMetadata.Builder();
         Job job = createScheduledJob("job_id").build(new Date());
-        mlMetadataBuilder.putJob(job, false);
-        mlMetadataBuilder.putDatafeed(createDatafeed("datafeed_id", job.getId(), Collections.singletonList("foo")), Collections.emptyMap());
-        mlMetadata = mlMetadataBuilder.build();
+        DatafeedConfig df = createDatafeed("datafeed_id", job.getId(), Collections.singletonList("foo"));
 
         PersistentTasksCustomMetaData.Builder tasksBuilder =  PersistentTasksCustomMetaData.builder();
         addJobTask(job.getId(), "node_id", null, tasksBuilder);
@@ -95,41 +88,35 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
         assertEquals("node_id", result.getExecutorNode());
-        new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").checkDatafeedTaskCanBeCreated();
+        new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated();
     }
 
     public void testNoJobTask() {
-        MlMetadata.Builder mlMetadataBuilder = new MlMetadata.Builder();
         Job job = createScheduledJob("job_id").build(new Date());
-        mlMetadataBuilder.putJob(job, false);
 
         // Using wildcard index name to test for index resolving as well
-        mlMetadataBuilder.putDatafeed(createDatafeed("datafeed_id", job.getId(), Collections.singletonList("fo*")), Collections.emptyMap());
-        mlMetadata = mlMetadataBuilder.build();
+        DatafeedConfig df = createDatafeed("datafeed_id", job.getId(), Collections.singletonList("fo*"));
 
         tasks = PersistentTasksCustomMetaData.builder().build();
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
         assertNull(result.getExecutorNode());
-        assertThat(result.getExplanation(), equalTo("cannot start datafeed [datafeed_id], because job's [job_id] state is " +
+        assertThat(result.getExplanation(), equalTo("cannot start datafeed [datafeed_id], because the job's [job_id] state is " +
                 "[closed] while state [opened] is required"));
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").checkDatafeedTaskCanBeCreated());
+                () -> new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated());
         assertThat(e.getMessage(), containsString("No node found to start datafeed [datafeed_id], allocation explanation "
-                + "[cannot start datafeed [datafeed_id], because job's [job_id] state is [closed] while state [opened] is required]"));
+                + "[cannot start datafeed [datafeed_id], because the job's [job_id] state is [closed] while state [opened] is required]"));
     }
 
     public void testSelectNode_GivenJobFailedOrClosed() {
-        MlMetadata.Builder mlMetadataBuilder = new MlMetadata.Builder();
         Job job = createScheduledJob("job_id").build(new Date());
-        mlMetadataBuilder.putJob(job, false);
-        mlMetadataBuilder.putDatafeed(createDatafeed("datafeed_id", job.getId(), Collections.singletonList("foo")), Collections.emptyMap());
-        mlMetadata = mlMetadataBuilder.build();
+        DatafeedConfig df = createDatafeed("datafeed_id", job.getId(), Collections.singletonList("foo"));
 
         PersistentTasksCustomMetaData.Builder tasksBuilder =  PersistentTasksCustomMetaData.builder();
         JobState jobState = randomFrom(JobState.FAILED, JobState.CLOSED);
@@ -138,26 +125,23 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
         assertNull(result.getExecutorNode());
-        assertEquals("cannot start datafeed [datafeed_id], because job's [job_id] state is [" + jobState +
+        assertEquals("cannot start datafeed [datafeed_id], because the job's [job_id] state is [" + jobState +
                 "] while state [opened] is required", result.getExplanation());
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").checkDatafeedTaskCanBeCreated());
+                () -> new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated());
         assertThat(e.getMessage(), containsString("No node found to start datafeed [datafeed_id], allocation explanation "
-                + "[cannot start datafeed [datafeed_id], because job's [job_id] state is [" + jobState
+                + "[cannot start datafeed [datafeed_id], because the job's [job_id] state is [" + jobState
                 + "] while state [opened] is required]"));
     }
 
     public void testShardUnassigned() {
-        MlMetadata.Builder mlMetadataBuilder = new MlMetadata.Builder();
         Job job = createScheduledJob("job_id").build(new Date());
-        mlMetadataBuilder.putJob(job, false);
 
         // Using wildcard index name to test for index resolving as well
-        mlMetadataBuilder.putDatafeed(createDatafeed("datafeed_id", job.getId(), Collections.singletonList("fo*")), Collections.emptyMap());
-        mlMetadata = mlMetadataBuilder.build();
+        DatafeedConfig df = createDatafeed("datafeed_id", job.getId(), Collections.singletonList("fo*"));
 
         PersistentTasksCustomMetaData.Builder tasksBuilder =  PersistentTasksCustomMetaData.builder();
         addJobTask(job.getId(), "node_id", JobState.OPENED, tasksBuilder);
@@ -168,22 +152,19 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0, states);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
         assertNull(result.getExecutorNode());
         assertThat(result.getExplanation(), equalTo("cannot start datafeed [datafeed_id] because index [foo] " +
                 "does not have all primary shards active yet."));
 
-        new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").checkDatafeedTaskCanBeCreated();
+        new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated();
     }
 
     public void testShardNotAllActive() {
-        MlMetadata.Builder mlMetadataBuilder = new MlMetadata.Builder();
         Job job = createScheduledJob("job_id").build(new Date());
-        mlMetadataBuilder.putJob(job, false);
 
         // Using wildcard index name to test for index resolving as well
-        mlMetadataBuilder.putDatafeed(createDatafeed("datafeed_id", job.getId(), Collections.singletonList("fo*")), Collections.emptyMap());
-        mlMetadata = mlMetadataBuilder.build();
+        DatafeedConfig df = createDatafeed("datafeed_id", job.getId(), Collections.singletonList("fo*"));
 
         PersistentTasksCustomMetaData.Builder tasksBuilder =  PersistentTasksCustomMetaData.builder();
         addJobTask(job.getId(), "node_id", JobState.OPENED, tasksBuilder);
@@ -195,21 +176,17 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 2, 0, states);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
         assertNull(result.getExecutorNode());
         assertThat(result.getExplanation(), equalTo("cannot start datafeed [datafeed_id] because index [foo] " +
                 "does not have all primary shards active yet."));
 
-        new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").checkDatafeedTaskCanBeCreated();
+        new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated();
     }
 
     public void testIndexDoesntExist() {
-        MlMetadata.Builder mlMetadataBuilder = new MlMetadata.Builder();
         Job job = createScheduledJob("job_id").build(new Date());
-        mlMetadataBuilder.putJob(job, false);
-        mlMetadataBuilder.putDatafeed(createDatafeed("datafeed_id", job.getId(), Collections.singletonList("not_foo")),
-                Collections.emptyMap());
-        mlMetadata = mlMetadataBuilder.build();
+        DatafeedConfig df = createDatafeed("datafeed_id", job.getId(), Collections.singletonList("not_foo"));
 
         PersistentTasksCustomMetaData.Builder tasksBuilder =  PersistentTasksCustomMetaData.builder();
         addJobTask(job.getId(), "node_id", JobState.OPENED, tasksBuilder);
@@ -217,24 +194,20 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
         assertNull(result.getExecutorNode());
         assertThat(result.getExplanation(), equalTo("cannot start datafeed [datafeed_id] because index [not_foo] " +
                 "does not exist, is closed, or is still initializing."));
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").checkDatafeedTaskCanBeCreated());
+                () -> new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated());
         assertThat(e.getMessage(), containsString("No node found to start datafeed [datafeed_id], allocation explanation "
                 + "[cannot start datafeed [datafeed_id] because index [not_foo] does not exist, is closed, or is still initializing.]"));
     }
 
     public void testRemoteIndex() {
-        MlMetadata.Builder mlMetadataBuilder = new MlMetadata.Builder();
         Job job = createScheduledJob("job_id").build(new Date());
-        mlMetadataBuilder.putJob(job, false);
-        mlMetadataBuilder.putDatafeed(createDatafeed("datafeed_id", job.getId(), Collections.singletonList("remote:foo")),
-                Collections.emptyMap());
-        mlMetadata = mlMetadataBuilder.build();
+        DatafeedConfig df = createDatafeed("datafeed_id", job.getId(), Collections.singletonList("remote:foo"));
 
         PersistentTasksCustomMetaData.Builder tasksBuilder =  PersistentTasksCustomMetaData.builder();
         addJobTask(job.getId(), "node_id", JobState.OPENED, tasksBuilder);
@@ -242,16 +215,13 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
         assertNotNull(result.getExecutorNode());
     }
 
     public void testSelectNode_jobTaskStale() {
-        MlMetadata.Builder mlMetadataBuilder = new MlMetadata.Builder();
         Job job = createScheduledJob("job_id").build(new Date());
-        mlMetadataBuilder.putJob(job, false);
-        mlMetadataBuilder.putDatafeed(createDatafeed("datafeed_id", job.getId(), Collections.singletonList("foo")), Collections.emptyMap());
-        mlMetadata = mlMetadataBuilder.build();
+        DatafeedConfig df = createDatafeed("datafeed_id", job.getId(), Collections.singletonList("foo"));
 
         String nodeId = randomBoolean() ? "node_id2" : null;
         PersistentTasksCustomMetaData.Builder tasksBuilder =  PersistentTasksCustomMetaData.builder();
@@ -262,44 +232,40 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         givenClusterState("foo", 1, 0);
 
-        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").selectNode();
+        PersistentTasksCustomMetaData.Assignment result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
         assertNull(result.getExecutorNode());
-        assertEquals("cannot start datafeed [datafeed_id], job [job_id] state is stale",
+        assertEquals("cannot start datafeed [datafeed_id], because the job's [job_id] state is stale",
                 result.getExplanation());
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").checkDatafeedTaskCanBeCreated());
+                () -> new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated());
         assertThat(e.getMessage(), containsString("No node found to start datafeed [datafeed_id], allocation explanation "
-                + "[cannot start datafeed [datafeed_id], job [job_id] state is stale]"));
+                + "[cannot start datafeed [datafeed_id], because the job's [job_id] state is stale]"));
 
         tasksBuilder =  PersistentTasksCustomMetaData.builder();
         addJobTask(job.getId(), "node_id1", JobState.OPENED, tasksBuilder);
         tasks = tasksBuilder.build();
         givenClusterState("foo", 1, 0);
-        result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").selectNode();
+        result = new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).selectNode();
         assertEquals("node_id1", result.getExecutorNode());
-        new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").checkDatafeedTaskCanBeCreated();
+        new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated();
     }
 
     public void testSelectNode_GivenJobOpeningAndIndexDoesNotExist() {
         // Here we test that when there are 2 problems, the most critical gets reported first.
         // In this case job is Opening (non-critical) and the index does not exist (critical)
 
-        MlMetadata.Builder mlMetadataBuilder = new MlMetadata.Builder();
         Job job = createScheduledJob("job_id").build(new Date());
-        mlMetadataBuilder.putJob(job, false);
-        mlMetadataBuilder.putDatafeed(createDatafeed("datafeed_id", job.getId(), Collections.singletonList("not_foo")),
-                Collections.emptyMap());
-        mlMetadata = mlMetadataBuilder.build();
+        DatafeedConfig df = createDatafeed("datafeed_id", job.getId(), Collections.singletonList("not_foo"));
 
-        PersistentTasksCustomMetaData.Builder tasksBuilder =  PersistentTasksCustomMetaData.builder();
+        PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
         addJobTask(job.getId(), "node_id", JobState.OPENING, tasksBuilder);
         tasks = tasksBuilder.build();
 
         givenClusterState("foo", 1, 0);
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> new DatafeedNodeSelector(clusterState, resolver, "datafeed_id").checkDatafeedTaskCanBeCreated());
+                () -> new DatafeedNodeSelector(clusterState, resolver, "datafeed_id", df).checkDatafeedTaskCanBeCreated());
         assertThat(e.getMessage(), containsString("No node found to start datafeed [datafeed_id], allocation explanation "
                 + "[cannot start datafeed [datafeed_id] because index [not_foo] does not exist, is closed, or is still initializing.]"));
     }
@@ -319,7 +285,6 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
 
         clusterState = ClusterState.builder(new ClusterName("cluster_name"))
                 .metaData(new MetaData.Builder()
-                        .putCustom(MlMetadata.TYPE, mlMetadata)
                         .putCustom(PersistentTasksCustomMetaData.TYPE, tasks)
                         .put(indexMetaData, false))
                 .nodes(nodes)

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockClientBuilder.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockClientBuilder.java
@@ -274,7 +274,7 @@ public class MockClientBuilder {
      * Creates a {@link SearchResponse} with a {@link SearchHit} for each element of {@code docs}
      * @param indexName Index being searched
      * @param docs Returned in the SearchResponse
-     * @return
+     * @return this
      */
     @SuppressWarnings("unchecked")
     public MockClientBuilder prepareSearch(String indexName, List<BytesReference> docs) {


### PR DESCRIPTION
Breaks the `DatafeedNodeSelector`s dependency on datafeed and job configuration defined in the cluster state. 

Similar to #33994 the required configuration is added to the persistent task's parameters. `TransportStartDatafeedAction` now collects the required config and adds it to `StartDatafeedAction.DatafeedParams`. The new fields added to the params cannot be streamed in BWC safe way but this isn't an issue as `TransportStartDatafeedAction` is a master node action and `StartDatafeedPersistentTasksExecutor.getAssignment` is also only called on the master node (by the `PersistentTasksClusterService`).

`DatafeedManager.run` is changed to accept the config as a parameter rather than reading from the clusterstate, this has the additional benefit that the validated configs are used rather than re-reading the config some point after validation. However, the BWC breaks down here as the datafeed may start on a node that isn't upgraded (mixed cluster) and the required config will not have been streamed in `StartDatafeedAction.DatafeedParams`.

### Discuss
I can think of 2 solutions to this, either re-read the missing config in DatafeedManager or prevent the datafeed from starting on an old node/in a mixed cluster state. I prefer the later as I think it will simplify the migration process. That change can sensibly be done as part of the migration/upgrade work. 