### PR TITLE
Remove some documentation that only makes sense with multiple types.

### DIFF
--- a/docs/reference/mapping/params/ignore-above.asciidoc
+++ b/docs/reference/mapping/params/ignore-above.asciidoc
@@ -49,10 +49,8 @@ GET _search <4>
 <3> This document will be indexed, but without indexing the `message` field.
 <4> Search returns both documents, but only the first is present in the terms aggregation.
 
-TIP: The `ignore_above` setting is allowed to have different settings for
-fields of the same name in the same index.  Its value can be updated on
+TIP: The `ignore_above` setting can be updated on
 existing fields using the <<indices-put-mapping,PUT mapping API>>.
-
 
 This option is also useful for protecting against Lucene's term byte-length
 limit of `32766`.

--- a/docs/reference/mapping/types/percolator.asciidoc
+++ b/docs/reference/mapping/types/percolator.asciidoc
@@ -55,7 +55,6 @@ PUT my_index/_doc/match_value
 Fields referred to in a percolator query must *already* exist in the mapping
 associated with the index used for percolation. In order to make sure these fields exist,
 add or update a mapping via the <<indices-create-index,create index>> or <<indices-put-mapping,put mapping>> APIs.
-Fields referred in a percolator query may exist in any type of the index containing the `percolator` field type.
 
 =====================================
 


### PR DESCRIPTION
* Remove a tip about ignore_above that only makes sense with multiple types.
* Remove a line from the percolator documentation that refers to multiple types.

Relates to https://github.com/elastic/elasticsearch/issues/34056.