### PR TITLE
Fixes randomDateTimeZone method

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -230,7 +230,7 @@ public abstract class ESTestCase extends LuceneTestCase {
 
         // filter out joda timezones that are deprecated for the java time migration
         List<String> jodaTZIds = DateTimeZone.getAvailableIDs().stream()
-            .filter(DateUtils.DEPRECATED_SHORT_TZ_IDS::contains).sorted().collect(Collectors.toList());
+            .filter(s -> DateUtils.DEPRECATED_SHORT_TZ_IDS.contains(s) == false).sorted().collect(Collectors.toList());
         JODA_TIMEZONE_IDS = Collections.unmodifiableList(jodaTZIds);
 
         List<String> javaTZIds = Arrays.asList(TimeZone.getAvailableIDs());


### PR DESCRIPTION
The randomDateTimeZone method shouldn't return deprecated timezones
this causes some tests to fail with deprecation warning.

To reproduce the original problem run:
```
./gradlew :server:test -Dtests.seed=76CEA73BEE556317 -Dtests.class=org.elasticsearch.index.query.RangeQueryBuilderTests -Dtests.method="testMustRewrite" -Dtests.security.manager=true -Dtests.jvms=4 -Dtests.locale=dz-BT -Dtests.timezone=America/Indiana/Marengo -Dcompiler.java=11 -Druntime.java=11
```