### PR TITLE
NETWORKING: RST Misbehaving Connections

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
@@ -72,7 +72,9 @@ public class Netty4TcpChannel implements TcpChannel {
 
     @Override
     public void setSoLinger(int value) {
-        channel.config().setOption(ChannelOption.SO_LINGER, value);
+        if (channel.isOpen()) {
+            channel.config().setOption(ChannelOption.SO_LINGER, value);
+        }
     }
 
     @Override

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
@@ -20,8 +20,10 @@
 package org.elasticsearch.transport.netty4;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPromise;
+import java.io.IOException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -71,9 +73,13 @@ public class Netty4TcpChannel implements TcpChannel {
     }
 
     @Override
-    public void setSoLinger(int value) {
+    public void setSoLinger(int value) throws IOException {
         if (channel.isOpen()) {
-            channel.config().setOption(ChannelOption.SO_LINGER, value);
+            try {
+                channel.config().setOption(ChannelOption.SO_LINGER, value);
+            } catch (ChannelException e) {
+                throw new IOException(e);
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
@@ -118,4 +118,19 @@ public interface TcpChannel extends CloseableChannel {
         }
     }
 
+    /**
+     * Aborts a channel's connection with RST, then closes the channel.
+     *
+     * @param channel Channel to disconnect with RST and close
+     */
+    static void rstAndClose(TcpChannel channel) {
+        try {
+            channel.setSoLinger(0);
+        } catch (IOException | RuntimeException e) {
+            // Depending on the implementation an already closed channel can either throw an IOException or a RuntimeException
+            // that we ignore because we are closing with RST because of an error here.
+        }
+        CloseableChannel.closeChannel(channel);
+    }
+
 }

--- a/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
@@ -126,9 +126,8 @@ public interface TcpChannel extends CloseableChannel {
     static void rstAndClose(TcpChannel channel) {
         try {
             channel.setSoLinger(0);
-        } catch (IOException | RuntimeException e) {
-            // Depending on the implementation an already closed channel can either throw an IOException or a RuntimeException
-            // that we ignore because we are closing with RST because of an error here.
+        } catch (IOException e) {
+            // We ignore the exception as we are closing with RST because of an error.
         }
         CloseableChannel.closeChannel(channel);
     }

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -765,7 +765,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     public void onException(TcpChannel channel, Exception e) {
         if (!lifecycle.started()) {
             // just close and ignore - we are already stopped and just need to make sure we release all resources
-            CloseableChannel.closeChannel(channel);
+            TcpChannel.rstAndClose(channel);
             return;
         }
 
@@ -815,7 +815,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         } else {
             logger.warn(() -> new ParameterizedMessage("exception caught on transport layer [{}], closing connection", channel), e);
             // close the channel, which will cause a node to be disconnected if relevant
-            CloseableChannel.closeChannel(channel);
+            TcpChannel.rstAndClose(channel);
         }
     }
 


### PR DESCRIPTION
* We should just RST misbehaving connections instead of just an active close that leaves us with a TIME_WAIT
* Relates #30876

-----------------------------------

This isn't a complete fix for #30876 but an improvement saving us some `TIME_WAIT` situations that are clearly needless and RST on misbehaving client should be fine in production anyway.