### PR TITLE
[Elasticsearch Monitoring] Collect only display_name (for now)

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDoc.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDoc.java
@@ -13,7 +13,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.MapBuilder;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.license.License;

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDoc.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDoc.java
@@ -47,7 +47,7 @@ public class ClusterStatsMonitoringDoc extends MonitoringDoc {
                                 ClusterState.Metric.NODES));
 
     public static final String TYPE = "cluster_stats";
-    protected static final String SETTING_CLUSTER_METADATA = "cluster.metadata";
+    protected static final String SETTING_DISPLAY_NAME = "cluster.metadata.display_name";
 
     private final String clusterName;
     private final String version;
@@ -121,12 +121,12 @@ public class ClusterStatsMonitoringDoc extends MonitoringDoc {
         return clusterNeedsTLSEnabled;
     }
 
-    Settings getClusterMetaDataSettings() {
+    String getClusterDisplayName() {
         MetaData metaData = this.clusterState.getMetaData();
         if (metaData == null) {
-            return Settings.EMPTY;
+            return null;
         }
-        return metaData.settings().getAsSettings(SETTING_CLUSTER_METADATA);
+        return metaData.settings().get(SETTING_DISPLAY_NAME);
     }
 
     @Override
@@ -167,21 +167,19 @@ public class ClusterStatsMonitoringDoc extends MonitoringDoc {
             builder.endObject();
         }
 
-        Settings clusterMetaDataSettings = getClusterMetaDataSettings();
-        if (clusterMetaDataSettings != null) {
+        String displayName = getClusterDisplayName();
+        if (displayName != null) {
             builder.startObject("cluster_settings");
             {
-                if (clusterMetaDataSettings.size() > 0) {
-                    builder.startObject("cluster");
+                builder.startObject("cluster");
+                {
+                    builder.startObject("metadata");
                     {
-                        builder.startObject("metadata");
-                        {
-                            clusterMetaDataSettings.toXContent(builder, params);
-                        }
-                        builder.endObject();
+                        builder.field("display_name", displayName);
                     }
                     builder.endObject();
                 }
+                builder.endObject();
             }
             builder.endObject();
         }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
@@ -206,6 +206,11 @@ public class MonitoringIT extends ESSingleNodeTestCase {
                            .status(),
                    is(RestStatus.CREATED));
 
+        final Settings settings = Settings.builder()
+            .put("cluster.metadata.display_name", "my cluster")
+            .build();
+        assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings));
+
         whenExportersAreReady(() -> {
             final AtomicReference<SearchResponse> searchResponse = new AtomicReference<>();
 
@@ -375,6 +380,11 @@ public class MonitoringIT extends ESSingleNodeTestCase {
         assertThat(clusterState.remove("master_node"), notNullValue());
         assertThat(clusterState.remove("nodes"), notNullValue());
         assertThat(clusterState.keySet(), empty());
+
+        final Map<String, Object> clusterSettings = (Map<String, Object>) source.get("cluster_settings");
+        assertThat(clusterSettings, notNullValue());
+        assertThat(clusterSettings.remove("cluster"), notNullValue());
+        assertThat(clusterSettings.keySet(), empty());
     }
 
     /**
@@ -614,6 +624,7 @@ public class MonitoringIT extends ESSingleNodeTestCase {
         final Settings settings = Settings.builder()
                 .putNull("xpack.monitoring.collection.enabled")
                 .putNull("xpack.monitoring.exporters._local.enabled")
+                .putNull("cluster.metadata.display_name")
                 .build();
 
         assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings));


### PR DESCRIPTION
This is a forward port of some of the changes made in #8445, specifically the change mentioned in https://github.com/elastic/elasticsearch/pull/34023#issuecomment-433212636.

Currently, in master, the `cluster_stats` collector collects _all_ cluster metadata and indexes it into `.monitoring-es-*`. However, per the discussion linked to above, we decided to collect _only_ the `display_name` cluster metadata setting for now. This PR makes this change.