### PR TITLE
PLUGIN/store-encrypt:support data encryption for Elasticsearch

### DIFF
--- a/plugins/store-encrypt/README-cn.md
+++ b/plugins/store-encrypt/README-cn.md
@@ -1,0 +1,132 @@
+# 支持Elasticsearch落地数据加密
+
+[TOC]
+
+## 支持落地数据加密的插件
+
+在ElasticSearch服务器中，存储中的数据在写入持久存储时不会被加密。在线上生成环境中，我们有非常高的数据安全要求，为此，我们开发了一个用于数据加密的存储组件，可以支持对落地数据的敏感部分进行数据加密。我们这样做的主要出发点，是考虑到lucene开源社区曾经讨论过落地数据安全的一个建议是通过文件系统加密，但这种做法对性能影响较大，为此，我们综合考虑了性能和落地数据安全的侧重点，对非常敏感的落地数据进行加密，比如tim、fdt、dvd这几种包含敏感信息的文件，同时对于其它数据文件不加密。
+
+
+## 设计
+
+为了保护落地数据被物理拖动库或备份窃取。 我们考虑设计加密的着陆数据存储并将用户的主密钥与登陆数据分开的能力。 启动节点后，只有在相对严格的身份验证授权（通常与公司的内部密钥安全机制相关）后才能获取主密钥。 为此，我们设计并实现了Store-encrypt插件，以支持登陆数据加密和密钥对接管理。
+
+功能包括
+
+* 支持AES-ECB模式加密（128bit）
+* 支持2种密钥传递方法，数据密钥存储在index settings、被加密的数据密钥存储在 index settings并支持对接主密钥
+* 保留Elasticsearch可选目录服务能力
+* 插件模式，可灵活对ES、lucene升级
+
+
+## 开始 Getting Started
+
+通过以下几个步骤就可以体验落地数据加密的能力。
+
+* 编译（可选）。可直接下载对应的版本plugin
+* 安装
+* 配置
+
+详情参考后问
+
+## 编译 
+
+首先，需要从仓库下载该插件，并编译Elasticsearch项目。编译的说明，请参考Elasticsearch的编译流程。配置完成后，进入elasticsearch的根目录，执行以下命令，即可完成编译：
+
+	gradlew assemble
+
+
+如果不想编译，可以下载对应的版本直接安装即可。详情参考以下的发布版本。
+可选版本：
+
+* [Plugin For Elasticsearch 6.3.2](http://)
+
+## 安装 Installation
+
+请参考  ElasticSearch 的插件安装指令。详情可以从下面获得参考
+https://www.elastic.co/guide/en/elasticsearch/plugins/6.4/plugin-management-custom-url.html
+
+## 配置 Configuration 
+
+1.设置Elasticsearch的lucene不开启文件合并模式（可选）
+		
+		setUseCompoundFile
+
+2.配置存储类型store type： index.store.type 
+
+默认情况下，Elasticsearch支持可选的文件存储。包括 fs、niofs、mmapfs、simplefs，详情可参考 https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-store.html 。如果需要加密，只需要在文件存储下加上 "encrypt\_" 前缀，如果想用默认，用 "encrypt_default" 即可。因此，可选的加密  "index.store.type" 值包括：
+
+* encrypt_default 
+* encrypt_fs
+* encrypt_niofs
+* ncrypt_mmapfs
+* encrypt_simplefs
+
+3.配置加密密钥：index.directkey 或者 index.encryptionkey
+
+密钥为16字节（128 bit）的长度。
+
+有2种配置密钥的方式。如果 index.directkey 有赋值，将优先使用该值作为数据加密的密钥。否则， 将用 index.encryptionkey 作为落地数据加密的密钥，但是  index.encryptionkey 并不是明文密钥，需要通过主密钥加密才能获得。
+
+4.配置获取主密钥的配置文件 encrypt.yml
+
+	encrypt:
+	    dsmhost: https://mydsm.oa?user=xxx
+	    rootCA:  config_path/dsm.crt 
+
+配置说明，dsmhost是请求的dsm系统host。rootCA是可配置的根CA证书路径。系统启动后，会请求dsmhost的路径，并期望返回以下格式的数据，因此需要用户自行实现DSM系统接口
+
+	{
+	   "dek" : "CpbCOtC9i0IuG5pBi+zl6R5iDZOSPSyxTs87zBiyLig=",
+	   "ret_code" : 0,
+	   "ret_msg" : ""
+	}
+	
+其中 dek是base64加密后的16字节128位密钥。
+
+
+例子1，通过直接配置密钥，数据密钥的值为（0123456789abcdef），base64编码后为（MDEyMzQ1Njc4OWFiY2RlZg==）。
+
+	PUT twitter
+	{
+	    "settings" : {
+	        "index" : {
+		        "directkey":"MDEyMzQ1Njc4OWFiY2RlZg==",
+		        "store":{
+					"type":"encrypt_fs"
+				}
+	        }
+	    }
+	}
+
+例子2，通过直接配置密钥，数据密钥的值为（0123456789abcdef），数据密钥被主密钥加密后的base64值为（KpltMAJDFYrjvy/ohXmr4Q==），主密钥通过DSM系统请求获取，主密钥的值为（aaaaaaaaaaffffff）。
+
+	PUT twitter
+	{
+	    "settings" : {
+	        "index" : {
+		        "encryptionkey":"KpltMAJDFYrjvy/ohXmr4Q==",
+		        "store":{
+					"type":"encrypt_fs"
+				}
+	        }
+	    }
+	}
+
+	DSM 系统应该实现返回以下内容的接口。（YWFhYWFhYWFhYWZmZmZmZg==）是（aaaaaaaaaaffffff）的base64值。
+	{
+	   "dek" : "YWFhYWFhYWFhYWZmZmZmZg==",
+	   "ret_code" : 0,
+	   "ret_msg" : ""
+	}
+
+for more information about
+
+	
+        
+## 安全说明
+
+
+
+index.store.type
+https://www.elastic.co/guide/en/elasticsearch/reference/6.4/breaking-changes-6.0.html 

--- a/plugins/store-encrypt/README.md
+++ b/plugins/store-encrypt/README.md
@@ -1,0 +1,131 @@
+# Support Elasticsearch landing data encryption
+
+[TOC]
+
+## Support for landing data encryption plugin
+
+In the ElasticSearch server, the data in the storage is not encrypted when it is written to persistent storage. In the online generation environment, we have very high data security requirements. To this end, we have developed a storage component for data encryption that can support data encryption for sensitive parts of the landing data. The main starting point for us to do this is to consider that the Lucene open source community has discussed the issue of data security. It is through file system encryption, but this approach has a great impact on performance. To this end, we have considered performance and data security. The focus is on encrypting very sensitive landing data, such as tim, fdt, dvd, which contain sensitive information, and not encrypting other data files.
+
+
+##Design 
+
+In order to protect the landing data, it is physically dragged by the library or backed up by the backup. We consider the ability to design an encrypted landing data store and separate the user's master key from the login data. Once the node is started, the master key can only be obtained after a relatively strict authentication authorization (usually related to the company's internal key security mechanism). To this end, we designed and implemented the Store-encrypt plugin to support login data encryption and key docking management.
+
+Features include
+
+* Support AES-ECB mode encryption (128bit)
+* Supports two key delivery methods, the data key is stored in the index settings, the encrypted data key is stored in the index settings and the docking master key is supported.
+* Retain Elasticsearch's optional directory service capabilities
+* Plug-in mode for flexible upgrade of ES and Lucene
+
+
+## Getting Started
+
+The ability to embed data encryption can be experienced in the following steps.
+
+* Compile (optional). The corresponding version plugin can be downloaded directly.
+* Installation
+* Configuration
+
+For details, please refer to the question.
+
+## Compile
+
+First, you need to download the plugin from the repository and compile the Elasticsearch project. For instructions on compiling, please refer to the Elasticsearch compilation process. After the configuration is complete, go to the root directory of elasticsearch and execute the following command to complete the compilation:
+
+Gradlew assemble
+
+
+If you do not want to compile, you can download the corresponding version and install it directly. Refer to the release version below for details.
+Optional version:
+
+* [Plugin For Elasticsearch 6.3.2] (http://)
+
+## Installation
+
+Please refer to the ElasticSearch plugin installation instructions. Details can be found below
+Https://www.elastic.co/guide/en/elasticsearch/plugins/6.4/plugin-management-custom-url.html
+
+## Configuration
+
+1.Set Elasticsearch's lucene does not open file merge mode (optional)
+
+	InternalEngine.java:1963 
+	iwc.setUseCompoundFile(false); // always use compound on flush - reduces # of file-handles on refresh
+
+2.Configure the storage type store type: index.store.type
+
+By default, Elasticsearch supports optional file storage. Including fs, niofs, mmapfs, simplefs, please refer to https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-store.html for details. If you need encryption, just add the "encrypt\_" prefix to the file storage. If you want to use the default, use "encrypt_default". Therefore, the optional encryption "index.store.type" value includes:
+
+* encrypt_default
+* encrypt_fs
+* encrypt_niofs
+* ncrypt_mmapfs
+* encrypt_simplefs
+
+3.Configure the encryption key: index.directkey or index.encryptionkey
+
+The key is 16 bytes (128 bit) long.
+
+There are two ways to configure the key. If index.directkey has an assignment, it will be used first as the key for data encryption. Otherwise, index.encryptionkey will be used as the key for landing data encryption, but index.encryptionkey is not a plaintext key and needs to be encrypted by master key.
+
+4.Configure the configuration file to get the master key encrypt.yml
+
+	Encrypt:
+	Dsmhost: https://mydsm.oa?user=xxx
+	rootCA: config_path/dsm.crt
+
+Configuration instructions, dsmhost is the requested dsm system host. The rootCA is a configurable root CA certificate path. After the system starts, it will request the path of dsmhost, and expect to return the data in the following format, so the user needs to implement the DSM system interface.
+
+	{
+		"dek" : "CpbCOtC9i0IuG5pBi+zl6R5iDZOSPSyxTs87zBiyLig=",
+		"ret_code" : 0,
+		"ret_msg" : ""
+	}
+
+The dek is a 16-byte 128-bit key encrypted by base64.
+
+
+Example 1, by directly configuring the key, the value of the data key is (0123456789abcdef), and the base64 is encoded as (MDEyMzQ1Njc4OWFiY2RlZg==).
+
+	PUT twitter
+	{
+		"settings" : {
+			"index" : {
+				"directkey":"MDEyMzQ1Njc4OWFiY2RlZg==",
+				"store":{
+					"type": "encrypt_fs"
+					}
+			}
+		}
+	}
+
+Example 2, by directly configuring the key, the value of the data key is (0123456789abcdef), and the base64 value of the data key encrypted by the master key is (KpltMAJDFYrjvy/ohXmr4Q==), and the master key is requested by the DSM system. The value of the key is (aaaaaaaaaaffffff).
+
+	PUT twitter
+	{
+		"settings" : {
+		"index" : {
+			"encryptionkey":"KpltMAJDFYrjvy/ohXmr4Q==",
+				"store":{
+					"type": "encrypt_fs"
+					}
+			}
+		}
+	}
+	
+	The DSM system should implement an interface that returns the following. (YWFhYWFhYWFhYWZmZmZmZg==) is the base64 value of (aaaaaaaaaaffffff).
+	{
+		"dek" : "YWFhYWFhYWFhYWZmZmZmZg==",
+		"ret_code" : 0,
+		"ret_msg" : ""
+	}
+
+For more information about
+
+
+        
+## Safety instructions
+
+Index.store.type
+Https://www.elastic.co/guide/en/elasticsearch/reference/6.4/breaking-changes-6.0.html

--- a/plugins/store-encrypt/build.gradle
+++ b/plugins/store-encrypt/build.gradle
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+esplugin {
+  description 'Encrypt store to encrypt data while be store in persistent storage.'
+  classname 'org.noop.essecure.plugin.EncryptStorePlugin'
+}
+
+dependencies {
+    // network stack
+    compile "io.netty:netty-buffer:4.1.16.Final"
+    compile "io.netty:netty-codec:4.1.16.Final"
+    compile "io.netty:netty-codec-http:4.1.16.Final"
+    compile "io.netty:netty-common:4.1.16.Final"
+    compile "io.netty:netty-handler:4.1.16.Final"
+    compile "io.netty:netty-resolver:4.1.16.Final"
+    compile "io.netty:netty-transport:4.1.16.Final"
+}
+

--- a/plugins/store-encrypt/encrypt.yml
+++ b/plugins/store-encrypt/encrypt.yml
@@ -1,0 +1,6 @@
+# Config store encryption 
+# 4 space indent.
+# 
+encrypt:
+    dsmhost: http://www.baidu.com
+    certfile: config/dsm_ca.crt

--- a/plugins/store-encrypt/src/main/config/encrypt.yml
+++ b/plugins/store-encrypt/src/main/config/encrypt.yml
@@ -1,0 +1,6 @@
+# Config store encryption 
+# 4 space indent.
+# 
+encrypt:
+    dsmhost: http://www.baidu.com
+    certfile: config/dsm_ca.crt

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/http/HttpSnoopClient.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/http/HttpSnoopClient.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.http;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.cookie.ClientCookieEncoder;
+import io.netty.handler.codec.http.cookie.DefaultCookie;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+
+import java.io.File;
+import java.net.URI;
+
+public final class HttpSnoopClient {
+
+	public interface HttpListener{
+
+		public void OnSuccess(String url,String content,String debugMessage);
+		public void OnFail(String url,String debugMessage);
+	};
+
+	static final String URL = "https://wx.qq.com/";
+
+	public static void main(String[] args) throws Exception {
+		HttpListener listener = new HttpListener (){
+			public void OnSuccess(String url,String content,String debugMessage)
+			{
+				System.out.println(url + content + debugMessage);
+			}
+			public void OnFail(String url,String debugMessage)
+			{
+				System.out.println(url + debugMessage);
+			}
+		};
+
+		SnoopHttpRequest request = new SnoopHttpRequest(URL,3000,"d:\\g_1.cer");
+		submitHttpRequest(request,listener);
+	}
+
+	public static void submitHttpRequest(SnoopHttpRequest request,HttpListener listener) throws Exception {
+
+		URI uri = new URI(request.url());
+		String scheme = uri.getScheme() == null? "http" : uri.getScheme();
+		String host = uri.getHost() == null? "127.0.0.1" : uri.getHost();
+		int port = uri.getPort();
+		if (port == -1) {
+			if ("http".equalsIgnoreCase(scheme)) {
+				port = 80;
+			} else if ("https".equalsIgnoreCase(scheme)) {
+				port = 443;
+			}
+		}
+
+		if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+			System.err.println("Only HTTP(S) is supported.");
+			return;
+		}
+
+		// Configure SSL context if necessary.
+		final boolean ssl = "https".equalsIgnoreCase(scheme);
+		final SslContext sslCtx;
+		if (ssl) {
+			if(request.rootCAFile()!= null)
+			{
+				sslCtx = SslContextBuilder.forClient()
+						.trustManager(new File(request.rootCAFile())).build();
+			}
+			else
+			{
+				sslCtx = SslContextBuilder.forClient()
+						.trustManager(InsecureTrustManagerFactory.INSTANCE).build();
+			}
+		} else {
+			sslCtx = null;
+		}
+
+		// Configure the client.
+		EventLoopGroup group = new NioEventLoopGroup();
+		try {
+			Bootstrap b = new Bootstrap();
+			b.group(group)
+			.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, request.timeoutMS())
+			.channel(NioSocketChannel.class)
+			.handler(new HttpSnoopClientInitializer(sslCtx,listener,request.timeoutMS()));
+
+			// Make the connection attempt.
+			Channel ch = b.connect(host, port).sync().channel();
+
+			// Prepare the HTTP request.
+			HttpRequest httpRequest = new DefaultFullHttpRequest(
+					HttpVersion.HTTP_1_1, HttpMethod.GET, uri.getRawPath());
+			httpRequest.headers().set(HttpHeaderNames.HOST, host);
+			httpRequest.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
+			httpRequest.headers().set(HttpHeaderNames.ACCEPT_ENCODING, HttpHeaderValues.GZIP);
+
+			// Send the HTTP request.
+			ch.writeAndFlush(httpRequest);
+
+			// Wait for the server to close the connection.
+			ch.closeFuture().sync();
+		} finally {
+			// Shut down executor threads to exit.
+			group.shutdownGracefully();
+		}
+	}
+}

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/http/HttpSnoopClientHandler.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/http/HttpSnoopClientHandler.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.http;
+
+import org.noop.essecure.http.HttpSnoopClient.HttpListener;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.CharsetUtil;
+
+public class HttpSnoopClientHandler extends SimpleChannelInboundHandler<HttpObject> {
+
+    private final HttpListener listener;
+    private String debugMessage = "";
+    private String responseData = "";
+
+    public HttpSnoopClientHandler(HttpListener listener)
+    {
+        this.listener = listener;
+    }
+
+    @Override
+    public void channelRead0(ChannelHandlerContext ctx, HttpObject msg) {
+        if (msg instanceof HttpResponse) {
+            HttpResponse response = (HttpResponse) msg;
+
+            debugMessage+=("STATUS: " + response.status());
+            debugMessage+=("VERSION: " + response.protocolVersion());
+
+            if (!response.headers().isEmpty()) {
+                for (CharSequence name: response.headers().names()) {
+                    for (CharSequence value: response.headers().getAll(name)) {
+                        debugMessage+=("HEADER: " + name + " = " + value);
+                    }
+                }
+            }
+
+            if (HttpUtil.isTransferEncodingChunked(response)) {
+                debugMessage+=("CHUNKED CONTENT {");
+            } else {
+                debugMessage+=("CONTENT {");
+            }
+        }
+        if (msg instanceof HttpContent) {
+            HttpContent content = (HttpContent) msg;
+
+            responseData += (content.content().toString(CharsetUtil.UTF_8));
+
+            if (content instanceof LastHttpContent) {
+                debugMessage+=("} END OF CONTENT");
+                ctx.close();
+                listener.OnSuccess("", responseData, debugMessage);
+            }
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        cause.printStackTrace();
+        ctx.close();
+        listener.OnFail("", debugMessage);
+    }
+}

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/http/HttpSnoopClientInitializer.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/http/HttpSnoopClientInitializer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.http;
+
+import java.util.concurrent.TimeUnit;
+
+import org.noop.essecure.http.HttpSnoopClient.HttpListener;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpContentDecompressor;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+
+public class HttpSnoopClientInitializer extends ChannelInitializer<SocketChannel> {
+
+    private final SslContext sslCtx;
+    private final HttpListener listener;
+    private final int timeoutMS;
+
+    public HttpSnoopClientInitializer(SslContext sslCtx,HttpListener listener,int timeoutMS) {
+        this.sslCtx = sslCtx;
+        this.listener = listener;
+        this.timeoutMS = timeoutMS;
+    }
+
+    @Override
+    public void initChannel(SocketChannel ch) {
+        ChannelPipeline p = ch.pipeline();
+
+        // Add timeout
+        p.addLast(new ReadTimeoutHandler(timeoutMS,TimeUnit.MILLISECONDS));
+        p.addLast(new WriteTimeoutHandler(timeoutMS,TimeUnit.MILLISECONDS));
+
+        // Enable HTTPS if necessary.
+        if (sslCtx != null) {
+            p.addLast(sslCtx.newHandler(ch.alloc()));
+        }
+
+        p.addLast(new HttpClientCodec());
+
+        // Remove the following line if you don't want automatic content decompression.
+        p.addLast(new HttpContentDecompressor());
+
+        // Uncomment the following line if you don't want to handle HttpContents.
+        //p.addLast(new HttpObjectAggregator(1048576));
+
+        p.addLast(new HttpSnoopClientHandler(listener));
+    }
+}

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/http/SnoopHttpRequest.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/http/SnoopHttpRequest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.http;
+
+import org.elasticsearch.common.Nullable;
+
+public class SnoopHttpRequest {
+
+	private final String url;
+	private final int timeoutMS;
+	private final String rootCAFile; 
+
+	public SnoopHttpRequest(String url,int timeoutMS,@Nullable String rootCAFile)
+	{
+		this.url = url;
+		this.timeoutMS = timeoutMS;
+		this.rootCAFile = rootCAFile;
+	}
+	
+	public String url()
+	{
+		return url;
+	}
+	
+	public int timeoutMS()
+	{
+		return timeoutMS;
+	}
+	
+	public String rootCAFile()
+	{
+		return rootCAFile;
+	}
+}

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/plugin/EncryptSettingsConfig.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/plugin/EncryptSettingsConfig.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.plugin;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.settings.SecureSetting;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.settings.Setting.Validator;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * If config "index.directkey",will use its value as AES's data encryption key.
+ * Else,the plugin will request "encrypt.dsmhost" to get data master key,then use the
+ * master key to decrypt "index.encryptionkey" to be the AES's data encryption key.
+ */
+public class EncryptSettingsConfig {
+
+	/**
+	 * Config for direct data encryption key.
+	 * First use 
+	 */
+    static final String DIRECT_KEY = "index.directkey";
+    static Validator<String> DIRECT_KEY_VALIDATOR = new  Validator<String>() {
+		@Override
+		public void validate(String value, Map<Setting<String>, String> settings) {
+		}};
+    public static final Setting<String> DIRECT_KEY_SETTING = Setting.simpleString(DIRECT_KEY, 
+    		DIRECT_KEY_VALIDATOR, Property.IndexScope,Property.Dynamic);
+    
+	/**
+	 * Config for data secure management system request url.
+	 * Recommend https request here.
+	 */
+	static final String ENCRYPT_DSMHOST = "encrypt.dsmhost";
+    static Validator<String> ENCRYPT_DSMHOST_VALIDATOR = new  Validator<String>() {
+		@Override
+		public void validate(String value, Map<Setting<String>, String> settings) {
+			// do nothing.
+		}};
+    static final Setting<String> DSMHOST_SETTING = Setting.simpleString(ENCRYPT_DSMHOST,ENCRYPT_DSMHOST_VALIDATOR,Property.NodeScope);
+    
+    static final Setting<String> ROOTCA_SETTING = Setting.simpleString("encrypt.rootCA",Property.NodeScope);
+
+    /**
+     * Config for encryption key data.
+     */
+    static final String ENCRYPTION_KEY = "index.encryptionkey";
+    static Validator<String> ENCRYPTION_KEY_VALIDATOR = new  Validator<String>() {
+		@Override
+		public void validate(String value, Map<Setting<String>, String> settings) {
+		}};
+    public static final Setting<String> ENCRYPTION_KEY_SETTING = Setting.simpleString(ENCRYPTION_KEY, 
+    		ENCRYPTION_KEY_VALIDATOR, Property.IndexScope,Property.Dynamic);
+
+  
+    private String dsmHost;
+    private String rootCAFile;
+
+    public EncryptSettingsConfig( Environment environment) {
+        final Path configDir = environment.configFile();
+        final Path customSettingsYamlFile = configDir.resolve("encrypt.yml");
+
+        final Settings customSettings;
+        try {
+            customSettings = Settings.builder().loadFromPath(customSettingsYamlFile).build();
+            assert customSettings != null;
+        } catch (IOException e) {
+            throw new ElasticsearchException("Failed to load settings", e);
+        }
+
+        this.dsmHost = DSMHOST_SETTING.get(customSettings);
+        if(null == this.dsmHost || this.dsmHost.trim().equals(""))
+        {
+        	this.dsmHost = null;
+        }
+        this.rootCAFile = ROOTCA_SETTING.get(customSettings);
+        if(null == this.rootCAFile || this.rootCAFile.trim().equals(""))
+        {
+        	this.rootCAFile = null;
+        }
+    }
+
+    public String getDsmHost() {
+        return dsmHost;
+    }
+
+    public String getRootCAFile()
+    {
+    	return this.rootCAFile;
+    }
+
+    public String toString()
+    {
+    	String str = "rootCA:" + this.rootCAFile;
+    	return str;
+    }
+
+}

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/plugin/EncryptStorePlugin.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/plugin/EncryptStorePlugin.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.plugin;
+
+
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.function.Function;
+
+import javax.crypto.NoSuchPaddingException;
+
+import java.util.Arrays;
+
+import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.store.IndexStore;
+import org.elasticsearch.plugins.Plugin;
+import org.noop.essecure.http.SnoopHttpRequest;
+import org.noop.essecure.http.HttpSnoopClient;
+import org.noop.essecure.http.HttpSnoopClient.HttpListener;
+import org.noop.essecure.services.EncryptionKey;
+import org.noop.essecure.services.KeyListener;
+import org.noop.essecure.services.KeyServices;
+import org.noop.essecure.store.encrypt.EncryptIndexStore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class EncryptStorePlugin extends Plugin {
+	final Logger logger;
+	boolean success = false;
+	
+    public static String[] storeTypes = {
+    		"encrypt_default",
+    		"encrypt_fs",
+    		"encrypt_niofs",
+            "encrypt_mmapfs",
+            "encrypt_simplefs"};
+    
+    @Override
+    public void onIndexModule(IndexModule indexModule) {
+        for(int i=0;i<storeTypes.length;i++)
+        {
+            indexModule.addIndexStore(storeTypes[i], EncryptIndexStore::new);
+        }
+    }
+    
+    private final EncryptSettingsConfig config;
+
+    public EncryptStorePlugin(final Settings settings, final Path configPath) throws Exception {
+        this.logger = Loggers.getLogger(getClass());
+
+        this.config = new EncryptSettingsConfig(new Environment(settings, configPath));
+        logger.info("loading plugin [EncryptStorePlugin] [{}]",config.toString());
+       
+        /**
+         * load master key from DSM system.
+         */
+        if(this.config.getDsmHost() != null)
+        {
+        	logger.info("request for master key");
+
+        	HttpListener listener = new HttpListener ()
+        	{
+        		public void OnSuccess(String url,String content,String debugMessage)
+        		{
+        			try 
+        			{
+						KeyServices.setMasterKey(content);
+						success = true;
+					} 
+        			catch (InvalidKeyException | NoSuchAlgorithmException | NoSuchPaddingException e) 
+        			{
+						e.printStackTrace();
+					}
+        			logger.info("get master key success.");
+        		}
+        		public void OnFail(String url,String debugMessage)
+        		{
+        			logger.info("get master key fail.error [{}]",debugMessage);
+        		}
+        	};
+        	SnoopHttpRequest request = 
+        			new SnoopHttpRequest(config.getDsmHost(),3000,config.getRootCAFile());
+        	HttpSnoopClient.submitHttpRequest(request,listener);
+        	
+        	if(!success)
+        	{
+        		throw new Exception("get master key from dsm fail");
+        	}
+        }
+
+        logger.info("load plugin [EncryptStorePlugin] successfully");
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return Arrays.asList(
+        		EncryptSettingsConfig.DIRECT_KEY_SETTING,
+        		EncryptSettingsConfig.ENCRYPTION_KEY_SETTING
+        		);
+    }
+
+    @Override
+    public Settings additionalSettings() {
+        final Settings.Builder builder = Settings.builder();
+        return builder.build();
+    }
+
+    public static void main(String[] args) throws Exception {
+
+    }
+}
+

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/services/AESEncryption.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/services/AESEncryption.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.services;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.logging.Loggers;
+
+public class AESEncryption implements EncryptionImpl {
+
+    protected final Logger logger;
+    private final String key;
+    private final byte[] keyBytes;
+    private AESWrapper encrypt;
+    private AESWrapper decrypt;
+
+	public AESEncryption(String key) throws InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException
+	{
+        this.logger = Loggers.getLogger(getClass());
+		this.key = key;
+		this.keyBytes = Base64.getDecoder().decode(this.key);
+		assert(this.keyBytes.length % 16 == 0);
+
+		this.encrypt = new AESWrapper(this.keyBytes,AESWrapper.CIPHER_ALGORITHM_ECB_NOPADDING,true);
+		this.decrypt = new AESWrapper(this.keyBytes,AESWrapper.CIPHER_ALGORITHM_ECB_NOPADDING,false);
+	}
+	
+	@Override
+	public void encryptData(byte[] data) throws IllegalBlockSizeException, BadPaddingException {
+		this.encrypt.encrypt(data);
+	}
+
+	@Override
+	public void decryptData(byte[] data) throws IllegalBlockSizeException, BadPaddingException {
+		this.decrypt.decrypt(data);
+	}
+
+	public static void main(String[] args) throws Exception {
+
+		byte[] keyBytes = "aaaaaaaaaaffffff".getBytes();
+		System.out.println("base64 key " + Base64.getEncoder().encodeToString(keyBytes));
+		AESWrapper encrypt = 
+				new AESWrapper(keyBytes,AESWrapper.CIPHER_ALGORITHM_ECB_NOPADDING,true);
+		
+		byte[] dataBytes = "0123456789abcdef".getBytes();
+		encrypt.encrypt(dataBytes);
+		
+		String str = Base64.getEncoder().encodeToString(dataBytes);
+		System.out.println("str " + str);
+
+		byte b = -128;
+		System.out.println("b = " + b);
+		b = 127;
+		System.out.println("b = " + b);
+		b = (byte) -b;
+		System.out.println("b = " + b);
+		b = 0;
+		System.out.println("b = " + b);
+		b = (byte) -b;
+		System.out.println("b = " + b);
+	}
+
+}

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/services/AESWrapper.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/services/AESWrapper.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.services;
+
+import java.nio.ByteBuffer;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Random;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.elasticsearch.common.Nullable;
+
+/**
+ * Code References:
+ * https://blog.csdn.net/jjwwmlp456/article/details/20960029 
+ * https://blog.csdn.net/u011781521/article/details/77932321 
+ */
+public class AESWrapper {
+	static final String KEY_ALGORITHM = "AES";
+	static final String CIPHER_ALGORITHM_ECB_NOPADDING = "AES/ECB/NoPadding";
+	static final String CIPHER_ALGORITHM_CBC_NOPADDING = "AES/CBC/NoPadding";
+	
+	final String mode;
+	final SecretKey secretKey;
+	final Cipher cipher;
+	final boolean encrypt;
+	final ByteBuffer buffer;
+	/**
+	 * 
+	 * @param userKey 
+	 * @param mode Refer to CIPHER_ALGORITHM_ECB_NOPADDING or CIPHER_ALGORITHM_CBC_NOPADDING
+	 * @param encrypt
+	 * @throws NoSuchPaddingException 
+	 * @throws NoSuchAlgorithmException 
+	 * @throws InvalidKeyException 
+	 */
+	public AESWrapper(byte[] userKey,String mode,boolean encrypt) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException
+	{
+		this.mode = mode;
+		this.secretKey = new SecretKeySpec(userKey,KEY_ALGORITHM);
+		this.encrypt = encrypt;
+		this.cipher = Cipher.getInstance(this.mode);	
+		this.buffer = ByteBuffer.allocate((int) KeyServices.BLOCKSIZE);
+		
+		if(this.encrypt)
+		{
+			cipher.init(Cipher.ENCRYPT_MODE, secretKey);
+		}
+		else
+		{
+			cipher.init(Cipher.DECRYPT_MODE, secretKey);
+		}
+	}
+
+	void encrypt(byte[] data) throws IllegalBlockSizeException, BadPaddingException
+	{
+		assert(data.length % 16 == 0);
+		assert(this.encrypt == true);
+	
+		byte[] out = this.cipher.doFinal(data);
+		assert(out.length == data.length);
+		System.arraycopy(out, 0, data, 0, data.length);
+	}
+
+	void decrypt(byte[] data) throws IllegalBlockSizeException, BadPaddingException
+	{
+		assert(data.length % 16 == 0);
+		assert(this.encrypt != true);
+	
+		byte[] out = this.cipher.doFinal(data);
+		assert(out.length == data.length);
+		System.arraycopy(out, 0, data, 0, data.length);
+	}
+	
+	public static void main(String[] args) throws Exception {
+
+		Random r = new Random();
+		for(int it=0;it<20;it++)
+		{
+			byte[] userKey = new byte[16];
+			r.nextBytes(userKey);
+
+			int dataSize = (((r.nextInt() & 0x7FFFFFFF) % 20) + 10)*16;
+			byte[] data = new byte[dataSize];
+			r.nextBytes(data);
+			byte[] data1 = new byte[dataSize];
+			System.arraycopy(data, 0, data1, 0, data.length);
+
+			AESWrapper encrypt = new AESWrapper(userKey,CIPHER_ALGORITHM_ECB_NOPADDING,true);
+			encrypt.encrypt(data1);
+			AESWrapper decrypt = new AESWrapper(userKey,CIPHER_ALGORITHM_ECB_NOPADDING,true);
+			decrypt.decrypt(data1);
+			for(int i=0;i<data.length;i++)
+			{
+				assert(data[i] == data1[i]);
+			}
+		}
+		System.out.println("success");
+	}
+
+}
+
+

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/services/EncryptionImpl.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/services/EncryptionImpl.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.services;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+
+public interface EncryptionImpl {
+
+	public void encryptData(byte data[]) throws IllegalBlockSizeException, BadPaddingException;
+
+	public void decryptData(byte data[]) throws IllegalBlockSizeException, BadPaddingException;
+}

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/services/EncryptionKey.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/services/EncryptionKey.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.services;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.NoSuchPaddingException;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+public class EncryptionKey implements Cloneable {
+    public boolean supportEncryption = false;
+    public String key;
+    public String algorithms;
+    
+    public EncryptionKey(boolean supportEncryption,String key,String algorithm)
+    {
+        this.supportEncryption = supportEncryption;
+        this.key = key;
+        this.algorithms = algorithm;
+    }
+    
+    public EncryptionImpl newEncryptionInstance() throws InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException
+    {
+    	if(this.supportEncryption)
+    		return new AESEncryption(key);
+    	else 
+    		return new NoEncryption();
+    }
+    
+    @Override
+	public Object clone() throws CloneNotSupportedException {
+    	EncryptionKey obj = (EncryptionKey)super.clone();
+    	obj.supportEncryption = this.supportEncryption;
+    	obj.key = this.key;
+    	obj.algorithms = this.algorithms;
+        return obj;
+    }
+    
+    public static void parseFromDSMJSon(EncryptionKey key,String json) throws JsonParseException, IOException
+    {
+    	JsonFactory factory = new JsonFactory();
+    	JsonParser  parser  = factory.createParser(json);
+    	long retCode = -1;
+    	String retMessage = "(json not set retMessage)";
+    	String dek = null;
+
+    	while(!parser.isClosed()){
+    		JsonToken jsonToken = parser.nextToken();
+    		if(JsonToken.FIELD_NAME.equals(jsonToken)){
+    			String fieldName = parser.getCurrentName();
+    			jsonToken = parser.nextToken();
+    			if("dek".equals(fieldName))
+    			{
+    				dek   = parser.getValueAsString();
+    			} 
+    			else if ("ret_code".equals(fieldName))
+    			{
+    				retCode = parser.getValueAsLong(retCode);
+    			} 
+    			else if("ret_msg".equals(fieldName))
+    			{
+    				retMessage = parser.getValueAsString();
+    			}
+    		}
+    	}
+
+    	if(retCode == 0 && dek!=null)
+    	{
+    		key.key = dek;
+    	}
+    	else 
+    	{
+    		throw new IOException("parser json error,json retcode " + retCode + ",retMessage " + retMessage);
+    	}
+    }
+
+}

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/services/KeyListener.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/services/KeyListener.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.services;
+
+public interface KeyListener {
+
+	public void OnKeyResponse(String key);
+}

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/services/KeyServices.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/services/KeyServices.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.services;
+
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+
+public class KeyServices {
+
+	public static long BLOCKSIZE = 1024;
+	private static String MASTERKEY = null;
+	private static AESEncryption encryptionImpl= null;
+	private static EncryptionKey defaultKey = new EncryptionKey(false,"asdfghjklqwertyyuuo","AES");
+
+	public synchronized static void setMasterKey(String masterKey) throws InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException
+	{
+		MASTERKEY = masterKey;
+		encryptionImpl = new AESEncryption(MASTERKEY);
+	}
+
+	public synchronized static String getMasterKey(String masterKey)
+	{
+		return MASTERKEY;
+	}
+
+	public static EncryptionKey getFromEncryptionKey(String base64EncryptionKey) throws UnsupportedEncodingException, IllegalBlockSizeException, BadPaddingException
+	{
+		if(null == encryptionImpl)
+			throw new IllegalArgumentException("master key not set");
+		byte[] directKey = base64EncryptionKey.getBytes("UTF-8");
+		encryptionImpl.decryptData(directKey);
+		EncryptionKey key = new EncryptionKey(true,new String(directKey, "UTF-8"),"AES");
+		return key;
+	}
+
+	public static EncryptionKey getFromDirectKey(String base64DirectKey)
+	{
+		EncryptionKey key = new EncryptionKey(true,base64DirectKey,"AES");
+		return key;
+	}
+}

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/services/NoEncryption.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/services/NoEncryption.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.services;
+
+public class NoEncryption implements EncryptionImpl {
+
+	public NoEncryption()
+	{
+	}
+	
+	@Override
+	public void encryptData(byte[] data) {
+		return ;
+	}
+
+	@Override
+	public void decryptData(byte[] data) {
+		return ;
+	}
+
+}

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/store/encrypt/EncryptDirectoryWrapper.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/store/encrypt/EncryptDirectoryWrapper.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.store.encrypt;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collection;
+
+import javax.crypto.NoSuchPaddingException;
+
+import org.apache.lucene.store.BufferedChecksumIndexInput;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.Lock;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.logging.Loggers;
+import org.noop.essecure.services.EncryptionKey;
+import org.noop.essecure.services.KeyListener;
+import org.noop.essecure.services.KeyServices;
+
+public final class EncryptDirectoryWrapper extends FilterDirectory {
+
+	private final Directory realDirectory;
+	private final EncryptionKey key;
+	protected final Logger logger;
+
+	// lucene version 7.3.*
+	private static String[] LUCENE_VERSION_7_3_ENCRYPT_FILES = {"tim","fdt","dvd"};
+	private static String[] CURRENT_ENCYRPT_FILES = LUCENE_VERSION_7_3_ENCRYPT_FILES;
+	public EncryptDirectoryWrapper(Directory in,EncryptionKey key) {
+		super(in);
+		this.realDirectory = in;
+		this.key = key;
+		this.logger = Loggers.getLogger(getClass());
+	}
+
+	private void ensureValid()
+	{
+	}
+
+	private boolean matchEncryptionFileName(String name)
+	{
+		for(int i=0;i<CURRENT_ENCYRPT_FILES.length;i++)
+		{
+			String entry = CURRENT_ENCYRPT_FILES[i];
+			if(name.length() >= entry.length() && 
+					entry.equals(name.substring(name.length() - entry.length())))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private EncryptionKey cloneEncryptionKey(boolean supportDataEncryption)
+	{
+		EncryptionKey tmpKey = new EncryptionKey(supportDataEncryption,this.key.key,this.key.algorithms);
+		return tmpKey;
+	}
+
+	@Override
+	public IndexInput openInput(String name, IOContext context) throws IOException
+	{
+		ensureValid();
+		EncryptionKey tmpKey = cloneEncryptionKey(this.matchEncryptionFileName(name));
+		if(null == tmpKey)
+			throw new IOException("clone encryption key fail");
+		try {
+			return new EncryptIndexInput("(new)",realDirectory.openInput(name, context),tmpKey);
+		} catch (InvalidKeyException | NoSuchAlgorithmException | NoSuchPaddingException e) {
+			e.printStackTrace();
+			throw new IOException(e);
+		}
+	}
+
+	@Override
+	public ChecksumIndexInput openChecksumInput(String name, IOContext context) throws IOException {
+		ensureValid();
+		EncryptionKey tmpKey = cloneEncryptionKey(this.matchEncryptionFileName(name));
+		if(null == tmpKey)
+			throw new IOException("clone encryption key fail");
+		try {
+			return new EncryptIndexInput("(new checksum)",realDirectory.openInput(name, context),tmpKey,true);
+		} catch (InvalidKeyException | NoSuchAlgorithmException | NoSuchPaddingException e) {
+			e.printStackTrace();
+			throw new IOException(e);
+		}
+	}
+
+	@Override
+	public IndexOutput createOutput(String name, IOContext context) throws IOException {
+		ensureValid();
+		EncryptionKey tmpKey = cloneEncryptionKey(this.matchEncryptionFileName(name));
+		if(null == tmpKey)
+			throw new IOException("clone encryption key fail");
+		try {
+			return new EncryptIndexOutput(realDirectory.createOutput(name, context),tmpKey);
+		} catch (InvalidKeyException | NoSuchAlgorithmException | NoSuchPaddingException e) {
+			e.printStackTrace();
+			throw new IOException(e);
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		ensureValid();
+		realDirectory.close();
+	}
+
+	@Override
+	public IndexOutput createTempOutput(String prefix, String suffix, IOContext context) throws IOException {
+		ensureValid();
+		EncryptionKey tmpKey = cloneEncryptionKey(this.matchEncryptionFileName(suffix));
+		if(null == tmpKey)
+			throw new IOException("clone encryption key fail");
+		try {
+			return new EncryptIndexOutput(realDirectory.createTempOutput(prefix, suffix, context),tmpKey);
+		} catch (InvalidKeyException | NoSuchAlgorithmException | NoSuchPaddingException e) {
+			e.printStackTrace();
+			throw new IOException(e);
+		}
+	}
+
+	@Override
+	public void deleteFile(String name) throws IOException {
+		ensureValid();
+		realDirectory.deleteFile(name);
+	}
+
+	@Override
+	public long fileLength(String name) throws IOException {
+		ensureValid();
+		return realDirectory.fileLength(name);
+	}
+
+	@Override
+	public String[] listAll() throws IOException {
+		ensureValid();
+		return realDirectory.listAll();
+	}
+
+	@Override
+	public Lock obtainLock(String name) throws IOException {
+		ensureValid();
+		return realDirectory.obtainLock(name);
+	}
+
+	@Override
+	public void rename(String source, String dest) throws IOException {
+		ensureValid();
+		realDirectory.rename(source, dest);
+	}
+
+	@Override
+	public void sync(Collection<String> files) throws IOException {
+		ensureValid();
+		realDirectory.sync(files);
+	}
+
+	@Override
+	public void syncMetaData() throws IOException {
+		ensureValid();
+		realDirectory.syncMetaData();
+	}
+
+}

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/store/encrypt/EncryptFsDirectoryService.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/store/encrypt/EncryptFsDirectoryService.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.store.encrypt;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.LockFactory;
+import org.apache.lucene.store.MMapDirectory;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.shard.ShardPath;
+import org.elasticsearch.index.store.DirectoryService;
+import org.elasticsearch.index.store.IndexStore;
+import org.noop.essecure.plugin.EncryptSettingsConfig;
+import org.noop.essecure.services.KeyServices;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.FileSwitchDirectory;
+import org.apache.lucene.store.NIOFSDirectory;
+import org.apache.lucene.store.NativeFSLockFactory;
+import org.apache.lucene.store.SimpleFSDirectory;
+import org.apache.lucene.store.SimpleFSLockFactory;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexModule;
+import java.nio.file.Files;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+
+/***
+ * Most of the code is copy from FsDirectoryServices in ElasticSearch servier core.
+ * We will wrapper the IndexInput and IndexOutput.Data will be encrypted while being 
+ * writting into storage.Support file system,include niofs,mmapfs,simplefs,fs,default.
+ * If we want encrypt fs,add prefix to fs type.Like encrypt_niofs.Support type include:
+ *     encrypt_default
+ *     encrypt_fs
+ *     encrypt_niofs
+ *     encrypt_mmapfs
+ *     encrypt_simplefs
+ *     
+ */
+public class EncryptFsDirectoryService extends DirectoryService {
+
+    protected final Logger logger;
+    private final String directKey;
+    private final String encryptionKey;
+
+    protected final IndexStore indexStore;
+    public static final Setting<LockFactory> INDEX_LOCK_FACTOR_SETTING = new Setting<>("index.store.fs.fs_lock", "native", (s) -> {
+        switch (s) {
+            case "native":
+                return NativeFSLockFactory.INSTANCE;
+            case "simple":
+                return SimpleFSLockFactory.INSTANCE;
+            default:
+                throw new IllegalArgumentException("unrecognized [index.store.fs.fs_lock] \"" + s + "\": must be native or simple");
+        } // can we set on both - node and index level, some nodes might be running on NFS so they might need simple rather than native
+    }, Property.IndexScope, Property.NodeScope);
+
+    private final ShardPath path;
+
+    @Inject
+    public EncryptFsDirectoryService(IndexSettings indexSettings, IndexStore indexStore, ShardPath path) {
+        super(path.getShardId(), indexSettings);
+        this.logger = Loggers.getLogger(getClass());
+        this.path = path;
+        this.indexStore = indexStore;
+        Settings settings = indexSettings.getSettings();
+        this.directKey = EncryptSettingsConfig.DIRECT_KEY_SETTING.get(settings);
+        this.encryptionKey = EncryptSettingsConfig.ENCRYPTION_KEY_SETTING.get(settings);
+        
+    }
+    
+    private String getStoreType() throws IOException
+    {
+    	String originalStoreType = indexSettings.getSettings().get(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(),
+    	        "encrypt_default");
+  	
+    	if(!originalStoreType.startsWith("encrypt_"))
+    	{
+    	   throw new IOException("store type not begin with encrypt_"); 
+    	}
+
+    	String storeType = originalStoreType.substring("encrypt_".length());
+    	if(storeType.equals("default"))
+    	{
+    	    storeType = IndexModule.Type.FS.getSettingsKey();
+    	}
+    	return storeType;
+    }
+
+    @Override
+    public Directory newDirectory() throws IOException {
+    	if(this.directKey != null && !this.directKey.trim().equals(""))
+    	{
+    		return new EncryptDirectoryWrapper(newInnerDirectory(),KeyServices.getFromDirectKey(this.directKey));
+    	}
+    	else
+    	{
+    		try {
+				return new EncryptDirectoryWrapper(newInnerDirectory(),KeyServices.getFromEncryptionKey(this.encryptionKey));
+			} catch (IllegalBlockSizeException | BadPaddingException e) {
+				e.printStackTrace();
+				throw new IOException("new encryption key fail");
+			}
+    	}
+    }
+    
+    public Directory newInnerDirectory() throws IOException {
+        final Path location = path.resolveIndex();
+        final LockFactory lockFactory = indexSettings.getValue(INDEX_LOCK_FACTOR_SETTING);
+        Files.createDirectories(location);
+        Directory wrapped = newFSDirectory(location, lockFactory);
+        Set<String> preLoadExtensions = new HashSet<>(
+                indexSettings.getValue(IndexModule.INDEX_STORE_PRE_LOAD_SETTING));
+        wrapped = setPreload(wrapped, location, lockFactory, preLoadExtensions);
+        return wrapped;
+    }
+
+    protected Directory newFSDirectory(Path location, LockFactory lockFactory) throws IOException {
+        final String storeType = getStoreType();
+        if (IndexModule.Type.FS.match(storeType)) {
+            return FSDirectory.open(location, lockFactory); // use lucene defaults
+        } else if (IndexModule.Type.SIMPLEFS.match(storeType)) {
+            return new SimpleFSDirectory(location, lockFactory);
+        } else if (IndexModule.Type.NIOFS.match(storeType)) {
+            return new NIOFSDirectory(location, lockFactory);
+        } else if (IndexModule.Type.MMAPFS.match(storeType)) {
+            return new MMapDirectory(location, lockFactory);
+        }
+        throw new IllegalArgumentException("No directory found for type [" + storeType + "]");
+    }
+
+    private static Directory setPreload(Directory directory, Path location, LockFactory lockFactory,
+            Set<String> preLoadExtensions) throws IOException {
+        if (preLoadExtensions.isEmpty() == false
+                && directory instanceof MMapDirectory
+                && ((MMapDirectory) directory).getPreload() == false) {
+            if (preLoadExtensions.contains("*")) {
+                ((MMapDirectory) directory).setPreload(true);
+                return directory;
+            }
+            MMapDirectory primary = new MMapDirectory(location, lockFactory);
+            primary.setPreload(true);
+            return new FileSwitchDirectory(preLoadExtensions, primary, directory, true) {
+                @Override
+                public String[] listAll() throws IOException {
+                    // avoid listing twice
+                    return primary.listAll();
+                }
+            };
+        }
+        return directory;
+    }
+}

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/store/encrypt/EncryptIndexInput.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/store/encrypt/EncryptIndexInput.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.store.encrypt;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.zip.CRC32;
+import java.util.zip.Checksum;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+
+import org.apache.lucene.store.BufferedChecksum;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.logging.Loggers;
+import org.noop.essecure.services.EncryptionImpl;
+import org.noop.essecure.services.KeyServices;
+import org.noop.essecure.services.EncryptionKey;
+/**
+ * Use head and tail to allign data to BlockSize.
+ * [head],[block],[block],...,[block],[tail] 
+ * head and tail buffer data have been decrypted by input.
+ * Two case:
+ * 	case 1,If the IndexInput is the whole encrypt file stream,the head size = 0,and the last tail will not be cnrypted.
+ *  case 2,If the IndexInput is the slice of one encrypt file stream,head size  may not be 0,ant the tail buffer too.
+ *  
+ */
+public class EncryptIndexInput extends ChecksumIndexInput {
+
+	private EncryptionKey key;
+	private EncryptionImpl decryptImpl;
+	private IndexInput in;
+	private long length;
+	private long currentPos;
+	private byte[] head;
+	private long headSize;
+	private byte[] tail;
+	private long tailSize;
+	private byte[] buffer;
+	private long bufferBase;
+	private static long invalidBufferBase = -2 - KeyServices.BLOCKSIZE;
+
+	private byte[] oneByte = new byte[1];
+	private Logger logger;
+	private boolean supportChecksum;
+	private Checksum digest;	// Only compute original data's checksum.
+	private String resourceDesc = "";
+	
+	public EncryptIndexInput(String resourceDesc,IndexInput _in,EncryptionKey _key) throws IOException, InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException {
+		this(resourceDesc,_in, _in.length(), _key,false);
+	}
+
+	public EncryptIndexInput(String resourceDesc,IndexInput _in,EncryptionKey _key,boolean supportChecksum) throws IOException, InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException {
+		this(resourceDesc,_in, _in.length(), _key,supportChecksum);
+	}   
+
+	private EncryptIndexInput(String resourceDesc,IndexInput _in,long _length,EncryptionKey _key,boolean supportChecksum) throws IOException, InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException {
+		super("EncrypteIndexInput," + resourceDesc + "," + _in.toString());
+		this.resourceDesc = resourceDesc;
+		
+		byte[] newHead = new byte[0];
+
+		int newTailSize = (int) (_length % KeyServices.BLOCKSIZE);
+		byte[] newTail = new byte[newTailSize];
+		_in.seek(_length - newTailSize);
+		_in.readBytes(newTail, 0, newTailSize);
+		_in.seek(0); 
+
+		init(_in,_length,newHead,newTail,_key,supportChecksum);
+	}
+
+	private EncryptIndexInput(String resourceDesc,IndexInput _in,long _length,byte[] _head,byte[] _tail,EncryptionKey _key,boolean supportChecksum) throws InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException {
+		super("EncrypteIndexInput," + resourceDesc + "," + _in.toString());
+		this.resourceDesc = resourceDesc;
+		// do not use logger before init()
+		init(_in,_length,_head,_tail,_key,supportChecksum);
+	}
+
+	private void init(IndexInput _in,long _length,byte[] _head,byte[] _tail,EncryptionKey _key,boolean supportChecksum) throws InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException
+	{
+		logger = Loggers.getLogger(getClass());
+		assert(_length >=0);
+		assert(_in != null && _key != null && _head != null && _tail!=null);
+		assert(_head.length >= 0 && _head.length <= KeyServices.BLOCKSIZE);
+		assert(_tail.length >= 0 && _tail.length <= KeyServices.BLOCKSIZE);
+
+		this.key = _key;
+		this.decryptImpl = this.key.newEncryptionInstance();
+		this.in = _in.clone();
+		this.length = _length;
+		_in.getFilePointer();
+		this.currentPos = 0;
+
+		this.headSize = _head.length;
+		this.head = _head;
+		this.tailSize = _tail.length;
+		this.tail = _tail;
+		this.buffer = new byte[(int) KeyServices.BLOCKSIZE];
+		this.bufferBase = invalidBufferBase;
+		this.supportChecksum = supportChecksum;
+
+		// Note,Directory's default checksum method is crc32.
+		this.digest = new BufferedChecksum(new CRC32());    
+	}
+
+	@Override
+	public void close() throws IOException {
+		in.close();
+	}
+
+	/**
+	 * Return next byte's position.
+	 */
+	@Override
+	public long getFilePointer() {
+		return currentPos;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * If support checksum operation,will pretect seek forward.
+	 * {@link ChecksumIndexInput} can only seek forward and seeks are expensive
+	 * since they imply to read bytes in-between the current position and the
+	 * target position in order to update the checksum.
+	 */
+	@Override
+	public void seek(long pos) throws IOException {
+		this.currentPos = pos;
+
+		final long curFP = getFilePointer();
+		final long skip = pos - curFP;
+		if(this.supportChecksum && skip < 0)
+		{
+			throw new IllegalStateException(getClass() + " cannot seek backwards (pos=" + pos + " getFilePointer()=" + curFP + ")");
+		}
+		skipBytes(skip);
+	}
+
+	@Override
+	public long length() {
+		return this.length;
+	}
+
+	@Override
+	public IndexInput slice(String sliceDescription, long _offset, long _length) throws IOException {
+		assert(_offset >= 0 && _length >= 0 && _offset + _length < this.length);
+
+		// restore now position of this IndexInput.
+		long tempCurrentPos = this.currentPos;
+
+		// BUGS:find bugs headsize > length
+		int newHeadSize = (int) (KeyServices.BLOCKSIZE -
+				((_offset + KeyServices.BLOCKSIZE - this.headSize) % KeyServices.BLOCKSIZE));
+		assert(newHeadSize >=0 && newHeadSize <= KeyServices.BLOCKSIZE);
+		newHeadSize = (int) (newHeadSize > _length ? _length:newHeadSize);
+		byte[] newHead = new byte[newHeadSize];
+		this.seek(_offset);
+		this.readBytes(newHead, 0, newHead.length);
+
+		assert(_length >= newHeadSize);
+		int newTailSize = (int)((_length - newHeadSize)%KeyServices.BLOCKSIZE);
+		assert(newTailSize >=0);
+		byte[] newTail = new byte[newTailSize];
+		this.seek(_offset + _length - newTail.length);
+		this.readBytes(newTail,0,newTail.length);
+
+		IndexInput sliceIn = this.in.slice(sliceDescription, _offset, _length);
+
+		this.seek(tempCurrentPos);
+
+		// TODO: optimize clone
+		try {
+			return new EncryptIndexInput("(slice "+this.resourceDesc+")",sliceIn,_length,newHead,newTail,this.key,this.supportChecksum);
+		} catch (InvalidKeyException | NoSuchAlgorithmException | NoSuchPaddingException e) {
+			e.printStackTrace();
+			throw new IOException("new slice error" + e);
+		}
+	}
+
+	@Override
+	public byte readByte() throws IOException {
+
+		// TODO: optimize for read one byte() ? 
+		if(this.bufferBase <= this.currentPos && this.currentPos < (this.bufferBase + KeyServices.BLOCKSIZE))
+		{
+			oneByte[0] = this.buffer[(int) (this.currentPos - this.bufferBase)];
+			this.currentPos++;
+			if(this.supportChecksum)
+				this.digest.update(oneByte[0]);
+		}
+		else 
+		{
+			readBytes(oneByte,0,1);
+		}
+		return oneByte[0];
+	}
+
+	@Override
+	public void readBytes(byte[] b, int offset, int len) throws IOException {
+		assert(len >=0);
+
+		int readBytes = 0;
+		if(len == readBytes)
+			return;
+
+		int tmp; 
+
+		// head 
+		if(readBytes < len && this.currentPos < this.headSize)
+		{
+			tmp = (int) Math.min(len - readBytes, this.headSize - this.currentPos);
+			System.arraycopy(this.head,(int) this.currentPos, b,offset + readBytes, tmp);
+			readBytes += tmp;
+			this.currentPos += tmp;
+			assert(readBytes <= len);
+			if(readBytes == len)
+			{
+				if(this.supportChecksum)
+					this.digest.update(b, offset, len);
+				return;
+			}
+		}
+
+		// middle 
+		while(readBytes < len && this.currentPos < (this.length - this.tailSize))
+		{
+			// refill buffer
+			if(this.currentPos < this.bufferBase || 
+					this.currentPos >= this.bufferBase + KeyServices.BLOCKSIZE)
+			{
+				this.bufferBase = this.currentPos - (this.currentPos - this.headSize) % KeyServices.BLOCKSIZE;
+				assert(this.bufferBase + KeyServices.BLOCKSIZE <= this.length);
+				this.in.seek(this.bufferBase);
+				this.in.readBytes(this.buffer, 0, this.buffer.length);
+				try {
+					this.decryptImpl.decryptData(buffer);
+				} catch (IllegalBlockSizeException | BadPaddingException e) {
+					e.printStackTrace();
+					throw new IOException("decrypt data error");
+				}
+			}
+
+			int bufferOffset = (int) (this.currentPos - this.bufferBase);
+			tmp = (int)Math.min(len - readBytes, KeyServices.BLOCKSIZE - bufferOffset);
+			assert(bufferOffset + tmp <= buffer.length);
+			assert(offset + readBytes + tmp <= b.length);
+			System.arraycopy(buffer, bufferOffset,b , offset + readBytes, tmp);
+			readBytes += tmp;
+			this.currentPos += tmp;
+			assert(readBytes <= len);
+			if(readBytes == len)
+			{
+				if(this.supportChecksum)
+					this.digest.update(b, offset, len);
+				return ;
+			}
+		}
+
+		// tail
+		if(readBytes < len && this.currentPos < this.length)
+		{
+			tmp = (int) Math.min(this.length - this.currentPos, len - readBytes);
+			System.arraycopy(tail, (int) (this.currentPos - (this.length - this.tailSize)),b,offset + readBytes,tmp);
+
+			readBytes += tmp;
+			this.currentPos += tmp;
+			assert(readBytes <= len);
+
+			if(this.supportChecksum)
+				this.digest.update(b, offset, len);
+		}
+	}
+
+	@Override
+	public IndexInput clone() {
+		EncryptIndexInput clone;
+		try {
+			clone = new EncryptIndexInput("(clone "+this.resourceDesc+")",this.in,this.length,
+					this.head,this.tail,this.key,this.supportChecksum);
+		} catch (InvalidKeyException | NoSuchAlgorithmException | NoSuchPaddingException e) {
+			e.printStackTrace();
+			return null;
+		}
+		return clone;
+	}
+
+	@Override
+	public long getChecksum() throws IOException {
+		long checksum = this.digest.getValue();
+		return checksum;
+	}
+}

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/store/encrypt/EncryptIndexOutput.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/store/encrypt/EncryptIndexOutput.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.store.encrypt;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.store.BufferedChecksum;
+import org.apache.lucene.store.IndexOutput;
+import org.elasticsearch.common.logging.Loggers;
+import org.noop.essecure.services.EncryptionImpl;
+import org.noop.essecure.services.KeyServices;
+import org.noop.essecure.services.EncryptionKey;
+
+import java.util.zip.CRC32;
+import java.util.zip.Checksum;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+
+public class EncryptIndexOutput extends IndexOutput {
+
+    private final IndexOutput out;
+    private final EncryptionKey key;
+    private final EncryptionImpl encryptImpl;
+    private final byte[] buffer;
+    private int bufferPos;
+    private boolean close = false;
+    protected Logger logger;
+    final Checksum digest;	// Only compute original data's checksum.
+
+    public EncryptIndexOutput(IndexOutput out,EncryptionKey key) throws InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException {
+        super("EncryptIndexOutput",out.getName());
+        this.logger = Loggers.getLogger(getClass());
+        assert(key != null);
+        this.out = out;
+        this.key = key;
+        this.digest = new BufferedChecksum(new CRC32());
+
+        if(key.supportEncryption)
+        {
+        	buffer = new byte[(int) KeyServices.BLOCKSIZE];
+        	bufferPos = 0;
+        	encryptImpl = this.key.newEncryptionInstance();
+        }
+        else
+        {
+        	buffer = null;
+        	bufferPos = 0;
+        	encryptImpl = null;
+        }
+    }    
+    
+    private void ensureValid()
+    {
+    	assert(!close);
+    }
+
+    private void flushTailBuffer() throws IOException
+    {
+    	if(bufferPos != 0 && null != buffer)
+    	{
+    		if(bufferPos == KeyServices.BLOCKSIZE && this.key.supportEncryption)
+    		{
+				try {
+					this.encryptImpl.encryptData(buffer);
+				} catch (IllegalBlockSizeException | BadPaddingException e) {
+					e.printStackTrace();
+					throw new IOException("encrypt data error");
+				}
+    		}
+    		out.writeBytes(buffer, bufferPos);
+    		bufferPos = 0;
+    	}
+    	close = true;
+    }
+    
+    @Override
+    public void close() throws IOException {
+    	flushTailBuffer();
+    	out.close();
+    }
+
+    @Override
+    public long getFilePointer() {
+        return out.getFilePointer() + bufferPos;
+    }
+
+    @Override
+    public long getChecksum() throws IOException {
+    	long checksum = this.digest.getValue();
+    	return checksum;
+    }
+    
+    @Override
+    public void writeByte(byte b) throws IOException {
+    	ensureValid();
+		this.digest.update(b);
+    	if(!key.supportEncryption)
+    	{
+    		this.out.writeByte(b);
+    		return;
+    	}
+    	
+    	assert(bufferPos <= KeyServices.BLOCKSIZE && bufferPos >= 0);
+    	if(bufferPos == KeyServices.BLOCKSIZE)
+    	{
+    		try {
+				this.encryptImpl.encryptData(buffer);
+			} catch (IllegalBlockSizeException | BadPaddingException e) {
+				e.printStackTrace();
+				throw new IOException("encrypt data error");
+			}
+    		out.writeBytes(buffer, bufferPos);
+    		bufferPos = 0;
+    	}
+    	buffer[bufferPos++] = b;
+    }
+
+    @Override
+    public void writeBytes(byte[] b, int offset, int length) throws IOException {
+    	ensureValid();
+    	assert(length >= 0);
+		this.digest.update(b, offset,length);
+    	if(!key.supportEncryption)
+    	{
+    		this.out.writeBytes(b, offset,length);
+    		return ;
+    	}
+    	
+    	int writtenLength = 0;
+    	while(writtenLength < length)
+    	{
+    		assert(bufferPos <= KeyServices.BLOCKSIZE && bufferPos >= 0);
+    		if(bufferPos == KeyServices.BLOCKSIZE)
+    		{
+    			try {
+					this.encryptImpl.encryptData(buffer);
+				} catch (IllegalBlockSizeException | BadPaddingException e) {
+					e.printStackTrace();
+					throw new IOException("encrypt data error");
+				}
+    			out.writeBytes(buffer, bufferPos);
+    			bufferPos = 0;
+    		}
+
+    		int appendLength = 
+    				(int) Math.min(length - writtenLength,KeyServices.BLOCKSIZE - bufferPos);
+    		System.arraycopy(b, offset + writtenLength, buffer, bufferPos, appendLength);
+    		assert(appendLength >0 && appendLength <= KeyServices.BLOCKSIZE);
+    		
+    		bufferPos += appendLength;
+    		writtenLength += appendLength;
+    		assert(bufferPos <= KeyServices.BLOCKSIZE && bufferPos >= 0);
+    	}
+    	assert(writtenLength == length);
+    }
+
+}

--- a/plugins/store-encrypt/src/main/java/org/noop/essecure/store/encrypt/EncryptIndexStore.java
+++ b/plugins/store-encrypt/src/main/java/org/noop/essecure/store/encrypt/EncryptIndexStore.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.noop.essecure.store.encrypt;
+
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.shard.ShardPath;
+import org.elasticsearch.index.store.DirectoryService;
+import org.elasticsearch.index.store.IndexStore;
+
+public class EncryptIndexStore extends IndexStore {
+    protected final Logger logger;
+
+    public EncryptIndexStore(IndexSettings indexSettings) {
+        super(indexSettings);
+        this.logger = Loggers.getLogger(getClass());
+    }
+
+    @Override
+    public DirectoryService newDirectoryService(ShardPath path) {
+        return new EncryptFsDirectoryService(indexSettings,this,path);
+    }
+}
+

--- a/plugins/store-encrypt/src/test/java/org/noop/essecure/services/testEncryptServices.java
+++ b/plugins/store-encrypt/src/test/java/org/noop/essecure/services/testEncryptServices.java
@@ -1,0 +1,263 @@
+package org.noop.essecure.services;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Date;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig.OpenMode;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.noop.essecure.store.encrypt.EncryptDirectoryWrapper;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+
+class testEncryptServices {
+
+	  /** Copy from lucene project's demo. 
+	   * Index all text files under a directory. 
+	 * @throws IOException */
+	  @Test
+	  void testDirectory() throws IOException {
+
+		  String indexPath = "index";
+		  boolean create = true;
+		  Date start = new Date();
+
+		  System.out.println("Indexing to directory '" + indexPath + "'...");
+
+		  Directory originalDir = FSDirectory.open(Paths.get(indexPath));
+		  EncryptDirectoryWrapper dir = 
+				  new EncryptDirectoryWrapper(originalDir,KeyServices.getDefaultKey());
+		  Analyzer analyzer = new StandardAnalyzer();
+		  IndexWriterConfig iwc = new IndexWriterConfig(analyzer);
+		  iwc.setUseCompoundFile(false);
+
+		  if (create) {
+			  iwc.setOpenMode(OpenMode.CREATE);
+		  } else {
+			  iwc.setOpenMode(OpenMode.CREATE_OR_APPEND);
+		  }
+
+		  IndexWriter writer = new IndexWriter(dir, iwc);
+		  indexDocs(writer);
+		  writer.close();
+
+		  Date end = new Date();
+		  System.out.println(end.getTime() - start.getTime() + " total milliseconds");
+
+	  }
+
+	  static void indexDocs(final IndexWriter writer) throws IOException {
+
+		  for(int i=0;i<2;i++)
+		  {
+			  Document doc = new Document();
+			  {
+				  doc.add(new TextField("id", "id" + 100 + i,Store.YES));
+				  doc.add(new LongPoint("value", i*2939));
+				  doc.add(new TextField("contents", 
+						  "I am contents.......abcdefghi......" + i,Store.YES));
+				  doc.add(new TextField("key", "value",Store.YES));
+			  }
+			  indexDoc(writer,doc);
+		  }
+	  }
+
+	  static void indexDoc(IndexWriter writer,Document doc) throws IOException {
+		  if (writer.getConfig().getOpenMode() == OpenMode.CREATE) {
+			  writer.addDocument(doc);
+		  } else {
+			  writer.updateDocument(new Term("id", doc.get("id")), doc);
+		  }
+	  }
+
+	  static String getUUID() {
+		  UUID uuid = UUID.randomUUID();
+		  String str = uuid.toString();
+		  String temp = str.substring(0, 8) + str.substring(9, 13) + str.substring(14, 18) + str.substring(19, 23) + str.substring(24);
+		  return str+","+temp;
+	  }
+
+	  static String[] getUUID(int number) {
+		  if (number < 1) {
+			  return null;
+		  }
+		  String[] ss = new String[number];
+		  for (int i = 0; i < number; i++) {
+			  ss[i] = getUUID();
+		  }
+		  return ss;
+	  }
+
+	  @Test
+	  void testSearch() throws Exception{
+
+		  String usage =
+				  "Usage:\tjava org.apache.lucene.demo.SearchFiles"
+						  + " [-index dir] [-field f] [-repeat n] "
+						  + " [-queries file] [-query string] "
+						  + " [-raw] [-paging hitsPerPage]\n\n"
+						  + " See http://lucene.apache.org/core/4_1_0/demo/ for details.";
+
+		  String index = "index";
+		  String field = "key";
+		  String queries = null;
+		  int repeat = 0;
+		  boolean raw = false;
+		  String queryString = "value";
+		  int hitsPerPage = 10;
+
+		  Directory originalDir = FSDirectory.open(Paths.get(index));
+		  EncryptDirectoryWrapper dir = 
+				  new EncryptDirectoryWrapper(originalDir,KeyServices.getDefaultKey());
+		  IndexReader reader = DirectoryReader.open(dir);
+		  IndexSearcher searcher = new IndexSearcher(reader);
+		  Analyzer analyzer = new StandardAnalyzer();
+
+		  BufferedReader in = null;
+		  if (queries != null) {
+			  in = Files.newBufferedReader(Paths.get(queries), StandardCharsets.UTF_8);
+		  } else {
+			  in = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
+		  }
+		  QueryParser parser = new QueryParser(field, analyzer);
+		  while (true) {
+			  if (queries == null && queryString == null) {                        // prompt the user
+				  System.out.println("Enter query: ");
+			  }
+
+			  String line = queryString != null ? queryString : in.readLine();
+
+			  if (line == null || line.length() == -1) {
+				  break;
+			  }
+
+			  line = line.trim();
+			  if (line.length() == 0) {
+				  break;
+			  }
+
+			  Query query = parser.parse(line);
+			  System.out.println("Searching for: " + query.toString(field));
+
+			  if (repeat > 0) {                           // repeat & time as benchmark
+				  Date start = new Date();
+				  for (int i = 0; i < repeat; i++) {
+					  searcher.search(query, 100);
+				  }
+				  Date end = new Date();
+				  System.out.println("Time: "+(end.getTime()-start.getTime())+"ms");
+			  }
+
+			  doPagingSearch(in, searcher, query, hitsPerPage, raw, queries == null && queryString == null);
+
+			  if (queryString != null) {
+				  break;
+			  }
+		  }
+		  reader.close();
+	  }
+
+	  public static void doPagingSearch(BufferedReader in, IndexSearcher searcher, Query query, 
+			  int hitsPerPage, boolean raw, boolean interactive) throws IOException {
+
+		  // Collect enough docs to show 5 pages
+		  TopDocs results = searcher.search(query, 5 * hitsPerPage);
+		  ScoreDoc[] hits = results.scoreDocs;
+
+		  int numTotalHits = Math.toIntExact(results.totalHits);
+		  System.out.println(numTotalHits + " total matching documents");
+
+		  int start = 0;
+		  int end = Math.min(numTotalHits, hitsPerPage);
+
+		  while (true) {
+			  if (end > hits.length) {
+				  System.out.println("Only results 1 - " + hits.length +" of " + numTotalHits + " total matching documents collected.");
+				  System.out.println("Collect more (y/n) ?");
+				  String line = in.readLine();
+				  if (line.length() == 0 || line.charAt(0) == 'n') {
+					  break;
+				  }
+
+				  hits = searcher.search(query, numTotalHits).scoreDocs;
+			  }
+
+			  end = Math.min(hits.length, start + hitsPerPage);
+
+			  for (int i = start; i < end; i++) {
+				  if (raw) {                              // output raw format
+					  System.out.println("doc="+hits[i].doc+" score="+hits[i].score);
+					  continue;
+				  }
+
+				  Document doc = searcher.doc(hits[i].doc);
+				  System.out.println("doc " + doc.toString());
+			  }
+
+			  if (!interactive || end == 0) {
+				  break;
+			  }
+
+			  if (numTotalHits >= end) {
+				  boolean quit = false;
+				  while (true) {
+					  System.out.print("Press ");
+					  if (start - hitsPerPage >= 0) {
+						  System.out.print("(p)revious page, ");  
+					  }
+					  if (start + hitsPerPage < numTotalHits) {
+						  System.out.print("(n)ext page, ");
+					  }
+					  System.out.println("(q)uit or enter number to jump to a page.");
+
+					  String line = in.readLine();
+					  if (line.length() == 0 || line.charAt(0)=='q') {
+						  quit = true;
+						  break;
+					  }
+					  if (line.charAt(0) == 'p') {
+						  start = Math.max(0, start - hitsPerPage);
+						  break;
+					  } else if (line.charAt(0) == 'n') {
+						  if (start + hitsPerPage < numTotalHits) {
+							  start+=hitsPerPage;
+						  }
+						  break;
+					  } else {
+						  int page = Integer.parseInt(line);
+						  if ((page - 1) * hitsPerPage < numTotalHits) {
+							  start = (page - 1) * hitsPerPage;
+							  break;
+						  } else {
+							  System.out.println("No such page");
+						  }
+					  }
+				  }
+				  if (quit) break;
+				  end = Math.min(numTotalHits, start + hitsPerPage);
+			  }
+		  }
+	  }
+
+}

--- a/plugins/store-encrypt/src/test/java/org/noop/essecure/services/testHttp.java
+++ b/plugins/store-encrypt/src/test/java/org/noop/essecure/services/testHttp.java
@@ -1,0 +1,32 @@
+package org.noop.essecure.services;
+
+import org.junit.jupiter.api.Test;
+import org.noop.essecure.http.HttpSnoopClient;
+import org.noop.essecure.http.HttpSnoopClient.HttpListener;
+
+class testHttp {
+
+	@Test
+	void test() {
+		
+        HttpListener wrapperListener = new HttpListener (){
+            public void OnSuccess(String url,String content,String debugMessage)
+            {
+               // System.out.println(url + content + debugMessage);
+               System.out.println("Success:" + content);
+            }
+            public void OnFail(String url,String debugMessage)
+            {
+                System.out.println(url + debugMessage);
+            }
+        };
+        
+		try {
+            HttpSnoopClient.submitHttpRequest("http://localhost:9200/", wrapperListener);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+		// fail("Not yet implemented");
+	}
+
+}

--- a/plugins/store-encrypt/src/test/java/org/noop/essecure/services/testJackson.java
+++ b/plugins/store-encrypt/src/test/java/org/noop/essecure/services/testJackson.java
@@ -1,0 +1,60 @@
+package org.noop.essecure.services;
+
+import java.io.IOException;
+
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+
+class testJackson {
+
+	@Test
+	void test() {
+
+		String dek = "abcdefghijk";
+    	String carJson = "{ \"dek\":\"" + dek + "\",\"ret_code\":0,\"ret_msg\":\"success\"}";
+		EncryptionKey key = new EncryptionKey();
+		try {
+			EncryptionKey.parseFromDSMJSon(key, carJson);
+			System.out.println(key.key);
+			System.out.println(dek);
+			assert(key.key.equals(dek));
+		} catch (JsonParseException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		/*
+		String message = "{\"test\":\"test\"}";
+		XContentBuilder b;
+		try {
+			b = XContentFactory.jsonBuilder().prettyPrint();
+			try (XContentParser p = 
+				XContentFactory.xContent(XContentType.JSON)
+					.createParser(NamedXContentRegistry.EMPTY, null, message)) {
+
+				XContentParser.Token token = null;
+				while ((token = p.nextToken()) != XContentParser.Token.END_OBJECT) {
+						System.out.println(token);
+				}
+				b.copyCurrentStructure(p);
+			}
+			System.out.println(b.toString());
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		*/
+		
+	}
+
+}

--- a/plugins/store-encrypt/src/test/java/org/noop/essecure/services/testNoopEncryption.java
+++ b/plugins/store-encrypt/src/test/java/org/noop/essecure/services/testNoopEncryption.java
@@ -1,0 +1,48 @@
+package org.noop.essecure.services;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.elasticsearch.search.aggregations.support.ValuesSource.Bytes;
+import org.junit.jupiter.api.Test;
+
+class testNoopEncryption {
+
+	@Test
+	void test() {
+		AESEncryption impl = new AESEncryption("");
+		
+		byte[] data = new byte[(int) KeyServices.BLOCKSIZE];
+		byte[] after = new byte[(int) KeyServices.BLOCKSIZE];
+		
+		byte b = 'a';
+		for(int i=0;i<data.length;i++)
+		{
+			data[i] = (byte) (b + i);
+		}
+		System.arraycopy(data, 0, after, 0, data.length);
+
+		impl.encryptData(after);
+		boolean find_not_equal = false;
+		for(int i=0;i<data.length;i++)
+		{
+			if(data[i] != after[i])
+			{
+				find_not_equal = true;
+			}
+		}
+	
+		if(!find_not_equal)
+			fail("same");
+		
+		impl.decryptData(after);
+		for(int i=0;i<data.length;i++)
+		{
+			if(data[i] != after[i])
+			{
+				fail("decrypt fail");
+			}
+		}
+	
+	}
+
+}


### PR DESCRIPTION
# Support Elasticsearch landing data encryption

## Support for landing data encryption plugin

In the ElasticSearch server, the data in the storage is not encrypted when it is written to persistent storage. In the online generation environment, we have very high data security requirements. To this end, we have developed a storage component for data encryption that can support data encryption for sensitive parts of the landing data. The main starting point for us to do this is to consider that the Lucene open source community has discussed the issue of data security. It is through file system encryption, but this approach has a great impact on performance. To this end, we have considered performance and data security. The focus is on encrypting very sensitive landing data, such as tim, fdt, dvd, which contain sensitive information, and not encrypting other data files.


## Design 

In order to protect the landing data, it is physically dragged by the library or backed up by the backup. We consider the ability to design an encrypted landing data store and separate the user's master key from the login data. Once the node is started, the master key can only be obtained after a relatively strict authentication authorization (usually related to the company's internal key security mechanism). To this end, we designed and implemented the Store-encrypt plugin to support login data encryption and key docking management.

Features include

* Support AES-ECB mode encryption (128bit)
* Supports two key delivery methods, the data key is stored in the index settings, the encrypted data key is stored in the index settings and the docking master key is supported.
* Retain Elasticsearch's optional directory service capabilities
* Plug-in mode for flexible upgrade of ES and Lucene


## Getting Started

The ability to embed data encryption can be experienced in the following steps.

* Compile (optional). The corresponding version plugin can be downloaded directly.
* Installation
* Configuration

For details, please refer to the question.

## Compile

First, you need to download the plugin from the repository and compile the Elasticsearch project. For instructions on compiling, please refer to the Elasticsearch compilation process. After the configuration is complete, go to the root directory of elasticsearch and execute the following command to complete the compilation:

Gradlew assemble


If you do not want to compile, you can download the corresponding version and install it directly. Refer to the release version below for details.
Optional version:

* [Plugin For Elasticsearch 6.3.2] (http://)

## Installation

Please refer to the ElasticSearch plugin installation instructions. Details can be found below
Https://www.elastic.co/guide/en/elasticsearch/plugins/6.4/plugin-management-custom-url.html

## Configuration

1.Set Elasticsearch's lucene does not open file merge mode (optional)

	InternalEngine.java:1963 
	iwc.setUseCompoundFile(false); // always use compound on flush - reduces # of file-handles on refresh

2.Configure the storage type store type: index.store.type

By default, Elasticsearch supports optional file storage. Including fs, niofs, mmapfs, simplefs, please refer to https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-store.html for details. If you need encryption, just add the "encrypt\_" prefix to the file storage. If you want to use the default, use "encrypt_default". Therefore, the optional encryption "index.store.type" value includes:

* encrypt_default
* encrypt_fs
* encrypt_niofs
* ncrypt_mmapfs
* encrypt_simplefs

3.Configure the encryption key: index.directkey or index.encryptionkey

The key is 16 bytes (128 bit) long.

There are two ways to configure the key. If index.directkey has an assignment, it will be used first as the key for data encryption. Otherwise, index.encryptionkey will be used as the key for landing data encryption, but index.encryptionkey is not a plaintext key and needs to be encrypted by master key.

4.Configure the configuration file to get the master key encrypt.yml

	Encrypt:
	Dsmhost: https://mydsm.oa?user=xxx
	rootCA: config_path/dsm.crt

Configuration instructions, dsmhost is the requested dsm system host. The rootCA is a configurable root CA certificate path. After the system starts, it will request the path of dsmhost, and expect to return the data in the following format, so the user needs to implement the DSM system interface.

	{
		"dek" : "CpbCOtC9i0IuG5pBi+zl6R5iDZOSPSyxTs87zBiyLig=",
		"ret_code" : 0,
		"ret_msg" : ""
	}

The dek is a 16-byte 128-bit key encrypted by base64.


Example 1, by directly configuring the key, the value of the data key is (0123456789abcdef), and the base64 is encoded as (MDEyMzQ1Njc4OWFiY2RlZg==).

	PUT twitter
	{
		"settings" : {
			"index" : {
				"directkey":"MDEyMzQ1Njc4OWFiY2RlZg==",
				"store":{
					"type": "encrypt_fs"
					}
			}
		}
	}

Example 2, by directly configuring the key, the value of the data key is (0123456789abcdef), and the base64 value of the data key encrypted by the master key is (KpltMAJDFYrjvy/ohXmr4Q==), and the master key is requested by the DSM system. The value of the key is (aaaaaaaaaaffffff).

	PUT twitter
	{
		"settings" : {
		"index" : {
			"encryptionkey":"KpltMAJDFYrjvy/ohXmr4Q==",
				"store":{
					"type": "encrypt_fs"
					}
			}
		}
	}
	
	The DSM system should implement an interface that returns the following. (YWFhYWFhYWFhYWZmZmZmZg==) is the base64 value of (aaaaaaaaaaffffff).
	{
		"dek" : "YWFhYWFhYWFhYWZmZmZmZg==",
		"ret_code" : 0,
		"ret_msg" : ""
	}

For more information about


        
## Safety instructions

Index.store.type
Https://www.elastic.co/guide/en/elasticsearch/reference/6.4/breaking-changes-6.0.html