### PR TITLE
[DOCS] Adds 6.5.0 release highlights to Elasticsearch Reference

### DIFF
--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -5,3 +5,5 @@
 ++++
 
 coming[6.5.0]
+
+See also <<release-notes-6.5.0,{es} 6.5.0 release notes>>. 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -9,10 +9,12 @@
 This section summarizes the most important changes in each release. For the 
 full list, see <<es-release-notes>> and <<breaking-changes>>. 
 
+* <<release-highlights-6.5.0>>
 * <<release-highlights-6.4.0>>
 * <<release-highlights-6.3.0>>
 
 --
 
+include::highlights-6.5.0.asciidoc[]
 include::highlights-6.4.0.asciidoc[]
 include::highlights-6.3.0.asciidoc[]


### PR DESCRIPTION
This PR adds the 6.5.0 Release Highlights page to the table of contents.  Currently it contains only the "coming" tag and a link to the release notes. 