### PR TITLE
Expose all permits acquisition in IndexShard and TransportReplicationAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -335,7 +335,7 @@ public abstract class TransportReplicationAction<
         @Override
         protected void doRun() throws Exception {
             final ShardId shardId = request.shardId();
-            final IndexShard indexShard = getIndexShard(shardId, targetAllocationID);
+            final IndexShard indexShard = getIndexShard(shardId);
             final ShardRouting shardRouting = indexShard.routingEntry();
             // we may end up here if the cluster state used to route the primary is so stale that the underlying
             // index shard was replaced with a replica. For example - in a two node cluster, if the primary fails
@@ -609,7 +609,7 @@ public abstract class TransportReplicationAction<
             this.maxSeqNoOfUpdatesOrDeletes = maxSeqNoOfUpdatesOrDeletes;
             final ShardId shardId = request.shardId();
             assert shardId != null : "request shardId must be set";
-            this.replica = getIndexShard(shardId, targetAllocationID);
+            this.replica = getIndexShard(shardId);
         }
 
         @Override
@@ -719,7 +719,7 @@ public abstract class TransportReplicationAction<
         }
     }
 
-    protected IndexShard getIndexShard(final ShardId shardId, final String targetAllocationID) {
+    protected IndexShard getIndexShard(final ShardId shardId) {
         IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
         return indexService.getShard(shardId.id());
     }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -334,7 +334,38 @@ public abstract class TransportReplicationAction<
 
         @Override
         protected void doRun() throws Exception {
-            acquirePrimaryShardReference(request.shardId(), targetAllocationID, primaryTerm, this, request);
+            final ShardId shardId = request.shardId();
+            final IndexShard indexShard = getIndexShard(shardId, targetAllocationID);
+            final ShardRouting shardRouting = indexShard.routingEntry();
+            // we may end up here if the cluster state used to route the primary is so stale that the underlying
+            // index shard was replaced with a replica. For example - in a two node cluster, if the primary fails
+            // the replica will take over and a replica will be assigned to the first node.
+            if (shardRouting.primary() == false) {
+                throw new ReplicationOperation.RetryOnPrimaryException(shardId, "actual shard is not a primary " + shardRouting);
+            }
+            final String actualAllocationId = shardRouting.allocationId().getId();
+            if (actualAllocationId.equals(targetAllocationID) == false) {
+                throw new ShardNotFoundException(shardId, "expected allocation id [{}] but found [{}]", targetAllocationID,
+                    actualAllocationId);
+            }
+            final long actualTerm = indexShard.getPendingPrimaryTerm();
+            if (actualTerm != primaryTerm) {
+                throw new ShardNotFoundException(shardId, "expected allocation id [{}] with term [{}] but found [{}]", targetAllocationID,
+                    primaryTerm, actualTerm);
+            }
+
+            final ActionListener<PrimaryShardReference> onReferenceAcquired = this;
+            acquirePrimaryOperationPermit(indexShard, request, new ActionListener<Releasable>() {
+                @Override
+                public void onResponse(Releasable releasable) {
+                    onReferenceAcquired.onResponse(new PrimaryShardReference(indexShard, releasable));
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    onReferenceAcquired.onFailure(e);
+                }
+            });
         }
 
         @Override
@@ -587,7 +618,7 @@ public abstract class TransportReplicationAction<
             this.maxSeqNoOfUpdatesOrDeletes = maxSeqNoOfUpdatesOrDeletes;
             final ShardId shardId = request.shardId();
             assert shardId != null : "request shardId must be set";
-            this.replica = getIndexShard(shardId);
+            this.replica = getIndexShard(shardId, targetAllocationID);
         }
 
         @Override
@@ -660,10 +691,10 @@ public abstract class TransportReplicationAction<
             setPhase(task, "replica");
             final String actualAllocationId = this.replica.routingEntry().allocationId().getId();
             if (actualAllocationId.equals(targetAllocationID) == false) {
-                throw new ShardNotFoundException(this.replica.shardId(), "expected aID [{}] but found [{}]", targetAllocationID,
+                throw new ShardNotFoundException(this.replica.shardId(), "expected allocation id [{}] but found [{}]", targetAllocationID,
                     actualAllocationId);
             }
-            replica.acquireReplicaOperationPermit(primaryTerm, globalCheckpoint, maxSeqNoOfUpdatesOrDeletes, this, executor, request);
+            acquireReplicaOperationPermit(replica, request, this, primaryTerm, globalCheckpoint, maxSeqNoOfUpdatesOrDeletes);
         }
 
         /**
@@ -697,7 +728,7 @@ public abstract class TransportReplicationAction<
         }
     }
 
-    protected IndexShard getIndexShard(ShardId shardId) {
+    protected IndexShard getIndexShard(final ShardId shardId, final String targetAllocationID) {
         IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
         return indexService.getShard(shardId.id());
     }
@@ -938,42 +969,26 @@ public abstract class TransportReplicationAction<
     }
 
     /**
-     * Tries to acquire reference to {@link IndexShard} to perform a primary operation. Released after performing primary operation locally
-     * and replication of the operation to all replica shards is completed / failed (see {@link ReplicationOperation}).
+     * Executes the logic for acquiring one or more operation permit on a primary shard. The default is to acquire a single permit but this
+     * method can be overridden to acquire more.
      */
-    private void acquirePrimaryShardReference(ShardId shardId, String allocationId, long primaryTerm,
-                                              ActionListener<PrimaryShardReference> onReferenceAcquired, Object debugInfo) {
-        IndexShard indexShard = getIndexShard(shardId);
-        // we may end up here if the cluster state used to route the primary is so stale that the underlying
-        // index shard was replaced with a replica. For example - in a two node cluster, if the primary fails
-        // the replica will take over and a replica will be assigned to the first node.
-        if (indexShard.routingEntry().primary() == false) {
-            throw new ReplicationOperation.RetryOnPrimaryException(indexShard.shardId(),
-                "actual shard is not a primary " + indexShard.routingEntry());
-        }
-        final String actualAllocationId = indexShard.routingEntry().allocationId().getId();
-        if (actualAllocationId.equals(allocationId) == false) {
-            throw new ShardNotFoundException(shardId, "expected aID [{}] but found [{}]", allocationId, actualAllocationId);
-        }
-        final long actualTerm = indexShard.getPendingPrimaryTerm();
-        if (actualTerm != primaryTerm) {
-            throw new ShardNotFoundException(shardId, "expected aID [{}] with term [{}] but found [{}]", allocationId,
-                primaryTerm, actualTerm);
-        }
+    protected void acquirePrimaryOperationPermit(final IndexShard primary,
+                                                 final Request request,
+                                                 final ActionListener<Releasable> onAcquired) {
+        primary.acquirePrimaryOperationPermit(onAcquired, executor, request);
+    }
 
-        ActionListener<Releasable> onAcquired = new ActionListener<Releasable>() {
-            @Override
-            public void onResponse(Releasable releasable) {
-                onReferenceAcquired.onResponse(new PrimaryShardReference(indexShard, releasable));
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                onReferenceAcquired.onFailure(e);
-            }
-        };
-
-        indexShard.acquirePrimaryOperationPermit(onAcquired, executor, debugInfo);
+    /**
+     * Executes the logic for acquiring one or more operation permit on a replica shard. The default is to acquire a single permit but this
+     * method can be overridden to acquire more.
+     */
+    protected void acquireReplicaOperationPermit(final IndexShard replica,
+                                                 final ReplicaRequest request,
+                                                 final ActionListener<Releasable> onAcquired,
+                                                 final long primaryTerm,
+                                                 final long globalCheckpoint,
+                                                 final long maxSeqNoOfUpdatesOrDeletes) {
+        replica.acquireReplicaOperationPermit(primaryTerm, globalCheckpoint, maxSeqNoOfUpdatesOrDeletes, onAcquired, executor, request);
     }
 
     class ShardReference implements Releasable {

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -355,12 +355,12 @@ public abstract class TransportReplicationAction<
             }
 
             acquirePrimaryOperationPermit(indexShard, request, ActionListener.wrap(
-                releasable -> runWithReleasable(new PrimaryShardReference(indexShard, releasable)),
+                releasable -> runWithPrimaryShardReference(new PrimaryShardReference(indexShard, releasable)),
                 this::onFailure
             ));
         }
 
-        void runWithReleasable(final PrimaryShardReference primaryShardReference) {
+        void runWithPrimaryShardReference(final PrimaryShardReference primaryShardReference) {
             try {
                 final ClusterState clusterState = clusterService.state();
                 final IndexMetaData indexMetaData = clusterState.metaData().getIndexSafe(primaryShardReference.routingEntry().index());

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -2306,9 +2306,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * Acquire all primary operation permits. Once all permits are acquired, the provided ActionListener is called.
      * It is the responsibility of the caller to close the {@link Releasable}.
      */
-    public void acquirePrimaryAllOperationsPermits(final ActionListener<Releasable> onPermitAcquired, final TimeValue timeout) {
+    public void acquireAllPrimaryOperationsPermits(final ActionListener<Releasable> onPermitAcquired, final TimeValue timeout) {
         verifyNotClosed();
-        assert shardRouting.primary() : "acquirePrimaryAllOperationsPermits should only be called on primary shard: " + shardRouting;
+        assert shardRouting.primary() : "acquireAllPrimaryOperationsPermits should only be called on primary shard: " + shardRouting;
 
         indexShardOperationPermits.asyncBlockOperations(onPermitAcquired, timeout.duration(), timeout.timeUnit());
     }
@@ -2458,7 +2458,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
     /**
      * Acquire all replica operation permits whenever the shard is ready for indexing (see
-     * {@link #acquirePrimaryAllOperationsPermits(ActionListener, TimeValue)}. If the given primary term is lower than then one in
+     * {@link #acquireAllPrimaryOperationsPermits(ActionListener, TimeValue)}. If the given primary term is lower than then one in
      * {@link #shardRouting}, the {@link ActionListener#onFailure(Exception)} method of the provided listener is invoked with an
      * {@link IllegalStateException}.
      *

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -784,7 +784,7 @@ public class TransportReplicationActionTests extends ESTestCase {
             new TestAction(Settings.EMPTY, "internal:testSeqNoIsSetOnPrimary", transportService, clusterService, shardStateAction,
                 threadPool) {
                 @Override
-                protected IndexShard getIndexShard(ShardId shardId) {
+                protected IndexShard getIndexShard(ShardId shardId, String targetAllocationId) {
                     return shard;
                 }
             };
@@ -949,11 +949,11 @@ public class TransportReplicationActionTests extends ESTestCase {
             logger.debug("got exception:" , throwable);
             assertTrue(throwable.getClass() + " is not a retry exception", action.retryPrimaryException(throwable));
             if (wrongAllocationId) {
-                assertThat(throwable.getMessage(), containsString("expected aID [_not_a_valid_aid_] but found [" +
+                assertThat(throwable.getMessage(), containsString("expected allocation id [_not_a_valid_aid_] but found [" +
                     primary.allocationId().getId() + "]"));
             } else {
-                assertThat(throwable.getMessage(), containsString("expected aID [" + primary.allocationId().getId() + "] with term [" +
-                    requestTerm + "] but found [" + primaryTerm + "]"));
+                assertThat(throwable.getMessage(), containsString("expected allocation id [" + primary.allocationId().getId()
+                    + "] with term [" + requestTerm + "] but found [" + primaryTerm + "]"));
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -784,7 +784,7 @@ public class TransportReplicationActionTests extends ESTestCase {
             new TestAction(Settings.EMPTY, "internal:testSeqNoIsSetOnPrimary", transportService, clusterService, shardStateAction,
                 threadPool) {
                 @Override
-                protected IndexShard getIndexShard(ShardId shardId, String targetAllocationId) {
+                protected IndexShard getIndexShard(ShardId shardId) {
                     return shard;
                 }
             };

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
@@ -208,11 +208,11 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
                         }
 
                         @Override
-                        void runWithReleasable(final TransportReplicationAction.PrimaryShardReference reference) {
+                        void runWithPrimaryShardReference(final TransportReplicationAction.PrimaryShardReference reference) {
                             assertThat(reference.indexShard.getActiveOperationsCount(), greaterThan(0));
                             assertSame(primary, reference.indexShard);
                             assertBlockIsPresentForDelayedOp();
-                            super.runWithReleasable(reference);
+                            super.runWithPrimaryShardReference(reference);
                         }
 
                         @Override
@@ -250,7 +250,7 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
             TransportReplicationAction.AsyncPrimaryAction asyncPrimaryAction =
                 allPermitsAction.new AsyncPrimaryAction(request(), allocationId(), primaryTerm(), transportChannel(allPermitFuture), null) {
                     @Override
-                    void runWithReleasable(final TransportReplicationAction.PrimaryShardReference reference) {
+                    void runWithPrimaryShardReference(final TransportReplicationAction.PrimaryShardReference reference) {
                         assertEquals("All permits must be acquired", 0, reference.indexShard.getActiveOperationsCount());
                         assertSame(primary, reference.indexShard);
 
@@ -274,7 +274,7 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
                         } catch (InterruptedException | BrokenBarrierException e) {
                             onFailure(e);
                         }
-                        super.runWithReleasable(reference);
+                        super.runWithPrimaryShardReference(reference);
                     }
                 };
             asyncPrimaryAction.run();
@@ -434,7 +434,7 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
             assertTrue(shard.routingEntry().primary());
             assertSame(primary, shard);
             if (acquireAllPermits) {
-                shard.acquirePrimaryAllOperationsPermits(onAcquired, timeout);
+                shard.acquireAllPrimaryOperationsPermits(onAcquired, timeout);
             } else {
                 super.acquirePrimaryOperationPermit(shard, request, onAcquired);
             }

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
@@ -208,11 +208,11 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
                         }
 
                         @Override
-                        public void onResponse(final TransportReplicationAction.PrimaryShardReference reference) {
+                        void runWithReleasable(final TransportReplicationAction.PrimaryShardReference reference) {
                             assertThat(reference.indexShard.getActiveOperationsCount(), greaterThan(0));
                             assertSame(primary, reference.indexShard);
                             assertBlockIsPresentForDelayedOp();
-                            super.onResponse(reference);
+                            super.runWithReleasable(reference);
                         }
 
                         @Override
@@ -250,7 +250,7 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
             TransportReplicationAction.AsyncPrimaryAction asyncPrimaryAction =
                 allPermitsAction.new AsyncPrimaryAction(request(), allocationId(), primaryTerm(), transportChannel(allPermitFuture), null) {
                     @Override
-                    public void onResponse(TransportReplicationAction<Request, Request, Response>.PrimaryShardReference reference) {
+                    void runWithReleasable(final TransportReplicationAction.PrimaryShardReference reference) {
                         assertEquals("All permits must be acquired", 0, reference.indexShard.getActiveOperationsCount());
                         assertSame(primary, reference.indexShard);
 
@@ -274,7 +274,7 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
                         } catch (InterruptedException | BrokenBarrierException e) {
                             onFailure(e);
                         }
-                        super.onResponse(reference);
+                        super.runWithReleasable(reference);
                     }
                 };
             asyncPrimaryAction.run();

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
@@ -1,0 +1,534 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.support.replication;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.engine.InternalEngineFactory;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardTestCase;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardNotFoundException;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportChannel;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportService;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+
+import static java.util.Collections.emptyMap;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_CREATION_DATE;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_INDEX_UUID;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_VERSION_CREATED;
+import static org.elasticsearch.cluster.routing.TestShardRouting.newShardRouting;
+import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
+import static org.elasticsearch.test.ClusterServiceUtils.setState;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTestCase {
+
+    private ClusterService clusterService;
+    private TransportService transportService;
+    private ShardStateAction shardStateAction;
+    private ShardId shardId;
+    private IndexShard primary;
+    private IndexShard replica;
+    private boolean globalBlock;
+    private ClusterBlock block;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        globalBlock = randomBoolean();
+        RestStatus restStatus = randomFrom(RestStatus.values());
+        block = new ClusterBlock(randomIntBetween(1, 10), randomAlphaOfLength(5), false, true, false, restStatus, ClusterBlockLevel.ALL);
+        clusterService = createClusterService(threadPool);
+
+        final ClusterState.Builder state = ClusterState.builder(clusterService.state());
+        Set<DiscoveryNode.Role> roles = new HashSet<>(Arrays.asList(DiscoveryNode.Role.values()));
+        DiscoveryNode node1 = new DiscoveryNode("_name1", "_node1", buildNewFakeTransportAddress(), emptyMap(), roles, Version.CURRENT);
+        DiscoveryNode node2 = new DiscoveryNode("_name2", "_node2", buildNewFakeTransportAddress(), emptyMap(), roles, Version.CURRENT);
+        state.nodes(DiscoveryNodes.builder()
+            .add(node1)
+            .add(node2)
+            .localNodeId(node1.getId())
+            .masterNodeId(node1.getId()));
+
+        shardId = new ShardId("index", UUID.randomUUID().toString(), 0);
+        ShardRouting shardRouting =
+            newShardRouting(shardId, node1.getId(), true, ShardRoutingState.INITIALIZING, RecoverySource.EmptyStoreRecoverySource.INSTANCE);
+
+        Settings indexSettings = Settings.builder()
+            .put(SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(SETTING_INDEX_UUID, shardId.getIndex().getUUID())
+            .put(SETTING_NUMBER_OF_SHARDS, 1)
+            .put(SETTING_NUMBER_OF_REPLICAS, 1)
+            .put(SETTING_CREATION_DATE, System.currentTimeMillis())
+            .build();
+
+        primary = newStartedShard(p -> newShard(shardRouting, indexSettings, new InternalEngineFactory()), true);
+        for (int i = 0; i < 10; i++) {
+            final String id = Integer.toString(i);
+            indexDoc(primary, "_doc", id, "{\"value\":" + id + "}");
+        }
+
+        IndexMetaData indexMetaData = IndexMetaData.builder(shardId.getIndexName())
+            .settings(indexSettings)
+            .primaryTerm(shardId.id(), primary.getOperationPrimaryTerm())
+            .putMapping("_doc","{ \"properties\": { \"value\":  { \"type\": \"short\"}}}")
+            .build();
+        state.metaData(MetaData.builder().put(indexMetaData, false).generateClusterUuidIfNeeded());
+
+        replica = newShard(primary.shardId(), false, node2.getId(), indexMetaData, null);
+        recoverReplica(replica, primary, true);
+
+        IndexRoutingTable.Builder routing = IndexRoutingTable.builder(indexMetaData.getIndex());
+        routing.addIndexShard(new IndexShardRoutingTable.Builder(shardId)
+            .addShard(primary.routingEntry())
+            .build());
+        state.routingTable(RoutingTable.builder().add(routing.build()).build());
+
+        setState(clusterService, state.build());
+
+        final Settings transportSettings = Settings.builder().put("node.name", node1.getId()).build();
+        transportService = MockTransportService.createNewService(transportSettings, Version.CURRENT, threadPool, null);
+        transportService.start();
+        transportService.acceptIncomingRequests();
+        shardStateAction = new ShardStateAction(clusterService, transportService, null, null, threadPool);
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        closeShards(primary, replica);
+        transportService.stop();
+        clusterService.close();
+        super.tearDown();
+    }
+
+    public void testTransportReplicationActionWithAllPermits() throws Exception {
+        final int numOperations = scaledRandomIntBetween(4, 32);
+        final int delayedOperations = randomIntBetween(1, numOperations);
+        logger.trace("starting [{}] operations, among which the first [{}] started ops should be blocked by [{}]",
+            numOperations, delayedOperations, block);
+
+        final CyclicBarrier delayedOperationsBarrier = new CyclicBarrier(delayedOperations + 1);
+        final List<Thread> threads = new ArrayList<>(delayedOperationsBarrier.getParties());
+
+        @SuppressWarnings("unchecked")
+        final PlainActionFuture<Response>[] futures = new PlainActionFuture[numOperations];
+        final TestAction[] actions = new TestAction[numOperations];
+
+        for (int i = 0; i < numOperations; i++) {
+            final int threadId = i;
+            final boolean delayed = (threadId < delayedOperations);
+
+            final PlainActionFuture<Response> listener = new PlainActionFuture<>();
+            futures[threadId] = listener;
+
+            // An action with blocks which acquires a single operation permit during execution
+            final TestAction singlePermitAction = new TestAction(Settings.EMPTY, "internal:singlePermitWithBlocks[" + threadId + "]",
+                transportService, clusterService, shardStateAction, threadPool, shardId, primary, replica, false, Optional.of(globalBlock));
+            actions[threadId] = singlePermitAction;
+
+            Thread thread = new Thread(() -> {
+                TransportReplicationAction.AsyncPrimaryAction asyncPrimaryAction =
+                    singlePermitAction.new AsyncPrimaryAction(request(), allocationId(), primaryTerm(), transportChannel(listener), null) {
+                        @Override
+                        protected void doRun() throws Exception {
+                            if (delayed) {
+                                logger.trace("op [{}] has started and will resume execution once allPermitsAction is terminated", threadId);
+                                delayedOperationsBarrier.await();
+                            }
+                            super.doRun();
+                        }
+
+                        @Override
+                        public void onResponse(final TransportReplicationAction.PrimaryShardReference reference) {
+                            assertThat(reference.indexShard.getActiveOperationsCount(), greaterThan(0));
+                            assertSame(primary, reference.indexShard);
+                            assertBlockIsPresentForDelayedOp();
+                            super.onResponse(reference);
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            assertBlockIsPresentForDelayedOp();
+                            super.onFailure(e);
+                        }
+
+                        private void assertBlockIsPresentForDelayedOp() {
+                            if (delayed) {
+                                final ClusterState clusterState = clusterService.state();
+                                if (globalBlock) {
+                                    assertTrue("Global block must exist", clusterState.blocks().hasGlobalBlock(block));
+                                } else {
+                                    String indexName = primary.shardId().getIndexName();
+                                    assertTrue("Index block must exist", clusterState.blocks().hasIndexBlock(indexName, block));
+                                }
+                            }
+                        }
+                    };
+                asyncPrimaryAction.run();
+            });
+            threads.add(thread);
+            thread.start();
+        }
+
+        logger.trace("now starting the operation that acquires all permits and sets the block in the cluster state");
+
+        // An action which acquires all operation permits during execution and set a block
+        final TestAction allPermitsAction = new TestAction(Settings.EMPTY, "internal:allPermits", transportService, clusterService,
+            shardStateAction, threadPool, shardId, primary, replica, true, Optional.empty());
+
+        final PlainActionFuture<Response> allPermitFuture = new PlainActionFuture<>();
+        Thread thread = new Thread(() -> {
+            TransportReplicationAction.AsyncPrimaryAction asyncPrimaryAction =
+                allPermitsAction.new AsyncPrimaryAction(request(), allocationId(), primaryTerm(), transportChannel(allPermitFuture), null) {
+                    @Override
+                    public void onResponse(TransportReplicationAction<Request, Request, Response>.PrimaryShardReference reference) {
+                        assertEquals("All permits must be acquired", 0, reference.indexShard.getActiveOperationsCount());
+                        assertSame(primary, reference.indexShard);
+
+                        final ClusterState clusterState = clusterService.state();
+                        final ClusterBlocks.Builder blocks = ClusterBlocks.builder();
+                        if (globalBlock) {
+                            assertFalse("Global block must not exist yet", clusterState.blocks().hasGlobalBlock(block));
+                            blocks.addGlobalBlock(block);
+                        } else {
+                            String indexName = reference.indexShard.shardId().getIndexName();
+                            assertFalse("Index block must not exist yet", clusterState.blocks().hasIndexBlock(indexName, block));
+                            blocks.addIndexBlock(indexName, block);
+                        }
+
+                        logger.trace("adding test block to cluster state {}", block);
+                        setState(clusterService, ClusterState.builder(clusterState).blocks(blocks));
+
+                        try {
+                            logger.trace("releasing delayed operations");
+                            delayedOperationsBarrier.await();
+                        } catch (InterruptedException | BrokenBarrierException e) {
+                            onFailure(e);
+                        }
+                        super.onResponse(reference);
+                    }
+                };
+            asyncPrimaryAction.run();
+        });
+        threads.add(thread);
+        thread.start();
+
+        logger.trace("waiting for all operations to terminate");
+        for (Thread t : threads) {
+            t.join();
+        }
+
+        final Response allPermitsResponse = allPermitFuture.get();
+        assertSuccessfulOperation(allPermitsAction, allPermitsResponse);
+
+        for (int i = 0; i < numOperations; i++) {
+            final PlainActionFuture<Response> future = futures[i];
+            final TestAction action = actions[i];
+
+            if (i < delayedOperations) {
+                ExecutionException exception = expectThrows(ExecutionException.class, "delayed operation should have failed", future::get);
+                assertFailedOperation(action, exception);
+            } else {
+                // non delayed operation might fail depending on the order they were executed
+                try {
+                    assertSuccessfulOperation(action, futures[i].get());
+                } catch (final ExecutionException e) {
+                    assertFailedOperation(action, e);
+                }
+            }
+        }
+    }
+
+    private void assertSuccessfulOperation(final TestAction action, final Response response) {
+        final String name = action.getActionName();
+        assertThat(name + " operation should have been executed on primary", action.executedOnPrimary.get(), is(true));
+        assertThat(name + " operation should have been executed on replica", action.executedOnReplica.get(), is(true));
+        assertThat(name + " operation must have a non null result", response, notNullValue());
+        assertThat(name + " operation should have been successful on 2 shards", response.getShardInfo().getSuccessful(), equalTo(2));
+    }
+
+    private void assertFailedOperation(final TestAction action,final ExecutionException exception) {
+        final String name = action.getActionName();
+        assertThat(name + " operation should not have been executed on primary", action.executedOnPrimary.get(), nullValue());
+        assertThat(name + " operation should not have been executed on replica", action.executedOnReplica.get(), nullValue());
+        assertThat(exception.getCause(), instanceOf(ClusterBlockException.class));
+        ClusterBlockException clusterBlockException = (ClusterBlockException) exception.getCause();
+        assertThat(clusterBlockException.blocks(), hasItem(equalTo(block)));
+    }
+
+    private long primaryTerm() {
+        return primary.getOperationPrimaryTerm();
+    }
+
+    private String allocationId() {
+        return primary.routingEntry().allocationId().getId();
+    }
+
+    private Request request() {
+        return new Request().setShardId(primary.shardId());
+    }
+
+
+    private class TestAction extends TransportReplicationAction<Request, Request, Response> {
+
+        private final ShardId shardId;
+        private final IndexShard primary;
+        private final IndexShard replica;
+        private final boolean acquireAllPermits;
+        private final Optional<Boolean> globalBlock;
+        private final TimeValue timeout = TimeValue.timeValueSeconds(30L);
+
+        private final SetOnce<Boolean> executedOnPrimary = new SetOnce<>();
+        private final SetOnce<Boolean> executedOnReplica = new SetOnce<>();
+
+        TestAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService,
+                   ShardStateAction shardStateAction, ThreadPool threadPool,
+                   ShardId shardId, IndexShard primary, IndexShard replica,
+                   boolean acquireAllPermits, Optional<Boolean> globalBlock) {
+            super(settings, actionName, transportService, clusterService, null, threadPool, shardStateAction,
+                new ActionFilters(new HashSet<>()), new IndexNameExpressionResolver(), Request::new, Request::new, ThreadPool.Names.SAME);
+            this.shardId = Objects.requireNonNull(shardId);
+            this.primary = Objects.requireNonNull(primary);
+            this.replica = Objects.requireNonNull(replica);
+            this.acquireAllPermits = acquireAllPermits;
+            this.globalBlock = globalBlock;
+        }
+
+        public String getActionName() {
+            return this.actionName;
+        }
+
+        @Override
+        protected ClusterBlockLevel globalBlockLevel() {
+            if (globalBlock.isPresent()) {
+                return globalBlock.get() ? ClusterBlockLevel.WRITE : super.globalBlockLevel();
+            }
+            return null;
+        }
+
+        @Override
+        protected ClusterBlockLevel indexBlockLevel() {
+            if (globalBlock.isPresent()) {
+                return globalBlock.get() == false ? ClusterBlockLevel.WRITE : super.indexBlockLevel();
+            }
+            return null;
+        }
+
+        @Override
+        protected IndexShard getIndexShard(final ShardId indexShardId, final String targetAllocationId) {
+            if (shardId.equals(indexShardId) == false) {
+                throw new AssertionError("shard id differs from " + shardId);
+            }
+            if (Objects.equals(primary.routingEntry().allocationId().getId(), targetAllocationId)) {
+                return primary;
+            } else if (Objects.equals(replica.routingEntry().allocationId().getId(), targetAllocationId)) {
+                return replica;
+            }
+            throw new ShardNotFoundException(shardId, "something went wrong");
+        }
+
+        @Override
+        protected void sendReplicaRequest(final ConcreteReplicaRequest<Request> replicaRequest,
+                                          final DiscoveryNode node,
+                                          final ActionListener<ReplicationOperation.ReplicaResponse> listener) {
+            assertEquals(clusterService.state().nodes().get("_node2"), node);
+            ReplicaOperationTransportHandler replicaOperationTransportHandler = this.new ReplicaOperationTransportHandler();
+            try {
+                replicaOperationTransportHandler.messageReceived(replicaRequest, new TransportChannel() {
+                    @Override
+                    public String getProfileName() {
+                        return null;
+                    }
+
+                    @Override
+                    public String getChannelType() {
+                        return null;
+                    }
+
+                    @Override
+                    public void sendResponse(TransportResponse response) throws IOException {
+                        listener.onResponse((ReplicationOperation.ReplicaResponse) response);
+                    }
+
+                    @Override
+                    public void sendResponse(Exception exception) throws IOException {
+                        listener.onFailure(exception);
+                    }
+                }, null);
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }
+
+        @Override
+        protected void acquirePrimaryOperationPermit(IndexShard shard, Request request, ActionListener<Releasable> onAcquired) {
+            assertTrue(shard.routingEntry().primary());
+            assertSame(primary, shard);
+            if (acquireAllPermits) {
+                shard.acquirePrimaryAllOperationsPermits(onAcquired, timeout);
+            } else {
+                super.acquirePrimaryOperationPermit(shard, request, onAcquired);
+            }
+        }
+
+        @Override
+        protected void acquireReplicaOperationPermit(IndexShard shard, Request request, ActionListener<Releasable> onAcquired,
+                                                     long primaryTerm, long globalCheckpoint, long maxSeqNo) {
+            assertFalse(shard.routingEntry().primary());
+            assertSame(replica, shard);
+            if (acquireAllPermits) {
+                shard.acquireReplicaAllOperationsPermits(primaryTerm, globalCheckpoint, maxSeqNo, onAcquired, timeout);
+            } else {
+                super.acquireReplicaOperationPermit(shard, request, onAcquired, primaryTerm, globalCheckpoint, maxSeqNo);
+            }
+        }
+
+        @Override
+        protected Response newResponseInstance() {
+            return new Response();
+        }
+
+        @Override
+        protected PrimaryResult<Request, Response> shardOperationOnPrimary(Request shardRequest, IndexShard shard) throws Exception {
+            assertSame(primary, shard);
+            if (acquireAllPermits) {
+                assertEquals("All permits must be acquired", 0, shard.getActiveOperationsCount());
+            } else {
+                assertThat(shard.getActiveOperationsCount(), greaterThan(0));
+            }
+            assertNoBlockOnSinglePermitOps();
+            executedOnPrimary.set(true);
+            return new PrimaryResult<>(shardRequest, new Response());
+        }
+
+        @Override
+        protected ReplicaResult shardOperationOnReplica(Request shardRequest, IndexShard shard) throws Exception {
+            assertSame(replica, shard);
+            if (acquireAllPermits) {
+                assertEquals("All permits must be acquired", 0, shard.getActiveOperationsCount());
+            } else {
+                assertThat(shard.getActiveOperationsCount(), greaterThan(0));
+            }
+            assertNoBlockOnSinglePermitOps();
+            executedOnReplica.set(true);
+            return new ReplicaResult();
+        }
+
+        private void assertNoBlockOnSinglePermitOps() {
+            // When a single permit operation is executed on primary/replica shard we must be sure that the block is not here,
+            // otherwise something went wrong.
+            if (acquireAllPermits == false) {
+                final ClusterState clusterState = clusterService.state();
+                assertFalse("Global block must not exist", clusterState.blocks().hasGlobalBlock(block));
+                assertFalse("Index block must not exist", clusterState.blocks().hasIndexBlock(shardId.getIndexName(), block));
+            }
+        }
+    }
+
+    static class Request extends ReplicationRequest<Request> {
+        @Override
+        public String toString() {
+            return getTestClass().getName() + ".Request";
+        }
+    }
+
+    static class Response extends ReplicationResponse {
+    }
+
+    /**
+     * Transport channel that is needed for replica operation testing.
+     */
+    public TransportChannel transportChannel(final PlainActionFuture<Response> listener) {
+        return new TransportChannel() {
+
+            @Override
+            public String getProfileName() {
+                return "";
+            }
+
+            @Override
+            public void sendResponse(TransportResponse response) throws IOException {
+                listener.onResponse(((Response) response));
+            }
+
+            @Override
+            public void sendResponse(Exception exception) throws IOException {
+                listener.onFailure(exception);
+            }
+
+            @Override
+            public String getChannelType() {
+                return "replica_test";
+            }
+        };
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -313,7 +313,7 @@ public class IndexShardTests extends IndexShardTestCase {
         expectThrows(IndexShardClosedException.class,
             () -> indexShard.acquirePrimaryOperationPermit(null, ThreadPool.Names.WRITE, ""));
         expectThrows(IndexShardClosedException.class,
-            () -> indexShard.acquirePrimaryAllOperationsPermits(null, TimeValue.timeValueSeconds(30L)));
+            () -> indexShard.acquireAllPrimaryOperationsPermits(null, TimeValue.timeValueSeconds(30L)));
         expectThrows(IndexShardClosedException.class,
             () -> indexShard.acquireReplicaOperationPermit(indexShard.getPendingPrimaryTerm(), SequenceNumbers.UNASSIGNED_SEQ_NO,
                 randomNonNegativeLong(), null, ThreadPool.Names.WRITE, ""));
@@ -665,7 +665,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 if (singlePermit) {
                     indexShard.acquirePrimaryOperationPermit(future, ThreadPool.Names.WRITE, "");
                 } else {
-                    indexShard.acquirePrimaryAllOperationsPermits(future, TimeValue.timeValueHours(1L));
+                    indexShard.acquireAllPrimaryOperationsPermits(future, TimeValue.timeValueHours(1L));
                 }
                 assertEquals(0, indexShard.getActiveOperationsCount());
             });
@@ -688,7 +688,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 }
             }
         };
-        indexShard.acquirePrimaryAllOperationsPermits(futureAllPermits, TimeValue.timeValueSeconds(30L));
+        indexShard.acquireAllPrimaryOperationsPermits(futureAllPermits, TimeValue.timeValueSeconds(30L));
         allPermitsAcquired.await();
         assertTrue(blocked.get());
         assertEquals(0, indexShard.getActiveOperationsCount());
@@ -781,7 +781,7 @@ public class IndexShardTests extends IndexShardTestCase {
             assertThat(e, hasToString(containsString("acquirePrimaryOperationPermit should only be called on primary shard")));
 
             e = expectThrows(AssertionError.class,
-                    () -> indexShard.acquirePrimaryAllOperationsPermits(null, TimeValue.timeValueSeconds(30L)));
+                    () -> indexShard.acquireAllPrimaryOperationsPermits(null, TimeValue.timeValueSeconds(30L)));
             assertThat(e, hasToString(containsString("acquirePrimaryAllOperationsPermits should only be called on primary shard")));
         }
 

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -318,7 +318,7 @@ public class IndexShardTests extends IndexShardTestCase {
             () -> indexShard.acquireReplicaOperationPermit(indexShard.getPendingPrimaryTerm(), SequenceNumbers.UNASSIGNED_SEQ_NO,
                 randomNonNegativeLong(), null, ThreadPool.Names.WRITE, ""));
         expectThrows(IndexShardClosedException.class,
-            () -> indexShard.acquireReplicaAllOperationsPermits(indexShard.getPendingPrimaryTerm(), SequenceNumbers.UNASSIGNED_SEQ_NO,
+            () -> indexShard.acquireAllReplicaOperationsPermits(indexShard.getPendingPrimaryTerm(), SequenceNumbers.UNASSIGNED_SEQ_NO,
                 randomNonNegativeLong(), null, TimeValue.timeValueSeconds(30L)));
     }
 
@@ -782,7 +782,7 @@ public class IndexShardTests extends IndexShardTestCase {
 
             e = expectThrows(AssertionError.class,
                     () -> indexShard.acquireAllPrimaryOperationsPermits(null, TimeValue.timeValueSeconds(30L)));
-            assertThat(e, hasToString(containsString("acquirePrimaryAllOperationsPermits should only be called on primary shard")));
+            assertThat(e, hasToString(containsString("acquireAllPrimaryOperationsPermits should only be called on primary shard")));
         }
 
         final long primaryTerm = indexShard.getPendingPrimaryTerm();
@@ -3604,7 +3604,7 @@ public class IndexShardTests extends IndexShardTestCase {
 
     /**
      * Randomizes the usage of {@link IndexShard#acquireReplicaOperationPermit(long, long, long, ActionListener, String, Object)} and
-     * {@link IndexShard#acquireReplicaAllOperationsPermits(long, long, long, ActionListener, TimeValue)} in order to acquire a permit.
+     * {@link IndexShard#acquireAllReplicaOperationsPermits(long, long, long, ActionListener, TimeValue)} in order to acquire a permit.
      */
     private void randomReplicaOperationPermitAcquisition(final IndexShard indexShard,
                                                          final long opPrimaryTerm,
@@ -3617,7 +3617,7 @@ public class IndexShardTests extends IndexShardTestCase {
             indexShard.acquireReplicaOperationPermit(opPrimaryTerm, globalCheckpoint, maxSeqNoOfUpdatesOrDeletes, listener, executor, info);
         } else {
             final TimeValue timeout = TimeValue.timeValueSeconds(30L);
-            indexShard.acquireReplicaAllOperationsPermits(opPrimaryTerm, globalCheckpoint, maxSeqNoOfUpdatesOrDeletes, listener, timeout);
+            indexShard.acquireAllReplicaOperationsPermits(opPrimaryTerm, globalCheckpoint, maxSeqNoOfUpdatesOrDeletes, listener, timeout);
         }
     }
 }


### PR DESCRIPTION
This pull request exposes two new methods in the `IndexShard` and `TransportReplicationAction` classes in order to allow transport replication actions to acquire all index shard operation permits for their execution.

It first adds the `acquirePrimaryAllOperationsPermits()` and the `acquireReplicaAllOperationsPermits()` methods to the `IndexShard` class which allow to acquire all operations permits on a shard  while exposing a `Releasable`. It also refactors the `TransportReplicationAction` class to expose two protected methods (`acquirePrimaryOperationPermit()` and `acquireReplicaOperationPermit()`) that can be overridden when a transport replication action requires the acquisition of all permits on primary and/or replica shard during execution.

Finally, it adds a `TransportReplicationAllPermitsAcquisitionTests` which illustrates how a transport replication action can grab all permits before adding a cluster block in the cluster state, making subsequent operations that requires a single permit to fail (such test has been discussed in https://github.com/elastic/elasticsearch/pull/35332#discussion_r231891192).

Related to elastic #33888 
