### PR TITLE
SNAPSHOT: Restore Should Check Min. Version

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -790,10 +790,11 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
             throw new SnapshotRestoreException(new Snapshot(repository, snapshotInfo.snapshotId()),
                                                "unsupported snapshot state [" + snapshotInfo.state() + "]");
         }
-        if (Version.CURRENT.before(snapshotInfo.version())) {
+        Version minVersion = clusterService.state().getNodes().getMinNodeVersion();
+        if (minVersion.before(snapshotInfo.version())) {
             throw new SnapshotRestoreException(new Snapshot(repository, snapshotInfo.snapshotId()),
                                                "the snapshot was created with Elasticsearch version [" + snapshotInfo.version() +
-                                                   "] which is higher than the version of this node [" + Version.CURRENT + "]");
+                                                   "] which is higher than the version of this cluster [" + minVersion + "]");
         }
     }
 


### PR DESCRIPTION
* Restore should check minimum version of all nodes in the cluster and not
the current master node's version for compatibility so that we never restore to a data node whose version is older than the snapshot to be restored
* Closes #34264
