### PR TITLE
[Docs] Add `indices.query.bool.max_clause_count` setting

### DIFF
--- a/docs/reference/modules/indices.asciidoc
+++ b/docs/reference/modules/indices.asciidoc
@@ -30,6 +30,10 @@ Available settings include:
 
     Control the resource limits on the shard recovery process.
 
+<<search-settings,Search Settings>>::
+
+    Control global search settings.
+
 include::indices/circuit_breaker.asciidoc[]
 
 include::indices/fielddata.asciidoc[]
@@ -41,4 +45,6 @@ include::indices/indexing_buffer.asciidoc[]
 include::indices/request_cache.asciidoc[]
 
 include::indices/recovery.asciidoc[]
+
+include::indices/search-settings.asciidoc[]
 

--- a/docs/reference/modules/indices/search-settings.asciidoc
+++ b/docs/reference/modules/indices/search-settings.asciidoc
@@ -1,0 +1,16 @@
+[[search-settings]]
+=== Search Settings
+
+The following _expert_ setting can be set to manage global search limits.
+
+`indices.query.bool.max_clause_count`::
+    Defaults to `1024`.
+
+This setting limits the number of clauses a Lucene BooleanQuery can have. The
+default of 1024 is quite high and should normally be sufficient. This limit does
+not only affect Elasticsearchs `bool` query, but many other queries are rewritten to Lucene's
+BooleanQuery internally. The limit is in place to prevent searches from becoming to large
+and taking up too much CPU and memory. In case you consider to increase this setting,
+make sure you exhausted all other options to avoid having to do this. Higher values can lead 
+to performance degradations and memory issues, especially in clusters with a high load or 
+few resources.


### PR DESCRIPTION
This change adds a section about the global search setting
`indices.query.bool.max_clause_count` that limits the number of boolean clauses
allowed in a Lucene BooleanQuery.

Closes #19858