### PR TITLE
NETWORK: Remove Dead Code from Netty4CorsConfig

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/cors/Netty4CorsConfig.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/cors/Netty4CorsConfig.java
@@ -48,7 +48,6 @@ public final class Netty4CorsConfig {
     private final long maxAge;
     private final Set<HttpMethod> allowedRequestMethods;
     private final Set<String> allowedRequestHeaders;
-    private final boolean allowNullOrigin;
     private final Map<CharSequence, Callable<?>> preflightHeaders;
     private final boolean shortCircuit;
 
@@ -61,7 +60,6 @@ public final class Netty4CorsConfig {
         maxAge = builder.maxAge;
         allowedRequestMethods = builder.requestMethods;
         allowedRequestHeaders = builder.requestHeaders;
-        allowNullOrigin = builder.allowNullOrigin;
         preflightHeaders = builder.preflightHeaders;
         shortCircuit = builder.shortCircuit;
     }
@@ -106,19 +104,6 @@ public final class Netty4CorsConfig {
             return pattern.get().matcher(origin).matches();
         }
         return false;
-    }
-
-    /**
-     * Web browsers may set the 'Origin' request header to 'null' if a resource is loaded
-     * from the local file system.
-     *
-     * If isNullOriginAllowed is true then the server will response with the wildcard for the
-     * the CORS response header 'Access-Control-Allow-Origin'.
-     *
-     * @return {@code true} if a 'null' origin should be supported.
-     */
-    public boolean isNullOriginAllowed() {
-        return allowNullOrigin;
     }
 
     /**

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/cors/Netty4CorsConfigBuilder.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/cors/Netty4CorsConfigBuilder.java
@@ -74,7 +74,6 @@ public final class Netty4CorsConfigBuilder {
     Optional<Set<String>> origins;
     Optional<Pattern> pattern;
     final boolean anyOrigin;
-    boolean allowNullOrigin;
     boolean enabled = true;
     boolean allowCredentials;
     long maxAge;

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/cors/Netty4CorsHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/cors/Netty4CorsHandler.java
@@ -167,11 +167,6 @@ public class Netty4CorsHandler extends ChannelDuplexHandler {
     private boolean setOrigin(final HttpResponse response) {
         final String origin = request.headers().get(HttpHeaderNames.ORIGIN);
         if (!Strings.isNullOrEmpty(origin)) {
-            if ("null".equals(origin) && config.isNullOriginAllowed()) {
-                setAnyOrigin(response);
-                return true;
-            }
-
             if (config.isAnyOriginSupported()) {
                 if (config.isCredentialsAllowed()) {
                     echoRequestOrigin(response);
@@ -198,10 +193,6 @@ public class Netty4CorsHandler extends ChannelDuplexHandler {
         final String origin = request.headers().get(HttpHeaderNames.ORIGIN);
         if (Strings.isNullOrEmpty(origin)) {
             // Not a CORS request so we cannot validate it. It may be a non CORS request.
-            return true;
-        }
-
-        if ("null".equals(origin) && config.isNullOriginAllowed()) {
             return true;
         }
 


### PR DESCRIPTION
* Same as #34324 for the NIO transport, the `isNullOriginAllowed` setting is always false