### PR TITLE
[ML] Job in index: Enable get and update actions for clusterstate jobs

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -9,6 +9,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.ml.datafeed.ChunkingConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DelayedDataCheckConfig;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisLimits;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
@@ -354,6 +355,16 @@ public class ElasticsearchMappings {
                     .field(TYPE, KEYWORD)
                 .endObject()
                 .startObject(ChunkingConfig.TIME_SPAN_FIELD.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+            .endObject()
+        .endObject()
+        .startObject(DatafeedConfig.DELAYED_DATA_CHECK_CONFIG.getPreferredName())
+            .startObject(PROPERTIES)
+                .startObject(DelayedDataCheckConfig.ENABLED.getPreferredName())
+                    .field(TYPE, BOOLEAN)
+                .endObject()
+                .startObject(DelayedDataCheckConfig.CHECK_WINDOW.getPreferredName())
                     .field(TYPE, KEYWORD)
                 .endObject()
             .endObject()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.core.ml.job.results;
 
 import org.elasticsearch.xpack.core.ml.datafeed.ChunkingConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DelayedDataCheckConfig;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisLimits;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
@@ -251,6 +252,9 @@ public final class ReservedFieldNames {
             DatafeedConfig.SCRIPT_FIELDS.getPreferredName(),
             DatafeedConfig.CHUNKING_CONFIG.getPreferredName(),
             DatafeedConfig.HEADERS.getPreferredName(),
+            DatafeedConfig.DELAYED_DATA_CHECK_CONFIG.getPreferredName(),
+            DelayedDataCheckConfig.ENABLED.getPreferredName(),
+            DelayedDataCheckConfig.CHECK_WINDOW.getPreferredName(),
 
             ChunkingConfig.MODE_FIELD.getPreferredName(),
             ChunkingConfig.TIME_SPAN_FIELD.getPreferredName(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookupTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookupTests.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -103,6 +104,8 @@ public class GroupOrJobLookupTests extends ESTestCase {
         assertThat(groupOrJobLookup.expandGroupIds("foo*"), contains("foo-group"));
         assertThat(groupOrJobLookup.expandGroupIds("bar-group,nogroup"), contains("bar-group"));
         assertThat(groupOrJobLookup.expandGroupIds("*"), contains("bar-group", "foo-group"));
+        assertThat(groupOrJobLookup.expandGroupIds("foo-group"), contains("foo-group"));
+        assertThat(groupOrJobLookup.expandGroupIds("no-group"), empty());
     }
 
     private static Job mockJob(String jobId, List<String> groups) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetBucketsAction.java
@@ -38,8 +38,8 @@ public class TransportGetBucketsAction extends HandledTransportAction<GetBuckets
 
     @Override
     protected void doExecute(GetBucketsAction.Request request, ActionListener<GetBucketsAction.Response> listener) {
-        jobManager.getJob(request.getJobId(), ActionListener.wrap(
-                job -> {
+        jobManager.jobExists(request.getJobId(), ActionListener.wrap(
+                jobFound -> {
                     BucketsQueryBuilder query =
                             new BucketsQueryBuilder().expand(request.isExpand())
                                     .includeInterim(request.isExcludeInterim() == false)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetInfluencersAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetInfluencersAction.java
@@ -39,8 +39,8 @@ public class TransportGetInfluencersAction extends HandledTransportAction<GetInf
     @Override
     protected void doExecute(GetInfluencersAction.Request request, ActionListener<GetInfluencersAction.Response> listener) {
 
-        jobManager.getJob(request.getJobId(), ActionListener.wrap(
-                job -> {
+        jobManager.jobExists(request.getJobId(), ActionListener.wrap(
+                jobFound -> {
                     InfluencersQueryBuilder.InfluencersQuery query = new InfluencersQueryBuilder()
                             .includeInterim(request.isExcludeInterim() == false)
                             .start(request.getStart())

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetRecordsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetRecordsAction.java
@@ -39,8 +39,8 @@ public class TransportGetRecordsAction extends HandledTransportAction<GetRecords
     @Override
     protected void doExecute(GetRecordsAction.Request request, ActionListener<GetRecordsAction.Response> listener) {
 
-        jobManager.getJob(request.getJobId(), ActionListener.wrap(
-                job -> {
+        jobManager.jobExists(request.getJobId(), ActionListener.wrap(
+                jobFound -> {
                     RecordsQueryBuilder query = new RecordsQueryBuilder()
                             .includeInterim(request.isExcludeInterim() == false)
                             .epochStart(request.getStart())

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
@@ -42,6 +42,28 @@ public class DatafeedConfigReader {
     }
 
     /**
+     * Read the datafeed config from {@code state} and if not found
+     * look for the index document
+     *
+     * @param datafeedId Id of datafeed to get
+     * @param state      Cluster state
+     * @param listener   DatafeedConfig listener
+     */
+    public void datafeedConfig(String datafeedId, ClusterState state, ActionListener<DatafeedConfig> listener) {
+        MlMetadata mlMetadata = MlMetadata.getMlMetadata(state);
+        DatafeedConfig config = mlMetadata.getDatafeed(datafeedId);
+
+        if (config != null) {
+            listener.onResponse(config);
+        } else {
+            datafeedConfigProvider.getDatafeedConfig(datafeedId, ActionListener.wrap(
+                    builder -> listener.onResponse(builder.build()),
+                    listener::onFailure
+            ));
+        }
+    }
+
+    /**
      * Merges the results of {@link MlMetadata#expandDatafeedIds}
      * and {@link DatafeedConfigProvider#expandDatafeedIds(String, boolean, ActionListener)}
      */

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -139,9 +139,9 @@ public class JobManager {
 
     public void groupExists(String groupId, ActionListener<Boolean> listener) {
         MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterService.state());
-        if (mlMetadata.expandGroupIds(groupId).isEmpty() == false) {
+        boolean groupExistsInMlMetadata = mlMetadata.expandGroupIds(groupId).isEmpty() == false;
+        if (groupExistsInMlMetadata) {
             listener.onResponse(Boolean.TRUE);
-            return;
         } else {
             jobConfigProvider.groupExists(groupId, listener);
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -137,6 +137,16 @@ public class JobManager {
         this.maxModelMemoryLimit = maxModelMemoryLimit;
     }
 
+    public void groupExists(String groupId, ActionListener<Boolean> listener) {
+        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterService.state());
+        if (mlMetadata.expandGroupIds(groupId).isEmpty() == false) {
+            listener.onResponse(Boolean.TRUE);
+            return;
+        } else {
+            jobConfigProvider.groupExists(groupId, listener);
+        }
+    }
+
     public void jobExists(String jobId, ActionListener<Boolean> listener) {
         jobConfigProvider.jobExists(jobId, false, ActionListener.wrap(
                 jobFound -> {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -138,7 +138,7 @@ public class JobManager {
     }
 
     public void jobExists(String jobId, ActionListener<Boolean> listener) {
-        jobConfigProvider.jobExists(jobId, true, ActionListener.wrap(
+        jobConfigProvider.jobExists(jobId, false, ActionListener.wrap(
                 jobFound -> {
                     if (jobFound) {
                         listener.onResponse(Boolean.TRUE);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/CalendarQueryBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/CalendarQueryBuilder.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.ml.job.persistence;
 
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.ml.action.util.PageParams;
@@ -67,10 +68,10 @@ public class CalendarQueryBuilder {
 
         if (jobIdAndGroups.isEmpty() == false) {
             qb = new BoolQueryBuilder()
-                    .filter(new TermsQueryBuilder(Calendar.TYPE.getPreferredName(), Calendar.CALENDAR_TYPE))
+                    .filter(new TermQueryBuilder(Calendar.TYPE.getPreferredName(), Calendar.CALENDAR_TYPE))
                     .filter(new TermsQueryBuilder(Calendar.JOB_IDS.getPreferredName(), jobIdAndGroups));
         } else {
-            qb = new TermsQueryBuilder(Calendar.TYPE.getPreferredName(), Calendar.CALENDAR_TYPE);
+            qb = new TermQueryBuilder(Calendar.TYPE.getPreferredName(), Calendar.CALENDAR_TYPE);
         }
 
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(qb);


### PR DESCRIPTION
In 6.6 and 6.7 job and datafeed configuration may be clusterstate or the index. As with #35590 these changes are mostly testing for the location of the config and reinstating the old clusterstate config update code.

This PR covers the get and update actions and is the last change for required for running mixed config jobs. 