### PR TITLE
Document smtp.ssl.trust configuration option

### DIFF
--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -120,6 +120,13 @@ can specify the following email account attributes:
   If `true`, then `STARTTLS` will be required. If that command fails, the
   connection will fail. Defaults to `false`.
 
+  `smtp.ssl.trust`;;
+  A list of SMTP server hosts that are assumed trusted and for which
+  certificate verification is disabled. If set to "*", all hosts are
+  trusted. If set to a whitespace separated list of hosts, those hosts
+  are trusted. Otherwise, trust depends on the certificate the server
+  presents.
+
   `smtp.timeout`;;
   The socket read timeout. Default is two minutes.
 


### PR DESCRIPTION
This adds documentation for `smtp.ssl.trust` that was reintroduced
in #31684 in 6.3.2.

Resolves #32936