### PR TITLE
[DOCS] Fix build due to typo in get role mappings API

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
@@ -217,7 +217,7 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
             // tag::get-role-mappings-list-execute
             final GetRoleMappingsRequest request = new GetRoleMappingsRequest("mapping-example-1", "mapping-example-2");
             final GetRoleMappingsResponse response = client.security().getRoleMappings(request, RequestOptions.DEFAULT);
-            // end::get-role-mappings-all-execute
+            // end::get-role-mappings-list-execute
             List<ExpressionRoleMapping> mappings = response.getMappings();
             assertNotNull(mappings);
             assertThat(mappings.size(), is(2));

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -327,7 +327,7 @@ The Java High Level REST Client supports the following Security APIs:
 * <<{upid}-clear-roles-cache>>
 * <<java-rest-high-security-get-certificates>>
 * <<java-rest-high-security-put-role-mapping>>
-* <<java-rest-high-security-get-role-mapping>>
+* <<java-rest-high-security-get-role-mappings>>
 * <<java-rest-high-security-delete-role-mapping>>
 
 include::security/put-user.asciidoc[]
@@ -338,7 +338,7 @@ include::security/delete-role.asciidoc[]
 include::security/clear-roles-cache.asciidoc[]
 include::security/get-certificates.asciidoc[]
 include::security/put-role-mapping.asciidoc[]
-include::security/get-role-mapping.asciidoc[]
+include::security/get-role-mappings.asciidoc[]
 include::security/delete-role-mapping.asciidoc[]
 
 == Watcher APIs


### PR DESCRIPTION
Fixed the type in the get role mappings API doco
