### PR TITLE
Switch to default to no build qualifier

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -245,7 +245,7 @@ class VersionPropertiesLoader {
                       elasticsearch
       )
     }
-    String qualifier = systemProperties.getProperty("build.version_qualifier", "alpha1");
+    String qualifier = systemProperties.getProperty("build.version_qualifier", "");
     if (qualifier.isEmpty() == false) {
       if (qualifier.matches("(alpha|beta|rc)\\d+") == false) {
         throw new IllegalStateException("Invalid qualifier: " + qualifier)


### PR DESCRIPTION
Now that we have a  non qualified ML build, we can also switch to defaulting to a non qualified version. 