### PR TITLE
Test: ensure char[] doesn't being with prefix

### DIFF
--- a/libs/core/src/test/java/org/elasticsearch/common/CharArraysTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/common/CharArraysTests.java
@@ -43,12 +43,12 @@ public class CharArraysTests extends ESTestCase {
         assertArrayEquals(expectedChars, convertedChars);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/34765")
     public void testCharsBeginsWith() {
         assertFalse(CharArrays.charsBeginsWith(randomAlphaOfLength(4), null));
         assertFalse(CharArrays.charsBeginsWith(null, null));
         assertFalse(CharArrays.charsBeginsWith(null, randomAlphaOfLength(4).toCharArray()));
-        assertFalse(CharArrays.charsBeginsWith(randomAlphaOfLength(2), randomAlphaOfLengthBetween(3, 8).toCharArray()));
+        final String undesiredPrefix = randomAlphaOfLength(2);
+        assertFalse(CharArrays.charsBeginsWith(undesiredPrefix, randomAlphaOfLengthNotBeginningWith(undesiredPrefix, 3, 8)));
 
         final String prefix = randomAlphaOfLengthBetween(2, 4);
         assertTrue(CharArrays.charsBeginsWith(prefix, prefix.toCharArray()));
@@ -72,5 +72,13 @@ public class CharArraysTests extends ESTestCase {
         final String other = randomAlphaOfLengthBetween(1, 32);
         assertFalse(CharArrays.constantTimeEquals(value, other));
         assertFalse(CharArrays.constantTimeEquals(value.toCharArray(), other.toCharArray()));
+    }
+
+    private char[] randomAlphaOfLengthNotBeginningWith(String undesiredPrefix, int min, int max) {
+        char[] nonMatchingValue;
+        do {
+            nonMatchingValue = randomAlphaOfLengthBetween(min, max).toCharArray();
+        } while (new String(nonMatchingValue).startsWith(undesiredPrefix));
+        return nonMatchingValue;
     }
 }


### PR DESCRIPTION
The testCharsBeginsWith test has a check that a random prefix of length
2 is not the prefix of a char[]. However, there is no check that the
char[] is not randomly generated with the same two characters as the
prefix. This change ensures that the char[] does not begin with the
prefix.

Closes #34765