### PR TITLE
[Zen2] Add low-level bootstrap implementation

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
@@ -132,17 +132,17 @@ public class CoordinationState extends AbstractComponent {
             throw new CoordinationStateRejectedException("initial state already set: last-accepted version now " + lastAcceptedVersion);
         }
 
-        assert getLastAcceptedTerm() == 0;
-        assert getLastAcceptedConfiguration().isEmpty();
-        assert getLastCommittedConfiguration().isEmpty();
-        assert lastPublishedVersion == 0;
-        assert lastPublishedConfiguration.isEmpty();
+        assert getLastAcceptedTerm() == 0 : getLastAcceptedTerm();
+        assert getLastAcceptedConfiguration().isEmpty() : getLastAcceptedConfiguration();
+        assert getLastCommittedConfiguration().isEmpty() : getLastCommittedConfiguration();
+        assert lastPublishedVersion == 0 : lastAcceptedVersion;
+        assert lastPublishedConfiguration.isEmpty() : lastPublishedConfiguration;
         assert electionWon == false;
-        assert joinVotes.isEmpty();
-        assert publishVotes.isEmpty();
+        assert joinVotes.isEmpty() : joinVotes;
+        assert publishVotes.isEmpty() : publishVotes;
 
-        assert initialState.term() == 0;
-        assert initialState.version() == 1;
+        assert initialState.term() == 0 : initialState;
+        assert initialState.version() == 1 : initialState;
         assert initialState.getLastAcceptedConfiguration().isEmpty() == false;
         assert initialState.getLastCommittedConfiguration().isEmpty() == false;
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -24,6 +24,8 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterState.Builder;
+import org.elasticsearch.cluster.ClusterState.VotingConfiguration;
 import org.elasticsearch.cluster.ClusterStateTaskConfig;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.coordination.FollowersChecker.FollowerCheckRequest;
@@ -480,6 +482,8 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
             assert followersChecker.getFastResponseState().term == getCurrentTerm() : followersChecker.getFastResponseState();
             assert followersChecker.getFastResponseState().mode == getMode() : followersChecker.getFastResponseState();
             assert (applierState.nodes().getMasterNodeId() == null) == applierState.blocks().hasGlobalBlock(NO_MASTER_BLOCK_WRITES.id());
+            assert preVoteCollector.getPreVoteResponse().equals(getPreVoteResponse())
+                : preVoteCollector + " vs " + getPreVoteResponse();
             if (mode == Mode.LEADER) {
                 final boolean becomingMaster = getStateForMasterService().term() != getCurrentTerm();
 
@@ -493,7 +497,6 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 assert leaderCheckScheduler == null : leaderCheckScheduler;
                 assert applierState.nodes().getMasterNodeId() == null || getLocalNode().equals(applierState.nodes().getMasterNode());
                 assert preVoteCollector.getLeader() == getLocalNode() : preVoteCollector;
-                assert preVoteCollector.getPreVoteResponse().equals(getPreVoteResponse()) : preVoteCollector;
 
                 final boolean activePublication = currentPublication.map(CoordinatorPublication::isActiveForCurrentLeader).orElse(false);
                 if (becomingMaster && activePublication == false) {
@@ -527,7 +530,6 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 assert followersChecker.getKnownFollowers().isEmpty();
                 assert currentPublication.map(Publication::isCommitted).orElse(true);
                 assert preVoteCollector.getLeader().equals(lastKnownLeader.get()) : preVoteCollector;
-                assert preVoteCollector.getPreVoteResponse().equals(getPreVoteResponse()) : preVoteCollector;
             } else {
                 assert mode == Mode.CANDIDATE;
                 assert joinAccumulator instanceof JoinHelper.CandidateJoinAccumulator;
@@ -540,8 +542,38 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 assert applierState.nodes().getMasterNodeId() == null;
                 assert currentPublication.map(Publication::isCommitted).orElse(true);
                 assert preVoteCollector.getLeader() == null : preVoteCollector;
-                assert preVoteCollector.getPreVoteResponse().equals(getPreVoteResponse()) : preVoteCollector;
             }
+        }
+    }
+
+    public void setInitialConfiguration(final VotingConfiguration votingConfiguration) {
+        synchronized (mutex) {
+            final ClusterState currentState = getStateForMasterService();
+
+            if (currentState.getLastAcceptedConfiguration().isEmpty() == false) {
+                throw new CoordinationStateRejectedException("Cannot set initial configuration: configuration has already been set");
+            }
+            assert currentState.term() == 0 : currentState;
+            assert currentState.version() == 0 : currentState;
+
+            if (mode != Mode.CANDIDATE) {
+                throw new CoordinationStateRejectedException("Cannot set initial configuration in mode " + mode);
+            }
+
+            final List<String> foundPeerIds = new ArrayList<>();
+            foundPeerIds.add(getLocalNode().getId());
+            peerFinder.getFoundPeers().forEach(peer -> foundPeerIds.add(peer.getId()));
+            if (votingConfiguration.hasQuorum(foundPeerIds) == false) {
+                throw new CoordinationStateRejectedException("Cannot set initial configuration: no quorum found yet");
+            }
+
+            logger.debug("setting initial configuration to {}", votingConfiguration);
+            final Builder builder = masterService.incrementVersion(currentState);
+            builder.lastAcceptedConfiguration(votingConfiguration);
+            builder.lastCommittedConfiguration(votingConfiguration);
+            coordinationState.get().setInitialState(builder.build());
+            startElectionScheduler();
+            preVoteCollector.update(getPreVoteResponse(), null); // pick up the change to last-accepted version
         }
     }
 
@@ -731,25 +763,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
 
                     if (foundQuorum) {
                         if (electionScheduler == null) {
-                            final TimeValue gracePeriod = TimeValue.ZERO; // TODO variable grace period
-                            electionScheduler = electionSchedulerFactory.startElectionScheduler(gracePeriod, new Runnable() {
-                                @Override
-                                public void run() {
-                                    synchronized (mutex) {
-                                        if (mode == Mode.CANDIDATE) {
-                                            if (prevotingRound != null) {
-                                                prevotingRound.close();
-                                            }
-                                            prevotingRound = preVoteCollector.start(lastAcceptedState, getDiscoveredNodes());
-                                        }
-                                    }
-                                }
-
-                                @Override
-                                public String toString() {
-                                    return "scheduling of new prevoting round";
-                                }
-                            });
+                            startElectionScheduler();
                         }
                     } else {
                         closePrevotingAndElectionScheduler();
@@ -757,6 +771,30 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 }
             }
         }
+    }
+
+    private void startElectionScheduler() {
+        assert electionScheduler == null : electionScheduler;
+        final TimeValue gracePeriod = TimeValue.ZERO; // TODO variable grace period
+        electionScheduler = electionSchedulerFactory.startElectionScheduler(gracePeriod, new Runnable() {
+            @Override
+            public void run() {
+                synchronized (mutex) {
+                    if (mode == Mode.CANDIDATE) {
+                        if (prevotingRound != null) {
+                            prevotingRound.close();
+                        }
+                        final ClusterState lastAcceptedState = coordinationState.get().getLastAcceptedState();
+                        prevotingRound = preVoteCollector.start(lastAcceptedState, getDiscoveredNodes());
+                    }
+                }
+            }
+
+            @Override
+            public String toString() {
+                return "scheduling of new prevoting round";
+            }
+        });
     }
 
     class CoordinatorPublication extends Publication {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -65,6 +65,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.discovery.DiscoverySettings.NO_MASTER_BLOCK_WRITES;
 import static org.elasticsearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
@@ -560,11 +561,12 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 throw new CoordinationStateRejectedException("Cannot set initial configuration in mode " + mode);
             }
 
-            final List<String> foundPeerIds = new ArrayList<>();
-            foundPeerIds.add(getLocalNode().getId());
-            peerFinder.getFoundPeers().forEach(peer -> foundPeerIds.add(peer.getId()));
-            if (votingConfiguration.hasQuorum(foundPeerIds) == false) {
-                throw new CoordinationStateRejectedException("Cannot set initial configuration: no quorum found yet");
+            final List<DiscoveryNode> knownNodes = new ArrayList<>();
+            knownNodes.add(getLocalNode());
+            peerFinder.getFoundPeers().forEach(knownNodes::add);
+            if (votingConfiguration.hasQuorum(knownNodes.stream().map(DiscoveryNode::getId).collect(Collectors.toList())) == false) {
+                throw new CoordinationStateRejectedException("not enough nodes discovered to form a quorum in the initial configuration " +
+                    "[knownNodes=" + knownNodes + ", " + votingConfiguration + "]");
             }
 
             logger.debug("setting initial configuration to {}", votingConfiguration);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -569,13 +569,13 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                     "[knownNodes=" + knownNodes + ", " + votingConfiguration + "]");
             }
 
-            logger.debug("setting initial configuration to {}", votingConfiguration);
+            logger.info("setting initial configuration to {}", votingConfiguration);
             final Builder builder = masterService.incrementVersion(currentState);
             builder.lastAcceptedConfiguration(votingConfiguration);
             builder.lastCommittedConfiguration(votingConfiguration);
             coordinationState.get().setInitialState(builder.build());
-            startElectionScheduler();
             preVoteCollector.update(getPreVoteResponse(), null); // pick up the change to last-accepted version
+            startElectionScheduler();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -329,7 +329,7 @@ public class MasterService extends AbstractLifecycleComponent {
         return newClusterState;
     }
 
-    protected Builder incrementVersion(ClusterState clusterState) {
+    public Builder incrementVersion(ClusterState clusterState) {
         return ClusterState.builder(clusterState).incrementVersion();
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -425,7 +425,8 @@ public class CoordinatorTests extends ESTestCase {
 
         cluster.getAnyNode().applyInitialConfiguration();
         cluster.stabilise(defaultMillis(
-            // the first election should succeed
+            // the first election should succeed, because only one node knows of the initial configuration and therefore can win a
+            // pre-voting round and proceed to an election, so there cannot be any collisions
             ELECTION_INITIAL_TIMEOUT_SETTING) // TODO this wait is unnecessary, we could trigger the election immediately
             // Allow two round-trip for pre-voting and voting
             + 4 * DEFAULT_DELAY_VARIABILITY


### PR DESCRIPTION
Today we inject the initial configuration of the cluster (i.e. the set of
voting nodes) at startup. In reality we must support injecting the initial
configuration after startup too. This commit adds low-level support for doing
so as safely as possible.