### PR TITLE
Fix Eclipse configuration

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -89,7 +89,10 @@ compileMinimumRuntimeGroovy {
   sourceCompatibility = minimumRuntimeVersion
 }
 dependencies {
-  compile sourceSets.minimumRuntime.output
+  if (project.ext.has("isEclipse") == false || project.ext.isEclipse == false) {
+      // eclipse is confused if this is set explicitly
+    compile sourceSets.minimumRuntime.output
+  }
   minimumRuntimeCompile "junit:junit:${props.getProperty('junit')}"
   minimumRuntimeCompile localGroovy()
 }


### PR DESCRIPTION
Eclipse was complaining due to how this dependency was configured, but turns out it doesn't need us to be explicit about it.