### PR TITLE
Make version field names more meaningful 

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
@@ -43,7 +43,7 @@ public class DocsTestPlugin extends RestTestPlugin {
                  * to the version being built for testing but needs to resolve to
                  * the last released version for docs. */
             '\\{version\\}': Version.fromString(VersionProperties.elasticsearch).toString(),
-            '\\{qualified_version\\}': VersionProperties.elasticsearch,
+            '\\{version_qualified\\}': VersionProperties.elasticsearch,
             '\\{lucene_version\\}' : VersionProperties.lucene.replaceAll('-snapshot-\\w+$', ''),
             '\\{build_flavor\\}' :
                 project.integTestCluster.distribution.startsWith('oss-') ? 'oss' : 'default',

--- a/docs/plugins/discovery-azure-classic.asciidoc
+++ b/docs/plugins/discovery-azure-classic.asciidoc
@@ -377,7 +377,7 @@ This command should give you a JSON result:
     "build_hash" : "f27399d",
     "build_date" : "2016-03-30T09:51:41.449Z",
     "build_snapshot" : false,
-    "version_qualified" : "{version_qualified}",
+    "qualified" : "{version_qualified}",
     "lucene_version" : "{lucene_version}",
     "minimum_wire_compatibility_version" : "1.2.3",
     "minimum_index_compatibility_version" : "1.2.3"

--- a/docs/plugins/discovery-azure-classic.asciidoc
+++ b/docs/plugins/discovery-azure-classic.asciidoc
@@ -377,7 +377,7 @@ This command should give you a JSON result:
     "build_hash" : "f27399d",
     "build_date" : "2016-03-30T09:51:41.449Z",
     "build_snapshot" : false,
-    "build_version" : "{qualified_version}",
+    "version_qualified" : "{version_qualified}",
     "lucene_version" : "{lucene_version}",
     "minimum_wire_compatibility_version" : "1.2.3",
     "minimum_index_compatibility_version" : "1.2.3"

--- a/docs/reference/cat/plugins.asciidoc
+++ b/docs/reference/cat/plugins.asciidoc
@@ -14,24 +14,24 @@ Might look like:
 ["source","txt",subs="attributes,callouts"]
 ------------------------------------------------------------------------------
 name    component               version   description
-U7321H6 analysis-icu            {qualified_version} The ICU Analysis plugin integrates Lucene ICU module into elasticsearch, adding ICU relates analysis components.
-U7321H6 analysis-kuromoji       {qualified_version} The Japanese (kuromoji) Analysis plugin integrates Lucene kuromoji analysis module into elasticsearch.
-U7321H6 analysis-nori           {qualified_version} The Korean (nori) Analysis plugin integrates Lucene nori analysis module into elasticsearch.
-U7321H6 analysis-phonetic       {qualified_version} The Phonetic Analysis plugin integrates phonetic token filter analysis with elasticsearch.
-U7321H6 analysis-smartcn        {qualified_version} Smart Chinese Analysis plugin integrates Lucene Smart Chinese analysis module into elasticsearch.
-U7321H6 analysis-stempel        {qualified_version} The Stempel (Polish) Analysis plugin integrates Lucene stempel (polish) analysis module into elasticsearch.
-U7321H6 analysis-ukrainian      {qualified_version} The Ukrainian Analysis plugin integrates the Lucene UkrainianMorfologikAnalyzer into elasticsearch.
-U7321H6 discovery-azure-classic {qualified_version} The Azure Classic Discovery plugin allows to use Azure Classic API for the unicast discovery mechanism
-U7321H6 discovery-ec2           {qualified_version} The EC2 discovery plugin allows to use AWS API for the unicast discovery mechanism.
-U7321H6 discovery-gce           {qualified_version} The Google Compute Engine (GCE) Discovery plugin allows to use GCE API for the unicast discovery mechanism.
-U7321H6 ingest-attachment       {qualified_version} Ingest processor that uses Apache Tika to extract contents
-U7321H6 ingest-geoip            {qualified_version} Ingest processor that uses looksup geo data based on ip adresses using the Maxmind geo database
-U7321H6 ingest-user-agent       {qualified_version} Ingest processor that extracts information from a user agent
-U7321H6 mapper-annotated-text   {qualified_version} The Mapper Annotated_text plugin adds support for text fields with markup used to inject annotation tokens into the index.
-U7321H6 mapper-murmur3          {qualified_version} The Mapper Murmur3 plugin allows to compute hashes of a field's values at index-time and to store them in the index.
-U7321H6 mapper-size             {qualified_version} The Mapper Size plugin allows document to record their uncompressed size at index time.
-U7321H6 store-smb               {qualified_version} The Store SMB plugin adds support for SMB stores.
-U7321H6 transport-nio           {qualified_version} The nio transport.
+U7321H6 analysis-icu            {version_qualified} The ICU Analysis plugin integrates Lucene ICU module into elasticsearch, adding ICU relates analysis components.
+U7321H6 analysis-kuromoji       {version_qualified} The Japanese (kuromoji) Analysis plugin integrates Lucene kuromoji analysis module into elasticsearch.
+U7321H6 analysis-nori           {version_qualified} The Korean (nori) Analysis plugin integrates Lucene nori analysis module into elasticsearch.
+U7321H6 analysis-phonetic       {version_qualified} The Phonetic Analysis plugin integrates phonetic token filter analysis with elasticsearch.
+U7321H6 analysis-smartcn        {version_qualified} Smart Chinese Analysis plugin integrates Lucene Smart Chinese analysis module into elasticsearch.
+U7321H6 analysis-stempel        {version_qualified} The Stempel (Polish) Analysis plugin integrates Lucene stempel (polish) analysis module into elasticsearch.
+U7321H6 analysis-ukrainian      {version_qualified} The Ukrainian Analysis plugin integrates the Lucene UkrainianMorfologikAnalyzer into elasticsearch.
+U7321H6 discovery-azure-classic {version_qualified} The Azure Classic Discovery plugin allows to use Azure Classic API for the unicast discovery mechanism
+U7321H6 discovery-ec2           {version_qualified} The EC2 discovery plugin allows to use AWS API for the unicast discovery mechanism.
+U7321H6 discovery-gce           {version_qualified} The Google Compute Engine (GCE) Discovery plugin allows to use GCE API for the unicast discovery mechanism.
+U7321H6 ingest-attachment       {version_qualified} Ingest processor that uses Apache Tika to extract contents
+U7321H6 ingest-geoip            {version_qualified} Ingest processor that uses looksup geo data based on ip adresses using the Maxmind geo database
+U7321H6 ingest-user-agent       {version_qualified} Ingest processor that extracts information from a user agent
+U7321H6 mapper-annotated-text   {version_qualified} The Mapper Annotated_text plugin adds support for text fields with markup used to inject annotation tokens into the index.
+U7321H6 mapper-murmur3          {version_qualified} The Mapper Murmur3 plugin allows to compute hashes of a field's values at index-time and to store them in the index.
+U7321H6 mapper-size             {version_qualified} The Mapper Size plugin allows document to record their uncompressed size at index time.
+U7321H6 store-smb               {version_qualified} The Store SMB plugin adds support for SMB stores.
+U7321H6 transport-nio           {version_qualified} The nio transport.
 ------------------------------------------------------------------------------
 // TESTRESPONSE[s/([.()])/\\$1/ s/U7321H6/.+/ _cat]
 

--- a/docs/reference/setup/install/check-running.asciidoc
+++ b/docs/reference/setup/install/check-running.asciidoc
@@ -24,7 +24,7 @@ which should give you a response something like this:
     "build_hash" : "f27399d",
     "build_date" : "2016-03-30T09:51:41.449Z",
     "build_snapshot" : false,
-    "version_qualified" : "{version_qualified}",
+    "qualified" : "{version_qualified}",
     "lucene_version" : "{lucene_version}",
     "minimum_wire_compatibility_version" : "1.2.3",
     "minimum_index_compatibility_version" : "1.2.3"

--- a/docs/reference/setup/install/check-running.asciidoc
+++ b/docs/reference/setup/install/check-running.asciidoc
@@ -24,7 +24,7 @@ which should give you a response something like this:
     "build_hash" : "f27399d",
     "build_date" : "2016-03-30T09:51:41.449Z",
     "build_snapshot" : false,
-    "build_version" : "{qualified_version}",
+    "version_qualified" : "{version_qualified}",
     "lucene_version" : "{lucene_version}",
     "minimum_wire_compatibility_version" : "1.2.3",
     "minimum_index_compatibility_version" : "1.2.3"

--- a/server/src/main/java/org/elasticsearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/main/MainResponse.java
@@ -113,7 +113,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
             .field("build_hash", build.shortHash())
             .field("build_date", build.date())
             .field("build_snapshot", build.isSnapshot())
-            .field("build_version", build.getQualifiedVersion())
+            .field("version_qualified", build.getQualifiedVersion())
             .field("lucene_version", version.luceneVersion.toString())
             .field("minimum_wire_compatibility_version", version.minimumCompatibilityVersion().toString())
             .field("minimum_index_compatibility_version", version.minimumIndexCompatibilityVersion().toString())
@@ -141,7 +141,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
                             (String) value.get("build_hash"),
                             (String) value.get("build_date"),
                             (boolean) value.get("build_snapshot"),
-                            (String) value.get("build_version")
+                            (String) value.get("version_qualified")
                     );
             response.version = Version.fromString((String) value.get("number"));
         }, (parser, context) -> parser.map(), new ParseField("version"));

--- a/server/src/main/java/org/elasticsearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/main/MainResponse.java
@@ -113,7 +113,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
             .field("build_hash", build.shortHash())
             .field("build_date", build.date())
             .field("build_snapshot", build.isSnapshot())
-            .field("version_qualified", build.getQualifiedVersion())
+            .field("qualified", build.getQualifiedVersion())
             .field("lucene_version", version.luceneVersion.toString())
             .field("minimum_wire_compatibility_version", version.minimumCompatibilityVersion().toString())
             .field("minimum_index_compatibility_version", version.minimumIndexCompatibilityVersion().toString())
@@ -141,7 +141,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
                             (String) value.get("build_hash"),
                             (String) value.get("build_date"),
                             (boolean) value.get("build_snapshot"),
-                            (String) value.get("version_qualified")
+                            (String) value.get("qualified")
                     );
             response.version = Version.fromString((String) value.get("number"));
         }, (parser, context) -> parser.map(), new ParseField("version"));

--- a/server/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
@@ -81,7 +81,7 @@ public class MainResponseTests extends AbstractStreamableXContentTestCase<MainRe
                     + "\"build_hash\":\"" + current.shortHash() + "\","
                     + "\"build_date\":\"" + current.date() + "\","
                     + "\"build_snapshot\":" + current.isSnapshot() + ","
-                    + "\"version_qualified\":\"" + current.getQualifiedVersion() + "\","
+                    + "\"qualified\":\"" + current.getQualifiedVersion() + "\","
                     + "\"lucene_version\":\"" + version.luceneVersion.toString() + "\","
                     + "\"minimum_wire_compatibility_version\":\"" + version.minimumCompatibilityVersion().toString() + "\","
                     + "\"minimum_index_compatibility_version\":\"" + version.minimumIndexCompatibilityVersion().toString() + "\"},"

--- a/server/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
@@ -81,7 +81,7 @@ public class MainResponseTests extends AbstractStreamableXContentTestCase<MainRe
                     + "\"build_hash\":\"" + current.shortHash() + "\","
                     + "\"build_date\":\"" + current.date() + "\","
                     + "\"build_snapshot\":" + current.isSnapshot() + ","
-                    + "\"build_version\":\"" + current.getQualifiedVersion() + "\","
+                    + "\"version_qualified\":\"" + current.getQualifiedVersion() + "\","
                     + "\"lucene_version\":\"" + version.luceneVersion.toString() + "\","
                     + "\"minimum_wire_compatibility_version\":\"" + version.minimumCompatibilityVersion().toString() + "\","
                     + "\"minimum_index_compatibility_version\":\"" + version.minimumIndexCompatibilityVersion().toString() + "\"},"


### PR DESCRIPTION
Replaces the recently added  `version.build_version` with `version.qualified` in the main response. 
We refer to it as `version_qualified` in the doc tests.
