### PR TITLE
Rollup: Skip cleanup if nodes too old

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -25,6 +25,7 @@ import org.apache.http.message.BasicHeader;
 import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.http.util.EntityUtils;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksAction;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
@@ -69,6 +70,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.sort;
@@ -103,22 +105,10 @@ public abstract class ESRestTestCase extends ESTestCase {
      * Does any node in the cluster being tested have x-pack installed?
      */
     public static boolean hasXPack() throws IOException {
-        RestClient client = adminClient();
-        if (client == null) {
+        if (hasXPack == null) {
             throw new IllegalStateException("must be called inside of a rest test case test");
         }
-        Map<?, ?> response = entityAsMap(client.performRequest(new Request("GET", "_nodes/plugins")));
-        Map<?, ?> nodes = (Map<?, ?>) response.get("nodes");
-        for (Map.Entry<?, ?> node : nodes.entrySet()) {
-            Map<?, ?> nodeInfo = (Map<?, ?>) node.getValue();
-            for (Object module: (List<?>) nodeInfo.get("modules")) {
-                Map<?, ?> moduleInfo = (Map<?, ?>) module;
-                if (moduleInfo.get("name").toString().startsWith("x-pack-")) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return hasXPack;
     }
 
     private static List<HttpHost> clusterHosts;
@@ -131,12 +121,16 @@ public abstract class ESRestTestCase extends ESTestCase {
      * completes
      */
     private static RestClient adminClient;
+    private static Boolean hasXPack;
+    private static TreeSet<Version> nodeVersions;
 
     @Before
     public void initClient() throws IOException {
         if (client == null) {
             assert adminClient == null;
             assert clusterHosts == null;
+            assert hasXPack == null;
+            assert nodeVersions == null;
             String cluster = System.getProperty("tests.rest.cluster");
             if (cluster == null) {
                 throw new RuntimeException("Must specify [tests.rest.cluster] system property with a comma delimited list of [host:port] "
@@ -157,10 +151,27 @@ public abstract class ESRestTestCase extends ESTestCase {
             logger.info("initializing REST clients against {}", clusterHosts);
             client = buildClient(restClientSettings(), clusterHosts.toArray(new HttpHost[clusterHosts.size()]));
             adminClient = buildClient(restAdminSettings(), clusterHosts.toArray(new HttpHost[clusterHosts.size()]));
+
+            hasXPack = false;
+            nodeVersions = new TreeSet<>();
+            Map<?, ?> response = entityAsMap(adminClient.performRequest(new Request("GET", "_nodes/plugins")));
+            Map<?, ?> nodes = (Map<?, ?>) response.get("nodes");
+            for (Map.Entry<?, ?> node : nodes.entrySet()) {
+                Map<?, ?> nodeInfo = (Map<?, ?>) node.getValue();
+                nodeVersions.add(Version.fromString(nodeInfo.get("version").toString()));
+                for (Object module: (List<?>) nodeInfo.get("modules")) {
+                    Map<?, ?> moduleInfo = (Map<?, ?>) module;
+                    if (moduleInfo.get("name").toString().startsWith("x-pack-")) {
+                        hasXPack = true;
+                    }
+                }
+            }
         }
         assert client != null;
         assert adminClient != null;
         assert clusterHosts != null;
+        assert hasXPack != null;
+        assert nodeVersions != null;
     }
 
     /**
@@ -190,6 +201,8 @@ public abstract class ESRestTestCase extends ESTestCase {
             clusterHosts = null;
             client = null;
             adminClient = null;
+            hasXPack = null;
+            nodeVersions = null;
         }
     }
 
@@ -276,8 +289,6 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     private void wipeCluster() throws Exception {
-        boolean hasXPack = hasXPack();
-
         if (preserveIndicesUponCompletion() == false) {
             // wipe indices
             try {
@@ -325,18 +336,13 @@ public abstract class ESRestTestCase extends ESTestCase {
             wipeClusterSettings();
         }
 
-        if (hasXPack && false == preserveRollupJobsUponCompletion()) {
-            try {
-                wipeRollupJobs();
-            } catch (ResponseException e) {
-                // Temporary work around for mixed clusters, some of which don't have rollup
-                if (    // The request was made to node without rollup
-                        e.getResponse().getStatusLine().getStatusCode() != 400
-                        // or the request was made to a node with rollup and it sent something to a node without it
-                        && false == e.getMessage().contains("No handler for action [cluster:monitor/xpack/rollup/get]")) {
-                    throw e;
-                }
-            }
+        /*
+         * Rollups were introduced in 6.3.0 so any cluster that contains older
+         * nodes won't be able to do *anything* with rollups, including cleanup.
+         */
+        if (hasXPack && nodeVersions.first().onOrAfter(Version.V_6_3_0)
+                && false == preserveRollupJobsUponCompletion()) {
+            wipeRollupJobs();
             waitForPendingRollupTasks();
         }
     }


### PR DESCRIPTION
Skips the rollup cleanup at the end of every test if some of the nodes
in the test cluster have a version before rollup was released.

As a side effect of doing this, I move the "is x-pack installed" test
from on-demand to before the first test. This should result in less
requests in general and it makes is a little simpler to store the node
versions and whether or not any node has x-pack installed.

I expect other cleanup code will be able to use this version checking
infrastructure. In addition, I think the yml tests could also reuse it.
They have some fairly complex logic to look up the versions of nodes but
I don't believe it is required. Both of those will have to wait for a
follow up change.

Closes #34629
