### PR TITLE
[Tests] Correct map lookup in ReplicationTrackerTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerTests.java
@@ -161,7 +161,7 @@ public class ReplicationTrackerTests extends ESTestCase {
 
         // first check that adding it without the master blessing doesn't change anything.
         updateLocalCheckpoint(tracker, extraId.getId(), minLocalCheckpointAfterUpdates + 1 + randomInt(4));
-        assertNull(tracker.checkpoints.get(extraId));
+        assertNull(tracker.checkpoints.get(extraId.getId()));
         expectThrows(IllegalStateException.class, () -> tracker.initiateTracking(extraId.getId()));
 
         Set<AllocationId> newInitializing = new HashSet<>(initializing);


### PR DESCRIPTION
Fixing what looks like an unintentional glitch in this test. `checkpoints` is a `Map<String, CheckpointState>`, 
so lookups should most likely be Strings too.