### PR TITLE
Check IOException for corruption specific messages

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -203,6 +203,11 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             // TODO this should be caught by lucene - EOF is almost certainly an index corruption
             throw new CorruptIndexException("Read past EOF while reading segment infos", "commit(" + commit + ")", eof);
         } catch (IOException exception) {
+            final String message = exception.getMessage();
+            // DataInput throws a generic IOException on odd data cases
+            if (message != null && (message.startsWith("Invalid vLong detected") || message.startsWith("Invalid vInt detected"))) {
+                throw new CorruptIndexException(message, "commit(" + commit + ")", exception);
+            }
             throw exception; // IOExceptions like too many open files are not necessarily a corruption - just bubble it up
         } catch (Exception ex) {
             throw new CorruptIndexException("Hit unexpected exception while reading segment infos", "commit(" + commit + ")", ex);

--- a/test/framework/src/main/java/org/elasticsearch/test/CorruptionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/CorruptionUtils.java
@@ -118,6 +118,19 @@ public final class CorruptionUtils {
     static void corruptAt(Path path, FileChannel channel, int position) throws IOException {
         // read
         channel.position(position);
+        ByteBuffer bb = ByteBuffer.wrap(new byte[1]);
+        channel.read(bb);
+        bb.flip();
+
+        // corrupt
+        byte newValue = (byte) (bb.get(0) + 1);
+
+        corruptAt(path, channel, position, newValue);
+    }
+
+    static void corruptAt(Path path, FileChannel channel, int position, byte newValue) throws IOException {
+        // read
+        channel.position(position);
         long filePointer = channel.position();
         ByteBuffer bb = ByteBuffer.wrap(new byte[1]);
         channel.read(bb);
@@ -125,14 +138,13 @@ public final class CorruptionUtils {
 
         // corrupt
         byte oldValue = bb.get(0);
-        byte newValue = (byte) (oldValue + 1);
         bb.put(0, newValue);
 
         // rewrite
         channel.position(filePointer);
         channel.write(bb);
         logger.info("Corrupting file --  flipping at position {} from {} to {} file: {}", filePointer,
-                Integer.toHexString(oldValue), Integer.toHexString(newValue), path.getFileName());
+            Integer.toHexString(0xFF & oldValue), Integer.toHexString(0xFF & newValue), path.getFileName());
     }
 
 

--- a/test/framework/src/test/java/org/elasticsearch/test/CorruptionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/CorruptionUtilsTests.java
@@ -19,12 +19,16 @@
 package org.elasticsearch.test;
 
 import org.apache.lucene.index.CheckIndex;
+import org.apache.lucene.index.IndexCommit;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.SimpleFSDirectory;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardTestCase;
 import org.elasticsearch.index.shard.ShardPath;
 
+import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -77,5 +81,56 @@ public class CorruptionUtilsTests extends IndexShardTestCase {
         assertThat("That's a good news! "
                 + "Lucene now validates CRC32 of CFS file: time to drop workaround at CorruptionUtils (and this test)",
             status.clean, equalTo(true));
+    }
+
+    /**
+     * There is a dependency on Lucene bug fix
+     * https://issues.apache.org/jira/browse/LUCENE-8525
+     *
+     * {@link org.elasticsearch.index.store.Store#readSegmentsInfo(IndexCommit, Directory)}
+     */
+    public void testLuceneDetectsSegmentCorruptionDataAsIOException() throws Exception {
+        final IndexShard indexShard = newStartedShard(true);
+
+        // doesn't matter - we to generate segment file
+        final int numDocs = randomIntBetween(10, 20);
+        for (long i = 0; i < numDocs; i++) {
+            indexDoc(indexShard, "_doc", Long.toString(i), "{}");
+        }
+        indexShard.flush(new FlushRequest());
+        closeShards(indexShard);
+
+        final ShardPath shardPath = indexShard.shardPath();
+
+        final Path indexPath = shardPath.getDataPath().resolve(ShardPath.INDEX_FOLDER_NAME);
+
+        final Path segmentFile;
+        try (Stream<Path> paths = Files.walk(indexPath)) {
+            segmentFile = paths.filter(p -> p.getFileName().toString().startsWith("segments_")).findFirst()
+                .orElseThrow(() -> new IllegalStateException("segment file has to be there"));
+        }
+
+        try (FileChannel raf = FileChannel.open(segmentFile, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+            // flipping a single byte at this position leads to reading numDVFields in SegmentInfos (while it was not there)
+            // after that the following data structure is handled as Map<Integer,Set<String>>
+            final int offset = 119;
+            corruptAt(segmentFile, raf, offset, (byte)1); // numDVFields = 1
+
+            // one of Set<String> has a negative size that triggers generic IOException
+            for (int i = 0; i < 4; i++) {
+                // numDVFields use a compressed byte as integer (1 byte)
+                // integer is used for size of Set (4 bytes)
+                corruptAt(segmentFile, raf, offset + Byte.BYTES + Integer.BYTES + i, (byte) -1);
+            }
+        }
+
+        try (Directory directory = new SimpleFSDirectory(indexPath)) {
+            final IOException exception = expectThrows(IOException.class, () -> Lucene.readSegmentInfos(directory));
+            assertThat("Looks like the data structure is changed",
+                exception.getMessage(), equalTo("Invalid vInt detected (too many bits)"));
+            assertThat("Lucene has fixed handling data errors as smth more specific than IOException,"
+                    + " time to clean up Store#readSegmentsInfo",
+                exception.getClass(), equalTo(IOException.class));
+        }
     }
 }

--- a/test/framework/src/test/java/org/elasticsearch/test/CorruptionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/CorruptionUtilsTests.java
@@ -133,49 +133,4 @@ public class CorruptionUtilsTests extends IndexShardTestCase {
                 exception.getClass(), equalTo(IOException.class));
         }
     }
-
-    public void testLuceneFacesNegativeArraySize() throws Exception {
-        final IndexShard indexShard = newStartedShard(true);
-
-        // doesn't matter - we to generate segment file
-        final int numDocs = randomIntBetween(10, 20);
-        for (long i = 0; i < numDocs; i++) {
-            indexDoc(indexShard, "_doc", Long.toString(i), "{}");
-        }
-        indexShard.flush(new FlushRequest());
-        closeShards(indexShard);
-
-        final ShardPath shardPath = indexShard.shardPath();
-
-        final Path indexPath = shardPath.getDataPath().resolve(ShardPath.INDEX_FOLDER_NAME);
-
-        final Path segmentFile;
-        try (Stream<Path> paths = Files.walk(indexPath)) {
-            segmentFile = paths.filter(p -> p.getFileName().toString().startsWith("segments_")).findFirst()
-                .orElseThrow(() -> new IllegalStateException("segment file has to be there"));
-        }
-
-        try (FileChannel raf = FileChannel.open(segmentFile, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
-            // flipping a single byte at this position leads to reading numDVFields in SegmentInfos (while it was not there)
-            // after that the following data structure is handled as Map<Integer,Set<String>>
-            final int offset = 119;
-            corruptAt(segmentFile, raf, offset, (byte)1); // numDVFields = 1
-
-            for (int i = 0; i < 4; i++) {
-                // numDVFields use a compressed byte as integer (1 byte)
-                // size of Set is a  compressed byte as integer (1 byte)
-                // for the string size use all negatives
-                corruptAt(segmentFile, raf, 125 + i, (byte) -1);
-            }
-            // and the last one is 0x0F that results to length of string = -1
-            corruptAt(segmentFile, raf, 125 + 4, (byte) 0x0F);
-        }
-
-        try (Directory directory = new SimpleFSDirectory(indexPath)) {
-            expectThrows(NegativeArraySizeException.class,
-                "Lucene has fixed handling negative string sizes,"
-                    + " time to clean up Store#readSegmentsInfo",
-                () -> Lucene.readSegmentInfos(directory));
-        }
-    }
 }

--- a/test/framework/src/test/java/org/elasticsearch/test/CorruptionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/CorruptionUtilsTests.java
@@ -92,7 +92,7 @@ public class CorruptionUtilsTests extends IndexShardTestCase {
     public void testLuceneDetectsSegmentCorruptionDataAsIOException() throws Exception {
         final IndexShard indexShard = newStartedShard(true);
 
-        // doesn't matter - we to generate segment file
+        // doesn't matter - have to generate segment file
         final int numDocs = randomIntBetween(10, 20);
         for (long i = 0; i < numDocs; i++) {
             indexDoc(indexShard, "_doc", Long.toString(i), "{}");


### PR DESCRIPTION
Lucene throws generic IOException due to corrupted data - https://github.com/apache/lucene-solr/blob/1d85cd783863f75cea133fb9c452302214165a4d/lucene/core/src/java/org/apache/lucene/store/DataInput.java#L141 - it is not handled properly on its level and effectively SegmentInfo.readCommit violates its contract 
```
   * @throws CorruptIndexException if the index is corrupt
   * @throws IOException if there is a low-level IO error
   */
  public static final SegmentInfos readCommit(Directory directory, String segmentFileName) throws IOException {
```

While there is https://issues.apache.org/jira/browse/LUCENE-8525 to address this problem, we can prevent this problem on our side relying on an exception message like we do in https://github.com/elastic/elasticsearch/blob/237650e9c054149fd08213b38a81a3666c1868e5/server/src/main/java/org/elasticsearch/common/transport/NetworkExceptionHelper.java#L40

**Note**: this PR is more a placeholder if we are not able to manage Lucene issue in some reasonable time

Closes #34322 