### PR TITLE
[TEST] Manually trigger resource watching

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLTrustRestrictionsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLTrustRestrictionsTests.java
@@ -13,9 +13,11 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.SecurityIntegTestCase;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.transport.Transport;
+import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.ssl.CertParsingUtils;
 import org.elasticsearch.xpack.core.ssl.PemUtils;
 import org.elasticsearch.xpack.core.ssl.RestrictedTrustManager;
@@ -50,7 +52,6 @@ import static org.hamcrest.Matchers.is;
 @TestLogging("org.elasticsearch.xpack.ssl.RestrictedTrustManager:DEBUG")
 public class SSLTrustRestrictionsTests extends SecurityIntegTestCase {
 
-    private static final int RESOURCE_RELOAD_MILLIS = 3;
     private static final TimeValue MAX_WAIT_RELOAD = TimeValue.timeValueSeconds(1);
 
     private static Path configPath;
@@ -107,6 +108,8 @@ public class SSLTrustRestrictionsTests extends SecurityIntegTestCase {
                 .build();
     }
 
+
+
     @AfterClass
     public static void cleanup() {
         configPath = null;
@@ -129,7 +132,6 @@ public class SSLTrustRestrictionsTests extends SecurityIntegTestCase {
 
         writeRestrictions("*.trusted");
         builder.put("xpack.ssl.trust_restrictions.path", restrictionsPath);
-        builder.put("resource.reload.interval.high", RESOURCE_RELOAD_MILLIS + "ms");
 
         return builder.build();
     }
@@ -145,6 +147,7 @@ public class SSLTrustRestrictionsTests extends SecurityIntegTestCase {
         } catch (IOException e) {
             throw new ElasticsearchException("failed to write restrictions", e);
         }
+        runResourceWatcher();
     }
 
     @Override
@@ -201,6 +204,23 @@ public class SSLTrustRestrictionsTests extends SecurityIntegTestCase {
                 // expected
             }
         }, MAX_WAIT_RELOAD.millis(), TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Force the file watch to be updated.
+     * Ideally we'd just left the service do its thing, but that means waiting for 5sec
+     * We can drop the 5s down, but then we run into resource contention issues.
+     * This method just tells the {@link ResourceWatcherService} to run its check at a time that suits the tests. In all other respects
+     * it works just like normal - the usual file checks apply for detecting it as "changed", and only the previously configured files
+     * are checked.
+     */
+    private void runResourceWatcher() {
+        final InternalTestCluster cluster = internalCluster();
+        if (cluster.size() > 0) {
+            final ResourceWatcherService service = cluster.getInstance(ResourceWatcherService.class);
+            logger.info("Triggering a reload of watched resources");
+            service.notifyNow(ResourceWatcherService.Frequency.HIGH);
+        }
     }
 
     private void tryConnect(CertificateInfo certificate) throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLTrustRestrictionsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLTrustRestrictionsTests.java
@@ -108,8 +108,6 @@ public class SSLTrustRestrictionsTests extends SecurityIntegTestCase {
                 .build();
     }
 
-
-
     @AfterClass
     public static void cleanup() {
         configPath = null;


### PR DESCRIPTION
SSLTrustRestrictionsTests.testRestrictionsAreReloaded checks that the
SSL trust configuration is automatically updated reapplied if the
underlying "trust_restrictions.yml" file is modified.

Since the default resource watcher frequency is 5seconds, it could
take 10 second to run that test (as it waits for 2 reloaded).

Previously this test set that frequency to a very low value (3ms) so
that the elapsed time for the test would be reduced. However this
caused other problems, including that the resource watcher would
frequently run while the cluster was shutting down and files were
being cleaned up.

This change resets that watch frequency back to its default (5s) and
then manually calls the "notifyNow" method on the resource watcher
whenever the restrictions file is modified, so that the SSL trust
configuration is reloaded at exactly the right time.

Resolves: #34502
