### PR TITLE
Remove hand-coded XContent duplicate checks

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ConstructingObjectParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ConstructingObjectParser.java
@@ -216,7 +216,7 @@ public final class ConstructingObjectParser<Value, Context> extends AbstractObje
             int position = constructorArgInfos.size();
             boolean required = consumer == REQUIRED_CONSTRUCTOR_ARG_MARKER;
             constructorArgInfos.add(new ConstructorArgInfo(parseField, required));
-            objectParser.declareField((target, v) -> target.constructorArg(position, parseField, v), parser, parseField, type);
+            objectParser.declareField((target, v) -> target.constructorArg(position, v), parser, parseField, type);
         } else {
             numberOfFields += 1;
             objectParser.declareField(queueingConsumer(consumer, parseField), parser, parseField, type);
@@ -249,7 +249,7 @@ public final class ConstructingObjectParser<Value, Context> extends AbstractObje
             int position = constructorArgInfos.size();
             boolean required = consumer == REQUIRED_CONSTRUCTOR_ARG_MARKER;
             constructorArgInfos.add(new ConstructorArgInfo(parseField, required));
-            objectParser.declareNamedObjects((target, v) -> target.constructorArg(position, parseField, v), namedObjectParser, parseField);
+            objectParser.declareNamedObjects((target, v) -> target.constructorArg(position, v), namedObjectParser, parseField);
         } else {
             numberOfFields += 1;
             objectParser.declareNamedObjects(queueingConsumer(consumer, parseField), namedObjectParser, parseField);
@@ -285,7 +285,7 @@ public final class ConstructingObjectParser<Value, Context> extends AbstractObje
             int position = constructorArgInfos.size();
             boolean required = consumer == REQUIRED_CONSTRUCTOR_ARG_MARKER;
             constructorArgInfos.add(new ConstructorArgInfo(parseField, required));
-            objectParser.declareNamedObjects((target, v) -> target.constructorArg(position, parseField, v), namedObjectParser,
+            objectParser.declareNamedObjects((target, v) -> target.constructorArg(position, v), namedObjectParser,
                     wrapOrderedModeCallBack(orderedModeCallback), parseField);
         } else {
             numberOfFields += 1;
@@ -395,10 +395,7 @@ public final class ConstructingObjectParser<Value, Context> extends AbstractObje
         /**
          * Set a constructor argument and build the target object if all constructor arguments have arrived.
          */
-        private void constructorArg(int position, ParseField parseField, Object value) {
-            if (constructorArgs[position] != null) {
-                throw new IllegalArgumentException("Can't repeat param [" + parseField + "]");
-            }
+        private void constructorArg(int position, Object value) {
             constructorArgs[position] = value;
             constructorArgsCollected++;
             if (constructorArgsCollected == constructorArgInfos.size()) {

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContent.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContent.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.common.xcontent;
 
-import org.elasticsearch.common.Booleans;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -32,28 +30,6 @@ import java.util.Set;
  * A generic abstraction on top of handling content, inspired by JSON and pull parsing.
  */
 public interface XContent {
-
-    /*
-     * NOTE: This comment is only meant for maintainers of the Elasticsearch code base and is intentionally not a Javadoc comment as it
-     *       describes an undocumented system property.
-     *
-     *
-     * Determines whether the XContent parser will always check for duplicate keys. This behavior is enabled by default but
-     * can be disabled by setting the otherwise undocumented system property "es.xcontent.strict_duplicate_detection to "false".
-     *
-     * Before we've enabled this mode, we had custom duplicate checks in various parts of the code base. As the user can still disable this
-     * mode and fall back to the legacy duplicate checks, we still need to keep the custom duplicate checks around and we also need to keep
-     * the tests around.
-     *
-     * If this fallback via system property is removed one day in the future you can remove all tests that call this method and also remove
-     * the corresponding custom duplicate check code.
-     *
-     */
-    static boolean isStrictDuplicateDetectionEnabled() {
-        // Don't allow duplicate keys in JSON content by default but let the user opt out
-        return Booleans.parseBoolean(System.getProperty("es.xcontent.strict_duplicate_detection", "true"), true);
-    }
-
     /**
      * The type this content handles and produces.
      */

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/cbor/CborXContent.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/cbor/CborXContent.java
@@ -56,7 +56,7 @@ public class CborXContent implements XContent {
         cborFactory.configure(CBORFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW, false); // this trips on many mappings now...
         // Do not automatically close unclosed objects/arrays in com.fasterxml.jackson.dataformat.cbor.CBORGenerator#close() method
         cborFactory.configure(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT, false);
-        cborFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, XContent.isStrictDuplicateDetectionEnabled());
+        cborFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
         cborXContent = new CborXContent();
     }
 

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContent.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContent.java
@@ -57,7 +57,7 @@ public class JsonXContent implements XContent {
         jsonFactory.configure(JsonFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW, false); // this trips on many mappings now...
         // Do not automatically close unclosed objects/arrays in com.fasterxml.jackson.core.json.UTF8JsonGenerator#close() method
         jsonFactory.configure(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT, false);
-        jsonFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, XContent.isStrictDuplicateDetectionEnabled());
+        jsonFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
         jsonXContent = new JsonXContent();
     }
 

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/smile/SmileXContent.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/smile/SmileXContent.java
@@ -58,7 +58,7 @@ public class SmileXContent implements XContent {
         smileFactory.configure(SmileFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW, false); // this trips on many mappings now...
         // Do not automatically close unclosed objects/arrays in com.fasterxml.jackson.dataformat.smile.SmileGenerator#close() method
         smileFactory.configure(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT, false);
-        smileFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, XContent.isStrictDuplicateDetectionEnabled());
+        smileFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
         smileXContent = new SmileXContent();
     }
 

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/yaml/YamlXContent.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/yaml/YamlXContent.java
@@ -51,7 +51,7 @@ public class YamlXContent implements XContent {
 
     static {
         yamlFactory = new YAMLFactory();
-        yamlFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, XContent.isStrictDuplicateDetectionEnabled());
+        yamlFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
         yamlXContent = new YamlXContent();
     }
 

--- a/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/ConstructingObjectParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/ConstructingObjectParserTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.common.xcontent;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
@@ -40,7 +39,6 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
 
 public class ConstructingObjectParserTests extends ESTestCase {
@@ -163,19 +161,6 @@ public class ConstructingObjectParserTests extends ESTestCase {
         HasCtorArguments parsed = HasCtorArguments.PARSER_ALL_OPTIONAL.apply(parser, null);
         assertEquals(1, parsed.mineral);
         assertEquals((Integer) 2, parsed.vegetable);
-    }
-
-    public void testRepeatedConstructorParam() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\n"
-                + "  \"vegetable\": 1,\n"
-                + "  \"vegetable\": 2\n"
-                + "}");
-        Throwable e = expectThrows(XContentParseException.class, () -> randomFrom(HasCtorArguments.ALL_PARSERS).apply(parser, null));
-        assertEquals("[2:16] [has_required_arguments] failed to parse object", e.getMessage());
-        e = e.getCause();
-        assertThat(e, instanceOf(JsonParseException.class));
-        assertThat(e.getMessage(), containsString("Duplicate field 'vegetable'"));
     }
 
     public void testBadParam() throws IOException {

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -712,21 +712,21 @@ public final class Settings implements ToXContentFragment {
                     }
                 }
                 String key = keyBuilder.toString();
-                validateValue(key, list, builder, parser, allowNullValues);
+                validateValue(key, list, parser, allowNullValues);
                 builder.putList(key, list);
             } else if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
                 String key = keyBuilder.toString();
-                validateValue(key, null, builder, parser, allowNullValues);
+                validateValue(key, null, parser, allowNullValues);
                 builder.putNull(key);
             } else if (parser.currentToken() == XContentParser.Token.VALUE_STRING
                 || parser.currentToken() == XContentParser.Token.VALUE_NUMBER) {
                 String key = keyBuilder.toString();
                 String value = parser.text();
-                validateValue(key, value, builder, parser, allowNullValues);
+                validateValue(key, value, parser, allowNullValues);
                 builder.put(key, value);
             } else if (parser.currentToken() == XContentParser.Token.VALUE_BOOLEAN) {
                 String key = keyBuilder.toString();
-                validateValue(key, parser.text(), builder, parser, allowNullValues);
+                validateValue(key, parser.text(), parser, allowNullValues);
                 builder.put(key, parser.booleanValue());
             } else {
                 XContentParserUtils.throwUnknownToken(parser.currentToken(), parser.getTokenLocation());
@@ -734,19 +734,7 @@ public final class Settings implements ToXContentFragment {
         }
     }
 
-    private static void validateValue(String key, Object currentValue, Settings.Builder builder, XContentParser parser,
-                                      boolean allowNullValues) {
-        if (builder.map.containsKey(key)) {
-            throw new ElasticsearchParseException(
-                "duplicate settings key [{}] found at line number [{}], column number [{}], previous value [{}], current value [{}]",
-                key,
-                parser.getTokenLocation().lineNumber,
-                parser.getTokenLocation().columnNumber,
-                builder.map.get(key),
-                currentValue
-            );
-        }
-
+    private static void validateValue(String key, Object currentValue, XContentParser parser, boolean allowNullValues) {
         if (currentValue == null && allowNullValues == false) {
             throw new ElasticsearchParseException(
                 "null-valued setting found for key [{}] found at line number [{}], column number [{}]",

--- a/server/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
@@ -98,10 +98,6 @@ public class ConstantScoreQueryBuilder extends AbstractQueryBuilder<ConstantScor
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (INNER_QUERY_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    if (queryFound) {
-                        throw new ParsingException(parser.getTokenLocation(), "[" + ConstantScoreQueryBuilder.NAME + "]"
-                                + " accepts only one 'filter' element.");
-                    }
                     query = parseInnerQueryBuilder(parser);
                     queryFound = true;
                 } else {

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.common.settings;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
@@ -550,20 +549,6 @@ public class SettingsTests extends ESTestCase {
         assertThat(settings.getAsList("test1.test3").size(), equalTo(2));
         assertThat(settings.getAsList("test1.test3").get(0), equalTo("test3-1"));
         assertThat(settings.getAsList("test1.test3").get(1), equalTo("test3-2"));
-    }
-
-    public void testDuplicateKeysThrowsException() {
-        final String json = "{\"foo\":\"bar\",\"foo\":\"baz\"}";
-        final SettingsException e = expectThrows(SettingsException.class,
-            () -> Settings.builder().loadFromSource(json, XContentType.JSON).build());
-        assertThat(e.toString(), containsString("Duplicate field 'foo'"));
-
-        String yaml = "foo: bar\nfoo: baz";
-        SettingsException e1 = expectThrows(SettingsException.class, () -> {
-            Settings.builder().loadFromSource(yaml, XContentType.YAML);
-        });
-        assertEquals(e1.getCause().getClass(), JsonParseException.class);
-        assertThat(e1.getCause().getMessage(), containsString("Duplicate field 'foo'"));
     }
 
     public void testToXContent() throws IOException {

--- a/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
@@ -1138,9 +1138,6 @@ public abstract class BaseXContentTestCase extends ESTestCase {
     }
 
     public void testChecksForDuplicates() throws Exception {
-        assumeTrue("Test only makes sense if XContent parser has strict duplicate checks enabled",
-            XContent.isStrictDuplicateDetectionEnabled());
-
         XContentBuilder builder = builder()
                 .startObject()
                     .field("key", 1)

--- a/server/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.index.query;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -336,8 +336,6 @@ public class BoolQueryBuilderTests extends AbstractQueryTestCase<BoolQueryBuilde
      * test that two queries in object throws error
      */
     public void testTooManyQueriesInObject() throws IOException {
-        assumeFalse("Test only makes sense if XContent parser doesn't have strict duplicate checks enabled",
-            XContent.isStrictDuplicateDetectionEnabled());
         String clauseType = randomFrom("must", "should", "must_not", "filter");
         // should also throw error if invalid query is preceded by a valid one
         String query = "{\n" +
@@ -352,8 +350,8 @@ public class BoolQueryBuilderTests extends AbstractQueryTestCase<BoolQueryBuilde
                 "    }\n" +
                 "  }\n" +
                 "}";
-        ParsingException ex = expectThrows(ParsingException.class, () -> parseQuery(query));
-        assertEquals("[match] malformed query, expected [END_OBJECT] but found [FIELD_NAME]", ex.getMessage());
+        JsonParseException ex = expectThrows(JsonParseException.class, () -> parseQuery(query));
+        assertTrue(ex.getMessage().contains("Duplicate field 'match'"));
     }
 
     public void testRewrite() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
@@ -330,28 +329,6 @@ public class BoolQueryBuilderTests extends AbstractQueryTestCase<BoolQueryBuilde
 
         ParsingException ex = expectThrows(ParsingException.class, () -> parseQuery(query));
         assertEquals("no [query] registered for [unknown_query]", ex.getMessage());
-    }
-
-    /**
-     * test that two queries in object throws error
-     */
-    public void testTooManyQueriesInObject() throws IOException {
-        String clauseType = randomFrom("must", "should", "must_not", "filter");
-        // should also throw error if invalid query is preceded by a valid one
-        String query = "{\n" +
-                "  \"bool\": {\n" +
-                "    \"" + clauseType + "\": {\n" +
-                "      \"match\": {\n" +
-                "        \"foo\": \"bar\"\n" +
-                "      },\n" +
-                "      \"match\": {\n" +
-                "        \"baz\": \"buzz\"\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }\n" +
-                "}";
-        JsonParseException ex = expectThrows(JsonParseException.class, () -> parseQuery(query));
-        assertTrue(ex.getMessage().contains("Duplicate field 'match'"));
     }
 
     public void testRewrite() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.ParsingException;
@@ -60,18 +59,6 @@ public class ConstantScoreQueryBuilderTests extends AbstractQueryTestCase<Consta
         String queryString = "{ \"" + ConstantScoreQueryBuilder.NAME + "\" : {} }";
         ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(queryString));
         assertThat(e.getMessage(), containsString("requires a 'filter' element"));
-    }
-
-    /**
-     * test that multiple "filter" elements causes {@link ParsingException}
-     */
-    public void testMultipleFilterElements() throws IOException {
-        String queryString = "{ \"" + ConstantScoreQueryBuilder.NAME + "\" : {\n" +
-                                    "\"filter\" : { \"term\": { \"foo\": \"a\" } },\n" +
-                                    "\"filter\" : { \"term\": { \"foo\": \"x\" } },\n" +
-                            "} }";
-        JsonParseException e = expectThrows(JsonParseException.class, () -> parseQuery(queryString));
-        assertThat(e.getMessage(), containsString("Duplicate field 'filter'"));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
@@ -19,10 +19,10 @@
 
 package org.elasticsearch.index.query;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
@@ -66,14 +66,12 @@ public class ConstantScoreQueryBuilderTests extends AbstractQueryTestCase<Consta
      * test that multiple "filter" elements causes {@link ParsingException}
      */
     public void testMultipleFilterElements() throws IOException {
-        assumeFalse("Test only makes sense if XContent parser doesn't have strict duplicate checks enabled",
-            XContent.isStrictDuplicateDetectionEnabled());
         String queryString = "{ \"" + ConstantScoreQueryBuilder.NAME + "\" : {\n" +
                                     "\"filter\" : { \"term\": { \"foo\": \"a\" } },\n" +
                                     "\"filter\" : { \"term\": { \"foo\": \"x\" } },\n" +
                             "} }";
-        ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(queryString));
-        assertThat(e.getMessage(), containsString("accepts only one 'filter' element"));
+        JsonParseException e = expectThrows(JsonParseException.class, () -> parseQuery(queryString));
+        assertThat(e.getMessage(), containsString("Duplicate field 'filter'"));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
 import org.elasticsearch.common.lucene.search.function.WeightFactorFunction;
 import org.elasticsearch.common.unit.DistanceUnit;
-import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -727,8 +726,6 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
     }
 
     public void testMalformedQueryMultipleQueryElements() throws IOException {
-        assumeFalse("Test only makes sense if XContent parser doesn't have strict duplicate checks enabled",
-            XContent.isStrictDuplicateDetectionEnabled());
         String json = "{\n" +
                 "    \"function_score\":{\n" +
                 "        \"query\":{\n" +
@@ -744,7 +741,8 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
                 "        }\n" +
                 "    }\n" +
                 "}";
-        expectParsingException(json, "[query] is already defined.");
+        JsonParseException e = expectThrows(JsonParseException.class, () -> parseQuery(json));
+        assertThat(e.getMessage(), containsString("Duplicate field 'query'"));
     }
 
     private void expectParsingException(String json, Matcher<String> messageMatcher) {

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
@@ -725,26 +725,6 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
         expectParsingException(json, equalTo("[bool] malformed query, expected [END_OBJECT] but found [FIELD_NAME]"));
     }
 
-    public void testMalformedQueryMultipleQueryElements() throws IOException {
-        String json = "{\n" +
-                "    \"function_score\":{\n" +
-                "        \"query\":{\n" +
-                "            \"bool\":{\n" +
-                "                \"must\":{\"match\":{\"field\":\"value\"}}" +
-                "             }\n" +
-                "            },\n" +
-                "        \"query\":{\n" +
-                "            \"bool\":{\n" +
-                "                \"must\":{\"match\":{\"field\":\"value\"}}" +
-                "             }\n" +
-                "            }\n" +
-                "        }\n" +
-                "    }\n" +
-                "}";
-        JsonParseException e = expectThrows(JsonParseException.class, () -> parseQuery(json));
-        assertThat(e.getMessage(), containsString("Duplicate field 'query'"));
-    }
-
     private void expectParsingException(String json, Matcher<String> messageMatcher) {
         ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(json));
         assertThat(e.getMessage(), messageMatcher);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
@@ -18,11 +18,11 @@
  */
 package org.elasticsearch.search.aggregations;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -111,8 +111,6 @@ public class AggregatorFactoriesTests extends ESTestCase {
     }
 
     public void testTwoAggs() throws Exception {
-        assumeFalse("Test only makes sense if XContent parser doesn't have strict duplicate checks enabled",
-            XContent.isStrictDuplicateDetectionEnabled());
         XContentBuilder source = JsonXContent.contentBuilder()
                 .startObject()
                     .startObject("by_date")
@@ -138,8 +136,8 @@ public class AggregatorFactoriesTests extends ESTestCase {
                 .endObject();
         XContentParser parser = createParser(source);
         assertSame(XContentParser.Token.START_OBJECT, parser.nextToken());
-        Exception e = expectThrows(ParsingException.class, () -> AggregatorFactories.parseAggregators(parser));
-        assertThat(e.toString(), containsString("Found two sub aggregation definitions under [by_date]"));
+        Exception e = expectThrows(JsonParseException.class, () -> AggregatorFactories.parseAggregators(parser));
+        assertThat(e.toString(), containsString("Duplicate field 'aggs'"));
     }
 
     public void testInvalidAggregationName() throws Exception {
@@ -177,8 +175,6 @@ public class AggregatorFactoriesTests extends ESTestCase {
     }
 
     public void testSameAggregationName() throws Exception {
-        assumeFalse("Test only makes sense if XContent parser doesn't have strict duplicate checks enabled",
-            XContent.isStrictDuplicateDetectionEnabled());
         final String name = randomAlphaOfLengthBetween(1, 10);
         XContentBuilder source = JsonXContent.contentBuilder()
                 .startObject()
@@ -195,8 +191,8 @@ public class AggregatorFactoriesTests extends ESTestCase {
                 .endObject();
         XContentParser parser = createParser(source);
         assertSame(XContentParser.Token.START_OBJECT, parser.nextToken());
-        Exception e = expectThrows(ParsingException.class, () -> AggregatorFactories.parseAggregators(parser));
-        assertThat(e.toString(), containsString("Two sibling aggregations cannot have the same name: [" + name + "]"));
+        Exception e = expectThrows(JsonParseException.class, () -> AggregatorFactories.parseAggregators(parser));
+        assertThat(e.toString(), containsString("Duplicate field '" + name + "'"));
     }
 
     public void testMissingName() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorTests.java
@@ -160,11 +160,6 @@ public class DirectCandidateGeneratorTests extends ESTestCase {
         assertIllegalXContent(directGenerator, IllegalArgumentException.class,
                 "Required [field]");
 
-        // test two fieldnames
-        directGenerator = "{ \"field\" : \"f1\", \"field\" : \"f2\" }";
-        assertIllegalXContent(directGenerator, XContentParseException.class,
-            "[direct_generator] failed to parse object");
-
         // test unknown field
         directGenerator = "{ \"unknown_param\" : \"f1\" }";
         assertIllegalXContent(directGenerator, IllegalArgumentException.class,

--- a/server/src/test/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorTests.java
@@ -26,7 +26,6 @@ import org.apache.lucene.search.spell.LuceneLevenshteinDistance;
 import org.apache.lucene.search.spell.NGramDistance;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParseException;
@@ -162,13 +161,9 @@ public class DirectCandidateGeneratorTests extends ESTestCase {
                 "Required [field]");
 
         // test two fieldnames
-        if (XContent.isStrictDuplicateDetectionEnabled()) {
-            logger.info("Skipping test as it uses a custom duplicate check that is obsolete when strict duplicate checks are enabled.");
-        } else {
-            directGenerator = "{ \"field\" : \"f1\", \"field\" : \"f2\" }";
-            assertIllegalXContent(directGenerator, IllegalArgumentException.class,
-                "[direct_generator] failed to parse field [field]");
-        }
+        directGenerator = "{ \"field\" : \"f1\", \"field\" : \"f2\" }";
+        assertIllegalXContent(directGenerator, XContentParseException.class,
+            "[direct_generator] failed to parse object");
 
         // test unknown field
         directGenerator = "{ \"unknown_param\" : \"f1\" }";

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParser.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParser.java
@@ -81,9 +81,6 @@ public class ClientYamlSuiteRestApiParser {
                         if (parser.currentToken() == XContentParser.Token.START_OBJECT && "parts".equals(currentFieldName)) {
                             while (parser.nextToken() == XContentParser.Token.FIELD_NAME) {
                                 String part = parser.currentName();
-                                if (restApi.getPathParts().containsKey(part)) {
-                                    throw new IllegalArgumentException("Found duplicate part [" + part + "]");
-                                }
                                 parser.nextToken();
                                 if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
                                     throw new IllegalArgumentException("Expected parts field in rest api definition to contain an object");
@@ -94,12 +91,7 @@ public class ClientYamlSuiteRestApiParser {
 
                         if (parser.currentToken() == XContentParser.Token.START_OBJECT && "params".equals(currentFieldName)) {
                             while (parser.nextToken() == XContentParser.Token.FIELD_NAME) {
-                                
                                 String param = parser.currentName();
-                                if (restApi.getParams().containsKey(param)) {
-                                    throw new IllegalArgumentException("Found duplicate param [" + param + "]");
-                                }
-                                
                                 parser.nextToken();
                                 if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
                                     throw new IllegalArgumentException("Expected params field in rest api definition to contain an object");

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -150,7 +150,10 @@ public class DoSection implements ExecutableSection {
                                 String body = parser.text();
                                 XContentParser bodyParser = JsonXContent.jsonXContent
                                     .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, body);
-                                apiCallSection.addBody(bodyParser.mapOrdered());
+                                //multiple bodies are supported e.g. in case of bulk provided as a whole string
+                                while(bodyParser.nextToken() != null) {
+                                    apiCallSection.addBody(bodyParser.mapOrdered());
+                                }
                             } else {
                                 apiCallSection.addParam(paramName, parser.text());
                             }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -150,10 +150,7 @@ public class DoSection implements ExecutableSection {
                                 String body = parser.text();
                                 XContentParser bodyParser = JsonXContent.jsonXContent
                                     .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, body);
-                                //multiple bodies are supported e.g. in case of bulk provided as a whole string
-                                while(bodyParser.nextToken() != null) {
-                                    apiCallSection.addBody(bodyParser.mapOrdered());
-                                }
+                                apiCallSection.addBody(bodyParser.mapOrdered());
                             } else {
                                 apiCallSection.addParam(paramName, parser.text());
                             }

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParserFailingTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParserFailingTests.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.test.rest.yaml.restspec;
 
-import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.yaml.YamlXContent;
 import org.elasticsearch.test.ESTestCase;
@@ -69,72 +68,6 @@ public class ClientYamlSuiteRestApiParserFailingTests extends ESTestCase {
                 "    \"body\": null" +
                 "  }" +
                 "}", "ping.json", "Found duplicate path [/pingtwo]");
-    }
-
-    public void testDuplicateParts() throws Exception {
-        assumeFalse("Test only makes sense if XContent parser doesn't have strict duplicate checks enabled",
-            XContent.isStrictDuplicateDetectionEnabled());
-        parseAndExpectFailure("{\n" +
-                "  \"ping\": {" +
-                "    \"documentation\": \"http://www.elasticsearch.org/guide/\"," +
-                "    \"methods\": [\"PUT\"]," +
-                "    \"url\": {" +
-                "      \"path\": \"/\"," +
-                "      \"paths\": [\"/\"]," +
-                "      \"parts\": {" +
-                "        \"index\": {" +
-                "          \"type\" : \"string\",\n" +
-                "          \"description\" : \"index part\"\n" +
-                "        }," +
-                "        \"type\": {" +
-                "          \"type\" : \"string\",\n" +
-                "          \"description\" : \"type part\"\n" +
-                "        }," +
-                "        \"index\": {" +
-                "          \"type\" : \"string\",\n" +
-                "          \"description\" : \"index parameter part\"\n" +
-                "        }" +
-                "      }," +
-                "      \"params\": {" +
-                "        \"type\" : \"boolean\",\n" +
-                "        \"description\" : \"Whether specified concrete indices should be ignored when unavailable (missing or closed)\"" +
-                "      }" +
-                "    }," +
-                "    \"body\": null" +
-                "  }" +
-                "}", "ping.json", "Found duplicate part [index]");
-    }
-
-    public void testDuplicateParams() throws Exception {
-        assumeFalse("Test only makes sense if XContent parser doesn't have strict duplicate checks enabled",
-            XContent.isStrictDuplicateDetectionEnabled());
-        parseAndExpectFailure("{\n" +
-                "  \"ping\": {" +
-                "    \"documentation\": \"http://www.elasticsearch.org/guide/\"," +
-                "    \"methods\": [\"PUT\"]," +
-                "    \"url\": {" +
-                "      \"path\": \"/\"," +
-                "      \"paths\": [\"/\"]," +
-                "      \"parts\": {" +
-                "      }," +
-                "      \"params\": {" +
-                "        \"timeout\": {" +
-                "          \"type\" : \"string\",\n" +
-                "          \"description\" : \"timeout parameter\"\n" +
-                "        }," +
-                "        \"refresh\": {" +
-                "          \"type\" : \"string\",\n" +
-                "          \"description\" : \"refresh parameter\"\n" +
-                "        }," +
-                "        \"timeout\": {" +
-                "          \"type\" : \"string\",\n" +
-                "          \"description\" : \"timeout parameter again\"\n" +
-                "        }" +
-                "      }" +
-                "    }," +
-                "    \"body\": null" +
-                "  }" +
-                "}", "ping.json", "Found duplicate param [timeout]");
     }
 
     public void testBrokenSpecShouldThrowUsefulExceptionWhenParsingFailsOnParams() throws Exception {

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.client.Node;
 import org.elasticsearch.client.NodeSelector;
 import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.yaml.YamlXContent;
@@ -215,9 +214,6 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
     }
 
     public void testParseDoSectionWithJsonMultipleBodiesRepeatedProperty() throws Exception {
-        assumeFalse("Test only makes sense if XContent parser doesn't have strict duplicate checks enabled",
-            XContent.isStrictDuplicateDetectionEnabled());
-
         String[] bodies = new String[] {
                 "{ \"index\": { \"_index\":\"test_index\", \"_type\":\"test_type\", \"_id\":\"test_id\" } }",
                 "{ \"f1\":\"v1\", \"f2\":42 }",
@@ -226,9 +222,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
                 "bulk:\n" +
                 "    refresh: true\n" +
                 "    body: \n" +
-                "        " + bodies[0] + "\n" +
-                "    body: \n" +
-                "        " + bodies[1]
+                "        " + bodies[0]
         );
 
         DoSection doSection = DoSection.parse(parser);
@@ -305,9 +299,6 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
     }
 
     public void testParseDoSectionWithYamlMultipleBodiesRepeatedProperty() throws Exception {
-        assumeFalse("Test only makes sense if XContent parser doesn't have strict duplicate checks enabled",
-            XContent.isStrictDuplicateDetectionEnabled());
-
         parser = createParser(YamlXContent.yamlXContent,
                 "bulk:\n" +
                 "    refresh: true\n" +
@@ -315,14 +306,10 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
                 "        index:\n" +
                 "            _index: test_index\n" +
                 "            _type:  test_type\n" +
-                "            _id:    test_id\n" +
-                "    body:\n" +
-                "        f1: v1\n" +
-                "        f2: 42\n"
+                "            _id:    test_id\n"
         );
-        String[] bodies = new String[2];
+        String[] bodies = new String[1];
         bodies[0] = "{\"index\": {\"_index\": \"test_index\", \"_type\":  \"test_type\", \"_id\": \"test_id\"}}";
-        bodies[1] = "{ \"f1\":\"v1\", \"f2\": 42 }";
 
         DoSection doSection = DoSection.parse(parser);
         ApiCallSection apiCallSection = doSection.getApiCallSection();

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -213,32 +213,6 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         assertThat(apiCallSection.getBodies().size(), equalTo(4));
     }
 
-    public void testParseDoSectionWithJsonMultipleBodiesRepeatedProperty() throws Exception {
-        String[] bodies = new String[] {
-                "{ \"index\": { \"_index\":\"test_index\", \"_type\":\"test_type\", \"_id\":\"test_id\" } }",
-                "{ \"f1\":\"v1\", \"f2\":42 }",
-        };
-        parser = createParser(YamlXContent.yamlXContent,
-                "bulk:\n" +
-                "    refresh: true\n" +
-                "    body: \n" +
-                "        " + bodies[0]
-        );
-
-        DoSection doSection = DoSection.parse(parser);
-        ApiCallSection apiCallSection = doSection.getApiCallSection();
-
-        assertThat(apiCallSection, notNullValue());
-        assertThat(apiCallSection.getApi(), equalTo("bulk"));
-        assertThat(apiCallSection.getParams().size(), equalTo(1));
-        assertThat(apiCallSection.getParams().get("refresh"), equalTo("true"));
-        assertThat(apiCallSection.hasBody(), equalTo(true));
-        assertThat(apiCallSection.getBodies().size(), equalTo(bodies.length));
-        for (int i = 0; i < bodies.length; i++) {
-            assertJsonEquals(apiCallSection.getBodies().get(i), bodies[i]);
-        }
-    }
-
     public void testParseDoSectionWithYamlBody() throws Exception {
         parser = createParser(YamlXContent.yamlXContent,
                 "search:\n" +
@@ -282,34 +256,6 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         bodies[1] = "{ \"f1\":\"v1\", \"f2\": 42 }";
         bodies[2] = "{\"index\": {\"_index\": \"test_index2\", \"_type\":  \"test_type2\", \"_id\": \"test_id2\"}}";
         bodies[3] = "{ \"f1\":\"v2\", \"f2\": 47 }";
-
-        DoSection doSection = DoSection.parse(parser);
-        ApiCallSection apiCallSection = doSection.getApiCallSection();
-
-        assertThat(apiCallSection, notNullValue());
-        assertThat(apiCallSection.getApi(), equalTo("bulk"));
-        assertThat(apiCallSection.getParams().size(), equalTo(1));
-        assertThat(apiCallSection.getParams().get("refresh"), equalTo("true"));
-        assertThat(apiCallSection.hasBody(), equalTo(true));
-        assertThat(apiCallSection.getBodies().size(), equalTo(bodies.length));
-
-        for (int i = 0; i < bodies.length; i++) {
-            assertJsonEquals(apiCallSection.getBodies().get(i), bodies[i]);
-        }
-    }
-
-    public void testParseDoSectionWithYamlMultipleBodiesRepeatedProperty() throws Exception {
-        parser = createParser(YamlXContent.yamlXContent,
-                "bulk:\n" +
-                "    refresh: true\n" +
-                "    body:\n" +
-                "        index:\n" +
-                "            _index: test_index\n" +
-                "            _type:  test_type\n" +
-                "            _id:    test_id\n"
-        );
-        String[] bodies = new String[1];
-        bodies[0] = "{\"index\": {\"_index\": \"test_index\", \"_type\":  \"test_type\", \"_id\": \"test_id\"}}";
 
         DoSection doSection = DoSection.parse(parser);
         ApiCallSection apiCallSection = doSection.getApiCallSection();

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/ArrayCompareCondition.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/ArrayCompareCondition.java
@@ -69,7 +69,6 @@ public final class ArrayCompareCondition extends AbstractCompareCondition {
         String path = null;
         Op op = null;
         Object value = null;
-        boolean haveValue = false;
         Quantifier quantifier = null;
 
         XContentParser.Token token;
@@ -86,11 +85,6 @@ public final class ArrayCompareCondition extends AbstractCompareCondition {
                             parser.nextToken();
                             path = parser.text();
                         } else {
-                            if (op != null) {
-                                throw new ElasticsearchParseException("could not parse [{}] condition for watch [{}]. encountered " +
-                                        "duplicate comparison operator, but already saw [{}].", TYPE, watchId, parser.currentName(), op
-                                        .id());
-                            }
                             try {
                                 op = Op.resolve(parser.currentName());
                             } catch (IllegalArgumentException iae) {
@@ -102,11 +96,6 @@ public final class ArrayCompareCondition extends AbstractCompareCondition {
                                 while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                                     if (token == XContentParser.Token.FIELD_NAME) {
                                         if (parser.currentName().equals("value")) {
-                                            if (haveValue) {
-                                                throw new ElasticsearchParseException("could not parse [{}] condition for watch [{}]. " +
-                                                        "encountered duplicate field \"value\", but already saw value [{}].", TYPE,
-                                                        watchId, value);
-                                            }
                                             token = parser.nextToken();
                                             if (!op.supportsStructures() && !token.isValue() && token != XContentParser.Token.VALUE_NULL) {
                                                 throw new ElasticsearchParseException("could not parse [{}] condition for watch [{}]. " +
@@ -115,13 +104,7 @@ public final class ArrayCompareCondition extends AbstractCompareCondition {
                                                         op.name().toLowerCase(Locale.ROOT), token);
                                             }
                                             value = XContentUtils.readValue(parser, token);
-                                            haveValue = true;
                                         } else if (parser.currentName().equals("quantifier")) {
-                                            if (quantifier != null) {
-                                                throw new ElasticsearchParseException("could not parse [{}] condition for watch [{}]. " +
-                                                        "encountered duplicate field \"quantifier\", but already saw quantifier [{}].",
-                                                        TYPE, watchId, quantifier.id());
-                                            }
                                             parser.nextToken();
                                             try {
                                                 quantifier = Quantifier.resolve(parser.text());

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/condition/ArrayCompareConditionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/condition/ArrayCompareConditionTests.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.watcher.condition;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -195,34 +194,6 @@ public class ArrayCompareConditionTests extends ESTestCase {
         assertThat(condition.getQuantifier(), is(quantifier));
     }
 
-    public void testParseContainsDuplicateOperator() throws IOException {
-        ArrayCompareCondition.Op op = randomFrom(ArrayCompareCondition.Op.values());
-        ArrayCompareCondition.Quantifier quantifier = randomFrom(ArrayCompareCondition.Quantifier.values());
-        Object value = randomFrom("value", 1, null);
-        XContentBuilder builder =
-                jsonBuilder().startObject()
-                    .startObject("key1.key2")
-                        .field("path", "key3.key4")
-                        .startObject(op.id())
-                            .field("value", value)
-                            .field("quantifier", quantifier.id())
-                        .endObject()
-                        .startObject(op.id())
-                            .field("value", value)
-                            .field("quantifier", quantifier.id())
-                        .endObject()
-                    .endObject()
-                .endObject();
-
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        parser.nextToken();
-
-        expectedException.expect(JsonParseException.class);
-        expectedException.expectMessage("Duplicate field '" + op.id() + "'");
-
-        ArrayCompareCondition.parse(ClockMock.frozen(), "_id", parser);
-    }
-
     public void testParseContainsUnknownOperator() throws IOException {
         ArrayCompareCondition.Quantifier quantifier = randomFrom(ArrayCompareCondition.Quantifier.values());
         Object value = randomFrom("value", 1, null);
@@ -242,56 +213,6 @@ public class ArrayCompareConditionTests extends ESTestCase {
 
         expectedException.expect(ElasticsearchParseException.class);
         expectedException.expectMessage("unknown comparison operator");
-
-        ArrayCompareCondition.parse(ClockMock.frozen(), "_id", parser);
-    }
-
-    public void testParseContainsDuplicateValue() throws IOException {
-        ArrayCompareCondition.Op op = randomFrom(ArrayCompareCondition.Op.values());
-        ArrayCompareCondition.Quantifier quantifier = randomFrom(ArrayCompareCondition.Quantifier.values());
-        Object value = randomFrom("value", 1, null);
-        XContentBuilder builder =
-                jsonBuilder().startObject()
-                    .startObject("key1.key2")
-                        .field("path", "key3.key4")
-                        .startObject(op.id())
-                            .field("value", value)
-                            .field("value", value)
-                            .field("quantifier", quantifier.id())
-                        .endObject()
-                    .endObject()
-                .endObject();
-
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        parser.nextToken();
-
-        expectedException.expect(JsonParseException.class);
-        expectedException.expectMessage("Duplicate field 'value'");
-
-        ArrayCompareCondition.parse(ClockMock.frozen(), "_id", parser);
-    }
-
-    public void testParseContainsDuplicateQuantifier() throws IOException {
-        ArrayCompareCondition.Op op = randomFrom(ArrayCompareCondition.Op.values());
-        ArrayCompareCondition.Quantifier quantifier = randomFrom(ArrayCompareCondition.Quantifier.values());
-        Object value = randomFrom("value", 1, null);
-        XContentBuilder builder =
-                jsonBuilder().startObject()
-                    .startObject("key1.key2")
-                        .field("path", "key3.key4")
-                        .startObject(op.id())
-                            .field("value", value)
-                            .field("quantifier", quantifier.id())
-                            .field("quantifier", quantifier.id())
-                        .endObject()
-                    .endObject()
-                .endObject();
-
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        parser.nextToken();
-
-        expectedException.expect(JsonParseException.class);
-        expectedException.expectMessage("Duplicate field 'quantifier'");
 
         ArrayCompareCondition.parse(ClockMock.frozen(), "_id", parser);
     }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/condition/ArrayCompareConditionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/condition/ArrayCompareConditionTests.java
@@ -5,9 +5,9 @@
  */
 package org.elasticsearch.xpack.watcher.condition;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -196,8 +196,6 @@ public class ArrayCompareConditionTests extends ESTestCase {
     }
 
     public void testParseContainsDuplicateOperator() throws IOException {
-        assumeFalse("Test only makes sense if XContent parser doesn't have strict duplicate checks enabled",
-                XContent.isStrictDuplicateDetectionEnabled());
         ArrayCompareCondition.Op op = randomFrom(ArrayCompareCondition.Op.values());
         ArrayCompareCondition.Quantifier quantifier = randomFrom(ArrayCompareCondition.Quantifier.values());
         Object value = randomFrom("value", 1, null);
@@ -219,8 +217,8 @@ public class ArrayCompareConditionTests extends ESTestCase {
         XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
         parser.nextToken();
 
-        expectedException.expect(ElasticsearchParseException.class);
-        expectedException.expectMessage("duplicate comparison operator");
+        expectedException.expect(JsonParseException.class);
+        expectedException.expectMessage("Duplicate field '" + op.id() + "'");
 
         ArrayCompareCondition.parse(ClockMock.frozen(), "_id", parser);
     }
@@ -249,8 +247,6 @@ public class ArrayCompareConditionTests extends ESTestCase {
     }
 
     public void testParseContainsDuplicateValue() throws IOException {
-        assumeFalse("Test only makes sense if XContent parser doesn't have strict duplicate checks enabled",
-                XContent.isStrictDuplicateDetectionEnabled());
         ArrayCompareCondition.Op op = randomFrom(ArrayCompareCondition.Op.values());
         ArrayCompareCondition.Quantifier quantifier = randomFrom(ArrayCompareCondition.Quantifier.values());
         Object value = randomFrom("value", 1, null);
@@ -269,15 +265,13 @@ public class ArrayCompareConditionTests extends ESTestCase {
         XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
         parser.nextToken();
 
-        expectedException.expect(ElasticsearchParseException.class);
-        expectedException.expectMessage("duplicate field \"value\"");
+        expectedException.expect(JsonParseException.class);
+        expectedException.expectMessage("Duplicate field 'value'");
 
         ArrayCompareCondition.parse(ClockMock.frozen(), "_id", parser);
     }
 
     public void testParseContainsDuplicateQuantifier() throws IOException {
-        assumeFalse("Test only makes sense if XContent parser doesn't have strict duplicate checks enabled",
-                XContent.isStrictDuplicateDetectionEnabled());
         ArrayCompareCondition.Op op = randomFrom(ArrayCompareCondition.Op.values());
         ArrayCompareCondition.Quantifier quantifier = randomFrom(ArrayCompareCondition.Quantifier.values());
         Object value = randomFrom("value", 1, null);
@@ -296,8 +290,8 @@ public class ArrayCompareConditionTests extends ESTestCase {
         XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
         parser.nextToken();
 
-        expectedException.expect(ElasticsearchParseException.class);
-        expectedException.expectMessage("duplicate field \"quantifier\"");
+        expectedException.expect(JsonParseException.class);
+        expectedException.expectMessage("Duplicate field 'quantifier'");
 
         ArrayCompareCondition.parse(ClockMock.frozen(), "_id", parser);
     }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/attachment/EmailAttachmentParsersTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/attachment/EmailAttachmentParsersTests.java
@@ -5,11 +5,11 @@
  */
 package org.elasticsearch.xpack.watcher.notification.email.attachment;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.ESTestCase;
@@ -116,8 +116,6 @@ public class EmailAttachmentParsersTests extends ESTestCase {
     }
 
     public void testThatTwoAttachmentsWithTheSameIdThrowError() throws Exception {
-        assumeFalse("Test only makes sense if XContent parser doesn't have strict duplicate checks enabled",
-                XContent.isStrictDuplicateDetectionEnabled());
         Map<String, EmailAttachmentParser> parsers = new HashMap<>();
         parsers.put("test", new TestEmailAttachmentParser());
         EmailAttachmentsParser parser = new EmailAttachmentsParser(parsers);
@@ -146,8 +144,8 @@ public class EmailAttachmentParsersTests extends ESTestCase {
 
             parser.parse(xContentParser);
             fail("Expected parser to fail but did not happen");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), is("Attachment with id [my-name.json] has already been created, must be renamed"));
+        } catch (JsonParseException e) {
+            assertThat(e.getMessage(), containsString("Duplicate field 'my-name.json'"));
         }
     }
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/attachment/EmailAttachmentParsersTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/attachment/EmailAttachmentParsersTests.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.watcher.notification.email.attachment;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
@@ -29,7 +28,6 @@ import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
@@ -112,40 +110,6 @@ public class EmailAttachmentParsersTests extends ESTestCase {
         assertThat(Strings.toString(builder), containsString("/"));
         if (inline) {
             assertThat(Strings.toString(builder), containsString("inline"));
-        }
-    }
-
-    public void testThatTwoAttachmentsWithTheSameIdThrowError() throws Exception {
-        Map<String, EmailAttachmentParser> parsers = new HashMap<>();
-        parsers.put("test", new TestEmailAttachmentParser());
-        EmailAttachmentsParser parser = new EmailAttachmentsParser(parsers);
-
-        List<EmailAttachmentParser.EmailAttachment> attachments = new ArrayList<>();
-        attachments.add(new TestEmailAttachment("my-name.json", "value"));
-        attachments.add(new TestEmailAttachment("my-name.json", "value"));
-
-        EmailAttachments emailAttachments = new EmailAttachments(attachments);
-        XContentBuilder builder = jsonBuilder();
-        builder.startObject();
-        emailAttachments.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        builder.endObject();
-        logger.info("JSON is: " + Strings.toString(builder));
-
-        XContentParser xContentParser = createParser(builder);
-        try {
-            XContentParser.Token token = xContentParser.currentToken();
-            assertNull(token);
-
-            token = xContentParser.nextToken();
-            assertThat(token, equalTo(XContentParser.Token.START_OBJECT));
-
-            token = xContentParser.nextToken();
-            assertThat(token, equalTo(XContentParser.Token.FIELD_NAME));
-
-            parser.parse(xContentParser);
-            fail("Expected parser to fail but did not happen");
-        } catch (JsonParseException e) {
-            assertThat(e.getMessage(), containsString("Duplicate field 'my-name.json'"));
         }
     }
 


### PR DESCRIPTION
With this commit we cleanup hand-coded duplicate checks in XContent
parsing. They were necessary previously but since we reconfigured the
underlying parser in #22073 and #22225, these checks are obsolete and
were also ineffective unless an undocumented system property has been
set. As we also remove this escape hatch, we can remove the additional
checks as well.

Closes #22253