### PR TITLE
Add RunOnce utility class that executes a Runnable exactly once

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/RunOnce.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/RunOnce.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util.concurrent;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A class which wraps an existing {@link Runnable} and allows to execute it exactly once
+ * whatever the number of times the wrapped {@link Runnable#run()} method is called.
+ */
+public class RunOnce implements Runnable {
+
+    private final AtomicBoolean executed;
+    private final Runnable delegate;
+
+    public RunOnce(final Runnable delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+        this.executed = new AtomicBoolean(false);
+    }
+
+    @Override
+    public void run() {
+        if (executed.compareAndSet(false, true)) {
+            delegate.run();
+        }
+    }
+
+    /**
+     *  {@code true} if the {@link RunOnce} has been executed once.
+     */
+    public boolean hasRun() {
+        return executed.get();
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/FlushListener.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/FlushListener.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.ml.job.process.autodetect.output;
 
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.util.concurrent.RunOnce;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.output.FlushAcknowledgement;
 
 import java.time.Duration;
@@ -14,16 +15,22 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 class FlushListener {
 
     final ConcurrentMap<String, FlushAcknowledgementHolder> awaitingFlushed = new ConcurrentHashMap<>();
-    final AtomicBoolean cleared = new AtomicBoolean(false);
+
+    final RunOnce onClear = new RunOnce(() -> {
+        Iterator<ConcurrentMap.Entry<String, FlushAcknowledgementHolder>> latches = awaitingFlushed.entrySet().iterator();
+        while (latches.hasNext()) {
+            latches.next().getValue().latch.countDown();
+            latches.remove();
+        }
+    });
 
     @Nullable
     FlushAcknowledgement waitForFlush(String flushId, Duration timeout) throws InterruptedException {
-        if (cleared.get()) {
+        if (onClear.hasRun()) {
             return null;
         }
 
@@ -49,13 +56,7 @@ class FlushListener {
     }
 
     void clear() {
-        if (cleared.compareAndSet(false, true)) {
-            Iterator<ConcurrentMap.Entry<String, FlushAcknowledgementHolder>> latches = awaitingFlushed.entrySet().iterator();
-            while (latches.hasNext()) {
-                latches.next().getValue().latch.countDown();
-                latches.remove();
-            }
-        }
+        onClear.run();
     }
 
     private static class FlushAcknowledgementHolder {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/FlushListenerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/FlushListenerTests.java
@@ -60,7 +60,7 @@ public class FlushListenerTests extends ESTestCase {
         }
         assertBusy(() -> assertEquals(numWaits, listener.awaitingFlushed.size()));
         assertThat(flushAcknowledgementHolders.stream().map(f -> f.get()).filter(f -> f != null).findAny().isPresent(), is(false));
-        assertFalse(listener.cleared.get());
+        assertFalse(listener.onClear.hasRun());
 
         listener.clear();
 
@@ -68,6 +68,6 @@ public class FlushListenerTests extends ESTestCase {
             assertBusy(() -> assertNotNull(f.get()));
         }
         assertTrue(listener.awaitingFlushed.isEmpty());
-        assertTrue(listener.cleared.get());
+        assertTrue(listener.onClear.hasRun());
     }
 }


### PR DESCRIPTION
This pull request adds a simple `RunOnce` class that can be used to execute a `Runnable `exactly once.

Related to https://github.com/elastic/elasticsearch/pull/34902#discussion_r231489785