### PR TITLE
SQL: [tests] Remove AbstractBuilderTestCase dep

### DIFF
--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryFolderTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryFolderTests.java
@@ -5,7 +5,7 @@
  */
 package org.elasticsearch.xpack.sql.planner;
 
-import org.elasticsearch.test.AbstractBuilderTestCase;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer;
 import org.elasticsearch.xpack.sql.analysis.index.EsIndex;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolution;
@@ -25,7 +25,7 @@ import java.util.TimeZone;
 
 import static org.hamcrest.Matchers.startsWith;
 
-public class QueryFolderTests extends AbstractBuilderTestCase {
+public class QueryFolderTests extends ESTestCase {
 
     private static SqlParser parser;
     private static Analyzer analyzer;


### PR DESCRIPTION
Extend directly from `EsTestCase` to speed up execution.

Fixes: #35098

