### PR TITLE
Enforce a limit on the depth of the JSON object.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
@@ -66,4 +66,8 @@ public final class ContentPath {
         sb.append(name);
         return sb.toString();
     }
+
+    public int length() {
+        return index;
+    }
 }


### PR DESCRIPTION
Currently, we error if a JSON field could contain fields deeper than the configured limit. The default value is 20, which matches `index.mapping.depth.limit`).

I was also wondering if it made sense to introduce a 'lenient' mode, in the general spirit of `ignore_malformed`. A couple options:
- If the depth limit is exceeded, we ignore the entire JSON field and continue parsing the rest of the document.
- We add fields that obey the depth limit, and only ignore those fields that too deeply nested.