### PR TITLE
Make sure to use the type _doc in the REST documentation.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -48,21 +48,21 @@ h3. Indexing
 Let's try and index some twitter like information. First, let's index some tweets (the @twitter@ index will be created automatically):
 
 <pre>
-curl -XPUT 'http://localhost:9200/twitter/doc/1?pretty' -H 'Content-Type: application/json' -d '
+curl -XPUT 'http://localhost:9200/twitter/_doc/1?pretty' -H 'Content-Type: application/json' -d '
 {
     "user": "kimchy",
     "post_date": "2009-11-15T13:12:00",
     "message": "Trying out Elasticsearch, so far so good?"
 }'
 
-curl -XPUT 'http://localhost:9200/twitter/doc/2?pretty' -H 'Content-Type: application/json' -d '
+curl -XPUT 'http://localhost:9200/twitter/_doc/2?pretty' -H 'Content-Type: application/json' -d '
 {
     "user": "kimchy",
     "post_date": "2009-11-15T14:12:12",
     "message": "Another tweet, will it be indexed?"
 }'
 
-curl -XPUT 'http://localhost:9200/twitter/doc/3?pretty' -H 'Content-Type: application/json' -d '
+curl -XPUT 'http://localhost:9200/twitter/_doc/3?pretty' -H 'Content-Type: application/json' -d '
 {
     "user": "elastic",
     "post_date": "2010-01-15T01:46:38",
@@ -73,9 +73,9 @@ curl -XPUT 'http://localhost:9200/twitter/doc/3?pretty' -H 'Content-Type: applic
 Now, let's see if the information was added by GETting it:
 
 <pre>
-curl -XGET 'http://localhost:9200/twitter/doc/1?pretty=true'
-curl -XGET 'http://localhost:9200/twitter/doc/2?pretty=true'
-curl -XGET 'http://localhost:9200/twitter/doc/3?pretty=true'
+curl -XGET 'http://localhost:9200/twitter/_doc/1?pretty=true'
+curl -XGET 'http://localhost:9200/twitter/_doc/2?pretty=true'
+curl -XGET 'http://localhost:9200/twitter/_doc/3?pretty=true'
 </pre>
 
 h3. Searching
@@ -133,14 +133,14 @@ Elasticsearch supports multiple indices. In the previous example we used an inde
 Another way to define our simple twitter system is to have a different index per user (note, though that each index has an overhead). Here is the indexing curl's in this case:
 
 <pre>
-curl -XPUT 'http://localhost:9200/kimchy/doc/1?pretty' -H 'Content-Type: application/json' -d '
+curl -XPUT 'http://localhost:9200/kimchy/_doc/1?pretty' -H 'Content-Type: application/json' -d '
 {
     "user": "kimchy",
     "post_date": "2009-11-15T13:12:00",
     "message": "Trying out Elasticsearch, so far so good?"
 }'
 
-curl -XPUT 'http://localhost:9200/kimchy/doc/2?pretty' -H 'Content-Type: application/json' -d '
+curl -XPUT 'http://localhost:9200/kimchy/_doc/2?pretty' -H 'Content-Type: application/json' -d '
 {
     "user": "kimchy",
     "post_date": "2009-11-15T14:12:12",

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -317,9 +317,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                 message.put("type", "text");
                 Map<String, Object> properties = new HashMap<>();
                 properties.put("message", message);
-                Map<String, Object> _doc = new HashMap<>();
-                _doc.put("properties", properties);
-                jsonMap.put("_doc", _doc);
+                Map<String, Object> mapping = new HashMap<>();
+                mapping.put("properties", properties);
+                jsonMap.put("_doc", mapping);
                 request.mapping("_doc", jsonMap); // <1>
                 //end::create-index-mappings-map
                 CreateIndexResponse createIndexResponse = client.indices().create(request, RequestOptions.DEFAULT);
@@ -623,7 +623,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             // tag::get-mapping-response
             ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> allMappings = getMappingResponse.mappings(); // <1>
             MappingMetaData typeMapping = allMappings.get("twitter").get("_doc"); // <2>
-            Map<String, Object> _docMapping = typeMapping.sourceAsMap(); // <3>
+            Map<String, Object> mapping = typeMapping.sourceAsMap(); // <3>
             // end::get-mapping-response
 
             Map<String, String> type = new HashMap<>();
@@ -632,7 +632,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             field.put("message", type);
             Map<String, Object> expected = new HashMap<>();
             expected.put("properties", field);
-            assertThat(_docMapping, equalTo(expected));
+            assertThat(mapping, equalTo(expected));
         }
     }
 
@@ -683,7 +683,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             listener = ActionListener.wrap(r -> {
                 ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> allMappings = r.mappings();
                 MappingMetaData typeMapping = allMappings.get("twitter").get("_doc");
-                Map<String, Object> _docMapping = typeMapping.sourceAsMap();
+                Map<String, Object> mapping = typeMapping.sourceAsMap();
 
                 Map<String, String> type = new HashMap<>();
                 type.put("type", "text");
@@ -691,7 +691,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                 field.put("message", type);
                 Map<String, Object> expected = new HashMap<>();
                 expected.put("properties", field);
-                assertThat(_docMapping, equalTo(expected));
+                assertThat(mapping, equalTo(expected));
                 latchListener.onResponse(r);
             }, e -> {
                 latchListener.onFailure(e);
@@ -2135,9 +2135,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             message.put("type", "text");
             Map<String, Object> properties = new HashMap<>();
             properties.put("message", message);
-            Map<String, Object> _doc = new HashMap<>();
-            _doc.put("properties", properties);
-            jsonMap.put("_doc", _doc);
+            Map<String, Object> mapping = new HashMap<>();
+            mapping.put("properties", properties);
+            jsonMap.put("_doc", mapping);
             request.mapping("_doc", jsonMap); // <1>
             //end::put-template-request-mappings-map
             assertTrue(client.indices().putTemplate(request, RequestOptions.DEFAULT).isAcknowledged());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -293,9 +293,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
 
             {
                 // tag::create-index-request-mappings
-                request.mapping("tweet", // <1>
+                request.mapping("_doc", // <1>
                         "{\n" +
-                        "  \"tweet\": {\n" +
+                        "  \"_doc\": {\n" +
                         "    \"properties\": {\n" +
                         "      \"message\": {\n" +
                         "        \"type\": \"text\"\n" +
@@ -317,10 +317,10 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                 message.put("type", "text");
                 Map<String, Object> properties = new HashMap<>();
                 properties.put("message", message);
-                Map<String, Object> tweet = new HashMap<>();
-                tweet.put("properties", properties);
-                jsonMap.put("tweet", tweet);
-                request.mapping("tweet", jsonMap); // <1>
+                Map<String, Object> _doc = new HashMap<>();
+                _doc.put("properties", properties);
+                jsonMap.put("_doc", _doc);
+                request.mapping("_doc", jsonMap); // <1>
                 //end::create-index-mappings-map
                 CreateIndexResponse createIndexResponse = client.indices().create(request, RequestOptions.DEFAULT);
                 assertTrue(createIndexResponse.isAcknowledged());
@@ -331,7 +331,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                 XContentBuilder builder = XContentFactory.jsonBuilder();
                 builder.startObject();
                 {
-                    builder.startObject("tweet");
+                    builder.startObject("_doc");
                     {
                         builder.startObject("properties");
                         {
@@ -346,7 +346,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                     builder.endObject();
                 }
                 builder.endObject();
-                request.mapping("tweet", builder); // <1>
+                request.mapping("_doc", builder); // <1>
                 //end::create-index-mappings-xcontent
                 CreateIndexResponse createIndexResponse = client.indices().create(request, RequestOptions.DEFAULT);
                 assertTrue(createIndexResponse.isAcknowledged());
@@ -354,7 +354,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             {
                 request = new CreateIndexRequest("twitter4");
                 //tag::create-index-mappings-shortcut
-                request.mapping("tweet", "message", "type=text"); // <1>
+                request.mapping("_doc", "message", "type=text"); // <1>
                 //end::create-index-mappings-shortcut
                 CreateIndexResponse createIndexResponse = client.indices().create(request, RequestOptions.DEFAULT);
                 assertTrue(createIndexResponse.isAcknowledged());
@@ -390,7 +390,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                     "        \"number_of_replicas\" : 0\n" +
                     "    },\n" +
                     "    \"mappings\" : {\n" +
-                    "        \"tweet\" : {\n" +
+                    "        \"_doc\" : {\n" +
                     "            \"properties\" : {\n" +
                     "                \"message\" : { \"type\" : \"text\" }\n" +
                     "            }\n" +
@@ -460,7 +460,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         {
             // tag::put-mapping-request
             PutMappingRequest request = new PutMappingRequest("twitter"); // <1>
-            request.type("tweet"); // <2>
+            request.type("_doc"); // <2>
             // end::put-mapping-request
 
             {
@@ -550,7 +550,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         }
 
         {
-            PutMappingRequest request = new PutMappingRequest("twitter").type("tweet");
+            PutMappingRequest request = new PutMappingRequest("twitter").type("_doc");
 
             // tag::put-mapping-execute-listener
             ActionListener<AcknowledgedResponse> listener =
@@ -586,7 +586,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             CreateIndexResponse createIndexResponse = client.indices().create(new CreateIndexRequest("twitter"), RequestOptions.DEFAULT);
             assertTrue(createIndexResponse.isAcknowledged());
             PutMappingRequest request = new PutMappingRequest("twitter");
-            request.type("tweet");
+            request.type("_doc");
             request.source(
                 "{\n" +
                     "  \"properties\": {\n" +
@@ -604,7 +604,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             // tag::get-mapping-request
             GetMappingsRequest request = new GetMappingsRequest(); // <1>
             request.indices("twitter"); // <2>
-            request.types("tweet"); // <3>
+            request.types("_doc"); // <3>
             // end::get-mapping-request
 
             // tag::get-mapping-request-masterTimeout
@@ -622,8 +622,8 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
 
             // tag::get-mapping-response
             ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> allMappings = getMappingResponse.mappings(); // <1>
-            MappingMetaData typeMapping = allMappings.get("twitter").get("tweet"); // <2>
-            Map<String, Object> tweetMapping = typeMapping.sourceAsMap(); // <3>
+            MappingMetaData typeMapping = allMappings.get("twitter").get("_doc"); // <2>
+            Map<String, Object> _docMapping = typeMapping.sourceAsMap(); // <3>
             // end::get-mapping-response
 
             Map<String, String> type = new HashMap<>();
@@ -632,7 +632,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             field.put("message", type);
             Map<String, Object> expected = new HashMap<>();
             expected.put("properties", field);
-            assertThat(tweetMapping, equalTo(expected));
+            assertThat(_docMapping, equalTo(expected));
         }
     }
 
@@ -643,7 +643,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             CreateIndexResponse createIndexResponse = client.indices().create(new CreateIndexRequest("twitter"), RequestOptions.DEFAULT);
             assertTrue(createIndexResponse.isAcknowledged());
             PutMappingRequest request = new PutMappingRequest("twitter");
-            request.type("tweet");
+            request.type("_doc");
             request.source(
                 "{\n" +
                     "  \"properties\": {\n" +
@@ -660,7 +660,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         {
             GetMappingsRequest request = new GetMappingsRequest();
             request.indices("twitter");
-            request.types("tweet");
+            request.types("_doc");
 
             // tag::get-mapping-execute-listener
             ActionListener<GetMappingsResponse> listener =
@@ -682,8 +682,8 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             final ActionListener<GetMappingsResponse> latchListener = new LatchedActionListener<>(listener, latch);
             listener = ActionListener.wrap(r -> {
                 ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> allMappings = r.mappings();
-                MappingMetaData typeMapping = allMappings.get("twitter").get("tweet");
-                Map<String, Object> tweetMapping = typeMapping.sourceAsMap();
+                MappingMetaData typeMapping = allMappings.get("twitter").get("_doc");
+                Map<String, Object> _docMapping = typeMapping.sourceAsMap();
 
                 Map<String, String> type = new HashMap<>();
                 type.put("type", "text");
@@ -691,7 +691,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                 field.put("message", type);
                 Map<String, Object> expected = new HashMap<>();
                 expected.put("properties", field);
-                assertThat(tweetMapping, equalTo(expected));
+                assertThat(_docMapping, equalTo(expected));
                 latchListener.onResponse(r);
             }, e -> {
                 latchListener.onFailure(e);
@@ -714,7 +714,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             CreateIndexResponse createIndexResponse = client.indices().create(new CreateIndexRequest("twitter"), RequestOptions.DEFAULT);
             assertTrue(createIndexResponse.isAcknowledged());
             PutMappingRequest request = new PutMappingRequest("twitter");
-            request.type("tweet");
+            request.type("_doc");
             request.source(
                 "{\n" +
                     "  \"properties\": {\n" +
@@ -734,7 +734,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         // tag::get-field-mapping-request
         GetFieldMappingsRequest request = new GetFieldMappingsRequest(); // <1>
         request.indices("twitter"); // <2>
-        request.types("tweet"); // <3>
+        request.types("_doc"); // <3>
         request.fields("message", "timestamp"); // <4>
         // end::get-field-mapping-request
 
@@ -757,7 +757,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             final Map<String, Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetaData>>> mappings =
                 response.mappings();// <1>
             final Map<String, GetFieldMappingsResponse.FieldMappingMetaData> typeMappings =
-                mappings.get("twitter").get("tweet"); // <2>
+                mappings.get("twitter").get("_doc"); // <2>
             final GetFieldMappingsResponse.FieldMappingMetaData metaData =
                 typeMappings.get("message");// <3>
 
@@ -789,7 +789,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                 final Map<String, Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetaData>>> mappings =
                     r.mappings();
                 final Map<String, GetFieldMappingsResponse.FieldMappingMetaData> typeMappings =
-                    mappings.get("twitter").get("tweet");
+                    mappings.get("twitter").get("_doc");
                 final GetFieldMappingsResponse.FieldMappingMetaData metaData1 = typeMappings.get("message");
 
                 final String fullName = metaData1.fullName();
@@ -2114,9 +2114,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
 
         {
             // tag::put-template-request-mappings-json
-            request.mapping("tweet", // <1>
+            request.mapping("_doc", // <1>
                 "{\n" +
-                    "  \"tweet\": {\n" +
+                    "  \"_doc\": {\n" +
                     "    \"properties\": {\n" +
                     "      \"message\": {\n" +
                     "        \"type\": \"text\"\n" +
@@ -2135,10 +2135,10 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             message.put("type", "text");
             Map<String, Object> properties = new HashMap<>();
             properties.put("message", message);
-            Map<String, Object> tweet = new HashMap<>();
-            tweet.put("properties", properties);
-            jsonMap.put("tweet", tweet);
-            request.mapping("tweet", jsonMap); // <1>
+            Map<String, Object> _doc = new HashMap<>();
+            _doc.put("properties", properties);
+            jsonMap.put("_doc", _doc);
+            request.mapping("_doc", jsonMap); // <1>
             //end::put-template-request-mappings-map
             assertTrue(client.indices().putTemplate(request, RequestOptions.DEFAULT).isAcknowledged());
         }
@@ -2147,7 +2147,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.startObject();
             {
-                builder.startObject("tweet");
+                builder.startObject("_doc");
                 {
                     builder.startObject("properties");
                     {
@@ -2162,13 +2162,13 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                 builder.endObject();
             }
             builder.endObject();
-            request.mapping("tweet", builder); // <1>
+            request.mapping("_doc", builder); // <1>
             //end::put-template-request-mappings-xcontent
             assertTrue(client.indices().putTemplate(request, RequestOptions.DEFAULT).isAcknowledged());
         }
         {
             //tag::put-template-request-mappings-shortcut
-            request.mapping("tweet", "message", "type=text"); // <1>
+            request.mapping("_doc", "message", "type=text"); // <1>
             //end::put-template-request-mappings-shortcut
             assertTrue(client.indices().putTemplate(request, RequestOptions.DEFAULT).isAcknowledged());
         }
@@ -2197,7 +2197,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             "    \"number_of_shards\": 1\n" +
             "  },\n" +
             "  \"mappings\": {\n" +
-            "    \"tweet\": {\n" +
+            "    \"_doc\": {\n" +
             "      \"properties\": {\n" +
             "        \"message\": {\n" +
             "          \"type\": \"text\"\n" +
@@ -2264,9 +2264,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest("my-template");
             putRequest.patterns(Arrays.asList("pattern-1", "log-*"));
             putRequest.settings(Settings.builder().put("index.number_of_shards", 3).put("index.number_of_replicas", 1));
-            putRequest.mapping("tweet",
+            putRequest.mapping("_doc",
                     "{\n" +
-                    "  \"tweet\": {\n" +
+                    "  \"_doc\": {\n" +
                     "    \"properties\": {\n" +
                     "      \"message\": {\n" +
                     "        \"type\": \"text\"\n" +

--- a/docs/groovy-api/anatomy.asciidoc
+++ b/docs/groovy-api/anatomy.asciidoc
@@ -21,7 +21,7 @@ success and failures, as well as blocking for the response. For example:
 --------------------------------------------------
 def indexR = client.index {
     index "test"
-    type "type1"
+    type "_doc"
     id "1"
     source {
         test = "value"
@@ -69,7 +69,7 @@ parameter option (the `GActionFuture` handling). For example:
 --------------------------------------------------
 def indexR = client.index (new IndexRequest(
         index: "test",
-        type: "type1",
+        type: "_doc",
         id: "1",
         source: {
             test = "value"
@@ -92,7 +92,7 @@ with the added `gexecute` which returns the `GActionFuture`:
 
 [source,groovy]
 --------------------------------------------------
-def indexR = node.client.prepareIndex("test", "type1", "1").setSource({
+def indexR = node.client.prepareIndex("test", "_doc", "1").setSource({
     test = "value"
     complex {
         value1 = "value1"

--- a/docs/groovy-api/delete.asciidoc
+++ b/docs/groovy-api/delete.asciidoc
@@ -10,7 +10,7 @@ example:
 --------------------------------------------------
 def deleteF = node.client.delete {
     index "test"
-    type "type1"
+    type "_doc"
     id "1"
 }
 --------------------------------------------------

--- a/docs/groovy-api/get.asciidoc
+++ b/docs/groovy-api/get.asciidoc
@@ -11,7 +11,7 @@ converted to a `Map` which means using Groovy to navigate it is simple:
 --------------------------------------------------
 def getF = node.client.get {
     index "test"
-    type "type1"
+    type "_doc"
     id "1"
 }
 

--- a/docs/groovy-api/index_.asciidoc
+++ b/docs/groovy-api/index_.asciidoc
@@ -11,7 +11,7 @@ closure. For example:
 --------------------------------------------------
 def indexR = client.index {
     index "test"
-    type "type1"
+    type "_doc"
     id "1"
     source {
         test = "value"

--- a/docs/groovy-api/search.asciidoc
+++ b/docs/groovy-api/search.asciidoc
@@ -11,7 +11,7 @@ including the query itself (similar to GORM criteria builder):
 --------------------------------------------------
 def search = node.client.search {
     indices "test"
-    types "type1"
+    types "_doc"
     source {
         query {
             term(test: "value")
@@ -52,7 +52,7 @@ Term query where multiple values are provided (see
 --------------------------------------------------
 def search = node.client.search {
     indices "test"
-    types "type1"
+    types "_doc"
     source {
         query {
             terms(test: ["value1", "value2"])
@@ -68,7 +68,7 @@ Query string (see
 --------------------------------------------------
 def search = node.client.search {
     indices "test"
-    types "type1"
+    types "_doc"
     source {
         query {
             query_string(
@@ -86,7 +86,7 @@ Pagination (see
 --------------------------------------------------
 def search = node.client.search {
     indices "test"
-    types "type1"
+    types "_doc"
     source {
         from = 0
         size = 10
@@ -103,7 +103,7 @@ Sorting (see {ref}/search-request-sort.html[sort]):
 --------------------------------------------------
 def search = node.client.search {
     indices "test"
-    types "type1"
+    types "_doc"
     source {
         query {
             term(test: "value")

--- a/docs/java-api/admin/indices/put-mapping.asciidoc
+++ b/docs/java-api/admin/indices/put-mapping.asciidoc
@@ -2,40 +2,29 @@
 
 ==== Put Mapping
 
-You can add mappings for a new type at index creation time:
+You can add mappings at index creation time:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{client-tests}/IndicesDocumentationIT.java[index-with-mapping]
 --------------------------------------------------
 <1> <<java-admin-indices-create-index,Creates an index>> called `twitter`
-<2> Add a `tweet` type with a field called `message` that has the datatype `text`.
+<2> Add a `_doc` type with a field called `message` that has the datatype `text`.
 
 There are several variants of the above `addMapping` method, some taking an
 `XContentBuilder` or a `Map` with the mapping definition as arguments. Make sure
 to check the javadocs to pick the simplest one for your use case.
 
-The PUT mapping API also allows to specify the mapping of a type after index
-creation. In this case you can provide the mapping as a String similar to the
-Rest API syntax:
+The PUT mapping API also allows for updating the mapping after index
+creation. In this case you can provide the mapping as a String similar
+to the REST API syntax:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{client-tests}/IndicesDocumentationIT.java[putMapping-request-source]
 --------------------------------------------------
 <1> Puts a mapping on existing index called `twitter`
-<2> Adds a `user` mapping type.
-<3> This `user` has a predefined type
-<4> type can be also provided within the source
-
-You can use the same API to update an existing mapping:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{client-tests}/IndicesDocumentationIT.java[putMapping-request-source-append]
---------------------------------------------------
-<1> Puts a mapping on existing index called `twitter`
-<2> Updates the `user` mapping type.
-<3> This `user` has now a new field `user_name`
+<2> Adds a new field `name` to the mapping
+<3> The type can be also provided within the source
 
 :base-dir!:

--- a/docs/java-api/docs/bulk.asciidoc
+++ b/docs/java-api/docs/bulk.asciidoc
@@ -11,7 +11,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.*;
 BulkRequestBuilder bulkRequest = client.prepareBulk();
 
 // either use client#prepare, or use Requests# to directly build index/delete requests
-bulkRequest.add(client.prepareIndex("twitter", "tweet", "1")
+bulkRequest.add(client.prepareIndex("twitter", "_doc", "1")
         .setSource(jsonBuilder()
                     .startObject()
                         .field("user", "kimchy")
@@ -21,7 +21,7 @@ bulkRequest.add(client.prepareIndex("twitter", "tweet", "1")
                   )
         );
 
-bulkRequest.add(client.prepareIndex("twitter", "tweet", "2")
+bulkRequest.add(client.prepareIndex("twitter", "_doc", "2")
         .setSource(jsonBuilder()
                     .startObject()
                         .field("user", "kimchy")
@@ -109,8 +109,8 @@ Then you can simply add your requests to the `BulkProcessor`:
 
 [source,java]
 --------------------------------------------------
-bulkProcessor.add(new IndexRequest("twitter", "tweet", "1").source(/* your doc here */));
-bulkProcessor.add(new DeleteRequest("twitter", "tweet", "2"));
+bulkProcessor.add(new IndexRequest("twitter", "_doc", "1").source(/* your doc here */));
+bulkProcessor.add(new DeleteRequest("twitter", "_doc", "2"));
 --------------------------------------------------
 
 [[java-docs-bulk-processor-close]]

--- a/docs/java-api/docs/delete.asciidoc
+++ b/docs/java-api/docs/delete.asciidoc
@@ -3,12 +3,12 @@
 
 The delete API allows one to delete a typed JSON document from a specific
 index based on its id. The following example deletes the JSON document
-from an index called twitter, under a type called tweet, with id valued
+from an index called twitter, under a type called `_doc`, with id valued
 1:
 
 [source,java]
 --------------------------------------------------
-DeleteResponse response = client.prepareDelete("twitter", "tweet", "1").get();
+DeleteResponse response = client.prepareDelete("twitter", "_doc", "1").get();
 --------------------------------------------------
 
 For more information on the delete operation, check out the

--- a/docs/java-api/docs/get.asciidoc
+++ b/docs/java-api/docs/get.asciidoc
@@ -3,11 +3,11 @@
 
 The get API allows to get a typed JSON document from the index based on
 its id. The following example gets a JSON document from an index called
-twitter, under a type called tweet, with id valued 1:
+twitter, under a type called `_doc``, with id valued 1:
 
 [source,java]
 --------------------------------------------------
-GetResponse response = client.prepareGet("twitter", "tweet", "1").get();
+GetResponse response = client.prepareGet("twitter", "_doc", "1").get();
 --------------------------------------------------
 
 For more information on the get operation, check out the REST

--- a/docs/java-api/docs/index_.asciidoc
+++ b/docs/java-api/docs/index_.asciidoc
@@ -113,13 +113,13 @@ String json = Strings.toString(builder);
 ==== Index document
 
 The following example indexes a JSON document into an index called
-twitter, under a type called tweet, with id valued 1:
+twitter, under a type called `_doc``, with id valued 1:
 
 [source,java]
 --------------------------------------------------
 import static org.elasticsearch.common.xcontent.XContentFactory.*;
 
-IndexResponse response = client.prepareIndex("twitter", "tweet", "1")
+IndexResponse response = client.prepareIndex("twitter", "_doc", "1")
         .setSource(jsonBuilder()
                     .startObject()
                         .field("user", "kimchy")
@@ -141,7 +141,7 @@ String json = "{" +
         "\"message\":\"trying out Elasticsearch\"" +
     "}";
 
-IndexResponse response = client.prepareIndex("twitter", "tweet")
+IndexResponse response = client.prepareIndex("twitter", "_doc")
         .setSource(json, XContentType.JSON)
         .get();
 --------------------------------------------------

--- a/docs/java-api/docs/multi-get.asciidoc
+++ b/docs/java-api/docs/multi-get.asciidoc
@@ -1,14 +1,14 @@
 [[java-docs-multi-get]]
 === Multi Get API
 
-The multi get API allows to get a list of documents based on their `index`, `type` and `id`:
+The multi get API allows to get a list of documents based on their `index` and `id`:
 
 [source,java]
 --------------------------------------------------
 MultiGetResponse multiGetItemResponses = client.prepareMultiGet()
-    .add("twitter", "tweet", "1")           <1>
-    .add("twitter", "tweet", "2", "3", "4") <2>
-    .add("another", "type", "foo")          <3>
+    .add("twitter", "_doc", "1")            <1>
+    .add("twitter", "_doc", "2", "3", "4")  <2>
+    .add("another", "_doc", "foo")          <3>
     .get();
 
 for (MultiGetItemResponse itemResponse : multiGetItemResponses) { <4>
@@ -19,7 +19,7 @@ for (MultiGetItemResponse itemResponse : multiGetItemResponses) { <4>
 }
 --------------------------------------------------
 <1> get by a single id
-<2> or by a list of ids for the same index / type
+<2> or by a list of ids for the same index
 <3> you can also get from another index
 <4> iterate over the result set
 <5> you can check if the document exists

--- a/docs/java-api/docs/update.asciidoc
+++ b/docs/java-api/docs/update.asciidoc
@@ -8,7 +8,7 @@ You can either create an `UpdateRequest` and send it to the client:
 --------------------------------------------------
 UpdateRequest updateRequest = new UpdateRequest();
 updateRequest.index("index");
-updateRequest.type("type");
+updateRequest.type("_doc");
 updateRequest.id("1");
 updateRequest.doc(jsonBuilder()
         .startObject()
@@ -92,7 +92,7 @@ client.update(updateRequest).get();
 --------------------------------------------------
 <1> If the document does not exist, the one in `indexRequest` will be added
 
-If the document `index/type/1` already exists, we will have after this operation a document like:
+If the document `index/_doc/1` already exists, we will have after this operation a document like:
 
 [source,js]
 --------------------------------------------------

--- a/docs/java-api/query-dsl/percolate-query.asciidoc
+++ b/docs/java-api/query-dsl/percolate-query.asciidoc
@@ -19,15 +19,14 @@ a document containing a percolator query should be indexed:
 --------------------------------------------------
 // create an index with a percolator field with the name 'query':
 client.admin().indices().prepareCreate("myIndexName")
-                        .addMapping("query", "query", "type=percolator")
-                        .addMapping("docs", "content", "type=text")
+                        .addMapping("_doc", "content", "type=text")
                         .get();
 
 //This is the query we're registering in the percolator
 QueryBuilder qb = termQuery("content", "amazing");
 
 //Index the query = register it in the percolator
-client.prepareIndex("myIndexName", "query", "myDesignatedQueryName")
+client.prepareIndex("myIndexName", "_doc", "myDesignatedQueryName")
     .setSource(jsonBuilder()
         .startObject()
             .field("query", qb) // Register the query
@@ -49,7 +48,7 @@ XContentBuilder docBuilder = XContentFactory.jsonBuilder().startObject();
 docBuilder.field("content", "This is amazing!");
 docBuilder.endObject(); //End of the JSON root object
 
-PercolateQueryBuilder percolateQuery = new PercolateQueryBuilder("query", "docs", BytesReference.bytes(docBuilder));
+PercolateQueryBuilder percolateQuery = new PercolateQueryBuilder("query", "_doc", BytesReference.bytes(docBuilder));
 
 // Percolate, by executing the percolator query in the query dsl:
 SearchResponse response = client().prepareSearch("myIndexName")

--- a/docs/java-api/query-dsl/percolate-query.asciidoc
+++ b/docs/java-api/query-dsl/percolate-query.asciidoc
@@ -19,7 +19,7 @@ a document containing a percolator query should be indexed:
 --------------------------------------------------
 // create an index with a percolator field with the name 'query':
 client.admin().indices().prepareCreate("myIndexName")
-                        .addMapping("_doc", "content", "type=text")
+                        .addMapping("_doc", "query", "type=percolator", "content", "type=text")
                         .get();
 
 //This is the query we're registering in the percolator

--- a/docs/java-api/search.asciidoc
+++ b/docs/java-api/search.asciidoc
@@ -16,7 +16,6 @@ import org.elasticsearch.index.query.QueryBuilders.*;
 [source,java]
 --------------------------------------------------
 SearchResponse response = client.prepareSearch("index1", "index2")
-        .setTypes("type1", "type2")
         .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
         .setQuery(QueryBuilders.termQuery("multi", "test"))                 // Query
         .setPostFilter(QueryBuilders.rangeQuery("age").from(12).to(18))     // Filter

--- a/docs/java-rest/high-level/indices/get_mappings.asciidoc
+++ b/docs/java-rest/high-level/indices/get_mappings.asciidoc
@@ -77,4 +77,4 @@ include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-mapping-respon
 --------------------------------------------------
 <1> Returning all indices' mappings
 <2> Retrieving the mappings for a particular index and type
-<3> Getting the mappings for the "tweet" as a Java Map
+<3> Getting the mappings as a Java Map

--- a/docs/painless/painless-contexts/painless-context-examples.asciidoc
+++ b/docs/painless/painless-contexts/painless-context-examples.asciidoc
@@ -46,7 +46,7 @@ the request URL.
 PUT /seats
 {
   "mappings": {
-    "seat": {
+    "_doc": {
       "properties": {
         "theatre":  { "type": "keyword" },
         "play":     { "type": "text"    },

--- a/docs/plugins/analysis-icu.asciidoc
+++ b/docs/plugins/analysis-icu.asciidoc
@@ -339,7 +339,7 @@ Below is an example of how to set up a field for sorting German names in
 PUT my_index
 {
   "mappings": {
-    "user": {
+    "_doc": {
       "properties": {
         "name": {   <1>
           "type": "text",

--- a/docs/plugins/ingest-geoip.asciidoc
+++ b/docs/plugins/ingest-geoip.asciidoc
@@ -57,11 +57,11 @@ PUT _ingest/pipeline/geoip
     }
   ]
 }
-PUT my_index/my_type/my_id?pipeline=geoip
+PUT my_index/_doc/my_id?pipeline=geoip
 {
   "ip": "8.8.8.8"
 }
-GET my_index/my_type/my_id
+GET my_index/_doc/my_id
 --------------------------------------------------
 // CONSOLE
 
@@ -72,7 +72,7 @@ Which returns:
 {
   "found": true,
   "_index": "my_index",
-  "_type": "my_type",
+  "_type": "_doc",
   "_id": "my_id",
   "_version": 1,
   "_source": {
@@ -106,11 +106,11 @@ PUT _ingest/pipeline/geoip
     }
   ]
 }
-PUT my_index/my_type/my_id?pipeline=geoip
+PUT my_index/_doc/my_id?pipeline=geoip
 {
   "ip": "8.8.8.8"
 }
-GET my_index/my_type/my_id
+GET my_index/_doc/my_id
 --------------------------------------------------
 // CONSOLE
 
@@ -121,7 +121,7 @@ returns this:
 {
   "found": true,
   "_index": "my_index",
-  "_type": "my_type",
+  "_type": "_doc",
   "_id": "my_id",
   "_version": 1,
   "_source": {
@@ -155,11 +155,11 @@ PUT _ingest/pipeline/geoip
     }
   ]
 }
-PUT my_index/my_type/my_id?pipeline=geoip
+PUT my_index/_doc/my_id?pipeline=geoip
 {
   "ip": "80.231.5.0"
 }
-GET my_index/my_type/my_id
+GET my_index/_doc/my_id
 --------------------------------------------------
 // CONSOLE
 
@@ -170,7 +170,7 @@ Which returns:
 {
   "found": true,
   "_index": "my_index",
-  "_type": "my_type",
+  "_type": "_doc",
   "_id": "my_id",
   "_version": 1,
   "_source": {

--- a/docs/plugins/ingest-user-agent.asciidoc
+++ b/docs/plugins/ingest-user-agent.asciidoc
@@ -39,11 +39,11 @@ PUT _ingest/pipeline/user_agent
     }
   ]
 }
-PUT my_index/my_type/my_id?pipeline=user_agent
+PUT my_index/_doc/my_id?pipeline=user_agent
 {
   "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"
 }
-GET my_index/my_type/my_id
+GET my_index/_doc/my_id
 --------------------------------------------------
 // CONSOLE
 
@@ -54,7 +54,7 @@ Which returns
 {
   "found": true,
   "_index": "my_index",
-  "_type": "my_type",
+  "_type": "_doc",
   "_id": "my_id",
   "_version": 1,
   "_source": {

--- a/docs/plugins/mapper-murmur3.asciidoc
+++ b/docs/plugins/mapper-murmur3.asciidoc
@@ -19,7 +19,7 @@ value and its hash are stored in the index:
 PUT my_index
 {
   "mappings": {
-    "my_type": {
+    "_doc": {
       "properties": {
         "my_field": {
           "type": "keyword",
@@ -43,12 +43,12 @@ of the values of the `my_field` field. This is only useful in order to run
 [source,js]
 --------------------------
 # Example documents
-PUT my_index/my_type/1
+PUT my_index/_doc/1
 {
   "my_field": "This is a document"
 }
 
-PUT my_index/my_type/2
+PUT my_index/_doc/2
 {
   "my_field": "This is another document"
 }

--- a/docs/plugins/mapper-size.asciidoc
+++ b/docs/plugins/mapper-size.asciidoc
@@ -18,7 +18,7 @@ In order to enable the `_size` field, set the mapping as follows:
 PUT my_index
 {
   "mappings": {
-    "my_type": {
+    "_doc": {
       "_size": {
         "enabled": true
       }
@@ -34,12 +34,12 @@ and when sorting:
 [source,js]
 --------------------------
 # Example documents
-PUT my_index/my_type/1
+PUT my_index/_doc/1
 {
   "text": "This is a document"
 }
 
-PUT my_index/my_type/2
+PUT my_index/_doc/2
 {
   "text": "This is another document"
 }

--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -19,7 +19,7 @@ a composite bucket.
 PUT /sales
 {
     "mappings": {
-        "docs": {
+        "_doc": {
             "properties": {
                 "product": {
                     "type": "keyword"
@@ -38,7 +38,7 @@ PUT /sales
     }
 }
 
-POST /sales/docs/_bulk?refresh
+POST /sales/_doc/_bulk?refresh
 {"index":{"_id":0}}
 {"product": "mad max", "price": "20", "timestamp": "2017-05-09T14:35"}
 {"index":{"_id":1}}

--- a/docs/reference/aggregations/bucket/geodistance-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/geodistance-aggregation.asciidoc
@@ -8,7 +8,7 @@ A multi-bucket aggregation that works on `geo_point` fields and conceptually wor
 PUT /museums
 {
     "mappings": {
-        "doc": {
+        "_doc": {
             "properties": {
                 "location": {
                     "type": "geo_point"
@@ -18,7 +18,7 @@ PUT /museums
     }
 }
 
-POST /museums/doc/_bulk?refresh
+POST /museums/_doc/_bulk?refresh
 {"index":{"_id":1}}
 {"location": "52.374081,4.912350", "name": "NEMO Science Museum"}
 {"index":{"_id":2}}

--- a/docs/reference/aggregations/bucket/geohashgrid-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/geohashgrid-aggregation.asciidoc
@@ -22,7 +22,7 @@ The specified field must be of type `geo_point` (which can only be set explicitl
 PUT /museums
 {
     "mappings": {
-        "doc": {
+        "_doc": {
             "properties": {
                 "location": {
                     "type": "geo_point"
@@ -32,7 +32,7 @@ PUT /museums
     }
 }
 
-POST /museums/doc/_bulk?refresh
+POST /museums/_doc/_bulk?refresh
 {"index":{"_id":1}}
 {"location": "52.374081,4.912350", "name": "NEMO Science Museum"}
 {"index":{"_id":2}}

--- a/docs/reference/aggregations/metrics/geobounds-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/geobounds-aggregation.asciidoc
@@ -11,7 +11,7 @@ Example:
 PUT /museums
 {
     "mappings": {
-        "doc": {
+        "_doc": {
             "properties": {
                 "location": {
                     "type": "geo_point"
@@ -21,7 +21,7 @@ PUT /museums
     }
 }
 
-POST /museums/doc/_bulk?refresh
+POST /museums/_doc/_bulk?refresh
 {"index":{"_id":1}}
 {"location": "52.374081,4.912350", "name": "NEMO Science Museum"}
 {"index":{"_id":2}}

--- a/docs/reference/aggregations/metrics/geocentroid-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/geocentroid-aggregation.asciidoc
@@ -10,7 +10,7 @@ Example:
 PUT /museums
 {
     "mappings": {
-        "doc": {
+        "_doc": {
             "properties": {
                 "location": {
                     "type": "geo_point"
@@ -20,7 +20,7 @@ PUT /museums
     }
 }
 
-POST /museums/doc/_bulk?refresh
+POST /museums/_doc/_bulk?refresh
 {"index":{"_id":1}}
 {"location": "52.374081,4.912350", "city": "Amsterdam", "name": "NEMO Science Museum"}
 {"index":{"_id":2}}

--- a/docs/reference/analysis/normalizers.asciidoc
+++ b/docs/reference/analysis/normalizers.asciidoc
@@ -46,7 +46,7 @@ PUT index
     }
   },
   "mappings": {
-    "type": {
+    "_doc": {
       "properties": {
         "foo": {
           "type": "keyword",

--- a/docs/reference/cat/fielddata.asciidoc
+++ b/docs/reference/cat/fielddata.asciidoc
@@ -12,7 +12,7 @@ Hidden setup snippet to build an index with fielddata so our results are real:
 PUT test
 {
   "mappings": {
-    "test": {
+    "_doc": {
       "properties": {
         "body": {
           "type": "text",
@@ -26,7 +26,7 @@ PUT test
     }
   }
 }
-POST test/test?refresh
+POST test/_doc?refresh
 {
   "body": "some words so there is a little field data",
   "soul": "some more words"

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -3,7 +3,7 @@
 
 The get API allows to get a typed JSON document from the index based on
 its id. The following example gets a JSON document from an index called
-twitter, under a type called _doc, with id valued 0:
+twitter, under a type called `_doc`, with id valued 0:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -5,7 +5,7 @@ IMPORTANT: See <<removal-of-types>>.
 
 The index API adds or updates a typed JSON document in a specific index,
 making it searchable. The following example inserts the JSON document
-into the "twitter" index, under a type called "_doc" with an id of 1:
+into the "twitter" index, under a type called `_doc` with an id of 1:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -56,7 +56,7 @@ And type:
 
 [source,js]
 --------------------------------------------------
-GET /test/type/_mget
+GET /test/_doc/_mget
 {
     "docs" : [
         {
@@ -75,7 +75,7 @@ request:
 
 [source,js]
 --------------------------------------------------
-GET /test/type/_mget
+GET /test/_doc/_mget
 {
     "ids" : ["1", "2"]
 }
@@ -160,7 +160,7 @@ as a default to be applied to all documents.
 
 [source,js]
 --------------------------------------------------
-GET /test/type/_mget?stored_fields=field1,field2
+GET /test/_doc/_mget?stored_fields=field1,field2
 {
     "docs" : [
         {
@@ -204,8 +204,8 @@ GET /_mget?routing=key1
 --------------------------------------------------
 // CONSOLE
 
-In this example, document `test/type/2` will be fetch from shard corresponding to routing key `key1` but
-document `test/type/1` will be fetch from shard corresponding to routing key `key2`.
+In this example, document `test/_doc/2` will be fetch from shard corresponding to routing key `key1` but
+document `test/_doc/1` will be fetch from shard corresponding to routing key `key2`.
 
 [float]
 [[mget-security]]

--- a/docs/reference/how-to/disk-usage.asciidoc
+++ b/docs/reference/how-to/disk-usage.asciidoc
@@ -15,7 +15,7 @@ filter on, you can safely disable indexing on this field in your
 PUT index
 {
   "mappings": {
-    "type": {
+    "_doc": {
       "properties": {
         "foo": {
           "type": "integer",
@@ -38,7 +38,7 @@ to not write norms to the index:
 PUT index
 {
   "mappings": {
-    "type": {
+    "_doc": {
       "properties": {
         "foo": {
           "type": "text",
@@ -61,7 +61,7 @@ Elasticsearch to not index positions:
 PUT index
 {
   "mappings": {
-    "type": {
+    "_doc": {
       "properties": {
         "foo": {
           "type": "text",
@@ -84,7 +84,7 @@ and scoring will assume that terms appear only once in every document.
 PUT index
 {
   "mappings": {
-    "type": {
+    "_doc": {
       "properties": {
         "foo": {
           "type": "text",
@@ -118,7 +118,7 @@ fields as `keyword`:
 PUT index
 {
   "mappings": {
-    "type": {
+    "_doc": {
       "dynamic_templates": [
         {
           "strings": {

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -145,7 +145,7 @@ exist in the mapping:
 PUT /test1
 {
   "mappings": {
-    "type1": {
+    "_doc": {
       "properties": {
         "user" : {
           "type": "keyword"
@@ -379,7 +379,7 @@ First create the index and add a mapping for the `user_id` field:
 PUT /users
 {
     "mappings" : {
-        "user" : {
+        "_doc" : {
             "properties" : {
                 "user_id" : {"type" : "integer"}
             }
@@ -419,7 +419,7 @@ Aliases can also be specified during <<create-index-aliases,index creation>>:
 PUT /logs_20162801
 {
     "mappings" : {
-        "type" : {
+        "_doc" : {
             "properties" : {
                 "year" : {"type" : "integer"}
             }

--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -88,7 +88,7 @@ PUT test
         "number_of_shards" : 1
     },
     "mappings" : {
-        "type1" : {
+        "_doc" : {
             "properties" : {
                 "field1" : { "type" : "text" }
             }

--- a/docs/reference/indices/get-field-mapping.asciidoc
+++ b/docs/reference/indices/get-field-mapping.asciidoc
@@ -76,9 +76,9 @@ following are some examples:
 --------------------------------------------------
 GET /twitter,kimchy/_mapping/field/message
 
-GET /_all/_mapping/_doc,tweet,book/field/message,user.id
+GET /_all/_mapping/_doc/field/message,user.id
 
-GET /_all/_mapping/_do*/field/*.id
+GET /_all/_mapping/_doc/field/*.id
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:twitter]

--- a/docs/reference/mapping.asciidoc
+++ b/docs/reference/mapping.asciidoc
@@ -140,7 +140,7 @@ A mapping could be specified when creating an index, as follows:
 PUT my_index <1>
 {
   "mappings": {
-    "doc": { <2>
+    "_doc": { <2>
       "properties": { <3>
         "title":    { "type": "text"  }, <4>
         "name":     { "type": "text"  }, <4>

--- a/docs/reference/mapping/fields/meta-field.asciidoc
+++ b/docs/reference/mapping/fields/meta-field.asciidoc
@@ -10,7 +10,7 @@ metadata, such as the class that a document belongs to:
 PUT my_index
 {
   "mappings": {
-    "user": {
+    "_doc": {
       "_meta": { <1>
         "class": "MyApp::User",
         "version": {

--- a/docs/reference/mapping/types/percolator.asciidoc
+++ b/docs/reference/mapping/types/percolator.asciidoc
@@ -461,7 +461,7 @@ PUT my_queries1
     }
   },
   "mappings": {
-    "query": {
+    "_doc": {
       "properties": {
         "query": {
           "type": "percolator"
@@ -508,7 +508,7 @@ this query below should be indexed:
 
 [source,js]
 --------------------------------------------------
-PUT /my_queries1/query/1?refresh
+PUT /my_queries1/_doc/1?refresh
 {
   "query": {
     "term": {
@@ -559,7 +559,7 @@ GET /my_queries1/_search
     "hits": [
       {
         "_index": "my_queries1",
-        "_type": "query",
+        "_type": "_doc",
         "_id": "1",
         "_score": 0.41501677,
         "_source": {
@@ -620,7 +620,7 @@ PUT my_queries2
     }
   },
   "mappings": {
-    "query": {
+    "_doc": {
       "properties": {
         "query": {
           "type": "percolator"
@@ -665,7 +665,7 @@ the following query below should be indexed:
 
 [source,js]
 --------------------------------------------------
-PUT /my_queries2/query/2?refresh
+PUT /my_queries2/_doc/2?refresh
 {
   "query": {
     "match": { <1>

--- a/docs/reference/ml/transforms.asciidoc
+++ b/docs/reference/ml/transforms.asciidoc
@@ -29,7 +29,7 @@ subsequent examples:
 PUT /my_index
 {
   "mappings":{
-    "my_type":{
+    "_doc":{
       "properties": {
         "@timestamp": {
           "type": "date"
@@ -76,7 +76,7 @@ PUT /my_index
   }
 }
 
-PUT /my_index/my_type/1
+PUT /my_index/_doc/1
 {
   "@timestamp":"2017-03-23T13:00:00",
   "error_count":36320,
@@ -127,7 +127,7 @@ PUT _xpack/ml/datafeeds/datafeed-test1
 {
   "job_id": "test1",
   "indices": ["my_index"],
-  "types": ["my_type"],
+  "types": ["_doc"],
   "query": {
     "match_all": {
           "boost": 1
@@ -233,7 +233,7 @@ PUT _xpack/ml/datafeeds/datafeed-test2
 {
   "job_id": "test2",
   "indices": ["my_index"],
-  "types": ["my_type"],
+  "types": ["_doc"],
   "query": {
     "match_all": {
           "boost": 1
@@ -482,7 +482,7 @@ PUT _xpack/ml/datafeeds/datafeed-test3
 {
   "job_id": "test3",
   "indices": ["my_index"],
-  "types": ["my_type"],
+  "types": ["_doc"],
   "query": {
     "match_all": {
           "boost": 1
@@ -551,7 +551,7 @@ PUT _xpack/ml/datafeeds/datafeed-test4
 {
   "job_id": "test4",
   "indices": ["my_index"],
-  "types": ["my_type"],
+  "types": ["_doc"],
   "query": {
     "match_all": {
           "boost": 1

--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -55,7 +55,7 @@ instance, if the `user` field were mapped as follows:
 PUT /example
 {
   "mappings": {
-    "doc": {
+    "_doc": {
       "properties": {
         "user": {
           "type": "keyword",

--- a/docs/reference/query-dsl/nested-query.asciidoc
+++ b/docs/reference/query-dsl/nested-query.asciidoc
@@ -13,7 +13,7 @@ will work with:
 PUT /my_index
 {
     "mappings": {
-        "type1" : {
+        "_doc" : {
             "properties" : {
                 "obj1" : {
                     "type" : "nested"

--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -19,7 +19,7 @@ the user name:
 
 [source,js]
 --------------------------------------------------
-POST /twitter/tweet?routing=kimchy
+POST /twitter/_doc?routing=kimchy
 {
     "user" : "kimchy",
     "postDate" : "2009-11-15T14:12:12",

--- a/docs/reference/search/suggesters/phrase-suggest.asciidoc
+++ b/docs/reference/search/suggesters/phrase-suggest.asciidoc
@@ -52,7 +52,7 @@ PUT test
     }
   },
   "mappings": {
-    "test": {
+    "_doc": {
       "properties": {
         "title": {
           "type": "text",
@@ -71,9 +71,9 @@ PUT test
     }
   }
 }
-POST test/test?refresh=true
+POST test/_doc?refresh=true
 {"title": "noble warriors"}
-POST test/test?refresh=true
+POST test/_doc?refresh=true
 {"title": "nobel prize"}
 --------------------------------------------------
 // CONSOLE

--- a/docs/reference/search/validate.asciidoc
+++ b/docs/reference/search/validate.asciidoc
@@ -180,7 +180,7 @@ Response:
       {
          "index": "twitter",
          "valid": true,
-         "explanation": "((user:terminator^3.71334 plot:future^2.763601 plot:human^2.8415773 plot:sarah^3.4193945 plot:kyle^3.8244398 plot:cyborg^3.9177752 plot:connor^4.040236 plot:reese^4.7133346 ... )~6) -ConstantScore(_id:2)) #(ConstantScore(_type:tweet))^0.0"
+         "explanation": "((user:terminator^3.71334 plot:future^2.763601 plot:human^2.8415773 plot:sarah^3.4193945 plot:kyle^3.8244398 plot:cyborg^3.9177752 plot:connor^4.040236 plot:reese^4.7133346 ... )~6) -ConstantScore(_id:2)) #(ConstantScore(_type:_doc))^0.0"
       }
    ]
 }

--- a/server/src/test/java/org/elasticsearch/client/documentation/IndicesDocumentationIT.java
+++ b/server/src/test/java/org/elasticsearch/client/documentation/IndicesDocumentationIT.java
@@ -26,9 +26,6 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESIntegTestCase;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -58,13 +55,13 @@ public class IndicesDocumentationIT extends ESIntegTestCase {
 
         // tag::index-with-mapping
         client.admin().indices().prepareCreate("twitter")    // <1>
-                .addMapping("tweet", "message", "type=text") // <2>
+                .addMapping("_doc", "message", "type=text") // <2>
                 .get();
         // end::index-with-mapping
         GetMappingsResponse getMappingsResponse = client.admin().indices().prepareGetMappings("twitter").get();
         assertEquals(1, getMappingsResponse.getMappings().size());
         ImmutableOpenMap<String, MappingMetaData> indexMapping = getMappingsResponse.getMappings().get("twitter");
-        assertThat(indexMapping.get("tweet"), instanceOf(MappingMetaData.class));
+        assertThat(indexMapping.get("_doc"), instanceOf(MappingMetaData.class));
 
         // we need to delete in order to create a fresh new index with another type
         client.admin().indices().prepareDelete("twitter").get();
@@ -72,10 +69,10 @@ public class IndicesDocumentationIT extends ESIntegTestCase {
 
         // tag::putMapping-request-source
         client.admin().indices().preparePutMapping("twitter")   // <1>
-        .setType("user")                                        // <2>
-        .setSource("{\n" +                                      // <3>
+        .setType("_doc")
+        .setSource("{\n" +
                 "  \"properties\": {\n" +
-                "    \"name\": {\n" +
+                "    \"name\": {\n" +                           // <2>
                 "      \"type\": \"text\"\n" +
                 "    }\n" +
                 "  }\n" +
@@ -84,9 +81,9 @@ public class IndicesDocumentationIT extends ESIntegTestCase {
 
         // You can also provide the type in the source document
         client.admin().indices().preparePutMapping("twitter")
-        .setType("user")
+        .setType("_doc")
         .setSource("{\n" +
-                "    \"user\":{\n" +                            // <4>
+                "    \"_doc\":{\n" +                            // <3>
                 "        \"properties\": {\n" +
                 "            \"name\": {\n" +
                 "                \"type\": \"text\"\n" +
@@ -100,27 +97,7 @@ public class IndicesDocumentationIT extends ESIntegTestCase {
         assertEquals(1, getMappingsResponse.getMappings().size());
         indexMapping = getMappingsResponse.getMappings().get("twitter");
         assertEquals(singletonMap("properties", singletonMap("name", singletonMap("type", "text"))),
-                indexMapping.get("user").getSourceAsMap());
-
-        // tag::putMapping-request-source-append
-        client.admin().indices().preparePutMapping("twitter")   // <1>
-        .setType("user")                                        // <2>
-        .setSource("{\n" +                                      // <3>
-                "  \"properties\": {\n" +
-                "    \"user_name\": {\n" +
-                "      \"type\": \"text\"\n" +
-                "    }\n" +
-                "  }\n" +
-                "}", XContentType.JSON)
-        .get();
-        // end::putMapping-request-source-append
-        getMappingsResponse = client.admin().indices().prepareGetMappings("twitter").get();
-        assertEquals(1, getMappingsResponse.getMappings().size());
-        indexMapping = getMappingsResponse.getMappings().get("twitter");
-        Map<String, Map<?,?>> expected = new HashMap<>();
-        expected.put("name", singletonMap("type", "text"));
-        expected.put("user_name", singletonMap("type", "text"));
-        assertEquals(expected, indexMapping.get("user").getSourceAsMap().get("properties"));
+                indexMapping.get("_doc").getSourceAsMap());
     }
 
 }


### PR DESCRIPTION
* Replace custom type names with _doc in REST examples.
* Avoid using two mapping types in the percolator docs.
* Rename doc -> _doc in the main repository README.
* Also replace some custom type names in the HLRC docs.