### PR TITLE
HLRC: add support for get license basic/trial status API

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseClient.java
@@ -26,6 +26,8 @@ import org.elasticsearch.client.license.StartTrialRequest;
 import org.elasticsearch.client.license.StartTrialResponse;
 import org.elasticsearch.client.license.StartBasicRequest;
 import org.elasticsearch.client.license.StartBasicResponse;
+import org.elasticsearch.client.license.GetBasicStatusResponse;
+import org.elasticsearch.client.license.GetTrialStatusResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
@@ -170,6 +172,28 @@ public final class LicenseClient {
                                 ActionListener<StartBasicResponse> listener) {
         restHighLevelClient.performRequestAsyncAndParseEntity(request, LicenseRequestConverters::startBasic, options,
             StartBasicResponse::fromXContent, listener, emptySet());
+    }
+
+    /**
+     * Retrieve the license trial status
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @return the response
+     * @throws IOException in case there is a problem sending the request or parsing back the response
+     */
+    public GetTrialStatusResponse getTrialStatus(RequestOptions options) throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(Validatable.EMPTY,
+            request -> LicenseRequestConverters.getLicenseTrialStatus(), options, GetTrialStatusResponse::fromXContent, emptySet());
+    }
+
+    /**
+     * Retrieve the license basic status
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @return the response
+     * @throws IOException in case there is a problem sending the request or parsing back the response
+     */
+    public GetBasicStatusResponse getBasicStatus(RequestOptions options) throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(Validatable.EMPTY,
+            request -> LicenseRequestConverters.getLicenseBasicStatus(), options, GetBasicStatusResponse::fromXContent, emptySet());
     }
 
     /**

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseRequestConverters.java
@@ -88,4 +88,12 @@ final class LicenseRequestConverters {
         }
         return request;
     }
+
+    static Request getLicenseTrialStatus() {
+        return new Request(HttpGet.METHOD_NAME, "/_xpack/license/trial_status");
+    }
+
+    static Request getLicenseBasicStatus() {
+        return new Request(HttpGet.METHOD_NAME, "/_xpack/license/basic_status");
+    }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/Validatable.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/Validatable.java
@@ -24,6 +24,9 @@ import java.util.Optional;
  * Defines a validation layer for Requests.
  */
 public interface Validatable {
+
+    Validatable EMPTY = new Validatable() {};
+
     /**
      * Perform validation. This method does not have to be overridden in the event that no validation needs to be done,
      * or the validation was done during object construction time. A {@link ValidationException} that is not null is

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/license/GetBasicStatusResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/license/GetBasicStatusResponse.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.license;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+
+/**
+ * Response class for license get basic status API
+ */
+public class GetBasicStatusResponse {
+
+    private static final ParseField ELIGIBLE_TO_START_BASIC = new ParseField("eligible_to_start_basic");
+
+    private static final ConstructingObjectParser<GetBasicStatusResponse, Void> PARSER = new ConstructingObjectParser<>(
+        "get_basic_status_response", true, a -> new GetBasicStatusResponse((boolean) a[0]));
+
+    static {
+        PARSER.declareField(constructorArg(), (parser, context) -> parser.booleanValue(), ELIGIBLE_TO_START_BASIC,
+            ObjectParser.ValueType.BOOLEAN);
+    }
+
+    private final boolean eligibleToStartBasic;
+
+    GetBasicStatusResponse(boolean eligibleToStartBasic) {
+        this.eligibleToStartBasic = eligibleToStartBasic;
+    }
+
+    /**
+     * Returns whether the license is eligible to start basic or not
+     */
+    public boolean isEligibleToStartBasic() {
+        return eligibleToStartBasic;
+    }
+
+    public static GetBasicStatusResponse fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GetBasicStatusResponse that = (GetBasicStatusResponse) o;
+        return eligibleToStartBasic == that.eligibleToStartBasic;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eligibleToStartBasic);
+    }
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/license/GetTrialStatusResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/license/GetTrialStatusResponse.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.license;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+
+/**
+ * Response class for license get trial status API
+ */
+public class GetTrialStatusResponse {
+
+    private static final ParseField ELIGIBLE_TO_START_TRIAL = new ParseField("eligible_to_start_trial");
+
+    private static final ConstructingObjectParser<GetTrialStatusResponse, Void> PARSER = new ConstructingObjectParser<>(
+        "get_trial_status_response", true, a -> new GetTrialStatusResponse((boolean) a[0]));
+
+    static {
+        PARSER.declareField(constructorArg(), (parser, context) -> parser.booleanValue(), ELIGIBLE_TO_START_TRIAL,
+            ObjectParser.ValueType.BOOLEAN);
+    }
+
+    private final boolean eligibleToStartTrial;
+
+    GetTrialStatusResponse(boolean eligibleToStartTrial) {
+        this.eligibleToStartTrial = eligibleToStartTrial;
+    }
+
+    /**
+     * Returns whether the license is eligible to start trial or not
+     */
+    public boolean isEligibleToStartTrial() {
+        return eligibleToStartTrial;
+    }
+
+    public static GetTrialStatusResponse fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GetTrialStatusResponse that = (GetTrialStatusResponse) o;
+        return eligibleToStartTrial == that.eligibleToStartTrial;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eligibleToStartTrial);
+    }
+
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/LicenseIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/LicenseIT.java
@@ -22,8 +22,10 @@ package org.elasticsearch.client;
 import org.elasticsearch.Build;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.license.DeleteLicenseRequest;
+import org.elasticsearch.client.license.GetBasicStatusResponse;
 import org.elasticsearch.client.license.GetLicenseRequest;
 import org.elasticsearch.client.license.GetLicenseResponse;
+import org.elasticsearch.client.license.GetTrialStatusResponse;
 import org.elasticsearch.client.license.LicensesStatus;
 import org.elasticsearch.client.license.PutLicenseRequest;
 import org.elasticsearch.client.license.PutLicenseResponse;
@@ -197,5 +199,15 @@ public class LicenseIT extends ESRestHighLevelClientTestCase {
         final DeleteLicenseRequest request = new DeleteLicenseRequest();
         final AcknowledgedResponse response = highLevelClient().license().deleteLicense(request, RequestOptions.DEFAULT);
         assertThat(response.isAcknowledged(), equalTo(true));
+    }
+
+    public void testGetTrialStatus() throws IOException {
+        GetTrialStatusResponse trialStatus = highLevelClient().license().getTrialStatus(RequestOptions.DEFAULT);
+        assertFalse(trialStatus.isEligibleToStartTrial());
+    }
+
+    public void testGetBasicStatus() throws IOException {
+        GetBasicStatusResponse basicStatus = highLevelClient().license().getBasicStatus(RequestOptions.DEFAULT);
+        assertTrue(basicStatus.isEligibleToStartBasic());
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/LicenseRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/LicenseRequestConvertersTests.java
@@ -128,4 +128,20 @@ public class LicenseRequestConvertersTests extends ESTestCase {
         assertThat(request.getParameters(), equalTo(expectedParams));
         assertThat(request.getEntity(), is(nullValue()));
     }
+
+    public void testGetLicenseTrialStatus() {
+        Request request = LicenseRequestConverters.getLicenseTrialStatus();
+        assertEquals(HttpGet.METHOD_NAME, request.getMethod());
+        assertEquals("/_xpack/license/trial_status", request.getEndpoint());
+        assertEquals(request.getParameters().size(), 0);
+        assertNull(request.getEntity());
+    }
+
+    public void testGetLicenseBasicStatus() {
+        Request request = LicenseRequestConverters.getLicenseBasicStatus();
+        assertEquals(HttpGet.METHOD_NAME, request.getMethod());
+        assertEquals("/_xpack/license/basic_status", request.getEndpoint());
+        assertEquals(request.getParameters().size(), 0);
+        assertNull(request.getEntity());
+    }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -753,7 +753,6 @@ public class RestHighLevelClientTests extends ESTestCase {
                 assertSubmitTaskMethod(methods, method, apiName, restSpec);
             } else {
                 assertSyncMethod(method, apiName);
-
                 boolean remove = apiSpec.remove(apiName);
                 if (remove == false) {
                     if (deprecatedMethods.contains(apiName)) {
@@ -788,7 +787,7 @@ public class RestHighLevelClientTests extends ESTestCase {
         assertThat("Some API are not supported but they should be: " + apiSpec, apiSpec.size(), equalTo(0));
     }
 
-    private void assertSyncMethod(Method method, String apiName) {
+    private static void assertSyncMethod(Method method, String apiName) {
         //A few methods return a boolean rather than a response object
         if (apiName.equals("ping") || apiName.contains("exist")) {
             assertThat("the return type for method [" + method + "] is incorrect",
@@ -804,7 +803,8 @@ public class RestHighLevelClientTests extends ESTestCase {
         assertEquals("incorrect number of exceptions for method [" + method + "]", 1, method.getExceptionTypes().length);
         //a few methods don't accept a request object as argument
         if (apiName.equals("ping") || apiName.equals("info") || apiName.equals("security.get_ssl_certificates")
-            || apiName.equals("security.authenticate")) {
+            || apiName.equals("security.authenticate") || apiName.equals("license.get_trial_status")
+            || apiName.equals("license.get_basic_status")) {
             assertEquals("incorrect number of arguments for method [" + method + "]", 1, method.getParameterTypes().length);
             assertThat("the parameter to method [" + method + "] is the wrong type",
                 method.getParameterTypes()[0], equalTo(RequestOptions.class));
@@ -817,7 +817,7 @@ public class RestHighLevelClientTests extends ESTestCase {
         }
     }
 
-    private void assertAsyncMethod(Map<String, Method> methods, Method method, String apiName) {
+    private static void assertAsyncMethod(Map<String, Method> methods, Method method, String apiName) {
         assertTrue("async method [" + method.getName() + "] doesn't have corresponding sync method",
                 methods.containsKey(apiName.substring(0, apiName.length() - 6)));
         assertThat("async method [" + method + "] should return void", method.getReturnType(), equalTo(Void.TYPE));
@@ -837,7 +837,8 @@ public class RestHighLevelClientTests extends ESTestCase {
         }
     }
 
-    private void assertSubmitTaskMethod(Map<String, Method> methods, Method method, String apiName, ClientYamlSuiteRestSpec restSpec) {
+    private static void assertSubmitTaskMethod(Map<String, Method> methods, Method method, String apiName,
+                                               ClientYamlSuiteRestSpec restSpec) {
         String methodName = extractMethodName(apiName);
         assertTrue("submit task method [" + method.getName() + "] doesn't have corresponding sync method",
             methods.containsKey(methodName));
@@ -851,11 +852,11 @@ public class RestHighLevelClientTests extends ESTestCase {
             restSpec.getApi(methodName).getParams(), Matchers.hasKey("wait_for_completion"));
     }
 
-    private String extractMethodName(String apiName) {
+    private static String extractMethodName(String apiName) {
         return apiName.substring(SUBMIT_TASK_PREFIX.length(), apiName.length() - SUBMIT_TASK_SUFFIX.length());
     }
 
-    private boolean isSubmitTaskMethod(String apiName) {
+    private static boolean isSubmitTaskMethod(String apiName) {
         return apiName.startsWith(SUBMIT_TASK_PREFIX) && apiName.endsWith(SUBMIT_TASK_SUFFIX);
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/LicensingDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/LicensingDocumentationIT.java
@@ -30,6 +30,8 @@ import org.elasticsearch.client.license.StartTrialRequest;
 import org.elasticsearch.client.license.StartTrialResponse;
 import org.elasticsearch.client.license.StartBasicRequest;
 import org.elasticsearch.client.license.StartBasicResponse;
+import org.elasticsearch.client.license.GetBasicStatusResponse;
+import org.elasticsearch.client.license.GetTrialStatusResponse;
 import org.elasticsearch.common.Booleans;
 import org.junit.After;
 import org.junit.BeforeClass;
@@ -334,6 +336,32 @@ public class LicensingDocumentationIT extends ESRestHighLevelClientTestCase {
             // end::start-basic-execute-async
 
             assertTrue(latch.await(30L, TimeUnit.SECONDS));
+        }
+    }
+
+    public void testGetTrialStatus() throws IOException {
+        RestHighLevelClient client = highLevelClient();
+        {
+            //tag::get-trial-status-execute
+            GetTrialStatusResponse response = client.license().getTrialStatus(RequestOptions.DEFAULT);
+            //end::get-trial-status-execute
+
+            //tag::get-trial-status-response
+            boolean eligibleToStartTrial = response.isEligibleToStartTrial(); // <1>
+            //end::get-trial-status-response
+        }
+    }
+
+    public void testGetBasicStatus() throws IOException {
+        RestHighLevelClient client = highLevelClient();
+        {
+            //tag::get-basic-status-execute
+            GetBasicStatusResponse response = client.license().getBasicStatus(RequestOptions.DEFAULT);
+            //end::get-basic-status-execute
+
+            //tag::get-basic-status-response
+            boolean eligibleToStartbasic = response.isEligibleToStartBasic(); // <1>
+            //end::get-basic-status-response
         }
     }
 }

--- a/docs/java-rest/high-level/licensing/get-basic-status.asciidoc
+++ b/docs/java-rest/high-level/licensing/get-basic-status.asciidoc
@@ -1,0 +1,23 @@
+[[java-rest-high-get-basic-status]]
+=== Get Basic Status
+
+[[java-rest-high-get-basic-status-execution]]
+==== Execution
+
+The basic status of the license can be retrieved as follows:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/LicensingDocumentationIT.java[get-basic-status-execute]
+--------------------------------------------------
+
+[[java-rest-high-get-basic-status-response]]
+==== Response
+
+The returned `GetTrialStatusResponse` holds only a `boolean` flag:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/LicensingDocumentationIT.java[get-basic-status-response]
+--------------------------------------------------
+<1> Whether the license is eligible to start basic or not

--- a/docs/java-rest/high-level/licensing/get-trial-status.asciidoc
+++ b/docs/java-rest/high-level/licensing/get-trial-status.asciidoc
@@ -1,0 +1,23 @@
+[[java-rest-high-get-trial-status]]
+=== Get Trial Status
+
+[[java-rest-high-get-trial-status-execution]]
+==== Execution
+
+The trial status of the license can be retrieved as follows:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/LicensingDocumentationIT.java[get-trial-status-execute]
+--------------------------------------------------
+
+[[java-rest-high-get-trial-status-response]]
+==== Response
+
+The returned `GetTrialStatusResponse` holds only a `boolean` flag:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/LicensingDocumentationIT.java[get-trial-status-response]
+--------------------------------------------------
+<1> Whether the license is eligible to start trial or not

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -220,12 +220,16 @@ The Java High Level REST Client supports the following Licensing APIs:
 * <<java-rest-high-delete-license>>
 * <<java-rest-high-start-trial>>
 * <<java-rest-high-start-basic>>
+* <<java-rest-high-get-trial-status>>
+* <<java-rest-high-get-basic-status>>
 
 include::licensing/put-license.asciidoc[]
 include::licensing/get-license.asciidoc[]
 include::licensing/delete-license.asciidoc[]
 include::licensing/start-trial.asciidoc[]
 include::licensing/start-basic.asciidoc[]
+include::licensing/get-trial-status.asciidoc[]
+include::licensing/get-basic-status.asciidoc[]
 
 == Machine Learning APIs
 :upid: {mainid}-x-pack-ml

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetBasicStatusResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetBasicStatusResponse.java
@@ -8,17 +8,20 @@ package org.elasticsearch.license;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Objects;
 
-class GetBasicStatusResponse extends ActionResponse {
+public class GetBasicStatusResponse extends ActionResponse implements ToXContentObject {
 
     private boolean eligibleToStartBasic;
 
     GetBasicStatusResponse() {
     }
 
-    GetBasicStatusResponse(boolean eligibleToStartBasic) {
+    public GetBasicStatusResponse(boolean eligibleToStartBasic) {
         this.eligibleToStartBasic = eligibleToStartBasic;
     }
 
@@ -34,5 +37,30 @@ class GetBasicStatusResponse extends ActionResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeBoolean(eligibleToStartBasic);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("eligible_to_start_basic", eligibleToStartBasic);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GetBasicStatusResponse that = (GetBasicStatusResponse) o;
+        return eligibleToStartBasic == that.eligibleToStartBasic;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eligibleToStartBasic);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetTrialStatusResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetTrialStatusResponse.java
@@ -8,17 +8,20 @@ package org.elasticsearch.license;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Objects;
 
-class GetTrialStatusResponse extends ActionResponse {
+public class GetTrialStatusResponse extends ActionResponse implements ToXContentObject {
 
     private boolean eligibleToStartTrial;
 
     GetTrialStatusResponse() {
     }
 
-    GetTrialStatusResponse(boolean eligibleToStartTrial) {
+    public GetTrialStatusResponse(boolean eligibleToStartTrial) {
         this.eligibleToStartTrial = eligibleToStartTrial;
     }
 
@@ -34,5 +37,30 @@ class GetTrialStatusResponse extends ActionResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeBoolean(eligibleToStartTrial);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GetTrialStatusResponse that = (GetTrialStatusResponse) o;
+        return eligibleToStartTrial == that.eligibleToStartTrial;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eligibleToStartTrial);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("eligible_to_start_trial", eligibleToStartTrial);
+        builder.endObject();
+        return builder;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetBasicStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetBasicStatus.java
@@ -6,17 +6,11 @@
 package org.elasticsearch.license;
 
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
-import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.rest.action.RestBuilderListener;
+import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.XPackClient;
 import org.elasticsearch.xpack.core.rest.XPackRestHandler;
-
-import java.io.IOException;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -28,17 +22,8 @@ public class RestGetBasicStatus extends XPackRestHandler {
     }
 
     @Override
-    protected RestChannelConsumer doPrepareRequest(RestRequest request, XPackClient client) throws IOException {
-        return channel -> client.licensing().prepareGetStartBasic().execute(
-                new RestBuilderListener<GetBasicStatusResponse>(channel) {
-                    @Override
-                    public RestResponse buildResponse(GetBasicStatusResponse response, XContentBuilder builder) throws Exception {
-                        builder.startObject();
-                        builder.field("eligible_to_start_basic", response.isEligibleToStartBasic());
-                        builder.endObject();
-                        return new BytesRestResponse(RestStatus.OK, builder);
-                    }
-                });
+    protected RestChannelConsumer doPrepareRequest(RestRequest request, XPackClient client) {
+        return channel -> client.licensing().prepareGetStartBasic().execute(new RestToXContentListener<>(channel));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetTrialStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetTrialStatus.java
@@ -6,17 +6,11 @@
 package org.elasticsearch.license;
 
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
-import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.rest.action.RestBuilderListener;
+import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.XPackClient;
 import org.elasticsearch.xpack.core.rest.XPackRestHandler;
-
-import java.io.IOException;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -28,17 +22,8 @@ public class RestGetTrialStatus extends XPackRestHandler {
     }
 
     @Override
-    protected RestChannelConsumer doPrepareRequest(RestRequest request, XPackClient client) throws IOException {
-        return channel -> client.licensing().prepareGetStartTrial().execute(
-                new RestBuilderListener<GetTrialStatusResponse>(channel) {
-                    @Override
-                    public RestResponse buildResponse(GetTrialStatusResponse response, XContentBuilder builder) throws Exception {
-                        builder.startObject();
-                        builder.field("eligible_to_start_trial", response.isEligibleToStartTrial());
-                        builder.endObject();
-                        return new BytesRestResponse(RestStatus.OK, builder);
-                    }
-                });
+    protected RestChannelConsumer doPrepareRequest(RestRequest request, XPackClient client) {
+        return channel -> client.licensing().prepareGetStartTrial().execute(new RestToXContentListener<>(channel));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/AbstractHlrcStreamableXContentTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/AbstractHlrcStreamableXContentTestCase.java
@@ -43,4 +43,10 @@ public abstract class AbstractHlrcStreamableXContentTestCase<T extends ToXConten
      */
     public abstract T convertHlrcToInternal(H instance);
 
+    //TODO this would be final ideally: why do both responses need to parse from xcontent, only one (H) should? I think that T#fromXContent
+    //are only there for testing and could go away?
+    @Override
+    protected T doParseInstance(XContentParser parser) throws IOException {
+        return convertHlrcToInternal(doHlrcParseInstance(parser));
+    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/xpack/license/GetBasicStatusResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/xpack/license/GetBasicStatusResponseTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.protocol.xpack.license;
+
+
+import org.elasticsearch.client.license.GetBasicStatusResponse;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.protocol.AbstractHlrcStreamableXContentTestCase;
+
+public class GetBasicStatusResponseTests
+    extends AbstractHlrcStreamableXContentTestCase<org.elasticsearch.license.GetBasicStatusResponse, GetBasicStatusResponse> {
+    @Override
+    public GetBasicStatusResponse doHlrcParseInstance(XContentParser parser) {
+        return GetBasicStatusResponse.fromXContent(parser);
+    }
+
+    @Override
+    public org.elasticsearch.license.GetBasicStatusResponse convertHlrcToInternal(GetBasicStatusResponse instance) {
+        return new org.elasticsearch.license.GetBasicStatusResponse(instance.isEligibleToStartBasic());
+    }
+
+    @Override
+    protected org.elasticsearch.license.GetBasicStatusResponse createBlankInstance() {
+        return new org.elasticsearch.license.GetBasicStatusResponse(false);
+    }
+
+    @Override
+    protected org.elasticsearch.license.GetBasicStatusResponse createTestInstance() {
+        return new org.elasticsearch.license.GetBasicStatusResponse(randomBoolean());
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/xpack/license/GetTrialStatusResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/xpack/license/GetTrialStatusResponseTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.protocol.xpack.license;
+
+import org.elasticsearch.client.license.GetTrialStatusResponse;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.protocol.AbstractHlrcStreamableXContentTestCase;
+
+public class GetTrialStatusResponseTests extends
+    AbstractHlrcStreamableXContentTestCase<org.elasticsearch.license.GetTrialStatusResponse, GetTrialStatusResponse> {
+
+    @Override
+    public GetTrialStatusResponse doHlrcParseInstance(XContentParser parser) {
+        return GetTrialStatusResponse.fromXContent(parser);
+    }
+
+    @Override
+    public org.elasticsearch.license.GetTrialStatusResponse convertHlrcToInternal(GetTrialStatusResponse instance) {
+        return new org.elasticsearch.license.GetTrialStatusResponse(instance.isEligibleToStartTrial());
+    }
+
+    @Override
+    protected org.elasticsearch.license.GetTrialStatusResponse createBlankInstance() {
+        return new org.elasticsearch.license.GetTrialStatusResponse(false);
+    }
+
+    @Override
+    protected org.elasticsearch.license.GetTrialStatusResponse createTestInstance() {
+        return new org.elasticsearch.license.GetTrialStatusResponse(randomBoolean());
+    }
+}


### PR DESCRIPTION
This is the 6.x backport for #33176 , opening only for CI coverage, no need to review.