### PR TITLE
[CCR] Change ShardFollowTask defaults

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -54,10 +54,10 @@ public class TransportResumeFollowAction extends HandledTransportAction<ResumeFo
 
     static final ByteSizeValue DEFAULT_MAX_BATCH_SIZE = new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES);
     private static final TimeValue DEFAULT_MAX_RETRY_DELAY = new TimeValue(500);
-    private static final int DEFAULT_MAX_CONCURRENT_WRITE_BATCHES = 1;
+    private static final int DEFAULT_MAX_CONCURRENT_WRITE_BATCHES = 9;
     private static final int DEFAULT_MAX_WRITE_BUFFER_SIZE = 10240;
-    private static final int DEFAULT_MAX_BATCH_OPERATION_COUNT = 1024;
-    private static final int DEFAULT_MAX_CONCURRENT_READ_BATCHES = 1;
+    private static final int DEFAULT_MAX_BATCH_OPERATION_COUNT = 5120;
+    private static final int DEFAULT_MAX_CONCURRENT_READ_BATCHES = 12;
     static final TimeValue DEFAULT_POLL_TIMEOUT = TimeValue.timeValueMinutes(1);
 
     private final Client client;


### PR DESCRIPTION
Per #31717 this commit changes the defaults to the following:

Batch size of 5120 ops.
Maximum of 12 concurrent read requests.
Maximum of 9 concurrent write requests.

This is not necessarily our final values but it's good to have these as defaults for the purposes of initial testing.