### PR TITLE
Handle pre-6.x time fields

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ExtractedField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ExtractedField.java
@@ -107,7 +107,7 @@ abstract class ExtractedField {
                 value[0] = Long.parseLong((String) value[0]);
             } else if (value[0] instanceof BaseDateTime) { // script field
                 value[0] = ((BaseDateTime) value[0]).getMillis();
-            } else {
+            } else if (value[0] instanceof Long == false) { // pre-6.0 field
                 throw new IllegalStateException("Unexpected value for a time field: " + value[0].getClass());
             }
             return value;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ExtractedFieldsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ExtractedFieldsTests.java
@@ -64,11 +64,25 @@ public class ExtractedFieldsTests extends ESTestCase {
     }
 
     public void testTimeFieldValue() {
-        SearchHit hit = new SearchHitBuilder(1).addField("time", new DateTime(1000L)).build();
+        final long millis = randomLong();
+        final SearchHit hit = new SearchHitBuilder(randomInt()).addField("time", new DateTime(millis)).build();
+        final ExtractedFields extractedFields = new ExtractedFields(timeField, Collections.singletonList(timeField));
+        assertThat(extractedFields.timeFieldValue(hit), equalTo(millis));
+    }
 
-        ExtractedFields extractedFields = new ExtractedFields(timeField, Arrays.asList(timeField));
+    public void testStringTimeFieldValue() {
+        final long millis = randomLong();
+        final SearchHit hit = new SearchHitBuilder(randomInt()).addField("time", Long.toString(millis)).build();
+        final ExtractedFields extractedFields = new ExtractedFields(timeField, Collections.singletonList(timeField));
+        assertThat(extractedFields.timeFieldValue(hit), equalTo(millis));
+    }
 
-        assertThat(extractedFields.timeFieldValue(hit), equalTo(1000L));
+    public void testPre6xTimeFieldValue() {
+        // Prior to 6.x, timestamps were simply `long` milliseconds-past-the-epoch values
+        final long millis = randomLong();
+        final SearchHit hit = new SearchHitBuilder(randomInt()).addField("time", millis).build();
+        final ExtractedFields extractedFields = new ExtractedFields(timeField, Collections.singletonList(timeField));
+        assertThat(extractedFields.timeFieldValue(hit), equalTo(millis));
     }
 
     public void testTimeFieldValueGivenEmptyArray() {


### PR DESCRIPTION
In ccb9ab5717d85c6786b081f197d67ac7dde4d317 we changed how we deal with time
fields to support the `DateTime`-format fields added in 6.0, but dropped
support for pre-6.x `Long`-format fields. This change reinstates this support
for cases where pre-6.x data is made available to ML (e.g. in a mixed-version
CCS setup or after an upgrade).