### PR TITLE
HLRC: Standardize access in *RequestConverters

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterRequestConverters.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 
 final class ClusterRequestConverters {
 
+    private ClusterRequestConverters() {}
+
     static Request clusterPutSettings(ClusterUpdateSettingsRequest clusterUpdateSettingsRequest) throws IOException {
         Request request = new Request(HttpPut.METHOD_NAME, "/_cluster/settings");
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/GraphRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/GraphRequestConverters.java
@@ -24,7 +24,9 @@ import org.elasticsearch.protocol.xpack.graph.GraphExploreRequest;
 
 import java.io.IOException;
 
-public class GraphRequestConverters {
+final class GraphRequestConverters {
+
+    private GraphRequestConverters() {}
 
     static Request explore(GraphExploreRequest exploreRequest) throws IOException {
         String endpoint = RequestConverters.endpoint(exploreRequest.indices(), exploreRequest.types(), "_xpack/graph/_explore");

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
@@ -53,7 +53,10 @@ import org.elasticsearch.common.Strings;
 import java.io.IOException;
 import java.util.Locale;
 
-public class IndicesRequestConverters {
+final class IndicesRequestConverters {
+
+    private IndicesRequestConverters() {}
+
     static Request deleteIndex(DeleteIndexRequest deleteIndexRequest) {
         String endpoint = RequestConverters.endpoint(deleteIndexRequest.indices());
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IngestRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IngestRequestConverters.java
@@ -30,7 +30,9 @@ import org.elasticsearch.action.ingest.SimulatePipelineRequest;
 
 import java.io.IOException;
 
-public class IngestRequestConverters {
+final class IngestRequestConverters {
+
+    private IngestRequestConverters() {}
 
     static Request getPipeline(GetPipelineRequest getPipelineRequest) {
         String endpoint = new RequestConverters.EndpointBuilder()

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseRequestConverters.java
@@ -29,7 +29,10 @@ import org.elasticsearch.client.license.DeleteLicenseRequest;
 import org.elasticsearch.client.license.GetLicenseRequest;
 import org.elasticsearch.client.license.PutLicenseRequest;
 
-public class LicenseRequestConverters {
+final class LicenseRequestConverters {
+
+    private LicenseRequestConverters() {}
+
     static Request putLicense(PutLicenseRequest putLicenseRequest) {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_xpack", "license").build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MigrationRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MigrationRequestConverters.java
@@ -22,7 +22,9 @@ package org.elasticsearch.client;
 import org.apache.http.client.methods.HttpGet;
 import org.elasticsearch.protocol.xpack.migration.IndexUpgradeInfoRequest;
 
-public class MigrationRequestConverters {
+final class MigrationRequestConverters {
+
+    private MigrationRequestConverters() {}
 
     static Request getMigrationAssistance(IndexUpgradeInfoRequest indexUpgradeInfoRequest) {
         RequestConverters.EndpointBuilder endpointBuilder = new RequestConverters.EndpointBuilder()

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/SnapshotRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/SnapshotRequestConverters.java
@@ -36,7 +36,9 @@ import org.elasticsearch.common.Strings;
 
 import java.io.IOException;
 
-public class SnapshotRequestConverters {
+final class SnapshotRequestConverters {
+
+    private SnapshotRequestConverters() {}
 
     static Request getRepositories(GetRepositoriesRequest getRepositoriesRequest) {
         String[] repositories = getRepositoriesRequest.repositories() == null ? Strings.EMPTY_ARRAY : getRepositoriesRequest.repositories();

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/TasksRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/TasksRequestConverters.java
@@ -24,7 +24,9 @@ import org.apache.http.client.methods.HttpPost;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
 
-public class TasksRequestConverters {
+final class TasksRequestConverters {
+
+    private TasksRequestConverters() {}
 
     static Request cancelTasks(CancelTasksRequest cancelTasksRequest) {
         Request request = new Request(HttpPost.METHOD_NAME, "/_tasks/_cancel");

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/WatcherRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/WatcherRequestConverters.java
@@ -32,7 +32,9 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.protocol.xpack.watcher.DeleteWatchRequest;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchRequest;
 
-public class WatcherRequestConverters {
+final class WatcherRequestConverters {
+
+    private WatcherRequestConverters() {}
 
     static Request startWatchService(StartWatchServiceRequest startWatchServiceRequest) {
         String endpoint = new RequestConverters.EndpointBuilder()

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/XPackRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/XPackRequestConverters.java
@@ -27,7 +27,9 @@ import java.util.EnumSet;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
-public class XPackRequestConverters {
+final class XPackRequestConverters {
+
+    private XPackRequestConverters() {}
 
     static Request info(XPackInfoRequest infoRequest) {
         Request request = new Request(HttpGet.METHOD_NAME, "/_xpack");


### PR DESCRIPTION
With the move to separate RequestConverters classes for each client,
some of the access restrictions on the new classes are more open than
the prior RequestConverters class. This standardizes the
*RequestConverters classes as package-private, final, and with a private
constructor so that no instances of them can be inadvertently created.