### PR TITLE
Make XContentBuilder in AliasActions build `is_write_index` field

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -521,7 +521,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertThat(aliasExists(alias), equalTo(false));
 
         IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
-        AliasActions addAction = new AliasActions(AliasActions.Type.ADD).index(index).aliases(alias);
+        AliasActions addAction = new AliasActions(AliasActions.Type.ADD).index(index).aliases(alias).writeIndex(true);
         addAction.routing("routing").searchRouting("search_routing").filter("{\"term\":{\"year\":2016}}");
         aliasesAddRequest.addAliasAction(addAction);
         AcknowledgedResponse aliasesAddResponse = execute(aliasesAddRequest, highLevelClient().indices()::updateAliases,
@@ -535,6 +535,8 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         Map<String, Object> filter = (Map<String, Object>) getAlias.get("filter");
         Map<String, Object> term = (Map<String, Object>) filter.get("term");
         assertEquals(2016, term.get("year"));
+        Boolean isWriteIndex = (Boolean) getAlias.get("is_write_index");
+        assertTrue(isWriteIndex);
 
         String alias2 = "alias2";
         IndicesAliasesRequest aliasesAddRemoveRequest = new IndicesAliasesRequest();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -521,7 +521,10 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertThat(aliasExists(alias), equalTo(false));
 
         IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
-        AliasActions addAction = new AliasActions(AliasActions.Type.ADD).index(index).aliases(alias).writeIndex(true);
+        AliasActions addAction = new AliasActions(AliasActions.Type.ADD).index(index).aliases(alias);
+        if (randomBoolean()) {
+            addAction.writeIndex(randomBoolean());
+        }
         addAction.routing("routing").searchRouting("search_routing").filter("{\"term\":{\"year\":2016}}");
         aliasesAddRequest.addAliasAction(addAction);
         AcknowledgedResponse aliasesAddResponse = execute(aliasesAddRequest, highLevelClient().indices()::updateAliases,
@@ -536,7 +539,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         Map<String, Object> term = (Map<String, Object>) filter.get("term");
         assertEquals(2016, term.get("year"));
         Boolean isWriteIndex = (Boolean) getAlias.get("is_write_index");
-        assertTrue(isWriteIndex);
+        assertThat(isWriteIndex, equalTo(addAction.writeIndex()));
 
         String alias2 = "alias2";
         IndicesAliasesRequest aliasesAddRemoveRequest = new IndicesAliasesRequest();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -525,7 +525,8 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
                     && Objects.equals(filter, other.filter)
                     && Objects.equals(routing, other.routing)
                     && Objects.equals(indexRouting, other.indexRouting)
-                    && Objects.equals(searchRouting, other.searchRouting);
+                    && Objects.equals(searchRouting, other.searchRouting)
+                    && Objects.equals(writeIndex, other.writeIndex);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -486,6 +486,9 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             if (false == Strings.isEmpty(searchRouting)) {
                 builder.field(SEARCH_ROUTING.getPreferredName(), searchRouting);
             }
+            if (null != writeIndex) {
+                builder.field(IS_WRITE_INDEX.getPreferredName(), writeIndex);
+            }
             builder.endObject();
             builder.endObject();
             return builder;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -508,6 +508,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
                     + ",routing=" + routing
                     + ",indexRouting=" + indexRouting
                     + ",searchRouting=" + searchRouting
+                    + ",writeIndex=" + writeIndex
                     + "]";
         }
 
@@ -529,7 +530,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
 
         @Override
         public int hashCode() {
-            return Objects.hash(type, indices, aliases, filter, routing, indexRouting, searchRouting);
+            return Objects.hash(type, indices, aliases, filter, routing, indexRouting, searchRouting, writeIndex);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/alias/RandomAliasActionsGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/alias/RandomAliasActionsGenerator.java
@@ -82,6 +82,9 @@ public final class RandomAliasActionsGenerator {
                     action.indexRouting(randomRouting().toString());
                 }
             }
+            if (randomBoolean()) {
+                action.writeIndex(randomBoolean());
+            }
         }
         return action;
     }


### PR DESCRIPTION
Alias 'is_write_index' feature was introduced in 6.4 version. but, toXContent method of AliasActions does not build for `is_write_index` field.

so `is_write_index` can not be set with IndicesAliasesRequest (RestHighLevelClient)

You can see it in the code below.

https://github.com/elastic/elasticsearch/blob/237650e9c054149fd08213b38a81a3666c1868e5/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java#L448


## Sample of RestHighLevelClient

It does not set `is_write_index` despite specifying options with `writeIndex` chaining method.

```java
IndicesAliasesRequest request = new IndicesAliasesRequest();
IndicesAliasesRequest.AliasActions aliasAction =
        new IndicesAliasesRequest.AliasActions(IndicesAliasesRequest.AliasActions.Type.ADD)
                .index(index)
                .alias(alias)
                .filter(filter)
                .writeIndex(isWriteIndex); // this chaining method does not working.

request.addAliasAction(aliasAction);
return client.indices().updateAliases(request, RequestOptions.DEFAULT);
```

## Notes
- I added test for this PR
