### PR TITLE
DISCOVERY: Exclude Port 30210 in 5.6 Branch

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/discovery/ClusterDiscoveryConfiguration.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/discovery/ClusterDiscoveryConfiguration.java
@@ -149,6 +149,11 @@ public class ClusterDiscoveryConfiguration extends NodeConfigurationSource {
             for (int i = 0; i < unicastHostPorts.length; i++) {
                 boolean foundPortInRange = false;
                 while (tries < PORTS_PER_JVM && !foundPortInRange) {
+                    // Port 30210 collides in tests for unknown reasons so we manually exclude it.
+                    // See https://github.com/elastic/elasticsearch/issues/33675 for more.
+                    if (nextPort == 30210) {
+                        nextPort++;
+                    }
                     try (ServerSocket serverSocket = new ServerSocket()) {
                         // Set SO_REUSEADDR as we may bind here and not be able to reuse the address immediately without it.
                         serverSocket.setReuseAddress(NetworkUtils.defaultReuseAddress());


### PR DESCRIPTION
* Exclude port 30210 from tests because it collides for unknown reasons
* Relates #33675
