### PR TITLE
[DOCS] Clarify results_index_name description

### DIFF
--- a/docs/reference/ml/apis/put-job.asciidoc
+++ b/docs/reference/ml/apis/put-job.asciidoc
@@ -65,8 +65,8 @@ Instantiates a job.
   score are applied, as new data is seen. See <<ml-job-resource>>.
 
 `results_index_name`::
-  (string) The name of the index in which to store the {ml} results. The default
-  value is `shared`, which corresponds to the index name `.ml-anomalies-shared`.
+  (string) A text string that affects the name of the {ml} results index. The 
+  default value is `shared`, which generates an index named `.ml-anomalies-shared`. 
 
 `results_retention_days`::
   (long) Advanced configuration option. The number of days for which job results


### PR DESCRIPTION
This PR clarifies the description of the results_index_name parameter in the create jobs API (https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html). 