### PR TITLE
Fix TcpTransport compression test

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
@@ -206,7 +206,9 @@ public class TcpTransportTests extends ESTestCase {
 
                 @Override
                 public NodeChannels openConnection(DiscoveryNode node, ConnectionProfile connectionProfile) {
-                    assertTrue(connectionProfile.getCompressionEnabled());
+                    if (compressed)  {
+                        assertTrue(connectionProfile.getCompressionEnabled());
+                    }
                     int numConnections = connectionProfile.getNumConnections();
                     ArrayList<TcpChannel> fakeChannels = new ArrayList<>(numConnections);
                     for (int i = 0; i < numConnections; ++i) {


### PR DESCRIPTION
This commit fixes an assertion in the TcpTransportTests compression
test.