### PR TITLE
Suppress CachedTimeThread in hot threads output

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -113,7 +113,7 @@ public class HotThreads {
                 methodName.equals("select")) {
                 return true;
             }
-            if (className.equals("org.elasticsearch.threadpool.ThreadPool$EstimatedTimeThread") &&
+            if (className.equals("org.elasticsearch.threadpool.ThreadPool$CachedTimeThread") &&
                 methodName.equals("run")) {
                 return true;
             }

--- a/server/src/test/java/org/elasticsearch/action/admin/HotThreadsIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/HotThreadsIT.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsReq
 import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsResponse;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.hamcrest.Matcher;
 
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -38,7 +39,9 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitC
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
 
 public class HotThreadsIT extends ESIntegTestCase {
 
@@ -135,9 +138,13 @@ public class HotThreadsIT extends ESIntegTestCase {
         builder.setThreads(Integer.MAX_VALUE);
         NodesHotThreadsResponse response = builder.execute().get();
 
+        final Matcher<String> containsCachedTimeThreadRunMethod
+            = containsString("org.elasticsearch.threadpool.ThreadPool$CachedTimeThread.run");
+
         int totSizeAll = 0;
         for (NodeHotThreads node : response.getNodesMap().values()) {
             totSizeAll += node.getHotThreads().length();
+            assertThat(node.getHotThreads(), containsCachedTimeThreadRunMethod);
         }
 
         // Second time, do ignore idle threads:
@@ -151,6 +158,7 @@ public class HotThreadsIT extends ESIntegTestCase {
         int totSizeIgnoreIdle = 0;
         for (NodeHotThreads node : response.getNodesMap().values()) {
             totSizeIgnoreIdle += node.getHotThreads().length();
+            assertThat(node.getHotThreads(), not(containsCachedTimeThreadRunMethod));
         }
 
         // The filtered stacks should be smaller than unfiltered ones:


### PR DESCRIPTION
In #23175 we renamed `ThreadPool$EstimatedTimeThread` to
`ThreadPool$CachedTimeThread` but did not update the corresponding entry in
`HotThreads#isIdleThread()`. This commit addresses this.