### PR TITLE
Adjust size of BigArrays in circuit breaker test

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
@@ -351,7 +351,7 @@ public class BigArraysTests extends ESTestCase {
 
     public void testMaxSizeExceededOnResize() throws Exception {
         for (String type : Arrays.asList("Byte", "Int", "Long", "Float", "Double", "Object")) {
-            final int maxSize = randomIntBetween(1 << 10, 1 << 22);
+            final int maxSize = randomIntBetween(1 << 8, 1 << 14);
             HierarchyCircuitBreakerService hcbs = new HierarchyCircuitBreakerService(
                     Settings.builder()
                             .put(REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), maxSize, ByteSizeUnit.BYTES)
@@ -360,12 +360,18 @@ public class BigArraysTests extends ESTestCase {
                     new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
             BigArrays bigArrays = new BigArrays(null, hcbs, false).withCircuitBreaking();
             Method create = BigArrays.class.getMethod("new" + type + "Array", long.class);
-            final int size = scaledRandomIntBetween(10, maxSize / 8);
+            final int size = scaledRandomIntBetween(10, maxSize / 16);
             BigArray array = (BigArray) create.invoke(bigArrays, size);
             Method resize = BigArrays.class.getMethod("resize", array.getClass().getInterfaces()[0], long.class);
-            final long newSize = maxSize + 1;
-            InvocationTargetException e = expectThrows(InvocationTargetException.class, () -> resize.invoke(bigArrays, array, newSize));
-            assertTrue(e.getCause() instanceof CircuitBreakingException);
+            while (true) {
+                long newSize = array.size() * 2;
+                try {
+                    array = (BigArray) resize.invoke(bigArrays, array, newSize);
+                } catch (InvocationTargetException e) {
+                    assertTrue(e.getCause() instanceof CircuitBreakingException);
+                    break;
+                }
+            }
             assertEquals(array.ramBytesUsed(), hcbs.getBreaker(CircuitBreaker.REQUEST).getUsed());
             array.close();
             assertEquals(0, hcbs.getBreaker(CircuitBreaker.REQUEST).getUsed());


### PR DESCRIPTION
With this commit we restore the previous behavior in
`BigArraysTests#testMaxSizeExceededOnResize` but lower the sizes that
are tested to the range between 256 bytes to 16 kB so the test does not
produce a whole lot of garbage.

The previous attempt to reduce the amount of garbage produced by that
test was to properly size the array initially but it failed to account
for object alignment which lead to test failures in some cases. While it
would be possible to account for object alignment, we would need to open
up BigArrays or directly use the underlying Lucene API which would
require us to allocate an array upfront only to determine its size (incl.
object alignment).

Instead we have fixed this issue by conservatively sizing the array
initially (so the initial allocation will never trip the circuit
breaker) and reduce garbage by reducing the circuit breaker's upper
bound as described previously.

Closes #33750