### PR TITLE
Add support for storing JSON fields.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -42,7 +42,6 @@ import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.query.QueryShardContext;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -379,7 +378,8 @@ public final class JsonFieldMapper extends FieldMapper {
         assert fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) <= 0;
 
         this.ignoreAbove = ignoreAbove;
-        this.fieldParser = new JsonFieldParser(fieldType.name(), keyedFieldName(), fieldType, ignoreAbove);
+        this.fieldParser = new JsonFieldParser(fieldType.name(), keyedFieldName(),
+            ignoreAbove, fieldType.nullValueAsString());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
@@ -28,16 +29,20 @@ import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.query.QueryShardContext;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -71,6 +76,9 @@ import static org.elasticsearch.index.mapper.TypeParsers.parseField;
  *
  * Note that \0 is a reserved separator character, and cannot be used in the keys of the JSON object
  * (see {@link JsonFieldParser#SEPARATOR}).
+ *
+ * When 'store' is enabled, a single stored field is added containing the entire JSON object in
+ * pretty-printed format.
  */
 public final class JsonFieldMapper extends FieldMapper {
 
@@ -137,12 +145,6 @@ public final class JsonFieldMapper extends FieldMapper {
         @Override
         public Builder copyTo(CopyTo copyTo) {
             throw new UnsupportedOperationException("[copy_to] is not supported for [" + CONTENT_TYPE + "] fields.");
-        }
-
-        @Override
-        public Builder store(boolean store) {
-            throw new UnsupportedOperationException("[store] is not currently supported for [" +
-                CONTENT_TYPE + "] fields.");
         }
 
         @Override
@@ -415,12 +417,36 @@ public final class JsonFieldMapper extends FieldMapper {
             return;
         }
 
-        if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
-            fields.addAll(fieldParser.parse(context.parser()));
-            createFieldNamesField(context, fields);
-        } else {
+        if (fieldType.indexOptions() == IndexOptions.NONE && !fieldType.stored()) {
             context.parser().skipChildren();
+            return;
         }
+
+        BytesRef storedValue = null;
+        if (fieldType.stored()) {
+            XContentBuilder builder = XContentFactory.jsonBuilder()
+                .prettyPrint()
+                .copyCurrentStructure(context.parser());
+            storedValue = BytesReference.bytes(builder).toBytesRef();
+            fields.add(new StoredField(fieldType.name(), storedValue));
+        }
+
+        if (fieldType().indexOptions() != IndexOptions.NONE) {
+            XContentParser indexedFieldsParser = context.parser();
+
+            // If store is enabled, we've already consumed the content to produce the stored field. Here we
+            // 'reset' the parser, so that we can traverse the content again.
+            if (storedValue != null) {
+                indexedFieldsParser = JsonXContent.jsonXContent.createParser(context.parser().getXContentRegistry(),
+                    context.parser().getDeprecationHandler(),
+                    storedValue.bytes);
+                indexedFieldsParser.nextToken();
+            }
+
+            fields.addAll(fieldParser.parse(indexedFieldsParser));
+        }
+
+        createFieldNamesField(context, fields);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldMapperTests.java
@@ -131,7 +131,11 @@ public class JsonFieldMapperTests extends ESSingleNodeTestCase {
         String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
             .startObject("type")
                 .startObject("properties")
-                    .startObject("field")
+                    .startObject("store_and_index")
+                        .field("type", "json")
+                        .field("store", true)
+                    .endObject()
+                    .startObject("store_only")
                         .field("type", "json")
                         .field("index", false)
                         .field("store", true)
@@ -144,24 +148,34 @@ public class JsonFieldMapperTests extends ESSingleNodeTestCase {
         assertEquals(mapping, mapper.mappingSource().toString());
 
         BytesReference doc = BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
-                .startObject("field")
+                .startObject("store_only")
+                    .field("key", "value")
+                .endObject()
+                .startObject("store_and_index")
                     .field("key", "value")
                 .endObject()
             .endObject());
-
         ParsedDocument parsedDoc = mapper.parse(SourceToParse.source("test", "type", "1", doc, XContentType.JSON));
-
-        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertTrue(fields[0].fieldType().stored());
 
         // We make sure to pretty-print here, since the field is always stored in pretty-printed format.
         BytesReference storedValue = BytesReference.bytes(JsonXContent.contentBuilder()
             .prettyPrint()
             .startObject()
-                .field("key", "value")
+            .field("key", "value")
             .endObject());
-        assertEquals(storedValue.toBytesRef(), fields[0].binaryValue());
+
+        IndexableField[] storeOnly = parsedDoc.rootDoc().getFields("store_only");
+        assertEquals(1, storeOnly.length);
+
+        assertTrue(storeOnly[0].fieldType().stored());
+        assertEquals(storedValue.toBytesRef(), storeOnly[0].binaryValue());
+
+        IndexableField[] storeAndIndex = parsedDoc.rootDoc().getFields("store_and_index");
+        assertEquals(2, storeAndIndex.length);
+
+        assertTrue(storeAndIndex[0].fieldType().stored());
+        assertEquals(storedValue.toBytesRef(), storeAndIndex[0].binaryValue());
+        assertFalse(storeAndIndex[1].fieldType().stored());
     }
 
     public void testIndexOptions() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldParserTests.java
@@ -41,10 +41,7 @@ public class JsonFieldParserTests extends ESTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-
-        MappedFieldType fieldType = new RootJsonFieldType();
-        fieldType.setName("field");
-        parser = new JsonFieldParser("field", "field._keyed", fieldType, Integer.MAX_VALUE);
+        parser = new JsonFieldParser("field", "field._keyed", Integer.MAX_VALUE, null);
     }
 
     public void testTextValues() throws Exception {
@@ -222,9 +219,9 @@ public class JsonFieldParserTests extends ESTestCase {
 
         RootJsonFieldType fieldType = new RootJsonFieldType();
         fieldType.setName("field");
-        JsonFieldParser ignoreAboveParser = new JsonFieldParser("field", "field._keyed", fieldType, 10);
+        JsonFieldParser parserWithIgnoreAbove = new JsonFieldParser("field", "field._keyed", 10, null);
 
-        List<IndexableField> fields = ignoreAboveParser.parse(xContentParser);
+        List<IndexableField> fields = parserWithIgnoreAbove.parse(xContentParser);
         assertEquals(0, fields.size());
     }
 
@@ -236,13 +233,10 @@ public class JsonFieldParserTests extends ESTestCase {
         assertEquals(0, fields.size());
 
         xContentParser = createXContentParser(input);
+        JsonFieldParser parserWithNullValue = new JsonFieldParser("field", "field._keyed",
+            Integer.MAX_VALUE, "placeholder");
 
-        RootJsonFieldType fieldType = new RootJsonFieldType();
-        fieldType.setName("field");
-        fieldType.setNullValue("placeholder");
-        JsonFieldParser nullValueParser = new JsonFieldParser("field", "field._keyed", fieldType, Integer.MAX_VALUE);
-
-        fields = nullValueParser.parse(xContentParser);
+        fields = parserWithNullValue.parse(xContentParser);
         assertEquals(2, fields.size());
 
         IndexableField field = fields.get(0);


### PR DESCRIPTION
When 'store' is enabled, a single stored field is added containing the entire JSON object in pretty-printed format.