### PR TITLE
NETWORKING: Simplify Transport Compression Setting

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4ScheduledPingTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4ScheduledPingTests.java
@@ -100,7 +100,7 @@ public class Netty4ScheduledPingTests extends ESTestCase {
         int rounds = scaledRandomIntBetween(100, 5000);
         for (int i = 0; i < rounds; i++) {
             serviceB.submitRequest(nodeA, "internal:sayHello",
-                TransportRequest.Empty.INSTANCE, TransportRequestOptions.builder().withCompress(randomBoolean()).build(),
+                TransportRequest.Empty.INSTANCE, TransportRequestOptions.builder().withDisableCompress(randomBoolean()).build(),
                 new TransportResponseHandler<TransportResponse.Empty>() {
                     @Override
                     public TransportResponse.Empty read(StreamInput in) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
@@ -101,7 +101,7 @@ public class TransportGetTaskAction extends HandledTransportAction<GetTaskReques
         if (request.getTimeout() != null) {
             builder.withTimeout(request.getTimeout());
         }
-        builder.withCompress(false);
+        builder.withDisableCompress(true);
         DiscoveryNode node = clusterService.state().nodes().get(request.getTaskId().getNodeId());
         if (node == null) {
             // Node is no longer part of the cluster! Try and look the task up from the results index.

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkAction.java
@@ -41,7 +41,8 @@ public class BulkAction extends Action<BulkResponse> {
     public TransportRequestOptions transportOptions(Settings settings) {
         return TransportRequestOptions.builder()
                 .withType(TransportRequestOptions.Type.BULK)
-                .withCompress(settings.getAsBoolean("action.bulk.compress", true)
+                .withDisableCompress(
+                    settings.getAsBoolean("action.bulk.compress", true) == false
                 ).build();
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -174,7 +174,7 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
             if (request.timeout() != null) {
                 builder.withTimeout(request.timeout());
             }
-            builder.withCompress(transportCompress());
+            builder.withDisableCompress(transportCompress() == false);
             for (int i = 0; i < nodes.length; i++) {
                 final int idx = i;
                 final DiscoveryNode node = nodes[i];

--- a/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
@@ -256,7 +256,7 @@ public abstract class TransportTasksAction<
                 if (request.getTimeout() != null) {
                     builder.withTimeout(request.getTimeout());
                 }
-                builder.withCompress(transportCompress());
+                builder.withDisableCompress(transportCompress() == false);
                 for (int i = 0; i < nodesIds.length; i++) {
                     final String nodeId = nodesIds[i];
                     final int idx = i;

--- a/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
@@ -287,7 +287,7 @@ public class PublishClusterStateAction extends AbstractComponent {
             //  and not log an error if it arrives after the timeout
             // -> no need to compress, we already compressed the bytes
             TransportRequestOptions options = TransportRequestOptions.builder()
-                .withType(TransportRequestOptions.Type.STATE).withCompress(false).build();
+                .withType(TransportRequestOptions.Type.STATE).withDisableCompress(true).build();
             transportService.sendRequest(node, SEND_ACTION_NAME,
                     new BytesTransportRequest(bytes, node.getVersion()),
                     options,

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
@@ -62,12 +62,11 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
         this.recoverySettings = recoverySettings;
         this.onSourceThrottle = onSourceThrottle;
         this.translogOpsRequestOptions = TransportRequestOptions.builder()
-                .withCompress(true)
                 .withType(TransportRequestOptions.Type.RECOVERY)
                 .withTimeout(recoverySettings.internalActionLongTimeout())
                 .build();
         this.fileChunkRequestOptions = TransportRequestOptions.builder()
-                .withCompress(false)  // lucene files are already compressed and therefore compressing this won't really help much so
+                .withDisableCompress(true)  // lucene files are already compressed and therefore compressing this won't really help much so
                 // we are saving the cpu for other things
                 .withType(TransportRequestOptions.Type.RECOVERY)
                 .withTimeout(recoverySettings.internalActionTimeout())

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -873,13 +873,9 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     private void sendRequestToChannel(final DiscoveryNode node, final TcpChannel channel, final long requestId, final String action,
                                       final TransportRequest request, TransportRequestOptions options, Version channelVersion,
                                       byte status) throws IOException, TransportException {
-        if (compress) {
-            options = TransportRequestOptions.builder(options).withCompress(true).build();
-        }
-
         // only compress if asked and the request is not bytes. Otherwise only
         // the header part is compressed, and the "body" can't be extracted as compressed
-        final boolean compressMessage = options.compress() && canCompress(request);
+        final boolean compressMessage = options.disableCompress() == false && canCompress(request);
 
         status = TransportStatus.setRequest(status);
         ReleasableBytesStreamOutput bStream = new ReleasableBytesStreamOutput(bigArrays);

--- a/server/src/main/java/org/elasticsearch/transport/TransportRequestOptions.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportRequestOptions.java
@@ -24,12 +24,12 @@ import org.elasticsearch.common.unit.TimeValue;
 public class TransportRequestOptions {
 
     private final TimeValue timeout;
-    private final boolean compress;
+    private final boolean disableCompress;
     private final Type type;
 
-    private TransportRequestOptions(TimeValue timeout, boolean compress, Type type) {
+    private TransportRequestOptions(TimeValue timeout, boolean disableCompress, Type type) {
         this.timeout = timeout;
-        this.compress = compress;
+        this.disableCompress = disableCompress;
         this.type = type;
     }
 
@@ -37,8 +37,8 @@ public class TransportRequestOptions {
         return this.timeout;
     }
 
-    public boolean compress() {
-        return this.compress;
+    public boolean disableCompress() {
+        return this.disableCompress;
     }
 
     public Type type() {
@@ -62,13 +62,13 @@ public class TransportRequestOptions {
     public static Builder builder(TransportRequestOptions options) {
         return new Builder()
                 .withTimeout(options.timeout)
-                .withCompress(options.compress)
+                .withDisableCompress(options.disableCompress)
                 .withType(options.type());
     }
 
     public static class Builder {
         private TimeValue timeout;
-        private boolean compress;
+        private boolean disableCompress;
         private Type type = Type.REG;
 
         private Builder() {
@@ -83,8 +83,8 @@ public class TransportRequestOptions {
             return this;
         }
 
-        public Builder withCompress(boolean compress) {
-            this.compress = compress;
+        public Builder withDisableCompress(boolean disableCompress) {
+            this.disableCompress = disableCompress;
             return this;
         }
 
@@ -94,7 +94,7 @@ public class TransportRequestOptions {
         }
 
         public TransportRequestOptions build() {
-            return new TransportRequestOptions(timeout, compress, type);
+            return new TransportRequestOptions(timeout, disableCompress, type);
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -262,7 +262,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         }
 
         res = serviceB.submitRequest(nodeA, "internal:sayHello", new StringMessageRequest("moshe"),
-            TransportRequestOptions.builder().withCompress(true).build(), new TransportResponseHandler<StringMessageResponse>() {
+            TransportRequestOptions.builder().build(), new TransportResponseHandler<StringMessageResponse>() {
                 @Override
                 public StringMessageResponse read(StreamInput in) throws IOException {
                     return new StringMessageResponse(in);
@@ -513,7 +513,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             });
 
         TransportFuture<TransportResponse.Empty> res = serviceB.submitRequest(nodeA, "internal:sayHello",
-            TransportRequest.Empty.INSTANCE, TransportRequestOptions.builder().withCompress(true).build(),
+            TransportRequest.Empty.INSTANCE, TransportRequestOptions.builder().build(),
             new TransportResponseHandler<TransportResponse.Empty>() {
                 @Override
                 public TransportResponse.Empty read(StreamInput in) {
@@ -561,7 +561,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             });
 
         TransportFuture<StringMessageResponse> res = serviceB.submitRequest(nodeA, "internal:sayHello",
-            new StringMessageRequest("moshe"), TransportRequestOptions.builder().withCompress(true).build(),
+            new StringMessageRequest("moshe"), TransportRequestOptions.builder().build(),
             new TransportResponseHandler<StringMessageResponse>() {
                 @Override
                 public StringMessageResponse read(StreamInput in) throws IOException {
@@ -1786,7 +1786,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                     DiscoveryNode node = randomFrom(nodeA, nodeB, nodeC);
                     logger.debug("send secondary request from {} to {} - {}", toNodeMap.get(service), node, request.info);
                     service.sendRequest(node, "internal:action1", new TestRequest("secondary " + request.info),
-                        TransportRequestOptions.builder().withCompress(randomBoolean()).build(),
+                        TransportRequestOptions.builder().withDisableCompress(randomBoolean()).build(),
                         new TransportResponseHandler<TestResponse>() {
                             @Override
                             public TestResponse read(StreamInput in) throws IOException {
@@ -1877,7 +1877,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             DiscoveryNode node = randomFrom(nodeC, nodeB, nodeA);
             logger.debug("send from {} to {}", toNodeMap.get(service), node);
             service.sendRequest(node, "internal:action1", new TestRequest("REQ[" + i + "]"),
-                TransportRequestOptions.builder().withCompress(randomBoolean()).build(), new TestResponseHandler(i));
+                TransportRequestOptions.builder().withDisableCompress(randomBoolean()).build(), new TestResponseHandler(i));
         }
         logger.debug("waiting for response");
         fail.set(randomBoolean());


### PR DESCRIPTION
* Individual setting should only be able to negate the global compress setting since `org.elasticsearch.transport.TcpTransport#canCompress` ensures that compression only ever happens if the global compression is enabled regardless of the `TransportRequestOptions`
* Disables compression of segment files during recovery to bring code and comment in line with each other
   * Also experiments and user reports have shown a ~50% compression size saving but with an order of magnitude performance loss 
* Fixes #33844