### PR TITLE
Apply masterNodeTimeout to MasterNodeRequest transmission

### DIFF
--- a/docs/reference/cluster/health.asciidoc
+++ b/docs/reference/cluster/health.asciidoc
@@ -113,9 +113,9 @@ The cluster health API accepts the following request parameters:
     the wait_for_XXX are provided. Defaults to `30s`.
 
 `master_timeout`::
-    A time based parameter controlling how long to wait if the master has not been
-    discovered yet or disconnected.
-    If not provided, uses the same value as `timeout`.
+    A time based parameter controlling how long to wait if the master has not
+    been discovered yet, is disconnected, or does not respond. If not provided,
+    uses the same value as `timeout`.
 
 `local`::
     If `true` returns the local node information and does not provide


### PR DESCRIPTION
Each `MasterNodeRequest` has a timeout, `masterNodeTimeout`, that limits how
long a request will wait while attempting to identify the current master node
before returning an error. However, once the requesting node has determined the
identity of the master it forwards the request and patiently waits for it to
respond, and this wait might be much longer than the configured
`masterNodeTimeout`: in traffic-dropping network partitions the trigger for a
response could be the closure of the underlying connection, which may take many
minutes, much longer than the time it takes the node to detect the partition
via fault detection.

This change applies the `masterNodeTimeout` to the transmission of the
`MasterNodeRequest` from originating node to its master so that clients can
more reliably request a timely response.