### PR TITLE
[ML] Job In Index: Enable GET APIS in mixed state

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
@@ -86,8 +86,8 @@ public class MlMetadata implements XPackPlugin.XPackMetaDataCustom {
         return groupOrJobLookup.isGroupOrJob(id);
     }
 
-    public Set<String> expandJobIds(String expression, boolean allowNoJobs) {
-        return groupOrJobLookup.expandJobIds(expression, allowNoJobs);
+    public Set<String> expandJobIds(String expression) {
+        return groupOrJobLookup.expandJobIds(expression);
     }
 
     public boolean isJobDeleting(String jobId) {
@@ -107,9 +107,9 @@ public class MlMetadata implements XPackPlugin.XPackMetaDataCustom {
         return datafeeds.values().stream().filter(s -> s.getJobId().equals(jobId)).findFirst();
     }
 
-    public Set<String> expandDatafeedIds(String expression, boolean allowNoDatafeeds) {
-        return NameResolver.newUnaliased(datafeeds.keySet(), ExceptionsHelper::missingDatafeedException)
-                .expand(expression, allowNoDatafeeds);
+    public Set<String> expandDatafeedIds(String expression) {
+        return NameResolver.newUnaliased(datafeeds.keySet())
+                .expand(expression);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
@@ -90,6 +90,11 @@ public class MlMetadata implements XPackPlugin.XPackMetaDataCustom {
         return groupOrJobLookup.expandJobIds(expression);
     }
 
+    // Matches only groups
+    public Set<String> expandGroupIds(String expression) {
+        return groupOrJobLookup.expandGroupIds(expression);
+    }
+
     public boolean isJobDeleting(String jobId) {
         Job job = jobs.get(jobId);
         return job == null || job.isDeleting();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookup.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookup.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.core.ml.job.groups;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
-import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.ml.utils.NameResolver;
 
 import java.util.ArrayList;
@@ -55,8 +54,8 @@ public class GroupOrJobLookup {
         }
     }
 
-    public Set<String> expandJobIds(String expression, boolean allowNoJobs) {
-        return new GroupOrJobResolver().expand(expression, allowNoJobs);
+    public Set<String> expandJobIds(String expression) {
+        return new GroupOrJobResolver().expand(expression);
     }
 
     public boolean isGroupOrJob(String id) {
@@ -66,7 +65,6 @@ public class GroupOrJobLookup {
     private class GroupOrJobResolver extends NameResolver {
 
         private GroupOrJobResolver() {
-            super(ExceptionsHelper::missingJobException);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookup.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookup.java
@@ -58,6 +58,10 @@ public class GroupOrJobLookup {
         return new GroupOrJobResolver().expand(expression);
     }
 
+    public Set<String> expandGroupIds(String expression) {
+        return new GroupResolver().expand(expression);
+    }
+
     public boolean isGroupOrJob(String id) {
         return groupOrJobLookup.containsKey(id);
     }
@@ -84,6 +88,35 @@ public class GroupOrJobLookup {
         protected List<String> lookup(String key) {
             GroupOrJob groupOrJob = groupOrJobLookup.get(key);
             return groupOrJob == null ? Collections.emptyList() : groupOrJob.jobs().stream().map(Job::getId).collect(Collectors.toList());
+        }
+    }
+
+    private class GroupResolver extends NameResolver {
+
+        private GroupResolver() {
+        }
+
+        @Override
+        protected Set<String> keys() {
+            return nameSet();
+        }
+
+        @Override
+        protected Set<String> nameSet() {
+            return groupOrJobLookup.entrySet().stream()
+                    .filter(entry -> entry.getValue().isGroup())
+                    .map(entry -> entry.getKey())
+                    .collect(Collectors.toSet());
+        }
+
+        @Override
+        protected List<String> lookup(String key) {
+            GroupOrJob groupOrJob = groupOrJobLookup.get(key);
+            if (groupOrJob == null || groupOrJob.isGroup() == false) {
+                return Collections.emptyList();
+            } else {
+                return Collections.singletonList(key);
+            }
         }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookupTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookupTests.java
@@ -92,6 +92,19 @@ public class GroupOrJobLookupTests extends ESTestCase {
         assertFalse(groupOrJobLookup.isGroupOrJob("missing"));
     }
 
+    public void testExpandGroupIds() {
+        List<Job> jobs = new ArrayList<>();
+        jobs.add(mockJob("foo-1", Arrays.asList("foo-group")));
+        jobs.add(mockJob("foo-2", Arrays.asList("foo-group")));
+        jobs.add(mockJob("bar-1", Arrays.asList("bar-group")));
+        jobs.add(mockJob("nogroup", Collections.emptyList()));
+
+        GroupOrJobLookup groupOrJobLookup = new GroupOrJobLookup(jobs);
+        assertThat(groupOrJobLookup.expandGroupIds("foo*"), contains("foo-group"));
+        assertThat(groupOrJobLookup.expandGroupIds("bar-group,nogroup"), contains("bar-group"));
+        assertThat(groupOrJobLookup.expandGroupIds("*"), contains("bar-group", "foo-group"));
+    }
+
     private static Job mockJob(String jobId, List<String> groups) {
         Job job = mock(Job.class);
         when(job.getId()).thenReturn(jobId);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookupTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookupTests.java
@@ -6,46 +6,34 @@
 package org.elasticsearch.xpack.core.ml.job.groups;
 
 import org.elasticsearch.ResourceAlreadyExistsException;
-import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
-import org.elasticsearch.xpack.core.ml.job.groups.GroupOrJobLookup;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.contains;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class GroupOrJobLookupTests extends ESTestCase {
 
-    public void testEmptyLookup_GivenAllowNoJobs() {
+    public void testEmptyLookup() {
         GroupOrJobLookup lookup = new GroupOrJobLookup(Collections.emptyList());
 
-        assertThat(lookup.expandJobIds("_all", true).isEmpty(), is(true));
-        assertThat(lookup.expandJobIds("*", true).isEmpty(), is(true));
-        assertThat(lookup.expandJobIds("foo*", true).isEmpty(), is(true));
-        expectThrows(ResourceNotFoundException.class, () -> lookup.expandJobIds("foo", true));
-    }
-
-    public void testEmptyLookup_GivenNotAllowNoJobs() {
-        GroupOrJobLookup lookup = new GroupOrJobLookup(Collections.emptyList());
-
-        expectThrows(ResourceNotFoundException.class, () -> lookup.expandJobIds("_all", false));
-        expectThrows(ResourceNotFoundException.class, () -> lookup.expandJobIds("*", false));
-        expectThrows(ResourceNotFoundException.class, () -> lookup.expandJobIds("foo*", false));
-        expectThrows(ResourceNotFoundException.class, () -> lookup.expandJobIds("foo", true));
+        assertThat(lookup.expandJobIds("_all").isEmpty(), is(true));
+        assertThat(lookup.expandJobIds("*").isEmpty(), is(true));
+        assertThat(lookup.expandJobIds("foo*").isEmpty(), is(true));
+        assertThat(lookup.expandJobIds("foo").isEmpty(), is(true));
     }
 
     public void testAllIsNotExpandedInCommaSeparatedExpression() {
         GroupOrJobLookup lookup = new GroupOrJobLookup(Collections.emptyList());
-        ResourceNotFoundException e = expectThrows(ResourceNotFoundException.class, () -> lookup.expandJobIds("foo-*,_all", true));
-        assertThat(e.getMessage(), equalTo("No known job with id '_all'"));
+        assertThat(lookup.expandJobIds("foo*,_all").isEmpty(), is(true));
     }
 
     public void testConstructor_GivenJobWithSameIdAsPreviousGroupName() {
@@ -75,19 +63,19 @@ public class GroupOrJobLookupTests extends ESTestCase {
         jobs.add(mockJob("nogroup", Collections.emptyList()));
         GroupOrJobLookup groupOrJobLookup = new GroupOrJobLookup(jobs);
 
-        assertThat(groupOrJobLookup.expandJobIds("_all", false), contains("bar-1", "bar-2", "foo-1", "foo-2", "nogroup"));
-        assertThat(groupOrJobLookup.expandJobIds("*", false), contains("bar-1", "bar-2", "foo-1", "foo-2", "nogroup"));
-        assertThat(groupOrJobLookup.expandJobIds("bar-1", false), contains("bar-1"));
-        assertThat(groupOrJobLookup.expandJobIds("foo-1", false), contains("foo-1"));
-        assertThat(groupOrJobLookup.expandJobIds("foo-2, bar-1", false), contains("bar-1", "foo-2"));
-        assertThat(groupOrJobLookup.expandJobIds("foo-group", false), contains("foo-1", "foo-2"));
-        assertThat(groupOrJobLookup.expandJobIds("bar-group", false), contains("bar-1", "bar-2"));
-        assertThat(groupOrJobLookup.expandJobIds("ones", false), contains("bar-1", "foo-1"));
-        assertThat(groupOrJobLookup.expandJobIds("twos", false), contains("bar-2", "foo-2"));
-        assertThat(groupOrJobLookup.expandJobIds("foo-group, nogroup", false), contains("foo-1", "foo-2", "nogroup"));
-        assertThat(groupOrJobLookup.expandJobIds("*-group", false), contains("bar-1", "bar-2", "foo-1", "foo-2"));
-        assertThat(groupOrJobLookup.expandJobIds("foo-group,foo-1,foo-2", false), contains("foo-1", "foo-2"));
-        assertThat(groupOrJobLookup.expandJobIds("foo-group,*-2", false), contains("bar-2", "foo-1", "foo-2"));
+        assertThat(groupOrJobLookup.expandJobIds("_all"), contains("bar-1", "bar-2", "foo-1", "foo-2", "nogroup"));
+        assertThat(groupOrJobLookup.expandJobIds("*"), contains("bar-1", "bar-2", "foo-1", "foo-2", "nogroup"));
+        assertThat(groupOrJobLookup.expandJobIds("bar-1"), contains("bar-1"));
+        assertThat(groupOrJobLookup.expandJobIds("foo-1"), contains("foo-1"));
+        assertThat(groupOrJobLookup.expandJobIds("foo-2, bar-1"), contains("bar-1", "foo-2"));
+        assertThat(groupOrJobLookup.expandJobIds("foo-group"), contains("foo-1", "foo-2"));
+        assertThat(groupOrJobLookup.expandJobIds("bar-group"), contains("bar-1", "bar-2"));
+        assertThat(groupOrJobLookup.expandJobIds("ones"), contains("bar-1", "foo-1"));
+        assertThat(groupOrJobLookup.expandJobIds("twos"), contains("bar-2", "foo-2"));
+        assertThat(groupOrJobLookup.expandJobIds("foo-group, nogroup"), contains("foo-1", "foo-2", "nogroup"));
+        assertThat(groupOrJobLookup.expandJobIds("*-group"), contains("bar-1", "bar-2", "foo-1", "foo-2"));
+        assertThat(groupOrJobLookup.expandJobIds("foo-group,foo-1,foo-2"), contains("foo-1", "foo-2"));
+        assertThat(groupOrJobLookup.expandJobIds("foo-group,*-2"), contains("bar-2", "foo-1", "foo-2"));
     }
 
     public void testIsGroupOrJob() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
@@ -98,17 +98,12 @@ public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<G
                                                             ClusterState clusterState) {
 
         Map<String, DatafeedConfig> configById = new HashMap<>();
-        try {
-            MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
-            Set<String> expandedDatafeedIds = mlMetadata.expandDatafeedIds(datafeedExpression, allowNoDatafeeds);
+        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
+        Set<String> expandedDatafeedIds = mlMetadata.expandDatafeedIds(datafeedExpression);
 
-            for (String expandedDatafeedId : expandedDatafeedIds) {
-                configById.put(expandedDatafeedId, mlMetadata.getDatafeed(expandedDatafeedId));
-            }
-        } catch (Exception e){
-            // ignore
+        for (String expandedDatafeedId : expandedDatafeedIds) {
+            configById.put(expandedDatafeedId, mlMetadata.getDatafeed(expandedDatafeedId));
         }
-
         return configById;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
@@ -20,18 +20,10 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsAction;
-import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedConfigReader;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<GetDatafeedsAction.Request,
         GetDatafeedsAction.Response> {
@@ -65,46 +57,15 @@ public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<G
                                    ActionListener<GetDatafeedsAction.Response> listener) {
         logger.debug("Get datafeed '{}'", request.getDatafeedId());
 
-        Map<String, DatafeedConfig> clusterStateConfigs =
-                expandClusterStateDatafeeds(request.getDatafeedId(), request.allowNoDatafeeds(), state);
+        DatafeedConfigReader datafeedConfigReader = new DatafeedConfigReader(datafeedConfigProvider);
 
-        datafeedConfigProvider.expandDatafeedConfigs(request.getDatafeedId(), request.allowNoDatafeeds(), ActionListener.wrap(
-                datafeedBuilders -> {
-                    // Check for duplicate datafeeds
-                    for (DatafeedConfig.Builder datafeed : datafeedBuilders) {
-                        if (clusterStateConfigs.containsKey(datafeed.getId())) {
-                            listener.onFailure(new IllegalStateException("Datafeed [" + datafeed.getId() + "] configuration " +
-                                    "exists in both clusterstate and index"));
-                            return;
-                        }
-                    }
-
-                    // Merge cluster state and index configs
-                    List<DatafeedConfig> datafeeds = new ArrayList<>(datafeedBuilders.size() + clusterStateConfigs.values().size());
-                    for (DatafeedConfig.Builder builder: datafeedBuilders) {
-                        datafeeds.add(builder.build());
-                    }
-
-                    datafeeds.addAll(clusterStateConfigs.values());
-                    Collections.sort(datafeeds, Comparator.comparing(DatafeedConfig::getId));
+        datafeedConfigReader.expandDatafeedConfigs(request.getDatafeedId(), request.allowNoDatafeeds(), state, ActionListener.wrap(
+                datafeeds -> {
                     listener.onResponse(new GetDatafeedsAction.Response(new QueryPage<>(datafeeds, datafeeds.size(),
                             DatafeedConfig.RESULTS_FIELD)));
                 },
                 listener::onFailure
         ));
-    }
-
-    Map<String, DatafeedConfig> expandClusterStateDatafeeds(String datafeedExpression, boolean allowNoDatafeeds,
-                                                            ClusterState clusterState) {
-
-        Map<String, DatafeedConfig> configById = new HashMap<>();
-        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
-        Set<String> expandedDatafeedIds = mlMetadata.expandDatafeedIds(datafeedExpression);
-
-        for (String expandedDatafeedId : expandedDatafeedIds) {
-            configById.put(expandedDatafeedId, mlMetadata.getDatafeed(expandedDatafeedId));
-        }
-        return configById;
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
@@ -44,7 +44,7 @@ public class TransportGetDatafeedsStatsAction extends TransportMasterNodeReadAct
                                             Client client,NamedXContentRegistry xContentRegistry) {
         super(settings, GetDatafeedsStatsAction.NAME, transportService, clusterService, threadPool, actionFilters,
                 indexNameExpressionResolver, GetDatafeedsStatsAction.Request::new);
-        this.datafeedConfigReader = new DatafeedConfigReader(client, settings, xContentRegistry);
+        this.datafeedConfigReader = new DatafeedConfigReader(client, xContentRegistry);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
@@ -41,7 +41,7 @@ public class TransportGetDatafeedsStatsAction extends TransportMasterNodeReadAct
                                             ClusterService clusterService, ThreadPool threadPool,
                                             ActionFilters actionFilters,
                                             IndexNameExpressionResolver indexNameExpressionResolver,
-                                            Client client,NamedXContentRegistry xContentRegistry) {
+                                            Client client, NamedXContentRegistry xContentRegistry) {
         super(settings, GetDatafeedsStatsAction.NAME, transportService, clusterService, threadPool, actionFilters,
                 indexNameExpressionResolver, GetDatafeedsStatsAction.Request::new);
         this.datafeedConfigReader = new DatafeedConfigReader(client, xContentRegistry);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml.action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -16,6 +17,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -24,7 +26,7 @@ import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
-import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedConfigReader;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,17 +34,17 @@ import java.util.stream.Collectors;
 public class TransportGetDatafeedsStatsAction extends TransportMasterNodeReadAction<GetDatafeedsStatsAction.Request,
         GetDatafeedsStatsAction.Response> {
 
-    private final DatafeedConfigProvider datafeedConfigProvider;
+    private final DatafeedConfigReader datafeedConfigReader;
 
     @Inject
     public TransportGetDatafeedsStatsAction(Settings settings, TransportService transportService,
                                             ClusterService clusterService, ThreadPool threadPool,
                                             ActionFilters actionFilters,
                                             IndexNameExpressionResolver indexNameExpressionResolver,
-                                            DatafeedConfigProvider datafeedConfigProvider) {
+                                            Client client,NamedXContentRegistry xContentRegistry) {
         super(settings, GetDatafeedsStatsAction.NAME, transportService, clusterService, threadPool, actionFilters,
                 indexNameExpressionResolver, GetDatafeedsStatsAction.Request::new);
-        this.datafeedConfigProvider = datafeedConfigProvider;
+        this.datafeedConfigReader = new DatafeedConfigReader(client, settings, xContentRegistry);
     }
 
     @Override
@@ -57,10 +59,10 @@ public class TransportGetDatafeedsStatsAction extends TransportMasterNodeReadAct
 
     @Override
     protected void masterOperation(GetDatafeedsStatsAction.Request request, ClusterState state,
-                                   ActionListener<GetDatafeedsStatsAction.Response> listener) throws Exception {
+                                   ActionListener<GetDatafeedsStatsAction.Response> listener) {
         logger.debug("Get stats for datafeed '{}'", request.getDatafeedId());
 
-        datafeedConfigProvider.expandDatafeedIds(request.getDatafeedId(), request.allowNoDatafeeds(), ActionListener.wrap(
+        datafeedConfigReader.expandDatafeedIds(request.getDatafeedId(), request.allowNoDatafeeds(), state, ActionListener.wrap(
                 expandedDatafeedIds -> {
                     PersistentTasksCustomMetaData tasksInProgress = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
                     List<GetDatafeedsStatsAction.Response.DatafeedStats> results = expandedDatafeedIds.stream()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
@@ -32,7 +32,7 @@ import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
 import org.elasticsearch.xpack.core.ml.stats.ForecastStats;
-import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
+import org.elasticsearch.xpack.ml.job.JobManager;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager;
 
@@ -54,27 +54,27 @@ public class TransportGetJobsStatsAction extends TransportTasksAction<TransportO
     private final ClusterService clusterService;
     private final AutodetectProcessManager processManager;
     private final JobResultsProvider jobResultsProvider;
-    private final JobConfigProvider jobConfigProvider;
+    private final JobManager jobManager;
 
     @Inject
     public TransportGetJobsStatsAction(Settings settings, TransportService transportService, ThreadPool threadPool,
                                        ActionFilters actionFilters, ClusterService clusterService,
                                        IndexNameExpressionResolver indexNameExpressionResolver,
                                        AutodetectProcessManager processManager, JobResultsProvider jobResultsProvider,
-                                       JobConfigProvider jobConfigProvider) {
+                                       JobManager jobManager) {
         super(settings, GetJobsStatsAction.NAME, threadPool, clusterService, transportService, actionFilters,
                 indexNameExpressionResolver, GetJobsStatsAction.Request::new, GetJobsStatsAction.Response::new,
                 ThreadPool.Names.MANAGEMENT);
         this.clusterService = clusterService;
         this.processManager = processManager;
         this.jobResultsProvider = jobResultsProvider;
-        this.jobConfigProvider = jobConfigProvider;
+        this.jobManager = jobManager;
     }
 
     @Override
     protected void doExecute(Task task, GetJobsStatsAction.Request request, ActionListener<GetJobsStatsAction.Response> finalListener) {
 
-        jobConfigProvider.expandJobsIds(request.getJobId(), request.allowNoJobs(), true, ActionListener.wrap(
+        jobManager.expandJobIds(request.getJobId(), request.allowNoJobs(), ActionListener.wrap(
                 expandedIds -> {
                     request.setExpandedJobsIds(new ArrayList<>(expandedIds));
                     ActionListener<GetJobsStatsAction.Response> jobStatsListener = ActionListener.wrap(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDatafeedAction.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.MachineLearning;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedConfigReader;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 
 import java.io.IOException;
@@ -115,7 +116,8 @@ public class TransportStopDatafeedAction extends TransportTasksAction<TransportS
                         new ActionListenerResponseHandler<>(listener, StopDatafeedAction.Response::new));
             }
         } else {
-            datafeedConfigProvider.expandDatafeedIds(request.getDatafeedId(), request.allowNoDatafeeds(), ActionListener.wrap(
+            DatafeedConfigReader datafeedConfigReader = new DatafeedConfigReader(datafeedConfigProvider);
+            datafeedConfigReader.expandDatafeedIds(request.getDatafeedId(), request.allowNoDatafeeds(), state, ActionListener.wrap(
                     expandedIds -> {
                         PersistentTasksCustomMetaData tasks = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
@@ -40,7 +40,7 @@ public class DatafeedConfigReader {
     }
 
     /**
-     * Merges the results of {@Link MlMetadata#expandDatafeedIds}
+     * Merges the results of {@link MlMetadata#expandDatafeedIds}
      * and {@link DatafeedConfigProvider#expandDatafeedIds(String, boolean, ActionListener)}
      */
     public void expandDatafeedIds(String expression, boolean allowNoDatafeeds, ClusterState clusterState,
@@ -75,7 +75,7 @@ public class DatafeedConfigReader {
     }
 
     /**
-     * Merges the results of {@Link MlMetadata#expandDatafeedIds}
+     * Merges the results of {@link MlMetadata#expandDatafeedIds}
      * and {@link DatafeedConfigProvider#expandDatafeedConfigs(String, boolean, ActionListener)}
      */
     public void expandDatafeedConfigs(String expression, boolean allowNoDatafeeds, ClusterState clusterState,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.datafeed;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
@@ -32,8 +31,8 @@ public class DatafeedConfigReader {
 
     private final DatafeedConfigProvider datafeedConfigProvider;
 
-    public DatafeedConfigReader(Client client, Settings settings, NamedXContentRegistry xContentRegistry) {
-        this.datafeedConfigProvider = new DatafeedConfigProvider(client, settings, xContentRegistry);
+    public DatafeedConfigReader(Client client, NamedXContentRegistry xContentRegistry) {
+        this.datafeedConfigProvider = new DatafeedConfigProvider(client, xContentRegistry);
     }
 
     public DatafeedConfigReader(DatafeedConfigProvider datafeedConfigProvider) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
@@ -16,6 +16,8 @@ import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.ExpandedIdsMatcher;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -108,6 +110,7 @@ public class DatafeedConfigReader {
                         listener.onFailure(ExceptionsHelper.missingDatafeedException(requiredMatches.unmatchedIdsString()));
                     } else {
                         datafeedConfigs.addAll(clusterStateConfigs.values());
+                        Collections.sort(datafeedConfigs, Comparator.comparing(DatafeedConfig::getId));
                         listener.onResponse(datafeedConfigs);
                     }
                 },

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
@@ -16,11 +16,11 @@ import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.ExpandedIdsMatcher;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -116,14 +116,8 @@ public class DatafeedConfigReader {
     }
 
     private Map<String, DatafeedConfig> expandClusterStateDatafeeds(String datafeedExpression, ClusterState clusterState) {
-
-        Map<String, DatafeedConfig> configById = new HashMap<>();
         MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
         Set<String> expandedDatafeedIds = mlMetadata.expandDatafeedIds(datafeedExpression);
-
-        for (String expandedDatafeedId : expandedDatafeedIds) {
-            configById.put(expandedDatafeedId, mlMetadata.getDatafeed(expandedDatafeedId));
-        }
-        return configById;
+        return expandedDatafeedIds.stream().collect(Collectors.toMap(Function.identity(), mlMetadata::getDatafeed));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.datafeed;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xpack.core.ml.MlMetadata;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
+import org.elasticsearch.xpack.ml.job.persistence.ExpandedIdsMatcher;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
+
+/**
+ * This class abstracts away reading datafeed configuration from either
+ * the cluster state or index documents.
+ */
+public class DatafeedConfigReader {
+
+    private final DatafeedConfigProvider datafeedConfigProvider;
+
+    public DatafeedConfigReader(Client client, Settings settings, NamedXContentRegistry xContentRegistry) {
+        this.datafeedConfigProvider = new DatafeedConfigProvider(client, settings, xContentRegistry);
+    }
+
+    public DatafeedConfigReader(DatafeedConfigProvider datafeedConfigProvider) {
+        this.datafeedConfigProvider = datafeedConfigProvider;
+    }
+
+    /**
+     * Merges the results of {@Link MlMetadata#expandDatafeedIds}
+     * and {@link DatafeedConfigProvider#expandDatafeedIds(String, boolean, ActionListener)}
+     */
+    public void expandDatafeedIds(String expression, boolean allowNoDatafeeds, ClusterState clusterState,
+                                  ActionListener<SortedSet<String>> listener) {
+
+        Set<String> clusterStateDatafeedIds = MlMetadata.getMlMetadata(clusterState).expandDatafeedIds(expression);
+        ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(expression, allowNoDatafeeds);
+        requiredMatches.filterMatchedIds(clusterStateDatafeedIds);
+
+        datafeedConfigProvider.expandDatafeedIdsWithoutMissingCheck(expression, ActionListener.wrap(
+                expandedDatafeedIds -> {
+                    // Check for duplicate Ids
+                    expandedDatafeedIds.forEach(id -> {
+                        if (clusterStateDatafeedIds.contains(id)) {
+                            listener.onFailure(new IllegalStateException("Datafeed [" + id + "] configuration " +
+                                    "exists in both clusterstate and index"));
+                            return;
+                        }
+                    });
+
+                    requiredMatches.filterMatchedIds(expandedDatafeedIds);
+
+                    if (requiredMatches.hasUnmatchedIds()) {
+                        listener.onFailure(ExceptionsHelper.missingDatafeedException(requiredMatches.unmatchedIdsString()));
+                    } else {
+                        expandedDatafeedIds.addAll(clusterStateDatafeedIds);
+                        listener.onResponse(expandedDatafeedIds);
+                    }
+                },
+               listener::onFailure
+        ));
+    }
+
+    /**
+     * Merges the results of {@Link MlMetadata#expandDatafeedIds}
+     * and {@link DatafeedConfigProvider#expandDatafeedConfigs(String, boolean, ActionListener)}
+     */
+    public void expandDatafeedConfigs(String expression, boolean allowNoDatafeeds, ClusterState clusterState,
+                                      ActionListener<List<DatafeedConfig>> listener) {
+
+        Map<String, DatafeedConfig> clusterStateConfigs = expandClusterStateDatafeeds(expression, clusterState);
+
+        ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(expression, allowNoDatafeeds);
+        requiredMatches.filterMatchedIds(clusterStateConfigs.keySet());
+
+        datafeedConfigProvider.expandDatafeedConfigsWithoutMissingCheck(expression, ActionListener.wrap(
+                datafeedBuilders -> {
+                    // Check for duplicate Ids
+                    datafeedBuilders.forEach(datafeedBuilder -> {
+                        if (clusterStateConfigs.containsKey(datafeedBuilder.getId())) {
+                            listener.onFailure(new IllegalStateException("Datafeed [" + datafeedBuilder.getId() + "] configuration " +
+                                    "exists in both clusterstate and index"));
+                            return;
+                        }
+                    });
+
+                    List<DatafeedConfig> datafeedConfigs = new ArrayList<>();
+                    for (DatafeedConfig.Builder builder : datafeedBuilders) {
+                        datafeedConfigs.add(builder.build());
+                    }
+
+                    requiredMatches.filterMatchedIds(datafeedConfigs.stream().map(DatafeedConfig::getId).collect(Collectors.toList()));
+
+                    if (requiredMatches.hasUnmatchedIds()) {
+                        listener.onFailure(ExceptionsHelper.missingDatafeedException(requiredMatches.unmatchedIdsString()));
+                    } else {
+                        datafeedConfigs.addAll(clusterStateConfigs.values());
+                        listener.onResponse(datafeedConfigs);
+                    }
+                },
+                listener::onFailure
+        ));
+    }
+
+    private Map<String, DatafeedConfig> expandClusterStateDatafeeds(String datafeedExpression, ClusterState clusterState) {
+
+        Map<String, DatafeedConfig> configById = new HashMap<>();
+        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
+        Set<String> expandedDatafeedIds = mlMetadata.expandDatafeedIds(datafeedExpression);
+
+        for (String expandedDatafeedId : expandedDatafeedIds) {
+            configById.put(expandedDatafeedId, mlMetadata.getDatafeed(expandedDatafeedId));
+        }
+        return configById;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -276,13 +276,13 @@ public class JobManager {
         jobConfigProvider.expandJobsIdsWithoutMissingCheck(expression, false, ActionListener.wrap(
                 jobIdsAndGroups -> {
                     // Check for duplicate job Ids
-                    jobIdsAndGroups.getJobs().forEach(id -> {
+                    for (String id : jobIdsAndGroups.getJobs()) {
                         if (clusterStateJobIds.contains(id)) {
                             jobsListener.onFailure(new IllegalStateException("Job [" + id + "] configuration " +
                                     "exists in both clusterstate and index"));
                             return;
                         }
-                    });
+                    }
 
                     requiredMatches.filterMatchedIds(jobIdsAndGroups.getJobs());
                     requiredMatches.filterMatchedIds(jobIdsAndGroups.getGroups());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/ExpandedIdsMatcher.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/ExpandedIdsMatcher.java
@@ -45,6 +45,18 @@ public final class ExpandedIdsMatcher {
     private final LinkedList<IdMatcher> requiredMatches;
 
     /**
+     * Generate the list of required matches from {@code tokenExpression} and initialize.
+     *
+     * @param tokenExpression           Token expression string will be split by {@link #tokenizeExpression(String)}
+     * @param allowNoMatchForWildcards  If true then it is not required for wildcard
+     *                                  expressions to match an Id meaning they are
+     *                                  not returned in the list of required matches
+     */
+    public ExpandedIdsMatcher(String tokenExpression, boolean allowNoMatchForWildcards) {
+        this(ExpandedIdsMatcher.tokenizeExpression(tokenExpression), allowNoMatchForWildcards);
+    }
+
+    /**
      * Generate the list of required matches from the expressions in {@code tokens}
      * and initialize.
      *

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
@@ -537,17 +537,9 @@ public class JobConfigProvider {
      * @param listener The expanded job Ids listener
      */
     public void expandJobsIds(String expression, boolean allowNoJobs, boolean excludeDeleting, ActionListener<SortedSet<String>> listener) {
+        SearchRequest searchRequest = makeExpandIdsSearchRequest(expression, excludeDeleting);
+
         String [] tokens = ExpandedIdsMatcher.tokenizeExpression(expression);
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildQuery(tokens, excludeDeleting));
-        sourceBuilder.sort(Job.ID.getPreferredName());
-        sourceBuilder.fetchSource(false);
-        sourceBuilder.docValueField(Job.ID.getPreferredName(), DocValueFieldsContext.USE_DEFAULT_FORMAT);
-        sourceBuilder.docValueField(Job.GROUPS.getPreferredName(), DocValueFieldsContext.USE_DEFAULT_FORMAT);
-
-        SearchRequest searchRequest = client.prepareSearch(AnomalyDetectorsIndex.configIndexName())
-                .setIndicesOptions(IndicesOptions.lenientExpandOpen())
-                .setSource(sourceBuilder).request();
-
         ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(tokens, allowNoJobs);
 
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, searchRequest,
@@ -577,6 +569,55 @@ public class JobConfigProvider {
                         listener::onFailure)
                 , client::search);
 
+    }
+
+    /**
+     * Similar to {@link #expandJobsIds(String, boolean, boolean, ActionListener)} but no error
+     * is generated if there are missing Ids. Whatever Ids match will be returned.
+     *
+     * This method is only for use when combining jobs Ids from multiple sources, its usage
+     * should be limited.
+     *
+     * @param expression the expression to resolve
+     * @param excludeDeleting If true exclude jobs marked as deleting
+     * @param listener The expanded job Ids listener
+     */
+    public void expandJobsIdsWithoutMissingCheck(String expression, boolean excludeDeleting, ActionListener<SortedSet<String>> listener) {
+
+        SearchRequest searchRequest = makeExpandIdsSearchRequest(expression, excludeDeleting);
+        executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, searchRequest,
+                ActionListener.<SearchResponse>wrap(
+                        response -> {
+                            SortedSet<String> jobIds = new TreeSet<>();
+                            SortedSet<String> groupsIds = new TreeSet<>();
+                            SearchHit[] hits = response.getHits().getHits();
+                            for (SearchHit hit : hits) {
+                                jobIds.add(hit.field(Job.ID.getPreferredName()).getValue());
+                                List<Object> groups = hit.field(Job.GROUPS.getPreferredName()).getValues();
+                                if (groups != null) {
+                                    groupsIds.addAll(groups.stream().map(Object::toString).collect(Collectors.toList()));
+                                }
+                            }
+
+                            groupsIds.addAll(jobIds);
+                            listener.onResponse(jobIds);
+                        },
+                        listener::onFailure)
+                , client::search);
+
+    }
+
+    private SearchRequest makeExpandIdsSearchRequest(String expression, boolean excludeDeleting) {
+        String [] tokens = ExpandedIdsMatcher.tokenizeExpression(expression);
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildQuery(tokens, excludeDeleting));
+        sourceBuilder.sort(Job.ID.getPreferredName());
+        sourceBuilder.fetchSource(false);
+        sourceBuilder.docValueField(Job.ID.getPreferredName(), DocValueFieldsContext.USE_DEFAULT_FORMAT);
+        sourceBuilder.docValueField(Job.GROUPS.getPreferredName(), DocValueFieldsContext.USE_DEFAULT_FORMAT);
+
+        return client.prepareSearch(AnomalyDetectorsIndex.configIndexName())
+                .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+                .setSource(sourceBuilder).request();
     }
 
     /**
@@ -629,6 +670,54 @@ public class JobConfigProvider {
                                 // some required jobs were not found
                                 listener.onFailure(ExceptionsHelper.missingJobException(requiredMatches.unmatchedIdsString()));
                                 return;
+                            }
+
+                            listener.onResponse(jobs);
+                        },
+                        listener::onFailure)
+                , client::search);
+
+    }
+
+    /**
+     * The same logic as {@link #expandJobsIdsWithoutMissingCheck(String, boolean, ActionListener)}
+     * but the full anomaly detector job configuration is returned.
+     *
+     * This method is only for use when combining jobs from multiple sources, its usage
+     * should be limited.
+     *
+     * @param expression the expression to resolve
+     * @param excludeDeleting If true exclude jobs marked as deleting
+     * @param listener The expanded jobs listener
+     */
+    // NORELEASE jobs should be paged or have a mechanism to return all jobs if there are many of them
+    public void expandJobsWithoutMissingcheck(String expression, boolean excludeDeleting, ActionListener<List<Job.Builder>> listener) {
+        String [] tokens = ExpandedIdsMatcher.tokenizeExpression(expression);
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildQuery(tokens, excludeDeleting));
+        sourceBuilder.sort(Job.ID.getPreferredName());
+
+        SearchRequest searchRequest = client.prepareSearch(AnomalyDetectorsIndex.configIndexName())
+                .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+                .setSource(sourceBuilder).request();
+
+        executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, searchRequest,
+                ActionListener.<SearchResponse>wrap(
+                        response -> {
+                            List<Job.Builder> jobs = new ArrayList<>();
+                            Set<String> jobAndGroupIds = new HashSet<>();
+
+                            SearchHit[] hits = response.getHits().getHits();
+                            for (SearchHit hit : hits) {
+                                try {
+                                    BytesReference source = hit.getSourceRef();
+                                    Job.Builder job = parseJobLenientlyFromSource(source);
+                                    jobs.add(job);
+                                    jobAndGroupIds.add(job.getId());
+                                    jobAndGroupIds.addAll(job.getGroups());
+                                } catch (IOException e) {
+                                    // TODO A better way to handle this rather than just ignoring the error?
+                                    logger.error("Error parsing anomaly detector job configuration [" + hit.getId() + "]", e);
+                                }
                             }
 
                             listener.onResponse(jobs);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlMetadataTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlMetadataTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractSerializingTestCase;
@@ -27,7 +28,6 @@ import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.config.JobTests;
-import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationServiceField;
 
 import java.util.Collections;
@@ -35,8 +35,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
 import static org.elasticsearch.persistent.PersistentTasksCustomMetaData.INITIAL_ASSIGNMENT;
+import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
 import static org.elasticsearch.xpack.ml.action.TransportOpenJobActionTests.addJobTask;
 import static org.elasticsearch.xpack.ml.datafeed.DatafeedManagerTests.createDatafeedConfig;
 import static org.elasticsearch.xpack.ml.datafeed.DatafeedManagerTests.createDatafeedJob;
@@ -397,10 +397,10 @@ public class MlMetadataTests extends AbstractSerializingTestCase<MlMetadata> {
     public void testExpandJobIds() {
         MlMetadata mlMetadata = newMlMetadataWithJobs("bar-1", "foo-1", "foo-2").build();
 
-        assertThat(mlMetadata.expandJobIds("_all", false), contains("bar-1", "foo-1", "foo-2"));
-        assertThat(mlMetadata.expandJobIds("*", false), contains("bar-1", "foo-1", "foo-2"));
-        assertThat(mlMetadata.expandJobIds("foo-*", false), contains("foo-1", "foo-2"));
-        assertThat(mlMetadata.expandJobIds("foo-1,bar-*", false), contains("bar-1", "foo-1"));
+        assertThat(mlMetadata.expandJobIds("_all"), contains("bar-1", "foo-1", "foo-2"));
+        assertThat(mlMetadata.expandJobIds("*"), contains("bar-1", "foo-1", "foo-2"));
+        assertThat(mlMetadata.expandJobIds("foo-*"), contains("foo-1", "foo-2"));
+        assertThat(mlMetadata.expandJobIds("foo-1,bar-*"), contains("bar-1", "foo-1"));
     }
 
     public void testExpandDatafeedIds() {
@@ -411,10 +411,10 @@ public class MlMetadataTests extends AbstractSerializingTestCase<MlMetadata> {
         MlMetadata mlMetadata = mlMetadataBuilder.build();
 
 
-        assertThat(mlMetadata.expandDatafeedIds("_all", false), contains("bar-1-feed", "foo-1-feed", "foo-2-feed"));
-        assertThat(mlMetadata.expandDatafeedIds("*", false), contains("bar-1-feed", "foo-1-feed", "foo-2-feed"));
-        assertThat(mlMetadata.expandDatafeedIds("foo-*", false), contains("foo-1-feed", "foo-2-feed"));
-        assertThat(mlMetadata.expandDatafeedIds("foo-1-feed,bar-1*", false), contains("bar-1-feed", "foo-1-feed"));
+        assertThat(mlMetadata.expandDatafeedIds("_all"), contains("bar-1-feed", "foo-1-feed", "foo-2-feed"));
+        assertThat(mlMetadata.expandDatafeedIds("*"), contains("bar-1-feed", "foo-1-feed", "foo-2-feed"));
+        assertThat(mlMetadata.expandDatafeedIds("foo-*"), contains("foo-1-feed", "foo-2-feed"));
+        assertThat(mlMetadata.expandDatafeedIds("foo-1-feed,bar-1*"), contains("bar-1-feed", "foo-1-feed"));
     }
 
     private static MlMetadata.Builder newMlMetadataWithJobs(String... jobIds) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReaderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReaderTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.SortedSet;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReaderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReaderTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.datafeed;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.MlMetadata;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
+import static org.hamcrest.Matchers.contains;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+public class DatafeedConfigReaderTests extends ESTestCase {
+
+    private final String JOB_ID = "foo";
+
+    private void mockProviderWithExpectedIds(DatafeedConfigProvider mockedProvider, String expression, SortedSet<String> datafeedIds) {
+        doAnswer(invocationOnMock -> {
+            ActionListener<SortedSet<String>> listener = (ActionListener<SortedSet<String>>) invocationOnMock.getArguments()[1];
+            listener.onResponse(datafeedIds);
+            return null;
+        }).when(mockedProvider).expandDatafeedIdsWithoutMissingCheck(eq(expression), any());
+    }
+
+    public void testExpandDatafeedIds_SplitBetweenClusterStateAndIndex() {
+        SortedSet<String> idsInIndex = new TreeSet<>();
+        idsInIndex.add("index-df");
+        DatafeedConfigProvider provider = mock(DatafeedConfigProvider.class);
+        mockProviderWithExpectedIds(provider, "cs-df,index-df", idsInIndex);
+
+        ClusterState clusterState = buildClusterStateWithJob(Collections.singletonList(createDatafeedConfig("cs-df", JOB_ID)));
+
+        DatafeedConfigReader reader = new DatafeedConfigReader(provider);
+
+        AtomicReference<SortedSet<String>> idsHolder = new AtomicReference<>();
+        reader.expandDatafeedIds("cs-df,index-df", true, clusterState, ActionListener.wrap(
+                idsHolder::set,
+                e -> fail(e.getMessage())
+        ));
+        assertNotNull(idsHolder.get());
+        assertThat(idsHolder.get(), contains("cs-df", "index-df"));
+
+        mockProviderWithExpectedIds(provider, "cs-df", new TreeSet<>());
+        reader.expandDatafeedIds("cs-df", true, clusterState, ActionListener.wrap(
+                idsHolder::set,
+                e -> assertNull(e)
+        ));
+        assertThat(idsHolder.get(), contains("cs-df"));
+
+        idsInIndex.clear();
+        idsInIndex.add("index-df");
+        mockProviderWithExpectedIds(provider, "index-df", idsInIndex);
+        reader.expandDatafeedIds("index-df", true, clusterState, ActionListener.wrap(
+                idsHolder::set,
+                e -> assertNull(e)
+        ));
+        assertThat(idsHolder.get(), contains("index-df"));
+
+    }
+
+    public void testExpandDatafeedIds_GivenAll() {
+        SortedSet<String> idsInIndex = new TreeSet<>();
+        idsInIndex.add("df1");
+        idsInIndex.add("df2");
+        DatafeedConfigProvider provider = mock(DatafeedConfigProvider.class);
+        mockProviderWithExpectedIds(provider, "_all", idsInIndex);
+
+        ClusterState clusterState = buildClusterStateWithJob(Collections.singletonList(createDatafeedConfig("df3", JOB_ID)));
+
+        DatafeedConfigReader reader = new DatafeedConfigReader(provider);
+
+        AtomicReference<SortedSet<String>> idsHolder = new AtomicReference<>();
+        reader.expandDatafeedIds("_all", true, clusterState, ActionListener.wrap(
+                idsHolder::set,
+                e -> fail(e.getMessage())
+        ));
+
+        assertNotNull(idsHolder.get());
+        assertThat(idsHolder.get(), contains("df1", "df2", "df3"));
+    }
+
+    private ClusterState buildClusterStateWithJob(List<DatafeedConfig> datafeeds) {
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder();
+        mlMetadata.putJob(buildJobBuilder(JOB_ID).build(), false);
+        for (DatafeedConfig df : datafeeds) {
+            mlMetadata.putDatafeed(df, Collections.emptyMap());
+        }
+
+        return ClusterState.builder(new ClusterName("datafeedconfigreadertests"))
+                .metaData(MetaData.builder()
+                        .putCustom(MlMetadata.TYPE, mlMetadata.build()))
+                .build();
+    }
+
+    private DatafeedConfig createDatafeedConfig(String id, String jobId) {
+        DatafeedConfig.Builder builder = new DatafeedConfig.Builder(id, jobId);
+        builder.setIndices(Collections.singletonList("beats*"));
+        return builder.build();
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobConfigProviderIT.java
@@ -437,6 +437,50 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
         assertThat(expandedJobsBuilders, hasSize(3));
     }
 
+    public void testExpandJobsIdsWithoutMissingCheck() throws Exception {
+        putJob(createJob("tom", null));
+        putJob(createJob("dick", null));
+        putJob(createJob("harry", Collections.singletonList("harry-group")));
+        putJob(createJob("harry-jnr", Collections.singletonList("harry-group")));
+
+        client().admin().indices().prepareRefresh(AnomalyDetectorsIndex.configIndexName()).get();
+
+        SortedSet<String> expandedIds = blockingCall(actionListener ->
+                jobConfigProvider.expandJobsIdsWithoutMissingCheck("dick,john", false, actionListener));
+        assertEquals(new TreeSet<>(Collections.singletonList("dick")), expandedIds);
+
+        expandedIds = blockingCall(actionListener -> jobConfigProvider.expandJobsIdsWithoutMissingCheck("foo*", true, actionListener));
+        assertThat(expandedIds, empty());
+
+        expandedIds = blockingCall(actionListener ->
+                jobConfigProvider.expandJobsIdsWithoutMissingCheck("harry-group,dave", false, actionListener));
+        assertEquals(new TreeSet<>(Arrays.asList("harry", "harry-jnr")), expandedIds);
+    }
+
+    public void testExpandJobsWithoutMissingCheck() throws Exception {
+        putJob(createJob("tom", null));
+        putJob(createJob("dick", null));
+        putJob(createJob("harry", Collections.singletonList("harry-group")));
+        putJob(createJob("harry-jnr", Collections.singletonList("harry-group")));
+
+        client().admin().indices().prepareRefresh(AnomalyDetectorsIndex.configIndexName()).get();
+
+        List<Job.Builder> expandedJobsBuilders =
+                blockingCall(actionListener -> jobConfigProvider.expandJobsWithoutMissingcheck("dick,john", true, actionListener));
+        List<String> expandedJobIds = expandedJobsBuilders.stream().map(Job.Builder::build).map(Job::getId).collect(Collectors.toList());
+        assertThat(expandedJobIds, contains("dick"));
+
+        expandedJobsBuilders = blockingCall(actionListener ->
+                jobConfigProvider.expandJobsWithoutMissingcheck("foo*", true, actionListener));
+        expandedJobIds = expandedJobsBuilders.stream().map(Job.Builder::build).map(Job::getId).collect(Collectors.toList());
+        assertThat(expandedJobIds, empty());
+
+        expandedJobsBuilders = blockingCall(actionListener ->
+                jobConfigProvider.expandJobsWithoutMissingcheck("harry-group,dave", true, actionListener));
+        expandedJobIds = expandedJobsBuilders.stream().map(Job.Builder::build).map(Job::getId).collect(Collectors.toList());
+        assertThat(expandedJobIds, contains("harry", "harry-jnr"));
+    }
+
     public void testExpandGroups() throws Exception {
         putJob(createJob("apples", Collections.singletonList("fruit")));
         putJob(createJob("pears", Collections.singletonList("fruit")));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobConfigProviderIT.java
@@ -445,16 +445,19 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
 
         client().admin().indices().prepareRefresh(AnomalyDetectorsIndex.configIndexName()).get();
 
-        SortedSet<String> expandedIds = blockingCall(actionListener ->
+        JobConfigProvider.JobIdsAndGroups expandedIds = blockingCall(actionListener ->
                 jobConfigProvider.expandJobsIdsWithoutMissingCheck("dick,john", false, actionListener));
-        assertEquals(new TreeSet<>(Collections.singletonList("dick")), expandedIds);
+        assertEquals(new TreeSet<>(Collections.singletonList("dick")), expandedIds.getJobs());
+        assertThat(expandedIds.getGroups(), empty());
 
         expandedIds = blockingCall(actionListener -> jobConfigProvider.expandJobsIdsWithoutMissingCheck("foo*", true, actionListener));
-        assertThat(expandedIds, empty());
+        assertThat(expandedIds.getJobs(), empty());
+        assertThat(expandedIds.getGroups(), empty());
 
         expandedIds = blockingCall(actionListener ->
                 jobConfigProvider.expandJobsIdsWithoutMissingCheck("harry-group,dave", false, actionListener));
-        assertEquals(new TreeSet<>(Arrays.asList("harry", "harry-jnr")), expandedIds);
+        assertEquals(new TreeSet<>(Arrays.asList("harry", "harry-jnr")), expandedIds.getJobs());
+        assertEquals(new TreeSet<>(Arrays.asList("harry-group")), expandedIds.getGroups());
     }
 
     public void testExpandJobsWithoutMissingCheck() throws Exception {


### PR DESCRIPTION
Jobs left open during an upgrade to 6.6 will not be migrated so this version must support running jobs that are stored in either the cluster state or index documents. New jobs will be stored as documents but old jobs will continue to run from the clusterstate. To achieve this the job and datafeed operations should look in both the clusterstate and the index for the configuration, this is the first change towards that goal and covers reading the configurations. 

- JobManager getJob/expandJob checks both cluster state and index
- Added `DatafeedConfigReader` as a wrapper around DatafeedConfigProvider but checks both cluster state and index for configuration

All methods to get the configs go through these 2 classes. 

This meant I had to change `NameResolver` to not throw on missing jobs as I now collect the clusterstate and index jobs and use `ExpandedIdsMatcher` to check the required job ids, datafeed ids and job groups are present. 

Rolling upgrade tests to follow but this is already a large PR

