### PR TITLE
Remove Swift plugin on 5.X banches

### DIFF
--- a/docs/plugins/repository.asciidoc
+++ b/docs/plugins/repository.asciidoc
@@ -26,15 +26,6 @@ The Hadoop HDFS Repository plugin adds support for using HDFS as a repository.
 
 The GCS repository plugin adds support for using Google Cloud Storage service as a repository.
 
-
-[float]
-=== Community contributed repository plugins
-
-The following plugin has been contributed by our community:
-
-* https://github.com/wikimedia/search-repository-swift[Openstack Swift] (by Wikimedia Foundation)
-
-
 include::repository-azure.asciidoc[]
 
 include::repository-s3.asciidoc[]


### PR DESCRIPTION
Swift plugin is not (and will not) be available on ES 5.X versions (see: https://github.com/BigDataBoutique/elasticsearch-repository-swift/issues/3#issuecomment-425397162)

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? *YES*
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)? *YES*
- If submitting code, have you built your formula locally prior to submission with `gradle check`? *N/A*
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed. *N/A*
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)? *N/A*
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that. *N/A*
