### PR TITLE
Tests: If dpkg fails try and log failure

### DIFF
--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/Packages.java
@@ -112,7 +112,16 @@ public class Packages {
         if (Platforms.isRPM()) {
             return sh.runIgnoreExitCode("rpm -i " + distributionFile);
         } else {
-            return sh.runIgnoreExitCode("dpkg -i " + distributionFile);
+            Result r = sh.runIgnoreExitCode("dpkg -i " + distributionFile);
+            if (r.exitCode != 0) {
+                Result lockOF = sh.runIgnoreExitCode("lsof /var/lib/dpkg/lock");
+                if (lockOF.exitCode == 0) {
+                    throw new RuntimeException(
+                            "dpkg failed and the lockfile still exists. "
+                            + "Failure:\n" + r + "\nLockfile:\n" + lockOF);
+                }
+            }
+            return r;
         }
     }
 

--- a/qa/vagrant/src/test/resources/packaging/utils/packages.bash
+++ b/qa/vagrant/src/test/resources/packaging/utils/packages.bash
@@ -76,7 +76,15 @@ install_package() {
     if is_rpm; then
         rpm $rpmCommand $PACKAGE_NAME-$version.rpm
     elif is_dpkg; then
-        dpkg $dpkgCommand -i $PACKAGE_NAME-$version.deb
+        run dpkg $dpkgCommand -i $PACKAGE_NAME-$version.deb
+        [[ "$status" -eq 0 ]] || {
+            echo "dpkg failed:"
+            echo "$output"
+            run lsof /var/lib/dpkg/lock
+            echo "lsof /var/lib/dpkg/lock:"
+            echo "$output"
+            false
+        }
     else
         skip "Only rpm or deb supported"
     fi


### PR DESCRIPTION
If `dpkg` fails, try and look for who has `/var/lib/dpkg/lock` open. If
it exists and is open then return a failure with information about who
has file open. This should help us debug #33762.

Closes #34309
