### PR TITLE
Tests: Fix DateFormatter equals tests with locale

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -111,8 +111,9 @@ public class DateFormattersTests extends ESTestCase {
         assertThat(DateFormatters.forPattern("YYYY").withZone(ZoneId.of("CET")), not(equalTo(DateFormatters.forPattern("YYYY"))));
 
         // different locale, thus not equals
-        assertThat(DateFormatters.forPattern("YYYY").withLocale(randomLocale(random())),
-            not(equalTo(DateFormatters.forPattern("YYYY"))));
+        DateFormatter f1 = DateFormatters.forPattern("YYYY").withLocale(Locale.CANADA);
+        DateFormatter f2 = f1.withLocale(Locale.FRENCH);
+        assertThat(f1, not(equalTo(f2)));
 
         // different pattern, thus not equals
         assertThat(DateFormatters.forPattern("YYYY"), not(equalTo(DateFormatters.forPattern("YY"))));


### PR DESCRIPTION
This commit removes randomization of locale for DateFormatter equals
tests, instead using explicit locales. The test framework already
randomizes locales, so the random choice of the second locale can
sometimes be equal to the already chosen locale. Randomization also does
not provide any extra protection, as the equality of DateFormatter does
not implement equality of the locales itself.

closes #34337
