### PR TITLE
MINOR: Remove SNAPSHOT Suffixes in Gradle

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
@@ -69,7 +69,7 @@ class ClusterConfiguration {
      */
     @Input
     Closure<Integer> minimumMasterNodes = {
-        if (bwcVersion != null && bwcVersion.before("SNAPSHOT")) {
+        if (bwcVersion != null && bwcVersion.before("6.5.0")) {
             return numNodes > 1 ? numNodes : -1
         } else {
             return numNodes > 1 ? numNodes.intdiv(2) + 1 : -1

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
@@ -69,7 +69,7 @@ class ClusterConfiguration {
      */
     @Input
     Closure<Integer> minimumMasterNodes = {
-        if (bwcVersion != null && bwcVersion.before("6.5.0-SNAPSHOT")) {
+        if (bwcVersion != null && bwcVersion.before("SNAPSHOT")) {
             return numNodes > 1 ? numNodes : -1
         } else {
             return numNodes > 1 ? numNodes.intdiv(2) + 1 : -1

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -127,7 +127,7 @@ class ClusterFormationTasks {
             nodes.add(node)
             Closure<Map> writeConfigSetup
             Object dependsOn
-            if (node.nodeVersion.onOrAfter("6.5.0-SNAPSHOT")) {
+            if (node.nodeVersion.onOrAfter("6.5.0")) {
                 writeConfigSetup = { Map esConfig ->
                     // Don't force discovery provider if one is set by the test cluster specs already
                     if (esConfig.containsKey('discovery.zen.hosts_provider') == false) {


### PR DESCRIPTION
* The snapshot qualifiers here are redundant and 6.5.0 is released anyway

@atorok from #35375 https://github.com/elastic/elasticsearch/pull/35532#discussion_r233728686 :)