### PR TITLE
Test fix - GraphExploreResponse HLRC xContent ordering is unreliable

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/xpack/graph/GraphExploreResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/xpack/graph/GraphExploreResponseTests.java
@@ -75,6 +75,11 @@ public class GraphExploreResponseTests extends AbstractXContentTestCase< GraphEx
     protected boolean supportsUnknownFields() {
         return true;
     }
+    
+    @Override
+    protected boolean assertToXContentEquivalence() {
+        return false;
+    }     
 
     @Override
     protected String[] getShuffleFieldsExceptions() {

--- a/x-pack/protocol/src/test/java/org/elasticsearch/protocol/xpack/graph/GraphExploreResponseTests.java
+++ b/x-pack/protocol/src/test/java/org/elasticsearch/protocol/xpack/graph/GraphExploreResponseTests.java
@@ -90,6 +90,11 @@ public class GraphExploreResponseTests extends AbstractXContentTestCase< GraphEx
     }
     
     @Override
+    protected boolean assertToXContentEquivalence() {
+        return false;
+    }        
+    
+    @Override
     protected String[] getShuffleFieldsExceptions() {
         return new String[]{"vertices", "connections"};
     }    


### PR DESCRIPTION
XContent ordering is unreliable when derived from map insertions but the parsed objects’ .equals() methods have the sort logic required to prove connections and vertices are correct. Disabled the xContent equivalence checks.

Closes #33686