### PR TITLE
Add doc section about range query for range type

### DIFF
--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -143,20 +143,22 @@ GET _search
 [[querying-range-fields]]
 ==== Querying range fields
 
-`range` queries can be used on fields of type <<range,`range`>>, allowing to match a range specified in the query
-with a range field value in the document. Parameter `relation` controls how these two ranges are matched:
+`range` queries can be used on fields of type <<range,`range`>>, allowing to
+match a range specified in the query with a range field value in the document.
+The `relation` parameter controls how these two ranges are matched:
 
 [horizontal]
 `WITHIN`::
 
-    Matches the document when document's range field is within the range specified in the query.
+    Matches documents who's range field is entirely within the query's range.
 
 `CONTAINS`::
 
-    Matches the document when document's range field contains the range specified in the query. 
+    Matches documents who's range field entirely contains the query's range.
 
 `INTERSECTS`::
 
-    Matches the document when document's range field intersects with the range specified in the query. This is the default value.
+    Matches documents who's range field intersects the query's range.
+    This is the default value when querying range fields.
 
 For examples, see <<range,`range`>> mapping type.

--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -139,3 +139,24 @@ GET _search
 // CONSOLE
 <1> This date will be converted to `2014-12-31T23:00:00 UTC`.
 <2> `now` is not affected by the `time_zone` parameter (dates must be stored as UTC).
+
+[[querying-range-fields]]
+==== Querying range fields
+
+`range` queries can be used on fields of type <<range,`range`>>, allowing to match a range specified in the query
+with a range field value in the document. Parameter `relation` controls how these two ranges are matched:
+
+[horizontal]
+`WITHIN`::
+
+    Matches the document when document's range field is within the range specified in the query.
+
+`CONTAINS`::
+
+    Matches the document when document's range field contains the range specified in the query. 
+
+`INTERSECTS`::
+
+    Matches the document when document's range field intersects with the range specified in the query. This is the default value.
+
+For examples, see <<range,`range`>> mapping type.


### PR DESCRIPTION
I didn't know about this mapping type until I saw it in an ES presentation. It's only described in the Mapping section. It should also be referenced in the Range Query documentation.