### PR TITLE
Resolve dependencies for each branch 

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -17,17 +17,28 @@ done
 
 cd $(dirname "${SCRIPT}")/..
 
-source .ci/java-versions.properties
+resolveAllDependencies() {
+    local REFRESH_FAILED=no
+    local MAX_TRIES=3
+    for i in $(seq 1 $MAX_TRIES) ; do 
+        echo "Resolving dependencies try $i/$MAX_TRIES"
+        JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA} ./gradlew resolveAllDependencies --parallel && break
+        REFRESH_FAILED=yes
+    done
+    if [ $REFRESH_FAILED != "no" ] ; then
+        echo "Resolving dependencies failed after 3 retries ..."
+        exit 1
+    fi   
+}
 
-REFRESH_FAILED=no
-MAX_TRIES=3
-for i in $(seq 1 $MAX_TRIES) ; do 
-    echo "Resolving dependencies try $i/$MAX_TRIES"
-    JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA} ./gradlew resolveAllDependencies --parallel && break
-    REFRESH_FAILED=yes
+for branch in "master" "6.x" "5.6" ; do 
+    echo "Resolving dependencies for $branch"
+    if  ! git checkout $branch ; then 
+        echo "Failed to switch branch to $branch"
+        exit 2
+    fi
+    source .ci/java-versions.properties
+    resolveAllDependencies
 done
-if [ $REFRESH_FAILED != "no" ] ; then
-    echo "Resolving dependencies failed after 3 retries ..."
-    exit 1
-fi   
+
 exit 0

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -15,5 +15,19 @@ while [ -h "$SCRIPT" ] ; do
   fi
 done
 
-source $(dirname "${SCRIPT}")/java-versions.properties
-JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA} ./gradlew resolveAllDependencies --parallel
+cd $(dirname "${SCRIPT}")/..
+
+source .ci/java-versions.properties
+
+REFRESH_FAILED=no
+MAX_TRIES=3
+for i in $(seq 1 $MAX_TRIES) ; do 
+    echo "Resolving dependencies try $i/$MAX_TRIES"
+    JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA} ./gradlew resolveAllDependencies --parallel && break
+    REFRESH_FAILED=yes
+done
+if [ $REFRESH_FAILED != "no" ] ; then
+    echo "Resolving dependencies failed after 3 retries ..."
+    exit 1
+fi   
+exit 0


### PR DESCRIPTION
Relates to elastic/infra#5207. 
We saw many network related failures in the past week. 
Many of those were when building BWC and pulling in older versions on the deps on which those older versions of ES rely on. Some of the failures are when building 6.x for the same reasons. 
This  change should help with both by and make things a bit faster too by making sure we have the deps of older versions in the cache as too. 