### PR TITLE
[ML] Job in index: Get datafeed and job stats from index

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
@@ -107,7 +107,7 @@ public class TransportCloseJobAction extends TransportTasksAction<TransportOpenJ
              */
 
             PersistentTasksCustomMetaData tasksMetaData = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
-            jobConfigProvider.expandJobsIds(request.getJobId(), request.allowNoJobs(), ActionListener.wrap(
+            jobConfigProvider.expandJobsIds(request.getJobId(), request.allowNoJobs(), true, ActionListener.wrap(
                     expandedJobIds -> {
                         validate(expandedJobIds, request.isForce(), tasksMetaData, ActionListener.wrap(
                                 response -> {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
@@ -16,30 +16,33 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
-import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
+import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public class TransportGetDatafeedsStatsAction extends TransportMasterNodeReadAction<GetDatafeedsStatsAction.Request,
         GetDatafeedsStatsAction.Response> {
 
+    private final DatafeedConfigProvider datafeedConfigProvider;
+
     @Inject
     public TransportGetDatafeedsStatsAction(Settings settings, TransportService transportService,
                                             ClusterService clusterService, ThreadPool threadPool,
                                             ActionFilters actionFilters,
-                                            IndexNameExpressionResolver indexNameExpressionResolver) {
+                                            IndexNameExpressionResolver indexNameExpressionResolver,
+                                            DatafeedConfigProvider datafeedConfigProvider) {
         super(settings, GetDatafeedsStatsAction.NAME, transportService, clusterService, threadPool, actionFilters,
                 indexNameExpressionResolver, GetDatafeedsStatsAction.Request::new);
+        this.datafeedConfigProvider = datafeedConfigProvider;
     }
 
     @Override
@@ -57,16 +60,18 @@ public class TransportGetDatafeedsStatsAction extends TransportMasterNodeReadAct
                                    ActionListener<GetDatafeedsStatsAction.Response> listener) throws Exception {
         logger.debug("Get stats for datafeed '{}'", request.getDatafeedId());
 
-        MlMetadata mlMetadata = MlMetadata.getMlMetadata(state);
-        Set<String> expandedDatafeedIds = mlMetadata.expandDatafeedIds(request.getDatafeedId(), request.allowNoDatafeeds());
-
-        PersistentTasksCustomMetaData tasksInProgress = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
-        List<GetDatafeedsStatsAction.Response.DatafeedStats> results = expandedDatafeedIds.stream()
-                .map(datafeedId -> getDatafeedStats(datafeedId, state, tasksInProgress))
-                .collect(Collectors.toList());
-        QueryPage<GetDatafeedsStatsAction.Response.DatafeedStats> statsPage = new QueryPage<>(results, results.size(),
-                DatafeedConfig.RESULTS_FIELD);
-        listener.onResponse(new GetDatafeedsStatsAction.Response(statsPage));
+        datafeedConfigProvider.expandDatafeedIds(request.getDatafeedId(), request.allowNoDatafeeds(), ActionListener.wrap(
+                expandedDatafeedIds -> {
+                    PersistentTasksCustomMetaData tasksInProgress = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
+                    List<GetDatafeedsStatsAction.Response.DatafeedStats> results = expandedDatafeedIds.stream()
+                            .map(datafeedId -> getDatafeedStats(datafeedId, state, tasksInProgress))
+                            .collect(Collectors.toList());
+                    QueryPage<GetDatafeedsStatsAction.Response.DatafeedStats> statsPage = new QueryPage<>(results, results.size(),
+                            DatafeedConfig.RESULTS_FIELD);
+                    listener.onResponse(new GetDatafeedsStatsAction.Response(statsPage));
+                },
+                listener::onFailure
+        ));
     }
 
     private static GetDatafeedsStatsAction.Response.DatafeedStats getDatafeedStats(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
@@ -20,10 +20,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
+import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.util.QueryPage;
@@ -32,7 +32,7 @@ import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
 import org.elasticsearch.xpack.core.ml.stats.ForecastStats;
-import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
+import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager;
 
@@ -54,28 +54,37 @@ public class TransportGetJobsStatsAction extends TransportTasksAction<TransportO
     private final ClusterService clusterService;
     private final AutodetectProcessManager processManager;
     private final JobResultsProvider jobResultsProvider;
+    private final JobConfigProvider jobConfigProvider;
 
     @Inject
     public TransportGetJobsStatsAction(Settings settings, TransportService transportService, ThreadPool threadPool,
                                        ActionFilters actionFilters, ClusterService clusterService,
                                        IndexNameExpressionResolver indexNameExpressionResolver,
-                                       AutodetectProcessManager processManager, JobResultsProvider jobResultsProvider) {
+                                       AutodetectProcessManager processManager, JobResultsProvider jobResultsProvider,
+                                       JobConfigProvider jobConfigProvider) {
         super(settings, GetJobsStatsAction.NAME, threadPool, clusterService, transportService, actionFilters,
                 indexNameExpressionResolver, GetJobsStatsAction.Request::new, GetJobsStatsAction.Response::new,
                 ThreadPool.Names.MANAGEMENT);
         this.clusterService = clusterService;
         this.processManager = processManager;
         this.jobResultsProvider = jobResultsProvider;
+        this.jobConfigProvider = jobConfigProvider;
     }
 
     @Override
-    protected void doExecute(Task task, GetJobsStatsAction.Request request, ActionListener<GetJobsStatsAction.Response> listener) {
-        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterService.state());
-        request.setExpandedJobsIds(new ArrayList<>(mlMetadata.expandJobIds(request.getJobId(), request.allowNoJobs())));
-        ActionListener<GetJobsStatsAction.Response> finalListener = listener;
-        listener = ActionListener.wrap(response -> gatherStatsForClosedJobs(mlMetadata,
-                request, response, finalListener), listener::onFailure);
-        super.doExecute(task, request, listener);
+    protected void doExecute(Task task, GetJobsStatsAction.Request request, ActionListener<GetJobsStatsAction.Response> finalListener) {
+
+        jobConfigProvider.expandJobsIds(request.getJobId(), request.allowNoJobs(), ActionListener.wrap(
+                expandedIds -> {
+                    request.setExpandedJobsIds(new ArrayList<>(expandedIds));
+                    ActionListener<GetJobsStatsAction.Response> jobStatsListener = ActionListener.wrap(
+                            response -> gatherStatsForClosedJobs(request, response, finalListener),
+                            finalListener::onFailure
+                    );
+                    super.doExecute(task, request, jobStatsListener);
+                },
+                finalListener::onFailure
+        ));
     }
 
     @Override
@@ -123,21 +132,20 @@ public class TransportGetJobsStatsAction extends TransportTasksAction<TransportO
 
     // Up until now we gathered the stats for jobs that were open,
     // This method will fetch the stats for missing jobs, that was stored in the jobs index
-    void gatherStatsForClosedJobs(MlMetadata mlMetadata, GetJobsStatsAction.Request request, GetJobsStatsAction.Response response,
+    void gatherStatsForClosedJobs(GetJobsStatsAction.Request request, GetJobsStatsAction.Response response,
                                   ActionListener<GetJobsStatsAction.Response> listener) {
-        List<String> jobIds = determineNonDeletedJobIdsWithoutLiveStats(mlMetadata,
-                request.getExpandedJobsIds(), response.getResponse().results());
-        if (jobIds.isEmpty()) {
+        List<String> closedJobIds = determineJobIdsWithoutLiveStats(request.getExpandedJobsIds(), response.getResponse().results());
+        if (closedJobIds.isEmpty()) {
             listener.onResponse(response);
             return;
         }
 
-        AtomicInteger counter = new AtomicInteger(jobIds.size());
-        AtomicArray<GetJobsStatsAction.Response.JobStats> jobStats = new AtomicArray<>(jobIds.size());
+        AtomicInteger counter = new AtomicInteger(closedJobIds.size());
+        AtomicArray<GetJobsStatsAction.Response.JobStats> jobStats = new AtomicArray<>(closedJobIds.size());
         PersistentTasksCustomMetaData tasks = clusterService.state().getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
-        for (int i = 0; i < jobIds.size(); i++) {
+        for (int i = 0; i < closedJobIds.size(); i++) {
             int slot = i;
-            String jobId = jobIds.get(i);
+            String jobId = closedJobIds.get(i);
             gatherForecastStats(jobId, forecastStats -> {
                 gatherDataCountsAndModelSizeStats(jobId, (dataCounts, modelSizeStats) -> {
                     JobState jobState = MlTasks.getJobState(jobId, tasks);
@@ -180,11 +188,9 @@ public class TransportGetJobsStatsAction extends TransportTasksAction<TransportO
         }
     }
 
-    static List<String> determineNonDeletedJobIdsWithoutLiveStats(MlMetadata mlMetadata,
-                                                                  List<String> requestedJobIds,
-                                                                  List<GetJobsStatsAction.Response.JobStats> stats) {
+    static List<String> determineJobIdsWithoutLiveStats(List<String> requestedJobIds,
+                                                        List<GetJobsStatsAction.Response.JobStats> stats) {
         Set<String> excludeJobIds = stats.stream().map(GetJobsStatsAction.Response.JobStats::getJobId).collect(Collectors.toSet());
-        return requestedJobIds.stream().filter(jobId -> !excludeJobIds.contains(jobId) &&
-                !mlMetadata.isJobDeleting(jobId)).collect(Collectors.toList());
+        return requestedJobIds.stream().filter(jobId -> !excludeJobIds.contains(jobId)).collect(Collectors.toList());
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
@@ -74,7 +74,7 @@ public class TransportGetJobsStatsAction extends TransportTasksAction<TransportO
     @Override
     protected void doExecute(Task task, GetJobsStatsAction.Request request, ActionListener<GetJobsStatsAction.Response> finalListener) {
 
-        jobConfigProvider.expandJobsIds(request.getJobId(), request.allowNoJobs(), ActionListener.wrap(
+        jobConfigProvider.expandJobsIds(request.getJobId(), request.allowNoJobs(), true, ActionListener.wrap(
                 expandedIds -> {
                     request.setExpandedJobsIds(new ArrayList<>(expandedIds));
                     ActionListener<GetJobsStatsAction.Response> jobStatsListener = ActionListener.wrap(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -172,7 +172,7 @@ public class JobManager extends AbstractComponent {
     public void expandJobs(String expression, boolean allowNoJobs, ActionListener<QueryPage<Job>> jobsListener) {
         Map<String, Job> clusterStateJobs = expandJobsFromClusterState(expression, allowNoJobs, clusterService.state());
 
-        jobConfigProvider.expandJobs(expression, allowNoJobs, ActionListener.wrap(
+        jobConfigProvider.expandJobs(expression, allowNoJobs, false, ActionListener.wrap(
                 jobBuilders -> {
                     // Check for duplicate jobs
                     for (Job.Builder jb : jobBuilders) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportCloseJobActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportCloseJobActionTests.java
@@ -288,11 +288,11 @@ public class TransportCloseJobActionTests extends ESTestCase {
 
     private void mockJobConfigProviderExpandIds(Set<String> expandedIds) {
         doAnswer(invocation -> {
-            ActionListener<Set<String>> listener = (ActionListener<Set<String>>) invocation.getArguments()[2];
+            ActionListener<Set<String>> listener = (ActionListener<Set<String>>) invocation.getArguments()[3];
             listener.onResponse(expandedIds);
 
             return null;
-        }).when(jobConfigProvider).expandJobsIds(any(), anyBoolean(), any(ActionListener.class));
+        }).when(jobConfigProvider).expandJobsIds(any(), anyBoolean(), anyBoolean(), any(ActionListener.class));
     }
 
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsActionTests.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.action;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
-import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 
@@ -18,37 +17,27 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static org.elasticsearch.xpack.ml.action.TransportGetJobsStatsAction.determineNonDeletedJobIdsWithoutLiveStats;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.elasticsearch.xpack.ml.action.TransportGetJobsStatsAction.determineJobIdsWithoutLiveStats;
 
 public class TransportGetJobsStatsActionTests extends ESTestCase {
 
     public void testDetermineJobIds() {
 
-        MlMetadata mlMetadata = mock(MlMetadata.class);
-        when(mlMetadata.isJobDeleting(eq("id4"))).thenReturn(true);
-
-        List<String> result = determineNonDeletedJobIdsWithoutLiveStats(mlMetadata,
-                Collections.singletonList("id1"), Collections.emptyList());
+        List<String> result = determineJobIdsWithoutLiveStats(Collections.singletonList("id1"), Collections.emptyList());
         assertEquals(1, result.size());
         assertEquals("id1", result.get(0));
 
-        result = determineNonDeletedJobIdsWithoutLiveStats(mlMetadata,
-                Collections.singletonList("id1"), Collections.singletonList(
+        result = determineJobIdsWithoutLiveStats(Collections.singletonList("id1"), Collections.singletonList(
                 new GetJobsStatsAction.Response.JobStats("id1", new DataCounts("id1"), null, null, JobState.OPENED, null, null, null)));
         assertEquals(0, result.size());
 
-        result = determineNonDeletedJobIdsWithoutLiveStats(mlMetadata,
-                Arrays.asList("id1", "id2", "id3"), Collections.emptyList());
+        result = determineJobIdsWithoutLiveStats(Arrays.asList("id1", "id2", "id3"), Collections.emptyList());
         assertEquals(3, result.size());
         assertEquals("id1", result.get(0));
         assertEquals("id2", result.get(1));
         assertEquals("id3", result.get(2));
 
-        result = determineNonDeletedJobIdsWithoutLiveStats(mlMetadata,
-                Arrays.asList("id1", "id2", "id3"),
+        result = determineJobIdsWithoutLiveStats(Arrays.asList("id1", "id2", "id3"),
                 Collections.singletonList(new GetJobsStatsAction.Response.JobStats("id1", new DataCounts("id1"), null, null,
                         JobState.CLOSED, null, null, null))
         );
@@ -56,27 +45,18 @@ public class TransportGetJobsStatsActionTests extends ESTestCase {
         assertEquals("id2", result.get(0));
         assertEquals("id3", result.get(1));
 
-        result = determineNonDeletedJobIdsWithoutLiveStats(mlMetadata,
-                Arrays.asList("id1", "id2", "id3"), Arrays.asList(
+        result = determineJobIdsWithoutLiveStats(Arrays.asList("id1", "id2", "id3"), Arrays.asList(
                 new GetJobsStatsAction.Response.JobStats("id1", new DataCounts("id1"), null, null, JobState.OPENED, null, null, null),
                 new GetJobsStatsAction.Response.JobStats("id3", new DataCounts("id3"), null, null, JobState.OPENED, null, null, null)
         ));
         assertEquals(1, result.size());
         assertEquals("id2", result.get(0));
 
-        result = determineNonDeletedJobIdsWithoutLiveStats(mlMetadata, Arrays.asList("id1", "id2", "id3"), Arrays.asList(
+        result = determineJobIdsWithoutLiveStats(Arrays.asList("id1", "id2", "id3"), Arrays.asList(
                 new GetJobsStatsAction.Response.JobStats("id1", new DataCounts("id1"), null, null, JobState.OPENED, null, null, null),
                 new GetJobsStatsAction.Response.JobStats("id2", new DataCounts("id2"), null, null, JobState.OPENED, null, null, null),
                 new GetJobsStatsAction.Response.JobStats("id3", new DataCounts("id3"), null, null, JobState.OPENED, null, null, null)));
         assertEquals(0, result.size());
-
-        // No jobs running, but job 4 is being deleted
-        result = determineNonDeletedJobIdsWithoutLiveStats(mlMetadata,
-                Arrays.asList("id1", "id2", "id3", "id4"), Collections.emptyList());
-        assertEquals(3, result.size());
-        assertEquals("id1", result.get(0));
-        assertEquals("id2", result.get(1));
-        assertEquals("id3", result.get(2));
     }
 
     public void testDurationToTimeValue() {


### PR DESCRIPTION
For both actions the datafeed and Id expressions must be expanded from the index documents.

I added a new parameter `excludeDeleting` to `JobConfigProvider.expandJobs/expandJobsIds` to filter out deleting jobs which is now used when closing jobs and in get job stats. This matches the functionality of `TransportGetJobStatsAction.determineNonDeletedJobIdsWithoutLiveStats` as is it no longer possible to check if the job is deleting in that method. However, the timings are different as `expandJobIds(... excludeDeleting...)` is called at the start of the action.

If a job starts deleting after `expandJobIds(... excludeDeleting...)` and before the calls to gatherForecastStats and gatherDataCountsAndModelSizeStats it is still safe because if those documents are deleted the response accepts null for forecast stats and model size stats. Gather data counts returns a default constructed object if the document is not found. 

Compare with GET jobs with returns all jobs including deleting jobs.