### PR TITLE
Address BWC bug due to default metrics in (#34764)

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/XPackIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/XPackIT.java
@@ -207,7 +207,6 @@ public class XPackIT extends AbstractRollingTestCase {
      * would pollute the cluster state with its job that the non-xpack
      * nodes couldn't understand.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/34764")
     public void testCreateRollup() throws IOException {
         // Rollup validates its input on job creation so lets make an index for it
         Request indexInputDoc = new Request("POST", "/rollup_test_input_1/doc/");


### PR DESCRIPTION
Adding the default metrics for date fields broke BWC with mixed nodes that do not allow `date` fields yet. 

If the requesting `StreamOutput` is before 6.5, that means that `date` fields are not supported, so the default value for the timefield should be removed. 

closes #34764