### PR TITLE
Rename RealmConfig.globalSettings() to settings()

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmConfig.java
@@ -20,16 +20,15 @@ public class RealmConfig {
     final boolean enabled;
     final int order;
     private final Environment env;
-    private final Settings globalSettings;
+    private final Settings settings;
     private final ThreadContext threadContext;
 
-    public RealmConfig(RealmIdentifier identifier, Settings globalSettings, Environment env,
-                       ThreadContext threadContext) {
+    public RealmConfig(RealmIdentifier identifier, Settings settings, Environment env, ThreadContext threadContext) {
         this.identifier = identifier;
-        this.globalSettings = globalSettings;
+        this.settings = settings;
         this.env = env;
-        enabled = getSetting(RealmSettings.ENABLED_SETTING);
-        order = getSetting(RealmSettings.ORDER_SETTING);
+        this.enabled = getSetting(RealmSettings.ENABLED_SETTING);
+        this.order = getSetting(RealmSettings.ORDER_SETTING);
         this.threadContext = threadContext;
     }
 
@@ -53,8 +52,13 @@ public class RealmConfig {
         return identifier.type;
     }
 
-    public Settings globalSettings() {
-        return globalSettings;
+    /**
+     * @return The settings for the current node.
+     * This will include the settings for this realm (as well as other realms, and other non-security settings).
+     * @see #getConcreteSetting(Setting.AffixSetting)
+     */
+    public Settings settings() {
+        return settings;
     }
 
     public Environment env() {
@@ -95,16 +99,16 @@ public class RealmConfig {
     }
 
     /**
-     * Obtain the value of the provided {@code setting} from the node's {@link #globalSettings global settings}.
+     * Obtain the value of the provided {@code setting} from the node's {@link #settings global settings}.
      * The {@link Setting.AffixSetting} is made <em>concrete</em> through {@link #getConcreteSetting(Setting.AffixSetting)}, which is then
      * used to {@link Setting#get(Settings) retrieve} the setting value.
      */
     public <T> T getSetting(Setting.AffixSetting<T> setting) {
-        return getConcreteSetting(setting).get(globalSettings);
+        return getConcreteSetting(setting).get(settings);
     }
 
     /**
-     * Obtain the value of the provided {@code setting} from the node's {@link #globalSettings global settings}.
+     * Obtain the value of the provided {@code setting} from the node's {@link #settings global settings}.
      * {@link #getConcreteSetting(Function)} is used to obtain a <em>concrete setting</em> from the provided
      * {@link Function}/{@link Setting.AffixSetting}, and this <em>concrete setting</em> is then used to
      * {@link Setting#get(Settings) retrieve} the setting value.
@@ -114,7 +118,7 @@ public class RealmConfig {
     }
 
     /**
-     * Obtain the value of the provided {@code setting} from the node's {@link #globalSettings global settings}.
+     * Obtain the value of the provided {@code setting} from the node's {@link #settings global settings}.
      * {@link #getConcreteSetting(Function)} is used to obtain a <em>concrete setting</em> from the provided
      * {@link Function}/{@link Setting.AffixSetting}.
      * If this <em>concrete setting</em> {@link Setting#exists(Settings) exists} in the global settings, then its value is returned,
@@ -125,7 +129,7 @@ public class RealmConfig {
     }
 
     /**
-     * Obtain the value of the provided {@code setting} from the node's {@link #globalSettings global settings}.
+     * Obtain the value of the provided {@code setting} from the node's {@link #settings global settings}.
      * {@link #getConcreteSetting(Setting.AffixSetting)} is used to obtain a <em>concrete setting</em> from the provided
      * {@link Setting.AffixSetting}.
      * If this <em>concrete setting</em> {@link Setting#exists(Settings) exists} in the global settings, then its value is returned,
@@ -133,30 +137,30 @@ public class RealmConfig {
      */
     public <T> T getSetting(Setting.AffixSetting<T> setting, Supplier<T> orElse) {
         final Setting<T> concrete = setting.getConcreteSettingForNamespace(name());
-        if (concrete.exists(globalSettings)) {
-            return concrete.get(globalSettings);
+        if (concrete.exists(settings)) {
+            return concrete.get(settings);
         } else {
             return orElse.get();
         }
     }
 
     /**
-     * Determines whether the provided {@code setting} has an explicit value in the node's {@link #globalSettings global settings}.
+     * Determines whether the provided {@code setting} has an explicit value in the node's {@link #settings global settings}.
      * {@link #getConcreteSetting(Function)} is used to obtain a <em>concrete setting</em> from the provided
      * {@link Function}/{@link Setting.AffixSetting}, and this <em>concrete setting</em> is then used to
      * {@link Setting#exists(Settings) check} for a value.
      */
     public <T> boolean hasSetting(Function<String, Setting.AffixSetting<T>> settingFactory) {
-        return getConcreteSetting(settingFactory).exists(globalSettings);
+        return getConcreteSetting(settingFactory).exists(settings);
     }
 
     /**
-     * Determines whether the provided {@code setting} has an explicit value in the node's {@link #globalSettings global settings}.
+     * Determines whether the provided {@code setting} has an explicit value in the node's {@link #settings global settings}.
      * {@link #getConcreteSetting(Setting.AffixSetting)} is used to obtain a <em>concrete setting</em> from the provided
      * {@link Setting.AffixSetting}, and this <em>concrete setting</em> is then used to {@link Setting#exists(Settings) check} for a value.
      */
     public <T> boolean hasSetting(Setting.AffixSetting<T> setting) {
-        return getConcreteSetting(setting).exists(globalSettings);
+        return getConcreteSetting(setting).exists(settings);
     }
 
     /**

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealm.java
@@ -87,7 +87,7 @@ public class ReservedRealm extends CachingUsernamePasswordRealm {
     protected void doAuthenticate(UsernamePasswordToken token, ActionListener<AuthenticationResult> listener) {
         if (realmEnabled == false) {
             listener.onResponse(AuthenticationResult.notHandled());
-        } else if (ClientReservedRealm.isReserved(token.principal(), config.globalSettings()) == false) {
+        } else if (ClientReservedRealm.isReserved(token.principal(), config.settings()) == false) {
             listener.onResponse(AuthenticationResult.notHandled());
         } else {
             getUserInfo(token.principal(), ActionListener.wrap((userInfo) -> {
@@ -120,13 +120,13 @@ public class ReservedRealm extends CachingUsernamePasswordRealm {
     @Override
     protected void doLookupUser(String username, ActionListener<User> listener) {
         if (realmEnabled == false) {
-            if (anonymousEnabled && AnonymousUser.isAnonymousUsername(username, config.globalSettings())) {
+            if (anonymousEnabled && AnonymousUser.isAnonymousUsername(username, config.settings())) {
                 listener.onResponse(anonymousUser);
             }
             listener.onResponse(null);
-        } else if (ClientReservedRealm.isReserved(username, config.globalSettings()) == false) {
+        } else if (ClientReservedRealm.isReserved(username, config.settings()) == false) {
             listener.onResponse(null);
-        } else if (AnonymousUser.isAnonymousUsername(username, config.globalSettings())) {
+        } else if (AnonymousUser.isAnonymousUsername(username, config.settings())) {
             listener.onResponse(anonymousEnabled ? anonymousUser : null);
         } else {
             getUserInfo(username, ActionListener.wrap((userInfo) -> {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/file/FileUserPasswdStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/file/FileUserPasswdStore.java
@@ -56,7 +56,7 @@ public class FileUserPasswdStore {
 
     FileUserPasswdStore(RealmConfig config, ResourceWatcherService watcherService, Runnable listener) {
         file = resolveFile(config.env());
-        settings = config.globalSettings();
+        settings = config.settings();
         users = parseFileLenient(file, logger, settings);
         listeners = new CopyOnWriteArrayList<>(Collections.singletonList(listener));
         FileWatcher watcher = new FileWatcher(file.getParent());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
@@ -249,7 +249,7 @@ public class PkiRealm extends Realm implements CachingRealm {
         try (SecureString password = realmConfig.getSetting(PkiRealmSettings.TRUST_STORE_PASSWORD)) {
             String trustStoreAlgorithm = realmConfig.getSetting(PkiRealmSettings.TRUST_STORE_ALGORITHM);
             String trustStoreType = SSLConfigurationSettings.getKeyStoreType(
-                    realmConfig.getConcreteSetting(PkiRealmSettings.TRUST_STORE_TYPE), realmConfig.globalSettings(),
+                    realmConfig.getConcreteSetting(PkiRealmSettings.TRUST_STORE_TYPE), realmConfig.settings(),
                     truststorePath);
             try {
                 return CertParsingUtils.trustManager(truststorePath, trustStoreType, password.getChars(), trustStoreAlgorithm, realmConfig

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlMetadataCommand.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlMetadataCommand.java
@@ -32,7 +32,6 @@ import joptsimple.OptionSpec;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.cli.EnvironmentAwareCommand;
 import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.cli.SuppressForbidden;
@@ -158,7 +157,7 @@ public class SamlMetadataCommand extends EnvironmentAwareCommand {
         final boolean batch = options.has(batchSpec);
 
         final RealmConfig realm = findRealm(terminal, options, env);
-        final Settings realmSettings = realm.globalSettings().getByPrefix(RealmSettings.realmSettingPrefix(realm.identifier()));
+        final Settings realmSettings = realm.settings().getByPrefix(RealmSettings.realmSettingPrefix(realm.identifier()));
         terminal.println(Terminal.Verbosity.VERBOSE,
                 "Using realm configuration\n=====\n" + realmSettings.toDelimitedString('\n') + "=====");
         final Locale locale = findLocale(options);
@@ -399,7 +398,7 @@ public class SamlMetadataCommand extends EnvironmentAwareCommand {
             attributes.put(a, null);
         }
         final String prefix = RealmSettings.realmSettingPrefix(realm.identifier()) + SamlRealmSettings.AttributeSetting.ATTRIBUTES_PREFIX;
-        final Settings attributeSettings = realm.globalSettings().getByPrefix(prefix);
+        final Settings attributeSettings = realm.settings().getByPrefix(prefix);
         for (String key : sorted(attributeSettings.keySet())) {
             final String attr = attributeSettings.get(key);
             attributes.put(attr, key);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
@@ -179,7 +179,7 @@ public final class SamlRealm extends Realm implements Releasable {
                                    UserRoleMapper roleMapper) throws Exception {
         SamlUtils.initialize(logger);
 
-        if (TokenService.isTokenServiceEnabled(config.globalSettings()) == false) {
+        if (TokenService.isTokenServiceEnabled(config.settings()) == false) {
             throw new IllegalStateException("SAML requires that the token service be enabled ("
                     + XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.getKey() + ")");
         }
@@ -317,7 +317,7 @@ public final class SamlRealm extends Realm implements Releasable {
     private static List<X509Credential> buildCredential(RealmConfig config, String prefix, Setting.AffixSetting<String> aliasSetting,
                                                         boolean allowMultiple) {
         final X509KeyPairSettings keyPairSettings = X509KeyPairSettings.withPrefix(prefix, false);
-        final X509KeyManager keyManager = CertParsingUtils.getKeyManager(keyPairSettings, config.globalSettings(), null, config.env());
+        final X509KeyManager keyManager = CertParsingUtils.getKeyManager(keyPairSettings, config.settings(), null, config.env());
         if (keyManager == null) {
             return null;
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/DelegatedAuthorizationSupport.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/DelegatedAuthorizationSupport.java
@@ -46,7 +46,7 @@ public class DelegatedAuthorizationSupport {
      * {@link #DelegatedAuthorizationSupport(Iterable, List, Settings, ThreadContext, XPackLicenseState)}
      */
     public DelegatedAuthorizationSupport(Iterable<? extends Realm> allRealms, RealmConfig config, XPackLicenseState licenseState) {
-        this(allRealms, config.getSetting(AUTHZ_REALMS), config.globalSettings(), config.threadContext(),
+        this(allRealms, config.getSetting(AUTHZ_REALMS), config.settings(), config.threadContext(),
             licenseState);
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
@@ -314,7 +314,7 @@ public class LdapRealmTests extends LdapTestCase {
                 .put(getFullSettingKey(identifier, SSLConfigurationSettings.VERIFICATION_MODE_SETTING_REALM), VerificationMode.CERTIFICATE)
                 .build();
         final RealmConfig config = getRealmConfig(identifier, settings);
-        SessionFactory sessionFactory = LdapRealm.sessionFactory(config, new SSLService(config.globalSettings(), config.env()), threadPool);
+        SessionFactory sessionFactory = LdapRealm.sessionFactory(config, new SSLService(config.settings(), config.env()), threadPool);
         try {
             assertThat(sessionFactory, is(instanceOf(LdapUserSearchSessionFactory.class)));
         } finally {
@@ -435,7 +435,7 @@ public class LdapRealmTests extends LdapTestCase {
 
         RealmConfig config = getRealmConfig(identifier, settings.build());
 
-        LdapSessionFactory ldapFactory = new LdapSessionFactory(config, new SSLService(config.globalSettings(), config.env()), threadPool);
+        LdapSessionFactory ldapFactory = new LdapSessionFactory(config, new SSLService(config.settings(), config.env()), threadPool);
         LdapRealm realm = new LdapRealm(config, ldapFactory, new DnRoleMapper(config, resourceWatcherService), threadPool);
         realm.initialize(Collections.singleton(realm), licenseState);
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactoryLoadBalancingTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactoryLoadBalancingTests.java
@@ -240,7 +240,7 @@ public class SessionFactoryLoadBalancingTests extends LdapTestCase {
         Settings globalSettings = Settings.builder().put("path.home", createTempDir()).put(settings).build();
         RealmConfig config = new RealmConfig(REALM_IDENTIFIER, globalSettings,
                 TestEnvironment.newEnvironment(globalSettings), new ThreadContext(Settings.EMPTY));
-        return new TestSessionFactory(config, new SSLService(Settings.EMPTY, TestEnvironment.newEnvironment(config.globalSettings())),
+        return new TestSessionFactory(config, new SSLService(Settings.EMPTY, TestEnvironment.newEnvironment(config.settings())),
                 threadPool);
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
@@ -140,7 +140,7 @@ public class SamlRealmTests extends SamlTestCase {
             assertEquals(0, proxyServer.requests().size());
 
             Tuple<RealmConfig, SSLService> config = buildConfig("https://localhost:" + proxyServer.getPort());
-            logger.info("Settings\n{}", config.v1().globalSettings().toDelimitedString('\n'));
+            logger.info("Settings\n{}", config.v1().settings().toDelimitedString('\n'));
             final ResourceWatcherService watcherService = mock(ResourceWatcherService.class);
             Tuple<AbstractReloadingMetadataResolver, Supplier<EntityDescriptor>> tuple
                     = SamlRealm.initializeResolver(logger, config.v1(), config.v2(), watcherService);
@@ -284,7 +284,7 @@ public class SamlRealmTests extends SamlTestCase {
         try {
             return new SamlRealm(config, roleMapper, authenticator, logoutHandler, () -> idp, sp);
         } catch (SettingsException e) {
-            logger.info(new ParameterizedMessage("Settings are invalid:\n{}", config.globalSettings().toDelimitedString('\n')), e);
+            logger.info(new ParameterizedMessage("Settings are invalid:\n{}", config.settings().toDelimitedString('\n')), e);
             throw e;
         }
     }


### PR DESCRIPTION
There is no longer a concept of non-global "realm settings". All realm
settings should be loaded from the node's settings using standard
Setting classes.

This change renames the "globalSettings" field and method to simply be
"settings".

Relates: #30241