### PR TITLE
Remove deprecated RealmConfig constructor

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmConfig.java
@@ -23,12 +23,6 @@ public class RealmConfig {
     private final Settings globalSettings;
     private final ThreadContext threadContext;
 
-    @Deprecated
-    public RealmConfig(RealmIdentifier identifier, Settings settings, Settings globalSettings, Environment env,
-                       ThreadContext threadContext) {
-        this(identifier, globalSettings, env, threadContext);
-    }
-
     public RealmConfig(RealmIdentifier identifier, Settings globalSettings, Environment env,
                        ThreadContext threadContext) {
         this.identifier = identifier;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/InternalRealmsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/InternalRealmsTests.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.security.authc;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -46,12 +47,13 @@ public class InternalRealmsTests extends ESTestCase {
         verifyZeroInteractions(securityIndex);
 
         Settings settings = Settings.builder().put("path.home", createTempDir()).build();
-        factories.get(NativeRealmSettings.TYPE).create(new RealmConfig(new RealmConfig.RealmIdentifier(NativeRealmSettings.TYPE, "test"),
-                Settings.EMPTY, settings, TestEnvironment.newEnvironment(settings), new ThreadContext(settings)));
+        final RealmConfig.RealmIdentifier realmId = new RealmConfig.RealmIdentifier(NativeRealmSettings.TYPE, "test");
+        final Environment env = TestEnvironment.newEnvironment(settings);
+        final ThreadContext threadContext = new ThreadContext(settings);
+        factories.get(NativeRealmSettings.TYPE).create(new RealmConfig(realmId, settings, env, threadContext));
         verify(securityIndex).addIndexStateListener(isA(BiConsumer.class));
 
-        factories.get(NativeRealmSettings.TYPE).create(new RealmConfig(new RealmConfig.RealmIdentifier(NativeRealmSettings.TYPE, "test"),
-                Settings.EMPTY, settings, TestEnvironment.newEnvironment(settings), new ThreadContext(settings)));
+        factories.get(NativeRealmSettings.TYPE).create(new RealmConfig(realmId, settings, env, threadContext));
         verify(securityIndex, times(2)).addIndexStateListener(isA(BiConsumer.class));
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmTests.java
@@ -32,8 +32,8 @@ public class NativeRealmTests extends ESTestCase {
         final AtomicInteger numInvalidation = new AtomicInteger(0);
         int expectedInvalidation = 0;
         Settings settings = Settings.builder().put("path.home", createTempDir()).build();
-        RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("native", "native"), Settings.EMPTY,
-                settings, TestEnvironment.newEnvironment(settings), new ThreadContext(settings));
+        RealmConfig.RealmIdentifier realmId = new RealmConfig.RealmIdentifier("native", "native")
+        RealmConfig config = new RealmConfig(realmId, settings, TestEnvironment.newEnvironment(settings), new ThreadContext(settings));
         final NativeRealm nativeRealm = new NativeRealm(config, mock(NativeUsersStore.class), threadPool) {
             @Override
             void clearCache() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmTests.java
@@ -32,7 +32,7 @@ public class NativeRealmTests extends ESTestCase {
         final AtomicInteger numInvalidation = new AtomicInteger(0);
         int expectedInvalidation = 0;
         Settings settings = Settings.builder().put("path.home", createTempDir()).build();
-        RealmConfig.RealmIdentifier realmId = new RealmConfig.RealmIdentifier("native", "native")
+        RealmConfig.RealmIdentifier realmId = new RealmConfig.RealmIdentifier("native", "native");
         RealmConfig config = new RealmConfig(realmId, settings, TestEnvironment.newEnvironment(settings), new ThreadContext(settings));
         final NativeRealm nativeRealm = new NativeRealm(config, mock(NativeUsersStore.class), threadPool) {
             @Override

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/file/FileUserPasswdStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/file/FileUserPasswdStoreTests.java
@@ -122,7 +122,7 @@ public class FileUserPasswdStoreTests extends ESTestCase {
 
     private RealmConfig getRealmConfig(Settings fileSettings) {
         final RealmConfig.RealmIdentifier identifier = new RealmConfig.RealmIdentifier("file", "file-test");
-        return new RealmConfig(identifier, fileSettings, settings, env, threadPool.getThreadContext());
+        return new RealmConfig(identifier, settings, env, threadPool.getThreadContext());
     }
 
     public void testStore_AutoReload_WithParseFailures() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/file/FileUserRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/file/FileUserRolesStoreTests.java
@@ -74,12 +74,8 @@ public class FileUserRolesStoreTests extends ESTestCase {
         // writing in utf_16 should cause a parsing error as we try to read the file in utf_8
         Files.write(file, lines, StandardCharsets.UTF_16);
 
-        Settings fileSettings = randomBoolean() ? Settings.EMPTY : Settings.builder()
-                .put("files.users_roles", file.toAbsolutePath())
-                .build();
-
-        RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("file", "file-test"), fileSettings, settings, env,
-                new ThreadContext(Settings.EMPTY));
+        RealmConfig.RealmIdentifier realmId = new RealmConfig.RealmIdentifier("file", "file-test");
+        RealmConfig config = new RealmConfig(realmId, settings, env, new ThreadContext(Settings.EMPTY));
         ResourceWatcherService watcherService = new ResourceWatcherService(settings, threadPool);
         FileUserRolesStore store = new FileUserRolesStore(config, watcherService);
         assertThat(store.entriesCount(), is(0));
@@ -90,12 +86,9 @@ public class FileUserRolesStoreTests extends ESTestCase {
         Path tmp = getUsersRolesPath();
         Files.copy(users, tmp, StandardCopyOption.REPLACE_EXISTING);
 
-        Settings fileSettings = randomBoolean() ? Settings.EMPTY : Settings.builder()
-                .put("files.users_roles", tmp.toAbsolutePath())
-                .build();
 
-        RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("file", "file-test"), fileSettings, settings, env,
-                new ThreadContext(Settings.EMPTY));
+        final RealmConfig.RealmIdentifier realmId = new RealmConfig.RealmIdentifier("file", "file-test");
+        RealmConfig config = new RealmConfig(realmId, settings, env, new ThreadContext(Settings.EMPTY));
         ResourceWatcherService watcherService = new ResourceWatcherService(settings, threadPool);
         final CountDownLatch latch = new CountDownLatch(1);
 
@@ -129,12 +122,8 @@ public class FileUserRolesStoreTests extends ESTestCase {
         Path tmp = getUsersRolesPath();
         Files.copy(users, tmp, StandardCopyOption.REPLACE_EXISTING);
 
-        Settings fileSettings = randomBoolean() ? Settings.EMPTY : Settings.builder()
-                .put("files.users_roles", tmp.toAbsolutePath())
-                .build();
-
-        RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("file", "file-test"), fileSettings, settings, env,
-                new ThreadContext(Settings.EMPTY));
+        final RealmConfig.RealmIdentifier realmId = new RealmConfig.RealmIdentifier("file", "file-test");
+        RealmConfig config = new RealmConfig(realmId, settings, env, new ThreadContext(Settings.EMPTY));
         ResourceWatcherService watcherService = new ResourceWatcherService(settings, threadPool);
         final CountDownLatch latch = new CountDownLatch(1);
 
@@ -222,13 +211,9 @@ public class FileUserRolesStoreTests extends ESTestCase {
                     .put("path.home", createTempDir())
                     .build();
 
-            Settings fileSettings = randomBoolean() ? Settings.EMPTY : Settings.builder()
-                    .put("files.users_roles", usersRoles.toAbsolutePath())
-                    .build();
-
             Environment env = TestEnvironment.newEnvironment(settings);
-            RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("file", "file-test"), fileSettings, settings, env,
-                    new ThreadContext(Settings.EMPTY));
+            final RealmConfig.RealmIdentifier realmId = new RealmConfig.RealmIdentifier("file", "file-test");
+            RealmConfig config = new RealmConfig(realmId, settings, env, new ThreadContext(Settings.EMPTY));
             ResourceWatcherService watcherService = new ResourceWatcherService(settings, threadPool);
             FileUserRolesStore store = new FileUserRolesStore(config, watcherService);
             assertThat(store.roles("user"), equalTo(Strings.EMPTY_ARRAY));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmAuthenticateFailedTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmAuthenticateFailedTests.java
@@ -122,7 +122,7 @@ public class KerberosRealmAuthenticateFailedTests extends KerberosRealmTestCase 
     public void testDelegatedAuthorizationFailedToResolve() throws Exception {
         final String username = randomPrincipalName();
         final MockLookupRealm otherRealm = new MockLookupRealm(new RealmConfig(new RealmConfig.RealmIdentifier("mock", "other_realm"),
-            Settings.EMPTY, globalSettings, TestEnvironment.newEnvironment(globalSettings), new ThreadContext(globalSettings)));
+            globalSettings, TestEnvironment.newEnvironment(globalSettings), new ThreadContext(globalSettings)));
         final User lookupUser = new User(randomAlphaOfLength(5));
         otherRealm.registerUser(lookupUser);
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealmTests.java
@@ -324,13 +324,13 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
     }
 
     public void testAuthenticateContract() throws Exception {
-        Realm realm = new FailingAuthenticationRealm(Settings.EMPTY, globalSettings, threadPool);
+        Realm realm = new FailingAuthenticationRealm(globalSettings, threadPool);
         PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
         realm.authenticate(new UsernamePasswordToken("user", new SecureString("pass")), future);
         User user = future.actionGet().getUser();
         assertThat(user, nullValue());
 
-        realm = new ThrowingAuthenticationRealm(Settings.EMPTY, globalSettings, threadPool);
+        realm = new ThrowingAuthenticationRealm(globalSettings, threadPool);
         future = new PlainActionFuture<>();
         realm.authenticate(new UsernamePasswordToken("user", new SecureString("pass")), future);
         RuntimeException e = expectThrows(RuntimeException.class, future::actionGet);
@@ -338,13 +338,13 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
     }
 
     public void testLookupContract() throws Exception {
-        Realm realm = new FailingAuthenticationRealm(Settings.EMPTY, globalSettings, threadPool);
+        Realm realm = new FailingAuthenticationRealm(globalSettings, threadPool);
         PlainActionFuture<User> future = new PlainActionFuture<>();
         realm.lookupUser("user", future);
         User user = future.actionGet();
         assertThat(user, nullValue());
 
-        realm = new ThrowingAuthenticationRealm(Settings.EMPTY, globalSettings, threadPool);
+        realm = new ThrowingAuthenticationRealm(globalSettings, threadPool);
         future = new PlainActionFuture<>();
         realm.lookupUser("user", future);
         RuntimeException e = expectThrows(RuntimeException.class, future::actionGet);
@@ -384,7 +384,7 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
         final AtomicInteger authCounter = new AtomicInteger(0);
         final Hasher pwdHasher = Hasher.resolve(randomFrom("pbkdf2", "pbkdf2_1000", "bcrypt", "bcrypt9"));
         final String passwordHash = new String(pwdHasher.hash(password));
-        RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("caching", "test_realm"), Settings.EMPTY, globalSettings,
+        RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("caching", "test_realm"), globalSettings,
             TestEnvironment.newEnvironment(globalSettings), new ThreadContext(Settings.EMPTY));
         final CachingUsernamePasswordRealm realm = new CachingUsernamePasswordRealm(config, threadPool) {
             @Override
@@ -450,7 +450,7 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
         final SecureString randomPassword = new SecureString(randomAlphaOfLength(password.length()).toCharArray());
         final Hasher localHasher = Hasher.resolve(randomFrom("pbkdf2", "pbkdf2_1000", "bcrypt", "bcrypt9"));
         final String passwordHash = new String(localHasher.hash(password));
-        RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("caching", "test_realm"), Settings.EMPTY, globalSettings,
+        RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("caching", "test_realm"), globalSettings,
                 TestEnvironment.newEnvironment(globalSettings), new ThreadContext(Settings.EMPTY));
         final CachingUsernamePasswordRealm realm = new CachingUsernamePasswordRealm(config, threadPool) {
             @Override
@@ -518,7 +518,7 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
         final String username = "username";
         final AtomicInteger lookupCounter = new AtomicInteger(0);
 
-        RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("caching", "test_realm"), Settings.EMPTY, globalSettings,
+        RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("caching", "test_realm"), globalSettings,
                 TestEnvironment.newEnvironment(globalSettings), new ThreadContext(Settings.EMPTY));
         final CachingUsernamePasswordRealm realm = new CachingUsernamePasswordRealm(config, threadPool) {
             @Override
@@ -605,8 +605,8 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
 
     static class FailingAuthenticationRealm extends CachingUsernamePasswordRealm {
 
-        FailingAuthenticationRealm(Settings settings, Settings global, ThreadPool threadPool) {
-            super(new RealmConfig(new RealmConfig.RealmIdentifier("caching", "failing-test"), settings, global,
+        FailingAuthenticationRealm(Settings global, ThreadPool threadPool) {
+            super(new RealmConfig(new RealmConfig.RealmIdentifier("caching", "failing-test"), global,
                     TestEnvironment.newEnvironment(global),
                     threadPool.getThreadContext()), threadPool);
         }
@@ -624,8 +624,8 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
 
     static class ThrowingAuthenticationRealm extends CachingUsernamePasswordRealm {
 
-        ThrowingAuthenticationRealm(Settings settings, Settings globalSettings, ThreadPool threadPool) {
-            super(new RealmConfig(new RealmConfig.RealmIdentifier("caching", "throwing-test"), settings, globalSettings,
+        ThrowingAuthenticationRealm(Settings globalSettings, ThreadPool threadPool) {
+            super(new RealmConfig(new RealmConfig.RealmIdentifier("caching", "throwing-test"), globalSettings,
                     TestEnvironment.newEnvironment(globalSettings),
                     threadPool.getThreadContext()), threadPool);
         }
@@ -649,7 +649,7 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
         private boolean usersEnabled = true;
 
         AlwaysAuthenticateCachingRealm(Settings globalSettings, ThreadPool threadPool) {
-            this(new RealmConfig(new RealmConfig.RealmIdentifier("caching", "always-test"), Settings.EMPTY, globalSettings,
+            this(new RealmConfig(new RealmConfig.RealmIdentifier("caching", "always-test"), globalSettings,
                     TestEnvironment.newEnvironment(globalSettings),
                     threadPool.getThreadContext()), threadPool);
         }
@@ -682,7 +682,7 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
         public final AtomicInteger lookupInvocationCounter = new AtomicInteger(0);
 
         LookupNotSupportedRealm(Settings globalSettings, ThreadPool threadPool) {
-            super(new RealmConfig(new RealmConfig.RealmIdentifier("caching", "lookup-notsupported-test"), Settings.EMPTY, globalSettings,
+            super(new RealmConfig(new RealmConfig.RealmIdentifier("caching", "lookup-notsupported-test"), globalSettings,
                     TestEnvironment.newEnvironment(globalSettings), threadPool.getThreadContext()), threadPool);
         }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/ExpressionRoleMappingTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/ExpressionRoleMappingTests.java
@@ -39,7 +39,7 @@ public class ExpressionRoleMappingTests extends ESTestCase {
     @Before
     public void setupMapping() throws Exception {
         realm = new RealmConfig(new RealmConfig.RealmIdentifier("ldap", "ldap1"),
-                Settings.EMPTY, Settings.EMPTY, Mockito.mock(Environment.class), new ThreadContext(Settings.EMPTY));
+                Settings.EMPTY, Mockito.mock(Environment.class), new ThreadContext(Settings.EMPTY));
     }
 
     public void testParseValidJson() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStoreTests.java
@@ -84,7 +84,7 @@ public class NativeRoleMappingStoreTests extends ESTestCase {
             }
         };
 
-        final RealmConfig realm = new RealmConfig(new RealmConfig.RealmIdentifier("ldap", "ldap1"), Settings.EMPTY, Settings.EMPTY,
+        final RealmConfig realm = new RealmConfig(new RealmConfig.RealmIdentifier("ldap", "ldap1"), Settings.EMPTY,
                 mock(Environment.class), new ThreadContext(Settings.EMPTY));
 
         final PlainActionFuture<Set<String>> future = new PlainActionFuture<>();
@@ -197,7 +197,7 @@ public class NativeRoleMappingStoreTests extends ESTestCase {
         }).when(client).execute(eq(ClearRealmCacheAction.INSTANCE), any(ClearRealmCacheRequest.class), any(ActionListener.class));
 
         final Environment env = TestEnvironment.newEnvironment(settings);
-        final RealmConfig realmConfig = new RealmConfig(new RealmConfig.RealmIdentifier("ldap", getTestName()), Settings.EMPTY,
+        final RealmConfig realmConfig = new RealmConfig(new RealmConfig.RealmIdentifier("ldap", getTestName()),
                 settings, env, threadContext);
         final CachingUsernamePasswordRealm mockRealm = new CachingUsernamePasswordRealm(realmConfig, threadPool) {
             @Override

--- a/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ADLdapUserSearchSessionFactoryTests.java
+++ b/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ADLdapUserSearchSessionFactoryTests.java
@@ -90,7 +90,7 @@ public class ADLdapUserSearchSessionFactoryTests extends AbstractActiveDirectory
         });
         Settings fullSettings = builder.build();
         sslService = new SSLService(fullSettings, TestEnvironment.newEnvironment(fullSettings));
-        RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("ad", "ad-as-ldap-test"), settings, globalSettings,
+        RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("ad", "ad-as-ldap-test"), globalSettings,
                 TestEnvironment.newEnvironment(globalSettings), new ThreadContext(globalSettings));
         LdapUserSearchSessionFactory sessionFactory = getLdapUserSearchSessionFactory(config, sslService, threadPool);
 


### PR DESCRIPTION
This removes an obsolete constructor that was still being called from
some tests.

Relates: #30241
