### PR TITLE
Ensure map keys cannot be self referencing

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -72,6 +73,7 @@ public final class ScriptProcessor extends AbstractProcessor {
     public IngestDocument execute(IngestDocument document) {
         IngestScript.Factory factory = scriptService.compile(script, IngestScript.CONTEXT);
         factory.newInstance(script.getParams()).execute(document.getSourceAndMetadata());
+        CollectionUtils.ensureNoSelfReferences(document.getSourceAndMetadata(), "ingest script");
         return document;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -19,6 +19,15 @@
 
 package org.elasticsearch.common.util;
 
+import com.carrotsearch.hppc.ObjectArrayList;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefArray;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.InPlaceMergeSorter;
+import org.apache.lucene.util.IntroSorter;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.Iterators;
+
 import java.nio.file.Path;
 import java.util.AbstractList;
 import java.util.ArrayList;
@@ -34,14 +43,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.RandomAccess;
 import java.util.Set;
-
-import com.carrotsearch.hppc.ObjectArrayList;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefArray;
-import org.apache.lucene.util.BytesRefBuilder;
-import org.apache.lucene.util.InPlaceMergeSorter;
-import org.apache.lucene.util.IntroSorter;
-import org.elasticsearch.common.Strings;
 
 /** Collections-related utility methods. */
 public class CollectionUtils {
@@ -246,7 +247,8 @@ public class CollectionUtils {
             return null;
         }
         if (value instanceof Map) {
-            return ((Map<?,?>) value).values();
+            Map<?,?> map = (Map<?,?>) value;
+            return () -> Iterators.concat(map.keySet().iterator(), map.values().iterator());
         } else if ((value instanceof Iterable) && (value instanceof Path == false)) {
             return (Iterable<?>) value;
         } else if (value instanceof Object[]) {

--- a/server/src/test/java/org/elasticsearch/common/util/CollectionUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/CollectionUtilsTests.java
@@ -185,11 +185,22 @@ public class CollectionUtilsTests extends ESTestCase {
         CollectionUtils.ensureNoSelfReferences(emptyMap(), "test with empty map");
         CollectionUtils.ensureNoSelfReferences(null, "test with null");
 
-        Map<String, Object> map = new HashMap<>();
-        map.put("field", map);
+        {
+            Map<String, Object> map = new HashMap<>();
+            map.put("field", map);
 
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-            () ->  CollectionUtils.ensureNoSelfReferences(map, "test with self ref"));
-        assertThat(e.getMessage(), containsString("Iterable object is self-referencing itself (test with self ref)"));
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> CollectionUtils.ensureNoSelfReferences(map, "test with self ref value"));
+            assertThat(e.getMessage(), containsString("Iterable object is self-referencing itself (test with self ref value)"));
+        }
+        {
+            Map<Object, Object> map = new HashMap<>();
+            map.put(map, 1);
+
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> CollectionUtils.ensureNoSelfReferences(map, "test with self ref key"));
+            assertThat(e.getMessage(), containsString("Iterable object is self-referencing itself (test with self ref key)"));
+        }
+
     }
 }


### PR DESCRIPTION
This commit improves self reference checking to map keys, as well as
adds it to ingest script processing.
