### PR TITLE
[HLRC] Update Set Policy API to use Validatable

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/SetIndexLifecyclePolicyRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/SetIndexLifecyclePolicyRequest.java
@@ -19,19 +19,13 @@
 
 package org.elasticsearch.client.indexlifecycle;
 
-import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.AcknowledgedRequest;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.client.TimedRequest;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
-public class SetIndexLifecyclePolicyRequest extends AcknowledgedRequest<SetIndexLifecyclePolicyRequest>
-    implements IndicesRequest.Replaceable {
+public class SetIndexLifecyclePolicyRequest extends TimedRequest {
 
     private String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
@@ -51,13 +45,11 @@ public class SetIndexLifecyclePolicyRequest extends AcknowledgedRequest<SetIndex
         this.policy = policy;
     }
 
-    @Override
     public SetIndexLifecyclePolicyRequest indices(String... indices) {
         this.indices = indices;
         return this;
     }
 
-    @Override
     public String[] indices() {
         return indices;
     }
@@ -77,27 +69,6 @@ public class SetIndexLifecyclePolicyRequest extends AcknowledgedRequest<SetIndex
 
     public IndicesOptions indicesOptions() {
         return indicesOptions;
-    }
-
-    @Override
-    public ActionRequestValidationException validate() {
-        return null;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        indices = in.readStringArray();
-        indicesOptions = IndicesOptions.readIndicesOptions(in);
-        policy = in.readString();
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeStringArray(indices);
-        indicesOptions.writeIndicesOptions(out);
-        out.writeString(policy);
     }
 
     @Override

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/SetIndexLifecyclePolicyResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/SetIndexLifecyclePolicyResponse.java
@@ -24,15 +24,13 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.elasticsearch.common.xcontent.ToXContentObject;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-public class SetIndexLifecyclePolicyResponse extends ActionResponse implements ToXContentObject {
+public class SetIndexLifecyclePolicyResponse extends ActionResponse {
 
     public static final ParseField HAS_FAILURES_FIELD = new ParseField("has_failures");
     public static final ParseField FAILED_INDEXES_FIELD = new ParseField("failed_indexes");
@@ -63,15 +61,6 @@ public class SetIndexLifecyclePolicyResponse extends ActionResponse implements T
 
     public boolean hasFailures() {
         return failedIndexes.isEmpty() == false;
-    }
-
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
-        builder.field(HAS_FAILURES_FIELD.getPreferredName(), hasFailures());
-        builder.field(FAILED_INDEXES_FIELD.getPreferredName(), failedIndexes);
-        builder.endObject();
-        return builder;
     }
 
     public static SetIndexLifecyclePolicyResponse fromXContent(XContentParser parser) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -1505,7 +1505,7 @@ public class RequestConvertersTests extends ESTestCase {
         req.policy(policyName);
         req.indices(indices);
         Map<String, String> expectedParams = new HashMap<>();
-        setRandomMasterTimeout(req, expectedParams);
+        setRandomMasterTimeout(req::setMasterTimeout, SetIndexLifecyclePolicyRequest.DEFAULT_MASTER_TIMEOUT, expectedParams);
         setRandomIndicesOptions(req::indicesOptions, req::indicesOptions, expectedParams);
 
         Request request = RequestConverters.setIndexLifecyclePolicy(req);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/SetIndexLifecyclePolicyRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/SetIndexLifecyclePolicyRequestTests.java
@@ -20,15 +20,15 @@
 package org.elasticsearch.client.indexlifecycle;
 
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
 import java.io.IOException;
 import java.util.Arrays;
 
-public class SetIndexLifecyclePolicyRequestTests extends AbstractStreamableTestCase<SetIndexLifecyclePolicyRequest> {
+public class SetIndexLifecyclePolicyRequestTests extends ESTestCase {
 
-    @Override
-    protected SetIndexLifecyclePolicyRequest createTestInstance() {
+    private SetIndexLifecyclePolicyRequest createTestInstance() {
         SetIndexLifecyclePolicyRequest request = new SetIndexLifecyclePolicyRequest(randomAlphaOfLength(20),
             generateRandomStringArray(20, 20, false));
         if (randomBoolean()) {
@@ -39,13 +39,7 @@ public class SetIndexLifecyclePolicyRequestTests extends AbstractStreamableTestC
         return request;
     }
 
-    @Override
-    protected SetIndexLifecyclePolicyRequest createBlankInstance() {
-        return new SetIndexLifecyclePolicyRequest();
-    }
-
-    @Override
-    protected SetIndexLifecyclePolicyRequest mutateInstance(SetIndexLifecyclePolicyRequest instance) throws IOException {
+    private SetIndexLifecyclePolicyRequest mutateInstance(SetIndexLifecyclePolicyRequest instance) throws IOException {
         String[] indices = instance.indices();
         IndicesOptions indicesOptions = instance.indicesOptions();
         String policy = instance.policy();
@@ -69,6 +63,16 @@ public class SetIndexLifecyclePolicyRequestTests extends AbstractStreamableTestC
         return newRequest;
     }
 
+    private SetIndexLifecyclePolicyRequest copyInstance(final SetIndexLifecyclePolicyRequest original) {
+        SetIndexLifecyclePolicyRequest copy = new SetIndexLifecyclePolicyRequest(original.policy(), original.indices());
+        copy.indicesOptions(original.indicesOptions());
+        return copy;
+    }
+
+    public void testEqualsAndHashcode() {
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(), this::copyInstance, this::mutateInstance);
+    }
+
     public void testNullIndices() {
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
                 () -> new SetIndexLifecyclePolicyRequest(randomAlphaOfLength(20), (String[]) null));
@@ -83,6 +87,6 @@ public class SetIndexLifecyclePolicyRequestTests extends AbstractStreamableTestC
 
     public void testValidate() {
         SetIndexLifecyclePolicyRequest request = createTestInstance();
-        assertNull(request.validate());
+        assertFalse(request.validate().isPresent());
     }
 }


### PR DESCRIPTION
Also reworks the tests for the Set Policy response object to use the new
XContent testing capabilities, rather than having to implement
ToXContent on the response object itself.