### PR TITLE
Fix UpdateRequest.fromXContent

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -30,6 +30,8 @@ import org.elasticsearch.action.support.single.instance.InstanceShardOperationRe
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -41,6 +43,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.rest.action.document.RestUpdateAction;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
@@ -55,6 +58,9 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
         implements DocWriteRequest<UpdateRequest>, WriteRequest<UpdateRequest>, ToXContentObject {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER =
+        new DeprecationLogger(Loggers.getLogger(RestUpdateAction.class));
 
     private String type;
     private String id;
@@ -772,6 +778,9 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
                 }
             } else if ("_source".equals(currentFieldName)) {
                 fetchSourceContext = FetchSourceContext.fromXContent(parser);
+            } else {
+                DEPRECATION_LOGGER.deprecated("Unknown field [{}] used in {} which has no value and will not be accepted in future",
+                    currentFieldName, UpdateRequest.class.getSimpleName());
             }
 
             // copyCurrentStructure / SomeObject.fromXContent moves current token to END_OBJECT

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -767,6 +767,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
             } else if ("detect_noop".equals(currentFieldName)) {
                 detectNoop(parser.booleanValue());
             } else if ("fields".equals(currentFieldName)) {
+                DEPRECATION_LOGGER.deprecated("Deprecated field [fields] used, expected [_source] instead");
                 List<Object> fields = null;
                 if (token == XContentParser.Token.START_ARRAY) {
                     fields = (List) parser.list();

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -43,7 +43,6 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.rest.action.document.RestUpdateAction;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
@@ -60,7 +59,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
         implements DocWriteRequest<UpdateRequest>, WriteRequest<UpdateRequest>, ToXContentObject {
 
     private static final DeprecationLogger DEPRECATION_LOGGER =
-        new DeprecationLogger(Loggers.getLogger(RestUpdateAction.class));
+        new DeprecationLogger(Loggers.getLogger(UpdateRequest.class));
 
     private String type;
     private String id;

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.VersionType;
-import org.elasticsearch.rest.action.document.RestUpdateAction;
 import org.elasticsearch.script.Script;
 
 import java.util.Map;
@@ -39,7 +38,7 @@ import java.util.Map;
 public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<UpdateRequest, UpdateResponse, UpdateRequestBuilder>
         implements WriteRequestBuilder<UpdateRequestBuilder> {
     private static final DeprecationLogger DEPRECATION_LOGGER =
-        new DeprecationLogger(Loggers.getLogger(RestUpdateAction.class));
+        new DeprecationLogger(Loggers.getLogger(UpdateRequestBuilder.class));
 
     public UpdateRequestBuilder(ElasticsearchClient client, UpdateAction action) {
         super(client, action, new UpdateRequest());

--- a/server/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
@@ -490,7 +490,9 @@ public class UpdateRequestTests extends ESTestCase {
             BytesReference source = RandomObjects.randomSource(random(), xContentType);
             updateRequest.upsert(new IndexRequest().source(source, xContentType));
         }
-        if (randomBoolean()) {
+
+        final boolean fieldsAreUsed = randomBoolean();
+        if (fieldsAreUsed) {
             String[] fields = new String[randomIntBetween(0, 5)];
             for (int i = 0; i < fields.length; i++) {
                 fields[i] = randomAlphaOfLength(5);
@@ -541,6 +543,10 @@ public class UpdateRequestTests extends ESTestCase {
 
         BytesReference finalBytes = toXContent(parsedUpdateRequest, xContentType, humanReadable);
         assertToXContentEquivalent(originalBytes, finalBytes, xContentType);
+
+        if (fieldsAreUsed) {
+            assertWarnings("Deprecated field [fields] used, expected [_source] instead");
+        }
     }
 
     public void testToValidateUpsertRequestAndVersion() {

--- a/server/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
@@ -286,6 +286,9 @@ public class UpdateRequestTests extends ESTestCase {
                     new BytesArray("{\"any_odd_name_for_update\":{\"doc\":{\"message\":\"set by update:doc\"}},"
                         + "\"script\":{\"source\":\"ctx._source.message = 'set by script'\"}}")));
 
+        assertWarnings("Unknown field [any_odd_name_for_update] used in UpdateRequest"
+            + " which has no value and will not be accepted in future");
+
         assertThat(request.doc(), notNullValue());
         assertThat(request.script(), notNullValue());
 
@@ -300,6 +303,13 @@ public class UpdateRequestTests extends ESTestCase {
                 createParser(JsonXContent.jsonXContent,
                     new BytesArray("{\"whatever\": {\"script\":{\"source\":\"ctx._source.message = 'set by script'\"}},"
                         + "\"nested_update1\":{\"nested_update2\":{\"doc\":{\"message\":\"set by update:doc\"}}}}")));
+
+        assertWarnings("Unknown field [whatever] used in UpdateRequest"
+            + " which has no value and will not be accepted in future",
+            "Unknown field [nested_update1] used in UpdateRequest"
+                + " which has no value and will not be accepted in future",
+            "Unknown field [nested_update2] used in UpdateRequest"
+                + " which has no value and will not be accepted in future");
 
         assertThat(request.doc(), notNullValue());
         assertThat(request.script(), notNullValue());

--- a/server/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
@@ -327,11 +327,13 @@ public class UpdateRequestTests extends ESTestCase {
                 createParser(JsonXContent.jsonXContent, new BytesArray("{\"doc\": {\"field1\": \"value1\"}, \"fields\": \"_source\"}")));
         assertThat(request.doc().sourceAsMap().get("field1").toString(), equalTo("value1"));
         assertThat(request.fields(), arrayContaining("_source"));
+        assertWarnings("Deprecated field [fields] used, expected [_source] instead");
 
         request = new UpdateRequest("test", "type2", "2").fromXContent(createParser(JsonXContent.jsonXContent,
                 new BytesArray("{\"doc\": {\"field2\": \"value2\"}, \"fields\": [\"field1\", \"field2\"]}")));
         assertThat(request.doc().sourceAsMap().get("field2").toString(), equalTo("value2"));
         assertThat(request.fields(), arrayContaining("field1", "field2"));
+        assertWarnings("Deprecated field [fields] used, expected [_source] instead");
     }
 
     public void testFetchSourceParsing() throws Exception {


### PR DESCRIPTION
`UpdateRequest` in `6.x` could have `doc`, `script` and other valuable commands on any level of depth. 

All of following requests 
`{"doc":{"message":"set by update:doc"}}` 
`{"whatever":{"doc":{"message":"set by update:doc"}}}` 
`{"aaa":{"whatever":{"doc":{"message":"set by update:doc"}}}}` 

are like `{"doc":{"message":"set by update:doc"}}` as all unknown fields ignored but parsing continues to look up for commands in depth.

Actually parsing of nested object is broken and it leads to issues like #34069.

This PR fixes parsing of nested objects for `UpdateRequest` for `6.x` branch. 

#29293 is a proper fix for `7.0` (it forbids such kind of behaviour) but it is breaking change that we could not apply for `6.x` branch.

Closes #34069
