### PR TITLE
[Test] Fix FullClusterRestartIT.testShrink() with copy_settings param

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -364,7 +364,9 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             client().performRequest(updateSettingsRequest);
 
             Request shrinkIndexRequest = new Request("PUT", "/" + index + "/_shrink/" + shrunkenIndex);
-            shrinkIndexRequest.addParameter("copy_settings", "true");
+            if (getOldClusterVersion().onOrAfter(Version.V_6_4_0)) {
+                shrinkIndexRequest.addParameter("copy_settings", "true");
+            }
             shrinkIndexRequest.setJsonEntity("{\"settings\": {\"index.number_of_shards\": 1}}");
             client().performRequest(shrinkIndexRequest);
 

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -325,7 +325,6 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/34853")
     public void testShrink() throws IOException {
         String shrunkenIndex = index + "_shrunk";
         int numDocs;


### PR DESCRIPTION
The pull request #34338 added strict deprecation mode to the REST tests
and adds the copy_settings param when testing the shrink of an index.

This parameter has been added in 6.4.0 and will be removed in 8.0, so
the test now needs to take care of the old cluster version when adding
the copy_settings param.

Details of the test failure:

<details>

08:44:03 Suite: org.elasticsearch.upgrades.FullClusterRestartIT
08:44:03   1> [2018-10-25T14:12:54,119][INFO ][o.e.u.FullClusterRestartIT] [testAliasWithBadName] before test
08:44:03   1> [2018-10-25T14:12:54,133][INFO ][o.e.u.FullClusterRestartIT] [testAliasWithBadName] initializing REST clients against [http://[::1]:53175, http://[::1]:60283]
08:44:03   2> REPRODUCE WITH: ./gradlew :qa:full-cluster-restart:v6.0.0#oldClusterTestRunner -Dtests.seed=342C433F8075401B -Dtests.class=org.elasticsearch.upgrades.FullClusterRestartIT -Dtests.method="testShrink" -Dtests.security.manager=true -Dtests.locale=ar-QA -Dtests.timezone=IST -Dcompiler.java=11 -Druntime.java=8
08:44:03   1> [2018-10-25T14:12:54,200][INFO ][o.e.u.FullClusterRestartIT] [testAliasWithBadName] after test
08:44:03 IGNOR/A 0.09s | FullClusterRestartIT.testAliasWithBadName
08:44:03    > Assumption #1: Can only test bad alias name if old cluster is on 5.1.0 or before
08:44:03   1> [2018-10-25T14:12:54,211][INFO ][o.e.u.FullClusterRestartIT] [testRecovery] before test
08:44:03   1> [2018-10-25T14:12:54,259][INFO ][o.e.u.FullClusterRestartIT] [testRecovery] Indexing 255 random documents
08:44:03   1> [2018-10-25T14:13:01,221][INFO ][o.e.u.FullClusterRestartIT] [testRecovery] after test
08:44:03   1> [2018-10-25T14:13:01,230][INFO ][o.e.u.FullClusterRestartIT] [testNewReplicasWork] before test
08:44:03   1> [2018-10-25T14:13:01,336][INFO ][o.e.u.FullClusterRestartIT] [testNewReplicasWork] Indexing 2213 random documents
08:44:03   1> [2018-10-25T14:13:17,682][INFO ][o.e.u.FullClusterRestartIT] [testNewReplicasWork] Refreshing [testnewreplicaswork]
08:44:03   1> [2018-10-25T14:13:17,705][INFO ][o.e.u.FullClusterRestartIT] [testNewReplicasWork] after test
08:44:03   1> [2018-10-25T14:13:17,716][INFO ][o.e.u.FullClusterRestartIT] [testEmptyShard] before test
08:44:03   1> [2018-10-25T14:13:18,442][INFO ][o.e.u.FullClusterRestartIT] [testEmptyShard] after test
08:44:03   1> [2018-10-25T14:13:18,451][INFO ][o.e.u.FullClusterRestartIT] [testSnapshotRestore] before test
08:44:03   1> [2018-10-25T14:13:18,469][INFO ][o.e.u.FullClusterRestartIT] [testSnapshotRestore] Indexing 258 random documents
08:44:03   1> [2018-10-25T14:13:23,913][INFO ][o.e.u.FullClusterRestartIT] [testSnapshotRestore] after test
08:44:03   1> [2018-10-25T14:13:23,922][INFO ][o.e.u.FullClusterRestartIT] [testSearch] before test
08:44:03   1> [2018-10-25T14:13:24,024][INFO ][o.e.u.FullClusterRestartIT] [testSearch] Indexing 2830 random documents
08:44:03   1> [2018-10-25T14:13:42,620][INFO ][o.e.u.FullClusterRestartIT] [testSearch] health api response: {number_of_pending_tasks=1, cluster_name=full-cluster-restart, active_shards=1, active_primary_shards=1, unassigned_shards=0, delayed_unassigned_shards=0, timed_out=false, relocating_shards=0, indices={testsearch={active_shards=1, shards={0={active_shards=1, initializing_shards=0, unassigned_shards=0, primary_active=true, status=green, relocating_shards=0}}, active_primary_shards=1, number_of_shards=1, initializing_shards=0, unassigned_shards=0, number_of_replicas=0, status=green, relocating_shards=0}}, initializing_shards=0, task_max_waiting_in_queue_millis=0, number_of_data_nodes=2, number_of_in_flight_fetch=0, active_shards_percent_as_number=100.0, status=green, number_of_nodes=2}
08:44:03   1> [2018-10-25T14:13:42,620][INFO ][o.e.u.FullClusterRestartIT] [testSearch] --> testing basic search
08:44:03   1> [2018-10-25T14:13:42,645][INFO ][o.e.u.FullClusterRestartIT] [testSearch] Found 2830 in old index
08:44:03   1> [2018-10-25T14:13:42,645][INFO ][o.e.u.FullClusterRestartIT] [testSearch] --> testing basic search with sort
08:44:03   1> [2018-10-25T14:13:42,685][INFO ][o.e.u.FullClusterRestartIT] [testSearch] --> testing exists filter
08:44:03   1> [2018-10-25T14:13:42,694][INFO ][o.e.u.FullClusterRestartIT] [testSearch] --> testing field with dots in the name
08:44:03   1> [2018-10-25T14:13:42,701][INFO ][o.e.u.FullClusterRestartIT] [testSearch] --> testing _all search
08:44:03   1> [2018-10-25T14:13:42,984][INFO ][o.e.u.FullClusterRestartIT] [testSearch] after test
08:44:03   1> [2018-10-25T14:13:42,998][INFO ][o.e.u.FullClusterRestartIT] [testHistoryUUIDIsAdded] before test
08:44:03   1> [2018-10-25T14:13:43,138][INFO ][o.e.u.FullClusterRestartIT] [testHistoryUUIDIsAdded] There are still tasks running after this test that might break subsequent tests [internal:index/shard/recovery/prepare_translog, internal:index/shard/recovery/start_recovery].
08:44:03   1> [2018-10-25T14:13:43,139][INFO ][o.e.u.FullClusterRestartIT] [testHistoryUUIDIsAdded] after test
08:44:03   1> [2018-10-25T14:13:43,163][INFO ][o.e.u.FullClusterRestartIT] [testSingleDoc] before test
08:44:03   1> [2018-10-25T14:13:43,661][INFO ][o.e.u.FullClusterRestartIT] [testSingleDoc] after test
08:44:03   1> [2018-10-25T14:13:43,671][INFO ][o.e.u.FullClusterRestartIT] [testRollover] before test
08:44:03   1> [2018-10-25T14:13:44,765][INFO ][o.e.u.FullClusterRestartIT] [testRollover] after test
08:44:03   1> [2018-10-25T14:13:44,776][INFO ][o.e.u.FullClusterRestartIT] [testClusterState] before test
08:44:03   1> [2018-10-25T14:13:44,945][INFO ][o.e.u.FullClusterRestartIT] [testClusterState] after test
08:44:03   1> [2018-10-25T14:13:44,956][INFO ][o.e.u.FullClusterRestartIT] [testShrinkAfterUpgrade] before test
08:44:03   1> [2018-10-25T14:13:45,201][INFO ][o.e.u.FullClusterRestartIT] [testShrinkAfterUpgrade] Indexing 872 random documents
08:44:03   1> [2018-10-25T14:13:57,393][INFO ][o.e.u.FullClusterRestartIT] [testShrinkAfterUpgrade] after test
08:44:03   1> [2018-10-25T14:13:57,402][INFO ][o.e.u.FullClusterRestartIT] [testShrink] before test
08:44:03   1> [2018-10-25T14:13:57,609][INFO ][o.e.u.FullClusterRestartIT] [testShrink] Indexing 520 random documents
08:44:03   1> [2018-10-25T14:14:03,645][INFO ][o.e.u.FullClusterRestartIT] [testShrink] after test
08:44:03 ERROR   6.26s | FullClusterRestartIT.testShrink <<< FAILURES!
08:44:03    > Throwable #1: org.elasticsearch.client.ResponseException: method [PUT], host [http://[::1]:60283], URI [/testshrink/_shrink/testshrink_shrunk?copy_settings=true], status line [HTTP/1.1 400 Bad Request]
08:44:03    > {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"request [/testshrink/_shrink/testshrink_shrunk] contains unrecognized parameter: [copy_settings]"}],"type":"illegal_argument_exception","reason":"request [/testshrink/_shrink/testshrink_shrunk] contains unrecognized parameter: [copy_settings]"},"status":400}
08:44:03    > 	at __randomizedtesting.SeedInfo.seed([342C433F8075401B:2F19C0582DE8EE1C]:0)
08:44:03    > 	at org.elasticsearch.client.RestClient$SyncResponseListener.get(RestClient.java:687)
08:44:03   2> NOTE: leaving temporary files on disk at: /var/lib/jenkins/workspace/elastic+elasticsearch+master+bwc-tests/qa/full-cluster-restart/build/testrun/v6.0.0#oldClusterTestRunner/J0/temp/org.elasticsearch.upgrades.FullClusterRestartIT_342C433F8075401B-001
08:44:03    > 	at org.elasticsearch.client.RestClient.performRequest(RestClient.java:218)
08:44:03   2> NOTE: test params are: codec=Asserting(Lucene80): {}, docValues:{}, maxPointsInLeafNode=1621, maxMBSortInHeap=5.460201099930291, sim=Asserting(org.apache.lucene.search.similarities.AssertingSimilarity@c52b816), locale=ar-QA, timezone=IST
08:44:03    > 	at org.elasticsearch.upgrades.FullClusterRestartIT.testShrink(FullClusterRestartIT.java:368)
08:44:03   2> NOTE: Linux 3.16.0-6-amd64 amd64/Oracle Corporation 1.8.0_192 (64-bit)/cpus=16,threads=1,free=357834152,total=514850816
08:44:03   2> NOTE: All tests run in this JVM: [FullClusterRestartSettingsUpgradeIT, FullClusterRestartIT]
08:44:03    > 	at java.lang.Thread.run(Thread.java:748)
08:44:03    > Caused by: org.elasticsearch.client.ResponseException: method [PUT], host [http://[::1]:60283], URI [/testshrink/_shrink/testshrink_shrunk?copy_settings=true], status line [HTTP/1.1 400 Bad Request]
08:44:03    > {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"request [/testshrink/_shrink/testshrink_shrunk] contains unrecognized parameter: [copy_settings]"}],"type":"illegal_argument_exception","reason":"request [/testshrink/_shrink/testshrink_shrunk] contains unrecognized parameter: [copy_settings]"},"status":400}
08:44:03    > 	at org.elasticsearch.client.RestClient$1.completed(RestClient.java:307)
08:44:03    > 	at org.elasticsearch.client.RestClient$1.completed(RestClient.java:292)
08:44:03    > 	at org.apache.http.concurrent.BasicFuture.completed(BasicFuture.java:119)
08:44:03    > 	at org.apache.http.impl.nio.client.DefaultClientExchangeHandlerImpl.responseCompleted(DefaultClientExchangeHandlerImpl.java:177)
08:44:03    > 	at org.apache.http.nio.protocol.HttpAsyncRequestExecutor.processResponse(HttpAsyncRequestExecutor.java:436)
08:44:03    > 	at org.apache.http.nio.protocol.HttpAsyncRequestExecutor.inputReady(HttpAsyncRequestExecutor.java:326)
08:44:03    > 	at org.apache.http.impl.nio.DefaultNHttpClientConnection.consumeInput(DefaultNHttpClientConnection.java:265)
08:44:03    > 	at org.apache.http.impl.nio.client.InternalIODispatch.onInputReady(InternalIODispatch.java:81)
08:44:03    > 	at org.apache.http.impl.nio.client.InternalIODispatch.onInputReady(InternalIODispatch.java:39)
08:44:03    > 	at org.apache.http.impl.nio.reactor.AbstractIODispatch.inputReady(AbstractIODispatch.java:114)
08:44:03    > 	at org.apache.http.impl.nio.reactor.BaseIOReactor.readable(BaseIOReactor.java:162)
08:44:03    > 	at org.apache.http.impl.nio.reactor.AbstractIOReactor.processEvent(AbstractIOReactor.java:337)
08:44:03    > 	at org.apache.http.impl.nio.reactor.AbstractIOReactor.processEvents(AbstractIOReactor.java:315)
08:44:03    > 	at org.apache.http.impl.nio.reactor.AbstractIOReactor.execute(AbstractIOReactor.java:276)
08:44:03    > 	at org.apache.http.impl.nio.reactor.BaseIOReactor.execute(BaseIOReactor.java:104)
08:44:03    > 	at org.apache.http.impl.nio.reactor.AbstractMultiworkerIOReactor$Worker.run(AbstractMultiworkerIOReactor.java:588)
08:44:03    > 	... 1 more
08:44:03 Completed [2/3] in 69.57s, 12 tests, 1 error, 1 skipped <<< FAILURES!
08:44:03 
08:44:04 Suite: org.elasticsearch.upgrades.QueryBuilderBWCIT
08:44:04 Completed [3/3] in 0.36s, 1 test
08:44:04 
08:44:04 [ant:junit4] JVM J0: stderr was not empty, see: /var/lib/jenkins/workspace/elastic+elasticsearch+master+bwc-tests/qa/full-cluster-restart/build/testrun/v6.0.0#oldClusterTestRunner/temp/junit4-J0-20181025_084251_00012554306467612107614.syserr
08:44:04 
08:44:04 > Task :qa:full-cluster-restart:v6.0.0#oldClusterTestRunner FAILED
08:44:04 Tests with failures:
08:44:04   - org.elasticsearch.upgrades.FullClusterRestartIT.testShrink
08:44:04 

</details>