### PR TITLE
remove index.lifecycle.skip setting

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/IndexLifecycleExplainResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/IndexLifecycleExplainResponse.java
@@ -39,7 +39,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject {
     private static final ParseField INDEX_FIELD = new ParseField("index");
     private static final ParseField MANAGED_BY_ILM_FIELD = new ParseField("managed");
     private static final ParseField POLICY_NAME_FIELD = new ParseField("policy");
-    private static final ParseField SKIP_FIELD = new ParseField("skip");
     private static final ParseField LIFECYCLE_DATE_FIELD = new ParseField("lifecycle_date");
     private static final ParseField PHASE_FIELD = new ParseField("phase");
     private static final ParseField ACTION_FIELD = new ParseField("action");
@@ -57,7 +56,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject {
             (String) a[0],
             (boolean) a[1],
             (String) a[2],
-            (boolean) (a[3] == null ? false: a[3]),
             (long) (a[4] == null ? -1L: a[4]),
             (String) a[5],
             (String) a[6],
@@ -72,7 +70,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX_FIELD);
         PARSER.declareBoolean(ConstructingObjectParser.constructorArg(), MANAGED_BY_ILM_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), POLICY_NAME_FIELD);
-        PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), SKIP_FIELD);
         PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), LIFECYCLE_DATE_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), PHASE_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), ACTION_FIELD);
@@ -100,24 +97,23 @@ public class IndexLifecycleExplainResponse implements ToXContentObject {
     private final long phaseTime;
     private final long actionTime;
     private final long stepTime;
-    private final boolean skip;
     private final boolean managedByILM;
     private final BytesReference stepInfo;
     private final PhaseExecutionInfo phaseExecutionInfo;
 
-    public static IndexLifecycleExplainResponse newManagedIndexResponse(String index, String policyName, boolean skip, long lifecycleDate,
+    public static IndexLifecycleExplainResponse newManagedIndexResponse(String index, String policyName, long lifecycleDate,
                                                                         String phase, String action, String step, String failedStep,
                                                                         long phaseTime, long actionTime, long stepTime,
                                                                         BytesReference stepInfo, PhaseExecutionInfo phaseExecutionInfo) {
-        return new IndexLifecycleExplainResponse(index, true, policyName, skip, lifecycleDate, phase, action, step, failedStep, phaseTime,
+        return new IndexLifecycleExplainResponse(index, true, policyName, lifecycleDate, phase, action, step, failedStep, phaseTime,
             actionTime, stepTime, stepInfo, phaseExecutionInfo);
     }
 
     public static IndexLifecycleExplainResponse newUnmanagedIndexResponse(String index) {
-        return new IndexLifecycleExplainResponse(index, false, null, false, -1L, null, null, null, null, -1L, -1L, -1L, null, null);
+        return new IndexLifecycleExplainResponse(index, false, null, -1L, null, null, null, null, -1L, -1L, -1L, null, null);
     }
 
-    private IndexLifecycleExplainResponse(String index, boolean managedByILM, String policyName, boolean skip, long lifecycleDate,
+    private IndexLifecycleExplainResponse(String index, boolean managedByILM, String policyName, long lifecycleDate,
                                           String phase, String action, String step, String failedStep, long phaseTime, long actionTime,
                                           long stepTime, BytesReference stepInfo, PhaseExecutionInfo phaseExecutionInfo) {
         if (managedByILM) {
@@ -134,7 +130,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject {
         this.index = index;
         this.policyName = policyName;
         this.managedByILM = managedByILM;
-        this.skip = skip;
         this.lifecycleDate = lifecycleDate;
         this.phase = phase;
         this.action = action;
@@ -157,10 +152,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject {
 
     public String getPolicyName() {
         return policyName;
-    }
-
-    public boolean skip() {
-        return skip;
     }
 
     public long getLifecycleDate() {
@@ -210,7 +201,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject {
         builder.field(MANAGED_BY_ILM_FIELD.getPreferredName(), managedByILM);
         if (managedByILM) {
             builder.field(POLICY_NAME_FIELD.getPreferredName(), policyName);
-            builder.field(SKIP_FIELD.getPreferredName(), skip);
             if (builder.humanReadable()) {
                 builder.field(LIFECYCLE_DATE_FIELD.getPreferredName(), new DateTime(lifecycleDate, ISOChronology.getInstanceUTC()));
             } else {
@@ -250,7 +240,7 @@ public class IndexLifecycleExplainResponse implements ToXContentObject {
 
     @Override
     public int hashCode() {
-        return Objects.hash(index, managedByILM, policyName, skip, lifecycleDate, phase, action, step, failedStep, phaseTime, actionTime,
+        return Objects.hash(index, managedByILM, policyName, lifecycleDate, phase, action, step, failedStep, phaseTime, actionTime,
             stepTime, stepInfo, phaseExecutionInfo);
     }
 
@@ -266,7 +256,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject {
         return Objects.equals(index, other.index) &&
             Objects.equals(managedByILM, other.managedByILM) &&
             Objects.equals(policyName, other.policyName) &&
-            Objects.equals(skip, other.skip) &&
             Objects.equals(lifecycleDate, other.lifecycleDate) &&
             Objects.equals(phase, other.phase) &&
             Objects.equals(action, other.action) &&

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/IndexLifecycleExplainResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/IndexLifecycleExplainResponse.java
@@ -56,16 +56,16 @@ public class IndexLifecycleExplainResponse implements ToXContentObject {
             (String) a[0],
             (boolean) a[1],
             (String) a[2],
-            (long) (a[4] == null ? -1L: a[4]),
+            (long) (a[3] == null ? -1L: a[3]),
+            (String) a[4],
             (String) a[5],
             (String) a[6],
             (String) a[7],
-            (String) a[8],
+            (long) (a[8] == null ? -1L: a[8]),
             (long) (a[9] == null ? -1L: a[9]),
             (long) (a[10] == null ? -1L: a[10]),
-            (long) (a[11] == null ? -1L: a[11]),
-            (BytesReference) a[12],
-            (PhaseExecutionInfo) a[13]));
+            (BytesReference) a[11],
+            (PhaseExecutionInfo) a[12]));
     static {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX_FIELD);
         PARSER.declareBoolean(ConstructingObjectParser.constructorArg(), MANAGED_BY_ILM_FIELD);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/IndexExplainResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/IndexExplainResponseTests.java
@@ -50,7 +50,7 @@ public class IndexExplainResponseTests extends AbstractXContentTestCase<IndexLif
     }
 
     private static IndexLifecycleExplainResponse randomManagedIndexExplainResponse() {
-        return IndexLifecycleExplainResponse.newManagedIndexResponse(randomAlphaOfLength(10), randomAlphaOfLength(10), randomBoolean(),
+        return IndexLifecycleExplainResponse.newManagedIndexResponse(randomAlphaOfLength(10), randomAlphaOfLength(10),
                 randomNonNegativeLong(), randomAlphaOfLength(10), randomAlphaOfLength(10), randomAlphaOfLength(10),
                 randomBoolean() ? null : randomAlphaOfLength(10), randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(),
                 randomBoolean() ? null : new BytesArray(new RandomStepInfo(() -> randomAlphaOfLength(10)).toString()),

--- a/x-pack/docs/en/ilm/apis/explain.asciidoc
+++ b/x-pack/docs/en/ilm/apis/explain.asciidoc
@@ -101,14 +101,13 @@ When the index is first taken over by ILM you will see a response like the follo
       "index": "my_index",
       "managed": true, <1>
       "policy": "my_policy", <2>
-      "skip": false, <3>
-      "lifecycle_date": 1538475653281, <4>
-      "phase": "new", <5>
-      "phase_time": 1538475653317, <6>
-      "action": "complete", <7>
-      "action_time": 1538475653317, <8>
-      "step": "complete", <9>
-      "step_time": 1538475653317 <10>
+      "lifecycle_date": 1538475653281, <3>
+      "phase": "new", <4>
+      "phase_time": 1538475653317, <5>
+      "action": "complete", <6>
+      "action_time": 1538475653317, <7>
+      "step": "complete", <8>
+      "step_time": 1538475653317 <9>
     }
   }
 }
@@ -121,14 +120,13 @@ When the index is first taken over by ILM you will see a response like the follo
 <1> Shows if the index is being managed by ILM. If the index is not managed by
 ILM the other fields will not be shown
 <2> The name of the policy which ILM is using for this index
-<3> Shows whether ILM execution for the index is currently set to be skipped
-<4> The timestamp used for the `minimum_age`
-<5> The current phase
-<6> The timestamp for when the index entered the current phase
-<7> The current action
-<8> The timestamp for when the index entered the current action
-<9> The current step
-<10> The timestamp for when the index entered the current step
+<3> The timestamp used for the `minimum_age`
+<4> The current phase
+<5> The timestamp for when the index entered the current phase
+<6> The current action
+<7> The timestamp for when the index entered the current action
+<8> The current step
+<9> The timestamp for when the index entered the current step
 
 When the policy is running on the index the response will contain a
 `phase_execution` object that describes the exact phase that is being run.
@@ -143,7 +141,6 @@ phase definition has been completely executed.
       "index": "test-000069",
       "managed": true,
       "policy": "my_lifecycle3",
-      "skip": false,
       "lifecycle_date": "2018-10-15T13:45:21.981Z",
       "phase": "hot",
       "phase_time": "2018-10-15T13:45:22.577Z",
@@ -190,7 +187,6 @@ If the policy is waiting for a step to complete for the index, the response will
       "index": "test-000020",
       "managed": true,
       "policy": "my_lifecycle3",
-      "skip": false,
       "lifecycle_date": "2018-10-15T13:20:28.042Z",
       "phase": "warm",
       "phase_time": "2018-10-15T13:20:28.428Z",
@@ -249,7 +245,6 @@ that occurred in `step_info`.
       "index": "test-000056",
       "managed": true,
       "policy": "my_lifecycle3",
-      "skip": false,
       "lifecycle_date": "2018-10-15T13:38:26.209Z",
       "phase": "hot",
       "phase_time": "2018-10-15T13:38:26.706Z",

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/IndexLifecycleExplainResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/IndexLifecycleExplainResponse.java
@@ -46,16 +46,16 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
                     (String) a[0],
                     (boolean) a[1],
                     (String) a[2],
-                    (Long) (a[4]),
+                    (Long) (a[3]),
+                    (String) a[4],
                     (String) a[5],
                     (String) a[6],
                     (String) a[7],
-                    (String) a[8],
+                    (Long) (a[8]),
                     (Long) (a[9]),
                     (Long) (a[10]),
-                    (Long) (a[11]),
-                    (BytesReference) a[12],
-                    (PhaseExecutionInfo) a[13]));
+                    (BytesReference) a[11],
+                    (PhaseExecutionInfo) a[12]));
     static {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX_FIELD);
         PARSER.declareBoolean(ConstructingObjectParser.constructorArg(), MANAGED_BY_ILM_FIELD);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/IndexLifecycleExplainResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/IndexLifecycleExplainResponse.java
@@ -29,7 +29,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
     private static final ParseField INDEX_FIELD = new ParseField("index");
     private static final ParseField MANAGED_BY_ILM_FIELD = new ParseField("managed");
     private static final ParseField POLICY_NAME_FIELD = new ParseField("policy");
-    private static final ParseField SKIP_FIELD = new ParseField("skip");
     private static final ParseField LIFECYCLE_DATE_FIELD = new ParseField("lifecycle_date");
     private static final ParseField PHASE_FIELD = new ParseField("phase");
     private static final ParseField ACTION_FIELD = new ParseField("action");
@@ -47,7 +46,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
                     (String) a[0],
                     (boolean) a[1],
                     (String) a[2],
-                    (boolean) (a[3] == null ? false: a[3]),
                     (Long) (a[4]),
                     (String) a[5],
                     (String) a[6],
@@ -62,7 +60,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
         PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX_FIELD);
         PARSER.declareBoolean(ConstructingObjectParser.constructorArg(), MANAGED_BY_ILM_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), POLICY_NAME_FIELD);
-        PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), SKIP_FIELD);
         PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), LIFECYCLE_DATE_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), PHASE_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), ACTION_FIELD);
@@ -90,23 +87,22 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
     private final Long phaseTime;
     private final Long actionTime;
     private final Long stepTime;
-    private final boolean skip;
     private final boolean managedByILM;
     private final BytesReference stepInfo;
     private final PhaseExecutionInfo phaseExecutionInfo;
 
-    public static IndexLifecycleExplainResponse newManagedIndexResponse(String index, String policyName, boolean skip, Long lifecycleDate,
+    public static IndexLifecycleExplainResponse newManagedIndexResponse(String index, String policyName, Long lifecycleDate,
             String phase, String action, String step, String failedStep, Long phaseTime, Long actionTime, Long stepTime,
             BytesReference stepInfo, PhaseExecutionInfo phaseExecutionInfo) {
-        return new IndexLifecycleExplainResponse(index, true, policyName, skip, lifecycleDate, phase, action, step, failedStep, phaseTime,
+        return new IndexLifecycleExplainResponse(index, true, policyName, lifecycleDate, phase, action, step, failedStep, phaseTime,
                 actionTime, stepTime, stepInfo, phaseExecutionInfo);
     }
 
     public static IndexLifecycleExplainResponse newUnmanagedIndexResponse(String index) {
-        return new IndexLifecycleExplainResponse(index, false, null, false, null, null, null, null, null, null, null, null, null, null);
+        return new IndexLifecycleExplainResponse(index, false, null, null, null, null, null, null, null, null, null, null, null);
     }
 
-    private IndexLifecycleExplainResponse(String index, boolean managedByILM, String policyName, boolean skip, Long lifecycleDate,
+    private IndexLifecycleExplainResponse(String index, boolean managedByILM, String policyName, Long lifecycleDate,
                                           String phase, String action, String step, String failedStep, Long phaseTime, Long actionTime,
                                           Long stepTime, BytesReference stepInfo, PhaseExecutionInfo phaseExecutionInfo) {
         if (managedByILM) {
@@ -123,7 +119,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
         this.index = index;
         this.policyName = policyName;
         this.managedByILM = managedByILM;
-        this.skip = skip;
         this.lifecycleDate = lifecycleDate;
         this.phase = phase;
         this.action = action;
@@ -141,7 +136,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
         managedByILM = in.readBoolean();
         if (managedByILM) {
             policyName = in.readString();
-            skip = in.readBoolean();
             lifecycleDate = in.readOptionalLong();
             phase = in.readOptionalString();
             action = in.readOptionalString();
@@ -154,7 +148,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
             phaseExecutionInfo = in.readOptionalWriteable(PhaseExecutionInfo::new);
         } else {
             policyName = null;
-            skip = false;
             lifecycleDate = null;
             phase = null;
             action = null;
@@ -174,7 +167,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
         out.writeBoolean(managedByILM);
         if (managedByILM) {
             out.writeString(policyName);
-            out.writeBoolean(skip);
             out.writeOptionalLong(lifecycleDate);
             out.writeOptionalString(phase);
             out.writeOptionalString(action);
@@ -198,10 +190,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
 
     public String getPolicyName() {
         return policyName;
-    }
-
-    public boolean skip() {
-        return skip;
     }
 
     public Long getLifecycleDate() {
@@ -251,7 +239,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
         builder.field(MANAGED_BY_ILM_FIELD.getPreferredName(), managedByILM);
         if (managedByILM) {
             builder.field(POLICY_NAME_FIELD.getPreferredName(), policyName);
-            builder.field(SKIP_FIELD.getPreferredName(), skip);
             if (builder.humanReadable()) {
                 builder.field(LIFECYCLE_DATE_FIELD.getPreferredName(), new DateTime(lifecycleDate, ISOChronology.getInstanceUTC()));
             } else {
@@ -291,7 +278,7 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
 
     @Override
     public int hashCode() {
-        return Objects.hash(index, managedByILM, policyName, skip, lifecycleDate, phase, action, step, failedStep, phaseTime, actionTime,
+        return Objects.hash(index, managedByILM, policyName, lifecycleDate, phase, action, step, failedStep, phaseTime, actionTime,
                 stepTime, stepInfo, phaseExecutionInfo);
     }
 
@@ -307,7 +294,6 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
         return Objects.equals(index, other.index) &&
                 Objects.equals(managedByILM, other.managedByILM) &&
                 Objects.equals(policyName, other.policyName) &&
-                Objects.equals(skip, other.skip) &&
                 Objects.equals(lifecycleDate, other.lifecycleDate) &&
                 Objects.equals(phase, other.phase) &&
                 Objects.equals(action, other.action) &&

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleSettings.java
@@ -14,12 +14,9 @@ import org.elasticsearch.common.unit.TimeValue;
 public class LifecycleSettings {
     public static final String LIFECYCLE_POLL_INTERVAL = "indices.lifecycle.poll_interval";
     public static final String LIFECYCLE_NAME = "index.lifecycle.name";
-    public static final String LIFECYCLE_SKIP = "index.lifecycle.skip";
 
     public static final Setting<TimeValue> LIFECYCLE_POLL_INTERVAL_SETTING = Setting.positiveTimeSetting(LIFECYCLE_POLL_INTERVAL,
         TimeValue.timeValueMinutes(10), Setting.Property.Dynamic, Setting.Property.NodeScope);
     public static final Setting<String> LIFECYCLE_NAME_SETTING = Setting.simpleString(LIFECYCLE_NAME,
-        Setting.Property.Dynamic, Setting.Property.IndexScope);
-    public static final Setting<Boolean> LIFECYCLE_SKIP_SETTING = Setting.boolSetting(LIFECYCLE_SKIP, false,
         Setting.Property.Dynamic, Setting.Property.IndexScope);
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/IndexExplainResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/IndexExplainResponseTests.java
@@ -41,7 +41,7 @@ public class IndexExplainResponseTests extends AbstractSerializingTestCase<Index
     }
 
     private static IndexLifecycleExplainResponse randomManagedIndexExplainResponse() {
-        return IndexLifecycleExplainResponse.newManagedIndexResponse(randomAlphaOfLength(10), randomAlphaOfLength(10), randomBoolean(),
+        return IndexLifecycleExplainResponse.newManagedIndexResponse(randomAlphaOfLength(10), randomAlphaOfLength(10),
             randomNonNegativeLong(), randomAlphaOfLength(10), randomAlphaOfLength(10), randomAlphaOfLength(10),
             randomBoolean() ? null : randomAlphaOfLength(10), randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(),
             randomBoolean() ? null : new BytesArray(new RandomStepInfo(() -> randomAlphaOfLength(10)).toString()),
@@ -76,11 +76,10 @@ public class IndexExplainResponseTests extends AbstractSerializingTestCase<Index
         Long actionTime = instance.getActionTime();
         Long stepTime = instance.getStepTime();
         boolean managed = instance.managedByILM();
-        boolean skip = instance.skip();
         BytesReference stepInfo = instance.getStepInfo();
         PhaseExecutionInfo phaseExecutionInfo = instance.getPhaseExecutionInfo();
         if (managed) {
-            switch (between(0, 13)) {
+            switch (between(0, 12)) {
             case 0:
                 index = index + randomAlphaOfLengthBetween(1, 5);
                 break;
@@ -128,17 +127,14 @@ public class IndexExplainResponseTests extends AbstractSerializingTestCase<Index
                 }
                 break;
             case 11:
-                skip = skip == false;
-                break;
-            case 12:
                 phaseExecutionInfo = randomValueOtherThan(phaseExecutionInfo, () -> PhaseExecutionInfoTests.randomPhaseExecutionInfo(""));
                 break;
-            case 13:
+            case 12:
                 return IndexLifecycleExplainResponse.newUnmanagedIndexResponse(index);
             default:
                 throw new AssertionError("Illegal randomisation branch");
             }
-            return IndexLifecycleExplainResponse.newManagedIndexResponse(index, policy, skip, policyTime, phase, action, step, failedStep,
+            return IndexLifecycleExplainResponse.newManagedIndexResponse(index, policy, policyTime, phase, action, step, failedStep,
                     phaseTime, actionTime, stepTime, stepInfo, phaseExecutionInfo);
         } else {
             switch (between(0, 1)) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycle.java
@@ -120,7 +120,6 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
         return Arrays.asList(
             LifecycleSettings.LIFECYCLE_POLL_INTERVAL_SETTING,
             LifecycleSettings.LIFECYCLE_NAME_SETTING,
-            LifecycleSettings.LIFECYCLE_SKIP_SETTING,
             RolloverAction.LIFECYCLE_ROLLOVER_ALIAS_SETTING);
     }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunner.java
@@ -89,13 +89,8 @@ public class IndexLifecycleRunner {
      * wait criteria are checked periodically from the ILM scheduler
      */
     public void runPeriodicStep(String policy, IndexMetaData indexMetaData) {
-        Settings indexSettings = indexMetaData.getSettings();
         String index = indexMetaData.getIndex().getName();
         LifecycleExecutionState lifecycleState = LifecycleExecutionState.fromIndexMetadata(indexMetaData);
-        if (LifecycleSettings.LIFECYCLE_SKIP_SETTING.get(indexSettings)) {
-            logger.info("skipping policy [{}] for index [{}]: {} == true", policy, index, LifecycleSettings.LIFECYCLE_SKIP);
-            return;
-        }
         Step currentStep = getCurrentStep(stepRegistry, policy, indexMetaData, lifecycleState);
         if (currentStep == null) {
             if (stepRegistry.policyExists(policy) == false) {
@@ -152,13 +147,8 @@ public class IndexLifecycleRunner {
      * If the current step (matching the expected step key) is an asynchronous action step, run it
      */
     public void maybeRunAsyncAction(ClusterState currentState, IndexMetaData indexMetaData, String policy, StepKey expectedStepKey) {
-        Settings indexSettings = indexMetaData.getSettings();
         String index = indexMetaData.getIndex().getName();
         LifecycleExecutionState lifecycleState = LifecycleExecutionState.fromIndexMetadata(indexMetaData);
-        if (LifecycleSettings.LIFECYCLE_SKIP_SETTING.get(indexSettings)) {
-            logger.info("skipping policy [{}] for index [{}]: {} == true", policy, index, LifecycleSettings.LIFECYCLE_SKIP);
-            return;
-        }
         Step currentStep = getCurrentStep(stepRegistry, policy, indexMetaData, lifecycleState);
         if (currentStep == null) {
             logger.warn("current step [{}] for index [{}] with policy [{}] is not recognized",
@@ -199,13 +189,8 @@ public class IndexLifecycleRunner {
      * Invoked after the cluster state has been changed
      */
     public void runPolicyAfterStateChange(String policy, IndexMetaData indexMetaData) {
-        Settings indexSettings = indexMetaData.getSettings();
         String index = indexMetaData.getIndex().getName();
         LifecycleExecutionState lifecycleState = LifecycleExecutionState.fromIndexMetadata(indexMetaData);
-        if (LifecycleSettings.LIFECYCLE_SKIP_SETTING.get(indexSettings)) {
-            logger.info("skipping policy [{}] for index [{}]: {} == true", policy, index, LifecycleSettings.LIFECYCLE_SKIP);
-            return;
-        }
         Step currentStep = getCurrentStep(stepRegistry, policy, indexMetaData, lifecycleState);
         if (currentStep == null) {
             if (stepRegistry.policyExists(policy) == false) {
@@ -507,7 +492,6 @@ public class IndexLifecycleRunner {
         boolean notChanged = true;
 
         notChanged &= Strings.isNullOrEmpty(newSettings.remove(LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey()));
-        notChanged &= Strings.isNullOrEmpty(newSettings.remove(LifecycleSettings.LIFECYCLE_SKIP_SETTING.getKey()));
         notChanged &= Strings.isNullOrEmpty(newSettings.remove(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS_SETTING.getKey()));
         long newSettingsVersion = notChanged ? indexMetadata.getSettingsVersion() : 1 + indexMetadata.getSettingsVersion();
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportExplainLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportExplainLifecycleAction.java
@@ -101,7 +101,6 @@ public class TransportExplainLifecycleAction
             final IndexLifecycleExplainResponse indexResponse;
             if (Strings.hasLength(policyName)) {
                 indexResponse = IndexLifecycleExplainResponse.newManagedIndexResponse(index, policyName,
-                    LifecycleSettings.LIFECYCLE_SKIP_SETTING.get(idxSettings),
                     lifecycleState.getLifecycleDate(),
                     lifecycleState.getPhase(),
                     lifecycleState.getAction(),

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunnerTests.java
@@ -950,27 +950,6 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         assertSame(newClusterState, runAgainClusterState);
     }
 
-    @SuppressWarnings("unchecked")
-    public void testSkipped() {
-        String policy = randomAlphaOfLength(5);
-        String index = randomAlphaOfLength(10);
-        LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(randomAlphaOfLength(5));
-        lifecycleState.setAction(randomAlphaOfLength(5));
-        lifecycleState.setStep(randomAlphaOfLength(5));
-        ClusterState clusterState = buildClusterState(index,
-            Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy).put(LifecycleSettings.LIFECYCLE_SKIP, true),
-            lifecycleState.build(),
-            Collections.emptyList());
-        Step step = mock(randomFrom(TerminalPolicyStep.class, ClusterStateActionStep.class,
-            ClusterStateWaitStep.class, AsyncActionStep.class, AsyncWaitStep.class));
-        PolicyStepsRegistry stepRegistry = createOneStepPolicyStepRegistry(policy, step);
-        ClusterService clusterService = mock(ClusterService.class);
-        IndexLifecycleRunner runner = new IndexLifecycleRunner(stepRegistry, clusterService, () -> 0L);
-        runner.runPolicyAfterStateChange(policy, clusterState.metaData().index(index));
-        Mockito.verifyZeroInteractions(clusterService);
-    }
-
     private ClusterState buildClusterState(String indexName, Settings.Builder indexSettingsBuilder,
                                            LifecycleExecutionState lifecycleState,
                                            List<LifecyclePolicyMetadata> lifecyclePolicyMetadatas) {
@@ -1020,8 +999,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         String oldPolicyName = "old_policy";
         StepKey currentStep = new StepKey(randomAlphaOfLength(10), MockAction.NAME, randomAlphaOfLength(10));
         LifecyclePolicy oldPolicy = createPolicy(oldPolicyName, currentStep, null);
-        Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, oldPolicyName)
-                .put(LifecycleSettings.LIFECYCLE_SKIP, true);
+        Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, oldPolicyName);
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
         lifecycleState.setPhase(currentStep.getPhase());
         lifecycleState.setAction(currentStep.getAction());
@@ -1060,8 +1038,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         String oldPolicyName = "old_policy";
         LifecyclePolicy oldPolicy = newTestLifecyclePolicy(oldPolicyName, Collections.emptyMap());
         StepKey currentStep = AbstractStepTestCase.randomStepKey();
-        Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, oldPolicyName)
-                .put(LifecycleSettings.LIFECYCLE_SKIP, true);
+        Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, oldPolicyName);
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
         lifecycleState.setPhase(currentStep.getPhase());
         lifecycleState.setAction(currentStep.getAction());
@@ -1086,8 +1063,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         String oldPolicyName = "old_policy";
         StepKey currentStep = new StepKey(randomAlphaOfLength(10), MockAction.NAME, randomAlphaOfLength(10));
         LifecyclePolicy oldPolicy = createPolicy(oldPolicyName, null, currentStep);
-        Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, oldPolicyName)
-                .put(LifecycleSettings.LIFECYCLE_SKIP, true);
+        Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, oldPolicyName);
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
         lifecycleState.setPhase(currentStep.getPhase());
         lifecycleState.setAction(currentStep.getAction());
@@ -1157,7 +1133,6 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         Settings indexSettings = indexMetadata.getSettings();
         assertNotNull(indexSettings);
         assertFalse(LifecycleSettings.LIFECYCLE_NAME_SETTING.exists(indexSettings));
-        assertFalse(LifecycleSettings.LIFECYCLE_SKIP_SETTING.exists(indexSettings));
         assertFalse(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS_SETTING.exists(indexSettings));
     }
 


### PR DESCRIPTION
With the introduction of _ilm/stop and _ilm/start APIs, the
use cases where one would only target a select group
of indices to start/stop has been reduced. Since there is no
strong use-case for skipping specific indices, it is best to
remove this functionality and only adding if later desired, with the
hopes of keeping things more simple.