### PR TITLE
Improved IndexNotFoundException's default error message

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -196,7 +196,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             ElasticsearchException exception = expectThrows(ElasticsearchException.class,
                     () -> execute(getRequest, highLevelClient()::get, highLevelClient()::getAsync));
             assertEquals(RestStatus.NOT_FOUND, exception.status());
-            assertEquals("Elasticsearch exception [type=index_not_found_exception, reason=no such index]", exception.getMessage());
+            assertEquals("Elasticsearch exception [type=index_not_found_exception, reason=no such index [index]]", exception.getMessage());
             assertEquals("index", exception.getMetadata("es.index").get(0));
         }
         IndexRequest index = new IndexRequest("index", "type", "id");
@@ -283,7 +283,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             assertEquals("id1", response.getResponses()[0].getFailure().getId());
             assertEquals("type", response.getResponses()[0].getFailure().getType());
             assertEquals("index", response.getResponses()[0].getFailure().getIndex());
-            assertEquals("Elasticsearch exception [type=index_not_found_exception, reason=no such index]",
+            assertEquals("Elasticsearch exception [type=index_not_found_exception, reason=no such index [index]]",
                     response.getResponses()[0].getFailure().getFailure().getMessage());
 
             assertTrue(response.getResponses()[1].isFailed());
@@ -291,7 +291,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             assertEquals("id2", response.getResponses()[1].getId());
             assertEquals("type", response.getResponses()[1].getType());
             assertEquals("index", response.getResponses()[1].getIndex());
-            assertEquals("Elasticsearch exception [type=index_not_found_exception, reason=no such index]",
+            assertEquals("Elasticsearch exception [type=index_not_found_exception, reason=no such index [index]]",
                     response.getResponses()[1].getFailure().getFailure().getMessage());
         }
         BulkRequest bulk = new BulkRequest();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/GetAliasesResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/GetAliasesResponseTests.java
@@ -109,7 +109,7 @@ public class GetAliasesResponseTests extends AbstractXContentTestCase<GetAliases
                 "    \"root_cause\": [" +
                 "      {" +
                 "        \"type\": \"index_not_found_exception\"," +
-                "        \"reason\": \"no such index\"," +
+                "        \"reason\": \"no such index [index]\"," +
                 "        \"resource.type\": \"index_or_alias\"," +
                 "        \"resource.id\": \"index\"," +
                 "        \"index_uuid\": \"_na_\"," +
@@ -117,7 +117,7 @@ public class GetAliasesResponseTests extends AbstractXContentTestCase<GetAliases
                 "      }" +
                 "    ]," +
                 "    \"type\": \"index_not_found_exception\"," +
-                "    \"reason\": \"no such index\"," +
+                "    \"reason\": \"no such index [index]\"," +
                 "    \"resource.type\": \"index_or_alias\"," +
                 "    \"resource.id\": \"index\"," +
                 "    \"index_uuid\": \"_na_\"," +
@@ -131,7 +131,7 @@ public class GetAliasesResponseTests extends AbstractXContentTestCase<GetAliases
             assertThat(getAliasesResponse.getError(), nullValue());
             assertThat(getAliasesResponse.status(), equalTo(RestStatus.NOT_FOUND));
             assertThat(getAliasesResponse.getException().getMessage(),
-                    equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index]"));
+                    equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index [index]]"));
         }
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -573,7 +573,8 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         ElasticsearchException exception = expectThrows(ElasticsearchException.class, () -> execute(nonExistentIndexRequest,
                 highLevelClient().indices()::updateAliases, highLevelClient().indices()::updateAliasesAsync));
         assertThat(exception.status(), equalTo(RestStatus.NOT_FOUND));
-        assertThat(exception.getMessage(), equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index]"));
+        assertThat(exception.getMessage(),
+            equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index [non_existent_index]]"));
         assertThat(exception.getMetadata("es.index"), hasItem(nonExistentIndex));
 
         createIndex(index, Settings.EMPTY);
@@ -583,7 +584,8 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         exception = expectThrows(ElasticsearchStatusException.class,
                 () -> execute(mixedRequest, highLevelClient().indices()::updateAliases, highLevelClient().indices()::updateAliasesAsync));
         assertThat(exception.status(), equalTo(RestStatus.NOT_FOUND));
-        assertThat(exception.getMessage(), equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index]"));
+        assertThat(exception.getMessage(),
+            equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index [non_existent_index]]"));
         assertThat(exception.getMetadata("es.index"), hasItem(nonExistentIndex));
         assertThat(exception.getMetadata("es.index"), not(hasItem(index)));
         assertThat(aliasExists(index, alias), equalTo(false));
@@ -595,7 +597,8 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         exception = expectThrows(ElasticsearchException.class, () -> execute(removeIndexRequest, highLevelClient().indices()::updateAliases,
                 highLevelClient().indices()::updateAliasesAsync));
         assertThat(exception.status(), equalTo(RestStatus.NOT_FOUND));
-        assertThat(exception.getMessage(), equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index]"));
+        assertThat(exception.getMessage(),
+            equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index [non_existent_index]]"));
         assertThat(exception.getMetadata("es.index"), hasItem(nonExistentIndex));
         assertThat(exception.getMetadata("es.index"), not(hasItem(index)));
         assertThat(aliasExists(index, alias), equalTo(false));
@@ -1060,7 +1063,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
                     highLevelClient().indices()::getAliasAsync);
             assertThat(getAliasesResponse.status(), equalTo(RestStatus.NOT_FOUND));
             assertThat(getAliasesResponse.getException().getMessage(),
-                    equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index]"));
+                    equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index [index]]"));
         }
         {
             GetAliasesRequest getAliasesRequest = new GetAliasesRequest(alias);
@@ -1077,7 +1080,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
                     highLevelClient().indices()::getAliasAsync);
             assertThat(getAliasesResponse.status(), equalTo(RestStatus.NOT_FOUND));
             assertThat(getAliasesResponse.getException().getMessage(),
-                    equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index]"));
+                    equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index [non_existent_index]]"));
         }
         {
             GetAliasesRequest getAliasesRequest = new GetAliasesRequest().indices(index, "non_existent_index").aliases(alias);
@@ -1085,7 +1088,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
                     highLevelClient().indices()::getAliasAsync);
             assertThat(getAliasesResponse.status(), equalTo(RestStatus.NOT_FOUND));
             assertThat(getAliasesResponse.getException().getMessage(),
-                    equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index]"));
+                    equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index [non_existent_index]]"));
         }
         {
             GetAliasesRequest getAliasesRequest = new GetAliasesRequest().indices("non_existent_index*");
@@ -1199,7 +1202,8 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         ElasticsearchException exception = expectThrows(ElasticsearchException.class, () -> execute(indexUpdateSettingsRequest,
                 highLevelClient().indices()::putSettings, highLevelClient().indices()::putSettingsAsync));
         assertEquals(RestStatus.NOT_FOUND, exception.status());
-        assertThat(exception.getMessage(), equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index]"));
+        assertThat(exception.getMessage(),
+            equalTo("Elasticsearch exception [type=index_not_found_exception, reason=no such index [index]]"));
 
         createIndex(index, Settings.EMPTY);
         exception = expectThrows(ElasticsearchException.class, () -> execute(indexUpdateSettingsRequest,

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
@@ -1079,7 +1079,7 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
             assertThat(exception.status(), equalTo(RestStatus.NOT_FOUND));
             assertThat(exception.getIndex().getName(), equalTo("non_existent_index"));
             assertThat(exception.getDetailedMessage(),
-                containsString("Elasticsearch exception [type=index_not_found_exception, reason=no such index]"));
+                containsString("Elasticsearch exception [type=index_not_found_exception, reason=no such index [non_existent_index]]"));
         }
         {
             ExplainRequest explainRequest = new ExplainRequest("index1", "doc", "999");

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
@@ -1592,7 +1592,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             // TODO status is broken! fix in a followup
             // assertEquals(RestStatus.NOT_FOUND, ee.status());        // <4>
             assertThat(e.getMessage(),
-                containsString("reason=no such index"));               // <5>
+                containsString("reason=no such index [missing_index]"));               // <5>
             // end::multi-get-indexnotfound
 
             // tag::multi-get-execute-listener

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
@@ -169,7 +169,7 @@ public class MultiSearchTemplateIT extends ESIntegTestCase {
         MultiSearchTemplateResponse.Item response4 = response.getResponses()[3];
         assertThat(response4.isFailure(), is(true));
         assertThat(response4.getFailure(), instanceOf(IndexNotFoundException.class));
-        assertThat(response4.getFailure().getMessage(), equalTo("no such index"));
+        assertThat(response4.getFailure().getMessage(), equalTo("no such index [unknown]"));
 
         MultiSearchTemplateResponse.Item response5 = response.getResponses()[4];
         assertThat(response5.isFailure(), is(false));

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexFailureTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexFailureTests.java
@@ -120,7 +120,7 @@ public class ReindexFailureTests extends ReindexTestCase {
                 assertThat(e.getMessage(),
                         either(containsString("all shards failed"))
                         .or(containsString("No search context found"))
-                        .or(containsString("no such index"))
+                        .or(containsString("no such index [source]"))
                         );
                 return;
             }

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/25_no_auto_create.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/25_no_auto_create.yml
@@ -19,7 +19,7 @@ teardown:
           transient:
             action.auto_create_index: false
   - do:
-      catch: /no such index \[test\] and \[action.auto_create_index\] is \[false\]/
+      catch: /no such index \[dest\] and \[action.auto_create_index\] is \[false\]/
       reindex:
         body:
           source:
@@ -41,7 +41,7 @@ teardown:
         id:      1
         body:    { "text": "test" }
   - do:
-      catch: /no such index \[test\] and \[action.auto_create_index\] \(\[test\]\) doesn't match/
+      catch: /no such index \[dest\] and \[action.auto_create_index\] \(\[test\]\) doesn't match/
       reindex:
         body:
           source:

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/25_no_auto_create.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/25_no_auto_create.yml
@@ -19,7 +19,7 @@ teardown:
           transient:
             action.auto_create_index: false
   - do:
-      catch: /no such index and \[action.auto_create_index\] is \[false\]/
+      catch: /no such index \[test\] and \[action.auto_create_index\] is \[false\]/
       reindex:
         body:
           source:
@@ -41,7 +41,7 @@ teardown:
         id:      1
         body:    { "text": "test" }
   - do:
-      catch: /no such index and \[action.auto_create_index\] \(\[test\]\) doesn't match/
+      catch: /no such index \[test\] and \[action.auto_create_index\] \(\[test\]\) doesn't match/
       reindex:
         body:
           source:
@@ -63,7 +63,7 @@ teardown:
         id:      1
         body:    { "text": "test" }
   - do:
-      catch: /no such index and \[action.auto_create_index\] contains \[-dest\] which forbids automatic creation of the index/
+      catch: /no such index \[dest\] and \[action.auto_create_index\] contains \[-dest\] which forbids automatic creation of the index/
       reindex:
         body:
           source:

--- a/server/src/main/java/org/elasticsearch/action/support/AutoCreateIndex.java
+++ b/server/src/main/java/org/elasticsearch/action/support/AutoCreateIndex.java
@@ -73,10 +73,10 @@ public final class AutoCreateIndex {
         // One volatile read, so that all checks are done against the same instance:
         final AutoCreate autoCreate = this.autoCreate;
         if (autoCreate.autoCreateIndex == false) {
-            throw new IndexNotFoundException("no such index and [" + AUTO_CREATE_INDEX_SETTING.getKey() + "] is [false]", index);
+            throw new IndexNotFoundException("[" + AUTO_CREATE_INDEX_SETTING.getKey() + "] is [false]", index);
         }
         if (dynamicMappingDisabled) {
-            throw new IndexNotFoundException("no such index and [" + MapperService.INDEX_MAPPER_DYNAMIC_SETTING.getKey() + "] is [false]",
+            throw new IndexNotFoundException("[" + MapperService.INDEX_MAPPER_DYNAMIC_SETTING.getKey() + "] is [false]",
                     index);
         }
         // matches not set, default value of "true"
@@ -90,11 +90,11 @@ public final class AutoCreateIndex {
                 if (include) {
                     return true;
                 }
-                throw new IndexNotFoundException("no such index and [" + AUTO_CREATE_INDEX_SETTING.getKey() + "] contains [-"
+                throw new IndexNotFoundException("[" + AUTO_CREATE_INDEX_SETTING.getKey() + "] contains [-"
                         + indexExpression + "] which forbids automatic creation of the index", index);
             }
         }
-        throw new IndexNotFoundException("no such index and [" + AUTO_CREATE_INDEX_SETTING.getKey() + "] ([" + autoCreate
+        throw new IndexNotFoundException("[" + AUTO_CREATE_INDEX_SETTING.getKey() + "] ([" + autoCreate
                 + "]) doesn't match", index);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/IndexNotFoundException.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexNotFoundException.java
@@ -37,7 +37,7 @@ public final class IndexNotFoundException extends ResourceNotFoundException {
     }
 
     public IndexNotFoundException(String index, Throwable cause) {
-        super("no such index: [" + index + "]", cause);
+        super("no such index [" + index + "]", cause);
         setIndex(index);
     }
 
@@ -46,7 +46,7 @@ public final class IndexNotFoundException extends ResourceNotFoundException {
     }
 
     public IndexNotFoundException(Index index, Throwable cause) {
-        super("no such index: " + index.toString(), cause);
+        super("no such index " + index.toString(), cause);
         setIndex(index);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/IndexNotFoundException.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexNotFoundException.java
@@ -46,7 +46,7 @@ public final class IndexNotFoundException extends ResourceNotFoundException {
     }
 
     public IndexNotFoundException(Index index, Throwable cause) {
-        super("no such index " + index.toString(), cause);
+        super("no such index [" + index.getName() + "]", cause);
         setIndex(index);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/IndexNotFoundException.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexNotFoundException.java
@@ -37,7 +37,7 @@ public final class IndexNotFoundException extends ResourceNotFoundException {
     }
 
     public IndexNotFoundException(String index, Throwable cause) {
-        super("no such index", cause);
+        super("no such index: [" + index + "]", cause);
         setIndex(index);
     }
 
@@ -46,7 +46,7 @@ public final class IndexNotFoundException extends ResourceNotFoundException {
     }
 
     public IndexNotFoundException(Index index, Throwable cause) {
-        super("no such index", cause);
+        super("no such index: " + index.toString(), cause);
         setIndex(index);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/IndexNotFoundException.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexNotFoundException.java
@@ -28,7 +28,7 @@ public final class IndexNotFoundException extends ResourceNotFoundException {
      * Construct with a custom message.
      */
     public IndexNotFoundException(String message, String index) {
-        super(message);
+        super("no such index [" + index + "] and " + message);
         setIndex(index);
     }
 

--- a/server/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/server/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -114,7 +114,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
             ElasticsearchException[] rootCauses = exception.guessRootCauses();
             assertEquals(rootCauses.length, 1);
             assertEquals(ElasticsearchException.getExceptionName(rootCauses[0]), "index_not_found_exception");
-            assertEquals(rootCauses[0].getMessage(), "no such index");
+            assertEquals("no such index [foo]", rootCauses[0].getMessage());
             ShardSearchFailure failure = new ShardSearchFailure(new ParsingException(1, 2, "foobar", null),
                     new SearchShardTarget("node_1", new Index("foo", "_na_"), 1, null));
             ShardSearchFailure failure1 = new ShardSearchFailure(new ParsingException(1, 2, "foobar", null),

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexIT.java
@@ -73,7 +73,7 @@ public class GetIndexIT extends ESIntegTestCase {
             client().admin().indices().prepareGetIndex().addIndices("missing_idx").get();
             fail("Expected IndexNotFoundException");
         } catch (IndexNotFoundException e) {
-            assertThat(e.getMessage(), is("no such index"));
+            assertThat(e.getMessage(), is("no such index [missing_idx]"));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessorClusterSettingsIT.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessorClusterSettingsIT.java
@@ -45,7 +45,7 @@ public class BulkProcessorClusterSettingsIT extends ESIntegTestCase {
         assertEquals(3, responses.length);
         assertFalse("Operation on existing index should succeed", responses[0].isFailed());
         assertTrue("Missing index should have been flagged", responses[1].isFailed());
-        assertEquals("[wontwork] IndexNotFoundException[no such index]", responses[1].getFailureMessage());
+        assertEquals("[wontwork] IndexNotFoundException[no such index [wontwork]]", responses[1].getFailureMessage());
         assertFalse("Operation on existing index should succeed", responses[2].isFailed());
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/support/AutoCreateIndexTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/AutoCreateIndexTests.java
@@ -83,9 +83,10 @@ public class AutoCreateIndexTests extends ESTestCase {
     public void testAutoCreationDisabled() {
         Settings settings = Settings.builder().put(AutoCreateIndex.AUTO_CREATE_INDEX_SETTING.getKey(), false).build();
         AutoCreateIndex autoCreateIndex = newAutoCreateIndex(settings);
+        String randomIndex = randomAlphaOfLengthBetween(1, 10);
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () ->
-            autoCreateIndex.shouldAutoCreate(randomAlphaOfLengthBetween(1, 10), buildClusterState()));
-        assertEquals("no such index and [action.auto_create_index] is [false]", e.getMessage());
+            autoCreateIndex.shouldAutoCreate(randomIndex, buildClusterState()));
+        assertEquals("no such index [" + randomIndex + "] and [action.auto_create_index] is [false]", e.getMessage());
     }
 
     public void testAutoCreationEnabled() {
@@ -207,14 +208,15 @@ public class AutoCreateIndexTests extends ESTestCase {
     private void expectNotMatch(ClusterState clusterState, AutoCreateIndex autoCreateIndex, String index) {
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () ->
             autoCreateIndex.shouldAutoCreate(index, clusterState));
-        assertEquals("no such index and [action.auto_create_index] ([" + autoCreateIndex.getAutoCreate() + "]) doesn't match",
-                e.getMessage());
+        assertEquals(
+            "no such index [" + index + "] and [action.auto_create_index] ([" + autoCreateIndex.getAutoCreate() + "]) doesn't match",
+            e.getMessage());
     }
 
     private void expectForbidden(ClusterState clusterState, AutoCreateIndex autoCreateIndex, String index, String forbiddingPattern) {
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () ->
             autoCreateIndex.shouldAutoCreate(index, clusterState));
-        assertEquals("no such index and [action.auto_create_index] contains [" + forbiddingPattern
+        assertEquals("no such index [" + index + "] and [action.auto_create_index] contains [" + forbiddingPattern
                 + "] which forbids automatic creation of the index", e.getMessage());
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/termvectors/MultiTermVectorsIT.java
+++ b/server/src/test/java/org/elasticsearch/action/termvectors/MultiTermVectorsIT.java
@@ -76,7 +76,7 @@ public class MultiTermVectorsIT extends AbstractTermVectorsTestCase {
         MultiTermVectorsResponse response = mtvBuilder.execute().actionGet();
         assertThat(response.getResponses().length, equalTo(1));
         assertThat(response.getResponses()[0].getFailure().getCause(), instanceOf(IndexNotFoundException.class));
-        assertThat(response.getResponses()[0].getFailure().getCause().getMessage(), equalTo("no such index"));
+        assertThat(response.getResponses()[0].getFailure().getCause().getMessage(), equalTo("no such index [testX]"));
     }
 
     public void testMultiTermVectorsWithVersion() throws Exception {

--- a/server/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -271,7 +271,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
             client().admin().cluster().prepareState().clear().setMetaData(true).setIndices("a*").setIndicesOptions(allowNoIndices).get();
             fail("Expected IndexNotFoundException");
         } catch (IndexNotFoundException e) {
-            assertThat(e.getMessage(), is("no such index"));
+            assertThat(e.getMessage(), is("no such index [a*]"));
         }
     }
 
@@ -282,7 +282,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
             client().admin().cluster().prepareState().clear().setMetaData(true).setIndices("fzzbzz").setIndicesOptions(allowNoIndices).get();
             fail("Expected IndexNotFoundException");
         } catch (IndexNotFoundException e) {
-            assertThat(e.getMessage(), is("no such index"));
+            assertThat(e.getMessage(), is("no such index [fzzbzz]"));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -530,7 +530,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
 
         IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
                 () -> indexNameExpressionResolver.concreteIndexNames(context, "testZZZ"));
-        assertThat(infe.getMessage(), is("no such index"));
+        assertThat(infe.getMessage(), is("no such index [testZZZ]"));
     }
 
     public void testConcreteIndicesIgnoreIndicesOneMissingIndexOtherFound() {
@@ -552,7 +552,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
 
         IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
                 () -> indexNameExpressionResolver.concreteIndexNames(context, "testMo", "testMahdy"));
-        assertThat(infe.getMessage(), is("no such index"));
+        assertThat(infe.getMessage(), is("no such index [testMo]"));
     }
 
     public void testConcreteIndicesIgnoreIndicesEmptyRequest() {
@@ -1161,7 +1161,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
                     () -> indexNameExpressionResolver.concreteIndexNames(state, new DeleteIndexRequest("does_not_exist")));
             assertEquals("does_not_exist", infe.getIndex().getName());
-            assertEquals("no such index", infe.getMessage());
+            assertEquals("no such index [does_not_exist]", infe.getMessage());
         }
         {
             IllegalArgumentException iae = expectThrows(IllegalArgumentException.class,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexServiceTests.java
@@ -124,9 +124,9 @@ public class MetaDataCreateIndexServiceTests extends ESTestCase {
                 MetaDataCreateIndexService.validateShrinkIndex(state, "target", Collections.emptySet(), "source", Settings.EMPTY)
             ).getMessage());
 
-        assertEquals("no such index",
+        assertEquals("no such index [no_such_index]",
             expectThrows(IndexNotFoundException.class, () ->
-                MetaDataCreateIndexService.validateShrinkIndex(state, "no such index", Collections.emptySet(), "target", Settings.EMPTY)
+                MetaDataCreateIndexService.validateShrinkIndex(state, "no_such_index", Collections.emptySet(), "target", Settings.EMPTY)
             ).getMessage());
 
         Settings targetSettings = Settings.builder().put("index.number_of_shards", 1).build();
@@ -200,9 +200,9 @@ public class MetaDataCreateIndexServiceTests extends ESTestCase {
                 MetaDataCreateIndexService.validateSplitIndex(state, "target", Collections.emptySet(), "source", targetSettings)
             ).getMessage());
 
-        assertEquals("no such index",
+        assertEquals("no such index [no_such_index]",
             expectThrows(IndexNotFoundException.class, () ->
-                MetaDataCreateIndexService.validateSplitIndex(state, "no such index", Collections.emptySet(), "target", targetSettings)
+                MetaDataCreateIndexService.validateSplitIndex(state, "no_such_index", Collections.emptySet(), "target", targetSettings)
             ).getMessage());
 
         assertEquals("the number of source shards [10] must be less that the number of target shards [5]",

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
@@ -180,7 +180,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
             allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand("test2", 0, "node2")), false, false);
             fail("expected ShardNotFoundException when allocating non-existing index");
         } catch (IndexNotFoundException e) {
-            assertThat(e.getMessage(), containsString("no such index"));
+            assertThat(e.getMessage(), containsString("no such index [test2]"));
         }
 
         logger.info("--> allocating empty primary with acceptDataLoss flag set to false");

--- a/server/src/test/java/org/elasticsearch/indices/flush/SyncedFlushSingleNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/flush/SyncedFlushSingleNodeTests.java
@@ -156,7 +156,7 @@ public class SyncedFlushSingleNodeTests extends ESSingleNodeTestCase {
         listener.latch.await();
         assertNotNull(listener.error);
         assertNull(listener.result);
-        assertEquals("no such index", listener.error.getMessage());
+        assertEquals("no such index [index not found]", listener.error.getMessage());
     }
 
     public void testFailAfterIntermediateCommit() throws InterruptedException {

--- a/server/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
@@ -76,14 +76,14 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
         Client client = client();
         Exception e = expectThrows(IndexNotFoundException.class, () ->
             client.admin().indices().prepareClose("test1").execute().actionGet());
-        assertThat(e.getMessage(), is("no such index"));
+        assertThat(e.getMessage(), is("no such index [test1]"));
     }
 
     public void testSimpleOpenMissingIndex() {
         Client client = client();
         Exception e = expectThrows(IndexNotFoundException.class, () ->
             client.admin().indices().prepareOpen("test1").execute().actionGet());
-        assertThat(e.getMessage(), is("no such index"));
+        assertThat(e.getMessage(), is("no such index [test1]"));
     }
 
     public void testCloseOneMissingIndex() {
@@ -93,7 +93,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         Exception e = expectThrows(IndexNotFoundException.class, () ->
             client.admin().indices().prepareClose("test1", "test2").execute().actionGet());
-        assertThat(e.getMessage(), is("no such index"));
+        assertThat(e.getMessage(), is("no such index [test2]"));
     }
 
     public void testCloseOneMissingIndexIgnoreMissing() {
@@ -114,7 +114,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         Exception e = expectThrows(IndexNotFoundException.class, () ->
             client.admin().indices().prepareOpen("test1", "test2").execute().actionGet());
-        assertThat(e.getMessage(), is("no such index"));
+        assertThat(e.getMessage(), is("no such index [test2]"));
     }
 
     public void testOpenOneMissingIndexIgnoreMissing() {

--- a/server/src/test/java/org/elasticsearch/mget/SimpleMgetIT.java
+++ b/server/src/test/java/org/elasticsearch/mget/SimpleMgetIT.java
@@ -62,7 +62,7 @@ public class SimpleMgetIT extends ESIntegTestCase {
 
         assertThat(mgetResponse.getResponses()[1].getIndex(), is("nonExistingIndex"));
         assertThat(mgetResponse.getResponses()[1].isFailed(), is(true));
-        assertThat(mgetResponse.getResponses()[1].getFailure().getMessage(), is("no such index"));
+        assertThat(mgetResponse.getResponses()[1].getFailure().getMessage(), is("no such index [nonExistingIndex]"));
         assertThat(((ElasticsearchException) mgetResponse.getResponses()[1].getFailure().getFailure()).getIndex().getName(),
             is("nonExistingIndex"));
 
@@ -72,7 +72,7 @@ public class SimpleMgetIT extends ESIntegTestCase {
         assertThat(mgetResponse.getResponses().length, is(1));
         assertThat(mgetResponse.getResponses()[0].getIndex(), is("nonExistingIndex"));
         assertThat(mgetResponse.getResponses()[0].isFailed(), is(true));
-        assertThat(mgetResponse.getResponses()[0].getFailure().getMessage(), is("no such index"));
+        assertThat(mgetResponse.getResponses()[0].getFailure().getMessage(), is("no such index [nonExistingIndex]"));
         assertThat(((ElasticsearchException) mgetResponse.getResponses()[0].getFailure().getFailure()).getIndex().getName(),
             is("nonExistingIndex"));
     }

--- a/server/src/test/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
+++ b/server/src/test/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
@@ -151,7 +151,7 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
             client().admin().indices().prepareValidateQuery().get();
             fail("Expected IndexNotFoundException");
         } catch (IndexNotFoundException e) {
-            assertThat(e.getMessage(), is("no such index"));
+            assertThat(e.getMessage(), is("no such index [null]"));
         }
     }
 

--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexIT.java
@@ -71,11 +71,11 @@ public class FollowIndexIT extends ESCCRRestTestCase {
     public void testFollowNonExistingLeaderIndex() throws Exception {
         assumeFalse("Test should only run when both clusters are running", "leader".equals(targetCluster));
         ResponseException e = expectThrows(ResponseException.class, () -> resumeFollow("non-existing-index"));
-        assertThat(e.getMessage(), containsString("no such index"));
+        assertThat(e.getMessage(), containsString("no such index [non-existing-index]"));
         assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(404));
 
         e = expectThrows(ResponseException.class, () -> followIndex("non-existing-index", "non-existing-index"));
-        assertThat(e.getMessage(), containsString("no such index"));
+        assertThat(e.getMessage(), containsString("no such index [non-existing-index]"));
         assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(404));
     }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
@@ -522,7 +522,7 @@ public class IndexFollowingIT extends CcrIntegTestCase {
             assertThat(response.getStatsResponses().get(0).status().numberOfFailedFetches(), greaterThanOrEqualTo(1L));
             ElasticsearchException fatalException = response.getStatsResponses().get(0).status().getFatalException();
             assertThat(fatalException, notNullValue());
-            assertThat(fatalException.getRootCause().getMessage(), equalTo("no such index"));
+            assertThat(fatalException.getRootCause().getMessage(), equalTo("no such index [index1]"));
         });
         pauseFollow("index2");
         ensureNoCcrTasks();
@@ -552,7 +552,7 @@ public class IndexFollowingIT extends CcrIntegTestCase {
             assertThat(response.getStatsResponses().get(0).status().numberOfFailedBulkOperations(), greaterThanOrEqualTo(1L));
             ElasticsearchException fatalException = response.getStatsResponses().get(0).status().getFatalException();
             assertThat(fatalException, notNullValue());
-            assertThat(fatalException.getMessage(), equalTo("no such index"));
+            assertThat(fatalException.getMessage(), equalTo("no such index [index2]"));
         });
         pauseFollow("index2");
         ensureNoCcrTasks();

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupResponseTranslationTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupResponseTranslationTests.java
@@ -231,7 +231,7 @@ public class RollupResponseTranslationTests extends AggregatorTestCase {
         MultiSearchResponse.Item missing = new MultiSearchResponse.Item(null, new IndexNotFoundException("foo"));
         Exception e = expectThrows(RuntimeException.class,
                 () -> RollupResponseTranslator.verifyResponse(missing));
-        assertThat(e.getMessage(), equalTo("no such index"));
+        assertThat(e.getMessage(), equalTo("no such index [foo]"));
     }
 
     public void testTranslateRollup() {
@@ -287,7 +287,7 @@ public class RollupResponseTranslationTests extends AggregatorTestCase {
 
         Exception e = expectThrows(RuntimeException.class,
                 () -> RollupResponseTranslator.translateResponse(new MultiSearchResponse.Item[]{missing}, context));
-        assertThat(e.getMessage(), equalTo("no such index"));
+        assertThat(e.getMessage(), equalTo("no such index [foo]"));
     }
 
     public void testMissingFilter() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndexAliasesTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndexAliasesTests.java
@@ -509,7 +509,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         //security plugin lets it through, but es core intercepts it due to strict indices options and throws index not found
         IndexNotFoundException indexNotFoundException = expectThrows(IndexNotFoundException.class, client.admin().indices()
                 .prepareGetAliases("alias_1").addIndices("test_1").setIndicesOptions(IndicesOptions.strictExpandOpen())::get);
-        assertEquals("no such index", indexNotFoundException.getMessage());
+        assertEquals("no such index [test_1]", indexNotFoundException.getMessage());
 
         //fails: no manage_aliases privilege on non_authorized alias
         assertThrowsAuthorizationException(client.admin().indices().prepareGetAliases("non_authorized").addIndices("test_1")

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -68,6 +68,9 @@ import org.elasticsearch.xpack.security.authz.IndicesAndAliasesResolver.Resolved
 import org.elasticsearch.xpack.security.authz.store.CompositeRolesStore;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 import org.elasticsearch.xpack.security.test.SecurityTestUtils;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
 import org.junit.Before;
 
 import java.util.Arrays;
@@ -469,7 +472,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()));
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)));
-        assertEquals("no such index", e.getMessage());
+        assertEquals("no such index [missing*]", e.getMessage());
     }
 
     public void testResolveExplicitIndicesStrict() {
@@ -506,7 +509,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()));
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(userNoIndices, SearchAction.NAME)));
-        assertEquals("no such index", e.getMessage());
+        assertEquals("no such index [[]]", e.getMessage());
     }
 
     public void testResolveMissingIndexStrict() {
@@ -848,7 +851,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.aliases("alias2");
         IndexNotFoundException exception = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(user, GetAliasesAction.NAME)).getLocal());
-        assertEquals("no such index", exception.getMessage());
+        assertEquals("no such index [[missing]]", exception.getMessage());
     }
 
     public void testGetAliasesRequestMissingIndexIgnoreUnavailableAllowNoIndices() {
@@ -928,7 +931,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indices("non_matching_*");
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(user, GetAliasesAction.NAME)).getLocal());
-        assertEquals("no such index", e.getMessage());
+        assertEquals("no such index [non_matching_*]", e.getMessage());
     }
 
     public void testWildcardsGetAliasesRequestNoMatchingIndicesAllowNoIndices() {
@@ -995,7 +998,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indices("_all");
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(userNoIndices, GetAliasesAction.NAME)));
-        assertEquals("no such index", e.getMessage());
+        assertEquals("no such index [[_all]]", e.getMessage());
     }
 
     public void testWildcardsGetAliasesRequestNoAuthorizedIndicesAllowNoIndices() {
@@ -1015,7 +1018,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         //current user is not authorized for any index, foo* resolves to no indices, the request fails
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(userNoIndices, GetAliasesAction.NAME)));
-        assertEquals("no such index", e.getMessage());
+        assertEquals("no such index [foo*]", e.getMessage());
     }
 
     public void testResolveAllAliasesGetAliasesRequest() {
@@ -1149,7 +1152,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         );
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(tuple.v1(), buildAuthorizedIndices(user, tuple.v2())).getLocal());
-        assertEquals("no such index", e.getMessage());
+        assertEquals("no such index [[remote:foo]]", e.getMessage());
     }
 
     public void testNonRemotableRequestDoesNotAllowRemoteWildcardIndices() {
@@ -1267,15 +1270,17 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(true, false, randomBoolean(), randomBoolean()));
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)));
-        assertEquals("no such index" , e.getMessage());
+        assertEquals("no such index [[<datetime-{now/M}>]]" , e.getMessage());
     }
 
     public void testUnauthorizedDateMathExpressionStrict() {
+        String expectedIndex = "datetime-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(
+            new DateTime(DateTimeZone.UTC).monthOfYear().roundFloorCopy());
         SearchRequest request = new SearchRequest("<datetime-{now/M}>");
         request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)));
-        assertEquals("no such index" , e.getMessage());
+        assertEquals("no such index [" + expectedIndex + "]" , e.getMessage());
     }
 
     public void testResolveDateMathExpression() {
@@ -1307,15 +1312,17 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(true, false, randomBoolean(), randomBoolean()));
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)));
-        assertEquals("no such index" , e.getMessage());
+        assertEquals("no such index [[<foobar-{now/M}>]]" , e.getMessage());
     }
 
     public void testMissingDateMathExpressionStrict() {
+        String expectedIndex = "foobar-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(
+            new DateTime(DateTimeZone.UTC).monthOfYear().roundFloorCopy());
         SearchRequest request = new SearchRequest("<foobar-{now/M}>");
         request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)));
-        assertEquals("no such index" , e.getMessage());
+        assertEquals("no such index [" + expectedIndex + "]" , e.getMessage());
     }
 
     public void testAliasDateMathExpressionNotSupported() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/ReadActionsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/ReadActionsTests.java
@@ -73,7 +73,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
         createIndicesWithRandomAliases("test1", "test2", "index1", "index2");
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> client().prepareSearch("index*")
                 .setIndicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean())).get());
-        assertEquals("no such index", e.getMessage());
+        assertEquals("no such index [index*]", e.getMessage());
     }
 
     public void testEmptyClusterSearchForAll() {
@@ -83,7 +83,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
     public void testEmptyClusterSearchForAllDisallowNoIndices() {
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> client().prepareSearch()
                 .setIndicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean())).get());
-        assertEquals("no such index", e.getMessage());
+        assertEquals("no such index [[]]", e.getMessage());
     }
 
     public void testEmptyClusterSearchForWildcard() {
@@ -94,7 +94,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
     public void testEmptyClusterSearchForWildcardDisallowNoIndices() {
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> client().prepareSearch("*")
                 .setIndicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean())).get());
-        assertEquals("no such index", e.getMessage());
+        assertEquals("no such index [*]", e.getMessage());
     }
 
     public void testEmptyAuthorizedIndicesSearchForAll() {
@@ -106,7 +106,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
         createIndicesWithRandomAliases("index1", "index2");
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> client().prepareSearch()
                 .setIndicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean())).get());
-        assertEquals("no such index", e.getMessage());
+        assertEquals("no such index [[]]", e.getMessage());
     }
 
     public void testEmptyAuthorizedIndicesSearchForWildcard() {
@@ -118,7 +118,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
         createIndicesWithRandomAliases("index1", "index2");
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> client().prepareSearch("*")
                 .setIndicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean())).get());
-        assertEquals("no such index", e.getMessage());
+        assertEquals("no such index [*]", e.getMessage());
     }
 
     public void testExplicitNonAuthorizedIndex() {
@@ -277,7 +277,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
             assertReturnedIndices(multiSearchResponse.getResponses()[0].getResponse(), "test1", "test2", "test3");
             assertTrue(multiSearchResponse.getResponses()[1].isFailure());
             assertThat(multiSearchResponse.getResponses()[1].getFailure().toString(),
-                    equalTo("[test4] IndexNotFoundException[no such index]"));
+                    equalTo("[test4] IndexNotFoundException[no such index [test4]]"));
         }
         {
             //we set ignore_unavailable and allow_no_indices to true, no errors returned, second item doesn't have hits.

--- a/x-pack/qa/reindex-tests-with-security/src/test/java/org/elasticsearch/xpack/security/ReindexWithSecurityIT.java
+++ b/x-pack/qa/reindex-tests-with-security/src/test/java/org/elasticsearch/xpack/security/ReindexWithSecurityIT.java
@@ -60,7 +60,7 @@ public class ReindexWithSecurityIT extends SecurityIntegTestCase {
                         .source("test1", "index1")
                         .filter(QueryBuilders.matchAllQuery())
                         .get());
-        assertEquals("no such index", e.getMessage());
+        assertEquals("no such index [index1]", e.getMessage());
     }
 
     public void testUpdateByQuery() {
@@ -75,7 +75,7 @@ public class ReindexWithSecurityIT extends SecurityIntegTestCase {
 
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> new UpdateByQueryRequestBuilder(client(), UpdateByQueryAction.INSTANCE).source("test1", "index1").get());
-        assertEquals("no such index", e.getMessage());
+        assertEquals("no such index [index1]", e.getMessage());
     }
 
     public void testReindex() {
@@ -90,6 +90,6 @@ public class ReindexWithSecurityIT extends SecurityIntegTestCase {
 
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> new ReindexRequestBuilder(client(), ReindexAction.INSTANCE).source("test1", "index1").destination("dest").get());
-        assertEquals("no such index", e.getMessage());
+        assertEquals("no such index [index1]", e.getMessage());
     }
 }


### PR DESCRIPTION
The message is improved by including the missing index name. Fixes #34628.
