### PR TITLE
Revert "Rollup add default metrics to histo groups (#34534)"

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/job/config/RollupJobConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/job/config/RollupJobConfig.java
@@ -42,11 +42,6 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optiona
 /**
  * This class holds the configuration details of a rollup job, such as the groupings, metrics, what
  * index to rollup and where to roll them to.
- *
- * When the configuration is stored server side, if there is no {@link MetricConfig} for the fields referenced in the
- * {@link HistogramGroupConfig} and {@link DateHistogramGroupConfig} in the passed {@link GroupConfig},
- * then default metrics of {@code ["min", "max"]} are provided
- *
  */
 public class RollupJobConfig implements Validatable, ToXContentObject {
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RollupIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RollupIT.java
@@ -46,7 +46,6 @@ import org.elasticsearch.client.rollup.job.config.GroupConfig;
 import org.elasticsearch.client.rollup.job.config.MetricConfig;
 import org.elasticsearch.client.rollup.job.config.RollupJobConfig;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
@@ -169,9 +168,7 @@ public class RollupIT extends ESRestHighLevelClientTestCase {
     public void testPutAndGetRollupJob() throws Exception {
         // TODO expand this to also test with histogram and terms?
         final GroupConfig groups = new GroupConfig(new DateHistogramGroupConfig("date", DateHistogramInterval.DAY));
-        final List<MetricConfig> metrics = Arrays.asList(
-            new MetricConfig("value", SUPPORTED_METRICS),
-            new MetricConfig("date", Arrays.asList(MaxAggregationBuilder.NAME)));
+        final List<MetricConfig> metrics = Collections.singletonList(new MetricConfig("value", SUPPORTED_METRICS));
         final TimeValue timeout = TimeValue.timeValueSeconds(randomIntBetween(30, 600));
 
         PutRollupJobRequest putRollupJobRequest =
@@ -199,28 +196,21 @@ public class RollupIT extends ESRestHighLevelClientTestCase {
             assertEquals(groups.getDateHistogram().getTimeZone(), source.get("date.date_histogram.time_zone"));
 
             for (MetricConfig metric : metrics) {
-                if (metric.getField().equals("value")) {
-                    for (String name : metric.getMetrics()) {
-                        Number value = (Number) source.get(metric.getField() + "." + name + ".value");
-                        if ("min".equals(name)) {
-                            assertEquals(min, value.intValue());
-                        } else if ("max".equals(name)) {
-                            assertEquals(max, value.intValue());
-                        } else if ("sum".equals(name)) {
-                            assertEquals(sum, value.doubleValue(), 0.0d);
-                        } else if ("avg".equals(name)) {
-                            assertEquals(sum, value.doubleValue(), 0.0d);
-                            Number avgCount = (Number) source.get(metric.getField() + "." + name + "._count");
-                            assertEquals(numDocs, avgCount.intValue());
-                        } else if ("value_count".equals(name)) {
-                            assertEquals(numDocs, value.intValue());
-                        }
+                for (String name : metric.getMetrics()) {
+                    Number value = (Number) source.get(metric.getField() + "." + name + ".value");
+                    if ("min".equals(name)) {
+                        assertEquals(min, value.intValue());
+                    } else if ("max".equals(name)) {
+                        assertEquals(max, value.intValue());
+                    } else if ("sum".equals(name)) {
+                        assertEquals(sum, value.doubleValue(), 0.0d);
+                    } else if ("avg".equals(name)) {
+                        assertEquals(sum, value.doubleValue(), 0.0d);
+                        Number avgCount = (Number) source.get(metric.getField() + "." + name + "._count");
+                        assertEquals(numDocs, avgCount.intValue());
+                    } else if ("value_count".equals(name)) {
+                        assertEquals(numDocs, value.intValue());
                     }
-                } else {
-                    Number value = (Number) source.get(metric.getField() + ".max.value");
-                    assertEquals(
-                        DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime("2018-01-01T00:59:50").getMillis(),
-                        value.longValue());
                 }
             }
         });

--- a/docs/java-rest/high-level/rollup/put_job.asciidoc
+++ b/docs/java-rest/high-level/rollup/put_job.asciidoc
@@ -119,68 +119,6 @@ include-tagged::{doc-tests}/RollupDocumentationIT.java[x-pack-rollup-put-rollup-
 <2> Adds the metrics to compute on the `temperature` field
 <3> Adds the metrics to compute on the `voltage` field
 
-By default, metrics `min`/`max` for the fields in `DateHistogramGroupConfig` and
-`HistogramGroupConfig` are added to the configuration unless the user already provided
-metrics for those fields.
-
-So, for the following configuration:
-
-[source,js]
---------------------------------------------------
-"groups" : {
-  "date_histogram": {
-    "field": "timestamp",
-    "interval": "1h",
-    "delay": "7d",
-    "time_zone": "UTC"
-  },
-  "terms": {
-    "fields": ["hostname", "datacenter"]
-  },
-  "histogram": {
-    "fields": ["load", "net_in", "net_out"],
-    "interval": 5
-  },
-},
-"metrics": [
-    {
-        "field": "load",
-        "metrics": ["max"]
-    },
-    {
-        "field": "net_in",
-        "metrics": ["max"]
-    }
-]
---------------------------------------------------
-// NOTCONSOLE
-
-The following will be the metrics in the configuration after
-the defaults are added server side. Note the default metrics
-provided for the fields `timestamp` and `net_out`
-
-[source,js]
---------------------------------------------------
-"metrics": [
-    {
-        "field": "load",
-        "metrics": ["max"]
-    },
-    {
-        "field": "net_in",
-        "metrics": ["max"]
-    },
-    {
-        "field": "timestamp",
-        "metrics": ["min", "max"]
-    },
-    {
-        "field": "net_out",
-        "metrics": ["min", "max"]
-    }
-]
---------------------------------------------------
-// NOTCONSOLE
 
 [[java-rest-high-x-pack-rollup-put-rollup-job-execution]]
 ==== Execution

--- a/docs/reference/rollup/apis/get-job.asciidoc
+++ b/docs/reference/rollup/apis/get-job.asciidoc
@@ -88,13 +88,6 @@ Which will yield the following response:
                 "metrics" : [
                   "avg"
                 ]
-              },
-              {
-                "field": "timestamp",
-                "metrics": [
-                  "max",
-                  "min"
-                 ]
               }
             ],
             "timeout" : "20s",
@@ -215,13 +208,6 @@ Which will yield the following response:
                 "metrics" : [
                   "avg"
                 ]
-              },
-              {
-                "field": "timestamp",
-                "metrics": [
-                  "min",
-                  "max"
-                ]
               }
             ],
             "timeout" : "20s",
@@ -271,13 +257,6 @@ Which will yield the following response:
                 "metrics" : [
                   "avg"
                 ]
-              },
-              {
-                "field": "timestamp",
-                "metrics": [
-                  "min",
-                  "max"
-                 ]
               }
             ],
             "timeout" : "20s",

--- a/docs/reference/rollup/apis/put-job.asciidoc
+++ b/docs/reference/rollup/apis/put-job.asciidoc
@@ -68,7 +68,7 @@ PUT _xpack/rollup/job/sensor
     "groups" : {
       "date_histogram": {
         "field": "timestamp",
-        "interval": "60m",
+        "interval": "1h",
         "delay": "7d"
       },
       "terms": {
@@ -99,83 +99,3 @@ When the job is created, you receive the following results:
 }
 ----
 // TESTRESPONSE
-
-By default the metrics `min`/`max` are added
-for the fields in the `date_histogram` and `histogram` configurations.
-If this behavior is not desired, explicitly configure metrics
-for those fields. This will override the defaults.
-
-If the following is provided
-
-[source,js]
---------------------------------------------------
-PUT _xpack/rollup/job/sensor2
-{
-    "index_pattern": "sensor-*",
-    "rollup_index": "sensor_rollup",
-    "cron": "*/30 * * * * ?",
-    "page_size" :1000,
-    "groups" : {
-      "date_histogram": {
-        "field": "timestamp",
-        "interval": "60m",
-        "delay": "7d"
-      },
-      "histogram": {
-        "fields": ["voltage", "temperature"],
-        "interval": 5
-      }
-    },
-    "metrics": [
-        {
-            "field": "temperature",
-            "metrics": ["min", "max", "sum"]
-        }
-    ]
-}
---------------------------------------------------
-// NOTCONSOLE
-// TEST[setup:sensor_index]
-
-The actual config when created in the cluster will look as follows.
-
-[source,js]
---------------------------------------------------
-{
-   "index_pattern": "sensor-*",
-   "rollup_index": "sensor_rollup",
-   "cron": "*/30 * * * * ?",
-   "page_size" :1000,
-   "groups" : {
-      "date_histogram": {
-         "field": "timestamp",
-         "interval": "60m",
-         "delay": "7d"
-      },
-      "histogram": {
-         "fields": ["voltage", "temperature"],
-         "interval": 5
-      }
-   },
-   "metrics": [
-       {
-           "field": "temperature",
-           "metrics": ["min", "max", "sum"]
-       },
-       {
-           "field": "voltage", <1>
-           "metrics": ["min", "max"]
-       },
-       {
-           "field": "timestamp", <1>
-           "metrics": ["min", "max"]
-       }
-   ]
-}
---------------------------------------------------
-// NOTCONSOLE
-<1> Notice the new default metrics gathered for `voltage` and `timestamp`.
-    Since these fields were referenced in `groups.histogram` and
-    `groups.date_histogram` configurations
-    respectively and no metrics were requested for them,
-    they both got the default metrics of `["min", "max"]`.

--- a/docs/reference/rollup/apis/rollup-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-caps.asciidoc
@@ -124,12 +124,6 @@ Which will yield the following response:
               "time_zone" : "UTC",
               "interval" : "1h",
               "delay": "7d"
-            },
-            {
-              "agg": "max"
-            },
-            {
-              "agg": "min"
             }
           ],
           "voltage" : [

--- a/docs/reference/rollup/apis/rollup-index-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-index-caps.asciidoc
@@ -120,12 +120,6 @@ This  will yield the following response:
               "time_zone" : "UTC",
               "interval" : "1h",
               "delay": "7d"
-            },
-            {
-              "agg" : "max"
-            },
-            {
-              "agg" : "min"
             }
           ],
           "voltage" : [

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/RollupJobConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/RollupJobConfig.java
@@ -20,19 +20,14 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.MinAggregationBuilder;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -51,7 +46,6 @@ public class RollupJobConfig implements NamedWriteable, ToXContentObject {
     private static final String PAGE_SIZE = "page_size";
     private static final String INDEX_PATTERN = "index_pattern";
     private static final String ROLLUP_INDEX = "rollup_index";
-    private static final List<String> DEFAULT_HISTO_METRICS = Arrays.asList(MaxAggregationBuilder.NAME, MinAggregationBuilder.NAME);
 
     private final String id;
     private final String indexPattern;
@@ -129,7 +123,7 @@ public class RollupJobConfig implements NamedWriteable, ToXContentObject {
         this.indexPattern = indexPattern;
         this.rollupIndex = rollupIndex;
         this.groupConfig = groupConfig;
-        this.metricsConfig = addDefaultMetricsIfNeeded(metricsConfig, groupConfig);
+        this.metricsConfig = metricsConfig != null ? metricsConfig : Collections.emptyList();
         this.timeout = timeout != null ? timeout : DEFAULT_TIMEOUT;
         this.cron = cron;
         this.pageSize = pageSize;
@@ -282,24 +276,5 @@ public class RollupJobConfig implements NamedWriteable, ToXContentObject {
 
     public static RollupJobConfig fromXContent(final XContentParser parser, @Nullable final String optionalJobId) throws IOException {
         return PARSER.parse(parser, optionalJobId);
-    }
-
-    private static List<MetricConfig> addDefaultMetricsIfNeeded(List<MetricConfig> metrics, GroupConfig groupConfig) {
-        List<MetricConfig> inputMetrics = metrics != null ? new ArrayList<>(metrics) : new ArrayList<>();
-        if (groupConfig != null) {
-            String timeField = groupConfig.getDateHistogram().getField();
-            Set<String> currentFields = inputMetrics.stream().map(MetricConfig::getField).collect(Collectors.toSet());
-            if (currentFields.contains(timeField) == false) {
-                inputMetrics.add(new MetricConfig(timeField, DEFAULT_HISTO_METRICS));
-            }
-            if (groupConfig.getHistogram() != null) {
-                for (String histoField : groupConfig.getHistogram().getFields()) {
-                    if (currentFields.contains(histoField) == false) {
-                        inputMetrics.add(new MetricConfig(histoField, DEFAULT_HISTO_METRICS));
-                    }
-                }
-            }
-        }
-        return Collections.unmodifiableList(inputMetrics);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/job/RollupJobConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/job/RollupJobConfigTests.java
@@ -11,23 +11,10 @@ import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import static com.carrotsearch.randomizedtesting.generators.RandomStrings.randomAsciiAlphanumOfLengthBetween;
 import static java.util.Collections.emptyList;
-import static org.elasticsearch.xpack.core.rollup.ConfigTestHelpers.randomCron;
-import static org.elasticsearch.xpack.core.rollup.ConfigTestHelpers.randomDateHistogramGroupConfig;
-import static org.elasticsearch.xpack.core.rollup.ConfigTestHelpers.randomHistogramGroupConfig;
-import static org.elasticsearch.xpack.core.rollup.ConfigTestHelpers.randomMetricsConfigs;
 import static org.elasticsearch.xpack.core.rollup.ConfigTestHelpers.randomRollupJobConfig;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.isIn;
 
 
 public class RollupJobConfigTests extends AbstractSerializingTestCase<RollupJobConfig> {
@@ -175,70 +162,5 @@ public class RollupJobConfigTests extends AbstractSerializingTestCase<RollupJobC
             new RollupJobConfig(sample.getId(), sample.getIndexPattern(), sample.getRollupIndex(), sample.getCron(), sample.getPageSize(),
                 null, emptyList(), sample.getTimeout()));
         assertThat(e.getMessage(), equalTo("At least one grouping or metric must be configured"));
-    }
-
-    public void testDefaultFieldsForDateHistograms() {
-        final Random random = random();
-        DateHistogramGroupConfig dateHistogramGroupConfig = randomDateHistogramGroupConfig(random);
-        HistogramGroupConfig histogramGroupConfig1 = randomHistogramGroupConfig(random);
-        List<MetricConfig> metrics = new ArrayList<>(randomMetricsConfigs(random));
-        for (String histoField : histogramGroupConfig1.getFields()) {
-            metrics.add(new MetricConfig(histoField, Arrays.asList("max")));
-        }
-        GroupConfig groupConfig = new GroupConfig(dateHistogramGroupConfig, histogramGroupConfig1, null);
-        RollupJobConfig rollupJobConfig = new RollupJobConfig(
-            randomAsciiAlphanumOfLengthBetween(random, 1, 20),
-            "indexes_*",
-            "rollup_" + randomAsciiAlphanumOfLengthBetween(random, 1, 20),
-            randomCron(),
-            randomIntBetween(1, 10),
-            groupConfig,
-            metrics,
-            null);
-        Set<String> metricFields = rollupJobConfig.getMetricsConfig().stream().map(MetricConfig::getField).collect(Collectors.toSet());
-        assertThat(dateHistogramGroupConfig.getField(), isIn(metricFields));
-        List<String> histoFields = Arrays.asList(histogramGroupConfig1.getFields());
-        rollupJobConfig.getMetricsConfig().forEach(metricConfig -> {
-            if (histoFields.contains(metricConfig.getField())) {
-                // Since it is explicitly included, the defaults should not be added
-                assertThat(metricConfig.getMetrics(), containsInAnyOrder("max"));
-            }
-            if (metricConfig.getField().equals(dateHistogramGroupConfig.getField())) {
-                assertThat(metricConfig.getMetrics(), containsInAnyOrder("max", "min"));
-            }
-        });
-    }
-
-    public void testDefaultFieldsForHistograms() {
-        final Random random = random();
-        DateHistogramGroupConfig dateHistogramGroupConfig = randomDateHistogramGroupConfig(random);
-        HistogramGroupConfig histogramGroupConfig1 = randomHistogramGroupConfig(random);
-        List<MetricConfig> metrics = new ArrayList<>(randomMetricsConfigs(random));
-        metrics.add(new MetricConfig(dateHistogramGroupConfig.getField(), Arrays.asList("max")));
-        GroupConfig groupConfig = new GroupConfig(dateHistogramGroupConfig, histogramGroupConfig1, null);
-        RollupJobConfig rollupJobConfig = new RollupJobConfig(
-            randomAsciiAlphanumOfLengthBetween(random, 1, 20),
-            "indexes_*",
-            "rollup_" + randomAsciiAlphanumOfLengthBetween(random, 1, 20),
-            randomCron(),
-            randomIntBetween(1, 10),
-            groupConfig,
-            metrics,
-            null);
-        Set<String> metricFields = rollupJobConfig.getMetricsConfig().stream().map(MetricConfig::getField).collect(Collectors.toSet());
-        for (String histoField : histogramGroupConfig1.getFields()) {
-            assertThat(histoField, isIn(metricFields));
-        }
-        assertThat(dateHistogramGroupConfig.getField(), isIn(metricFields));
-        List<String> histoFields = Arrays.asList(histogramGroupConfig1.getFields());
-        rollupJobConfig.getMetricsConfig().forEach(metricConfig -> {
-            if (histoFields.contains(metricConfig.getField())) {
-                assertThat(metricConfig.getMetrics(), containsInAnyOrder("max", "min"));
-            }
-            if (metricConfig.getField().equals(dateHistogramGroupConfig.getField())) {
-                // Since it is explicitly included, the defaults should not be added
-                assertThat(metricConfig.getMetrics(), containsInAnyOrder("max"));
-            }
-        });
     }
 }

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -116,8 +116,6 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                             "the_histo.date_histogram.interval", "1ms",
                             "the_histo.date_histogram._count", 2,
                             "the_histo.date_histogram.time_zone", DateTimeZone.UTC.toString(),
-                            "the_histo.min.value", 3.0,
-                            "the_histo.max.value", 3.0,
                             "_rollup.id", job.getId()
                     )
             ));
@@ -131,8 +129,6 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                             "the_histo.date_histogram.interval", "1ms",
                             "the_histo.date_histogram._count", 1,
                             "the_histo.date_histogram.time_zone", DateTimeZone.UTC.toString(),
-                            "the_histo.min.value", 7.0,
-                            "the_histo.max.value", 7.0,
                             "_rollup.id", job.getId()
                     )
             ));
@@ -183,8 +179,6 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                             "counter.max.value", 20.0,
                             "counter.sum.value", 50.0,
                             "the_histo.date_histogram.time_zone", DateTimeZone.UTC.toString(),
-                            "the_histo.min.value", (double) asLong("2015-03-31T03:00:00"),
-                            "the_histo.max.value", (double) asLong("2015-03-31T03:40:00"),
                             "_rollup.id", job.getId()
                     )
             ));
@@ -203,8 +197,6 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                             "counter.max.value", 55.0,
                             "counter.sum.value", 141.0,
                             "the_histo.date_histogram.time_zone", DateTimeZone.UTC.toString(),
-                            "the_histo.min.value", (double) asLong("2015-03-31T04:00:00"),
-                            "the_histo.max.value", (double) asLong("2015-03-31T04:40:00"),
                             "_rollup.id", job.getId()
                     )
             ));
@@ -223,8 +215,6 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                             "counter.max.value", 80.0,
                             "counter.sum.value", 275.0,
                             "the_histo.date_histogram.time_zone", DateTimeZone.UTC.toString(),
-                            "the_histo.min.value", (double) asLong("2015-03-31T05:00:00"),
-                            "the_histo.max.value", (double) asLong("2015-03-31T05:40:00"),
                             "_rollup.id", job.getId()
                     )
             ));
@@ -243,8 +233,6 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                             "counter.max.value", 100.0,
                             "counter.sum.value", 270.0,
                             "the_histo.date_histogram.time_zone", DateTimeZone.UTC.toString(),
-                            "the_histo.min.value", (double) asLong("2015-03-31T06:00:00"),
-                            "the_histo.max.value", (double) asLong("2015-03-31T06:40:00"),
                             "_rollup.id", job.getId()
                     )
             ));
@@ -263,8 +251,6 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                             "counter.max.value", 200.0,
                             "counter.sum.value", 440.0,
                             "the_histo.date_histogram.time_zone", DateTimeZone.UTC.toString(),
-                            "the_histo.min.value", (double) asLong("2015-03-31T07:00:00"),
-                            "the_histo.max.value", (double) asLong("2015-03-31T07:40:00"),
                             "_rollup.id", job.getId()
                     )
             ));
@@ -306,8 +292,6 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                             "the_histo.date_histogram.interval", "1m",
                             "the_histo.date_histogram._count", 2,
                             "the_histo.date_histogram.time_zone", DateTimeZone.UTC.toString(),
-                            "the_histo.min.value", (double) (now - TimeValue.timeValueHours(5).getMillis()),
-                            "the_histo.max.value", (double) (now - TimeValue.timeValueHours(5).getMillis()),
                             "_rollup.id", job.getId()
                     )
             ));
@@ -321,8 +305,6 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                             "the_histo.date_histogram.interval", "1m",
                             "the_histo.date_histogram._count", 2,
                             "the_histo.date_histogram.time_zone", DateTimeZone.UTC.toString(),
-                            "the_histo.min.value", (double) (now - TimeValue.timeValueMinutes(75).getMillis()),
-                            "the_histo.max.value", (double) (now - TimeValue.timeValueMinutes(75).getMillis()),
                             "_rollup.id", job.getId()
                     )
             ));
@@ -336,8 +318,6 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                             "the_histo.date_histogram.interval", "1m",
                             "the_histo.date_histogram._count", 1,
                             "the_histo.date_histogram.time_zone", DateTimeZone.UTC.toString(),
-                            "the_histo.min.value", (double) (now - TimeValue.timeValueMinutes(61).getMillis()),
-                            "the_histo.max.value", (double) (now - TimeValue.timeValueMinutes(61).getMillis()),
                             "_rollup.id", job.getId()
                     )
             ));
@@ -377,8 +357,6 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                                     "the_histo.date_histogram.interval", "1d",
                                     "the_histo.date_histogram._count", 2,
                                     "the_histo.date_histogram.time_zone", timeZone.toString(),
-                                    "the_histo.min.value", (double) (now - TimeValue.timeValueHours(10).getMillis()),
-                                    "the_histo.max.value", (double) (now - TimeValue.timeValueHours(8).getMillis()),
                                     "_rollup.id", job.getId()
                             )
                     ));
@@ -398,8 +376,6 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                             "the_histo.date_histogram.interval", "1d",
                             "the_histo.date_histogram._count", 2,
                             "the_histo.date_histogram.time_zone", timeZone.toString(),
-                            "the_histo.min.value", (double) (now - TimeValue.timeValueHours(10).getMillis()),
-                            "the_histo.max.value", (double) (now - TimeValue.timeValueHours(8).getMillis()),
                             "_rollup.id", job.getId()
                     )
             ));
@@ -413,8 +389,6 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                             "the_histo.date_histogram.interval", "1d",
                             "the_histo.date_histogram._count", 5,
                             "the_histo.date_histogram.time_zone", timeZone.toString(),
-                            "the_histo.min.value", (double) (now - TimeValue.timeValueHours(6).getMillis()),
-                            "the_histo.max.value", (double) now,
                             "_rollup.id", job.getId()
                     )
             ));

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/delete_job.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/delete_job.yml
@@ -62,10 +62,6 @@ setup:
                  - "min"
                  - "max"
                  - "sum"
-              - field: "the_field"
-                metrics:
-                 - "max"
-                 - "min"
             timeout: "20s"
           stats:
             pages_processed: 0
@@ -113,10 +109,6 @@ setup:
                  - "min"
                  - "max"
                  - "sum"
-              - field: "the_field"
-                metrics:
-                 - "max"
-                 - "min"
             timeout: "20s"
           stats:
             pages_processed: 0
@@ -164,10 +156,6 @@ setup:
                  - "min"
                  - "max"
                  - "sum"
-              - field: "the_field"
-                metrics:
-                 - "max"
-                 - "min"
             timeout: "20s"
           stats:
             pages_processed: 0

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/get_jobs.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/get_jobs.yml
@@ -63,10 +63,6 @@ setup:
                  - "min"
                  - "max"
                  - "sum"
-              - field: "the_field"
-                metrics:
-                 - "max"
-                 - "min"
             timeout: "20s"
           stats:
             pages_processed: 0
@@ -178,10 +174,6 @@ setup:
                  - "min"
                  - "max"
                  - "sum"
-              - field: "the_field"
-                metrics:
-                 - "max"
-                 - "min"
             timeout: "20s"
           stats:
             pages_processed: 0
@@ -208,10 +200,6 @@ setup:
                  - "min"
                  - "max"
                  - "sum"
-              - field: "the_field"
-                metrics:
-                 - "max"
-                 - "min"
             timeout: "20s"
           stats:
             pages_processed: 0

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/get_rollup_caps.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/get_rollup_caps.yml
@@ -77,8 +77,6 @@ setup:
                 - agg: "date_histogram"
                   interval: "1h"
                   time_zone: "UTC"
-                - agg: "max"
-                - agg: "min"
               value_field:
                 - agg: "min"
                 - agg: "max"
@@ -126,8 +124,6 @@ setup:
                 - agg: "date_histogram"
                   interval: "1h"
                   time_zone: "UTC"
-                - agg: "max"
-                - agg: "min"
               value_field:
                 - agg: "min"
                 - agg: "max"
@@ -140,8 +136,6 @@ setup:
                 - agg: "date_histogram"
                   interval: "1h"
                   time_zone: "UTC"
-                - agg: "max"
-                - agg: "min"
               value_field:
                 - agg: "min"
                 - agg: "max"
@@ -215,8 +209,6 @@ setup:
                 - agg: "date_histogram"
                   interval: "1h"
                   time_zone: "UTC"
-                - agg: "max"
-                - agg: "min"
               value_field:
                 - agg: "min"
                 - agg: "max"
@@ -229,8 +221,6 @@ setup:
                 - agg: "date_histogram"
                   interval: "1h"
                   time_zone: "UTC"
-                - agg: "max"
-                - agg: "min"
               value_field:
                 - agg: "min"
                 - agg: "max"
@@ -246,8 +236,6 @@ setup:
                 - agg: "date_histogram"
                   interval: "1h"
                   time_zone: "UTC"
-                - agg: "max"
-                - agg: "min"
               value_field:
                 - agg: "min"
                 - agg: "max"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/get_rollup_index_caps.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/get_rollup_index_caps.yml
@@ -77,8 +77,6 @@ setup:
                 - agg: "date_histogram"
                   interval: "1h"
                   time_zone: "UTC"
-                - agg: "max"
-                - agg: "min"
               value_field:
                 - agg: "min"
                 - agg: "max"
@@ -126,8 +124,6 @@ setup:
                 - agg: "date_histogram"
                   interval: "1h"
                   time_zone: "UTC"
-                - agg: "max"
-                - agg: "min"
               value_field:
                 - agg: "min"
                 - agg: "max"
@@ -140,8 +136,6 @@ setup:
                 - agg: "date_histogram"
                   interval: "1h"
                   time_zone: "UTC"
-                - agg: "max"
-                - agg: "min"
               value_field:
                 - agg: "min"
                 - agg: "max"
@@ -190,8 +184,6 @@ setup:
                 - agg: "date_histogram"
                   interval: "1h"
                   time_zone: "UTC"
-                - agg: "max"
-                - agg: "min"
               value_field:
                 - agg: "min"
                 - agg: "max"
@@ -265,8 +257,6 @@ setup:
                   - agg: "date_histogram"
                     interval: "1h"
                     time_zone: "UTC"
-                  - agg: "max"
-                  - agg: "min"
                 value_field:
                   - agg: "min"
                   - agg: "max"
@@ -279,8 +269,6 @@ setup:
                   - agg: "date_histogram"
                     interval: "1h"
                     time_zone: "UTC"
-                  - agg: "max"
-                  - agg: "min"
                 value_field:
                   - agg: "min"
                   - agg: "max"
@@ -295,8 +283,6 @@ setup:
                   - agg: "date_histogram"
                     interval: "1h"
                     time_zone: "UTC"
-                  - agg: "max"
-                  - agg: "min"
                 value_field:
                   - agg: "min"
                   - agg: "max"
@@ -374,8 +360,6 @@ setup:
             - agg: "date_histogram"
               interval: "1h"
               time_zone: "UTC"
-            - agg: "max"
-            - agg: "min"
             value_field:
             - agg: "min"
             - agg: "max"
@@ -388,8 +372,6 @@ setup:
             - agg: "date_histogram"
               interval: "1h"
               time_zone: "UTC"
-            - agg: "max"
-            - agg: "min"
             value_field:
             - agg: "min"
             - agg: "max"
@@ -404,8 +386,6 @@ setup:
             - agg: "date_histogram"
               interval: "1h"
               time_zone: "UTC"
-            - agg: "max"
-            - agg: "min"
             value_field:
             - agg: "min"
             - agg: "max"
@@ -479,8 +459,6 @@ setup:
                   - agg: "date_histogram"
                     interval: "1h"
                     time_zone: "UTC"
-                  - agg: "max"
-                  - agg: "min"
                 value_field:
                   - agg: "min"
                   - agg: "max"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/put_job.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/put_job.yml
@@ -63,10 +63,6 @@ setup:
                  - "min"
                  - "max"
                  - "sum"
-              - field: "the_field"
-                metrics:
-                 - "max"
-                 - "min"
             timeout: "20s"
           stats:
             pages_processed: 0

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/security_tests.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/security_tests.yml
@@ -173,8 +173,6 @@ teardown:
       hits.hits.0._source:
         timestamp.date_histogram.time_zone: "UTC"
         timestamp.date_histogram.timestamp: 0
-        timestamp.max.value: 123.0
-        timestamp.min.value: 123.0
         value_field.max.value: 1232.0
         _rollup.version: 2
         timestamp.date_histogram.interval: "1s"
@@ -336,8 +334,6 @@ teardown:
       hits.hits.0._source:
         timestamp.date_histogram.time_zone: "UTC"
         timestamp.date_histogram.timestamp: 0
-        timestamp.max.value: 123.0
-        timestamp.min.value: 123.0
         value_field.max.value: 1232.0
         _rollup.version: 2
         timestamp.date_histogram.interval: "1s"


### PR DESCRIPTION
This reverts commit 4236358f5d53ab4f0d8457faacb19983b6b1ab82.
