### PR TITLE
[ML] Fix find_file_structure NPE with should_trim_fields

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/filestructurefinder/DelimitedFileStructureFinder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/filestructurefinder/DelimitedFileStructureFinder.java
@@ -82,7 +82,7 @@ public class DelimitedFileStructureFinder implements FileStructureFinder {
             int lineNumber = lineNumbers.get(index);
             Map<String, String> sampleRecord = new LinkedHashMap<>();
             Util.filterListToMap(sampleRecord, columnNames,
-                trimFields ? row.stream().map(String::trim).collect(Collectors.toList()) : row);
+                trimFields ? row.stream().map(field -> (field == null) ? null : field.trim()).collect(Collectors.toList()) : row);
             sampleRecords.add(sampleRecord);
             sampleMessages.add(
                 sampleLines.subList(prevMessageEndLineNumber + 1, lineNumbers.get(index)).stream().collect(Collectors.joining("\n")));


### PR DESCRIPTION
The NPE would occur if should_trim_fields was overridden to
true and any field value was completely blank.  This change
defends against this situation.

Fixes #35462