### PR TITLE
[TEST][ML] Reinstate date parsing test

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/DataDescriptionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/DataDescriptionTests.java
@@ -55,7 +55,6 @@ public class DataDescriptionTests extends AbstractSerializingTestCase<DataDescri
         description.setTimeFormat("yyyy-MM-dd HH");
     }
 
-    @AwaitsFix(bugUrl = "https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8206980")
     public void testVerify_GivenValidFormat_Java11Bug() {
         DataDescription.Builder description = new DataDescription.Builder();
         description.setTimeFormat("yyyy.MM.dd G 'at' HH:mm:ss z");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/DataDescriptionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/DataDescriptionTests.java
@@ -53,10 +53,6 @@ public class DataDescriptionTests extends AbstractSerializingTestCase<DataDescri
         description.setTimeFormat("epoch");
         description.setTimeFormat("epoch_ms");
         description.setTimeFormat("yyyy-MM-dd HH");
-    }
-
-    public void testVerify_GivenValidFormat_Java11Bug() {
-        DataDescription.Builder description = new DataDescription.Builder();
         description.setTimeFormat("yyyy.MM.dd G 'at' HH:mm:ss z");
     }
 


### PR DESCRIPTION
The test was muted due to a bug in an early access build of Java 11
which is now resolved

https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8206980