### PR TITLE
[DOCS] improve formatting of Query String Query doc page

### DIFF
--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -255,12 +255,6 @@ following additional parameters are allowed:
 |`type` |How the fields should be combined to build the text query.
 See <<multi-match-types, types>> for a complete example.
 Defaults to `best_fields`
-|=======================================================================
-
-
-[cols="<,<",options="header",]
-|=======================================================================
-|Parameter |Description
 
 |`tie_breaker` |The disjunction max tie breaker for multi fields.
 Defaults to `0`


### PR DESCRIPTION
Hello dear sirs,

This pull request is to fix what seems to be a formatting issue in the [Query String Query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_multi_field) doc page (section "Multi Field").

To have a complete idea please see screenshots attached.

Before:
![2018-10-13_query_string_before](https://user-images.githubusercontent.com/7804425/46907208-6aea5000-cf0f-11e8-9cf0-1d8b0df3a161.png)
After:
![2018-10-13_query_string_after](https://user-images.githubusercontent.com/7804425/46907211-6de54080-cf0f-11e8-9f34-7b557106b4ec.png)

It looked like the two "Parameters" tables should have been one, and I made them so.

Doc tests pass (`./gradlew :docs:check`), also the "after" screenshot was created from an HTML built with an `elastic/docs` script.

Please tell me if you find this useful or if there are any issues I am open to discussion.

Thank you!
