### PR TITLE
[DOCS] Adds highlight for authorization realms

### DIFF
--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -101,3 +101,14 @@ in 6.5, you can also use {metricbeat} to collect and ship data about {es}. If
 you are monitoring {ls} or Beats, at this time you must still use exporters to 
 route the data. See <<configuring-metricbeat>> and 
 {stack-ov}/how-monitoring-works.html[How monitoring works]. 
+
+[float]
+=== Delegate authorization to other realms
+
+If you enable the {es} {security-features}, some realms now have the 
+ability to perform _authentication_ internally then delegate _authorization_ to 
+another realm. For example, you could authenticate using PKI then delegate to an 
+LDAP realm for role information. The realms that support this feature have a 
+new `authorization_realms` setting that you can configure in the 
+`elasticsearch.yml` file. For more information, see 
+{stack-ov}/realm-chains.html#authorization_realms[Realm chains] and <<realm-settings>>.  


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/100

This PR adds an item to the Elasticsearch 6.5 Release Highlights (https://www.elastic.co/guide/en/elasticsearch/reference/current/release-highlights-6.5.0.html) for authorization realms. 