### PR TITLE
Always initialize the global checkpoint

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -402,7 +402,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
             final long globalCheckpoint,
             final LongConsumer onGlobalCheckpointUpdated) {
         super(shardId, indexSettings);
-        assert globalCheckpoint >= SequenceNumbers.UNASSIGNED_SEQ_NO : "illegal initial global checkpoint: " + globalCheckpoint;
+        assert globalCheckpoint >= SequenceNumbers.NO_OPS_PERFORMED : "illegal initial global checkpoint: " + globalCheckpoint;
         this.shardAllocationId = allocationId;
         this.primaryMode = false;
         this.handoffInProgress = false;

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -158,7 +158,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static org.elasticsearch.index.mapper.SourceToParse.source;
-import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.elasticsearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
 
 public class IndexShard extends AbstractIndexShardComponent implements IndicesClusterStateService.Shard {
 
@@ -300,7 +300,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         this.globalCheckpointListeners =
                 new GlobalCheckpointListeners(shardId, threadPool.executor(ThreadPool.Names.LISTENER), threadPool.scheduler(), logger);
         this.replicationTracker =
-                new ReplicationTracker(shardId, aId, indexSettings, UNASSIGNED_SEQ_NO, globalCheckpointListeners::globalCheckpointUpdated);
+                new ReplicationTracker(shardId, aId, indexSettings, NO_OPS_PERFORMED, globalCheckpointListeners::globalCheckpointUpdated);
 
         // the query cache is a node-level thing, however we want the most popular filters
         // to be computed on a per-shard basis

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -159,6 +159,7 @@ import java.util.stream.StreamSupport;
 
 import static org.elasticsearch.index.mapper.SourceToParse.source;
 import static org.elasticsearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
+import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 
 public class IndexShard extends AbstractIndexShardComponent implements IndicesClusterStateService.Shard {
 

--- a/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerTests.java
@@ -65,7 +65,7 @@ public class ReplicationTrackerTests extends ESTestCase {
     
     public void testEmptyShards() {
         final ReplicationTracker tracker = newTracker(AllocationId.newInitializing());
-        assertThat(tracker.getGlobalCheckpoint(), equalTo(UNASSIGNED_SEQ_NO));
+        assertThat(tracker.getGlobalCheckpoint(), equalTo(NO_OPS_PERFORMED));
     }
 
     private Map<AllocationId, Long> randomAllocationsWithLocalCheckpoints(int min, int max) {
@@ -124,7 +124,7 @@ public class ReplicationTrackerTests extends ESTestCase {
 
         final AllocationId primaryId = active.iterator().next();
         final ReplicationTracker tracker = newTracker(primaryId);
-        assertThat(tracker.getGlobalCheckpoint(), equalTo(UNASSIGNED_SEQ_NO));
+        assertThat(tracker.getGlobalCheckpoint(), equalTo(NO_OPS_PERFORMED));
 
         logger.info("--> using allocations");
         allocations.keySet().forEach(aId -> {
@@ -259,8 +259,8 @@ public class ReplicationTrackerTests extends ESTestCase {
                 .forEach(e -> updateLocalCheckpoint(tracker, e.getKey().getId(), e.getValue()));
 
         if (missingActiveID.equals(primaryId) == false) {
-            assertThat(tracker.getGlobalCheckpoint(), equalTo(UNASSIGNED_SEQ_NO));
-            assertThat(updatedGlobalCheckpoint.get(), equalTo(UNASSIGNED_SEQ_NO));
+            assertThat(tracker.getGlobalCheckpoint(), equalTo(NO_OPS_PERFORMED));
+            assertThat(updatedGlobalCheckpoint.get(), equalTo(NO_OPS_PERFORMED));
         }
         // now update all knowledge of all shards
         assigned.forEach((aid, localCP) -> updateLocalCheckpoint(tracker, aid.getId(), localCP));
@@ -425,14 +425,14 @@ public class ReplicationTrackerTests extends ESTestCase {
         thread.join();
     }
     
-    private AtomicLong updatedGlobalCheckpoint = new AtomicLong(UNASSIGNED_SEQ_NO);
+    private AtomicLong updatedGlobalCheckpoint = new AtomicLong(NO_OPS_PERFORMED);
 
     private ReplicationTracker newTracker(final AllocationId allocationId) {
         return new ReplicationTracker(
                 new ShardId("test", "_na_", 0),
                 allocationId.getId(),
                 IndexSettingsModule.newIndexSettings("test", Settings.EMPTY),
-                UNASSIGNED_SEQ_NO,
+                NO_OPS_PERFORMED,
                 updatedGlobalCheckpoint::set);
     }
 
@@ -710,9 +710,9 @@ public class ReplicationTrackerTests extends ESTestCase {
         final AllocationId primaryAllocationId = clusterState.routingTable.primaryShard().allocationId();
         final LongConsumer onUpdate = updatedGlobalCheckpoint -> {};
         ReplicationTracker oldPrimary =
-                new ReplicationTracker(shardId, primaryAllocationId.getId(), indexSettings, UNASSIGNED_SEQ_NO, onUpdate);
+                new ReplicationTracker(shardId, primaryAllocationId.getId(), indexSettings, NO_OPS_PERFORMED, onUpdate);
         ReplicationTracker newPrimary =
-                new ReplicationTracker(shardId, primaryAllocationId.getRelocationId(), indexSettings, UNASSIGNED_SEQ_NO, onUpdate);
+                new ReplicationTracker(shardId, primaryAllocationId.getRelocationId(), indexSettings, NO_OPS_PERFORMED, onUpdate);
 
         Set<String> allocationIds = new HashSet<>(Arrays.asList(oldPrimary.shardAllocationId, newPrimary.shardAllocationId));
 


### PR DESCRIPTION
The global checkpoint of a 5.x index after upgraded to 6.x can be either
unassigned(-2) or initialized to no_ops(-1) inconsistently. Moreover, an
unassigned global checkpoint might cause replicas to execute Lucene
rollback although all operations in Lucene are safe.

This change makes sure that the global checkpoint is always initialized.
