### PR TITLE
[DOCS] Adds release highlight for CCR

### DIFF
--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -44,18 +44,17 @@ alerts for the job.
 [float]
 === Find multi-bucket anomalies in {ml} jobs
 
-Sometimes events are not interesting or anomalous in the context of a single
-bucket. However, they become interesting when you take into consideration a
-sequence of buckets as a whole. In 6.5, there is a new {ml}
-_multi-bucket analysis_, which uses features from multiple contiguous buckets
-for anomaly detection. The final anomaly score is now a combination of values
-from both the “standard” single-bucket analysis and the new multi-bucket
-analysis. A new `multi_bucket_impact` property in the
-<<ml-results-records,record results>> indicates how strongly either form of
-analysis influences the score. In {kib}, anomalies with medium or high
-multi-bucket impact are depicted in the *Anomaly Explorer* and the
-*Single Metric Viewer* with a cross symbol instead of a dot.
-
+Sometimes events are not interesting or anomalous in the context of a single 
+bucket. However, they become interesting when you take into consideration a 
+sequence of buckets as a whole. In 6.5, there is a new {ml} 
+_multi-bucket analysis_, which uses features from multiple contiguous buckets 
+for anomaly detection. The final anomaly score is now a combination of values 
+from both the “standard” single-bucket analysis and the new multi-bucket 
+analysis. A new `multi_bucket_impact` property in the 
+<<ml-results-records,record results>> indicates how strongly either form of 
+analysis influences the score. In {kib}, anomalies with medium or high 
+multi-bucket impact are depicted in the *Anomaly Explorer* and the 
+*Single Metric Viewer* with a cross symbol instead of a dot. 
 
 [float]
 === Create source-only snapshots
@@ -79,3 +78,14 @@ applying token filters required creating and using custom analysis plugins.
 {es} SQL now supports ODBC mode in addition to JDBC. The functionality is
 currently the same as JDBC. An alpha version of the ODBC client is now
 available for download.
+
+[float]
+=== Cross-cluster replication (beta)
+
+Cross-cluster replication enables you to replicate indices that exist in remote 
+clusters to your local cluster. You create an index in your local cluster 
+(known as a _follower index_) that follows an index (known as a _leader index_)
+in a remote cluster. You can also automatically follow indices in a 
+remote cluster that match a pattern. The individual write operations that occur 
+on the leader indices are then replayed on the follower indices. For more 
+information, see {stack-ov}/xpack-ccr.html[Cross-cluster replication] and <<ccr-apis>>. 

--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -87,5 +87,9 @@ clusters to your local cluster. You create an index in your local cluster
 (known as a _follower index_) that follows an index (known as a _leader index_)
 in a remote cluster. You can also automatically follow indices in a 
 remote cluster that match a pattern. The individual write operations that occur 
-on the leader indices are then replayed on the follower indices. For more 
-information, see {stack-ov}/xpack-ccr.html[Cross-cluster replication] and <<ccr-apis>>. 
+on the leader indices are then replayed on the follower indices. This 
+functionality is useful for replicating data to a second cluster for disaster 
+recovery purposes and for geo-proximity so that reads can be served locally.
+
+For more information, see {stack-ov}/xpack-ccr.html[Cross-cluster replication] 
+and <<ccr-apis>>. 


### PR DESCRIPTION
This PR adds an item in the Elasticsearch 6.5 release highlights (https://www.elastic.co/guide/en/elasticsearch/reference/6.5/release-highlights-6.5.0.html) for the cross-cluster replication feature. 