### PR TITLE
HLRC: ML %s/Boolean is/Boolean get/g

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
@@ -88,8 +88,8 @@ final class MLRequestConverters {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
         RequestConverters.Params params = new RequestConverters.Params(request);
-        if (getJobRequest.isAllowNoJobs() != null) {
-            params.putParam("allow_no_jobs", Boolean.toString(getJobRequest.isAllowNoJobs()));
+        if (getJobRequest.getAllowNoJobs() != null) {
+            params.putParam("allow_no_jobs", Boolean.toString(getJobRequest.getAllowNoJobs()));
         }
 
         return request;
@@ -106,8 +106,8 @@ final class MLRequestConverters {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
         RequestConverters.Params params = new RequestConverters.Params(request);
-        if (getJobStatsRequest.isAllowNoJobs() != null) {
-            params.putParam("allow_no_jobs", Boolean.toString(getJobStatsRequest.isAllowNoJobs()));
+        if (getJobStatsRequest.getAllowNoJobs() != null) {
+            params.putParam("allow_no_jobs", Boolean.toString(getJobStatsRequest.getAllowNoJobs()));
         }
         return request;
     }
@@ -219,9 +219,9 @@ final class MLRequestConverters {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
         RequestConverters.Params params = new RequestConverters.Params(request);
-        if (getDatafeedRequest.isAllowNoDatafeeds() != null) {
+        if (getDatafeedRequest.getAllowNoDatafeeds() != null) {
             params.putParam(GetDatafeedRequest.ALLOW_NO_DATAFEEDS.getPreferredName(),
-                    Boolean.toString(getDatafeedRequest.isAllowNoDatafeeds()));
+                    Boolean.toString(getDatafeedRequest.getAllowNoDatafeeds()));
         }
 
         return request;
@@ -236,7 +236,9 @@ final class MLRequestConverters {
                 .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
         RequestConverters.Params params = new RequestConverters.Params(request);
-        params.putParam("force", Boolean.toString(deleteDatafeedRequest.isForce()));
+        if (deleteDatafeedRequest.getForce() != null) {
+            params.putParam("force", Boolean.toString(deleteDatafeedRequest.getForce()));
+        }
         return request;
     }
 
@@ -277,8 +279,8 @@ final class MLRequestConverters {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
         RequestConverters.Params params = new RequestConverters.Params(request);
-        if (getDatafeedStatsRequest.isAllowNoDatafeeds() != null) {
-            params.putParam("allow_no_datafeeds", Boolean.toString(getDatafeedStatsRequest.isAllowNoDatafeeds()));
+        if (getDatafeedStatsRequest.getAllowNoDatafeeds() != null) {
+            params.putParam("allow_no_datafeeds", Boolean.toString(getDatafeedStatsRequest.getAllowNoDatafeeds()));
         }
         return request;
     }
@@ -305,8 +307,8 @@ final class MLRequestConverters {
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
         RequestConverters.Params params = new RequestConverters.Params(request);
-        if (deleteForecastRequest.isAllowNoForecasts() != null) {
-            params.putParam("allow_no_forecasts", Boolean.toString(deleteForecastRequest.isAllowNoForecasts()));
+        if (deleteForecastRequest.getAllowNoForecasts() != null) {
+            params.putParam("allow_no_forecasts", Boolean.toString(deleteForecastRequest.getAllowNoForecasts()));
         }
         if (deleteForecastRequest.timeout() != null) {
             params.putParam("timeout", deleteForecastRequest.timeout().getStringRep());

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/CloseJobRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/CloseJobRequest.java
@@ -114,7 +114,7 @@ public class CloseJobRequest extends ActionRequest implements ToXContentObject {
         this.timeout = timeout;
     }
 
-    public Boolean isForce() {
+    public Boolean getForce() {
         return force;
     }
 
@@ -129,7 +129,7 @@ public class CloseJobRequest extends ActionRequest implements ToXContentObject {
         this.force = force;
     }
 
-    public Boolean isAllowNoJobs() {
+    public Boolean getAllowNoJobs() {
         return this.allowNoJobs;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/DeleteDatafeedRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/DeleteDatafeedRequest.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 public class DeleteDatafeedRequest extends ActionRequest {
 
     private String datafeedId;
-    private boolean force;
+    private Boolean force;
 
     public DeleteDatafeedRequest(String datafeedId) {
         this.datafeedId = Objects.requireNonNull(datafeedId, "[datafeed_id] must not be null");
@@ -39,7 +39,7 @@ public class DeleteDatafeedRequest extends ActionRequest {
         return datafeedId;
     }
 
-    public boolean isForce() {
+    public Boolean getForce() {
         return force;
     }
 
@@ -49,7 +49,7 @@ public class DeleteDatafeedRequest extends ActionRequest {
      *
      * @param force When {@code true} forcefully delete a started datafeed. Defaults to {@code false}
      */
-    public void setForce(boolean force) {
+    public void setForce(Boolean force) {
         this.force = force;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/DeleteForecastRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/DeleteForecastRequest.java
@@ -104,7 +104,7 @@ public class DeleteForecastRequest extends ActionRequest implements ToXContentOb
         this.forecastIds = new ArrayList<>(forecastIds);
     }
 
-    public Boolean isAllowNoForecasts() {
+    public Boolean getAllowNoForecasts() {
         return allowNoForecasts;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetBucketsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetBucketsRequest.java
@@ -109,7 +109,7 @@ public class GetBucketsRequest extends ActionRequest implements ToXContentObject
         this.expand = expand;
     }
 
-    public Boolean isExcludeInterim() {
+    public Boolean getExcludeInterim() {
         return excludeInterim;
     }
 
@@ -186,7 +186,7 @@ public class GetBucketsRequest extends ActionRequest implements ToXContentObject
         this.sort = sort;
     }
 
-    public Boolean isDescending() {
+    public Boolean getDescending() {
         return descending;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDatafeedRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDatafeedRequest.java
@@ -97,7 +97,7 @@ public class GetDatafeedRequest extends ActionRequest implements ToXContentObjec
         this.allowNoDatafeeds = allowNoDatafeeds;
     }
 
-    public Boolean isAllowNoDatafeeds() {
+    public Boolean getAllowNoDatafeeds() {
         return allowNoDatafeeds;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDatafeedStatsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetDatafeedStatsRequest.java
@@ -93,7 +93,7 @@ public class GetDatafeedStatsRequest extends ActionRequest implements ToXContent
         return datafeedIds;
     }
 
-    public Boolean isAllowNoDatafeeds() {
+    public Boolean getAllowNoDatafeeds() {
         return this.allowNoDatafeeds;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetInfluencersRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetInfluencersRequest.java
@@ -77,7 +77,7 @@ public class GetInfluencersRequest extends ActionRequest implements ToXContentOb
         return jobId;
     }
 
-    public Boolean isExcludeInterim() {
+    public Boolean getExcludeInterim() {
         return excludeInterim;
     }
 
@@ -154,7 +154,7 @@ public class GetInfluencersRequest extends ActionRequest implements ToXContentOb
         this.sort = sort;
     }
 
-    public Boolean isDescending() {
+    public Boolean getDescending() {
         return descending;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetJobRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetJobRequest.java
@@ -97,7 +97,7 @@ public class GetJobRequest extends ActionRequest implements ToXContentObject {
         this.allowNoJobs = allowNoJobs;
     }
 
-    public Boolean isAllowNoJobs() {
+    public Boolean getAllowNoJobs() {
         return allowNoJobs;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetJobStatsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetJobStatsRequest.java
@@ -93,7 +93,7 @@ public class GetJobStatsRequest extends ActionRequest implements ToXContentObjec
         return jobIds;
     }
 
-    public Boolean isAllowNoJobs() {
+    public Boolean getAllowNoJobs() {
         return this.allowNoJobs;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetOverallBucketsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetOverallBucketsRequest.java
@@ -187,7 +187,7 @@ public class GetOverallBucketsRequest extends ActionRequest implements ToXConten
     }
 
     /**
-     * See {@link GetJobRequest#isAllowNoJobs()}
+     * See {@link GetJobRequest#getAllowNoJobs()}
      * @param allowNoJobs value of "allow_no_jobs".
      */
     public void setAllowNoJobs(boolean allowNoJobs) {
@@ -199,7 +199,7 @@ public class GetOverallBucketsRequest extends ActionRequest implements ToXConten
      *
      * If this is {@code false}, then an error is returned when a wildcard (or {@code _all}) does not match any jobs
      */
-    public Boolean isAllowNoJobs() {
+    public Boolean getAllowNoJobs() {
         return allowNoJobs;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetRecordsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/GetRecordsRequest.java
@@ -77,7 +77,7 @@ public class GetRecordsRequest implements ToXContentObject, Validatable {
         return jobId;
     }
 
-    public Boolean isExcludeInterim() {
+    public Boolean getExcludeInterim() {
         return excludeInterim;
     }
 
@@ -154,7 +154,7 @@ public class GetRecordsRequest implements ToXContentObject, Validatable {
         this.sort = sort;
     }
 
-    public Boolean isDescending() {
+    public Boolean getDescending() {
         return descending;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StopDatafeedRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StopDatafeedRequest.java
@@ -114,7 +114,7 @@ public class StopDatafeedRequest extends ActionRequest implements ToXContentObje
         this.timeout = timeout;
     }
 
-    public Boolean isForce() {
+    public Boolean getForce() {
         return force;
     }
 
@@ -129,7 +129,7 @@ public class StopDatafeedRequest extends ActionRequest implements ToXContentObje
         this.force = force;
     }
 
-    public Boolean isAllowNoDatafeeds() {
+    public Boolean getAllowNoDatafeeds() {
         return this.allowNoDatafeeds;
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MLRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MLRequestConvertersTests.java
@@ -266,7 +266,7 @@ public class MLRequestConvertersTests extends ESTestCase {
         Request request = MLRequestConverters.deleteDatafeed(deleteDatafeedRequest);
         assertEquals(HttpDelete.METHOD_NAME, request.getMethod());
         assertEquals("/_xpack/ml/datafeeds/" + datafeedId, request.getEndpoint());
-        assertEquals(Boolean.toString(false), request.getParameters().get("force"));
+        assertFalse(request.getParameters().containsKey("force"));
 
         deleteDatafeedRequest.setForce(true);
         request = MLRequestConverters.deleteDatafeed(deleteDatafeedRequest);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/DeleteDatafeedRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/DeleteDatafeedRequestTests.java
@@ -30,10 +30,10 @@ public class DeleteDatafeedRequestTests extends ESTestCase {
 
     public void testSetForce() {
         DeleteDatafeedRequest deleteDatafeedRequest = createTestInstance();
-        assertFalse(deleteDatafeedRequest.isForce());
+        assertNull(deleteDatafeedRequest.getForce());
 
         deleteDatafeedRequest.setForce(true);
-        assertTrue(deleteDatafeedRequest.isForce());
+        assertTrue(deleteDatafeedRequest.getForce());
     }
 
     private DeleteDatafeedRequest createTestInstance() {


### PR DESCRIPTION
Replaces `Boolean is` with `Boolean get` for requests. 

Also changes `DeleteDatafeedRequest#force` to be `Boolean` and updates `DeleteDatafeedRequest#(get|set)Force` accordingly 

closes #33374