### PR TITLE
Remove ALL shard check in CheckShrinkReadyStep

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/CheckShrinkReadyStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/CheckShrinkReadyStep.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.core.indexlifecycle;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
@@ -52,12 +51,6 @@ public class CheckShrinkReadyStep extends ClusterStateWaitStep {
 
         // How many shards the node should have
         int expectedShardCount = idxMeta.getNumberOfShards();
-
-        if (ActiveShardCount.ALL.enoughShardsActive(clusterState, index.getName()) == false) {
-            logger.debug("[{}] shrink action for [{}] cannot make progress because not all shards are active",
-                getKey().getAction(), index.getName());
-            return new Result(false, new CheckShrinkReadyStep.Info("", expectedShardCount, -1));
-        }
 
         // The id of the node the shards should be on
         final String idShardsShouldBeOn = idxMeta.getSettings().get(IndexMetaData.INDEX_ROUTING_REQUIRE_GROUP_PREFIX + "._id");


### PR DESCRIPTION
Since it's still possible to shrink an index when replicas are unassigned, we
should not check that all copies are available when performing the shrink, since
we set the allocation requirement for a single node.

Resolves #35321
