### PR TITLE
Build: Pull "skip assemble on qa" to common build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -555,11 +555,13 @@ wrapper {
     }
 }
 
-/* Remove assemble/dependenciesInfo on all qa projects because we don't need to publish
- * artifacts for them. */
 gradle.projectsEvaluated {
   subprojects {
-    if (project.path.startsWith(':qa')) {
+    /*
+     * Remove assemble/dependenciesInfo on all qa projects because we don't
+     * need to publish artifacts for them.
+     */
+    if (project.name.equals('qa') || project.path.contains(':qa:')) {
       Task assemble = project.tasks.findByName('assemble')
       if (assemble) {
         assemble.enabled = false

--- a/x-pack/plugin/ccr/qa/build.gradle
+++ b/x-pack/plugin/ccr/qa/build.gradle
@@ -15,14 +15,3 @@ subprojects {
     }
   }
 }
-
-/* Remove assemble on all qa projects because we don't need to publish
- * artifacts for them. */
-gradle.projectsEvaluated {
-  subprojects {
-    Task assemble = project.tasks.findByName('assemble')
-    if (assemble) {
-      assemble.enabled = false
-    }
-  }
-}

--- a/x-pack/plugin/graph/qa/build.gradle
+++ b/x-pack/plugin/graph/qa/build.gradle
@@ -15,16 +15,3 @@ subprojects {
         }
     }
 }
-
-gradle.projectsEvaluated {
-    subprojects {
-        Task assemble = project.tasks.findByName('assemble')
-        if (assemble) {
-            assemble.enabled = false
-        }
-        Task dependenciesInfo = project.tasks.findByName('dependenciesInfo')
-        if (dependenciesInfo) {
-            dependenciesInfo.enabled = false
-        }
-    }
-}

--- a/x-pack/plugin/ilm/build.gradle
+++ b/x-pack/plugin/ilm/build.gradle
@@ -27,18 +27,6 @@ gradle.projectsEvaluated {
             .each { check.dependsOn it.check }
 }
 
-
-/* Remove assemble on all qa projects because we don't need to publish
- * artifacts for them. */
-gradle.projectsEvaluated {
-    subprojects {
-        Task assemble = project.tasks.findByName('assemble')
-        if (assemble) {
-            assemble.enabled = false
-        }
-    }
-}
-
 integTest.enabled = false
 
 run {

--- a/x-pack/plugin/ilm/qa/build.gradle
+++ b/x-pack/plugin/ilm/qa/build.gradle
@@ -16,16 +16,5 @@ subprojects {
     }
 }
 
-/* Remove assemble on all qa projects because we don't need to publish
- * artifacts for them. */
-gradle.projectsEvaluated {
-    subprojects {
-        Task assemble = project.tasks.findByName('assemble')
-        if (assemble) {
-            assemble.enabled = false
-        }
-    }
-}
-
 // the qa modules does not have any source files
 licenseHeaders.enabled = false

--- a/x-pack/plugin/ml/qa/build.gradle
+++ b/x-pack/plugin/ml/qa/build.gradle
@@ -15,16 +15,3 @@ subprojects {
         }
     }
 }
-
-gradle.projectsEvaluated {
-    subprojects {
-        Task assemble = project.tasks.findByName('assemble')
-        if (assemble) {
-            assemble.enabled = false
-        }
-        Task dependenciesInfo = project.tasks.findByName('dependenciesInfo')
-        if (dependenciesInfo) {
-            dependenciesInfo.enabled = false
-        }
-    }
-}

--- a/x-pack/plugin/sql/qa/build.gradle
+++ b/x-pack/plugin/sql/qa/build.gradle
@@ -125,13 +125,4 @@ subprojects {
       setting 'script.max_compilations_rate', '1000/1m'
     }
   }
-
-  Task assemble = project.tasks.findByName('assemble')
-  if (assemble) {
-      assemble.enabled = false
-  }
-  Task dependenciesInfo = project.tasks.findByName('dependenciesInfo')
-  if (dependenciesInfo) {
-      dependenciesInfo.enabled = false
-  }
 }

--- a/x-pack/qa/build.gradle
+++ b/x-pack/qa/build.gradle
@@ -18,18 +18,3 @@ subprojects {
     }
   }
 }
-
-/* Remove assemble on all qa projects because we don't need to publish
- * artifacts for them. */
-gradle.projectsEvaluated {
-  subprojects {
-    Task assemble = project.tasks.findByName('assemble')
-    if (assemble) {
-      assemble.enabled = false
-    }
-    Task dependenciesInfo = project.tasks.findByName('dependenciesInfo')
-    if (dependenciesInfo) {
-      dependenciesInfo.enabled = false
-    }
-  }
-}


### PR DESCRIPTION
Pull all of the logic that we use to skip the `assemble` and
`dependenciesInfo` tasks on `qa` projects into one spot in our root
build file.
