### PR TITLE
[DOCS] Adds new lazy ml node setting

### DIFF
--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -81,3 +81,10 @@ sufficient:
 The maximum number of records that are output per bucket. The default value is 
 `500`.
 
+`xpack.ml.max_lazy_ml_nodes`:: (<<cluster-update-settings,Dynamic>>)
+The number of lazily spun up Machine Learning nodes. Useful in situations
+where ML nodes are not desired until the first Machine Learning Job
+is created. It defaults to `0` and has a maximum acceptable value of `3`.
+When a job is opened with this setting set at `>0`, it will stay in
+the `OPENING` state until a new ML node is added to the cluster and
+the job is assigned to run on that node.

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -91,3 +91,7 @@ of nodes have already been provisioned. When a job is opened with this
 setting set at `>0` and there are no nodes that can accept the job, then
 the job will stay in the `OPENING` state until a new ML node is added to the
 cluster and the job is assigned to run on that node.
++
+IMPORTANT: This setting assumes some external process is capable of adding ML nodes
+to the cluster. This setting is only useful when used in conjunction with
+such an external process.

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -84,7 +84,10 @@ The maximum number of records that are output per bucket. The default value is
 `xpack.ml.max_lazy_ml_nodes`:: (<<cluster-update-settings,Dynamic>>)
 The number of lazily spun up Machine Learning nodes. Useful in situations
 where ML nodes are not desired until the first Machine Learning Job
-is created. It defaults to `0` and has a maximum acceptable value of `3`.
-When a job is opened with this setting set at `>0`, it will stay in
-the `OPENING` state until a new ML node is added to the cluster and
-the job is assigned to run on that node.
+is opened. It defaults to `0` and has a maximum acceptable value of `3`.
+If the current number of ML nodes is `>=` than this setting, then it is
+assumed that there are no more lazy nodes available as the desired number
+of nodes have already been provisioned. When a job is opened with this
+setting set at `>0` and there are no nodes that can accept the job, then
+the job will stay in the `OPENING` state until a new ML node is added to the
+cluster and the job is assigned to run on that node.


### PR DESCRIPTION
We now have a new setting that allows a number of lazily provisioned ML nodes.