### PR TITLE
[Monitoring] Add additional necessary mappings for apm-server

### DIFF
--- a/x-pack/plugin/core/src/main/resources/monitoring-beats.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-beats.json
@@ -487,6 +487,13 @@
                               "type": "long"
                             }
                           }
+                        },
+                        "span": {
+                          "properties": {
+                            "transformations": {
+                              "type": "long"
+                            }
+                          }
                         }
                       }
                     }
@@ -537,6 +544,9 @@
                               "type": "long"
                             },
                             "total": {
+                              "type": "long"
+                            },
+                            "toomany": {
                               "type": "long"
                             }
                           }

--- a/x-pack/plugin/core/src/main/resources/monitoring-beats.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-beats.json
@@ -221,6 +221,23 @@
                           "type": "long"
                         }
                       }
+                    },
+                    "handles": {
+                      "properties": {
+                        "open": {
+                          "type": "long"
+                        },
+                        "limit": {
+                          "properties": {
+                            "hard": {
+                              "type": "long"
+                            },
+                            "soft": {
+                              "type": "long"
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 },

--- a/x-pack/plugin/core/src/main/resources/monitoring-es.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-es.json
@@ -835,6 +835,16 @@
                       "type": "long"
                     }
                   }
+                },
+                "write": {
+                  "properties": {
+                    "queue": {
+                      "type": "integer"
+                    },
+                    "rejected": {
+                      "type": "long"
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/23959

This PR adds necessary mappings for an existing field currently used in the UI as well as an additional field that the UI will use.

Update: This PR also includes [fields from here](https://github.com/elastic/stack-monitoring/issues/3#issuecomment-427389611) and [from here](https://github.com/elastic/kibana/issues/23862)

cc @graphaelli 