### PR TITLE
Update TESTING.asciidoc title

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -1,4 +1,4 @@
-[[Testing Framework Cheatsheet]]
+[[TestingFrameworkCheatsheet]]
 = Testing
 
 [partintro]


### PR DESCRIPTION
Minor change displaying `Testing` as `h1` instead of plain text.

Asciidoc anchorId cannot contain white spaces, hence the rendering till now has been `[[Testing Framework Cheatsheet]] = Testing` as plain text. The change is defining `TestingFrameworkCheatsheet` as an anchor to the block (by simply removing the white spaces), thus `= Testing` can be correctly parsed as `h1`.
The anchor is not used in a cross reference, so this change should not brake any references.