### PR TITLE
SQL: Verifier allows aliases aggregates for sorting

### DIFF
--- a/x-pack/qa/sql/src/main/resources/agg.sql-spec
+++ b/x-pack/qa/sql/src/main/resources/agg.sql-spec
@@ -36,7 +36,7 @@ SELECT emp_no e FROM "test_emp" WHERE emp_no < 10020 GROUP BY emp_no ORDER BY em
 groupByOnNumberOnAlias
 SELECT emp_no e FROM "test_emp" WHERE emp_no < 10020 GROUP BY e ORDER BY emp_no DESC;
 groupByOnNumberWithAliasInSelect
-SELECT emp_no e FROM "test_emp" WHERE emp_no < 10020 GROUP BY e ORDER BY e DESC;
+SELECT emp_no e FROM "test_emp" WHERE emp_no < 10020 GROUP BY emp_no ORDER BY e DESC;
 
 // group by scalar
 groupByAddScalar

--- a/x-pack/qa/sql/src/main/resources/agg.sql-spec
+++ b/x-pack/qa/sql/src/main/resources/agg.sql-spec
@@ -35,6 +35,8 @@ groupByOnNumberWithWhereAndLimit
 SELECT emp_no e FROM "test_emp" WHERE emp_no < 10020 GROUP BY emp_no ORDER BY emp_no DESC LIMIT 1;
 groupByOnNumberOnAlias
 SELECT emp_no e FROM "test_emp" WHERE emp_no < 10020 GROUP BY e ORDER BY emp_no DESC;
+groupByOnNumberWithAliasInSelect
+SELECT emp_no e FROM "test_emp" WHERE emp_no < 10020 GROUP BY e ORDER BY e DESC;
 
 // group by scalar
 groupByAddScalar


### PR DESCRIPTION
Improve Verifier rule that prevented grouping, aliases inside aggregates
to not be accepted for ordering.

Close #34607