### PR TITLE
Add Punjabi to unsupported Kerberos locales list

### DIFF
--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
@@ -76,6 +76,7 @@ public abstract class KerberosTestCase extends ESTestCase {
         unsupportedLocaleLanguages.add("my");
         unsupportedLocaleLanguages.add("ps");
         unsupportedLocaleLanguages.add("ur");
+        unsupportedLocaleLanguages.add("pa");
     }
 
     @BeforeClass


### PR DESCRIPTION
Relates #33253 and fixes another test failure similar to #33228.