### PR TITLE
[MINOR] Docs .security index is never auto-created

### DIFF
--- a/docs/reference/setup/install/xpack-indices.asciidoc
+++ b/docs/reference/setup/install/xpack-indices.asciidoc
@@ -6,7 +6,7 @@ creation in {es}, you must configure
 
 [source,yaml]
 -----------------------------------------------------------
-action.auto_create_index: .security,.monitoring*,.watches,.triggered_watches,.watcher-history*,.ml*
+action.auto_create_index: .monitoring*,.watches,.triggered_watches,.watcher-history*,.ml*
 -----------------------------------------------------------
 
 [IMPORTANT]


### PR DESCRIPTION
@droberts195 reported that the `.security-*` index is not auto-created anymore.
This is true since a long time (cec90f452a6d9763ae7d9f233 I guess).