### PR TITLE
[Rollup] improve handling of failures on first search

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
@@ -261,7 +261,7 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
             doSaveState(finishAndSetState(), position.get(), () -> onFailure(exc));
         } catch (Exception e) {
             onFailure(exc);
-            onFailure(new RuntimeException("Failed to save State", e));
+            onFailure(new RuntimeException("Failed to save state", e));
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
@@ -257,12 +257,7 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
     protected abstract void onAbort();
 
     private void finishWithFailure(Exception exc) {
-        try {
-            doSaveState(finishAndSetState(), position.get(), () -> onFailure(exc));
-        } catch (Exception e) {
-            onFailure(exc);
-            onFailure(new RuntimeException("Failed to save state", e));
-        }
+        doSaveState(finishAndSetState(), position.get(), () -> onFailure(exc));
     }
 
     private IndexerState finishAndSetState() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
@@ -7,10 +7,8 @@
 package org.elasticsearch.xpack.core.indexing;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchResponseSections;
@@ -112,104 +110,6 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
 
     }
 
-    private class MockIndexerThrowsOnSaveState extends AsyncTwoPhaseIndexer<Integer, MockJobStats> {
-
-        // test the execution order
-        private int step;
-        private int failures;
-
-        protected MockIndexerThrowsOnSaveState(Executor executor, AtomicReference<IndexerState> initialState, Integer initialPosition) {
-            super(executor, initialState, initialPosition, new MockJobStats());
-        }
-
-        @Override
-        protected String getJobId() {
-            return "mock";
-        }
-
-        @Override
-        protected IterationResult<Integer> doProcess(SearchResponse searchResponse) {
-            if (step == 3) {
-                ++step;
-                return new IterationResult<Integer>(Collections.singletonList(new IndexRequest()), 3, false);
-            } else if (step == 7) {
-                ++step;
-                return new IterationResult<Integer>(Collections.singletonList(new IndexRequest()), 3, true);
-            }
-            fail("number of steps mismatch: " + step + "expected 3 or 7");
-            return null;
-        }
-
-        @Override
-        protected SearchRequest buildSearchRequest() {
-            if (step == 1 || step == 5) {
-                ++step;
-            } else {
-                fail("number of steps mismatch: " + step + "expected 1 or 5");
-            }
-            return null;
-        }
-
-        @Override
-        protected void onStartJob(long now) {
-            assertThat(step, equalTo(0));
-            ++step;
-        }
-
-        @Override
-        protected void doNextSearch(SearchRequest request, ActionListener<SearchResponse> nextPhase) {
-            if (step == 2 || step == 6) {
-                ++step;
-                final SearchResponseSections sections = new SearchResponseSections(new SearchHits(new SearchHit[0], 0, 0), null, null,
-                        false, null, null, 1);
-
-                nextPhase.onResponse(new SearchResponse(sections, null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, null));
-            } else {
-                fail("number of steps mismatch: " + step + " expected 2 or 6");
-            }
-        }
-
-        @Override
-        protected void doNextBulk(BulkRequest request, ActionListener<BulkResponse> nextPhase) {
-            assertThat(step, equalTo(4));
-            ++step;
-            nextPhase.onResponse(new BulkResponse(new BulkItemResponse[0], 0L));
-        }
-
-        @Override
-        protected void doSaveState(IndexerState state, Integer position, Runnable next) {
-            assertThat(step, equalTo(8));
-            ++step;
-            throw new RuntimeException("Failed to save state");
-        }
-
-        @Override
-        protected void onFailure(Exception exc) {
-            ++failures;
-            if (getFailures() == 2) {
-                isFinished.set(true);
-            }
-        }
-
-        @Override
-        protected void onFinish() {
-            fail("should not be called");
-        }
-
-        @Override
-        protected void onAbort() {
-            fail("should not be called");
-        }
-
-        public int getStep() {
-            return step;
-        }
-
-        public int getFailures() {
-            return failures;
-        }
-    }
-
     private class MockIndexerThrowsFirstSearch extends AsyncTwoPhaseIndexer<Integer, MockJobStats> {
 
         // test the execution order
@@ -308,30 +208,6 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
             assertThat(indexer.getStats().getNumPages(), equalTo(1L));
             assertThat(indexer.getStats().getOutputDocuments(), equalTo(0L));
             assertTrue(indexer.abort());
-        } finally {
-            executor.shutdownNow();
-        }
-    }
-
-    public void testStateMachineBrokenSave() throws InterruptedException {
-        AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
-        final ExecutorService executor = Executors.newFixedThreadPool(1);
-        isFinished.set(false);
-        try {
-
-            MockIndexerThrowsOnSaveState indexer = new MockIndexerThrowsOnSaveState(executor, state, 2);
-            indexer.start();
-            assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
-            assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
-            assertThat(indexer.getState(), equalTo(IndexerState.INDEXING));
-            assertThat(indexer.getPosition(), equalTo(2));
-            assertTrue(ESTestCase.awaitBusy(() -> isFinished.get()));
-            assertThat(indexer.getStep(), equalTo(9));
-            assertThat(indexer.getFailures(), equalTo(2));
-            assertThat(indexer.getStats().getNumInvocations(), equalTo(1L));
-            assertThat(indexer.getStats().getNumPages(), equalTo(2L));
-            assertThat(indexer.getStats().getOutputDocuments(), equalTo(0L));
-
         } finally {
             executor.shutdownNow();
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
@@ -7,8 +7,10 @@
 package org.elasticsearch.xpack.core.indexing;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchResponseSections;
@@ -110,6 +112,176 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
 
     }
 
+    private class MockIndexerThrowsOnSaveState extends AsyncTwoPhaseIndexer<Integer, MockJobStats> {
+
+        // test the execution order
+        private int step;
+        private int failures;
+
+        protected MockIndexerThrowsOnSaveState(Executor executor, AtomicReference<IndexerState> initialState, Integer initialPosition) {
+            super(executor, initialState, initialPosition, new MockJobStats());
+        }
+
+        @Override
+        protected String getJobId() {
+            return "mock";
+        }
+
+        @Override
+        protected IterationResult<Integer> doProcess(SearchResponse searchResponse) {
+            if (step == 3) {
+                ++step;
+                return new IterationResult<Integer>(Collections.singletonList(new IndexRequest()), 3, false);
+            } else if (step == 7) {
+                ++step;
+                return new IterationResult<Integer>(Collections.singletonList(new IndexRequest()), 3, true);
+            }
+            fail("number of steps mismatch: " + step + "expected 3 or 7");
+            return null;
+        }
+
+        @Override
+        protected SearchRequest buildSearchRequest() {
+            if (step == 1 || step == 5) {
+                ++step;
+            } else {
+                fail("number of steps mismatch: " + step + "expected 1 or 5");
+            }
+            return null;
+        }
+
+        @Override
+        protected void onStartJob(long now) {
+            assertThat(step, equalTo(0));
+            ++step;
+        }
+
+        @Override
+        protected void doNextSearch(SearchRequest request, ActionListener<SearchResponse> nextPhase) {
+            if (step == 2 || step == 6) {
+                ++step;
+                final SearchResponseSections sections = new SearchResponseSections(new SearchHits(new SearchHit[0], 0, 0), null, null,
+                        false, null, null, 1);
+
+                nextPhase.onResponse(new SearchResponse(sections, null, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, null));
+            } else {
+                fail("number of steps mismatch: " + step + " expected 2 or 6");
+            }
+        }
+
+        @Override
+        protected void doNextBulk(BulkRequest request, ActionListener<BulkResponse> nextPhase) {
+            assertThat(step, equalTo(4));
+            ++step;
+            nextPhase.onResponse(new BulkResponse(new BulkItemResponse[0], 0L));
+        }
+
+        @Override
+        protected void doSaveState(IndexerState state, Integer position, Runnable next) {
+            assertThat(step, equalTo(8));
+            ++step;
+            throw new RuntimeException("Failed to save state");
+        }
+
+        @Override
+        protected void onFailure(Exception exc) {
+            ++failures;
+            if (getFailures() == 2) {
+                isFinished.set(true);
+            }
+        }
+
+        @Override
+        protected void onFinish() {
+            fail("should not be called");
+        }
+
+        @Override
+        protected void onAbort() {
+            fail("should not be called");
+        }
+
+        public int getStep() {
+            return step;
+        }
+
+        public int getFailures() {
+            return failures;
+        }
+    }
+
+    private class MockIndexerThrowsFirstSearch extends AsyncTwoPhaseIndexer<Integer, MockJobStats> {
+
+        // test the execution order
+        private int step;
+
+        protected MockIndexerThrowsFirstSearch(Executor executor, AtomicReference<IndexerState> initialState, Integer initialPosition) {
+            super(executor, initialState, initialPosition, new MockJobStats());
+        }
+
+        @Override
+        protected String getJobId() {
+            return "mock";
+        }
+
+        @Override
+        protected IterationResult<Integer> doProcess(SearchResponse searchResponse) {
+            fail("should not be called");
+            return null;
+        }
+
+        @Override
+        protected SearchRequest buildSearchRequest() {
+            assertThat(step, equalTo(1));
+            ++step;
+            return null;
+        }
+
+        @Override
+        protected void onStartJob(long now) {
+            assertThat(step, equalTo(0));
+            ++step;
+        }
+
+        @Override
+        protected void doNextSearch(SearchRequest request, ActionListener<SearchResponse> nextPhase) {
+            throw new RuntimeException("Failed to build search request");
+        }
+
+        @Override
+        protected void doNextBulk(BulkRequest request, ActionListener<BulkResponse> nextPhase) {
+            fail("should not be called");
+        }
+
+        @Override
+        protected void doSaveState(IndexerState state, Integer position, Runnable next) {
+            assertThat(step, equalTo(2));
+            ++step;
+            next.run();
+        }
+
+        @Override
+        protected void onFailure(Exception exc) {
+            assertThat(step, equalTo(3));
+            ++step;
+            isFinished.set(true);
+        }
+
+        @Override
+        protected void onFinish() {
+            fail("should not be called");
+        }
+
+        @Override
+        protected void onAbort() {
+            fail("should not be called");
+        }
+
+        public int getStep() {
+            return step;
+        }
+    }
+
     private static class MockJobStats extends IndexerJobStats {
 
         @Override
@@ -121,7 +293,7 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
     public void testStateMachine() throws InterruptedException {
         AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
         final ExecutorService executor = Executors.newFixedThreadPool(1);
-
+        isFinished.set(false);
         try {
 
             MockIndexer indexer = new MockIndexer(executor, state, 2);
@@ -136,6 +308,48 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
             assertThat(indexer.getStats().getNumPages(), equalTo(1L));
             assertThat(indexer.getStats().getOutputDocuments(), equalTo(0L));
             assertTrue(indexer.abort());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    public void testStateMachineBrokenSave() throws InterruptedException {
+        AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
+        final ExecutorService executor = Executors.newFixedThreadPool(1);
+        isFinished.set(false);
+        try {
+
+            MockIndexerThrowsOnSaveState indexer = new MockIndexerThrowsOnSaveState(executor, state, 2);
+            indexer.start();
+            assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
+            assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+            assertThat(indexer.getState(), equalTo(IndexerState.INDEXING));
+            assertThat(indexer.getPosition(), equalTo(2));
+            assertTrue(ESTestCase.awaitBusy(() -> isFinished.get()));
+            assertThat(indexer.getStep(), equalTo(9));
+            assertThat(indexer.getFailures(), equalTo(2));
+            assertThat(indexer.getStats().getNumInvocations(), equalTo(1L));
+            assertThat(indexer.getStats().getNumPages(), equalTo(2L));
+            assertThat(indexer.getStats().getOutputDocuments(), equalTo(0L));
+
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    public void testStateMachineBrokenSearch() throws InterruptedException {
+        AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
+        final ExecutorService executor = Executors.newFixedThreadPool(1);
+        isFinished.set(false);
+        try {
+
+            MockIndexerThrowsFirstSearch indexer = new MockIndexerThrowsFirstSearch(executor, state, 2);
+            indexer.start();
+            assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
+            assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+            assertTrue(ESTestCase.awaitBusy(() -> isFinished.get()));
+            assertThat(indexer.getStep(), equalTo(4));
+
         } finally {
             executor.shutdownNow();
         }


### PR DESCRIPTION
Improve error handling in the Indexer if an exception occurs ~during saving state and/or~ during the very 1st retrieval (query execution)

*Notes*

- Tagging this as Rollup, because roolup is the only user of this code at the moment.
- I am not aware of any reported bugs in the wild, the 2 problems have been found as part reading the code and re-using it. So severity seems low, but I still classify this as `bug`

/cc @jimczi @polyfractal 