### PR TITLE
fix PolicyStatsTests mutateInstance

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/PolicyStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/PolicyStatsTests.java
@@ -38,10 +38,10 @@ public class PolicyStatsTests extends AbstractWireSerializingTestCase<PolicyStat
         switch (between(0, 1)) {
         case 0:
             phaseStats = new HashMap<>(instance.getPhaseStats());
-            phaseStats.put(randomAlphaOfLengthBetween(1, 20), PhaseStatsTests.createRandomInstance());
+            phaseStats.put(randomAlphaOfLengthBetween(21, 25), PhaseStatsTests.createRandomInstance());
             break;
         case 1:
-            indicesManaged = randomIntBetween(1, 50);
+            indicesManaged = randomIntBetween(11, 50);
             break;
         default:
             throw new AssertionError("Illegal randomisation branch");

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/PolicyStatsTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/PolicyStatsTests.java
@@ -39,7 +39,7 @@ public class PolicyStatsTests extends AbstractWireSerializingTestCase<PolicyStat
         switch (between(0, 1)) {
         case 0:
             phaseStats = new HashMap<>(phaseStats);
-            phaseStats.put(randomAlphaOfLength(10), PhaseStatsTests.randomPhaseStats());
+            phaseStats.put(randomAlphaOfLength(11), PhaseStatsTests.randomPhaseStats());
             break;
         case 1:
             numberIndicesManaged += randomIntBetween(1, 10);


### PR DESCRIPTION
through randomization, there is a chance that the mutateInstance
for PolicyStatsTests does not actually mutate the original object.
This PR aims to fix this