### PR TITLE
document the search context is freed if the scroll is not extended

### DIFF
--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -109,7 +109,8 @@ request) tells Elasticsearch how long it should keep the search context alive.
 Its value (e.g. `1m`, see <<time-units>>) does not need to be long enough to
 process all data -- it just needs to be long enough to process the previous
 batch of results. Each `scroll` request (with the `scroll` parameter) sets a
-new  expiry time.
+new  expiry time. If the `scroll` parameter is not passed, then the next
+scroll request will close the search context.
 
 Normally, the background merge process optimizes the
 index by merging together smaller segments to create new bigger segments, at

--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -109,8 +109,9 @@ request) tells Elasticsearch how long it should keep the search context alive.
 Its value (e.g. `1m`, see <<time-units>>) does not need to be long enough to
 process all data -- it just needs to be long enough to process the previous
 batch of results. Each `scroll` request (with the `scroll` parameter) sets a
-new  expiry time. If the `scroll` parameter is not passed, then the next
-scroll request will close the search context.
+new  expiry time. If a `scroll` request doesn't pass in the `scroll`
+parameter, then the search context will be freed as part of _that_ `scroll`
+request.
 
 Normally, the background merge process optimizes the
 index by merging together smaller segments to create new bigger segments, at


### PR DESCRIPTION
The `fetchPhaseShouldFreeContext` returns true when there is a scroll context but the scroll parameter is null, thus freeing the search context.

https://github.com/elastic/elasticsearch/blob/183c32d4c39948e037a7fb44dccf31ab0d60d3c3/server/src/main/java/org/elasticsearch/search/SearchService.java#L491
