### PR TITLE
[ML-Dataframe] Feature/fib reenable agg config tests

### DIFF
--- a/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/SourceConfig.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/SourceConfig.java
@@ -53,7 +53,7 @@ public class SourceConfig implements Writeable, ToXContentObject {
         List<CompositeValuesSourceBuilder<?>> sources = new ArrayList<>(num);
         for (int i = 0; i < num; i++) {
             CompositeValuesSourceBuilder<?> builder = CompositeValuesSourceParserHelper.readFrom(in);
-            getSources().add(builder);
+            sources.add(builder);
         }
         this.sources = Collections.unmodifiableList(sources);
     }

--- a/x-pack/plugin/ml-feature-index-builder/src/test/java/org/elasticsearch/xpack/ml/featureindexbuilder/action/PutFeatureIndexBuilderJobActionRequestTests.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/test/java/org/elasticsearch/xpack/ml/featureindexbuilder/action/PutFeatureIndexBuilderJobActionRequestTests.java
@@ -6,7 +6,11 @@
 
 package org.elasticsearch.xpack.ml.featureindexbuilder.action;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractStreamableXContentTestCase;
 import org.elasticsearch.xpack.ml.featureindexbuilder.action.PutFeatureIndexBuilderJobAction.Request;
 import org.elasticsearch.xpack.ml.featureindexbuilder.job.FeatureIndexBuilderJobConfig;
@@ -15,18 +19,41 @@ import org.junit.Before;
 
 import java.io.IOException;
 
+import static java.util.Collections.emptyList;
+
 public class PutFeatureIndexBuilderJobActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
 
     private String jobId;
 
+    private NamedWriteableRegistry namedWriteableRegistry;
+    private NamedXContentRegistry namedXContentRegistry;
+
+    @Before
+    public void registerAggregationNamedObjects() throws Exception {
+        // register aggregations as NamedWriteable
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, emptyList());
+        namedWriteableRegistry = new NamedWriteableRegistry(searchModule.getNamedWriteables());
+        namedXContentRegistry = new NamedXContentRegistry(searchModule.getNamedXContents());
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return namedWriteableRegistry;
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        return namedXContentRegistry;
+    }
+
     @Before
     public void setupJobID() {
-        jobId = randomAlphaOfLengthBetween(1,10);
+        jobId = randomAlphaOfLengthBetween(1, 10);
     }
 
     @Override
     protected Request doParseInstance(XContentParser parser) throws IOException {
-        return  Request.fromXContent(parser, jobId);
+        return Request.fromXContent(parser, jobId);
     }
 
     @Override

--- a/x-pack/plugin/ml-feature-index-builder/src/test/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/AggregationConfigTests.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/test/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/AggregationConfigTests.java
@@ -12,6 +12,8 @@ import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -20,8 +22,13 @@ public class AggregationConfigTests extends AbstractSerializingFeatureIndexBuild
     public static AggregationConfig randomAggregationConfig() {
         AggregatorFactories.Builder builder = new AggregatorFactories.Builder();
 
-        for (int i = 0; i < randomIntBetween(1, 20); ++i) {
-            builder.addAggregator(getRandomSupportedAggregation());
+        // ensure that the unlikely does not happen: 2 aggs share the same name
+        Set<String> names = new HashSet<>();
+        for (int i = 1; i < randomIntBetween(1, 20); ++i) {
+            AggregationBuilder aggBuilder = getRandomSupportedAggregation();
+            if (names.add(aggBuilder.getName())) {
+                builder.addAggregator(aggBuilder);
+            }
         }
 
         return new AggregationConfig(builder);

--- a/x-pack/plugin/ml-feature-index-builder/src/test/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/AggregationConfigTests.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/test/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/AggregationConfigTests.java
@@ -6,7 +6,6 @@
 
 package org.elasticsearch.xpack.ml.featureindexbuilder.job;
 
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -16,8 +15,6 @@ import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
 
-// broken upstream
-@AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/33942")
 public class AggregationConfigTests extends AbstractSerializingFeatureIndexBuilderTestCase<AggregationConfig> {
 
     public static AggregationConfig randomAggregationConfig() {

--- a/x-pack/plugin/ml-feature-index-builder/src/test/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderJobConfigTests.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/test/java/org/elasticsearch/xpack/ml/featureindexbuilder/job/FeatureIndexBuilderJobConfigTests.java
@@ -17,10 +17,9 @@ public class FeatureIndexBuilderJobConfigTests extends AbstractSerializingFeatur
     private String jobId;
 
     public static FeatureIndexBuilderJobConfig randomFeatureIndexBuilderJobConfig() {
-        // AggregationConfig disabled, see: https://github.com/elastic/elasticsearch/pull/33942
         return new FeatureIndexBuilderJobConfig(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10),
                 randomAlphaOfLengthBetween(1, 10), SourceConfigTests.randomSourceConfig(),
-                null /* AggregationConfigTests.randonAggregationConfig() */);
+                AggregationConfigTests.randomAggregationConfig());
     }
 
     @Before


### PR DESCRIPTION
**FEATURE BRANCH PR**

re-enables tests after upstream fixes, see #34005 