### PR TITLE
SQL: Proper handling of nested fields at the beginning of the columns list

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitRowSet.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitRowSet.java
@@ -44,9 +44,11 @@ class SearchHitRowSet extends AbstractRowSet {
 
         String innerHit = null;
         for (HitExtractor ex : exts) {
-            innerHit = ex.hitName();
-            if (innerHit != null) {
-                innerHits.add(innerHit);
+            if (ex.hitName() != null) {
+                innerHits.add(ex.hitName());
+                if (innerHit == null) {
+                    innerHit = ex.hitName();
+                }
             }
         }
 

--- a/x-pack/qa/sql/src/main/resources/nested.csv-spec
+++ b/x-pack/qa/sql/src/main/resources/nested.csv-spec
@@ -150,3 +150,63 @@ Anneke         |Development    |Preusig
 Anoosh         |Development    |Peyn
 Arumugam       |Research       |Ossenbruggen
 ;
+
+selectNestedFieldInTheMiddleAndAtTheEnd
+SELECT first_name, dep.dep_name, last_name, dep.dep_id FROM test_emp ORDER BY first_name LIMIT 5;
+
+ first_name:s  |dep.dep_name:s | last_name:s   |  dep.dep_id:s
+
+Alejandro      |Finance        |McAlpine       |d002
+Amabile        |Development    |Gomatam        |d005
+Anneke         |Development    |Preusig        |d005
+Anoosh         |Development    |Peyn           |d005
+Arumugam       |Research       |Ossenbruggen   |d008
+;
+
+selectNestedFieldInTheMiddleAndAtBeggining
+SELECT dep.dep_id, first_name, dep.dep_name, last_name FROM test_emp ORDER BY first_name LIMIT 5;
+
+ dep.dep_id:s  | first_name:s  |dep.dep_name:s | last_name:s
+
+d002           |Alejandro      |Finance        |McAlpine
+d005           |Amabile        |Development    |Gomatam
+d005           |Anneke         |Development    |Preusig
+d005           |Anoosh         |Development    |Peyn
+d008           |Arumugam       |Research       |Ossenbruggen
+;
+
+selectNestedFieldWithWildcardAtBeggining
+SELECT dep.*, first_name FROM test_emp ORDER BY first_name LIMIT 5;
+
+ dep.dep_id:s  |dep.dep_name:s |   dep.from_date:ts     |    dep.to_date:ts      |  first_name:s
+
+d002           |Finance        |1991-06-26T00:00:00.000Z|9999-01-01T00:00:00.000Z|Alejandro
+d005           |Development    |1992-11-18T00:00:00.000Z|9999-01-01T00:00:00.000Z|Amabile
+d005           |Development    |1990-08-05T00:00:00.000Z|9999-01-01T00:00:00.000Z|Anneke
+d005           |Development    |1991-08-30T00:00:00.000Z|9999-01-01T00:00:00.000Z|Anoosh
+d008           |Research       |1987-04-18T00:00:00.000Z|1997-11-08T00:00:00.000Z|Arumugam
+;
+
+selectNestedFieldWithWildcardAtTheEnd
+SELECT first_name, dep.* FROM test_emp ORDER BY first_name LIMIT 5;
+
+ first_name:s  | dep.dep_id:s  |dep.dep_name:s |   dep.from_date:ts     |     dep.to_date:ts
+
+Alejandro      |d002           |Finance        |1991-06-26T00:00:00.000Z|9999-01-01T00:00:00.000Z
+Amabile        |d005           |Development    |1992-11-18T00:00:00.000Z|9999-01-01T00:00:00.000Z
+Anneke         |d005           |Development    |1990-08-05T00:00:00.000Z|9999-01-01T00:00:00.000Z
+Anoosh         |d005           |Development    |1991-08-30T00:00:00.000Z|9999-01-01T00:00:00.000Z
+Arumugam       |d008           |Research       |1987-04-18T00:00:00.000Z|1997-11-08T00:00:00.000Z
+;
+
+selectNestedFieldWithWildcardInTheMiddle
+SELECT first_name, dep.*, last_name FROM test_emp ORDER BY first_name LIMIT 5;
+
+ first_name:s  | dep.dep_id:s  |dep.dep_name:s |   dep.from_date:ts     |    dep.to_date:ts      |   last_name:s
+
+Alejandro      |d002           |Finance        |1991-06-26T00:00:00.000Z|9999-01-01T00:00:00.000Z|McAlpine
+Amabile        |d005           |Development    |1992-11-18T00:00:00.000Z|9999-01-01T00:00:00.000Z|Gomatam
+Anneke         |d005           |Development    |1990-08-05T00:00:00.000Z|9999-01-01T00:00:00.000Z|Preusig
+Anoosh         |d005           |Development    |1991-08-30T00:00:00.000Z|9999-01-01T00:00:00.000Z|Peyn
+Arumugam       |d008           |Research       |1987-04-18T00:00:00.000Z|1997-11-08T00:00:00.000Z|Ossenbruggen
+;

--- a/x-pack/qa/sql/src/main/resources/nested.csv-spec
+++ b/x-pack/qa/sql/src/main/resources/nested.csv-spec
@@ -110,3 +110,43 @@ Chirstian            |Koblick
 null                 |Chappelet      
 Zvonko               |Nyanchama  
 ;
+
+//
+// Tests for bug https://github.com/elastic/elasticsearch/issues/32951 fix
+//
+
+selectNestedFieldFirst
+SELECT dep.dep_id, last_name FROM test_emp ORDER BY last_name LIMIT 5;
+
+dep.dep_id:s   |   last_name:s   
+
+d005           |Awdeh
+d003           |Azuma
+d002           |Baek
+d003           |Baek
+d004           |Bamford
+; 
+
+selectNestedFieldLast
+SELECT first_name, dep.dep_id FROM test_emp ORDER BY first_name LIMIT 5;
+
+first_name:s   |  dep.dep_id:s
+---------------+---------------
+Alejandro      |d002           
+Amabile        |d005           
+Anneke         |d005           
+Anoosh         |d005           
+Arumugam       |d008           
+;
+
+selectNestedFieldInTheMiddle
+SELECT first_name, dep.dep_name, last_name FROM test_emp ORDER BY first_name LIMIT 5;
+
+first_name:s   |dep.dep_name:s |last_name:s
+
+Alejandro      |Finance        |McAlpine
+Amabile        |Development    |Gomatam
+Anneke         |Development    |Preusig
+Anoosh         |Development    |Peyn
+Arumugam       |Research       |Ossenbruggen
+;


### PR DESCRIPTION
This fixes https://github.com/elastic/elasticsearch/issues/32951 by considering the first nested field to be extracted as the first one from the left and not as the last one (even if it's not coming from a nested document) in the list of columns to be retrieved.