### PR TITLE
Fix usages of XContentParserUtils.ensureExpectedToken()

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineResponse.java
@@ -67,7 +67,7 @@ public class SimulatePipelineResponse extends ActionResponse implements ToXConte
                 ensureExpectedToken(Token.START_OBJECT, token, parser::getTokenLocation);
                 SimulateDocumentResult result = null;
                 while ((token = parser.nextToken()) != Token.END_OBJECT) {
-                    ensureExpectedToken(token, Token.FIELD_NAME, parser::getTokenLocation);
+                    ensureExpectedToken(Token.FIELD_NAME, token, parser::getTokenLocation);
                     String fieldName = parser.currentName();
                     token = parser.nextToken();
                     if (token == Token.START_ARRAY) {

--- a/server/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
@@ -196,9 +196,9 @@ public final class ProfileResult implements Writeable, ToXContentObject {
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (BREAKDOWN.match(currentFieldName, parser.getDeprecationHandler())) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                        ensureExpectedToken(parser.currentToken(), XContentParser.Token.FIELD_NAME, parser::getTokenLocation);
+                        ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser::getTokenLocation);
                         String name = parser.currentName();
-                        ensureExpectedToken(parser.nextToken(), XContentParser.Token.VALUE_NUMBER, parser::getTokenLocation);
+                        ensureExpectedToken(XContentParser.Token.VALUE_NUMBER, parser.nextToken(), parser::getTokenLocation);
                         long value = parser.longValue();
                         timings.put(name, value);
                     }

--- a/server/src/test/java/org/elasticsearch/search/profile/SearchProfileShardResultsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/SearchProfileShardResultsTests.java
@@ -87,9 +87,9 @@ public class SearchProfileShardResultsTests  extends ESTestCase {
         }
         SearchProfileShardResults parsed;
         try (XContentParser parser = createParser(xContentType.xContent(), mutated)) {
-            ensureExpectedToken(parser.nextToken(), XContentParser.Token.START_OBJECT, parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
             ensureFieldName(parser, parser.nextToken(), SearchProfileShardResults.PROFILE_FIELD);
-            ensureExpectedToken(parser.nextToken(), XContentParser.Token.START_OBJECT, parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
             parsed = SearchProfileShardResults.fromXContent(parser);
             assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
             assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());

--- a/server/src/test/java/org/elasticsearch/search/profile/aggregation/AggregationProfileShardResultTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/aggregation/AggregationProfileShardResultTests.java
@@ -57,9 +57,9 @@ public class AggregationProfileShardResultTests extends ESTestCase {
 
         AggregationProfileShardResult parsed;
         try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
-            XContentParserUtils.ensureExpectedToken(parser.nextToken(), XContentParser.Token.START_OBJECT, parser::getTokenLocation);
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
             XContentParserUtils.ensureFieldName(parser, parser.nextToken(), AggregationProfileShardResult.AGGREGATIONS);
-            XContentParserUtils.ensureExpectedToken(parser.nextToken(), XContentParser.Token.START_ARRAY, parser::getTokenLocation);
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser::getTokenLocation);
             parsed = AggregationProfileShardResult.fromXContent(parser);
             assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
             assertNull(parser.nextToken());

--- a/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfileShardResultTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfileShardResultTests.java
@@ -59,7 +59,7 @@ public class QueryProfileShardResultTests extends ESTestCase {
 
         QueryProfileShardResult parsed;
         try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
-            XContentParserUtils.ensureExpectedToken(parser.nextToken(), XContentParser.Token.START_OBJECT, parser::getTokenLocation);
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
             parsed = QueryProfileShardResult.fromXContent(parser);
             assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
             assertNull(parser.nextToken());


### PR DESCRIPTION
Some usages of XContentParserUtils.ensureExpectedToken() are inverting
the expected and actual tokens, resulting in wrong error messages.
