### PR TITLE
[Docs] Clarify multi match query field limit

### DIFF
--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -63,7 +63,9 @@ index settings, which in turn defaults to `*`. `*` extracts all fields in the ma
 are eligible to term queries and filters the metadata fields. All extracted fields are then
 combined to build a query.
 
-WARNING: There is a limit of no more than 1024 fields being queried at once.
+WARNING: If you have a huge number of fields, the above auto expansion might lead to
+querying a large number of felds which might cause performance issues. In future versions
+(stating in 7.0) there will be a limit of no more than 1024 fields that can be queried at once.
 
 [[multi-match-types]]
 [float]


### PR DESCRIPTION
We limit the number of fields that a query can be expanded to to 1024 starting
with 7.0. However, I think that we don't enforce this in earlier versions
already. This change clarifies that while leaving a note that the limit is going
to be in effect in future versions and that a large number of fields can cause
problems.

Relates to #34778