### PR TITLE
REST-Tests: Use Dedicated AntBuilders

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
@@ -69,7 +69,7 @@ class ClusterConfiguration {
      */
     @Input
     Closure<Integer> minimumMasterNodes = {
-        if (bwcVersion != null && bwcVersion.before("6.5.0-SNAPSHOT")) {
+        if (bwcVersion != null && bwcVersion.before("6.5.0")) {
             return numNodes > 1 ? numNodes : -1
         } else {
             return numNodes > 1 ? numNodes.intdiv(2) + 1 : -1

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
@@ -69,7 +69,7 @@ class ClusterConfiguration {
      */
     @Input
     Closure<Integer> minimumMasterNodes = {
-        if (bwcVersion != null && bwcVersion.before("6.5.0")) {
+        if (bwcVersion != null && bwcVersion.before("6.5.0-SNAPSHOT")) {
             return numNodes > 1 ? numNodes : -1
         } else {
             return numNodes > 1 ? numNodes.intdiv(2) + 1 : -1

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -127,7 +127,7 @@ class ClusterFormationTasks {
             nodes.add(node)
             Closure<Map> writeConfigSetup
             Object dependsOn
-            if (node.nodeVersion.onOrAfter("6.5.0-SNAPSHOT")) {
+            if (node.nodeVersion.onOrAfter("6.5.0")) {
                 writeConfigSetup = { Map esConfig ->
                     // Don't force discovery provider if one is set by the test cluster specs already
                     if (esConfig.containsKey('discovery.zen.hosts_provider') == false) {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -140,7 +140,7 @@ class ClusterFormationTasks {
             } else {
                 dependsOn = startTasks.empty ? startDependencies : startTasks.get(0)
                 writeConfigSetup = { Map esConfig ->
-                    String unicastTransportUri = node.config.unicastTransportUri(nodes.get(0), node, project.ant)
+                    String unicastTransportUri = node.config.unicastTransportUri(nodes.get(0), node, project.createAntBuilder())
                     if (unicastTransportUri == null) {
                         esConfig['discovery.zen.ping.unicast.hosts'] = []
                     } else {
@@ -717,7 +717,7 @@ class ClusterFormationTasks {
             Collection<String> unicastHosts = new HashSet<>()
             nodes.forEach { node ->
                 unicastHosts.addAll(node.config.otherUnicastHostAddresses.call())
-                String unicastHost = node.config.unicastTransportUri(node, null, project.ant)
+                String unicastHost = node.config.unicastTransportUri(node, null, project.createAntBuilder())
                 if (unicastHost != null) {
                     unicastHosts.add(unicastHost)
                 }
@@ -913,9 +913,10 @@ class ClusterFormationTasks {
                 outputPrintStream: outputStream,
                 messageOutputLevel: org.apache.tools.ant.Project.MSG_INFO)
 
-        project.ant.project.addBuildListener(listener)
-        Object retVal = command(project.ant)
-        project.ant.project.removeBuildListener(listener)
+        AntBuilder ant = project.createAntBuilder()
+        ant.project.addBuildListener(listener)
+        Object retVal = command(ant)
+        ant.project.removeBuildListener(listener)
         return retVal
     }
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -127,7 +127,7 @@ class ClusterFormationTasks {
             nodes.add(node)
             Closure<Map> writeConfigSetup
             Object dependsOn
-            if (node.nodeVersion.onOrAfter("6.5.0")) {
+            if (node.nodeVersion.onOrAfter("6.5.0-SNAPSHOT")) {
                 writeConfigSetup = { Map esConfig ->
                     // Don't force discovery provider if one is set by the test cluster specs already
                     if (esConfig.containsKey('discovery.zen.hosts_provider') == false) {


### PR DESCRIPTION
* Use dedicated AntBuilder everywhere since AntBuilder is not threadsafe
* Closes #33778

-------------------------------------------------

@atorok see my explanation [here](https://github.com/elastic/elasticsearch/issues/33778#issuecomment-438695632). The execution order of starting `node 0` and waiting for `node 1` is off despite the Gradle logging to the contrary (both are Ant tasks). This is my best guess, based on the fact that `AntBuilder` isn't thread-safe and the fact that Gradle logs different worker threads for the `node1.configure` and `node0.start` tasks in e.g. this build https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+6.5+bwc-tests/36/console (starts node 0 in thread 9,5 but configures node1 in 10,5?).
... that said, I guess this change may be valuable regardless of #33778 to move us forward in terms of enabling `--parallel`? :)