### PR TITLE
[ILM] rolling upgrade tests

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/70_ilm.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/70_ilm.yml
@@ -1,0 +1,31 @@
+---
+"Test Set Policy On Index":
+  - do:
+      ilm.get_lifecycle:
+        policy: "my_lifecycle"
+  - match: { my_lifecycle.policy.phases.warm.minimum_age: "1000d" }
+
+  - do:
+      ilm.explain_lifecycle:
+        index: "my_old_index"
+  - is_true: indices.my_old_index.managed
+  - match: { indices.my_old_index.index: "my_old_index" }
+  - match: { indices.my_old_index.policy: "my_lifecycle" }
+
+  - do:
+      indices.create:
+        index: my_mixed_index
+        body:
+          settings:
+            index.lifecycle.name: "my_lifecycle"
+
+  - do:
+      ilm.explain_lifecycle:
+        index: "my_mixed_index"
+  - is_true: indices.my_mixed_index.managed
+  - match: { indices.my_mixed_index.index: "my_mixed_index" }
+  - match: { indices.my_mixed_index.policy: "my_lifecycle" }
+
+  - do:
+      indices.delete:
+        index: my_mixed_index

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/70_ilm.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/70_ilm.yml
@@ -3,7 +3,7 @@
   - do:
       ilm.get_lifecycle:
         policy: "my_lifecycle"
-  - match: { my_lifecycle.policy.phases.warm.minimum_age: "1000d" }
+  - match: { my_lifecycle.policy.phases.warm.min_age: "1000d" }
 
   - do:
       ilm.explain_lifecycle:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/70_ilm.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/70_ilm.yml
@@ -1,0 +1,49 @@
+---
+"Test Basic Policy Creation":
+  - do:
+      catch: missing
+      ilm.get_lifecycle:
+        policy: "my_lifecycle"
+
+  - do:
+      catch: missing
+      ilm.delete_lifecycle:
+        policy: "my_lifecycle"
+
+  - do:
+      ilm.put_lifecycle:
+        policy: "my_lifecycle"
+        body: |
+           {
+             "policy": {
+               "phases": {
+                 "warm": {
+                   "minimum_age": "1000d",
+                   "actions": {
+                     "forcemerge": {
+                       "max_num_segments": 10000
+                     }
+                   }
+                 }
+               }
+             }
+           }
+
+  - do:
+      ilm.get_lifecycle:
+        policy: "my_lifecycle"
+  - match: { my_lifecycle.policy.phases.warm.minimum_age: "1000d" }
+
+  - do:
+      indices.create:
+        index: my_old_index
+        body:
+          settings:
+            index.lifecycle.name: "my_lifecycle"
+
+  - do:
+      ilm.explain_lifecycle:
+        index: "my_old_index"
+  - is_true: indices.my_old_index.managed
+  - match: { indices.my_old_index.index: "my_old_index" }
+  - match: { indices.my_old_index.policy: "my_lifecycle" }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/70_ilm.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/70_ilm.yml
@@ -18,7 +18,7 @@
              "policy": {
                "phases": {
                  "warm": {
-                   "minimum_age": "1000d",
+                   "min_age": "1000d",
                    "actions": {
                      "forcemerge": {
                        "max_num_segments": 10000
@@ -32,7 +32,7 @@
   - do:
       ilm.get_lifecycle:
         policy: "my_lifecycle"
-  - match: { my_lifecycle.policy.phases.warm.minimum_age: "1000d" }
+  - match: { my_lifecycle.policy.phases.warm.min_age: "1000d" }
 
   - do:
       indices.create:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/70_ilm.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/70_ilm.yml
@@ -1,0 +1,21 @@
+---
+"Test Lifecycle Still There And Indices Are Still Managed":
+  - do:
+      ilm.get_lifecycle:
+        policy: "my_lifecycle"
+  - match: { my_lifecycle.policy.phases.warm.minimum_age: "1000d" }
+
+  - do:
+      ilm.explain_lifecycle:
+        index: "my_old_index"
+  - is_true: indices.my_old_index.managed
+  - match: { indices.my_old_index.index: "my_old_index" }
+  - match: { indices.my_old_index.policy: "my_lifecycle" }
+
+  - do:
+      indices.delete:
+        index: my_old_index
+
+  - do:
+      ilm.delete_lifecycle:
+        policy: "my_lifecycle"

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/70_ilm.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/70_ilm.yml
@@ -3,7 +3,7 @@
   - do:
       ilm.get_lifecycle:
         policy: "my_lifecycle"
-  - match: { my_lifecycle.policy.phases.warm.minimum_age: "1000d" }
+  - match: { my_lifecycle.policy.phases.warm.min_age: "1000d" }
 
   - do:
       ilm.explain_lifecycle:


### PR DESCRIPTION
This is a re-boot of the previous PR against `index-lifecycle` that needed to be 
reverted due to CI bwc issues. https://github.com/elastic/elasticsearch/pull/32828

original description:

> Adds basic rolling upgrade tests to check that lifecycles are still recognizable between rolling cluster upgrades and managed indices stay managed.
>
>This is a placeholder for discussing types of checks so they are ready once we backported

The commit was cherry-picked and updated to reflect the change from [minimum_age to min_age](https://github.com/elastic/elasticsearch/pull/35058). https://github.com/elastic/elasticsearch/pull/35058
