### PR TITLE
Docs: Update CONTRIBUTING.md with shortcut command for assembling only the tar distribution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,7 +196,17 @@ the settings window and/or restart IntelliJ to see your changes take effect.
 
 ### Creating A Distribution
 
-To create all distributable artifacts from the source, simply run:
+To build a tar distribution, run this command:
+
+```sh
+./gradlew -p distribution/archives/tar assemble
+```
+
+You will find the distribution under:
+`./distribution/archives/tar/build/distributions/`
+
+To create all build artifacts (e.g., plugins and Javadocs) as well as
+distributions in all formats, run this command:
 
 ```sh
 cd elasticsearch/
@@ -208,14 +218,6 @@ The package distributions (Debian and RPM) can be found under:
 
 The archive distributions (tar and zip) can be found under:
 `./distribution/archives/(tar|zip)/build/distributions/`
-
-Note that this assembles every distributable artifact (e.g. plugins, javadocs) as well as
-distributions in all formats. If you want to quickly assemble _only_ a tar distribution, run this
-command instead:
-
-```sh
-./gradlew -p distribution/archives/tar assemble
-```
 
 ### Running The Full Test Suite
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,7 +196,7 @@ the settings window and/or restart IntelliJ to see your changes take effect.
 
 ### Creating A Distribution
 
-To create a distribution from the source, simply run:
+To create all distributable artifacts from the source, simply run:
 
 ```sh
 cd elasticsearch/
@@ -209,6 +209,13 @@ The package distributions (Debian and RPM) can be found under:
 The archive distributions (tar and zip) can be found under:
 `./distribution/archives/(tar|zip)/build/distributions/`
 
+Note that this assembles every distributable artifact (e.g. plugins, javadocs) as well as
+distributions in all formats. If you want to quickly assemble _only_ a tar distribution, run this
+command instead:
+
+```sh
+./gradlew -p distribution/archives/tar assemble
+```
 
 ### Running The Full Test Suite
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,6 +196,12 @@ the settings window and/or restart IntelliJ to see your changes take effect.
 
 ### Creating A Distribution
 
+Run all build commands from within the root directory:
+
+```sh
+cd elasticsearch/
+```
+
 To build a tar distribution, run this command:
 
 ```sh
@@ -209,8 +215,13 @@ To create all build artifacts (e.g., plugins and Javadocs) as well as
 distributions in all formats, run this command:
 
 ```sh
-cd elasticsearch/
 ./gradlew assemble
+```
+
+You can also build the artifacts and distributions in parallel:
+
+```sh
+./gradlew assemble --parallel
 ```
 
 The package distributions (Debian and RPM) can be found under:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,7 +205,7 @@ cd elasticsearch/
 To build a tar distribution, run this command:
 
 ```sh
-./gradlew -p distribution/archives/tar assemble
+./gradlew -p distribution/archives/tar assemble --parallel
 ```
 
 You will find the distribution under:
@@ -213,12 +213,6 @@ You will find the distribution under:
 
 To create all build artifacts (e.g., plugins and Javadocs) as well as
 distributions in all formats, run this command:
-
-```sh
-./gradlew assemble
-```
-
-You can also build the artifacts and distributions in parallel:
 
 ```sh
 ./gradlew assemble --parallel


### PR DESCRIPTION
This will help people assemble distributions without running into a problem I ran into when running the normal `assemble` command, in which `buildBwcVersion` failed because I lacked old Java versions:

```sh
> Task :distribution:bwc:bugfix:buildBwcVersion FAILED

 [6.4.3] ERROR: JAVA_HOME is set to an invalid directory: null
 [6.4.3]
 [6.4.3] Please set the JAVA_HOME variable in your environment to match the
 [6.4.3] location of your Java installation.
```