### PR TITLE
Docs: Remove range notation from random score docs

### DIFF
--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -208,10 +208,10 @@ not. The number value is of type float.
 [[function-random]]
 ==== Random
 
-The `random_score` generates scores that are uniformly distributed in [0, 1[.
-By default, it uses the internal Lucene doc ids as a source of randomness,
-which is very efficient but unfortunately not reproducible since documents might
-be renumbered by merges.
+The `random_score` generates scores that are uniformly distributed between 0
+(inclusive) and 1 (exclusive). By default, it uses the internal Lucene doc ids
+as a source of randomness, which is very efficient but unfortunately not
+reproducible since documents might be renumbered by merges.
 
 In case you want scores to be reproducible, it is possible to provide a `seed`
 and `field`. The final score will then be computed based on this seed, the

--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -208,9 +208,9 @@ not. The number value is of type float.
 [[function-random]]
 ==== Random
 
-The `random_score` generates scores that are uniformly distributed between 0
-(inclusive) and 1 (exclusive). By default, it uses the internal Lucene doc ids
-as a source of randomness, which is very efficient but unfortunately not
+The `random_score` generates scores that are uniformly distributed from 0 up to
+but not including 1. By default, it uses the internal Lucene doc ids as a
+source of randomness, which is very efficient but unfortunately not
 reproducible since documents might be renumbered by merges.
 
 In case you want scores to be reproducible, it is possible to provide a `seed`


### PR DESCRIPTION
The `random_score` function produces values between 0 (inclusive) and 1
(exclusive) and documented it with fancy methematical range notation. It
is so fancy I thought it was a typo. This changes the documentation to
use words.

Relates to #35084
