### PR TITLE
SQL: Fix negation of equals comparison.

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/logical/Not.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/logical/Not.java
@@ -5,11 +5,13 @@
  */
 package org.elasticsearch.xpack.sql.expression.predicate.logical;
 
-import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 import org.elasticsearch.xpack.sql.expression.Expression;
 import org.elasticsearch.xpack.sql.expression.Expressions;
 import org.elasticsearch.xpack.sql.expression.function.scalar.UnaryScalarFunction;
 import org.elasticsearch.xpack.sql.expression.gen.pipeline.Pipe;
+import org.elasticsearch.xpack.sql.expression.gen.pipeline.UnaryPipe;
+import org.elasticsearch.xpack.sql.expression.gen.script.Params;
+import org.elasticsearch.xpack.sql.expression.gen.script.ParamsBuilder;
 import org.elasticsearch.xpack.sql.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.sql.expression.predicate.BinaryOperator.Negateable;
 import org.elasticsearch.xpack.sql.tree.Location;
@@ -17,6 +19,8 @@ import org.elasticsearch.xpack.sql.tree.NodeInfo;
 import org.elasticsearch.xpack.sql.type.DataType;
 
 import java.util.Objects;
+
+import static org.elasticsearch.xpack.sql.expression.gen.script.Scripts.nullSafeFilter;
 
 public class Not extends UnaryScalarFunction {
 
@@ -50,12 +54,14 @@ public class Not extends UnaryScalarFunction {
 
     @Override
     protected Pipe makePipe() {
-        throw new SqlIllegalArgumentException("Not supported yet");
+        return new UnaryPipe(location(), this, Expressions.pipe(field()), new NotLogicProcessor());
     }
 
     @Override
     public ScriptTemplate asScript() {
-        throw new SqlIllegalArgumentException("Not supported yet");
+        ScriptTemplate fieldScript = asScript(field());
+        Params params = ParamsBuilder.paramsBuilder().script(fieldScript.params()).build();
+        return new ScriptTemplate("!(" + nullSafeFilter(fieldScript) + ")", params, DataType.BOOLEAN);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/logical/NotLogicProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/logical/NotLogicProcessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.sql.expression.predicate.logical;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.sql.expression.gen.processor.Processor;
+
+import java.io.IOException;
+
+public class NotLogicProcessor implements Processor {
+
+    private static final String NAME = "not";
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+    }
+
+    @Override
+    public Boolean process(Object input) {
+        if (input == null) {
+            return null;
+        }
+        return !((Boolean) input);
+    }
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/query/NotQuery.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/query/NotQuery.java
@@ -24,6 +24,11 @@ public class NotQuery extends Query {
         this.child = child;
     }
 
+    // For testing
+    public Query childQuery() {
+        return child;
+    }
+
     @Override
     public boolean containsNestedField(String path, String field) {
         return child.containsNestedField(path, field);

--- a/x-pack/qa/sql/src/main/resources/agg.sql-spec
+++ b/x-pack/qa/sql/src/main/resources/agg.sql-spec
@@ -127,6 +127,8 @@ aggCountAndHaving
 SELECT gender g, COUNT(*) c FROM "test_emp" GROUP BY g HAVING COUNT(*) > 10 ORDER BY gender;
 aggCountAndHavingEquality
 SELECT gender g, COUNT(*) c FROM "test_emp" GROUP BY g HAVING COUNT(*) = 10 ORDER BY gender;
+aggCountAndHavingNegateEquality
+SELECT gender g, COUNT(*) c FROM "test_emp" GROUP BY g HAVING NOT COUNT(*) = 10 ORDER BY gender;
 aggCountOnColumnAndHaving
 SELECT gender g, COUNT(gender) c FROM "test_emp" GROUP BY g HAVING COUNT(gender) > 10 ORDER BY gender;
 aggCountOnColumnAndWildcardAndHaving

--- a/x-pack/qa/sql/src/main/resources/select.csv-spec
+++ b/x-pack/qa/sql/src/main/resources/select.csv-spec
@@ -1,0 +1,19 @@
+// Cannot be in sql-spec as the column name in H2 is translated to "!="
+negateEqualsInSelectClause
+SELECT NOT MONTH(birth_date) = 4, MONTH(birth_date), emp_no FROM "test_emp" ORDER BY 2;
+
+NOT((MONTH_OF_YEAR(birth_date [UTC])) == 5)|birth_date
+false                                      |1958-05-21T00:00:00Z
+true                                       |1959-10-01T00:00:00Z
+true                                       |1960-07-20T00:00:00Z
+null                                       |null
+null                                       |null
+null                                       |null
+null                                       |null
+null                                       |null
+null                                       |null
+null                                       |null
+null                                       |null
+null                                       |null
+null                                       |null
+;


### PR DESCRIPTION
For other logical operators adding `NOT` in front of the expression
results in negation of the binary operator, e.g.:
`NOT a > b` becomes `a <= b`
but this is not the case for `NOT a = b`.

This implements the negation of equals when encountered in the SELECT
clause or needs to be translated to a painless script (e.g.:
`HAVING NOT count(*) = 10`)

Previously, an `SqlIllegalArgumentException[Not supported yet]` was
thrown.

Fixes: #34558
