### PR TITLE
[ilm] change remove-policy-from-index http method from DELETE to POST

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleRequestConverters.java
@@ -78,7 +78,7 @@ final class IndexLifecycleRequestConverters {
     static Request removeIndexLifecyclePolicy(RemoveIndexLifecyclePolicyRequest removePolicyRequest) {
         String[] indices = removePolicyRequest.indices() == null ?
                 Strings.EMPTY_ARRAY : removePolicyRequest.indices().toArray(new String[] {});
-        Request request = new Request(HttpDelete.METHOD_NAME,
+        Request request = new Request(HttpPost.METHOD_NAME,
                 new RequestConverters.EndpointBuilder()
                         .addCommaSeparatedPathParts(indices)
                         .addPathPartAsIs("_ilm")

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleRequestConverters.java
@@ -81,7 +81,7 @@ final class IndexLifecycleRequestConverters {
         Request request = new Request(HttpPost.METHOD_NAME,
                 new RequestConverters.EndpointBuilder()
                         .addCommaSeparatedPathParts(indices)
-                        .addPathPartAsIs("_ilm")
+                        .addPathPartAsIs("_ilm", "remove")
                         .build());
         RequestConverters.Params params = new RequestConverters.Params(request);
         params.withIndicesOptions(removePolicyRequest.indicesOptions());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndexLifecycleRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndexLifecycleRequestConvertersTests.java
@@ -99,9 +99,9 @@ public class IndexLifecycleRequestConvertersTests extends ESTestCase {
         setRandomMasterTimeout(req::setMasterTimeout, TimedRequest.DEFAULT_MASTER_NODE_TIMEOUT, expectedParams);
 
         Request request = IndexLifecycleRequestConverters.removeIndexLifecyclePolicy(req);
-        assertThat(request.getMethod(), equalTo(HttpDelete.METHOD_NAME));
+        assertThat(request.getMethod(), equalTo(HttpPost.METHOD_NAME));
         String idxString = Strings.arrayToCommaDelimitedString(indices);
-        assertThat(request.getEndpoint(), equalTo("/" + (idxString.isEmpty() ? "" : (idxString + "/")) + "_ilm"));
+        assertThat(request.getEndpoint(), equalTo("/" + (idxString.isEmpty() ? "" : (idxString + "/")) + "_ilm/remove"));
         assertThat(request.getParameters(), equalTo(expectedParams));
     }
 

--- a/docs/reference/ilm/apis/remove-policy.asciidoc
+++ b/docs/reference/ilm/apis/remove-policy.asciidoc
@@ -10,7 +10,7 @@ Unassigns a policy from a specified index pattern
 
 ==== Request
 
-`DELETE <index>/_ilm`
+`POST <index>/_ilm`
 
 ==== Description
 
@@ -80,7 +80,7 @@ PUT my_index
 
 [source,js]
 --------------------------------------------------
-DELETE my_index/_ilm
+POST my_index/_ilm
 --------------------------------------------------
 // CONSOLE
 // TEST[continued]

--- a/docs/reference/ilm/apis/remove-policy.asciidoc
+++ b/docs/reference/ilm/apis/remove-policy.asciidoc
@@ -10,7 +10,7 @@ Unassigns a policy from a specified index pattern
 
 ==== Request
 
-`POST <index>/_ilm`
+`POST <index>/_ilm/remove`
 
 ==== Description
 
@@ -80,7 +80,7 @@ PUT my_index
 
 [source,js]
 --------------------------------------------------
-POST my_index/_ilm
+POST my_index/_ilm/remove
 --------------------------------------------------
 // CONSOLE
 // TEST[continued]

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/RestRemoveIndexLifecyclePolicyAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/RestRemoveIndexLifecyclePolicyAction.java
@@ -22,7 +22,7 @@ public class RestRemoveIndexLifecyclePolicyAction extends BaseRestHandler {
 
     public RestRemoveIndexLifecyclePolicyAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.POST, "/{index}/_ilm", this);
+        controller.registerHandler(RestRequest.Method.POST, "/{index}/_ilm/remove", this);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/RestRemoveIndexLifecyclePolicyAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/RestRemoveIndexLifecyclePolicyAction.java
@@ -22,7 +22,7 @@ public class RestRemoveIndexLifecyclePolicyAction extends BaseRestHandler {
 
     public RestRemoveIndexLifecyclePolicyAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.DELETE, "/{index}/_ilm", this);
+        controller.registerHandler(RestRequest.Method.POST, "/{index}/_ilm", this);
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.remove_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.remove_policy.json
@@ -1,7 +1,7 @@
 {
   "ilm.remove_policy": {
     "documentation": "http://www.elastic.co/guide/en/index_lifecycle/current/index_lifecycle.html",
-    "methods": [ "DELETE" ],
+    "methods": [ "POST" ],
     "url": {
       "path": "/{index}/_ilm",
       "paths": ["/{index}/_ilm", "/_ilm"],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.remove_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.remove_policy.json
@@ -3,8 +3,8 @@
     "documentation": "http://www.elastic.co/guide/en/index_lifecycle/current/index_lifecycle.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/{index}/_ilm",
-      "paths": ["/{index}/_ilm", "/_ilm"],
+      "path": "/{index}/_ilm/remove",
+      "paths": ["/{index}/_ilm/remove", "/_ilm/remove"],
       "parts": {
         "index": {
           "type" : "string",


### PR DESCRIPTION
The remove-ilm-from-index API was using the DELETE http method
to signify that something is being removed. Although, metadata
about ILM for the index is being deleted, no entity/resource
is being deleted during this operation. POST is more in line with
what this API is actually doing, it is modifying the metadata for
an index.

cc @bmcconaghy