### PR TITLE
[DOC] Add missing "ssl.truststore.type" setting

### DIFF
--- a/docs/reference/sql/endpoints/jdbc.asciidoc
+++ b/docs/reference/sql/endpoints/jdbc.asciidoc
@@ -113,6 +113,8 @@ Query timeout (in seconds). That is the maximum amount of time waiting for a que
 
 `ssl.truststore.pass`:: trust store password
 
+`ssl.truststore.type` (default `JKS`):: trust store type. `PKCS12` is a common, alternative format
+
 `ssl.cert.allow.self.signed` (default `false`):: Whether or not to allow self signed certificates
 
 `ssl.protocol`(default `TLS`):: SSL protocol to be used


### PR DESCRIPTION
According to https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/SslConfig.java#L53 this is an existing setting that defaults to `JKS`, just as `ssl.keystore.type`