### PR TITLE
[DOCS] Adds footnote about beta functionality in Release Highlights

### DIFF
--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -113,3 +113,8 @@ LDAP realm for role information. The realms that support this feature have a
 new `authorization_realms` setting that you can configure in the 
 `elasticsearch.yml` file. For more information, see 
 {stack-ov}/realm-chains.html#authorization_realms[Realm chains] and <<realm-settings>>.  
+
+^*^ This functionality is in beta and is subject to change. The design and code 
+is less mature than official GA features and is being provided as-is with no 
+warranties. Please try this functionality in your test and development environments 
+and provide feedback in the https://discuss.elastic.co/[Elastic community forums].

--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -79,6 +79,17 @@ currently the same as JDBC. An alpha version of the ODBC client is now
 available for download.
 
 [float]
+=== Delegate authorization to other realms
+
+If you enable the {es} {security-features}, some realms now have the 
+ability to perform _authentication_ internally then delegate _authorization_ to 
+another realm. For example, you could authenticate using PKI then delegate to an 
+LDAP realm for role information. The realms that support this feature have a 
+new `authorization_realms` setting that you can configure in the 
+`elasticsearch.yml` file. For more information, see 
+{stack-ov}/realm-chains.html#authorization_realms[Realm chains] and <<realm-settings>>. 
+
+[float]
 === Cross-cluster replication (beta^*^)
 
 Cross-cluster replication enables you to replicate indices that exist in remote 
@@ -102,17 +113,7 @@ in 6.5, you can also use {metricbeat} to collect and ship data about {es}. If
 you are monitoring {ls} or Beats, at this time you must still use exporters to 
 route the data. See <<configuring-metricbeat>> and 
 {stack-ov}/how-monitoring-works.html[How monitoring works]. 
-
-[float]
-=== Delegate authorization to other realms
-
-If you enable the {es} {security-features}, some realms now have the 
-ability to perform _authentication_ internally then delegate _authorization_ to 
-another realm. For example, you could authenticate using PKI then delegate to an 
-LDAP realm for role information. The realms that support this feature have a 
-new `authorization_realms` setting that you can configure in the 
-`elasticsearch.yml` file. For more information, see 
-{stack-ov}/realm-chains.html#authorization_realms[Realm chains] and <<realm-settings>>.  
+ 
 
 ^*^ This functionality is in beta and is subject to change. The design and code 
 is less mature than official GA features and is being provided as-is with no 

--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -79,7 +79,7 @@ currently the same as JDBC. An alpha version of the ODBC client is now
 available for download.
 
 [float]
-=== Cross-cluster replication (beta)
+=== Cross-cluster replication (beta^*^)
 
 Cross-cluster replication enables you to replicate indices that exist in remote 
 clusters to your local cluster. You create an index in your local cluster 
@@ -94,7 +94,7 @@ For more information, see {stack-ov}/xpack-ccr.html[Cross-cluster replication]
 and <<ccr-apis>>. 
 
 [float]
-=== Monitor {es} with {metricbeat} (beta)
+=== Monitor {es} with {metricbeat} (beta^*^)
 
 In 6.4 and later, you can use {metricbeat} to collect data about {kib} and ship 
 it directly to your monitoring cluster, rather than routing it through {es}. Now 


### PR DESCRIPTION
Per https://github.com/elastic/elasticsearch/pull/35517#discussion_r233226259 this PR adds a footnote about the beta items in the Elasticsearch 6.5 Release Highlights. 