### PR TITLE
Backport: A small typo in migration-assistance doc (#34704)

### DIFF
--- a/docs/reference/migration/apis/assistance.asciidoc
+++ b/docs/reference/migration/apis/assistance.asciidoc
@@ -40,7 +40,7 @@ GET /_xpack/migration/assistance
 // CONSOLE
 // TEST[skip:cannot create an old index in docs test]
 
-A successful call returns a list of indices that need to updated or reindexed:
+A successful call returns a list of indices that need to be updated or reindexed:
 
 [source,js]
 --------------------------------------------------
@@ -73,7 +73,7 @@ GET /_xpack/migration/assistance/my_*
 // CONSOLE
 // TEST[skip:cannot create an old index in docs test]
 
-A successful call returns a list of indices that needs to updated or reindexed
+A successful call returns a list of indices that needs to be updated or reindexed
 and match the index specified on the endpoint:
 
 [source,js]


### PR DESCRIPTION
typo - missing word "be"

This is to back port from master.
Review not needed