### PR TITLE
HLRC: Add parameters to stopRollupJob API

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -50,6 +50,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.core.CountRequest;
+import org.elasticsearch.client.core.TermVectorsRequest;
 import org.elasticsearch.client.security.RefreshPolicy;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.common.Nullable;
@@ -78,7 +79,6 @@ import org.elasticsearch.script.mustache.MultiSearchTemplateRequest;
 import org.elasticsearch.script.mustache.SearchTemplateRequest;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.tasks.TaskId;
-import org.elasticsearch.client.core.TermVectorsRequest;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -264,7 +264,7 @@ final class RequestConverters {
 
         return request;
     }
-    
+
     static Request sourceExists(GetRequest getRequest) {
         Request request = new Request(HttpHead.METHOD_NAME, endpoint(getRequest.index(), getRequest.type(), getRequest.id(), "_source"));
 
@@ -275,7 +275,7 @@ final class RequestConverters {
         parameters.withRealtime(getRequest.realtime());
         // Version params are not currently supported by the source exists API so are not passed
         return request;
-    }    
+    }
 
     static Request multiGet(MultiGetRequest multiGetRequest) throws IOException {
         Request request = new Request(HttpPost.METHOD_NAME, "/_mget");

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RollupRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RollupRequestConverters.java
@@ -65,7 +65,14 @@ final class RollupRequestConverters {
             .addPathPart(stopRollupJobRequest.getJobId())
             .addPathPartAsIs("_stop")
             .build();
-        return new Request(HttpPost.METHOD_NAME, endpoint);
+
+        Request request = new Request(HttpPost.METHOD_NAME, endpoint);
+        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        parameters.withTimeout(stopRollupJobRequest.timeout());
+        if (stopRollupJobRequest.waitForCompletion() != null) {
+            parameters.withWaitForCompletion(stopRollupJobRequest.waitForCompletion());
+        }
+        return request;
     }
 
     static Request getJob(final GetRollupJobRequest getRollupJobRequest) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/StopRollupJobRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/StopRollupJobRequest.java
@@ -19,12 +19,15 @@
 package org.elasticsearch.client.rollup;
 
 import org.elasticsearch.client.Validatable;
+import org.elasticsearch.common.unit.TimeValue;
 
 import java.util.Objects;
 
 public class StopRollupJobRequest implements Validatable {
 
     private final String jobId;
+    private TimeValue timeout;
+    private Boolean waitForCompletion;
 
     public StopRollupJobRequest(final String jobId) {
         this.jobId = Objects.requireNonNull(jobId, "id parameter must not be null");
@@ -45,5 +48,27 @@ public class StopRollupJobRequest implements Validatable {
     @Override
     public int hashCode() {
         return Objects.hash(jobId);
+    }
+
+    /**
+     * Sets the requests optional "timeout" parameter.
+     */
+    public void timeout(TimeValue timeout) {
+        this.timeout = timeout;
+    }
+
+    public TimeValue timeout() {
+        return this.timeout;
+    }
+
+    /**
+     * Sets the requests optional "wait_for_completion".
+     */
+    public void waitForCompletion(boolean waitForCompletion) {
+        this.waitForCompletion = waitForCompletion;
+    }
+
+    public Boolean waitForCompletion() {
+        return this.waitForCompletion;
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RollupIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RollupIT.java
@@ -235,8 +235,14 @@ public class RollupIT extends ESRestHighLevelClientTestCase {
 
         // stop the job
         StopRollupJobRequest stopRequest = new StopRollupJobRequest(id);
+        stopRequest.waitForCompletion(randomBoolean());
         StopRollupJobResponse stopResponse = execute(stopRequest, rollupClient::stopRollupJob, rollupClient::stopRollupJobAsync);
         assertTrue(stopResponse.isAcknowledged());
+        if (stopRequest.waitForCompletion()) {
+            getResponse = execute(new GetRollupJobRequest(id), rollupClient::getRollupJob, rollupClient::getRollupJobAsync);
+            assertThat(getResponse.getJobs(), hasSize(1));
+            assertThat(getResponse.getJobs().get(0).getStatus().getState(), equalTo(IndexerState.STOPPED));
+        }
     }
 
     public void testGetMissingRollupJob() throws Exception {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/RollupDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/RollupDocumentationIT.java
@@ -288,6 +288,8 @@ public class RollupDocumentationIT extends ESRestHighLevelClientTestCase {
         String id = "job_1";
         // tag::rollup-stop-job-request
         StopRollupJobRequest request = new StopRollupJobRequest(id); // <1>
+        request.waitForCompletion(true);                             // <2>
+        request.timeout(TimeValue.timeValueSeconds(10));             // <3>
         // end::rollup-stop-job-request
 
 

--- a/docs/java-rest/high-level/rollup/stop_job.asciidoc
+++ b/docs/java-rest/high-level/rollup/stop_job.asciidoc
@@ -17,6 +17,11 @@ The Stop Rollup Job API allows you to stop a job by ID.
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> The ID of the job to stop.
+<2> Whether the request should wait that the stop operation has completed
+before returning (optional, defaults to `false`)
+<3> If `wait_for_completion=true`, this parameter controls how long to wait
+before giving up and throwing an error (optional, defaults to 30 seconds).
+
 
 [id="{upid}-{api}-response"]
 ==== Response


### PR DESCRIPTION
With #34811 the API for stopping rollup jobs got two new url parameters
"wait_for_completion" and "timeout". This change adds these to the HLRC APIs as
well.

Relates to #34811