### PR TITLE
[DOCS] Adds release highlight for multi-bucket analysis

### DIFF
--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -22,7 +22,7 @@ the new File Data Visualizer in {kib}.
 [float]
 === Improved {ml} results for partitioned multi-metric jobs
 
-If you use the `partition_field_name` parameter in a {ml} job (or the 
+If you use the +partition_field_name+ parameter in a {ml} job (or the 
 *Split Data* field in the {kib} multi-metric job wizard), it generates many 
 simultaneous analyses that are modeled independently. In 6.5, we have decreased 
 the influence of the anomaly scores in each partition on other partitions' scores. 

--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -29,3 +29,17 @@ the influence of the anomaly scores in each partition on other partitions' score
 The overall effect of the change is to produce a much wider range of scores in 
 partitioned multi-metric jobs. 
 
+[float]
+=== Find multi-bucket anomalies in {ml} jobs
+
+Sometimes events are not interesting or anomalous in the context of a single 
+bucket. However, they become interesting when you take into consideration the 
+buckets that came before and after. In 6.5, there is a new {ml} 
+_multi-bucket analysis_, which uses features from multiple contiguous buckets 
+for anomaly detection. The final anomaly score is now a combination of values 
+from both the “standard” single-bucket analysis and the new multi-bucket 
+analysis. A new `multi_bucket_impact` property in the 
+<<ml-results-records,record results>> indicates how strongly either form of 
+analysis influences the score. In {kib}, anomalies with medium or high 
+multi-bucket impact are depicted in the *Anomaly Explorer* and the 
+*Single Metric Viewer* with a cross symbol instead of a dot. 

--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -33,8 +33,8 @@ partitioned multi-metric jobs.
 === Find multi-bucket anomalies in {ml} jobs
 
 Sometimes events are not interesting or anomalous in the context of a single 
-bucket. However, they become interesting when you take into consideration the 
-buckets that came before and after. In 6.5, there is a new {ml} 
+bucket. However, they become interesting when you take into consideration a 
+sequence of buckets as a whole. In 6.5, there is a new {ml} 
 _multi-bucket analysis_, which uses features from multiple contiguous buckets 
 for anomaly detection. The final anomaly score is now a combination of values 
 from both the “standard” single-bucket analysis and the new multi-bucket 


### PR DESCRIPTION
This PR adds a blurb to the 6.5 Release Highlights (https://www.elastic.co/guide/en/elasticsearch/reference/6.5/release-highlights-6.5.0.html) for multi-bucket analysis (https://github.com/elastic/elasticsearch/pull/34233). 
