### PR TITLE
Add equals/hashCode to SeqNoStats

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/seqno/SeqNoStats.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/SeqNoStats.java
@@ -84,6 +84,24 @@ public class SeqNoStats implements ToXContentFragment, Writeable {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final SeqNoStats that = (SeqNoStats) o;
+        return maxSeqNo == that.maxSeqNo &&
+            localCheckpoint == that.localCheckpoint &&
+            globalCheckpoint == that.globalCheckpoint;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Long.hashCode(maxSeqNo);
+        result = 31 * result + Long.hashCode(localCheckpoint);
+        result = 31 * result + Long.hashCode(globalCheckpoint);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "SeqNoStats{" +
             "maxSeqNo=" + maxSeqNo +

--- a/server/src/main/java/org/elasticsearch/index/seqno/SeqNoStats.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/SeqNoStats.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public class SeqNoStats implements ToXContentFragment, Writeable {
 
@@ -95,10 +96,7 @@ public class SeqNoStats implements ToXContentFragment, Writeable {
 
     @Override
     public int hashCode() {
-        int result = Long.hashCode(maxSeqNo);
-        result = 31 * result + Long.hashCode(localCheckpoint);
-        result = 31 * result + Long.hashCode(globalCheckpoint);
-        return result;
+        return Objects.hash(maxSeqNo, localCheckpoint, globalCheckpoint);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/seqno/SequenceNumbersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/SequenceNumbersTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.seqno;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -57,4 +58,11 @@ public class SequenceNumbersTests extends ESTestCase {
         assertThat(e, hasToString(containsString("sequence number must be assigned")));
     }
 
+    public void testSeqNoStatsEqualsAndHashCode() {
+        final long maxSeqNo = randomLongBetween(SequenceNumbers.UNASSIGNED_SEQ_NO, Long.MAX_VALUE);
+        final long localCheckpoint = randomLongBetween(SequenceNumbers.UNASSIGNED_SEQ_NO, maxSeqNo);
+        final long globalCheckpoint = randomLongBetween(SequenceNumbers.UNASSIGNED_SEQ_NO, localCheckpoint);
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(new SeqNoStats(maxSeqNo, localCheckpoint, globalCheckpoint),
+            stats -> new SeqNoStats(stats.getMaxSeqNo(), stats.getLocalCheckpoint(), stats.getGlobalCheckpoint()));
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1308,12 +1308,7 @@ public final class InternalTestCluster extends TestCluster {
                         } catch (AlreadyClosedException e) {
                             continue; // shard is closed - just ignore
                         }
-                        assertThat(replicaShardRouting + " local checkpoint mismatch",
-                            seqNoStats.getLocalCheckpoint(), equalTo(primarySeqNoStats.getLocalCheckpoint()));
-                        assertThat(replicaShardRouting + " global checkpoint mismatch",
-                            seqNoStats.getGlobalCheckpoint(), equalTo(primarySeqNoStats.getGlobalCheckpoint()));
-                        assertThat(replicaShardRouting + " max seq no mismatch",
-                            seqNoStats.getMaxSeqNo(), equalTo(primarySeqNoStats.getMaxSeqNo()));
+                        assertThat(replicaShardRouting + " seq_no_stats mismatch", seqNoStats, equalTo(primarySeqNoStats));
                         // the local knowledge on the primary of the global checkpoint equals the global checkpoint on the shard
                         assertThat(replicaShardRouting + " global checkpoint syncs mismatch", seqNoStats.getGlobalCheckpoint(),
                             equalTo(syncGlobalCheckpoints.get(replicaShardRouting.allocationId().getId())));


### PR DESCRIPTION
This commit adds equals/hashCode to SeqNoStats so we can verify it wholly in tests.