### PR TITLE
HLRC: Drop extra level from user parser

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/security/PutUserResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/security/PutUserResponse.java
@@ -62,7 +62,6 @@ public final class PutUserResponse {
 
     static {
         PARSER.declareBoolean(constructorArg(), new ParseField("created"));
-        PARSER.declareObject((a,b) -> {}, (parser, context) -> null, new ParseField("user")); // ignore the user field!
     }
 
     public static PutUserResponse fromXContent(XContentParser parser) throws IOException {


### PR DESCRIPTION
It had support for an object between `created` and the root that we
don't return in 7.0+.
