### PR TITLE
JDBC: Fix artifactId in pom

### DIFF
--- a/x-pack/plugin/sql/jdbc/build.gradle
+++ b/x-pack/plugin/sql/jdbc/build.gradle
@@ -57,3 +57,11 @@ artifacts  {
     nodeps nodepsJar
     archives shadowJar
 }
+
+publishing {
+    publications {
+        nebula {
+            artifactId = archivesBaseName
+        }
+    }
+}


### PR DESCRIPTION
We're publishing jdbc into our maven repo as though its artifactId is
`x-pack-sql-jdbc` but the pom listed the artifactId as `jdbc`. This
fixes the pom to line up with where we're publishing the artifact.

Closes #34399
