### PR TITLE
MINOR: Remove Hack in TestCluster Task

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -719,7 +719,7 @@ class ClusterFormationTasks {
                 unicastHosts.addAll(node.config.otherUnicastHostAddresses.call())
                 String unicastHost = node.config.unicastTransportUri(node, null, project.ant)
                 if (unicastHost != null) {
-                    unicastHosts.addAll(Arrays.asList(unicastHost.split(",")))
+                    unicastHosts.add(unicastHost)
                 }
             }
             String unicastHostsTxt = String.join("\n", unicastHosts)


### PR DESCRIPTION
*  The logic that splits by `","` isn't necessary anymore since #35375 removed the hack that set the comma separated list for the unicast host

@DaveCTurner just random thing I noticed :)