### PR TITLE
Docs - removed experimental/beta markers from adjacency matrix aggregation

### DIFF
--- a/docs/reference/aggregations/bucket/adjacency-matrix-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/adjacency-matrix-aggregation.asciidoc
@@ -6,9 +6,6 @@ The request provides a collection of named filter expressions, similar to the `f
 request. 
 Each bucket in the response represents a non-empty cell in the matrix of intersecting filters.
 
-beta[The `adjacency_matrix` aggregation is a new feature and we may evolve its design as we get feedback on its use.  As a result, the API for this feature may change in non-backwards compatible ways]
-
-
 Given filters named `A`, `B` and `C` the response would return buckets with the following names:
 
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregator.java
@@ -52,8 +52,6 @@ import static org.elasticsearch.index.query.AbstractQueryBuilder.parseInnerQuery
 /**
  * Aggregation for adjacency matrices.
  *
- * NOTE! This is an experimental class.
- *
  * TODO the aggregation produces a sparse response but in the
  * computation it uses a non-sparse structure (an array of Bits
  * objects). This could be changed to a sparse structure in future.


### PR DESCRIPTION
This is now a GA feature