### PR TITLE
[ML] Job in index: Restore ability to update cluster state jobs

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateJobAction.java
@@ -54,6 +54,7 @@ public class UpdateJobAction extends Action<UpdateJobAction.Request, PutJobActio
 
         /** Indicates an update that was not triggered by a user */
         private boolean isInternal;
+        private boolean waitForAck = true;
 
         public Request(String jobId, JobUpdate update) {
             this(jobId, update, false);
@@ -87,6 +88,14 @@ public class UpdateJobAction extends Action<UpdateJobAction.Request, PutJobActio
             return isInternal;
         }
 
+        public boolean isWaitForAck() {
+            return waitForAck;
+        }
+
+        public void setWaitForAck(boolean waitForAck) {
+            this.waitForAck = waitForAck;
+        }
+
         @Override
         public ActionRequestValidationException validate() {
             return null;
@@ -102,9 +111,10 @@ public class UpdateJobAction extends Action<UpdateJobAction.Request, PutJobActio
             } else {
                 isInternal = false;
             }
-            // TODO jindex change CURRENT to specific version when feature branch is merged
-            if (in.getVersion().onOrAfter(Version.V_6_3_0) && in.getVersion().before(Version.CURRENT)) {
-                in.readBoolean(); // was waitForAck
+            if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
+                waitForAck = in.readBoolean();
+            } else {
+                waitForAck = true;
             }
         }
 
@@ -116,9 +126,8 @@ public class UpdateJobAction extends Action<UpdateJobAction.Request, PutJobActio
             if (out.getVersion().onOrAfter(Version.V_6_2_2)) {
                 out.writeBoolean(isInternal);
             }
-            // TODO jindex change CURRENT to specific version when feature branch is merged
-            if (out.getVersion().onOrAfter(Version.V_6_3_0) && out.getVersion().before(Version.CURRENT)) {
-                out.writeBoolean(false); // was waitForAck
+            if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
+                out.writeBoolean(waitForAck);
             }
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionAction.java
@@ -62,9 +62,8 @@ public class TransportFinalizeJobExecutionAction extends TransportMasterNodeActi
                 .filter(id -> mlMetadata.getJobs().containsKey(id))
                 .collect(Collectors.toList());
 
-        // As this action is only called by pre v6.6.0 nodes that cannot run jobs
-        // defined in the index this check should not be necessary i.e. the
-        // job config must be in the clusterstate
+        // This action should not be called for jobs that have
+        // their configuration in index documents 
 
         if (jobsInClusterState.isEmpty()) {
             // This action is a no-op for jobs not defined in the cluster state.

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionAction.java
@@ -10,16 +10,27 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.XPackPlugin;
+import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.action.FinalizeJobExecutionAction;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
 
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+// This action is only called from modes before version 6.6.0
 public class TransportFinalizeJobExecutionAction extends TransportMasterNodeAction<FinalizeJobExecutionAction.Request,
     AcknowledgedResponse> {
 
@@ -45,9 +56,56 @@ public class TransportFinalizeJobExecutionAction extends TransportMasterNodeActi
     @Override
     protected void masterOperation(FinalizeJobExecutionAction.Request request, ClusterState state,
                                    ActionListener<AcknowledgedResponse> listener) {
-        // This action is no longer required but needs to be preserved
-        // in case it is called by an old node in a mixed cluster
-        listener.onResponse(new AcknowledgedResponse(true));
+
+        MlMetadata mlMetadata = MlMetadata.getMlMetadata(state);
+        List<String> jobsInClusterState = Arrays.stream(request.getJobIds())
+                .filter(id -> mlMetadata.getJobs().containsKey(id))
+                .collect(Collectors.toList());
+
+        // As this action is only called by pre v6.6.0 nodes that cannot run jobs
+        // defined in the index this check should not be necessary i.e. the
+        // job config must be in the clusterstate
+
+        if (jobsInClusterState.isEmpty()) {
+            // This action is a no-op for jobs not defined in the cluster state.
+            listener.onResponse(new AcknowledgedResponse(true));
+            return;
+        }
+
+        String jobIdString = String.join(",", jobsInClusterState);
+        String source = "finalize_job_execution [" + jobIdString + "]";
+        logger.debug("finalizing jobs [{}]", jobIdString);
+        clusterService.submitStateUpdateTask(source, new ClusterStateUpdateTask() {
+            @Override
+            public ClusterState execute(ClusterState currentState) {
+                XPackPlugin.checkReadyForXPackCustomMetadata(currentState);
+                MlMetadata mlMetadata = MlMetadata.getMlMetadata(currentState);
+                MlMetadata.Builder mlMetadataBuilder = new MlMetadata.Builder(mlMetadata);
+                Date finishedTime = new Date();
+
+                for (String jobId : jobsInClusterState) {
+                    Job.Builder jobBuilder = new Job.Builder(mlMetadata.getJobs().get(jobId));
+                    jobBuilder.setFinishedTime(finishedTime);
+                    mlMetadataBuilder.putJob(jobBuilder.build(), true);
+                }
+                ClusterState.Builder builder = ClusterState.builder(currentState);
+                return builder.metaData(new MetaData.Builder(currentState.metaData())
+                        .putCustom(MlMetadata.TYPE, mlMetadataBuilder.build()))
+                        .build();
+            }
+
+            @Override
+            public void onFailure(String source, Exception e) {
+                listener.onFailure(e);
+            }
+
+            @Override
+            public void clusterStateProcessed(String source, ClusterState oldState,
+                                              ClusterState newState) {
+                logger.debug("finalized job [{}]", jobIdString);
+                listener.onResponse(new AcknowledgedResponse(true));
+            }
+        });
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionAction.java
@@ -63,7 +63,7 @@ public class TransportFinalizeJobExecutionAction extends TransportMasterNodeActi
                 .collect(Collectors.toList());
 
         // This action should not be called for jobs that have
-        // their configuration in index documents 
+        // their configuration in index documents
 
         if (jobsInClusterState.isEmpty()) {
             // This action is a no-op for jobs not defined in the cluster state.

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/ClusterStateJobUpdate.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/ClusterStateJobUpdate.java
@@ -24,11 +24,11 @@ public final class ClusterStateJobUpdate {
         return mlMetadata.getJobs().containsKey(jobId);
     }
 
-    public static boolean jobIsInClusterState(MlMetadata mlMetadata, String jobId) {
+    public static boolean jobIsInMlMetadata(MlMetadata mlMetadata, String jobId) {
         return mlMetadata.getJobs().containsKey(jobId);
     }
 
-    public static ClusterState updateClusterState(Job job, boolean overwrite, ClusterState currentState) {
+    public static ClusterState putJobInClusterState(Job job, boolean overwrite, ClusterState currentState) {
         MlMetadata.Builder builder = createMlMetadataBuilder(currentState);
         builder.putJob(job, overwrite);
         return buildNewClusterState(currentState, builder);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/ClusterStateJobUpdate.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/ClusterStateJobUpdate.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.job;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.xpack.core.XPackPlugin;
+import org.elasticsearch.xpack.core.ml.MlMetadata;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+
+/**
+ * Helper functions for managing cluster state job configurations
+ */
+public final class ClusterStateJobUpdate {
+
+    private ClusterStateJobUpdate() {
+    }
+
+    public static ClusterState updateClusterState(Job job, boolean overwrite, ClusterState currentState) {
+        MlMetadata.Builder builder = createMlMetadataBuilder(currentState);
+        builder.putJob(job, overwrite);
+        return buildNewClusterState(currentState, builder);
+    }
+
+    private static MlMetadata.Builder createMlMetadataBuilder(ClusterState currentState) {
+        return new MlMetadata.Builder(MlMetadata.getMlMetadata(currentState));
+    }
+
+    private static ClusterState buildNewClusterState(ClusterState currentState, MlMetadata.Builder builder) {
+        XPackPlugin.checkReadyForXPackCustomMetadata(currentState);
+        ClusterState.Builder newState = ClusterState.builder(currentState);
+        newState.metaData(MetaData.builder(currentState.getMetaData()).putCustom(MlMetadata.TYPE, builder.build()).build());
+        return newState.build();
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/ClusterStateJobUpdate.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/ClusterStateJobUpdate.java
@@ -19,6 +19,15 @@ public final class ClusterStateJobUpdate {
     private ClusterStateJobUpdate() {
     }
 
+    public static boolean jobIsInClusterState(ClusterState clusterState, String jobId) {
+        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
+        return mlMetadata.getJobs().containsKey(jobId);
+    }
+
+    public static boolean jobIsInClusterState(MlMetadata mlMetadata, String jobId) {
+        return mlMetadata.getJobs().containsKey(jobId);
+    }
+
     public static ClusterState updateClusterState(Job job, boolean overwrite, ClusterState currentState) {
         MlMetadata.Builder builder = createMlMetadataBuilder(currentState);
         builder.putJob(job, overwrite);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionActionTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.ml.MlMetadata;
+import org.elasticsearch.xpack.core.ml.action.FinalizeJobExecutionAction;
+import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
+
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class TransportFinalizeJobExecutionActionTests extends ESTestCase {
+
+    public void testOperation_noJobsInClusterState() {
+        ClusterService clusterService = mock(ClusterService.class);
+        TransportFinalizeJobExecutionAction action = createAction(clusterService);
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("finalize-job-action-tests")).build();
+
+        FinalizeJobExecutionAction.Request request = new FinalizeJobExecutionAction.Request(new String[]{"index-job1", "index-job2"});
+        AtomicReference<AcknowledgedResponse> ack = new AtomicReference<>();
+        action.masterOperation(request, clusterState, ActionListener.wrap(
+                ack::set,
+                e -> fail(e.getMessage())
+        ));
+
+        assertTrue(ack.get().isAcknowledged());
+        verify(clusterService, never()).submitStateUpdateTask(any(), any());
+    }
+
+    public void testOperation_jobInClusterState() {
+        ClusterService clusterService = mock(ClusterService.class);
+        TransportFinalizeJobExecutionAction action = createAction(clusterService);
+
+        MlMetadata.Builder mlBuilder = new MlMetadata.Builder();
+        mlBuilder.putJob(BaseMlIntegTestCase.createFareQuoteJob("cs-job").build(new Date()), false);
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("finalize-job-action-tests"))
+                .metaData(MetaData.builder()
+                        .putCustom(MlMetadata.TYPE, mlBuilder.build()))
+                .build();
+
+        FinalizeJobExecutionAction.Request request = new FinalizeJobExecutionAction.Request(new String[]{"cs-job"});
+        AtomicReference<AcknowledgedResponse> ack = new AtomicReference<>();
+        action.masterOperation(request, clusterState, ActionListener.wrap(
+                ack::set,
+                e -> fail(e.getMessage())
+        ));
+
+        verify(clusterService, times(1)).submitStateUpdateTask(any(), any());
+    }
+
+    private TransportFinalizeJobExecutionAction createAction(ClusterService clusterService) {
+        return new TransportFinalizeJobExecutionAction(Settings.EMPTY, mock(TransportService.class), clusterService,
+                mock(ThreadPool.class), mock(ActionFilters.class), mock(IndexNameExpressionResolver.class));
+
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
@@ -53,7 +53,6 @@ import org.elasticsearch.xpack.ml.job.process.autodetect.UpdateParams;
 import org.elasticsearch.xpack.ml.notifications.Auditor;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 import java.io.IOException;


### PR DESCRIPTION
Feature branch PR.

In 6.6 and 6.7 jobs left open during upgrade will not be migrated and will continue to run with clusterstate configuration meaning the ability to update those jobs needs to be restored.

- Restore FinalizeJobExecutionAction for cluster state jobs only
- Restore JobManager `updateJob()` and `revertSnapshot()`. The approach here is to first look in the clusterstate for the job configuration then update the appropriate location

