### PR TITLE
Update type to "seat"

### DIFF
--- a/docs/painless/painless-contexts/painless-context-examples.asciidoc
+++ b/docs/painless/painless-contexts/painless-context-examples.asciidoc
@@ -46,7 +46,7 @@ the request URL.
 PUT /seats
 {
   "mappings": {
-    "_doc": {
+    "seat": {
       "properties": {
         "theatre":  { "type": "keyword" },
         "play":     { "type": "text"    },


### PR DESCRIPTION
otherwise this throws an exception: java.lang.IllegalArgumentException: Rejecting mapping update to [seats] as the final mapping would have more than 1 type: [seat, _doc]

May be, later for the types removal, we can modify `seats.json` to have a type `_doc` instead of `seat`
