### PR TITLE
Remove Comparable interface from ScoreAccessor

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/ScoreAccessor.java
+++ b/server/src/main/java/org/elasticsearch/script/ScoreAccessor.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * The provided {@link DocLookup} is used to retrieve the score
  * for the current document.
  */
-public final class ScoreAccessor extends Number implements Comparable<Number> {
+public final class ScoreAccessor extends Number {
 
     Scorable scorer;
 
@@ -64,10 +64,5 @@ public final class ScoreAccessor extends Number implements Comparable<Number> {
     @Override
     public double doubleValue() {
         return score();
-    }
-
-    @Override
-    public int compareTo(Number o) {
-        return Float.compare(this.score(), o.floatValue());
     }
 }


### PR DESCRIPTION
The way ScoreAccessor implements `compareTo()` is problematic because it doesn't
completely follow the Comparable contract, specificaly symmetry (if x is a
ScoreAccessor and y any Number then x.comparTo(y) works, but y.compareTo(x)
generally does not even compile). Fortunately we don't seem to use the fact that
ScoreAccessor is a Comparable anywhere, so we can simply remove it.