### PR TITLE
Add a new "contains" feature to yml test

### DIFF
--- a/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/10_basic.yml
+++ b/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for Matrix Aggs Plugin
 #
 "Matrix stats aggs loaded":
+    - skip:
+          reason: "contains is a newly added assertion"
+          features: contains
     - do:
         cluster.state: {}
 

--- a/modules/analysis-common/src/test/resources/rest-api-spec/test/analysis-common/10_basic.yml
+++ b/modules/analysis-common/src/test/resources/rest-api-spec/test/analysis-common/10_basic.yml
@@ -1,4 +1,7 @@
 "Module loaded":
+    - skip:
+          reason: "contains is a newly added assertion"
+          features: contains
     - do:
         cluster.state: {}
 

--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/10_basic.yml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/10_basic.yml
@@ -1,4 +1,7 @@
 "Ingest common installed":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/modules/lang-expression/src/test/resources/rest-api-spec/test/lang_expression/10_basic.yml
+++ b/modules/lang-expression/src/test/resources/rest-api-spec/test/lang_expression/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for Expression scripts
 #
 "Expression loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/modules/lang-mustache/src/test/resources/rest-api-spec/test/lang_mustache/10_basic.yml
+++ b/modules/lang-mustache/src/test/resources/rest-api-spec/test/lang_mustache/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for Mustache scripts
 #
 "Mustache loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/10_basic.yml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for Painless Plugin
 #
 "Painless plugin loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/modules/repository-url/src/test/resources/rest-api-spec/test/repository_url/10_basic.yml
+++ b/modules/repository-url/src/test/resources/rest-api-spec/test/repository_url/10_basic.yml
@@ -103,6 +103,9 @@ teardown:
 
 ---
 "Module repository-url is loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/modules/transport-netty4/src/test/resources/rest-api-spec/test/10_basic.yml
+++ b/modules/transport-netty4/src/test/resources/rest-api-spec/test/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for Netty transport
 #
 "Netty loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/discovery-azure-classic/src/test/resources/rest-api-spec/test/discovery_azure_classic/10_basic.yml
+++ b/plugins/discovery-azure-classic/src/test/resources/rest-api-spec/test/discovery_azure_classic/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for Azure Classic Discovery component
 #
 "Discovery Azure Classic loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/discovery-ec2/src/test/resources/rest-api-spec/test/discovery_ec2/10_basic.yml
+++ b/plugins/discovery-ec2/src/test/resources/rest-api-spec/test/discovery_ec2/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for Discovery EC2 component
 #
 "Discovery EC2 loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/discovery-gce/src/test/resources/rest-api-spec/test/discovery_gce/10_basic.yml
+++ b/plugins/discovery-gce/src/test/resources/rest-api-spec/test/discovery_gce/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for Discovery GCE components
 #
 "Discovery GCE loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/examples/custom-suggester/src/test/resources/rest-api-spec/test/custom-suggester/10_basic.yml
+++ b/plugins/examples/custom-suggester/src/test/resources/rest-api-spec/test/custom-suggester/10_basic.yml
@@ -1,6 +1,9 @@
 # tests that the custom suggester plugin is installed
 ---
 "plugin loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/examples/painless-whitelist/src/test/resources/rest-api-spec/test/painless_whitelist/10_basic.yml
+++ b/plugins/examples/painless-whitelist/src/test/resources/rest-api-spec/test/painless_whitelist/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for the painless whitelist example plugin
 #
 "Plugin loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/examples/rescore/src/test/resources/rest-api-spec/test/example-rescore/10_basic.yml
+++ b/plugins/examples/rescore/src/test/resources/rest-api-spec/test/example-rescore/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for the expert scoring script example plugin
 #
 "Plugin loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/examples/script-expert-scoring/src/test/resources/rest-api-spec/test/script_expert_scoring/10_basic.yml
+++ b/plugins/examples/script-expert-scoring/src/test/resources/rest-api-spec/test/script_expert_scoring/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for the expert scoring script example plugin
 #
 "Plugin loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/ingest-attachment/src/test/resources/rest-api-spec/test/ingest_attachment/10_basic.yml
+++ b/plugins/ingest-attachment/src/test/resources/rest-api-spec/test/ingest_attachment/10_basic.yml
@@ -1,4 +1,7 @@
 "Ingest attachment plugin installed":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/ingest-geoip/src/test/resources/rest-api-spec/test/ingest_geoip/10_basic.yml
+++ b/plugins/ingest-geoip/src/test/resources/rest-api-spec/test/ingest_geoip/10_basic.yml
@@ -1,4 +1,7 @@
 "Ingest plugin installed":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/10_basic.yml
+++ b/plugins/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/10_basic.yml
@@ -1,4 +1,7 @@
 "ingest-user-agent plugin installed":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/repository-azure/src/test/resources/rest-api-spec/test/repository_azure/10_basic.yml
+++ b/plugins/repository-azure/src/test/resources/rest-api-spec/test/repository_azure/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for repository-azure
 #
 "Plugin repository-azure is loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/repository-gcs/src/test/resources/rest-api-spec/test/repository_gcs/10_basic.yml
+++ b/plugins/repository-gcs/src/test/resources/rest-api-spec/test/repository_gcs/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for repository-gcs
 #
 "Plugin repository-gcs is loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/hdfs_repository/10_basic.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/hdfs_repository/10_basic.yml
@@ -3,6 +3,9 @@
 # Check plugin is installed
 #
 "Plugin loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/10_basic.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/10_basic.yml
@@ -3,6 +3,9 @@
 # Check plugin is installed
 #
 "Plugin loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/10_basic.yml
+++ b/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for repository-s3
 #
 "Plugin repository-s3 is loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/plugins/store-smb/src/test/resources/rest-api-spec/test/store_smb/10_basic.yml
+++ b/plugins/store-smb/src/test/resources/rest-api-spec/test/store_smb/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for SMB Store component
 #
 "SMB Store loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Features.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Features.java
@@ -46,7 +46,9 @@ public final class Features {
             "stash_in_path",
             "stash_path_replace",
             "warnings",
-            "yaml"));
+            "yaml",
+            "contains"
+    ));
 
     private Features() {
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/40_get_user_privs.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/40_get_user_privs.yml
@@ -202,6 +202,9 @@ teardown:
 ---
 
 "Test get_user_privileges for single role":
+  - skip:
+          reason: "contains is a newly added assertion"
+          features: contains  
   - do:
       headers: { Authorization: "Basic dGVzdC0xOjEyMzQ1Njc4" } # test-1
       xpack.security.get_user_privileges: {}
@@ -261,6 +264,9 @@ teardown:
 ---
 
 "Test get_user_privileges for merged roles":
+  - skip:
+      reason: "contains is a newly added assertion"
+      features: contains
   - do:
       headers: { Authorization: "Basic dGVzdC0zOjEyMzQ1Njc4" } # test-3
       xpack.security.get_user_privileges: {}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/xpack/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/xpack/10_basic.yml
@@ -1,6 +1,9 @@
 # Integration tests for monitoring
 #
 "X-Pack loaded":
+    - skip:
+        reason: "contains is a newly added assertion"
+        features: contains
     - do:
         cluster.state: {}
 


### PR DESCRIPTION
The contains syntax was added in #30874 but the skips were not properly
put in place.
The java runner has the feature so the tests will run as part of the
build, but language clients will be able to support it at their own
pace.
