### PR TITLE
[ILM] Check shard and relocation status in AllocationRoutedStep

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/AllocationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/AllocationRoutedStep.java
@@ -71,7 +71,7 @@ public class AllocationRoutedStep extends ClusterStateWaitStep {
                 boolean canRemainOnCurrentNode = ALLOCATION_DECIDERS
                         .canRemain(shardRouting, clusterState.getRoutingNodes().node(currentNodeId), allocation)
                         .type() == Decision.Type.YES;
-                if (canRemainOnCurrentNode == false) {
+                if (canRemainOnCurrentNode == false || shardRouting.started() == false || shardRouting.relocating()) {
                     allocationPendingAllShards++;
                 }
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/AllocationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/AllocationRoutedStep.java
@@ -71,7 +71,7 @@ public class AllocationRoutedStep extends ClusterStateWaitStep {
                 boolean canRemainOnCurrentNode = ALLOCATION_DECIDERS
                         .canRemain(shardRouting, clusterState.getRoutingNodes().node(currentNodeId), allocation)
                         .type() == Decision.Type.YES;
-                if (canRemainOnCurrentNode == false || shardRouting.started() == false || shardRouting.relocating()) {
+                if (canRemainOnCurrentNode == false || shardRouting.started() == false) {
                     allocationPendingAllShards++;
                 }
             }


### PR DESCRIPTION
This is a follow-up from #35161 where we now check for started and relocating
state in `AllocationRoutedStep`.

Resolves #35258
