### PR TITLE
Section header preceded by blank line

### DIFF
--- a/docs/reference/aggregations/pipeline/movfn-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/movfn-aggregation.asciidoc
@@ -7,6 +7,7 @@ etc.
 
 This is conceptually very similar to the <<search-aggregations-pipeline-movavg-aggregation, Moving Average>> pipeline aggregation, except
 it provides more functionality.
+
 ==== Syntax
 
 A `moving_fn` aggregation looks like this in isolation:


### PR DESCRIPTION
This PR updates the documentation to insert a blank line before the section header, so that the asciidoc renders correctly.
