### PR TITLE
Release memory used by logged exec

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/LoggedExec.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/LoggedExec.java
@@ -10,6 +10,7 @@ import org.gradle.process.ExecSpec;
 import org.gradle.process.JavaExecSpec;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.function.Function;
 
@@ -33,6 +34,12 @@ public class LoggedExec extends Exec {
                             }
                         } catch (UnsupportedEncodingException e) {
                             throw new GradleException("Failed to read exec output", e);
+                        } finally {
+                            try {
+                                output.close();
+                            } catch (IOException e) {
+                                throw new GradleException("Failed to close buffers", e);
+                            }
                         }
                         throw new GradleException(
                             String.format(
@@ -80,6 +87,12 @@ public class LoggedExec extends Exec {
                 throw new GradleException("Failed to read exec output", ue);
             }
             throw e;
+        } finally {
+            try {
+                output.close();
+            } catch (IOException e) {
+                throw new GradleException("Failed to close buffers", e);
+            }
         }
     }
 }


### PR DESCRIPTION
I noticed that `precommit` slows down or OOMs after a while when running multiple times with the daemon turned on.
This is surely one of the possible reasons. It's not yet clear to me why the tasks are not disposed of in the first place or weather our build or Gradle is at fault, but this will reduce the intensity of the issue until I can investigate it further.  