### PR TITLE
deprecate percolate in api spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count_percolate.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count_percolate.json
@@ -65,7 +65,7 @@
       }
     },
     "body": {
-      "description": "The count percolator request definition using the percolate DSL",
+      "description": "This has been deprecated since 5.0, use regular count endpoint. The count percolator request definition using the percolate DSL",
       "required": false
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mpercolate.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mpercolate.json
@@ -33,7 +33,7 @@
       }
     },
     "body": {
-      "description": "The percolate request definitions (header & body pair), separated by newlines",
+      "description": "This has been deprecated since 5.0, use regular msearch endpoint. The percolate request definitions (header & body pair), separated by newlines",
       "required": true,
       "serialize" : "bulk"
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/percolate.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/percolate.json
@@ -78,7 +78,7 @@
       }
     },
     "body": {
-      "description" : "The percolator request definition using the percolate DSL",
+      "description" : "This has been deprecated since 5.0, use regular search endpoint. The percolator request definition using the percolate DSL",
       "required" : false
     }
   }


### PR DESCRIPTION
As requested in https://github.com/elastic/elasticsearch-js/pull/713