### PR TITLE
CCR: Add NodeClosedException to retryable list

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
@@ -26,6 +26,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndexClosedException;
+import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.NodeDisconnectedException;
@@ -416,6 +417,7 @@ public abstract class ShardFollowNodeTask extends AllocatedPersistentTask {
             actual instanceof IndexClosedException || // If follow index is closed
             actual instanceof NodeDisconnectedException ||
             actual instanceof NodeNotConnectedException ||
+            actual instanceof NodeClosedException ||
             (actual.getMessage() != null && actual.getMessage().contains("TransportService is closed"));
     }
 


### PR DESCRIPTION
This change adds NodeClosedException to the retry-able exception list.

CI instance: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+6.x+matrix-java-periodic/ES_BUILD_JAVA=java11,ES_RUNTIME_JAVA=java8,nodes=virtual&&linux/33/console

Error log:
```
1> [2018-11-02T02:01:33,765][WARN ][o.e.x.c.a.ShardFollowNodeTask] [follower2] shard follow task encounter non-retryable error
  1> org.elasticsearch.node.NodeClosedException: node closed {follower2}{hHpicNRuSy-szrRAPPQZNQ}{wVoQ350CTRCp0YsEYECggg}{127.0.0.1}{127.0.0.1:44889}{xpack.installed=true}
  1> 	at org.elasticsearch.action.support.replication.TransportReplicationAction$ReroutePhase$2.onClusterServiceClose(TransportReplicationAction.java:894) ~[elasticsearch-6.6.0-SNAPSHOT.jar:6.6.0-SNAPSHOT]
  1> 	at org.elasticsearch.cluster.ClusterStateObserver$ContextPreservingListener.onClusterServiceClose(ClusterStateObserver.java:315) ~[elasticsearch-6.6.0-SNAPSHOT.jar:6.6.0-SNAPSHOT]
```