### PR TITLE
Use trial license in docs tests

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -38,6 +38,10 @@ buildRestTests.expectedUnconvertedCandidates = [
 integTestCluster {
   /* Enable regexes in painless so our tests don't complain about example
    * snippets that use them. */
+  if ("zip".equals(integTestCluster.distribution)) {
+    setting 'xpack.license.self_generated.type', 'trial'
+  }
+
   setting 'script.painless.regex.enabled', 'true'
   Closure configFile = {
     extraConfigFile it, "src/test/cluster/config/$it"

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -36,12 +36,11 @@ buildRestTests.expectedUnconvertedCandidates = [
 ]
 
 integTestCluster {
-  /* Enable regexes in painless so our tests don't complain about example
-   * snippets that use them. */
   if ("zip".equals(integTestCluster.distribution)) {
     setting 'xpack.license.self_generated.type', 'trial'
   }
 
+  // enable regexes in painless so our tests don't complain about example snippets that use them
   setting 'script.painless.regex.enabled', 'true'
   Closure configFile = {
     extraConfigFile it, "src/test/cluster/config/$it"

--- a/docs/reference/licensing/get-license.asciidoc
+++ b/docs/reference/licensing/get-license.asciidoc
@@ -39,7 +39,7 @@ For more information, see
 [float]
 ==== Examples
 
-The following example provides information about a basic license:
+The following example provides information about a trial license:
 
 [source,js]
 --------------------------------------------------
@@ -53,9 +53,11 @@ GET _xpack/license
   "license" : {
     "status" : "active",
     "uid" : "cbff45e7-c553-41f7-ae4f-9205eabd80xx",
-    "type" : "basic",
-    "issue_date" : "2018-02-22T23:12:05.550Z",
-    "issue_date_in_millis" : 1519341125550,
+    "type" : "trial",
+    "issue_date" : "2018-10-20T22:05:12.332Z",
+    "issue_date_in_millis" : 1540073112332,
+    "expiry_date" : "2018-11-19T22:05:12.332Z",
+    "expiry_date_in_millis" : 1542665112332,
     "max_nodes" : 1000,
     "issued_to" : "test",
     "issuer" : "elasticsearch",
@@ -65,8 +67,10 @@ GET _xpack/license
 --------------------------------------------------
 // TESTRESPONSE[s/"cbff45e7-c553-41f7-ae4f-9205eabd80xx"/$body.license.uid/]
 // TESTRESPONSE[s/"basic"/$body.license.type/]
-// TESTRESPONSE[s/"2018-02-22T23:12:05.550Z"/$body.license.issue_date/]
-// TESTRESPONSE[s/1519341125550/$body.license.issue_date_in_millis/]
+// TESTRESPONSE[s/"2018-10-20T22:05:12.332Z"/$body.license.issue_date/]
+// TESTRESPONSE[s/1540073112332/$body.license.issue_date_in_millis/]
+// TESTRESPONSE[s/"2018-11-19T22:05:12.332Z"/$body.license.expiry_date/]
+// TESTRESPONSE[s/1542665112332/$body.license.expiry_date_in_millis/]
 // TESTRESPONSE[s/1000/$body.license.max_nodes/]
 // TESTRESPONSE[s/"test"/$body.license.issued_to/]
 // TESTRESPONSE[s/"elasticsearch"/$body.license.issuer/]

--- a/docs/reference/rest-api/info.asciidoc
+++ b/docs/reference/rest-api/info.asciidoc
@@ -57,24 +57,25 @@ Example response:
    },
    "license" : {
       "uid" : "893361dc-9749-4997-93cb-xxx",
-      "type" : "basic",
-      "mode" : "basic",
-      "status" : "active"
+      "type" : "trial",
+      "mode" : "trial",
+      "status" : "active",
+      "expiry_date_in_millis" : 1542665112332
    },
    "features" : {
       "graph" : {
          "description" : "Graph Data Exploration for the Elastic Stack",
-         "available" : false,
+         "available" : true,
          "enabled" : true
       },
       "logstash" : {
          "description" : "Logstash management component for X-Pack",
-         "available" : false,
+         "available" : true,
          "enabled" : true
       },
       "ml" : {
          "description" : "Machine Learning for the Elastic Stack",
-         "available" : false,
+         "available" : true,
          "enabled" : true,
          "native_code_info" : {
            "version" : "7.0.0-alpha1-SNAPSHOT",
@@ -93,12 +94,12 @@ Example response:
       },
       "security" : {
          "description" : "Security for the Elastic Stack",
-         "available" : false,
-         "enabled" : true
+         "available" : true,
+         "enabled" : false
       },
       "watcher" : {
          "description" : "Alerting, Notification and Automation for the Elastic Stack",
-         "available" : false,
+         "available" : true,
          "enabled" : true
       }
    },
@@ -108,7 +109,7 @@ Example response:
 // TESTRESPONSE[s/"hash" : "2798b1a3ce779b3611bb53a0082d4d741e4d3168",/"hash" : "$body.build.hash",/]
 // TESTRESPONSE[s/"date" : "2015-04-07T13:34:42Z"/"date" : "$body.build.date"/]
 // TESTRESPONSE[s/"uid" : "893361dc-9749-4997-93cb-xxx",/"uid": "$body.license.uid",/]
-// TESTRESPONSE[s/"expiry_date_in_millis" : 1914278399999/"expiry_date_in_millis" : "$body.license.expiry_date_in_millis"/]
+// TESTRESPONSE[s/"expiry_date_in_millis" : 1542665112332/"expiry_date_in_millis" : "$body.license.expiry_date_in_millis"/]
 // TESTRESPONSE[s/"version" : "7.0.0-alpha1-SNAPSHOT",/"version": "$body.features.ml.native_code_info.version",/]
 // TESTRESPONSE[s/"build_hash" : "99a07c016d5a73"/"build_hash": "$body.features.ml.native_code_info.build_hash"/]
 // So much s/// but at least we test that the layout is close to matching....


### PR DESCRIPTION
This commit switches to using a trial license in the docs tests that run on the default distribution. This is needed so that docs tests can be executed against non-basic features.