### PR TITLE
SQL: Return error with ORDER BY on non-grouped.

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.sql.plan.logical.Distinct;
 import org.elasticsearch.xpack.sql.plan.logical.Filter;
 import org.elasticsearch.xpack.sql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.sql.plan.logical.OrderBy;
+import org.elasticsearch.xpack.sql.plan.logical.Project;
 import org.elasticsearch.xpack.sql.tree.Node;
 import org.elasticsearch.xpack.sql.type.DataType;
 import org.elasticsearch.xpack.sql.util.StringUtils;
@@ -238,54 +239,69 @@ final class Verifier {
             Set<LogicalPlan> groupingFailures, Map<String, Function> functions) {
         if (p instanceof OrderBy) {
             OrderBy o = (OrderBy) p;
+            LogicalPlan child = o.child();
 
-            o.forEachDown(child -> {
-                if (child instanceof Aggregate) {
-                    Aggregate a = (Aggregate) child;
+            if (child instanceof Project) {
+                child = ((Project) child).child();
+            }
+            if (child instanceof Filter) {
+                Filter f = (Filter) child;
+                child = f.child();
+            }
 
-                    Map<Expression, Node<?>> missing = new LinkedHashMap<>();
-                    o.order().forEach(oe -> {
-                        Expression e = oe.child();
-                        // cannot order by aggregates (not supported by composite)
-                        if (Functions.isAggregate(e)) {
-                            missing.put(e, oe);
-                            return;
-                        }
+            if (child instanceof Aggregate) {
+                Aggregate a = (Aggregate) child;
 
-                        // take aliases declared inside the aggregates which point to the grouping (but are not included in there)
-                        // to correlate them to the order
-                        List<Expression> groupingAndMatchingAggregatesAliases = new ArrayList<>(a.groupings());
-
-                        a.aggregates().forEach(as -> {
-                            if (as instanceof Alias) {
-                                Alias al = (Alias) as;
-                                if (Expressions.anyMatch(a.groupings(), g -> Expressions.equalsAsAttribute(al.child(), g))) {
-                                    groupingAndMatchingAggregatesAliases.add(al);
-                                }
-                            }
-                        });
-
-                        // make sure to compare attributes directly
-                        if (Expressions.anyMatch(groupingAndMatchingAggregatesAliases,
-                            g -> e.semanticEquals(e instanceof Attribute ? Expressions.attribute(g) : g))) {
-                            return;
-                        }
-
-                        // nothing matched, cannot group by it
+                Map<Expression, Node<?>> missing = new LinkedHashMap<>();
+                o.order().forEach(oe -> {
+                    Expression e = oe.child();
+                    // cannot order by aggregates (not supported by composite)
+                    if (Functions.isAggregate(e)) {
                         missing.put(e, oe);
+                        return;
+                    }
+
+                    // take aliases declared inside the aggregates which point to the grouping (but are not included in there)
+                    // to correlate them to the order
+                    List<Expression> groupingAndMatchingAggregatesAliases = new ArrayList<>(a.groupings());
+
+                    a.aggregates().forEach(as -> {
+                        if (as instanceof Alias) {
+                            Alias al = (Alias) as;
+                            if (Expressions.anyMatch(a.groupings(), g -> Expressions.equalsAsAttribute(al.child(), g))) {
+                                groupingAndMatchingAggregatesAliases.add(al);
+                            }
+                        }
                     });
 
-                    if (!missing.isEmpty()) {
-                        String plural = missing.size() > 1 ? "s" : StringUtils.EMPTY;
-                        // get the location of the first missing expression as the order by might be on a different line
-                        localFailures.add(
-                            fail(missing.values().iterator().next(), "Cannot order by non-grouped column" + plural + " %s, expected %s",
-                                Expressions.names(missing.keySet()),
-                                Expressions.names(a.groupings())));
-                        groupingFailures.add(a);
+                    // Make sure you can apply functions on top of the grouped by expressions in the ORDER BY:
+                    // e.g.: if "GROUP BY f2(f1(field))" you can "ORDER BY f4(f3(f2(f1(field))))"
+                    //
+                    // Also, make sure to compare attributes directly
+                    final boolean[] matched = {false};
+                    e.forEachDown(expression ->
+                            matched[0] |= Expressions.anyMatch(groupingAndMatchingAggregatesAliases,
+                                g -> expression.semanticEquals(expression instanceof Attribute ? Expressions.attribute(g) : g))
+                    );
+                    if (matched[0]) {
+                        return;
                     }
+
+                    // nothing matched, cannot group by it
+                    missing.put(e, oe);
+                });
+
+                if (!missing.isEmpty()) {
+                    String plural = missing.size() > 1 ? "s" : StringUtils.EMPTY;
+                    // get the location of the first missing expression as the order by might be on a different line
+                    localFailures.add(
+                            fail(missing.values().iterator().next(), "Cannot order by non-grouped column" + plural + " %s, expected %s",
+                                    Expressions.names(missing.keySet()),
+                                    Expressions.names(a.groupings())));
+                    groupingFailures.add(a);
+                    return false;
                 }
-            });
+            }
         }
         return true;
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
@@ -302,12 +302,6 @@ final class Verifier {
         return true;
     }
 
-    private static boolean lala(Expression e, List<Expression> groupingAndMatchingAggregatesAliases) {
-        return e.anyMatch(expression -> Expressions.anyMatch(groupingAndMatchingAggregatesAliases,
-            g -> expression.semanticEquals(expression instanceof Attribute ? Expressions.attribute(g) : g)));
-    }
-
-
     private static boolean checkGroupByHaving(LogicalPlan p, Set<Failure> localFailures,
             Set<LogicalPlan> groupingFailures, Map<String, Function> functions) {
         if (p instanceof Filter) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
@@ -278,12 +278,8 @@ final class Verifier {
                     // e.g.: if "GROUP BY f2(f1(field))" you can "ORDER BY f4(f3(f2(f1(field))))"
                     //
                     // Also, make sure to compare attributes directly
-                    final boolean[] matched = {false};
-                    e.forEachDown(expression ->
-                            matched[0] |= Expressions.anyMatch(groupingAndMatchingAggregatesAliases,
-                                g -> expression.semanticEquals(expression instanceof Attribute ? Expressions.attribute(g) : g))
-                    );
-                    if (matched[0]) {
+                    if (e.anyMatch(expression -> Expressions.anyMatch(groupingAndMatchingAggregatesAliases,
+                        g -> expression.semanticEquals(expression instanceof Attribute ? Expressions.attribute(g) : g)))) {
                         return;
                     }
 
@@ -304,6 +300,11 @@ final class Verifier {
             }
         }
         return true;
+    }
+
+    private static boolean lala(Expression e, List<Expression> groupingAndMatchingAggregatesAliases) {
+        return e.anyMatch(expression -> Expressions.anyMatch(groupingAndMatchingAggregatesAliases,
+            g -> expression.semanticEquals(expression instanceof Attribute ? Expressions.attribute(g) : g)));
     }
 
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
@@ -25,7 +25,6 @@ import org.elasticsearch.xpack.sql.plan.logical.Distinct;
 import org.elasticsearch.xpack.sql.plan.logical.Filter;
 import org.elasticsearch.xpack.sql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.sql.plan.logical.OrderBy;
-import org.elasticsearch.xpack.sql.plan.logical.Project;
 import org.elasticsearch.xpack.sql.tree.Node;
 import org.elasticsearch.xpack.sql.type.DataType;
 import org.elasticsearch.xpack.sql.util.StringUtils;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
@@ -245,8 +245,7 @@ final class Verifier {
                 child = ((Project) child).child();
             }
             if (child instanceof Filter) {
-                Filter f = (Filter) child;
-                child = f.child();
+                child = ((Filter) child).child();
             }
 
             if (child instanceof Aggregate) {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -133,7 +133,7 @@ public class VerifierErrorMessagesTests extends ESTestCase {
                 verify("SELECT MAX(int) FROM test GROUP BY text ORDER BY YEAR(date)"));
     }
 
-    public void testGroupByOrderByScalarÎOverNonGrouped_WithHaving() {
+    public void testGroupByOrderByScalarOverNonGrouped_WithHaving() {
         assertEquals("1:71: Cannot order by non-grouped column [YEAR(date [UTC])], expected [text]",
             verify("SELECT MAX(int) FROM test GROUP BY text HAVING MAX(int) > 10 ORDER BY YEAR(date)"));
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -118,6 +118,11 @@ public class VerifierErrorMessagesTests extends ESTestCase {
                 verify("SELECT MAX(int) FROM test GROUP BY text ORDER BY bool"));
     }
 
+    public void testGroupByOrderByNonGrouped_WithHaving() {
+        assertEquals("1:71: Cannot order by non-grouped column [bool], expected [text]",
+            verify("SELECT MAX(int) FROM test GROUP BY text HAVING MAX(int) > 10 ORDER BY bool"));
+    }
+
     public void testGroupByOrderByAliasedInSelectAllowed() {
         LogicalPlan lp = accepted("SELECT text t FROM test GROUP BY text ORDER BY t");
         assertNotNull(lp);
@@ -126,6 +131,11 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     public void testGroupByOrderByScalarOverNonGrouped() {
         assertEquals("1:50: Cannot order by non-grouped column [YEAR(date [UTC])], expected [text]",
                 verify("SELECT MAX(int) FROM test GROUP BY text ORDER BY YEAR(date)"));
+    }
+
+    public void testGroupByOrderByScalarÎOverNonGrouped_WithHaving() {
+        assertEquals("1:71: Cannot order by non-grouped column [YEAR(date [UTC])], expected [text]",
+            verify("SELECT MAX(int) FROM test GROUP BY text HAVING MAX(int) > 10 ORDER BY YEAR(date)"));
     }
 
     public void testGroupByHavingNonGrouped() {


### PR DESCRIPTION
Previously, for some queries the validation for ORDER BY
fields didn't kick in since a HAVING close or an ORDER BY
with scalar function would add `Filter` and `Project` plans
between the `OrderBy` and the `Aggregate`.

Now the LogicalPlan tree beneath `OrderBy` is traversed and
the ORDER BY fields are properly verified.

Fixes: #34590
