### PR TITLE
Disallow common terms queries on all field types except text.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
@@ -42,6 +43,7 @@ import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.QueryShardException;
@@ -325,6 +327,17 @@ public abstract class MappedFieldType extends FieldType {
             builder.add(termQuery(value, context), Occur.SHOULD);
         }
         return new ConstantScoreQuery(builder.build());
+    }
+
+    public Query commonTermsQuery(String queryString,
+                                  Analyzer analyzer,
+                                  float cutoffFrequency,
+                                  Operator lowFreqOperator,
+                                  Operator highFreqOperator,
+                                  String lowFreqMinimumShouldMatch,
+                                  String highFreqMinimumShouldMatch) throws IOException {
+        throw new IllegalArgumentException("Can only use [common] queries on text fields - not on [" + name
+            + "] which is of type [" + typeName() + "].");
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.KeywordFieldMapper.KeywordFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType.Relation;
+import org.elasticsearch.index.query.Operator;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -183,5 +184,15 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
         assertEquals(new TermQuery(new Term("field", new BytesRef("FOO"))), ft.termQuery("FOO", null));
         ft.setSearchAnalyzer(Lucene.STANDARD_ANALYZER);
         assertEquals(new TermQuery(new Term("field", new BytesRef("foo"))), ft.termQuery("FOO", null));
+    }
+
+    public void testCommonTermsQuery() {
+        MappedFieldType ft = createDefaultFieldType();
+        ft.setName("field");
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
+            ft.commonTermsQuery("value", null, 0.01f, Operator.OR, Operator.OR, null, null));
+        assertEquals("Can only use [common] queries on text fields - not on [field] which" +
+            " is of type [keyword].", e.getMessage());
     }
 }

--- a/server/src/test/resources/org/elasticsearch/index/query/commonTerms-query1.json
+++ b/server/src/test/resources/org/elasticsearch/index/query/commonTerms-query1.json
@@ -1,6 +1,6 @@
 {
     "common" : {
-        "dogs" : {
+        "mapped_string" : {
             "query" : "buck mia tom",
             "cutoff_frequency" : 1,
             "minimum_should_match" : {

--- a/server/src/test/resources/org/elasticsearch/index/query/commonTerms-query2.json
+++ b/server/src/test/resources/org/elasticsearch/index/query/commonTerms-query2.json
@@ -1,6 +1,6 @@
 {
     "common" : {
-        "dogs" : {
+        "mapped_string" : {
             "query" : "buck mia tom",
             "minimum_should_match" : {
                 "high_freq" : "50%",

--- a/server/src/test/resources/org/elasticsearch/index/query/commonTerms-query3.json
+++ b/server/src/test/resources/org/elasticsearch/index/query/commonTerms-query3.json
@@ -1,6 +1,6 @@
 {
     "common" : {
-        "dogs" : {
+        "mapped_string" : {
             "query" : "buck mia tom",
             "cutoff_frequency" : 1,
             "minimum_should_match" : 2


### PR DESCRIPTION
These queries make the most sense for text queries, and are actually broken for some term-based field types like `boolean` because we don't call `indexedValueForSearch` during query construction.

It would be great to double-check my intuition that these queries don't make sense for `keyword` fields -- the other option would be to allow them for `text` and `keyword`, but disallow all other types.