### PR TITLE
MINOR: Remove Dead Code in  ExpressionTermSetQuery

### DIFF
--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
@@ -221,8 +221,7 @@ public class ExpressionScriptEngine extends AbstractComponent implements ScriptE
                 throw convertToScriptException("link error", expr.sourceText, variable, e);
             }
         }
-        ReplaceableConstDoubleValueSource specialValue = null;
-        return new ExpressionTermSetQueryScript(expr, bindings, specialValue);
+        return new ExpressionTermSetQueryScript(expr, bindings);
     }
 
     /**

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionTermSetQueryScript.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionTermSetQueryScript.java
@@ -38,13 +38,11 @@ class ExpressionTermSetQueryScript implements TermsSetQueryScript.LeafFactory {
     final Expression exprScript;
     final SimpleBindings bindings;
     final DoubleValuesSource source;
-    final ReplaceableConstDoubleValueSource specialValue; // _value
 
-    ExpressionTermSetQueryScript(Expression e, SimpleBindings b, ReplaceableConstDoubleValueSource v) {
+    ExpressionTermSetQueryScript(Expression e, SimpleBindings b) {
         exprScript = e;
         bindings = b;
         source = exprScript.getDoubleValuesSource(bindings);
-        specialValue = v;
     }
 
     @Override


### PR DESCRIPTION
No need to pass the `null` here.