### PR TITLE
Tasks: Graduate the tasks API from beta

### DIFF
--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -1,8 +1,6 @@
 [[tasks]]
 == Task Management API
 
-beta[The Task Management API is new and should still be considered a beta feature.  The API may change in ways that are not backwards compatible]
-
 [float]
 === Current Tasks Information
 


### PR DESCRIPTION
The tasks API has been around for a while now and we haven't changed it
in backwards incompatible ways for a long time now. I think we're more
than ready to graduate the tasks APIs from beta.

This doesn't mean that we won't change *how* these APIs work, just that
we won't change the REST API without a deprecation period.
