### PR TITLE
Enable using defined setups from test setup in docs

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
@@ -193,7 +193,7 @@ public class RestTestsFromSnippetsTask extends SnippetsTask {
                         "$snippet: Use `js` instead of `${snippet.language}`.")
             }
             if (snippet.testSetup) {
-                setup(snippet)
+                testSetup(snippet)
                 previousTest = snippet
                 return
             }
@@ -259,18 +259,21 @@ public class RestTestsFromSnippetsTask extends SnippetsTask {
                 current.println("      reason: $test.skip")
             }
             if (test.setup != null) {
-                // Insert a setup defined outside of the docs
-                for (String setupName : test.setup.split(',')) {
-                    String setup = setups[setupName]
-                    if (setup == null) {
-                        throw new InvalidUserDataException("Couldn't find setup "
-                                + "for $test")
-                    }
-                    current.println(setup)
-                }
+                setup(test)
             }
 
             body(test, false)
+        }
+
+        private void setup(final Snippet snippet) {
+            // insert a setup defined outside of the docs
+            for (final String setupName : snippet.setup.split(',')) {
+                final String setup = setups[setupName]
+                if (setup == null) {
+                    throw new InvalidUserDataException("Couldn't find setup for $snippet")
+                }
+                current.println(setup)
+            }
         }
 
         private void response(Snippet response) {
@@ -339,14 +342,17 @@ public class RestTestsFromSnippetsTask extends SnippetsTask {
             }
         }
 
-        private void setup(Snippet setup) {
-            if (lastDocsPath == setup.path) {
-                throw new InvalidUserDataException("$setup: wasn't first")
+        private void testSetup(Snippet snippet) {
+            if (lastDocsPath == snippet.path) {
+                throw new InvalidUserDataException("$snippet: wasn't first")
             }
-            setupCurrent(setup)
+            setupCurrent(snippet)
             current.println('---')
             current.println("setup:")
-            body(setup, true)
+            if (snippet.setup != null) {
+                setup(snippet)
+            }
+            body(snippet, true)
         }
 
         private void body(Snippet snippet, boolean inSetup) {


### PR DESCRIPTION
In the docs tests, we have pre-defined setups in the build.gradle file, and we can also define test setup sections within the doc page itself. Alas, these two are incompatible in that if you try to use a pre-defined setup alongside a test setup section, the pre-defined setup will be silently ignored. This commit enables pre-defined setup sections to be used together with test setup sections. The ordering here is that pre-defined setup sections will be executed first, followed by the test setup section.
