### PR TITLE
[DOCS] Release highlight for structured audit logs

### DIFF
--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -9,6 +9,17 @@ coming[6.5.0]
 See also <<release-notes-6.5.0,{es} 6.5.0 release notes>>. 
 
 [float]
+=== Audit security events in new structured logs 
+
+By default, when you enable auditing, it uses the 
+{stack-ov}/audit-log-output.html[logfile audit output], which persists events to 
+a `<clustername>_audit.log` file in the logs directory. This file is new to 
+version 6.5 and prints audit entries as JSON documents. 
+
+For backwards compatibility purposes, a `<clustername>_access.log` with the old style of 
+formatting is also generated. See also <<breaking_65_settings_changes>>. 
+
+[float]
 === Discover the structure of text files
 
 experimental[] The new <<ml-find-file-structure,find file structure API>> 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/31046

This PR adds an item in the Elasticsearch 6.5 Release Highlights for structured audit logs.
