### PR TITLE
Docs: Reenable rollup docs tests

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -90,16 +90,6 @@ buildRestTests.docs = fileTree(projectDir) {
   // Just syntax examples
   exclude 'README.asciidoc'
   // Broken code snippet tests
-  exclude 'reference/rollup/rollup-getting-started.asciidoc'
-  exclude 'reference/rollup/apis/rollup-job-config.asciidoc'
-  exclude 'reference/rollup/apis/rollup-index-caps.asciidoc'
-  exclude 'reference/rollup/apis/put-job.asciidoc'
-  exclude 'reference/rollup/apis/stop-job.asciidoc'
-  exclude 'reference/rollup/apis/start-job.asciidoc'
-  exclude 'reference/rollup/apis/rollup-search.asciidoc'
-  exclude 'reference/rollup/apis/delete-job.asciidoc'
-  exclude 'reference/rollup/apis/get-job.asciidoc'
-  exclude 'reference/rollup/apis/rollup-caps.asciidoc'
   exclude 'reference/graph/explore.asciidoc'
 }
 
@@ -641,8 +631,9 @@ buildRestTests.setups['sensor_rollup_job'] = '''
                 node:
                   type: keyword
   - do:
-      xpack.rollup.put_job:
-        id: "sensor"
+      raw:
+        method: PUT
+        path: _xpack/rollup/job/sensor
         body:  >
             {
                 "index_pattern": "sensor-*",
@@ -711,8 +702,9 @@ buildRestTests.setups['sensor_started_rollup_job'] = '''
           {"timestamp": 1516297294000, "temperature": 202, "voltage": 4.0, "node": "c"}
 
   - do:
-      xpack.rollup.put_job:
-        id: "sensor"
+      raw:
+        method: PUT
+        path: _xpack/rollup/job/sensor
         body:  >
             {
                 "index_pattern": "sensor-*",
@@ -741,8 +733,9 @@ buildRestTests.setups['sensor_started_rollup_job'] = '''
                 ]
             }
   - do:
-      xpack.rollup.start_job:
-        id: "sensor"
+      raw:
+        method: POST
+        path: _xpack/rollup/job/sensor/_start
 '''
 
 buildRestTests.setups['sensor_index'] = '''
@@ -841,7 +834,7 @@ buildRestTests.setups['sensor_prefab_data'] = '''
                       date_histogram:
                         delay: "7d"
                         field: "timestamp"
-                        interval: "1h"
+                        interval: "60m"
                         time_zone: "UTC"
                       terms:
                         fields:

--- a/docs/reference/rollup/apis/rollup-index-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-index-caps.asciidoc
@@ -1,4 +1,5 @@
 [role="xpack"]
+[testenv="basic"]
 [[rollup-get-rollup-index-caps]]
 === Get Rollup Index Capabilities
 ++++


### PR DESCRIPTION
We'd disabled them because we didn't have a way to clean up after each
test. I implemented #34342 which adds the clean ups so now we can
re-enable the tests.

In the `setup` sections we have to use `raw` requests instead of
`x-pack` requests because we don't have the json config for x-pack.

Closes #33319
