### PR TITLE
Fix JDK references in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,8 +100,8 @@ JDK 11 and testing on a JDK 8 runtime; to do this, set `RUNTIME_JAVA_HOME`
 pointing to the Java home of a JDK 8 installation. Note that this mechanism can
 be used to test against other JDKs as well, this is not only limited to JDK 8.
 
-> Note: It is also required to have `JAVA8_HOME` available so that the tests can
-pass.
+> Note: It is also required to have `JAVA8_HOME`, and `JAVA10_HOME` available so
+that the tests can pass.
 
 > Warning: do not use `sdkman` for Java installations which do not have proper
 `jrunscript` for jdk distributions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,8 +100,8 @@ JDK 11 and testing on a JDK 8 runtime; to do this, set `RUNTIME_JAVA_HOME`
 pointing to the Java home of a JDK 8 installation. Note that this mechanism can
 be used to test against other JDKs as well, this is not only limited to JDK 8.
 
-> Note: It is also required to have `JAVA8_HOME`, and `JAVA10_HOME` available so
-that the tests can pass.
+> Note: It is also required to have `JAVA8_HOME`, `JAVA9_HOME`, and
+`JAVA10_HOME` are available so that the tests can pass.
 
 > Warning: do not use `sdkman` for Java installations which do not have proper
 `jrunscript` for jdk distributions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,16 +92,16 @@ Contributing to the Elasticsearch codebase
 
 **Repository:** [https://github.com/elastic/elasticsearch](https://github.com/elastic/elasticsearch)
 
-JDK 10 is required to build Elasticsearch. You must have a JDK 10 installation
+JDK 11 is required to build Elasticsearch. You must have a JDK 11 installation
 with the environment variable `JAVA_HOME` referencing the path to Java home for
-your JDK 10 installation. By default, tests use the same runtime as `JAVA_HOME`.
+your JDK 11 installation. By default, tests use the same runtime as `JAVA_HOME`.
 However, since Elasticsearch supports JDK 8, the build supports compiling with
-JDK 10 and testing on a JDK 8 runtime; to do this, set `RUNTIME_JAVA_HOME`
+JDK 11 and testing on a JDK 8 runtime; to do this, set `RUNTIME_JAVA_HOME`
 pointing to the Java home of a JDK 8 installation. Note that this mechanism can
 be used to test against other JDKs as well, this is not only limited to JDK 8.
 
-> Note: It is also required to have `JAVA7_HOME`, `JAVA8_HOME` and
-`JAVA10_HOME` available so that the tests can pass.
+> Note: It is also required to have `JAVA8_HOME` available so that the tests can
+pass.
 
 > Warning: do not use `sdkman` for Java installations which do not have proper
 `jrunscript` for jdk distributions.


### PR DESCRIPTION
After we bumped the JDK compiler minimum requirements to JDK 11, we missed updating the contributing docs to point to JDK 11 instead of JDK 10. This commit fixes that.

Additionally, when we stopped requiring JDK 7 to run the reindex from old tests, we did not update the contributing docs to reflect this. This commit also fixes that.

Closes #34668, relates #34103, relates #34646