### PR TITLE
[DOCS] Adds authorization info for CCR APIs

### DIFF
--- a/docs/reference/ccr/apis/follow/post-pause-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-pause-follow.asciidoc
@@ -48,6 +48,15 @@ POST /<follower_index>/_ccr/pause_follow
 `follower_index` (required)::
   (string) the name of the follower index
 
+
+==== Authorization
+
+If the {es} {security-features} are enabled, to use this API you must have 
+`write` index privileges for the follower index and `read` index privileges for 
+the leader index. You must also have `manage_ccr` cluster privileges. For more 
+information, see {stack-ov}/security-privileges.html[Security privileges].
+
+
 ==== Example
 
 This example pauses a follower index named `follower_index`:

--- a/docs/reference/ccr/apis/follow/post-pause-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-pause-follow.asciidoc
@@ -51,10 +51,9 @@ POST /<follower_index>/_ccr/pause_follow
 
 ==== Authorization
 
-If the {es} {security-features} are enabled, to use this API you must have 
-`write` index privileges for the follower index and `read` index privileges for 
-the leader index. You must also have `manage_ccr` cluster privileges. For more 
-information, see {stack-ov}/security-privileges.html[Security privileges].
+If the {es} {security-features} are enabled, you must have `manage_ccr` cluster
+privileges on the cluster that contains the follower index. For more information,
+see {stack-ov}/security-privileges.html[Security privileges].
 
 
 ==== Example

--- a/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
@@ -65,11 +65,10 @@ include::../follow-request-body.asciidoc[]
 
 ==== Authorization
 
-If the {es} {security-features} are enabled, you must have `write` index
-privileges for the follower index and `read` index privileges for the leader
-index. You must have `manage_ccr` and `monitor` cluster privileges on the
-cluster that contains the follower index. You must also have `monitor` cluster
-privileges on the cluster that contains the leader index. For more information,
+If the {es} {security-features} are enabled, you must have `write` and `monitor`
+index privileges for the follower index. You must have `read` and `monitor`
+index privileges for the leader index. You must also have `manage_ccr` cluster
+privileges on the cluster that contains the follower index. For more information,
 see {stack-ov}/security-privileges.html[Security privileges].
 
 ==== Example

--- a/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
@@ -65,10 +65,12 @@ include::../follow-request-body.asciidoc[]
 
 ==== Authorization
 
-If the {es} {security-features} are enabled, to use this API you must have 
-`write` index privileges for the follower index and `read` index privileges for 
-the leader index. You must also have `manage_ccr` cluster privileges. For more 
-information, see {stack-ov}/security-privileges.html[Security privileges].
+If the {es} {security-features} are enabled, you must have `write` index
+privileges for the follower index and `read` index privileges for the leader
+index. You must have `manage_ccr` and `monitor` cluster privileges on the
+cluster that contains the follower index. You must also have `monitor` cluster
+privileges on the cluster that contains the leader index. For more information,
+see {stack-ov}/security-privileges.html[Security privileges].
 
 ==== Example
 

--- a/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
@@ -63,6 +63,13 @@ POST /<follower_index>/_ccr/resume_follow
 ==== Request Body
 include::../follow-request-body.asciidoc[]
 
+==== Authorization
+
+If the {es} {security-features} are enabled, to use this API you must have 
+`write` index privileges for the follower index and `read` index privileges for 
+the leader index. You must also have `manage_ccr` cluster privileges. For more 
+information, see {stack-ov}/security-privileges.html[Security privileges].
+
 ==== Example
 
 This example resumes a follower index named `follower_index`:

--- a/docs/reference/ccr/apis/follow/put-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/put-follow.asciidoc
@@ -60,12 +60,11 @@ include::../follow-request-body.asciidoc[]
 
 ==== Authorization
 
-If the {es} {security-features} are enabled, you must have `write` and
-`manage_follow_index` index privileges for the follower index and `read` index
-privileges for the leader index. You must have `manage_ccr` and `monitor`
-cluster privileges on the cluster that contains the follower index. You must
-also have `monitor` cluster privileges on the cluster that contains the leader
-index. For more information, see
+If the {es} {security-features} are enabled, you must have `write`, `monitor`,
+and `manage_follow_index` index privileges for the follower index. You must have
+`read` and `monitor` index privileges for the leader index. You must also have
+`manage_ccr` cluster privileges on the cluster that contains the follower index.
+For more information, see
 {stack-ov}/security-privileges.html[Security privileges].
 
 ==== Example

--- a/docs/reference/ccr/apis/follow/put-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/put-follow.asciidoc
@@ -58,6 +58,16 @@ PUT /<follower_index>/_ccr/follow
 
 include::../follow-request-body.asciidoc[]
 
+==== Authorization
+
+If the {es} {security-features} are enabled, you must have `write` and
+`manage_follow_index` index privileges for the follower index and `read` index
+privileges for the leader index. You must have `manage_ccr` and `monitor`
+cluster privileges on the cluster that contains the follower index. You must
+also have `monitor` cluster privileges on the cluster that contains the leader
+index. For more information, see
+{stack-ov}/security-privileges.html[Security privileges].
+
 ==== Example
 
 This example creates a follower index named `follower_index`:


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/149#discussion_r233326927

This PR adds an "Authorization" section to two cross-cluster replication APIs, similar to what exists for other X-Pack APIs.  The other CCR APIs can be augmented in subsequent PRs. 