### PR TITLE
Build: Pass offline flag through to bwc build

### DIFF
--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -179,6 +179,9 @@ subprojects {
     } else {
       executable new File(checkoutDir, 'gradlew').toString()
     }
+    if (gradle.startParameter.isOffline()) {
+      args "--offline"
+    }
     for (String dir : projectDirs) {
       args ":${dir.replace('/', ':')}:assemble"
     }


### PR DESCRIPTION
This commit makes the bwc build aware of the offline flag passed to the outer build.

closes #34361