### PR TITLE
Remove AbstractComponent usage in x-pack core

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationReloader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationReloader.java
@@ -5,7 +5,8 @@
  */
 package org.elasticsearch.xpack.core.ssl;
 
-import org.elasticsearch.common.component.AbstractComponent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.watcher.FileChangesListener;
 import org.elasticsearch.watcher.FileWatcher;
@@ -27,7 +28,9 @@ import java.util.concurrent.CopyOnWriteArraySet;
  * Ensures that the files backing an {@link SSLConfiguration} are monitored for changes and the underlying key/trust material is reloaded
  * and the {@link SSLContext} has existing sessions invalidated to force the use of the new key/trust material
  */
-public class SSLConfigurationReloader extends AbstractComponent {
+public class SSLConfigurationReloader {
+
+    private static final Logger logger = LogManager.getLogger(SSLConfigurationReloader.class);
 
     private final ConcurrentHashMap<Path, ChangeListener> pathToChangeListenerMap = new ConcurrentHashMap<>();
     private final Environment environment;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
@@ -7,11 +7,12 @@ package org.elasticsearch.xpack.core.ssl;
 
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.xpack.core.XPackSettings;
@@ -58,7 +59,9 @@ import java.util.stream.Collectors;
  * Provides access to {@link SSLEngine} and {@link SSLSocketFactory} objects based on a provided configuration. All
  * configurations loaded by this service must be configured on construction.
  */
-public class SSLService extends AbstractComponent {
+public class SSLService {
+
+    private static final Logger logger = LogManager.getLogger(SSLService.class);
 
     private final Settings settings;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/crypto/CryptoService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/crypto/CryptoService.java
@@ -5,8 +5,9 @@
  */
 package org.elasticsearch.xpack.core.watcher.crypto;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -34,7 +35,7 @@ import java.util.List;
 /**
  * Service that provides cryptographic methods based on a shared system key
  */
-public class CryptoService extends AbstractComponent {
+public class CryptoService {
 
     public static final String KEY_ALGO = "HmacSHA512";
     public static final int KEY_SIZE = 1024;
@@ -58,6 +59,7 @@ public class CryptoService extends AbstractComponent {
             Setting.intSetting(SecurityField.setting("encryption_key.length"), DEFAULT_KEY_LENGTH, Property.NodeScope);
     private static final Setting<String> ENCRYPTION_KEY_ALGO_SETTING =
             new Setting<>(SecurityField.setting("encryption_key.algorithm"), DEFAULT_KEY_ALGORITH, s -> s, Property.NodeScope);
+    private static final Logger logger = LogManager.getLogger(CryptoService.class);
 
     private final SecureRandom secureRandom = new SecureRandom();
     private final String encryptionAlgorithm;


### PR DESCRIPTION
This change removes the use of AbstractComponent in the security
module. The classes now declare their own loggers.

Relates #34488