### PR TITLE
Generate non-encrypted license public key

### DIFF
--- a/x-pack/license-tools/src/main/java/org/elasticsearch/license/licensor/tools/KeyPairGeneratorTool.java
+++ b/x-pack/license-tools/src/main/java/org/elasticsearch/license/licensor/tools/KeyPairGeneratorTool.java
@@ -21,7 +21,6 @@ import java.security.KeyPairGenerator;
 import java.security.SecureRandom;
 
 import static org.elasticsearch.license.CryptUtils.writeEncryptedPrivateKey;
-import static org.elasticsearch.license.CryptUtils.writeEncryptedPublicKey;
 
 public class KeyPairGeneratorTool extends LoggingAwareCommand {
 
@@ -65,7 +64,7 @@ public class KeyPairGeneratorTool extends LoggingAwareCommand {
         KeyPair keyPair = keyGen.generateKeyPair();
 
         Files.write(privateKeyPath, writeEncryptedPrivateKey(keyPair.getPrivate()));
-        Files.write(publicKeyPath, writeEncryptedPublicKey(keyPair.getPublic()));
+        Files.write(publicKeyPath, keyPair.getPublic().getEncoded());
 
         terminal.println(
                 Terminal.Verbosity.VERBOSE,


### PR DESCRIPTION
After this commit(https://github.com/elastic/elasticsearch/commit/cca1a2a7cf55230a21f1b777009dfa90c428bb85), Elasticsearch use fips-140 compliant key-pair to sign x-pack license , which public key is store in plain-text, but the key-pair-generator tool still generate old-style encrypted public key. 
This patch edit the key-pair-generator to generate a key pair that public key is not encrypted.
