### PR TITLE
[Painless] Allow statically imported methods without whitelisted class

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/StaticTest.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/StaticTest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless;
+
+public class StaticTest {
+    public static int staticAddIntsTest(int x, int y) {
+        return x + y;
+    }
+}

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupBuilder.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupBuilder.java
@@ -691,13 +691,6 @@ public final class PainlessLookupBuilder {
                     "invalid imported method name [" + methodName + "] for target class [" + targetCanonicalClassName + "].");
         }
 
-        PainlessClassBuilder painlessClassBuilder = classesToPainlessClassBuilders.get(targetClass);
-
-        if (painlessClassBuilder == null) {
-            throw new IllegalArgumentException("target class [" + targetCanonicalClassName + "] not found for imported method " +
-                    "[[" + targetCanonicalClassName + "], [" + methodName + "], " + typesToCanonicalTypeNames(typeParameters) + "]");
-        }
-
         int typeParametersSize = typeParameters.size();
         List<Class<?>> javaTypeParameters = new ArrayList<>(typeParametersSize);
 

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
@@ -261,6 +261,7 @@ class org.elasticsearch.painless.FeatureTest no_import {
 
 # for testing
 static_import {
+  int staticAddIntsTest(int, int) from_class org.elasticsearch.painless.StaticTest
   float staticAddFloatsTest(float, float) from_class org.elasticsearch.painless.FeatureTest
   int testAddWithState(int, int, int, double) bound_to org.elasticsearch.painless.BindingTest
 }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
@@ -136,6 +136,7 @@ public class BasicAPITests extends ScriptTestCase {
     }
 
     public void testStatic() {
+        assertEquals(10, exec("staticAddIntsTest(7, 3)"));
         assertEquals(15.5f, exec("staticAddFloatsTest(6.5f, 9.0f)"));
     }
 }


### PR DESCRIPTION
Currently, a class must be whitelisted separately to allow a statically imported method to also be whitelisted.  This removes the extraneous check to see if the class for a statically imported method is already whitelisted, so a statically imported method can be whitelisted independently.