### PR TITLE
Updated version to 5.6.13

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -1,4 +1,4 @@
-:version:               5.6.12
+:version:               5.6.13
 :major-version:         5.x
 :lucene_version:        6.6.1
 :lucene_version_path:   6_6_1


### PR DESCRIPTION
Updated the Elasticsearch docs version from 5.6.12 to 5.6.13
