### PR TITLE
Fix inner_hits retrieval when stored fields are disabled

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -288,6 +288,7 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
                 context.getMapperService().types().size() > 1) {
 
             // for multi types indices we need to retrieve the _uid to extract the type of the document
+            // so it is not allowed to disable stored fields
             throw new IllegalArgumentException("It is not allowed to disable stored fields [_none_] inside [inner_hits] on an index with" +
                 "multiple types.");
         }

--- a/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -282,6 +282,15 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
         if (!nestedObjectMapper.nested().isNested()) {
             throw new IllegalStateException("[" + NAME + "] nested object under path [" + path + "] is not of nested type");
         }
+        if (innerHitBuilder != null &&
+            innerHitBuilder.getStoredFieldsContext() != null &&
+            innerHitBuilder.getStoredFieldsContext().fetchFields() == false &&
+                context.getMapperService().types().size() > 1) {
+
+            // for multi types indices we need to retrieve the _uid to extract the type of the document
+            throw new IllegalArgumentException("It is not allowed to disable stored fields [_none_] inside [inner_hits] on an index with" +
+                "multiple types.");
+        }
         final BitSetProducer parentFilter;
         Query innerQuery;
         ObjectMapper objectMapper = context.nestedScope().getObjectMapper();

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -281,6 +281,9 @@ public class FetchPhase implements SearchPhase {
         if (uid != null && uid.type() != null) {
             typeText = uid.type();
         } else {
+            // stored fields are disabled but it is not allowed to disable them on inner hits
+            // if the index has multiple types so we can assume that the index has a single type.
+            assert context.mapperService().types().size() == 1;
             typeText = context.mapperService().types().iterator().next();
         }
         DocumentMapper documentMapper = context.mapperService().documentMapper(typeText);

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -277,7 +277,13 @@ public class FetchPhase implements SearchPhase {
                 storedToRequestedFields, subReaderContext);
         }
 
-        DocumentMapper documentMapper = context.mapperService().documentMapper(uid.type());
+        final String typeText;
+        if (uid != null && uid.type() != null) {
+            typeText = uid.type();
+        } else {
+            typeText = context.mapperService().types().iterator().next();
+        }
+        DocumentMapper documentMapper = context.mapperService().documentMapper(typeText);
         SourceLookup sourceLookup = context.lookup().source();
         sourceLookup.setSegmentAndDocument(subReaderContext, nestedSubDocId);
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
@@ -1052,7 +1052,7 @@ public class TopHitsIT extends ESIntegTestCase {
             for (SearchHit hit : hits) {
                 assertThat(hit.getSourceAsMap(), nullValue());
                 assertThat(hit.getId(), nullValue());
-                assertThat(hit.getType(), nullValue());
+                assertThat(hit.getType(), equalTo(null));
             }
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -37,7 +37,6 @@ import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.index.Index;

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.index.Index;


### PR DESCRIPTION
This is the backport of #33018, a change was needed to handle indices with multiple types.
This change throws an error if stored fields are disabled on `inner_hits` for an index with multiple types

Closes #32941
