### PR TITLE
[Docs] Emphasize suggest behaviour with missing query part

### DIFF
--- a/docs/reference/search/suggesters.asciidoc
+++ b/docs/reference/search/suggesters.asciidoc
@@ -6,7 +6,7 @@ text by using a suggester. Parts of the suggest feature are still under
 development.
 
 The suggest request part is defined alongside the query part in a `_search`
-request.
+request. If the query part is left out, only suggestions are returned.
 
 NOTE: `_suggest` endpoint has been deprecated in favour of using suggest via
 `_search` endpoint. In 5.0, the `_search` endpoint has been optimized for


### PR DESCRIPTION
Add a short extra sentence that explains that a missing query part in a search
request containing a "suggest" section will mean only suggestions are returned.

Closes #31640