### PR TITLE
[ML] Need to wait for shards to replicate in distributed test

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -201,6 +201,10 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         internalCluster().ensureAtLeastNumDataNodes(3);
         ensureStableClusterOnAllNodes(3);
 
+        // Wait for the cluster to be green - this means the indices have been replicated.
+
+        ensureGreen(".ml-config", ".ml-anomalies-shared", ".ml-notifications");
+
         // Open a big job.  This should go on a different node to the 4 small ones.
 
         setupJobWithoutDatafeed("big1", new ByteSizeValue(500, ByteSizeUnit.MB));


### PR DESCRIPTION
**Feature branch PR**

Because the cluster was expanded from 1 node to 3 indices would
initially start off with 0 replicas.  If the original node was
killed before auto-expansion to 1 replica was complete then
the test would fail because the indices would be unavailable.