### PR TITLE
Allow set section in setup section of REST tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -347,8 +347,8 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
 
         if (!testCandidate.getSetupSection().isEmpty()) {
             logger.debug("start setup test [{}]", testCandidate.getTestPath());
-            for (DoSection doSection : testCandidate.getSetupSection().getDoSections()) {
-                executeSection(doSection);
+            for (ExecutableSection executableSection : testCandidate.getSetupSection().getExecutableSections()) {
+                executeSection(executableSection);
             }
             logger.debug("end setup test [{}]", testCandidate.getTestPath());
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/SetupSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/SetupSection.java
@@ -50,11 +50,14 @@ public class SetupSection {
 
         while (parser.currentToken() != XContentParser.Token.END_ARRAY) {
             ParserUtils.advanceToFieldName(parser);
-            if (!"do".equals(parser.currentName())) {
+            if ("do".equals(parser.currentName())) {
+                setupSection.addDoSection(DoSection.parse(parser));
+            } else if ("set".equals(parser.currentName())) {
+                setupSection.addSetSection(SetSection.parse(parser));
+            } else {
                 throw new IllegalArgumentException("section [" + parser.currentName() + "] not supported within setup section");
             }
 
-            setupSection.addDoSection(DoSection.parse(parser));
             parser.nextToken();
         }
 
@@ -72,7 +75,7 @@ public class SetupSection {
 
     private SkipSection skipSection;
 
-    private List<DoSection> doSections = new ArrayList<>();
+    private List<ExecutableSection> executableSections = new ArrayList<>();
 
     public SkipSection getSkipSection() {
         return skipSection;
@@ -82,12 +85,16 @@ public class SetupSection {
         this.skipSection = skipSection;
     }
 
-    public List<DoSection> getDoSections() {
-        return doSections;
+    public List<ExecutableSection> getExecutableSections() {
+        return executableSections;
     }
 
     public void addDoSection(DoSection doSection) {
-        this.doSections.add(doSection);
+        this.executableSections.add(doSection);
+    }
+
+    public void addSetSection(SetSection setSection) {
+        this.executableSections.add(setSection);
     }
 
     public boolean isEmpty() {

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
@@ -89,10 +89,13 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         if (includeSetup) {
             assertThat(restTestSuite.getSetupSection().isEmpty(), equalTo(false));
             assertThat(restTestSuite.getSetupSection().getSkipSection().isEmpty(), equalTo(true));
-            assertThat(restTestSuite.getSetupSection().getDoSections().size(), equalTo(1));
-            assertThat(restTestSuite.getSetupSection().getDoSections().get(0).getApiCallSection().getApi(), equalTo("indices.create"));
-            assertThat(restTestSuite.getSetupSection().getDoSections().get(0).getApiCallSection().getParams().size(), equalTo(1));
-            assertThat(restTestSuite.getSetupSection().getDoSections().get(0).getApiCallSection().getParams().get("index"),
+            assertThat(restTestSuite.getSetupSection().getExecutableSections().size(), equalTo(1));
+            final ExecutableSection maybeDoSection = restTestSuite.getSetupSection().getExecutableSections().get(0);
+            assertThat(maybeDoSection, instanceOf(DoSection.class));
+            final DoSection doSection = (DoSection) maybeDoSection;
+            assertThat(doSection.getApiCallSection().getApi(), equalTo("indices.create"));
+            assertThat(doSection.getApiCallSection().getParams().size(), equalTo(1));
+            assertThat(doSection.getApiCallSection().getParams().get("index"),
                     equalTo("test_index"));
         } else {
             assertThat(restTestSuite.getSetupSection().isEmpty(), equalTo(true));

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/SetupSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/SetupSectionTests.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.hasValue;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/SetupSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/SetupSectionTests.java
@@ -21,7 +21,13 @@ package org.elasticsearch.test.rest.yaml.section;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.xcontent.yaml.YamlXContent;
 
+import java.io.IOException;
+
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.hasValue;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class SetupSectionTests extends AbstractClientYamlTestFragmentParserTestCase {
@@ -45,9 +51,48 @@ public class SetupSectionTests extends AbstractClientYamlTestFragmentParserTestC
 
         assertThat(setupSection, notNullValue());
         assertThat(setupSection.getSkipSection().isEmpty(), equalTo(true));
-        assertThat(setupSection.getDoSections().size(), equalTo(2));
-        assertThat(setupSection.getDoSections().get(0).getApiCallSection().getApi(), equalTo("index1"));
-        assertThat(setupSection.getDoSections().get(1).getApiCallSection().getApi(), equalTo("index2"));
+        assertThat(setupSection.getExecutableSections().size(), equalTo(2));
+        assertThat(setupSection.getExecutableSections().get(0), instanceOf(DoSection.class));
+        assertThat(((DoSection)setupSection.getExecutableSections().get(0)).getApiCallSection().getApi(), equalTo("index1"));
+        assertThat(setupSection.getExecutableSections().get(1), instanceOf(DoSection.class));
+        assertThat(((DoSection)setupSection.getExecutableSections().get(1)).getApiCallSection().getApi(), equalTo("index2"));
+    }
+
+    public void testParseSetSectionInSetupSection() throws IOException {
+        parser = createParser(YamlXContent.yamlXContent,
+                "- do:\n" +
+                "    cluster.state: {}\n" +
+                "- set: { master_node: master }\n" +
+                "- do:\n" +
+                "    nodes.info:\n" +
+                "      metric: [ http, transport ]\n" +
+                "- set: {nodes.$master.http.publish_address: host}\n" +
+                "- set: {nodes.$master.transport.publish_address: transport_host}\n");
+
+        final SetupSection setupSection = SetupSection.parse(parser);
+
+        assertNotNull(setupSection);
+        assertTrue(setupSection.getSkipSection().isEmpty());
+        assertThat(setupSection.getExecutableSections().size(), equalTo(5));
+        assertThat(setupSection.getExecutableSections().get(0), instanceOf(DoSection.class));
+        assertThat(((DoSection)setupSection.getExecutableSections().get(0)).getApiCallSection().getApi(), equalTo("cluster.state"));
+        assertThat(setupSection.getExecutableSections().get(1), instanceOf(SetSection.class));
+        final SetSection firstSetSection = (SetSection)setupSection.getExecutableSections().get(1);
+        assertThat(firstSetSection.getStash().entrySet(), hasSize(1));
+        assertThat(firstSetSection.getStash(), hasKey("master_node"));
+        assertThat(firstSetSection.getStash().get("master_node"), equalTo("master"));
+        assertThat(setupSection.getExecutableSections().get(2), instanceOf(DoSection.class));
+        assertThat(((DoSection)setupSection.getExecutableSections().get(2)).getApiCallSection().getApi(), equalTo("nodes.info"));
+        assertThat(setupSection.getExecutableSections().get(3), instanceOf(SetSection.class));
+        final SetSection secondSetSection = (SetSection)setupSection.getExecutableSections().get(3);
+        assertThat(secondSetSection.getStash().entrySet(), hasSize(1));
+        assertThat(secondSetSection.getStash(), hasKey("nodes.$master.http.publish_address"));
+        assertThat(secondSetSection.getStash().get("nodes.$master.http.publish_address"), equalTo("host"));
+        assertThat(setupSection.getExecutableSections().get(4), instanceOf(SetSection.class));
+        final SetSection thirdSetSection = (SetSection)setupSection.getExecutableSections().get(4);
+        assertThat(thirdSetSection.getStash().entrySet(), hasSize(1));
+        assertThat(thirdSetSection.getStash(), hasKey("nodes.$master.transport.publish_address"));
+        assertThat(thirdSetSection.getStash().get("nodes.$master.transport.publish_address"), equalTo("transport_host"));
     }
 
     public void testParseSetupAndSkipSectionNoSkip() throws Exception {
@@ -78,8 +123,10 @@ public class SetupSectionTests extends AbstractClientYamlTestFragmentParserTestC
         assertThat(setupSection.getSkipSection().getUpperVersion(),
                 equalTo(Version.V_6_3_0));
         assertThat(setupSection.getSkipSection().getReason(), equalTo("Update doesn't return metadata fields, waiting for #3259"));
-        assertThat(setupSection.getDoSections().size(), equalTo(2));
-        assertThat(setupSection.getDoSections().get(0).getApiCallSection().getApi(), equalTo("index1"));
-        assertThat(setupSection.getDoSections().get(1).getApiCallSection().getApi(), equalTo("index2"));
+        assertThat(setupSection.getExecutableSections().size(), equalTo(2));
+        assertThat(setupSection.getExecutableSections().get(0), instanceOf(DoSection.class));
+        assertThat(((DoSection)setupSection.getExecutableSections().get(0)).getApiCallSection().getApi(), equalTo("index1"));
+        assertThat(setupSection.getExecutableSections().get(1), instanceOf(DoSection.class));
+        assertThat(((DoSection)setupSection.getExecutableSections().get(1)).getApiCallSection().getApi(), equalTo("index2"));
     }
 }


### PR DESCRIPTION
This commit enables using a set section in the setup section of REST tests.
