### PR TITLE
[DOCS] Move CCR overview pages

### DIFF
--- a/docs/reference/ccr/index.asciidoc
+++ b/docs/reference/ccr/index.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="platinum"]
 [[xpack-ccr]]
-= Cross-cluster replication
+= Replicating data across multiple clusters
 
 [partintro]
 --

--- a/docs/reference/ccr/index.asciidoc
+++ b/docs/reference/ccr/index.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="platinum"]
 [[xpack-ccr]]
-= Replicating data across multiple clusters
+= Cross-cluster replication
 
 [partintro]
 --

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -57,8 +57,6 @@ include::ingest.asciidoc[]
 
 include::ilm/index.asciidoc[]
 
-include::ccr/index.asciidoc[]
-
 include::sql/index.asciidoc[]
 
 include::monitoring/index.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/34726 and https://github.com/elastic/stack-docs/pull/132

This PR removes the CCR overview pages from the Elasticsearch Reference (since they exist in the Stack Overview here: https://www.elastic.co/guide/en/elastic-stack-overview/master/xpack-ccr.html).  It also updates the title of the CCR section so that it aligns with the other titles. 