### PR TITLE
SQL: test for https://github.com/elastic/elasticsearch/issues/30054 bug

### DIFF
--- a/x-pack/qa/sql/src/main/resources/nested.csv-spec
+++ b/x-pack/qa/sql/src/main/resources/nested.csv-spec
@@ -1,7 +1,7 @@
 //
 //  Nested documents
 //
-// CsvJdbc has issues with foo.bar so msot fields are aliases or wrapped inside a function
+// CsvJdbc has issues with foo.bar so most fields are aliases or wrapped inside a function
 
 describeParent
 DESCRIBE test_emp;
@@ -26,18 +26,30 @@ last_name.keyword   |VARCHAR        |KEYWORD
 salary              |INTEGER        |INTEGER   
 ;
 
-// disable until we figure out how to use field names with . in their name
-//nestedStar
-//SELECT dep.* FROM test_emp ORDER BY dep.dep_id LIMIT 5;
+nestedStar
+SELECT dep.* FROM test_emp ORDER BY dep.dep_id LIMIT 5;
 
-//dep.dep_id:s         | dep.dep_name:s       | dep.from_date:ts     | dep.to_date:ts
+  dep.dep_id:s   | dep.dep_name:s |    dep.from_date:ts    |     dep.to_date:ts
 
-//d001                 | Marketing            | 744336000000         | 253370764800000
-//d001                 | Marketing            | 704332800000         | 806371200000
-//d001                 | Marketing            | 577929600000         | 253370764800000
-//d002                 | Finance              | 732672000000         | 965865600000
-//d007                 | Sales                | 720921600000         | 253370764800000
-//;
+d001             |Marketing       |1993-08-03T00:00:00.000Z|9999-01-01T00:00:00.000Z
+d001             |Marketing       |1992-04-27T00:00:00.000Z|1995-07-22T00:00:00.000Z
+d001             |Marketing       |1988-04-25T00:00:00.000Z|9999-01-01T00:00:00.000Z
+d002             |Finance         |1993-03-21T00:00:00.000Z|2000-08-10T00:00:00.000Z
+d002             |Finance         |1990-12-25T00:00:00.000Z|1992-11-05T00:00:00.000Z
+;
+
+// Test for https://github.com/elastic/elasticsearch/issues/30054
+nestedSingleFieldSelect
+SELECT dep.dep_id FROM test_emp LIMIT 5;
+
+ dep.dep_id:s   
+
+d005           
+d007           
+d004           
+d004           
+d003           
+;
 
 filterPerNestedWithOrderByTopLevel
 SELECT first_name f, last_name l, YEAR(dep.from_date) d FROM test_emp WHERE dep.dep_name = 'Production' ORDER BY f LIMIT 5;


### PR DESCRIPTION
The issue was happening when only a nested field column was `SELECT`ed and it was a bug in ES code. This PR adds a test to check the fix holds.
I have also activated another test which was muted in the early days when discussion were taking place regarding dot handling in SQL.

Related to https://github.com/elastic/elasticsearch/issues/30054