### PR TITLE
Swithc to jcenter and hope to have fewer network failures in builds

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -142,7 +142,6 @@ if (project == rootProject) {
     if (System.getProperty("repos.mavenLocal") != null) {
       mavenLocal()
     }
-    mavenCentral()
   }
   test {
     include "**/*Tests.class"

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -442,7 +442,7 @@ class BuildPlugin implements Plugin<Project> {
             // such that we don't have to pass hardcoded files to gradle
             repos.mavenLocal()
         }
-        repos.mavenCentral()
+        repos.jcenter()
         repos.maven {
             name "elastic"
             url "https://artifacts.elastic.co/maven"

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -159,8 +159,7 @@ class VagrantTestPlugin implements Plugin<Project> {
     private static void configurePackagingArchiveRepositories(Project project) {
         RepositoryHandler repos = project.repositories
 
-        // Try maven central first, it'll have releases before 5.0.0
-        repos.jcenter()
+        repos.jcenter() // will have releases before 5.0.0
 
         /* Setup a repository that tries to download from
           https://artifacts.elastic.co/downloads/elasticsearch/[module]-[revision].[ext]

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -160,7 +160,7 @@ class VagrantTestPlugin implements Plugin<Project> {
         RepositoryHandler repos = project.repositories
 
         // Try maven central first, it'll have releases before 5.0.0
-        repos.mavenCentral()
+        repos.jcenter()
 
         /* Setup a repository that tries to download from
           https://artifacts.elastic.co/downloads/elasticsearch/[module]-[revision].[ext]

--- a/buildSrc/src/testKit/elasticsearch.build/build.gradle
+++ b/buildSrc/src/testKit/elasticsearch.build/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 repositories {
-    mavenCentral()
+    jcenter()
     repositories {
         maven {
             url System.getProperty("local.repo.path")

--- a/buildSrc/src/testKit/jarHell/build.gradle
+++ b/buildSrc/src/testKit/jarHell/build.gradle
@@ -13,7 +13,7 @@ ext.licenseFile = file("$buildDir/dummy/license")
 ext.noticeFile = file("$buildDir/dummy/notice")
 
 repositories {
-    mavenCentral()
+    jcenter()
     repositories {
         maven {
             url System.getProperty("local.repo.path")

--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -35,7 +35,6 @@ final String wildflyInstall = "${buildDir}/wildfly/wildfly-${wildflyVersion}"
 int managementPort
 
 repositories {
-    mavenCentral()
     // the Wildfly distribution is not available via a repository, so we fake an Ivy repository on top of the download site
     ivy {
         url "http://download.jboss.org"


### PR DESCRIPTION
Jcenter suposedly operates on a CDN.
It should be faster and more reliable.
It's the default in Andorid Studio currently
( it switched from mavenCentral ).

This change is safe because jcenter is a super-set of mavenCentral.

