### PR TITLE
Core: Remove two methods from AbstractComponent

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/component/AbstractComponent.java
+++ b/server/src/main/java/org/elasticsearch/common/component/AbstractComponent.java
@@ -21,7 +21,6 @@ package org.elasticsearch.common.component;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
@@ -44,23 +43,4 @@ public abstract class AbstractComponent {
     public final String nodeName() {
         return Node.NODE_NAME_SETTING.get(settings);
     }
-
-    /**
-     * Checks for a deprecated setting and logs the correct alternative
-     */
-    protected void logDeprecatedSetting(String settingName, String alternativeName) {
-        if (!Strings.isNullOrEmpty(settings.get(settingName))) {
-            deprecationLogger.deprecated("Setting [{}] is deprecated, use [{}] instead", settingName, alternativeName);
-        }
-    }
-
-    /**
-     * Checks for a removed setting and logs the correct alternative
-     */
-    protected void logRemovedSetting(String settingName, String alternativeName) {
-        if (!Strings.isNullOrEmpty(settings.get(settingName))) {
-            deprecationLogger.deprecated("Setting [{}] has been removed, use [{}] instead", settingName, alternativeName);
-        }
-    }
-
 }

--- a/server/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
+++ b/server/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.watcher;
 
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Setting;
@@ -98,12 +97,6 @@ public class ResourceWatcherService extends AbstractLifecycleComponent {
         mediumMonitor = new ResourceMonitor(interval, Frequency.MEDIUM);
         interval = RELOAD_INTERVAL_HIGH.get(settings);
         highMonitor = new ResourceMonitor(interval, Frequency.HIGH);
-
-        logRemovedSetting("watcher.enabled", "resource.reload.enabled");
-        logRemovedSetting("watcher.interval", "resource.reload.interval");
-        logRemovedSetting("watcher.interval.low", "resource.reload.interval.low");
-        logRemovedSetting("watcher.interval.medium", "resource.reload.interval.medium");
-        logRemovedSetting("watcher.interval.high", "resource.reload.interval.high");
     }
 
     @Override
@@ -200,15 +193,6 @@ public class ResourceWatcherService extends AbstractLifecycleComponent {
                     logger.trace("failed to check resource watcher", e);
                 }
             }
-        }
-    }
-
-    /**
-     * Checks for a removed setting and logs the correct alternative
-     */
-    private void logRemovedSetting(String settingName, String alternativeName) {
-        if (!Strings.isNullOrEmpty(settings.get(settingName))) {
-            deprecationLogger.deprecated("Setting [{}] has been removed, use [{}] instead", settingName, alternativeName);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
+++ b/server/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.watcher;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Setting;
@@ -199,6 +200,15 @@ public class ResourceWatcherService extends AbstractLifecycleComponent {
                     logger.trace("failed to check resource watcher", e);
                 }
             }
+        }
+    }
+
+    /**
+     * Checks for a removed setting and logs the correct alternative
+     */
+    private void logRemovedSetting(String settingName, String alternativeName) {
+        if (!Strings.isNullOrEmpty(settings.get(settingName))) {
+            deprecationLogger.deprecated("Setting [{}] has been removed, use [{}] instead", settingName, alternativeName);
         }
     }
 }


### PR DESCRIPTION
This removes another two methods from `AbstractComponent`. One isn't
used at all and another is only used in a single class in our resource
watcher to log messages about settings we removed years ago. I've
dropped the logging and removed that method as well.
