### PR TITLE
Enable docs tests to have tear down snippet

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
@@ -197,6 +197,11 @@ public class RestTestsFromSnippetsTask extends SnippetsTask {
                 previousTest = snippet
                 return
             }
+            if (snippet.testTearDown) {
+                testTearDown(snippet)
+                previousTest = snippet
+                return
+            }
             if (snippet.testResponse) {
                 response(snippet)
                 return
@@ -222,6 +227,10 @@ public class RestTestsFromSnippetsTask extends SnippetsTask {
                 if (previousTest != null && previousTest.testSetup) {
                     throw new InvalidUserDataException("// TEST[continued] " +
                         "cannot immediately follow // TESTSETUP: $test")
+                }
+                if (previousTest != null && previousTest.testTearDown) {
+                    throw new InvalidUserDataException("// TEST[continued] " +
+                        "cannot immediately follow // TEARDOWN: $test")
                 }
             } else {
                 current.println('---')
@@ -352,6 +361,16 @@ public class RestTestsFromSnippetsTask extends SnippetsTask {
             if (snippet.setup != null) {
                 setup(snippet)
             }
+            body(snippet, true)
+        }
+
+        private void testTearDown(Snippet snippet) {
+            if (previousTest.testSetup == false && lastDocsPath == snippet.path) {
+                throw new InvalidUserDataException("$snippet must follow test setup or be first")
+            }
+            setupCurrent(snippet)
+            current.println('---')
+            current.println('teardown:')
             body(snippet, true)
         }
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/SnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/SnippetsTask.groovy
@@ -273,6 +273,10 @@ public class SnippetsTask extends DefaultTask {
                     snippet.testSetup = true
                     return
                 }
+                if (line ==~ /\/\/\s*TEARDOWN\s*/) {
+                    snippet.testTearDown = true
+                    return
+                }
                 if (snippet == null) {
                     // Outside
                     return
@@ -317,6 +321,7 @@ public class SnippetsTask extends DefaultTask {
         boolean test = false
         boolean testResponse = false
         boolean testSetup = false
+        boolean testTearDown = false
         String skip = null
         boolean continued = false
         String language = null


### PR DESCRIPTION
This commit adds the ability for docs tests to add a tear down snippet. This snippet will be converted to a tear down section of the generated REST tests.
