### PR TITLE
[ILM] Convert Explain request to new HLRC classes

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/ExplainLifecycleRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/ExplainLifecycleRequest.java
@@ -19,13 +19,14 @@
 
 package org.elasticsearch.client.indexlifecycle;
 
-import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.master.info.ClusterInfoRequest;
-import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.TimedRequest;
+import org.elasticsearch.client.ValidationException;
+import org.elasticsearch.common.Strings;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * The request object used by the Explain Lifecycle API.
@@ -33,19 +34,36 @@ import java.util.Objects;
  * Multiple indices may be queried in the same request using the
  * {@link #indices(String...)} method
  */
-public class ExplainLifecycleRequest extends ClusterInfoRequest<ExplainLifecycleRequest> {
+public class ExplainLifecycleRequest extends TimedRequest {
+
+    private String[] indices = Strings.EMPTY_ARRAY;
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
     public ExplainLifecycleRequest() {
         super();
     }
 
-    public ExplainLifecycleRequest(StreamInput in) throws IOException {
-        super(in);
+    public ExplainLifecycleRequest indices(String... indices) {
+        this.indices = indices;
+        return this;
     }
 
+    public String[] indices() {
+        return indices;
+    }
+
+    public ExplainLifecycleRequest indicesOptions(IndicesOptions indicesOptions) {
+        this.indicesOptions = indicesOptions;
+        return this;
+    }
+
+    public IndicesOptions indicesOptions() {
+        return indicesOptions;
+    }
+    
     @Override
-    public ActionRequestValidationException validate() {
-        return null;
+    public Optional<ValidationException> validate() {
+        return Optional.empty();
     }
 
     @Override

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/ExplainLifecycleRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/ExplainLifecycleRequestTests.java
@@ -20,16 +20,18 @@
 package org.elasticsearch.client.indexlifecycle;
 
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.common.io.stream.Writeable.Reader;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
-import java.io.IOException;
 import java.util.Arrays;
 
-public class ExplainLifecycleRequestTests extends AbstractWireSerializingTestCase<ExplainLifecycleRequest> {
+public class ExplainLifecycleRequestTests extends ESTestCase {
 
-    @Override
-    protected ExplainLifecycleRequest createTestInstance() {
+    public void testEqualsAndHashcode() {
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(), this::copy, this::mutateInstance);
+    }
+
+    private ExplainLifecycleRequest createTestInstance() {
         ExplainLifecycleRequest request = new ExplainLifecycleRequest();
         if (randomBoolean()) {
             request.indices(generateRandomStringArray(20, 20, false, true));
@@ -42,8 +44,7 @@ public class ExplainLifecycleRequestTests extends AbstractWireSerializingTestCas
         return request;
     }
 
-    @Override
-    protected ExplainLifecycleRequest mutateInstance(ExplainLifecycleRequest instance) throws IOException {
+    private ExplainLifecycleRequest mutateInstance(ExplainLifecycleRequest instance) {
         String[] indices = instance.indices();
         IndicesOptions indicesOptions = instance.indicesOptions();
         switch (between(0, 1)) {
@@ -64,9 +65,11 @@ public class ExplainLifecycleRequestTests extends AbstractWireSerializingTestCas
         return newRequest;
     }
 
-    @Override
-    protected Reader<ExplainLifecycleRequest> instanceReader() {
-        return ExplainLifecycleRequest::new;
+    private ExplainLifecycleRequest copy(ExplainLifecycleRequest original) {
+        ExplainLifecycleRequest copy = new ExplainLifecycleRequest();
+        copy.indices(original.indices());
+        copy.indicesOptions(original.indicesOptions());
+        return copy;
     }
 
 }


### PR DESCRIPTION
Converts `ExplainLifecycleRequest` to use Validatable.

Relates to https://github.com/elastic/elasticsearch/issues/33100