### PR TITLE
TESTING.asciidoc fix examples using forbidden annotation

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -91,7 +91,6 @@ Run any test methods that contain 'esi' (like: ...r*esi*ze...).
 
 You can also filter tests by certain annotations ie:
 
-  * `@Nightly` - tests that only run in nightly builds (disabled by default)
   * `@Backwards` - backwards compatibility tests (disabled by default)
   * `@AwaitsFix` - tests that are waiting for a bugfix (disabled by default)
   * `@BadApple` - tests that are known to fail randomly (disabled by default)
@@ -99,15 +98,15 @@ You can also filter tests by certain annotations ie:
 Those annotation names can be combined into a filter expression like:
 
 ------------------------------------------------
-./gradlew test -Dtests.filter="@nightly and not @backwards"
+./gradlew test -Dtests.filter="@awaitsfix and not @backwards"
 ------------------------------------------------
 
-to run all nightly test but not the ones that are backwards tests. `tests.filter` supports
-the boolean operators `and, or, not` and grouping ie:
+to run all tests waiting for a bug fix but not the ones that are backwards tests.
+`tests.filter` supports the boolean operators `and, or, not` and grouping ie:
 
 
 ---------------------------------------------------------------
-./gradlew test -Dtests.filter="@nightly and not(@badapple or @backwards)"
+./gradlew test -Dtests.filter="@awaitsfix and not(@badapple or @backwards)"
 ---------------------------------------------------------------
 
 === Seed and repetitions.
@@ -160,7 +159,6 @@ Test groups can be enabled or disabled (true/false).
 Default value provided below in [brackets].
 
 ------------------------------------------------------------------
-./gradlew test -Dtests.nightly=[false]   - nightly test group (@Nightly)
 ./gradlew test -Dtests.weekly=[false]    - weekly tests (@Weekly)
 ./gradlew test -Dtests.awaitsfix=[false] - known issue (@AwaitsFix)
 ------------------------------------------------------------------

--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -77,37 +77,23 @@ Run a single test case (variants)
 ./gradlew test "-Dtests.class=*.ClassName"
 ----------------------------------------------------------
 
-Run all tests in a package and sub-packages
+Run all tests in a package and its sub-packages
 
 ----------------------------------------------------
 ./gradlew test "-Dtests.class=org.elasticsearch.package.*"
 ----------------------------------------------------
 
-Run any test methods that contain 'esi' (like: ...r*esi*ze...).
+Run any test methods that contain 'esi' (like: ...r*esi*ze...)
 
 -------------------------------
 ./gradlew test "-Dtests.method=*esi*"
 -------------------------------
 
-You can also filter tests by certain annotations ie:
-
-  * `@Backwards` - backwards compatibility tests (disabled by default)
-  * `@AwaitsFix` - tests that are waiting for a bugfix (disabled by default)
-  * `@BadApple` - tests that are known to fail randomly (disabled by default)
-
-Those annotation names can be combined into a filter expression like:
+Run all tests that are waiting for a bugfix (disabled by default)
 
 ------------------------------------------------
-./gradlew test -Dtests.filter="@awaitsfix and not @backwards"
+./gradlew test -Dtests.filter=@awaitsfix
 ------------------------------------------------
-
-to run all tests waiting for a bug fix but not the ones that are backwards tests.
-`tests.filter` supports the boolean operators `and, or, not` and grouping ie:
-
-
----------------------------------------------------------------
-./gradlew test -Dtests.filter="@awaitsfix and not(@badapple or @backwards)"
----------------------------------------------------------------
 
 === Seed and repetitions.
 
@@ -159,7 +145,6 @@ Test groups can be enabled or disabled (true/false).
 Default value provided below in [brackets].
 
 ------------------------------------------------------------------
-./gradlew test -Dtests.weekly=[false]    - weekly tests (@Weekly)
 ./gradlew test -Dtests.awaitsfix=[false] - known issue (@AwaitsFix)
 ------------------------------------------------------------------
 


### PR DESCRIPTION
`@Nightly` has been added to the forbidden test annotations : 
https://github.com/elastic/elasticsearch/blob/237650e9c054149fd08213b38a81a3666c1868e5/buildSrc/src/main/resources/forbidden/es-test-signatures.txt#L24
guaranteeing that no tests can be annotated as `@Nightly`.

This PR removes any examples containing `@Nightly`, so that contributors do not try to implement, filter or run nightly tests.