### PR TITLE
Rename testcluster extension to align with plugin name

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -39,8 +39,8 @@ import java.util.Map;
 
 public class TestClustersPlugin implements Plugin<Project> {
 
-    public static final String LIST_TASK_NAME = "listElasticSearchClusters";
-    public static final String EXTENSION_NAME = "elasticSearchClusters";
+    private static final String LIST_TASK_NAME = "listTestClusters";
+    private static final String NODE_EXTENSION_NAME = "testClusters";
 
     private final Logger logger =  Logging.getLogger(TestClustersPlugin.class);
 
@@ -50,7 +50,7 @@ public class TestClustersPlugin implements Plugin<Project> {
             ElasticsearchNode.class,
             (name) -> new ElasticsearchNode(name, GradleServicesAdapter.getInstance(project))
         );
-        project.getExtensions().add(EXTENSION_NAME, container);
+        project.getExtensions().add(NODE_EXTENSION_NAME, container);
 
         Task listTask = project.getTasks().create(LIST_TASK_NAME);
         listTask.setGroup("ES cluster formation");

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/testclusters/TestClustersPluginIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/testclusters/TestClustersPluginIT.java
@@ -31,11 +31,11 @@ public class TestClustersPluginIT extends GradleIntegrationTestCase {
     public void testListClusters() {
         BuildResult result = GradleRunner.create()
             .withProjectDir(getProjectDir("testclusters"))
-            .withArguments("listElasticSearchClusters", "-s")
+            .withArguments("listTestClusters", "-s")
             .withPluginClasspath()
             .build();
 
-        assertEquals(TaskOutcome.SUCCESS, result.task(":listElasticSearchClusters").getOutcome());
+        assertEquals(TaskOutcome.SUCCESS, result.task(":listTestClusters").getOutcome());
         assertOutputContains(
             result.getOutput(),
                 "   * myTestCluster:"

--- a/buildSrc/src/testKit/testclusters/build.gradle
+++ b/buildSrc/src/testKit/testclusters/build.gradle
@@ -2,40 +2,40 @@ plugins {
     id 'elasticsearch.testclusters'
 }
 
-elasticSearchClusters {
+testClusters {
     myTestCluster {
        distribution = 'ZIP'
     }
 }
 
 task user1 {
-    useCluster elasticSearchClusters.myTestCluster
+    useCluster testClusters.myTestCluster
     doLast {
         println "user1 executing"
     }
 }
 
 task user2 {
-    useCluster elasticSearchClusters.myTestCluster
+    useCluster testClusters.myTestCluster
     doLast {
         println "user2 executing"
     }
 }
 
 task upToDate1 {
-    useCluster elasticSearchClusters.myTestCluster
+    useCluster testClusters.myTestCluster
 }
 
 task upToDate2 {
-    useCluster elasticSearchClusters.myTestCluster
+    useCluster testClusters.myTestCluster
 }
 
 task skipped1 {
     enabled = false
-    useCluster elasticSearchClusters.myTestCluster
+    useCluster testClusters.myTestCluster
 }
 
 task skipped2 {
     enabled = false
-    useCluster elasticSearchClusters.myTestCluster
+    useCluster testClusters.myTestCluster
 }


### PR DESCRIPTION
Previous renames did not rename the extension that allows nodes to be configured. 
This change does just that.