### PR TITLE
SQL: Handle aggregation for null group

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -253,8 +253,9 @@ public class Querier {
             List<FieldExtraction> refs = query.columns();
 
             List<BucketExtractor> exts = new ArrayList<>(refs.size());
+            ConstantExtractor totalCount = new ConstantExtractor(response.getHits().getTotalHits());
             for (FieldExtraction ref : refs) {
-                exts.add(createExtractor(ref, new ConstantExtractor(response.getHits().getTotalHits())));
+                exts.add(createExtractor(ref, totalCount));
             }
             return exts;
         }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractor.java
@@ -9,7 +9,12 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
+import org.elasticsearch.search.aggregations.matrix.stats.MatrixStats;
 import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation.SingleValue;
+import org.elasticsearch.search.aggregations.metrics.InternalStats;
+import org.elasticsearch.search.aggregations.metrics.PercentileRanks;
+import org.elasticsearch.search.aggregations.metrics.Percentiles;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 import org.elasticsearch.xpack.sql.querydsl.agg.Aggs;
 
@@ -67,6 +72,11 @@ public class MetricAggExtractor implements BucketExtractor {
         if (agg == null) {
             throw new SqlIllegalArgumentException("Cannot find an aggregation named {}", name);
         }
+
+        if (!containsValues(agg)) {
+            return null;
+        }
+
         if (agg instanceof InternalNumericMetricsAggregation.MultiValue) {
             //TODO: need to investigate when this can be not-null
             //if (innerKey == null) {
@@ -77,6 +87,33 @@ public class MetricAggExtractor implements BucketExtractor {
 
         Object v = agg.getProperty(property);
         return innerKey != null && v instanceof Map ? ((Map<?, ?>) v).get(innerKey) : v;
+    }
+
+    /**
+     * Check if the given aggregate has been executed and has computed values
+     * or not (the bucket is null).
+     * 
+     * Hopefully solved by
+     */
+    private static boolean containsValues(InternalAggregation agg) {
+        // Stats & ExtendedStats
+        if (agg instanceof InternalStats) {
+            return ((InternalStats) agg).getCount() != 0;
+        }
+        if (agg instanceof MatrixStats) {
+            return ((MatrixStats) agg).getDocCount() != 0;
+        }
+        // sum returns 0 even for null; since that's a common case, we return it as such
+        if (agg instanceof SingleValue) {
+            return Double.isFinite(((SingleValue) agg).value());
+        }
+        if (agg instanceof PercentileRanks) {
+            return Double.isFinite(((PercentileRanks) agg).percent(0));
+        }
+        if (agg instanceof Percentiles) {
+            return Double.isFinite(((Percentiles) agg).percentile(0));
+        }
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractor.java
@@ -93,7 +93,7 @@ public class MetricAggExtractor implements BucketExtractor {
      * Check if the given aggregate has been executed and has computed values
      * or not (the bucket is null).
      * 
-     * Hopefully solved by
+     * Waiting on https://github.com/elastic/elasticsearch/issues/34903
      */
     private static boolean containsValues(InternalAggregation agg) {
         // Stats & ExtendedStats

--- a/x-pack/qa/sql/src/main/resources/agg.csv-spec
+++ b/x-pack/qa/sql/src/main/resources/agg.csv-spec
@@ -122,3 +122,18 @@ null                 |2.2215791166941923    |-0.03373126000214023
 F                    |1.7873117044424276    |0.05504995122217512 
 M                    |2.280646181070106     |0.44302407229580243
 ;
+
+nullAggs
+SELECT MAX(languages) max, MIN(languages) min, SUM(languages) sum, AVG(languages) avg,
+       PERCENTILE(languages, 80) percent, PERCENTILE_RANK(languages, 3) percent_rank, 
+       KURTOSIS(languages) kurtosis, SKEWNESS(languages) skewness  
+       FROM test_emp GROUP BY languages ORDER BY languages ASC LIMIT 5;
+
+      max:bt   |      min:bt   |      sum:bt   |      avg:bt   |    percent:d  | percent_rank:d|   kurtosis:d  |   skewness:d    
+---------------+---------------+---------------+---------------+---------------+---------------+---------------+---------------
+null           |null           |null           |null           |null           |null           |null           |null           
+1              |1              |15             |1              |1.0            |100.0          |NaN            |NaN            
+2              |2              |38             |2              |2.0            |100.0          |NaN            |NaN            
+3              |3              |51             |3              |3.0            |100.0          |NaN            |NaN            
+4              |4              |72             |4              |4.0            |0.0            |NaN            |NaN   
+;


### PR DESCRIPTION
When dealing with a null group, make sure the associated aggs return
null

Fix #34896