### PR TITLE
Fix the names of CCR stats endpoints in usage API

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestCcrStatsAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestCcrStatsAction.java
@@ -25,7 +25,7 @@ public class RestCcrStatsAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "ccr_auto_follow_stats";
+        return "ccr_stats";
     }
 
     @Override

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestFollowStatsAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestFollowStatsAction.java
@@ -26,7 +26,7 @@ public class RestFollowStatsAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "ccr_stats";
+        return "ccr_follower_stats";
     }
 
     @Override


### PR DESCRIPTION
This commit fixes the names of the CCR stats endpoints reported in the usage API.
