### PR TITLE
Synonym Query Style (configurable single term syn queries)

### DIFF
--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -99,6 +99,44 @@ GET /_search
 --------------------------------------------------
 // CONSOLE
 
+[[query-dsl-match-query-synonym-style]]
+===== Synonym Query Style
+What should the behavior of overlapping synonyms be at query time?
+By default, `blended_terms` blends the document frequency of the terms. In
+this case, occurrences of two synonyms (say `dog, doggie`) are scored with
+equal weight. This behavior works well for true synonyms.
+
+[source,js]
+--------------------------------------------------
+GET /_search
+{
+    "query": {
+        "match" : {
+            "message" : {
+                "query" : "dog",
+                "operator" : "and",
+                "synonym_query_style": "blended_terms"
+            }
+        }
+    }
+}
+
+Synonyms are used to model terms that are not exact 1-1 replacements. For
+example, it's common to use synonym functionality to broaden searches. You
+might expand jeans to a broader term - trousers `jeans => jeans, trousers`.
+In this case, you'd prefer occurrences of the rarer term (jeans) to score higher
+than the broader term (trousers).
+
+For these use cases `most_terms` scores terms preserving the original document
+frequencies, summing the term scores in a document. The style `most_terms`
+preserves Elasticsearch functionality from before the 6.0 release.
+
+The style `best_terms` also preserves original document frequencies, but
+scores a document with the highest scoring synonym - ignoring all other terms.
+
+--------------------------------------------------
+// CONSOLE
+
 [[query-dsl-match-query-cutoff]]
 ===== Cutoff frequency
 

--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -146,7 +146,8 @@ follows:
 
 Also, accepts `analyzer`, `boost`, `operator`, `minimum_should_match`,
 `fuzziness`, `lenient`, `prefix_length`, `max_expansions`, `rewrite`, `zero_terms_query`,
- `cutoff_frequency`, `auto_generate_synonyms_phrase_query` and `fuzzy_transpositions`,
+`synonym_query_style`, `cutoff_frequency`, `auto_generate_synonyms_phrase_query` and
+`fuzzy_transpositions`,
   as explained in <<query-dsl-match-query, match query>>.
 
 [IMPORTANT]
@@ -287,9 +288,9 @@ GET /_search
 --------------------------------------------------
 // CONSOLE
 
-Also, accepts `analyzer`, `boost`, `lenient`, `slop` and `zero_terms_query`  as explained
-in <<query-dsl-match-query>>.  Type `phrase_prefix` additionally accepts
-`max_expansions`.
+Also, accepts `analyzer`, `boost`, `lenient`, `slop`, `synonym_query_style`
+and `zero_terms_query`  as explained in <<query-dsl-match-query>>.  Type
+`phrase_prefix` additionally accepts `max_expansions`.
 
 [IMPORTANT]
 [[phrase-fuzziness]]
@@ -384,7 +385,8 @@ explanation:
     +blended("smith", fields: [first_name, last_name])
 
 Also, accepts `analyzer`, `boost`, `operator`, `minimum_should_match`,
-`lenient`, `zero_terms_query` and `cutoff_frequency`, as explained in
+`lenient`, `synonym_query_style`, `zero_terms_query` and
+`cutoff_frequency`, as explained in
 <<query-dsl-match-query, match query>>.
 
 ===== `cross_field` and analysis

--- a/server/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -369,6 +369,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
         return this.zeroTermsQuery;
     }
 
+    public MatchQuery.SynonymQueryStyle synonymQueryStyle() {return synonymQueryStyle; }
 
     public MatchQueryBuilder autoGenerateSynonymsPhraseQuery(boolean enable) {
         this.autoGenerateSynonymsPhraseQuery = enable;
@@ -557,7 +558,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
                             }
                             else {
                                 throw new ParsingException(parser.getTokenLocation(),
-                                    "Unsupported zero_terms_query value [" + synonymQueryStyle + "]");
+                                    "Unsupported synonym_query_style value [" + synonymQueryStyle + "]");
                             }
                         }
                         else {

--- a/server/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -355,7 +355,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
      */
     public MatchQueryBuilder synonymQueryStyle(MatchQuery.SynonymQueryStyle synQueryStyle) {
         if (synQueryStyle == null) {
-            throw new IllegalArgumentException("[" + NAME + "] requires synQueryStyle to be non-null");
+            throw new IllegalArgumentException("[" + NAME + "] requires synonym_query_style to be non-null");
         }
         this.synonymQueryStyle = synQueryStyle;
         return this;

--- a/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -541,7 +541,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
 
     public MultiMatchQueryBuilder synonymQueryStyle(MatchQuery.SynonymQueryStyle synQueryStyle) {
         if (synonymQueryStyle == null) {
-            throw new IllegalArgumentException("[" + NAME + "] requires synonym query style to be non-null");
+            throw new IllegalArgumentException("[" + NAME + "] requires synonym_query_style to be non-null");
         }
         this.synonymQueryStyle = synQueryStyle;
         return this;

--- a/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -231,7 +231,7 @@ public class MatchQuery {
 
     protected boolean autoGenerateSynonymsPhraseQuery = true;
 
-    protected SynonymQueryStyle synonymQueryStyle = SynonymQueryStyle.BLENDED_TERMS;
+    protected SynonymQueryStyle synonymQueryStyle = DEFAULT_SYNONYM_QUERY_STYLE;
 
     public MatchQuery(QueryShardContext context) {
         this.context = context;
@@ -431,7 +431,7 @@ public class MatchQuery {
                     case BLENDED_TERMS:
                         return blendTermsQuery(terms, mapper);
                     default:
-                        throw new IllegalStateException("unrecognized synonymQueryStyle passed when creating newSynonymQuery");
+                        throw new IllegalStateException("unrecognized synonymQueryStyle [" + this.synonymQueryStyle + "] passed when creating newSynonymQuery");
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -76,7 +76,7 @@ public class MatchQuery {
      *  {@link #BEST_TERMS}
      *  {@link #MOST_TERMS}
      */
-    public static enum SynonymQueryStyle implements Writeable {
+    public enum SynonymQueryStyle implements Writeable {
         /** (default) synonym terms share doc freq - ie they are blended
          *  so if "pants" has df 500, and "khakis" a df of 50, uses 500 df when scoring both terms
          *  appropriate for exact synonyms

--- a/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -267,6 +267,7 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
             "      \"lenient\" : false,\n" +
             "      \"zero_terms_query\" : \"ALL\",\n" +
             "      \"auto_generate_synonyms_phrase_query\" : true,\n" +
+            "      \"synonym_query_style\" : \"BEST_TERMS\",\n" +
             "      \"boost\" : 1.0\n" +
             "    }\n" +
             "  }\n" +

--- a/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -247,6 +247,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
                 "    \"max_expansions\" : 50,\n" +
                 "    \"lenient\" : false,\n" +
                 "    \"zero_terms_query\" : \"NONE\",\n" +
+                "    \"synonym_query_style\" : \"BEST_TERMS\",\n" +
                 "    \"auto_generate_synonyms_phrase_query\" : true,\n" +
                 "    \"fuzzy_transpositions\" : false,\n" +
                 "    \"boost\" : 1.0\n" +


### PR DESCRIPTION
In Lucene, SynonymQuery became the default behavior for single term synonym queries, which ES 6.0 inherited. While this is a good default, it interferes with other legitimate uses of synonyms. You don't always want to blend document frequencies of the terms.

It's common to want to expand a term to a broadening term, but maintaining the specificity of the original term. (ie `jeans => jeans, trousers`). I and others have written about [these techniques](https://opensourceconnections.com/blog/2016/12/23/elasticsearch-synonyms-patterns-taxonomies/) for implementing hierarchical vocabularies. In these cases blending ends up doing more harm, so this PR  makes this behavior configurable.

This PR introduces an option to the match query, `synonym_query_style` which can have the values `blended` (default), `most_terms`, or `best_terms`. 

```
{
   "match": {
      "text": {
        "query": "blue jeans",
        "synonym_query_style": "most_terms"
       }
   }
}
```

with a synonym file `jeans, trousers` would turn into a search: `text:jeans text:trousers`. This is basically the pre 6.0 behavior.

Using `best_terms` changes the synonym query to a dismax `text:jeans | text:trousers` which tends to ignore the broader term in the narrower term is present.

One note on this PR, 
- tests seem to be failing locally for me for unrelated functionality (transport client stuff...)
- any feedback on where to place a test is greatly appreciated. I looked for how other match query options were tested and did not find anything.

