### PR TITLE
Remove Joda usage from ILM

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/IndexLifecycleExplainResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/IndexLifecycleExplainResponse.java
@@ -28,8 +28,6 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.joda.time.DateTime;
-import org.joda.time.chrono.ISOChronology;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -39,13 +37,17 @@ public class IndexLifecycleExplainResponse implements ToXContentObject {
     private static final ParseField INDEX_FIELD = new ParseField("index");
     private static final ParseField MANAGED_BY_ILM_FIELD = new ParseField("managed");
     private static final ParseField POLICY_NAME_FIELD = new ParseField("policy");
+    private static final ParseField LIFECYCLE_DATE_MILLIS_FIELD = new ParseField("lifecycle_date_millis");
     private static final ParseField LIFECYCLE_DATE_FIELD = new ParseField("lifecycle_date");
     private static final ParseField PHASE_FIELD = new ParseField("phase");
     private static final ParseField ACTION_FIELD = new ParseField("action");
     private static final ParseField STEP_FIELD = new ParseField("step");
     private static final ParseField FAILED_STEP_FIELD = new ParseField("failed_step");
+    private static final ParseField PHASE_TIME_MILLIS_FIELD = new ParseField("phase_time_millis");
     private static final ParseField PHASE_TIME_FIELD = new ParseField("phase_time");
+    private static final ParseField ACTION_TIME_MILLIS_FIELD = new ParseField("action_time_millis");
     private static final ParseField ACTION_TIME_FIELD = new ParseField("action_time");
+    private static final ParseField STEP_TIME_MILLIS_FIELD = new ParseField("step_time_millis");
     private static final ParseField STEP_TIME_FIELD = new ParseField("step_time");
     private static final ParseField STEP_INFO_FIELD = new ParseField("step_info");
     private static final ParseField PHASE_EXECUTION_INFO = new ParseField("phase_execution");
@@ -70,14 +72,14 @@ public class IndexLifecycleExplainResponse implements ToXContentObject {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX_FIELD);
         PARSER.declareBoolean(ConstructingObjectParser.constructorArg(), MANAGED_BY_ILM_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), POLICY_NAME_FIELD);
-        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), LIFECYCLE_DATE_FIELD);
+        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), LIFECYCLE_DATE_MILLIS_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), PHASE_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), ACTION_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), STEP_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), FAILED_STEP_FIELD);
-        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), PHASE_TIME_FIELD);
-        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), ACTION_TIME_FIELD);
-        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), STEP_TIME_FIELD);
+        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), PHASE_TIME_MILLIS_FIELD);
+        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), ACTION_TIME_MILLIS_FIELD);
+        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), STEP_TIME_MILLIS_FIELD);
         PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> {
             XContentBuilder builder = JsonXContent.contentBuilder();
             builder.copyCurrentStructure(p);
@@ -201,29 +203,13 @@ public class IndexLifecycleExplainResponse implements ToXContentObject {
         builder.field(MANAGED_BY_ILM_FIELD.getPreferredName(), managedByILM);
         if (managedByILM) {
             builder.field(POLICY_NAME_FIELD.getPreferredName(), policyName);
-            if (builder.humanReadable()) {
-                builder.field(LIFECYCLE_DATE_FIELD.getPreferredName(), new DateTime(lifecycleDate, ISOChronology.getInstanceUTC()));
-            } else {
-                builder.field(LIFECYCLE_DATE_FIELD.getPreferredName(), lifecycleDate);
-            }
+            builder.timeField(LIFECYCLE_DATE_MILLIS_FIELD.getPreferredName(), LIFECYCLE_DATE_FIELD.getPreferredName(), lifecycleDate);
             builder.field(PHASE_FIELD.getPreferredName(), phase);
-            if (builder.humanReadable()) {
-                builder.field(PHASE_TIME_FIELD.getPreferredName(), new DateTime(phaseTime, ISOChronology.getInstanceUTC()));
-            } else {
-                builder.field(PHASE_TIME_FIELD.getPreferredName(), phaseTime);
-            }
+            builder.timeField(PHASE_TIME_MILLIS_FIELD.getPreferredName(), PHASE_TIME_FIELD.getPreferredName(), phaseTime);
             builder.field(ACTION_FIELD.getPreferredName(), action);
-            if (builder.humanReadable()) {
-                builder.field(ACTION_TIME_FIELD.getPreferredName(), new DateTime(actionTime, ISOChronology.getInstanceUTC()));
-            } else {
-                builder.field(ACTION_TIME_FIELD.getPreferredName(), actionTime);
-            }
+            builder.timeField(ACTION_TIME_MILLIS_FIELD.getPreferredName(), ACTION_TIME_FIELD.getPreferredName(), actionTime);
             builder.field(STEP_FIELD.getPreferredName(), step);
-            if (builder.humanReadable()) {
-                builder.field(STEP_TIME_FIELD.getPreferredName(), new DateTime(stepTime, ISOChronology.getInstanceUTC()));
-            } else {
-                builder.field(STEP_TIME_FIELD.getPreferredName(), stepTime);
-            }
+            builder.timeField(STEP_TIME_MILLIS_FIELD.getPreferredName(), STEP_TIME_FIELD.getPreferredName(), stepTime);
             if (Strings.hasLength(failedStep)) {
                 builder.field(FAILED_STEP_FIELD.getPreferredName(), failedStep);
             }

--- a/docs/reference/ilm/apis/explain.asciidoc
+++ b/docs/reference/ilm/apis/explain.asciidoc
@@ -101,22 +101,22 @@ When the index is first taken over by ILM you will see a response like the follo
       "index": "my_index",
       "managed": true, <1>
       "policy": "my_policy", <2>
-      "lifecycle_date": 1538475653281, <3>
+      "lifecycle_date_millis": 1538475653281, <3>
       "phase": "new", <4>
-      "phase_time": 1538475653317, <5>
+      "phase_time_millis": 1538475653317, <5>
       "action": "complete", <6>
-      "action_time": 1538475653317, <7>
+      "action_time_millis": 1538475653317, <7>
       "step": "complete", <8>
-      "step_time": 1538475653317 <9>
+      "step_time_millis": 1538475653317 <9>
     }
   }
 }
 --------------------------------------------------
 // CONSOLE
-// TESTRESPONSE[s/"lifecycle_date": 1538475653281/"lifecycle_date": $body.indices.my_index.lifecycle_date/]
-// TESTRESPONSE[s/"phase_time": 1538475653317/"phase_time": $body.indices.my_index.phase_time/]
-// TESTRESPONSE[s/"action_time": 1538475653317/"action_time": $body.indices.my_index.action_time/]
-// TESTRESPONSE[s/"step_time": 1538475653317/"step_time": $body.indices.my_index.step_time/]
+// TESTRESPONSE[s/"lifecycle_date_millis": 1538475653281/"lifecycle_date_millis": $body.indices.my_index.lifecycle_date_millis/]
+// TESTRESPONSE[s/"phase_time_millis": 1538475653317/"phase_time_millis": $body.indices.my_index.phase_time_millis/]
+// TESTRESPONSE[s/"action_time_millis": 1538475653317/"action_time_millis": $body.indices.my_index.action_time_millis/]
+// TESTRESPONSE[s/"step_time_millis": 1538475653317/"step_time_millis": $body.indices.my_index.step_time_millis/]
 <1> Shows if the index is being managed by ILM. If the index is not managed by
 ILM the other fields will not be shown
 <2> The name of the policy which ILM is using for this index
@@ -141,12 +141,16 @@ phase definition has been completely executed.
       "index": "test-000069",
       "managed": true,
       "policy": "my_lifecycle3",
+      "lifecycle_date_millis": 1538475653281,
       "lifecycle_date": "2018-10-15T13:45:21.981Z",
       "phase": "hot",
+      "phase_time_millis": 1538475653317,
       "phase_time": "2018-10-15T13:45:22.577Z",
       "action": "rollover",
+      "action_time_millis": 1538475653317,
       "action_time": "2018-10-15T13:45:22.577Z",
       "step": "attempt_rollover",
+      "step_time_millis": 1538475653317,
       "step_time": "2018-10-15T13:45:22.577Z",
       "phase_execution": { <1>
         "policy": "my_lifecycle3", <2>
@@ -187,13 +191,17 @@ If the policy is waiting for a step to complete for the index, the response will
       "index": "test-000020",
       "managed": true,
       "policy": "my_lifecycle3",
-      "lifecycle_date": "2018-10-15T13:20:28.042Z",
+      "lifecycle_date_millis": 1538475653281,
+      "lifecycle_date": "2018-10-15T13:45:21.981Z",
       "phase": "warm",
-      "phase_time": "2018-10-15T13:20:28.428Z",
+      "phase_time_millis": 1538475653317,
+      "phase_time": "2018-10-15T13:45:22.577Z",
       "action": "allocate",
-      "action_time": "2018-10-15T13:20:28.428Z",
+      "action_time_millis": 1538475653317,
+      "action_time": "2018-10-15T13:45:22.577Z",
       "step": "check-allocation",
-      "step_time": "2018-10-15T13:20:28.633Z",
+      "step_time_millis": 1538475653317,
+      "step_time": "2018-10-15T13:45:22.577Z",
       "step_info": { <1>
         "message": "Waiting for all shard copies to be active",
         "shards_left_to_allocate": -1,
@@ -245,13 +253,17 @@ that occurred in `step_info`.
       "index": "test-000056",
       "managed": true,
       "policy": "my_lifecycle3",
-      "lifecycle_date": "2018-10-15T13:38:26.209Z",
+      "lifecycle_date_millis": 1538475653281,
+      "lifecycle_date": "2018-10-15T13:45:21.981Z",
       "phase": "hot",
-      "phase_time": "2018-10-15T13:38:26.706Z",
+      "phase_time_millis": 1538475653317,
+      "phase_time": "2018-10-15T13:45:22.577Z",
       "action": "rollover",
-      "action_time": "2018-10-15T13:38:26.706Z",
+      "action_time_millis": 1538475653317,
+      "action_time": "2018-10-15T13:45:22.577Z",
       "step": "ERROR",
-      "step_time": "2018-10-15T13:39:15.304Z",
+      "step_time_millis": 1538475653317,
+      "step_time": "2018-10-15T13:45:22.577Z",
       "failed_step": "attempt_rollover", <1>
       "step_info": { <2>
         "type": "resource_already_exists_exception",

--- a/docs/reference/ilm/update-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/update-lifecycle-policy.asciidoc
@@ -191,13 +191,13 @@ GET my_index/_ilm/explain
       "index": "my_index",
       "managed": true,
       "policy": "my_executing_policy",
-      "lifecycle_date": 1538475653281,
+      "lifecycle_date_millis": 1538475653281,
       "phase": "hot",
-      "phase_time": 1538475653317,
+      "phase_time_millis": 1538475653317,
       "action": "rollover",
-      "action_time": 1538475653317,
+      "action_time_millis": 1538475653317,
       "step": "attempt_rollover",
-      "step_time": 1538475653317,
+      "step_time_millis": 1538475653317,
       "phase_execution": {
         "policy": "my_executing_policy",
         "modified_date_in_millis": 1538475653317,
@@ -216,10 +216,10 @@ GET my_index/_ilm/explain
 }
 --------------------------------------------------
 // CONSOLE
-// TESTRESPONSE[s/"lifecycle_date": 1538475653281/"lifecycle_date": $body.indices.my_index.lifecycle_date/]
-// TESTRESPONSE[s/"phase_time": 1538475653317/"phase_time": $body.indices.my_index.phase_time/]
-// TESTRESPONSE[s/"action_time": 1538475653317/"action_time": $body.indices.my_index.action_time/]
-// TESTRESPONSE[s/"step_time": 1538475653317/"step_time": $body.indices.my_index.step_time/]
+// TESTRESPONSE[s/"lifecycle_date_millis": 1538475653281/"lifecycle_date_millis": $body.indices.my_index.lifecycle_date_millis/]
+// TESTRESPONSE[s/"phase_time_millis": 1538475653317/"phase_time_millis": $body.indices.my_index.phase_time_millis/]
+// TESTRESPONSE[s/"action_time_millis": 1538475653317/"action_time_millis": $body.indices.my_index.action_time_millis/]
+// TESTRESPONSE[s/"step_time_millis": 1538475653317/"step_time_millis": $body.indices.my_index.step_time_millis/]
 // TESTRESPONSE[s/"modified_date_in_millis": 1538475653317/"modified_date_in_millis": $body.indices.my_index.phase_execution.modified_date_in_millis/]
 
 Updating `my_executing_policy` to have no rollover action and, instead, go directly into a newly introduced `warm` phase.
@@ -271,13 +271,13 @@ GET my_index/_ilm/explain
       "index": "my_index",
       "managed": true,
       "policy": "my_executing_policy",
-      "lifecycle_date": 1538475653281,
+      "lifecycle_date_millis": 1538475653281,
       "phase": "hot",
-      "phase_time": 1538475653317,
+      "phase_time_millis": 1538475653317,
       "action": "rollover",
-      "action_time": 1538475653317,
+      "action_time_millis": 1538475653317,
       "step": "attempt_rollover",
-      "step_time": 1538475653317,
+      "step_time_millis": 1538475653317,
       "phase_execution": {
         "policy": "my_executing_policy",
         "modified_date_in_millis": 1538475653317,
@@ -296,10 +296,10 @@ GET my_index/_ilm/explain
 }
 --------------------------------------------------
 // CONSOLE
-// TESTRESPONSE[s/"lifecycle_date": 1538475653281/"lifecycle_date": $body.indices.my_index.lifecycle_date/]
-// TESTRESPONSE[s/"phase_time": 1538475653317/"phase_time": $body.indices.my_index.phase_time/]
-// TESTRESPONSE[s/"action_time": 1538475653317/"action_time": $body.indices.my_index.action_time/]
-// TESTRESPONSE[s/"step_time": 1538475653317/"step_time": $body.indices.my_index.step_time/]
+// TESTRESPONSE[s/"lifecycle_date_millis": 1538475653281/"lifecycle_date_millis": $body.indices.my_index.lifecycle_date_millis/]
+// TESTRESPONSE[s/"phase_time_millis": 1538475653317/"phase_time_millis": $body.indices.my_index.phase_time_millis/]
+// TESTRESPONSE[s/"action_time_millis": 1538475653317/"action_time_millis": $body.indices.my_index.action_time_millis/]
+// TESTRESPONSE[s/"step_time_millis": 1538475653317/"step_time_millis": $body.indices.my_index.step_time_millis/]
 // TESTRESPONSE[s/"modified_date_in_millis": 1538475653317/"modified_date_in_millis": $body.indices.my_index.phase_execution.modified_date_in_millis/]
 
 After indexing one document into `my_index` so that rollover succeeds and moves onto the next phase, we will notice something new. The
@@ -327,13 +327,13 @@ GET my_index/_ilm/explain
       "index": "my_index",
       "managed": true,
       "policy": "my_executing_policy",
-      "lifecycle_date": 1538475653281,
+      "lifecycle_date_millis": 1538475653281,
       "phase": "warm",
-      "phase_time": 1538475653317,
+      "phase_time_millis": 1538475653317,
       "action": "forcemerge",
-      "action_time": 1538475653317,
+      "action_time_millis": 1538475653317,
       "step": "forcemerge",
-      "step_time": 1538475653317,
+      "step_time_millis": 1538475653317,
       "phase_execution": {
         "policy": "my_executing_policy",
         "modified_date_in_millis": 1538475653317,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/IndexLifecycleExplainResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/IndexLifecycleExplainResponse.java
@@ -18,8 +18,6 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.joda.time.DateTime;
-import org.joda.time.chrono.ISOChronology;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -29,13 +27,17 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
     private static final ParseField INDEX_FIELD = new ParseField("index");
     private static final ParseField MANAGED_BY_ILM_FIELD = new ParseField("managed");
     private static final ParseField POLICY_NAME_FIELD = new ParseField("policy");
+    private static final ParseField LIFECYCLE_DATE_MILLIS_FIELD = new ParseField("lifecycle_date_millis");
     private static final ParseField LIFECYCLE_DATE_FIELD = new ParseField("lifecycle_date");
     private static final ParseField PHASE_FIELD = new ParseField("phase");
     private static final ParseField ACTION_FIELD = new ParseField("action");
     private static final ParseField STEP_FIELD = new ParseField("step");
     private static final ParseField FAILED_STEP_FIELD = new ParseField("failed_step");
+    private static final ParseField PHASE_TIME_MILLIS_FIELD = new ParseField("phase_time_millis");
     private static final ParseField PHASE_TIME_FIELD = new ParseField("phase_time");
+    private static final ParseField ACTION_TIME_MILLIS_FIELD = new ParseField("action_time_millis");
     private static final ParseField ACTION_TIME_FIELD = new ParseField("action_time");
+    private static final ParseField STEP_TIME_MILLIS_FIELD = new ParseField("step_time_millis");
     private static final ParseField STEP_TIME_FIELD = new ParseField("step_time");
     private static final ParseField STEP_INFO_FIELD = new ParseField("step_info");
     private static final ParseField PHASE_EXECUTION_INFO = new ParseField("phase_execution");
@@ -60,14 +62,14 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
         PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX_FIELD);
         PARSER.declareBoolean(ConstructingObjectParser.constructorArg(), MANAGED_BY_ILM_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), POLICY_NAME_FIELD);
-        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), LIFECYCLE_DATE_FIELD);
+        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), LIFECYCLE_DATE_MILLIS_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), PHASE_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), ACTION_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), STEP_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), FAILED_STEP_FIELD);
-        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), PHASE_TIME_FIELD);
-        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), ACTION_TIME_FIELD);
-        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), STEP_TIME_FIELD);
+        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), PHASE_TIME_MILLIS_FIELD);
+        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), ACTION_TIME_MILLIS_FIELD);
+        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), STEP_TIME_MILLIS_FIELD);
         PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> {
             XContentBuilder builder = JsonXContent.contentBuilder();
             builder.copyCurrentStructure(p);
@@ -239,28 +241,20 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
         builder.field(MANAGED_BY_ILM_FIELD.getPreferredName(), managedByILM);
         if (managedByILM) {
             builder.field(POLICY_NAME_FIELD.getPreferredName(), policyName);
-            if (builder.humanReadable()) {
-                builder.field(LIFECYCLE_DATE_FIELD.getPreferredName(), new DateTime(lifecycleDate, ISOChronology.getInstanceUTC()));
-            } else {
-                builder.field(LIFECYCLE_DATE_FIELD.getPreferredName(), lifecycleDate);
+            if (lifecycleDate != null) {
+                builder.timeField(LIFECYCLE_DATE_MILLIS_FIELD.getPreferredName(), LIFECYCLE_DATE_FIELD.getPreferredName(), lifecycleDate);
             }
             builder.field(PHASE_FIELD.getPreferredName(), phase);
-            if (builder.humanReadable()) {
-                builder.field(PHASE_TIME_FIELD.getPreferredName(), new DateTime(phaseTime, ISOChronology.getInstanceUTC()));
-            } else {
-                builder.field(PHASE_TIME_FIELD.getPreferredName(), phaseTime);
+            if (phaseTime != null) {
+                builder.timeField(PHASE_TIME_MILLIS_FIELD.getPreferredName(), PHASE_TIME_FIELD.getPreferredName(), phaseTime);
             }
             builder.field(ACTION_FIELD.getPreferredName(), action);
-            if (builder.humanReadable()) {
-                builder.field(ACTION_TIME_FIELD.getPreferredName(), new DateTime(actionTime, ISOChronology.getInstanceUTC()));
-            } else {
-                builder.field(ACTION_TIME_FIELD.getPreferredName(), actionTime);
+            if (actionTime != null) {
+                builder.timeField(ACTION_TIME_MILLIS_FIELD.getPreferredName(), ACTION_TIME_FIELD.getPreferredName(), actionTime);
             }
             builder.field(STEP_FIELD.getPreferredName(), step);
-            if (builder.humanReadable()) {
-                builder.field(STEP_TIME_FIELD.getPreferredName(), new DateTime(stepTime, ISOChronology.getInstanceUTC()));
-            } else {
-                builder.field(STEP_TIME_FIELD.getPreferredName(), stepTime);
+            if (stepTime != null) {
+                builder.timeField(STEP_TIME_MILLIS_FIELD.getPreferredName(), STEP_TIME_FIELD.getPreferredName(), stepTime);
             }
             if (Strings.hasLength(failedStep)) {
                 builder.field(FAILED_STEP_FIELD.getPreferredName(), failedStep);

--- a/x-pack/plugin/ilm/qa/rest/src/test/resources/rest-api-spec/test/ilm/40_explain_lifecycle.yml
+++ b/x-pack/plugin/ilm/qa/rest/src/test/resources/rest-api-spec/test/ilm/40_explain_lifecycle.yml
@@ -103,7 +103,7 @@ teardown:
   - match: { indices.my_index.phase: "new" }
   - match: { indices.my_index.action: "complete" }
   - match: { indices.my_index.step: "complete" }
-  - is_true: indices.my_index.phase_time
+  - is_true: indices.my_index.phase_time_millis
   - is_false: indices.my_index.failed_step
   - is_false: indices.my_index.step_info
   - is_false: indices.my_index.phase_execution
@@ -125,7 +125,7 @@ teardown:
   - match: { indices.my_index.phase: "new" }
   - match: { indices.my_index.action: "complete" }
   - match: { indices.my_index.step: "complete" }
-  - is_true: indices.my_index.phase_time
+  - is_true: indices.my_index.phase_time_millis
   - is_false: indices.my_index.failed_step
   - is_false: indices.my_index.step_info
   - is_false: indices.my_index.phase_execution
@@ -136,7 +136,7 @@ teardown:
   - match: { indices.my_index2.phase: "new" }
   - match: { indices.my_index2.action: "complete" }
   - match: { indices.my_index2.step: "complete" }
-  - is_true: indices.my_index2.phase_time
+  - is_true: indices.my_index2.phase_time_millis
   - is_false: indices.my_index2.failed_step
   - is_false: indices.my_index2.step_info
   - is_false: indices.my_index2.phase_execution
@@ -158,7 +158,7 @@ teardown:
   - match: { indices.my_index.phase: "new" }
   - match: { indices.my_index.action: "complete" }
   - match: { indices.my_index.step: "complete" }
-  - is_true: indices.my_index.phase_time
+  - is_true: indices.my_index.phase_time_millis
   - is_false: indices.my_index.failed_step
   - is_false: indices.my_index.step_info
   - is_false: indices.my_index.phase_execution
@@ -169,7 +169,7 @@ teardown:
   - match: { indices.my_index2.phase: "new" }
   - match: { indices.my_index2.action: "complete" }
   - match: { indices.my_index2.step: "complete" }
-  - is_true: indices.my_index2.phase_time
+  - is_true: indices.my_index2.phase_time_millis
   - is_false: indices.my_index2.failed_step
   - is_false: indices.my_index2.step_info
   - is_false: indices.my_index2.phase_execution
@@ -180,7 +180,7 @@ teardown:
   - match: { indices.another_index.phase: "new" }
   - match: { indices.another_index.action: "complete" }
   - match: { indices.another_index.step: "complete" }
-  - is_true: indices.another_index.phase_time
+  - is_true: indices.another_index.phase_time_millis
   - is_false: indices.another_index.failed_step
   - is_false: indices.another_index.step_info
   - is_false: indices.another_index.phase_execution
@@ -257,7 +257,7 @@ teardown:
   - match: { indices.foo.phase: "new" }
   - match: { indices.foo.action: "complete" }
   - match: { indices.foo.step: "complete" }
-  - is_true: indices.foo.phase_time
+  - is_true: indices.foo.phase_time_millis
   - is_false: indices.foo.failed_step
   - is_false: indices.foo.step_info
   - is_false: indices.foo.phase_execution


### PR DESCRIPTION
This commit removes the Joda time usage from ILM and the HLRC components of ILM.
It also fixes an issue where using the `?human=true` flag could have caused the
parser not to work. These millisecond fields now follow the standard we use
elsewhere in the code, with additional fields added iff the `human` flag is
specified.

This is a breaking change for ILM, but since ILM has not yet been released, no
compatibility shim is needed.
