### PR TITLE
Disallow negative query boost

### DIFF
--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -61,6 +61,7 @@ Scroll queries are not meant to be cached.
 
 [float]
 ==== Scroll queries cannot use `rescore`  anymore
+
 Including a rescore clause on a query that creates a scroll (`scroll=1m`) has
 been deprecated in 6.5 and will now return a `400 - Bad request`.  Allowing
 rescore on scroll queries would break the scroll sort.  In the 6.x line, the
@@ -123,3 +124,9 @@ max number of concurrent shard requests per node. The default is now `5`.
 
 `max_score` used to be set to `0` whenever scores are not tracked. `null` is now used
 instead which is a more appropriate value for a scenario where scores are not available.
+
+[float]
+==== Negative boosts are not allowed
+
+Setting a negative `boost` in a query, deprecated in 6x, are not allowed in this version.
+To deboost a specific query you can use a `boost` comprise between 0 and 1.

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -159,6 +159,10 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
     @SuppressWarnings("unchecked")
     @Override
     public final QB boost(float boost) {
+        if (Float.compare(boost, 0f) < 0) {
+            throw new IllegalArgumentException("negative [boost] are not allowed in [" + toString() + "], " +
+                "use a value between 0 and 1 to deboost");
+        }
         this.boost = boost;
         return (QB) this;
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -101,6 +101,13 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
      */
     protected abstract QB doCreateTestQueryBuilder();
 
+    public void testNegativeBoosts() {
+        QB testQuery = createTestQueryBuilder();
+        IllegalArgumentException exc =
+            expectThrows(IllegalArgumentException.class, () -> testQuery.boost(-0.5f));
+        assertThat(exc.getMessage(), containsString("negative [boost]"));
+    }
+
     /**
      * Generic test that creates new query from the test query and checks both for equality
      * and asserts equality on the two queries.


### PR DESCRIPTION
This change disallows negative query boosts. Negative scores are not allowed in Lucene 8 so
it is easier to just disallow negative boosts entirely. We should also deprecate negative boosts
in 6x in order to ensure that users are aware when they'll upgrade to ES 7.

Relates #33309