### PR TITLE
Refactor realm tests to use single settings 

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
@@ -102,7 +102,10 @@ public class LdapRealmTests extends LdapTestCase {
     public void testAuthenticateSubTreeGroupSearch() throws Exception {
         String groupSearchBase = "o=sevenSeas";
         String userTemplate = VALID_USER_TEMPLATE;
-        Settings settings = buildLdapSettings(ldapUrls(), userTemplate, groupSearchBase, LdapSearchScope.SUB_TREE);
+        Settings settings = Settings.builder()
+            .put(defaultGlobalSettings)
+            .put(buildLdapSettings(ldapUrls(), userTemplate, groupSearchBase, LdapSearchScope.SUB_TREE))
+            .build();
         RealmConfig config = getRealmConfig(REALM_IDENTIFIER, settings);
         LdapSessionFactory ldapFactory = new LdapSessionFactory(config, sslService, threadPool);
         LdapRealm ldap = new LdapRealm(config, ldapFactory, buildGroupAsRoleMapper(resourceWatcherService),
@@ -123,15 +126,15 @@ public class LdapRealmTests extends LdapTestCase {
     }
 
     private RealmConfig getRealmConfig(RealmConfig.RealmIdentifier identifier, Settings settings) {
-        final Settings globalSettings = mergeSettings(settings, defaultGlobalSettings);
-        final Environment env = TestEnvironment.newEnvironment(globalSettings);
-        return new RealmConfig(identifier, globalSettings, env, new ThreadContext(globalSettings));
+        final Environment env = TestEnvironment.newEnvironment(settings);
+        return new RealmConfig(identifier, settings, env, new ThreadContext(settings));
     }
 
     public void testAuthenticateOneLevelGroupSearch() throws Exception {
         String groupSearchBase = "ou=crews,ou=groups,o=sevenSeas";
         String userTemplate = VALID_USER_TEMPLATE;
         Settings settings = Settings.builder()
+                .put(defaultGlobalSettings)
                 .put(buildLdapSettings(ldapUrls(), userTemplate, groupSearchBase, LdapSearchScope.ONE_LEVEL))
                 .build();
         RealmConfig config = getRealmConfig(REALM_IDENTIFIER, settings);
@@ -158,6 +161,7 @@ public class LdapRealmTests extends LdapTestCase {
         String groupSearchBase = "o=sevenSeas";
         String userTemplate = VALID_USER_TEMPLATE;
         Settings settings = Settings.builder()
+                .put(defaultGlobalSettings)
                 .put(buildLdapSettings(ldapUrls(), userTemplate, groupSearchBase, LdapSearchScope.SUB_TREE))
                 .build();
         RealmConfig config = getRealmConfig(REALM_IDENTIFIER, settings);
@@ -185,6 +189,7 @@ public class LdapRealmTests extends LdapTestCase {
         String userTemplate = VALID_USER_TEMPLATE;
         Settings settings = Settings.builder()
                 .put(buildLdapSettings(ldapUrls(), userTemplate, groupSearchBase, LdapSearchScope.SUB_TREE))
+                .put(defaultGlobalSettings)
                 .build();
         RealmConfig config = getRealmConfig(REALM_IDENTIFIER, settings);
 
@@ -218,6 +223,7 @@ public class LdapRealmTests extends LdapTestCase {
         String groupSearchBase = "o=sevenSeas";
         String userTemplate = VALID_USER_TEMPLATE;
         Settings settings = Settings.builder()
+                .put(defaultGlobalSettings)
                 .put(buildLdapSettings(ldapUrls(), userTemplate, groupSearchBase, LdapSearchScope.SUB_TREE))
                 .put(getFullSettingKey(REALM_IDENTIFIER, CachingUsernamePasswordRealmSettings.CACHE_TTL_SETTING), -1)
                 .build();
@@ -287,6 +293,7 @@ public class LdapRealmTests extends LdapTestCase {
         String groupSearchBase = "o=sevenSeas";
         String userTemplate = VALID_USER_TEMPLATE;
         Settings settings = Settings.builder()
+                .put(defaultGlobalSettings)
                 .putList(getFullSettingKey(identifier, URLS_SETTING), ldapUrls())
                 .putList(getFullSettingKey(identifier.getName(), LdapSessionFactorySettings.USER_DN_TEMPLATES_SETTING), userTemplate)
                 .put(getFullSettingKey(identifier, SearchGroupsResolverSettings.BASE_DN), groupSearchBase)
@@ -326,6 +333,7 @@ public class LdapRealmTests extends LdapTestCase {
         final RealmConfig.RealmIdentifier identifier
                 = new RealmConfig.RealmIdentifier(LdapRealmSettings.LDAP_TYPE, "test-ldap-realm-user-search");
         Settings settings = Settings.builder()
+                .put(defaultGlobalSettings)
                 .putList(getFullSettingKey(identifier, URLS_SETTING), ldapUrls())
                 .putList(getFullSettingKey(identifier.getName(), LdapSessionFactorySettings.USER_DN_TEMPLATES_SETTING), "cn=foo")
                 .put(getFullSettingKey(identifier.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), "cn=bar")
@@ -346,6 +354,7 @@ public class LdapRealmTests extends LdapTestCase {
         final RealmConfig.RealmIdentifier identifier
                 = new RealmConfig.RealmIdentifier(LdapRealmSettings.LDAP_TYPE, "test-ldap-realm-user-search");
         Settings settings = Settings.builder()
+                .put(defaultGlobalSettings)
                 .putList(getFullSettingKey(identifier, URLS_SETTING), ldapUrls())
                 .put(getFullSettingKey(identifier, SearchGroupsResolverSettings.BASE_DN), "")
                 .put(getFullSettingKey(identifier, SearchGroupsResolverSettings.SCOPE), LdapSearchScope.SUB_TREE)
@@ -364,6 +373,7 @@ public class LdapRealmTests extends LdapTestCase {
         String groupSearchBase = "o=sevenSeas";
         String userTemplate = VALID_USER_TEMPLATE;
         Settings settings = Settings.builder()
+                .put(defaultGlobalSettings)
                 .put(buildLdapSettings(ldapUrls(), userTemplate, groupSearchBase, LdapSearchScope.SUB_TREE))
                 .put(getFullSettingKey(REALM_IDENTIFIER, DnRoleMapperSettings.ROLE_MAPPING_FILE_SETTING),
                         getDataPath("/org/elasticsearch/xpack/security/authc/support/role_mapping.yml"))
@@ -395,7 +405,10 @@ public class LdapRealmTests extends LdapTestCase {
         LDAPURL url = new LDAPURL("ldap", "..", 12345, null, null, null, null);
         String groupSearchBase = "o=sevenSeas";
         String userTemplate = VALID_USER_TEMPLATE;
-        Settings settings = buildLdapSettings(new String[] { url.toString() }, userTemplate, groupSearchBase, LdapSearchScope.SUB_TREE);
+        Settings settings = Settings.builder()
+            .put(defaultGlobalSettings)
+            .put(buildLdapSettings(new String[]{url.toString()}, userTemplate, groupSearchBase, LdapSearchScope.SUB_TREE))
+            .build();
         RealmConfig config = getRealmConfig(REALM_IDENTIFIER, settings);
         LdapSessionFactory ldapFactory = new LdapSessionFactory(config, sslService, threadPool);
         LdapRealm ldap = new LdapRealm(config, ldapFactory, buildGroupAsRoleMapper(resourceWatcherService),
@@ -416,6 +429,7 @@ public class LdapRealmTests extends LdapTestCase {
         final RealmConfig.RealmIdentifier identifier = new RealmConfig.RealmIdentifier(LdapRealmSettings.LDAP_TYPE, "ldap-realm");
         String groupSearchBase = "o=sevenSeas";
         Settings.Builder settings = Settings.builder()
+                .put(defaultGlobalSettings)
                 .putList(getFullSettingKey(identifier, URLS_SETTING), ldapUrls())
                 .put(getFullSettingKey(identifier, PoolingSessionFactorySettings.BIND_DN),
                     "cn=Thomas Masterman Hardy,ou=people,o=sevenSeas")

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapSessionFactoryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapSessionFactoryTests.java
@@ -58,12 +58,13 @@ public class LdapSessionFactoryTests extends LdapTestCase {
         String userTemplates = "cn={0},ou=people,o=sevenSeas";
 
         Settings settings = Settings.builder()
+                .put(globalSettings)
                 .put(buildLdapSettings(ldapUrl, userTemplates, groupSearchBase, LdapSearchScope.SUB_TREE))
                 .put(RealmSettings.getFullSettingKey(REALM_IDENTIFIER, SessionFactorySettings.TIMEOUT_TCP_READ_SETTING), "1ms")
                 .put("path.home", createTempDir())
                 .build();
 
-        RealmConfig config = new RealmConfig(REALM_IDENTIFIER, mergeSettings(settings, globalSettings),
+        RealmConfig config = new RealmConfig(REALM_IDENTIFIER, settings,
                 TestEnvironment.newEnvironment(globalSettings), new ThreadContext(globalSettings));
         LdapSessionFactory sessionFactory = new LdapSessionFactory(config, sslService, threadPool);
         String user = "Horatio Hornblower";
@@ -88,8 +89,11 @@ public class LdapSessionFactoryTests extends LdapTestCase {
                 "wrongname={0},ou=people,o=sevenSeas",
                 "cn={0},ou=people,o=sevenSeas", //this last one should work
         };
-        RealmConfig config = new RealmConfig(REALM_IDENTIFIER,
-                mergeSettings(buildLdapSettings(ldapUrls(), userTemplates, groupSearchBase, LdapSearchScope.SUB_TREE), globalSettings),
+        Settings settings = Settings.builder()
+            .put(globalSettings)
+            .put(buildLdapSettings(ldapUrls(), userTemplates, groupSearchBase, LdapSearchScope.SUB_TREE))
+            .build();
+        RealmConfig config = new RealmConfig(REALM_IDENTIFIER, settings,
                 TestEnvironment.newEnvironment(globalSettings), new ThreadContext(globalSettings));
 
         LdapSessionFactory sessionFactory = new LdapSessionFactory(config, sslService, threadPool);
@@ -112,8 +116,11 @@ public class LdapSessionFactoryTests extends LdapTestCase {
                 "wrongname={0},ou=people,o=sevenSeas",
                 "asdf={0},ou=people,o=sevenSeas", //none of these should work
         };
-        RealmConfig config = new RealmConfig(REALM_IDENTIFIER,
-                mergeSettings(buildLdapSettings(ldapUrls(), userTemplates, groupSearchBase, LdapSearchScope.SUB_TREE), globalSettings),
+        Settings settings = Settings.builder()
+            .put(globalSettings)
+            .put(buildLdapSettings(ldapUrls(), userTemplates, groupSearchBase, LdapSearchScope.SUB_TREE))
+            .build();
+        RealmConfig config = new RealmConfig(REALM_IDENTIFIER, settings,
                 TestEnvironment.newEnvironment(globalSettings), new ThreadContext(globalSettings));
 
         LdapSessionFactory ldapFac = new LdapSessionFactory(config, sslService, threadPool);
@@ -131,9 +138,12 @@ public class LdapSessionFactoryTests extends LdapTestCase {
     public void testGroupLookupSubtree() throws Exception {
         String groupSearchBase = "o=sevenSeas";
         String userTemplate = "cn={0},ou=people,o=sevenSeas";
-        RealmConfig config = new RealmConfig(REALM_IDENTIFIER,
-                mergeSettings(buildLdapSettings(ldapUrls(), userTemplate, groupSearchBase, LdapSearchScope.SUB_TREE), globalSettings),
-                TestEnvironment.newEnvironment(globalSettings), new ThreadContext(globalSettings));
+        Settings settings = Settings.builder()
+            .put(globalSettings)
+            .put(buildLdapSettings(ldapUrls(), userTemplate, groupSearchBase, LdapSearchScope.SUB_TREE))
+            .build();
+        RealmConfig config = new RealmConfig(REALM_IDENTIFIER, settings,
+            TestEnvironment.newEnvironment(globalSettings), new ThreadContext(globalSettings));
 
         LdapSessionFactory ldapFac = new LdapSessionFactory(config, sslService, threadPool);
 
@@ -151,8 +161,11 @@ public class LdapSessionFactoryTests extends LdapTestCase {
     public void testGroupLookupOneLevel() throws Exception {
         String groupSearchBase = "ou=crews,ou=groups,o=sevenSeas";
         String userTemplate = "cn={0},ou=people,o=sevenSeas";
-        RealmConfig config = new RealmConfig(REALM_IDENTIFIER,
-                mergeSettings(buildLdapSettings(ldapUrls(), userTemplate, groupSearchBase, LdapSearchScope.ONE_LEVEL), globalSettings),
+        Settings settings = Settings.builder()
+            .put(globalSettings)
+            .put(buildLdapSettings(ldapUrls(), userTemplate, groupSearchBase, LdapSearchScope.ONE_LEVEL))
+            .build();
+        RealmConfig config = new RealmConfig(REALM_IDENTIFIER, settings,
                 TestEnvironment.newEnvironment(globalSettings), new ThreadContext(globalSettings));
 
         LdapSessionFactory ldapFac = new LdapSessionFactory(config, sslService, threadPool);
@@ -170,8 +183,11 @@ public class LdapSessionFactoryTests extends LdapTestCase {
     public void testGroupLookupBase() throws Exception {
         String groupSearchBase = "cn=HMS Lydia,ou=crews,ou=groups,o=sevenSeas";
         String userTemplate = "cn={0},ou=people,o=sevenSeas";
-        RealmConfig config = new RealmConfig(REALM_IDENTIFIER,
-                mergeSettings(buildLdapSettings(ldapUrls(), userTemplate, groupSearchBase, LdapSearchScope.BASE), globalSettings),
+        Settings settings = Settings.builder()
+            .put(globalSettings)
+            .put(buildLdapSettings(ldapUrls(), userTemplate, groupSearchBase, LdapSearchScope.BASE))
+            .build();
+        RealmConfig config = new RealmConfig(REALM_IDENTIFIER, settings,
                 TestEnvironment.newEnvironment(globalSettings), new ThreadContext(globalSettings));
 
         LdapSessionFactory ldapFac = new LdapSessionFactory(config, sslService, threadPool);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapUserSearchSessionFactoryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapUserSearchSessionFactoryTests.java
@@ -85,6 +85,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
     public void testSupportsUnauthenticatedSessions() throws Exception {
         final boolean useAttribute = randomBoolean();
         Settings.Builder builder = Settings.builder()
+                .put(globalSettings)
                 .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, "", LdapSearchScope.SUB_TREE))
                 .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), "")
                 .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.BIND_DN),
@@ -97,7 +98,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
             builder.put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_FILTER), "(cn={0})");
         }
 
-        RealmConfig config = getRealmConfig(builder);
+        RealmConfig config = getRealmConfig(builder.build());
 
         LdapUserSearchSessionFactory sessionFactory = getLdapUserSearchSessionFactory(config, sslService, threadPool);
         try {
@@ -109,10 +110,8 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         assertDeprecationWarnings(config.identifier(), useAttribute, useLegacyBindPassword);
     }
 
-    private RealmConfig getRealmConfig(Settings.Builder builder) {
-        return new RealmConfig(REALM_IDENTIFIER,
-                mergeSettings(builder.build(), globalSettings),
-                TestEnvironment.newEnvironment(globalSettings), new ThreadContext(globalSettings));
+    private RealmConfig getRealmConfig(Settings settings) {
+        return new RealmConfig(REALM_IDENTIFIER, settings, TestEnvironment.newEnvironment(settings), new ThreadContext(settings));
     }
 
     public void testUserSearchSubTree() throws Exception {
@@ -121,6 +120,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
 
         final boolean useAttribute = randomBoolean();
         Settings.Builder builder = Settings.builder()
+                .put(globalSettings)
                 .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, groupSearchBase, LdapSearchScope.SUB_TREE))
                 .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase)
                 .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.BIND_DN),
@@ -132,7 +132,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         } else {
             builder.put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_FILTER), "(cn={0})");
         }
-        RealmConfig config = getRealmConfig(builder);
+        RealmConfig config = getRealmConfig(builder.build());
 
         LdapUserSearchSessionFactory sessionFactory = getLdapUserSearchSessionFactory(config, sslService, threadPool);
 
@@ -166,6 +166,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
 
         final boolean useAttribute = randomBoolean();
         Settings.Builder builder = Settings.builder()
+                .put(globalSettings)
                 .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, groupSearchBase, LdapSearchScope.SUB_TREE))
                 .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase)
                 .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.BIND_DN),
@@ -178,7 +179,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         } else {
             builder.put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_FILTER), "(cn={0})");
         }
-        RealmConfig config = getRealmConfig(builder);
+        RealmConfig config = getRealmConfig(builder.build());
 
         LdapUserSearchSessionFactory sessionFactory = getLdapUserSearchSessionFactory(config, sslService, threadPool);
 
@@ -200,6 +201,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         String userSearchBase = "cn=William Bush,ou=people,o=sevenSeas";
 
         Settings.Builder builder = Settings.builder()
+                .put(globalSettings)
                 .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, groupSearchBase, LdapSearchScope.SUB_TREE))
                 .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase)
                 .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.BIND_DN),
@@ -213,7 +215,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         } else {
             builder.put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_FILTER), "(cn={0})");
         }
-        RealmConfig config = getRealmConfig(builder);
+        RealmConfig config = getRealmConfig(builder.build());
 
         LdapUserSearchSessionFactory sessionFactory = getLdapUserSearchSessionFactory(config, sslService, threadPool);
 
@@ -246,6 +248,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         String userSearchBase = "o=sevenSeas";
 
         Settings.Builder builder = Settings.builder()
+                .put(globalSettings)
                 .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, groupSearchBase, LdapSearchScope.SUB_TREE))
                 .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase)
                 .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.BIND_DN),
@@ -260,7 +263,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         } else {
             builder.put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_FILTER), "(cn={0})");
         }
-        RealmConfig config = getRealmConfig(builder);
+        RealmConfig config = getRealmConfig(builder.build());
 
         LdapUserSearchSessionFactory sessionFactory = getLdapUserSearchSessionFactory(config, sslService, threadPool);
 
@@ -282,6 +285,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         String userSearchBase = "ou=people,o=sevenSeas";
 
         Settings.Builder builder = Settings.builder()
+                .put(globalSettings)
                 .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, groupSearchBase, LdapSearchScope.SUB_TREE))
                 .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase)
                 .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.BIND_DN),
@@ -296,7 +300,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         } else {
             builder.put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_FILTER), "(cn={0})");
         }
-        RealmConfig config = getRealmConfig(builder);
+        RealmConfig config = getRealmConfig(builder.build());
 
         LdapUserSearchSessionFactory sessionFactory = getLdapUserSearchSessionFactory(config, sslService, threadPool);
 
@@ -329,6 +333,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         String userSearchBase = "o=sevenSeas";
 
         Settings.Builder builder = Settings.builder()
+                .put(globalSettings)
                 .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, groupSearchBase, LdapSearchScope.SUB_TREE))
                 .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase)
                 .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.BIND_DN),
@@ -341,7 +346,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         } else {
             builder.put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_FILTER), "(uid1={0})");
         }
-        RealmConfig config = getRealmConfig(builder);
+        RealmConfig config = getRealmConfig(builder.build());
 
         LdapUserSearchSessionFactory sessionFactory = getLdapUserSearchSessionFactory(config, sslService, threadPool);
 
@@ -363,13 +368,14 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         String userSearchBase = "o=sevenSeas";
 
         final Settings.Builder realmSettings = Settings.builder()
+                .put(globalSettings)
                 .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, groupSearchBase, LdapSearchScope.SUB_TREE))
                 .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase)
                 .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.BIND_DN),
                     "cn=Horatio Hornblower,ou=people,o=sevenSeas")
                 .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.POOL_ENABLED), randomBoolean());
         final boolean useLegacyBindPassword = configureBindPassword(realmSettings);
-        RealmConfig config = getRealmConfig(realmSettings);
+        RealmConfig config = getRealmConfig(realmSettings.build());
 
         LdapUserSearchSessionFactory sessionFactory = getLdapUserSearchSessionFactory(config, sslService, threadPool);
 
@@ -401,12 +407,13 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         String groupSearchBase = "o=sevenSeas";
         String userSearchBase = "o=sevenSeas";
         final Settings.Builder realmSettings = Settings.builder()
+                .put(globalSettings)
                 .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, groupSearchBase, LdapSearchScope.SUB_TREE))
                 .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase)
                 .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.BIND_DN),
                     "cn=Horatio Hornblower,ou=people,o=sevenSeas");
         configureBindPassword(realmSettings);
-        RealmConfig config = getRealmConfig(realmSettings);
+        RealmConfig config = getRealmConfig(realmSettings.build());
 
         LDAPConnectionPool connectionPool = LdapUserSearchSessionFactory.createConnectionPool(config, new SingleServerSet("localhost",
                         randomFrom(ldapServers).getListenPort()), TimeValue.timeValueSeconds(5), NoOpLogger.INSTANCE,
@@ -430,6 +437,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         String groupSearchBase = "o=sevenSeas";
         String userSearchBase = "o=sevenSeas";
         final Settings.Builder realmSettings = Settings.builder()
+                .put(globalSettings)
                 .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, groupSearchBase, LdapSearchScope.SUB_TREE))
                 .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase)
                 .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.BIND_DN),
@@ -438,7 +446,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
                 .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.POOL_SIZE), 12)
                 .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.HEALTH_CHECK_ENABLED), false);
         configureBindPassword(realmSettings);
-        RealmConfig config = getRealmConfig(realmSettings);
+        RealmConfig config = getRealmConfig(realmSettings.build());
 
         LDAPConnectionPool connectionPool = LdapUserSearchSessionFactory.createConnectionPool(config, new SingleServerSet("localhost",
                         randomFrom(ldapServers).getListenPort()), TimeValue.timeValueSeconds(5), NoOpLogger.INSTANCE,
@@ -457,10 +465,13 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
     public void testThatEmptyBindDNWithHealthCheckEnabledDoesNotThrow() throws Exception {
         String groupSearchBase = "o=sevenSeas";
         String userSearchBase = "o=sevenSeas";
-        RealmConfig config = getRealmConfig(Settings.builder()
-                .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, groupSearchBase, LdapSearchScope.SUB_TREE))
-                .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase)
-                .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.LEGACY_BIND_PASSWORD), "pass"));
+        final Settings settings = Settings.builder()
+            .put(globalSettings)
+            .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, groupSearchBase, LdapSearchScope.SUB_TREE))
+            .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase)
+            .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.LEGACY_BIND_PASSWORD), "pass")
+            .build();
+        RealmConfig config = getRealmConfig(settings);
 
         LdapUserSearchSessionFactory searchSessionFactory = null;
         try {
@@ -477,11 +488,14 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
     public void testThatEmptyBindDNAndDisabledPoolingDoesNotThrow() throws Exception {
         String groupSearchBase = "o=sevenSeas";
         String userSearchBase = "o=sevenSeas";
-        RealmConfig config = getRealmConfig(Settings.builder()
-                .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, groupSearchBase, LdapSearchScope.SUB_TREE))
-                .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase)
-                .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.POOL_ENABLED), false)
-                .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.LEGACY_BIND_PASSWORD), "pass"));
+        final Settings settings = Settings.builder()
+            .put(globalSettings)
+            .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, groupSearchBase, LdapSearchScope.SUB_TREE))
+            .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase)
+            .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.POOL_ENABLED), false)
+            .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.LEGACY_BIND_PASSWORD), "pass")
+            .build();
+        RealmConfig config = getRealmConfig(settings);
 
         LdapUserSearchSessionFactory searchSessionFactory = null;
         try {
@@ -502,11 +516,11 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         String groupSearchBase = "o=sevenSeas";
         String userSearchBase = "o=sevenSeas";
         final Settings.Builder realmSettings = Settings.builder()
+                .put(globalSettings)
                 .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, groupSearchBase, LdapSearchScope.SUB_TREE))
                 .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase);
         final boolean useLegacyBindPassword = configureBindPassword(realmSettings);
-        RealmConfig config = new RealmConfig(REALM_IDENTIFIER,
-                mergeSettings(realmSettings.build(), globalSettings),
+        RealmConfig config = new RealmConfig(REALM_IDENTIFIER, realmSettings.build(),
                 TestEnvironment.newEnvironment(globalSettings), new ThreadContext(globalSettings));
         try (LdapUserSearchSessionFactory searchSessionFactory = getLdapUserSearchSessionFactory(config, sslService, threadPool)) {
             assertThat(searchSessionFactory.bindCredentials, notNullValue());
@@ -519,12 +533,12 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         String groupSearchBase = "o=sevenSeas";
         String userSearchBase = "o=sevenSeas";
         final Settings.Builder realmSettings = Settings.builder()
+                .put(globalSettings)
                 .put(buildLdapSettings(ldapUrls(), Strings.EMPTY_ARRAY, groupSearchBase, LdapSearchScope.SUB_TREE))
                 .put(getFullSettingKey(REALM_IDENTIFIER, PoolingSessionFactorySettings.BIND_DN), "cn=ironman")
                 .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase);
         final boolean useLegacyBindPassword = configureBindPassword(realmSettings);
-        RealmConfig config = new RealmConfig(REALM_IDENTIFIER,
-                mergeSettings(realmSettings.build(), globalSettings),
+        RealmConfig config = new RealmConfig(REALM_IDENTIFIER, realmSettings.build(),
                 TestEnvironment.newEnvironment(globalSettings), new ThreadContext(globalSettings));
         try (LdapUserSearchSessionFactory searchSessionFactory = getLdapUserSearchSessionFactory(config, sslService, threadPool)) {
             assertThat(searchSessionFactory.bindCredentials, notNullValue());
@@ -543,6 +557,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
         inMemoryDirectoryServer.shutDown(true);
 
         final Settings.Builder ldapSettingsBuilder = Settings.builder()
+                .put(globalSettings)
                 .put(LdapTestCase.buildLdapSettings(new String[]{ldapUrl}, Strings.EMPTY_ARRAY,
                         groupSearchBase, LdapSearchScope.SUB_TREE))
                 .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.SEARCH_BASE_DN), userSearchBase)
@@ -554,7 +569,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
                 .put(getFullSettingKey(REALM_IDENTIFIER.getName(), LdapUserSearchSessionFactorySettings.POOL_ENABLED), randomBoolean());
 
         final boolean useLegacyBindPassword = configureBindPassword(ldapSettingsBuilder);
-        RealmConfig config = getRealmConfig(ldapSettingsBuilder);
+        RealmConfig config = getRealmConfig(ldapSettingsBuilder.build());
         LdapUserSearchSessionFactory searchSessionFactory = null;
         try {
             searchSessionFactory = getLdapUserSearchSessionFactory(config, sslService, threadPool);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapTestCase.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.SecuritySettingsSource;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.ldap.LdapSessionFactorySettings;
@@ -204,16 +203,5 @@ public abstract class LdapTestCase extends ESTestCase {
                 return null;
             }
         });
-    }
-
-    protected Settings mergeSettings(Settings local, Settings global) {
-        final Settings.Builder builder = Settings.builder()
-                .put(global, true)
-                .put(local, false);
-        final Settings.Builder tmpLocal = Settings.builder().put(local, true);
-        SecuritySettingsSource.addSecureSettings(builder,
-                mainSecure -> SecuritySettingsSource.addSecureSettings(tmpLocal, localSecure -> mainSecure.merge(localSecure))
-        );
-        return builder.build();
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactoryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactoryTests.java
@@ -124,10 +124,11 @@ public class SessionFactoryTests extends ESTestCase {
     private SessionFactory createSessionFactory() {
         Settings global = Settings.builder().put("path.home", createTempDir()).build();
         final RealmConfig.RealmIdentifier realmIdentifier = new RealmConfig.RealmIdentifier("ldap", "_name");
-        final RealmConfig realmConfig = new RealmConfig(realmIdentifier, mergeSettings(
+        final RealmConfig realmConfig = new RealmConfig(realmIdentifier,
                 Settings.builder()
                         .put(getFullSettingKey(realmIdentifier, SessionFactorySettings.URLS_SETTING), "ldap://localhost:389")
-                        .build(), global),
+                        .put(global)
+                        .build(),
                 TestEnvironment.newEnvironment(global), new ThreadContext(Settings.EMPTY));
         return new SessionFactory(realmConfig, null, threadPool) {
 
@@ -136,9 +137,5 @@ public class SessionFactoryTests extends ESTestCase {
                 listener.onResponse(null);
             }
         };
-    }
-
-    private Settings mergeSettings(Settings local, Settings global) {
-        return Settings.builder().put(global).put(local).build();
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlTestCase.java
@@ -11,7 +11,6 @@ import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.PathUtils;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ssl.CertParsingUtils;
 import org.elasticsearch.xpack.core.ssl.PemUtils;
@@ -135,9 +134,5 @@ public abstract class SamlTestCase extends ESTestCase {
         final ElasticsearchSecurityException exception = expectThrows(ElasticsearchSecurityException.class, runnable);
         assertThat("Exception " + exception + " should be a SAML exception", SamlUtils.isSamlException(exception), is(true));
         return exception;
-    }
-
-    protected Settings mergeSettings(Settings local, Settings global) {
-        return Settings.builder().put(global).put(local).build();
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/DnRoleMapperTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/DnRoleMapperTests.java
@@ -282,9 +282,10 @@ public class DnRoleMapperTests extends ESTestCase {
         Path file = getDataPath("role_mapping.yml");
         final RealmConfig.RealmIdentifier realmIdentifier = new RealmConfig.RealmIdentifier("ldap", "ldap1");
         Settings ldapSettings = Settings.builder()
-                .put(getFullSettingKey(realmIdentifier, DnRoleMapperSettings.ROLE_MAPPING_FILE_SETTING), file.toAbsolutePath())
-                .build();
-        RealmConfig config = new RealmConfig(realmIdentifier, mergeSettings(ldapSettings, settings),
+            .put(settings)
+            .put(getFullSettingKey(realmIdentifier, DnRoleMapperSettings.ROLE_MAPPING_FILE_SETTING), file.toAbsolutePath())
+            .build();
+        RealmConfig config = new RealmConfig(realmIdentifier, ldapSettings,
                 TestEnvironment.newEnvironment(settings), new ThreadContext(Settings.EMPTY));
 
         DnRoleMapper mapper = new DnRoleMapper(config, new ResourceWatcherService(settings, threadPool));
@@ -298,10 +299,10 @@ public class DnRoleMapperTests extends ESTestCase {
     public void testRelativeDN() {
         final RealmConfig.RealmIdentifier realmIdentifier = new RealmConfig.RealmIdentifier("ldap", "ldap1");
         Settings ldapSettings = Settings.builder()
+                .put(settings)
                 .put(getFullSettingKey(realmIdentifier, DnRoleMapperSettings.USE_UNMAPPED_GROUPS_AS_ROLES_SETTING), true)
                 .build();
-        RealmConfig config = new RealmConfig(realmIdentifier,
-                mergeSettings(ldapSettings, settings),
+        RealmConfig config = new RealmConfig(realmIdentifier, ldapSettings,
                 TestEnvironment.newEnvironment(settings), new ThreadContext(Settings.EMPTY));
 
         DnRoleMapper mapper = new DnRoleMapper(config, new ResourceWatcherService(settings, threadPool));
@@ -314,10 +315,11 @@ public class DnRoleMapperTests extends ESTestCase {
         final RealmConfig.RealmIdentifier realmIdentifier = new RealmConfig.RealmIdentifier("ldap", "ldap-userdn-role");
         Path file = getDataPath("role_mapping.yml");
         Settings ldapSettings = Settings.builder()
+                .put(settings)
                 .put(getFullSettingKey(realmIdentifier, DnRoleMapperSettings.ROLE_MAPPING_FILE_SETTING), file.toAbsolutePath())
                 .put(getFullSettingKey(realmIdentifier, DnRoleMapperSettings.USE_UNMAPPED_GROUPS_AS_ROLES_SETTING), false)
                 .build();
-        RealmConfig config = new RealmConfig(realmIdentifier, mergeSettings(ldapSettings, settings),
+        RealmConfig config = new RealmConfig(realmIdentifier, ldapSettings,
                 TestEnvironment.newEnvironment(settings), new ThreadContext(Settings.EMPTY));
 
         DnRoleMapper mapper = new DnRoleMapper(config, new ResourceWatcherService(settings, threadPool));
@@ -335,9 +337,4 @@ public class DnRoleMapperTests extends ESTestCase {
         RealmConfig config = new RealmConfig(identifier, mergedSettings, env, new ThreadContext(Settings.EMPTY));
         return new DnRoleMapper(config, watcherService);
     }
-
-    private Settings mergeSettings(Settings local, Settings global) {
-        return Settings.builder().put(global).put(local).build();
-    }
-
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/RoleMappingFileBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/RoleMappingFileBootstrapCheckTests.java
@@ -45,6 +45,7 @@ public class RoleMappingFileBootstrapCheckTests extends ESTestCase {
     public void testBootstrapCheckOfValidFile() {
         Path file = getDataPath("role_mapping.yml");
         Settings ldapSettings = Settings.builder()
+                .put(settings)
                 .put(ROLE_MAPPING_FILE_SETTING, file.toAbsolutePath())
                 .build();
         RealmConfig config = getRealmConfig(ldapSettings);
@@ -54,15 +55,15 @@ public class RoleMappingFileBootstrapCheckTests extends ESTestCase {
         assertFalse(check.check(new BootstrapContext(settings, null)).isFailure());
     }
 
-    private RealmConfig getRealmConfig(Settings realmSettings) {
-        return new RealmConfig(REALM_ID, mergeSettings(realmSettings, settings),
-                TestEnvironment.newEnvironment(settings), new ThreadContext(Settings.EMPTY));
+    private static RealmConfig getRealmConfig(Settings settings) {
+        return new RealmConfig(REALM_ID, settings, TestEnvironment.newEnvironment(settings), new ThreadContext(Settings.EMPTY));
     }
 
     public void testBootstrapCheckOfMissingFile() {
         final String fileName = randomAlphaOfLength(10);
         Path file = createTempDir().resolve(fileName);
         Settings ldapSettings = Settings.builder()
+                .put(settings)
                 .put(ROLE_MAPPING_FILE_SETTING, file.toAbsolutePath())
                 .build();
         RealmConfig config = getRealmConfig(ldapSettings);
@@ -82,6 +83,7 @@ public class RoleMappingFileBootstrapCheckTests extends ESTestCase {
         Files.write(file, Collections.singletonList("junk"), StandardCharsets.UTF_16);
 
         Settings ldapSettings = Settings.builder()
+                .put(settings)
                 .put(ROLE_MAPPING_FILE_SETTING, file.toAbsolutePath())
                 .build();
         RealmConfig config = getRealmConfig(ldapSettings);
@@ -101,6 +103,7 @@ public class RoleMappingFileBootstrapCheckTests extends ESTestCase {
         Files.write(file, Collections.singletonList("role: not-a-dn"));
 
         Settings ldapSettings = Settings.builder()
+                .put(settings)
                 .put(ROLE_MAPPING_FILE_SETTING, file.toAbsolutePath())
                 .build();
         RealmConfig config = getRealmConfig(ldapSettings);
@@ -115,7 +118,4 @@ public class RoleMappingFileBootstrapCheckTests extends ESTestCase {
         assertThat(result.getMessage(), containsString("not-a-dn"));
     }
 
-    private Settings mergeSettings(Settings local, Settings global) {
-        return Settings.builder().put(global).put(local).build();
-    }
 }


### PR DESCRIPTION
Many realm tests were written to use separate setting objects for
"global settings" and "realm settings".
Since #30241 there is no distinction between these settings, so these
tests can be cleaned up to use a single Settings object.