### PR TITLE
Rename and deprecated `prefix` logfile audit setting names

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -109,13 +109,19 @@ public class LoggingAuditTrail extends AbstractComponent implements AuditTrail, 
     public static final String OPAQUE_ID_FIELD_NAME = "opaque_id";
 
     public static final String NAME = "logfile";
-    public static final Setting<Boolean> EMIT_HOST_ADDRESS_SETTING = Setting
-            .boolSetting(setting("audit.logfile.prefix.emit_node_host_address"), false, Property.NodeScope, Property.Dynamic);
-    public static final Setting<Boolean> EMIT_HOST_NAME_SETTING = Setting.boolSetting(setting("audit.logfile.prefix.emit_node_host_name"),
-            false, Property.NodeScope, Property.Dynamic);
-    public static final Setting<Boolean> EMIT_NODE_NAME_SETTING = Setting.boolSetting(setting("audit.logfile.prefix.emit_node_name"), false,
-            Property.NodeScope, Property.Dynamic);
-    public static final Setting<Boolean> EMIT_NODE_ID_SETTING = Setting.boolSetting(setting("audit.logfile.prefix.emit_node_id"), true,
+    public static final Setting<Boolean> DEPRECATED_EMIT_HOST_ADDRESS_SETTING = Setting.boolSetting(
+            setting("audit.logfile.prefix.emit_node_host_address"), false, Property.NodeScope, Property.Dynamic, Property.Deprecated);
+    public static final Setting<Boolean> EMIT_HOST_ADDRESS_SETTING = Setting.boolSetting(setting("audit.logfile.emit_node_host_address"),
+            DEPRECATED_EMIT_HOST_ADDRESS_SETTING, Property.NodeScope, Property.Dynamic);
+    public static final Setting<Boolean> DEPRECATED_EMIT_HOST_NAME_SETTING = Setting.boolSetting(
+            setting("audit.logfile.prefix.emit_node_host_name"), false, Property.NodeScope, Property.Dynamic, Property.Deprecated);
+    public static final Setting<Boolean> EMIT_HOST_NAME_SETTING = Setting.boolSetting(setting("audit.logfile.emit_node_host_name"),
+            DEPRECATED_EMIT_HOST_NAME_SETTING, Property.NodeScope, Property.Dynamic);
+    public static final Setting<Boolean> DEPRECATED_EMIT_NODE_NAME_SETTING = Setting
+            .boolSetting(setting("audit.logfile.prefix.emit_node_name"), false, Property.NodeScope, Property.Dynamic, Property.Deprecated);
+    public static final Setting<Boolean> EMIT_NODE_NAME_SETTING = Setting.boolSetting(setting("audit.logfile.emit_node_name"),
+            DEPRECATED_EMIT_NODE_NAME_SETTING, Property.NodeScope, Property.Dynamic);
+    public static final Setting<Boolean> EMIT_NODE_ID_SETTING = Setting.boolSetting(setting("audit.logfile.emit_node_id"), true,
             Property.NodeScope, Property.Dynamic);
     private static final List<String> DEFAULT_EVENT_INCLUDES = Arrays.asList(ACCESS_DENIED.toString(), ACCESS_GRANTED.toString(),
             ANONYMOUS_ACCESS_DENIED.toString(), AUTHENTICATION_FAILED.toString(), CONNECTION_DENIED.toString(), TAMPERED_REQUEST.toString(),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailFilterTests.java
@@ -63,11 +63,11 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
     @Before
     public void init() throws Exception {
         settings = Settings.builder()
-                .put("xpack.security.audit.logfile.prefix.emit_node_host_address", randomBoolean())
-                .put("xpack.security.audit.logfile.prefix.emit_node_host_name", randomBoolean())
-                .put("xpack.security.audit.logfile.prefix.emit_node_name", randomBoolean())
-                .put("xpack.security.audit.logfile.events.emit_request_body", randomBoolean())
-                .put("xpack.security.audit.logfile.events.include", "_all")
+                .put(LoggingAuditTrail.EMIT_HOST_ADDRESS_SETTING.getKey(), randomBoolean())
+                .put(LoggingAuditTrail.EMIT_HOST_NAME_SETTING.getKey(), randomBoolean())
+                .put(LoggingAuditTrail.EMIT_NODE_NAME_SETTING.getKey(), randomBoolean())
+                .put(LoggingAuditTrail.INCLUDE_REQUEST_BODY.getKey(), randomBoolean())
+                .put(LoggingAuditTrail.INCLUDE_EVENT_SETTINGS.getKey(), "_all")
                 .build();
         localNode = mock(DiscoveryNode.class);
         when(localNode.getHostAddress()).thenReturn(buildNewFakeTransportAddress().toString());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -166,9 +166,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
     public void init() throws Exception {
         includeRequestBody = randomBoolean();
         settings = Settings.builder()
-                .put("xpack.security.audit.logfile.prefix.emit_node_host_address", randomBoolean())
-                .put("xpack.security.audit.logfile.prefix.emit_node_host_name", randomBoolean())
-                .put("xpack.security.audit.logfile.prefix.emit_node_name", randomBoolean())
+                .put(LoggingAuditTrail.EMIT_HOST_ADDRESS_SETTING.getKey(), randomBoolean())
+                .put(LoggingAuditTrail.EMIT_HOST_NAME_SETTING.getKey(), randomBoolean())
+                .put(LoggingAuditTrail.EMIT_NODE_NAME_SETTING.getKey(), randomBoolean())
+                .put(LoggingAuditTrail.EMIT_NODE_ID_SETTING.getKey(), randomBoolean())
                 .put("xpack.security.audit.logfile.events.emit_request_body", includeRequestBody)
                 .build();
         localNode = mock(DiscoveryNode.class);


### PR DESCRIPTION
#31931 Changed the format of the logfile audit log.
It is no longer formed by prefix fields followed by key value fields, it is all formed by key value fields only (JSON format).

Consequently, the following settings, which toggled some of the prefix fields, should be renamed:
audit.logfile ~.prefix~.emit_node_host_address
audit.logfile ~.prefix~.emit_node_host_name
audit.logfile ~.prefix~.emit_node_name
The _prefix_ variants have been deprecated (in 7.0 also?) in favor of the variants lacking the _prefix._ .

The setting `audit.logfile.prefix.emit_node_id` which has not seen the release light has simply been renamed to `audit.logfile.emit_node_id` .


Relates #31931 (should have been considered there).
