### PR TITLE
`Convert Processor` enhancement (description, snippet)

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -828,7 +828,7 @@ include::ingest-node-common-processor.asciidoc[]
 
 [[convert-processor]]
 === Convert Processor
-Converts a source field's value which is not ingested yet to a different type, such as converting a string to an integer.
+Converts a field in the currently ingested document to a different type, such as converting a string to an integer.
 If the field value is an array, all members will be converted.
 
 The supported types include: `integer`, `long`, `float`, `double`, `string`, `boolean`, and `auto`.
@@ -857,9 +857,9 @@ include::ingest-node-common-processor.asciidoc[]
 
 [source,js]
 --------------------------------------------------
-PUT _ingest/pipeline/studentindex
+PUT _ingest/pipeline/my-pipeline-id
 {
-  "description": "for student index converting from string id field to integer one ",
+  "description": "converts the content of the id field to an integer",
   "processors" : [
     {
       "convert" : {

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -828,7 +828,7 @@ include::ingest-node-common-processor.asciidoc[]
 
 [[convert-processor]]
 === Convert Processor
-Converts an existing field's value to a different type, such as converting a string to an integer.
+Converts a source field's value which is not ingested yet to a different type, such as converting a string to an integer.
 If the field value is an array, all members will be converted.
 
 The supported types include: `integer`, `long`, `float`, `double`, `string`, `boolean`, and `auto`.
@@ -857,11 +857,17 @@ include::ingest-node-common-processor.asciidoc[]
 
 [source,js]
 --------------------------------------------------
+PUT _ingest/pipeline/studentindex
 {
-  "convert": {
-    "field" : "url.port",
-    "type": "integer"
-  }
+  "description": "for student index converting from string id field to integer one ",
+  "processors" : [
+    {
+      "convert" : {
+        "field" : "id",
+        "type": "integer"
+      }
+    }
+  ]
 }
 --------------------------------------------------
 // NOTCONSOLE


### PR DESCRIPTION
Sometimes, the users are confused about they can use `Convert Processor` for changing existing field's type to other types even the existing one is already ingested. This confusion is from the first line of description.
Also, code snippet has not complete syntax, so it is misleading the right usage.
