### PR TITLE
Switch old reindex tests to use use JDK 8

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -119,7 +119,7 @@ class BuildPlugin implements Plugin<Project> {
             File gradleJavaHome = Jvm.current().javaHome
 
             final Map<Integer, String> javaVersions = [:]
-            for (int version = 7; version <= Integer.parseInt(minimumCompilerVersion.majorVersion); version++) {
+            for (int version = 8; version <= Integer.parseInt(minimumCompilerVersion.majorVersion); version++) {
                 if(System.getenv(getJavaHomeEnvVarName(version.toString())) != null) {
                     javaVersions.put(version, findJavaHome(version.toString()));
                 }

--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -116,7 +116,7 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
       dependsOn unzip
       executable = new File(project.runtimeJavaHome, 'bin/java')
       env 'CLASSPATH', "${ -> project.configurations.oldesFixture.asPath }"
-      env 'JAVA_HOME', getJavaHome(it, 7)
+      env 'JAVA_HOME', getJavaHome(it, 8)
       args 'oldes.OldElasticsearch',
            baseDir,
            unzip.temporaryDir,


### PR DESCRIPTION
This commit switches the old reindex tests to use JDK 8. This enables us to not require that JDK 7 be installed, easing the burden on developers.

Closes #34341