### PR TITLE
[ML] Prevent notifications being created on deletion of a non existent job

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
@@ -64,6 +64,7 @@ import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFiel
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.CategorizerState;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.Quantiles;
+import org.elasticsearch.xpack.ml.job.JobManager;
 import org.elasticsearch.xpack.ml.job.persistence.JobDataDeleter;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 import org.elasticsearch.xpack.ml.notifications.Auditor;
@@ -135,6 +136,8 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
     protected void masterOperation(Task task, DeleteJobAction.Request request, ClusterState state,
                                    ActionListener<AcknowledgedResponse> listener) {
         logger.debug("Deleting job '{}'", request.getJobId());
+
+        JobManager.getJobOrThrowIfUnknown(request.getJobId(), state);
 
         TaskId taskId = new TaskId(clusterService.localNode().getId(), task.getId());
         ParentTaskAssigningClient parentTaskClient = new ParentTaskAssigningClient(client, taskId);

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -461,6 +461,13 @@
   - match: { analysis_limits.model_memory_limit: "30mb" }
 
 ---
+"Test delete job that does not exist":
+  - do:
+      catch: missing
+      xpack.ml.delete_job:
+        job_id: not-a-job
+
+---
 "Test delete job that is referred by a datafeed":
   - do:
       xpack.ml.put_job:


### PR DESCRIPTION
If the job does not exist return a 404 immediately rather than creating audit messages about failing to delete a job that is not there. 

Fixes a bug introduced in #34058 (6.5.0) 

Closes #35336