### PR TITLE
INGEST: Rename Pipeline Processor Param.

### DIFF
--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/210_pipeline_processor.yml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/210_pipeline_processor.yml
@@ -44,7 +44,7 @@ teardown:
           "processors" : [
             {
               "pipeline" : {
-                "pipeline": "inner"
+                "name": "inner"
               }
             }
           ]
@@ -78,7 +78,7 @@ teardown:
           "processors" : [
             {
               "pipeline" : {
-                "pipeline": "inner"
+                "name": "inner"
               }
             }
           ]
@@ -94,7 +94,7 @@ teardown:
           "processors" : [
             {
               "pipeline" : {
-                "pipeline": "outer"
+                "name": "outer"
               }
             }
           ]

--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/90_simulate.yml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/90_simulate.yml
@@ -617,7 +617,7 @@ teardown:
           "processors" : [
             {
               "pipeline" : {
-                "pipeline": "inner"
+                "name": "inner"
               }
             }
           ]
@@ -633,7 +633,7 @@ teardown:
           "processors" : [
             {
               "pipeline" : {
-                "pipeline": "outer"
+                "name": "outer"
               }
             }
           ]
@@ -650,7 +650,7 @@ teardown:
             "processors" : [
             {
               "pipeline" : {
-                "pipeline": "outer"
+                "name": "outer"
               }
             }
             ]
@@ -686,7 +686,7 @@ teardown:
           },
           {
             "pipeline": {
-              "pipeline": "pipeline2"
+              "name": "pipeline2"
             }
           }
           ]
@@ -724,7 +724,7 @@ teardown:
             },
             {
               "pipeline": {
-                "pipeline": "pipeline1"
+                "name": "pipeline1"
               }
             }
             ]

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineProcessor.java
@@ -65,7 +65,7 @@ public class PipelineProcessor extends AbstractProcessor {
         public PipelineProcessor create(Map<String, Processor.Factory> registry, String processorTag,
             Map<String, Object> config) throws Exception {
             String pipeline =
-                ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "pipeline");
+                ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "name");
             return new PipelineProcessor(processorTag, pipeline, ingestService);
         }
     }

--- a/server/src/test/java/org/elasticsearch/ingest/PipelineProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/PipelineProcessorTests.java
@@ -62,7 +62,7 @@ public class PipelineProcessorTests extends ESTestCase {
         when(ingestService.getPipeline(pipelineId)).thenReturn(pipeline);
         PipelineProcessor.Factory factory = new PipelineProcessor.Factory(ingestService);
         Map<String, Object> config = new HashMap<>();
-        config.put("pipeline", pipelineId);
+        config.put("name", pipelineId);
         factory.create(Collections.emptyMap(), null, config).execute(testIngestDocument);
         assertEquals(testIngestDocument, invoked.get());
     }
@@ -72,7 +72,7 @@ public class PipelineProcessorTests extends ESTestCase {
         IngestDocument testIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         PipelineProcessor.Factory factory = new PipelineProcessor.Factory(ingestService);
         Map<String, Object> config = new HashMap<>();
-        config.put("pipeline", "missingPipelineId");
+        config.put("name", "missingPipelineId");
         IllegalStateException e = expectThrows(
             IllegalStateException.class,
             () -> factory.create(Collections.emptyMap(), null, config).execute(testIngestDocument)
@@ -88,21 +88,21 @@ public class PipelineProcessorTests extends ESTestCase {
         IngestService ingestService = mock(IngestService.class);
         IngestDocument testIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         Map<String, Object> outerConfig = new HashMap<>();
-        outerConfig.put("pipeline", innerPipelineId);
+        outerConfig.put("name", innerPipelineId);
         PipelineProcessor.Factory factory = new PipelineProcessor.Factory(ingestService);
         Pipeline outer = new Pipeline(
             outerPipelineId, null, null,
             new CompoundProcessor(factory.create(Collections.emptyMap(), null, outerConfig))
         );
         Map<String, Object> innerConfig = new HashMap<>();
-        innerConfig.put("pipeline", outerPipelineId);
+        innerConfig.put("name", outerPipelineId);
         Pipeline inner = new Pipeline(
             innerPipelineId, null, null,
             new CompoundProcessor(factory.create(Collections.emptyMap(), null, innerConfig))
         );
         when(ingestService.getPipeline(outerPipelineId)).thenReturn(outer);
         when(ingestService.getPipeline(innerPipelineId)).thenReturn(inner);
-        outerConfig.put("pipeline", innerPipelineId);
+        outerConfig.put("name", innerPipelineId);
         ElasticsearchException e = expectThrows(
             ElasticsearchException.class,
             () -> factory.create(Collections.emptyMap(), null, outerConfig).execute(testIngestDocument)
@@ -117,7 +117,7 @@ public class PipelineProcessorTests extends ESTestCase {
         IngestService ingestService = mock(IngestService.class);
         IngestDocument testIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         Map<String, Object> outerConfig = new HashMap<>();
-        outerConfig.put("pipeline", innerPipelineId);
+        outerConfig.put("name", innerPipelineId);
         PipelineProcessor.Factory factory = new PipelineProcessor.Factory(ingestService);
         Pipeline inner = new Pipeline(
             innerPipelineId, null, null, new CompoundProcessor()
@@ -136,11 +136,11 @@ public class PipelineProcessorTests extends ESTestCase {
         PipelineProcessor.Factory factory = new PipelineProcessor.Factory(ingestService);
 
         Map<String, Object> pipeline1ProcessorConfig = new HashMap<>();
-        pipeline1ProcessorConfig.put("pipeline", pipeline2Id);
+        pipeline1ProcessorConfig.put("name", pipeline2Id);
         PipelineProcessor pipeline1Processor = factory.create(Collections.emptyMap(), null, pipeline1ProcessorConfig);
 
         Map<String, Object> pipeline2ProcessorConfig = new HashMap<>();
-        pipeline2ProcessorConfig.put("pipeline", pipeline3Id);
+        pipeline2ProcessorConfig.put("name", pipeline3Id);
         PipelineProcessor pipeline2Processor = factory.create(Collections.emptyMap(), null, pipeline2ProcessorConfig);
 
         Clock clock = mock(Clock.class);

--- a/server/src/test/java/org/elasticsearch/ingest/TrackingResultProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/TrackingResultProcessorTests.java
@@ -158,7 +158,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
         String pipelineId = "pipeline1";
         IngestService ingestService = mock(IngestService.class);
         Map<String, Object> pipelineConfig = new HashMap<>();
-        pipelineConfig.put("pipeline", pipelineId);
+        pipelineConfig.put("name", pipelineId);
         PipelineProcessor.Factory factory = new PipelineProcessor.Factory(ingestService);
 
         String key1 = randomAlphaOfLength(10);
@@ -204,7 +204,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
         String pipelineId = "pipeline1";
         IngestService ingestService = mock(IngestService.class);
         Map<String, Object> pipelineConfig = new HashMap<>();
-        pipelineConfig.put("pipeline", pipelineId);
+        pipelineConfig.put("name", pipelineId);
         PipelineProcessor.Factory factory = new PipelineProcessor.Factory(ingestService);
 
         String key1 = randomAlphaOfLength(10);
@@ -256,7 +256,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
         String pipelineId = "pipeline1";
         IngestService ingestService = mock(IngestService.class);
         Map<String, Object> pipelineConfig = new HashMap<>();
-        pipelineConfig.put("pipeline", pipelineId);
+        pipelineConfig.put("name", pipelineId);
         PipelineProcessor.Factory factory = new PipelineProcessor.Factory(ingestService);
 
         PipelineProcessor pipelineProcessor = factory.create(Collections.emptyMap(), null, pipelineConfig);
@@ -277,7 +277,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
         String pipelineId = "pipeline1";
         IngestService ingestService = mock(IngestService.class);
         Map<String, Object> pipelineConfig = new HashMap<>();
-        pipelineConfig.put("pipeline", pipelineId);
+        pipelineConfig.put("name", pipelineId);
         PipelineProcessor.Factory factory = new PipelineProcessor.Factory(ingestService);
 
         String key1 = randomAlphaOfLength(10);


### PR DESCRIPTION
* `name` is more readable/ergonomic than having `pipeline` twice
