### PR TITLE
[DOCS] Adds release highlight for monitoring

### DIFF
--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -92,3 +92,12 @@ recovery purposes and for geo-proximity so that reads can be served locally.
 
 For more information, see {stack-ov}/xpack-ccr.html[Cross-cluster replication] 
 and <<ccr-apis>>. 
+
+=== Monitor {es} with {metribeat} (beta)
+
+In 6.4 and later, you can use {metribeat} to collect data about {kib} and ship 
+it directly to your monitoring cluster, rather than routing it through {es}. Now 
+in 6.5, you can also use {metricbeat} to collect and ship data about {es}. If 
+you are monitoring {ls} or Beats, at this time you must still use exporters to 
+route the data. See <<configuring-metricbeat>> and 
+{stack-ov}/how-monitoring-works.html[How monitoring works]. 

--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -95,7 +95,7 @@ and <<ccr-apis>>.
 
 === Monitor {es} with {metribeat} (beta)
 
-In 6.4 and later, you can use {metribeat} to collect data about {kib} and ship 
+In 6.4 and later, you can use {metricbeat} to collect data about {kib} and ship 
 it directly to your monitoring cluster, rather than routing it through {es}. Now 
 in 6.5, you can also use {metricbeat} to collect and ship data about {es}. If 
 you are monitoring {ls} or Beats, at this time you must still use exporters to 


### PR DESCRIPTION
Related to https://github.com/elastic/beats/issues/7035

This PR adds an item in the Elasticsearch 6.5 Release Highlights for metricbeat monitoring. 