### PR TITLE
[DOCS] Adds more authorization info for CCR APIs

### DIFF
--- a/docs/reference/ccr/apis/auto-follow/delete-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/delete-auto-follow-pattern.asciidoc
@@ -48,6 +48,12 @@ DELETE /_ccr/auto_follow/<auto_follow_pattern_name>
 `auto_follow_pattern_name` (required)::
   (string) specifies the auto-follow pattern collection to delete
 
+==== Authorization
+
+If the {es} {security-features} are enabled, you must have `manage_ccr` cluster
+privileges on the cluster that contains the follower index. For more information,
+see {stack-ov}/security-privileges.html[Security privileges].
+
 ==== Example
 
 This example deletes an auto-follow pattern collection named

--- a/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
@@ -64,11 +64,11 @@ GET /_ccr/auto_follow/<auto_follow_pattern_name>
   retrieve; if you do not specify a name, the API returns information for all
   collections
 
-//==== Authorization
+==== Authorization
 
-//TBD
-//For more information, see
-//{stack-ov}/security-privileges.html[Security privileges].
+If the {es} {security-features} are enabled, you must have `manage_ccr` cluster
+privileges on the cluster that contains the follower index. For more information,
+see {stack-ov}/security-privileges.html[Security privileges].
 
 ==== Example
 

--- a/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
@@ -64,6 +64,12 @@ GET /_ccr/auto_follow/<auto_follow_pattern_name>
   retrieve; if you do not specify a name, the API returns information for all
   collections
 
+//==== Authorization
+
+//TBD
+//For more information, see
+//{stack-ov}/security-privileges.html[Security privileges].
+
 ==== Example
 
 This example retrieves information about an auto-follow pattern collection

--- a/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
@@ -72,9 +72,11 @@ include::../follow-request-body.asciidoc[]
 
 ==== Authorization
 
-If the {es} {security-features} are enabled, you must have `manage_ccr` cluster
-privileges on the cluster that contains the follower index. For more information,
-see {stack-ov}/security-privileges.html[Security privileges].
+If the {es} {security-features} are enabled, you must have `read` and `monitor`
+index privileges for the leader index patterns. You must also have `manage_ccr`
+cluster privileges on the cluster that contains the follower index. For more
+information, see
+{stack-ov}/security-privileges.html[Security privileges].
 
 ==== Example
 

--- a/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
@@ -70,6 +70,12 @@ DELETE /_ccr/auto_follow/auto_follow_pattern_name
 
 include::../follow-request-body.asciidoc[]
 
+==== Authorization
+
+If the {es} {security-features} are enabled, you must have `manage_ccr` cluster
+privileges on the cluster that contains the follower index. For more information,
+see {stack-ov}/security-privileges.html[Security privileges].
+
 ==== Example
 
 This example creates an auto-follow pattern named `my_auto_follow_pattern`:

--- a/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
@@ -182,8 +182,9 @@ Continuing with the fields from `shards`:
 ==== Authorization
 
 If the {es} {security-features} are enabled, you must have `read` and `monitor`
-index privileges for the follower indices. For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+index privileges for the follower indices. You must also have `monitor` cluster
+privileges on the cluster that contains the follower index. For more information,
+see {stack-ov}/security-privileges.html[Security privileges].
 
 ==== Example
 

--- a/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
@@ -179,6 +179,12 @@ Continuing with the fields from `shards`:
   task; in this situation, the following task must be resumed manually with the
   <<ccr-post-resume-follow,resume follower API>>
 
+==== Authorization
+
+If the {es} {security-features} are enabled, you must have `read` and `monitor`
+index privileges for the follower indices. For more information, see
+{stack-ov}/security-privileges.html[Security privileges].
+
 ==== Example
 
 This example retrieves follower stats:

--- a/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
@@ -181,8 +181,7 @@ Continuing with the fields from `shards`:
 
 ==== Authorization
 
-If the {es} {security-features} are enabled, you must have `read` and `monitor`
-index privileges for the follower indices. You must also have `monitor` cluster
+If the {es} {security-features} are enabled, you must have `monitor` cluster
 privileges on the cluster that contains the follower index. For more information,
 see {stack-ov}/security-privileges.html[Security privileges].
 

--- a/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
@@ -54,6 +54,13 @@ POST /<follower_index>/_ccr/unfollow
 
 `follower_index` (required)::
   (string) the name of the follower index
+  
+==== Authorization
+
+If the {es} {security-features} are enabled, you must have `manage_follow_index` 
+index privileges for the follower index. You must also have `manage_ccr` cluster
+privileges on the cluster that contains the follower index. For more information,
+see {stack-ov}/security-privileges.html[Security privileges].  
 
 ==== Example
 

--- a/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
@@ -58,9 +58,8 @@ POST /<follower_index>/_ccr/unfollow
 ==== Authorization
 
 If the {es} {security-features} are enabled, you must have `manage_follow_index` 
-index privileges for the follower index. You must also have `manage_ccr` cluster
-privileges on the cluster that contains the follower index. For more information,
-see {stack-ov}/security-privileges.html[Security privileges].  
+index privileges for the follower index. For more information, see
+{stack-ov}/security-privileges.html[Security privileges].  
 
 ==== Example
 

--- a/docs/reference/ccr/apis/get-ccr-stats.asciidoc
+++ b/docs/reference/ccr/apis/get-ccr-stats.asciidoc
@@ -3,7 +3,7 @@
 [[ccr-get-stats]]
 === Get Cross-Cluster Replication Stats API
 ++++
-<titleabbrev>Get Follower Stats</titleabbrev>
+<titleabbrev>Get CCR Stats</titleabbrev>
 ++++
 
 beta[]
@@ -82,9 +82,9 @@ This object consists of the following fields:
 
 ==== Authorization
 
-If the {es} {security-features} are enabled, you must have `read` and `monitor`
-index privileges for the follower indices. For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+If the {es} {security-features} are enabled, you must have `monitor` cluster
+privileges on the cluster that contains the follower index. For more information,
+see {stack-ov}/security-privileges.html[Security privileges].
 
 ==== Example
 

--- a/docs/reference/ccr/apis/get-ccr-stats.asciidoc
+++ b/docs/reference/ccr/apis/get-ccr-stats.asciidoc
@@ -80,6 +80,12 @@ This object consists of the following fields:
   to the details of the response in the
   <<ccr-get-follow-stats,get follower stats API>>
 
+==== Authorization
+
+If the {es} {security-features} are enabled, you must have `read` and `monitor`
+index privileges for the follower indices. For more information, see
+{stack-ov}/security-privileges.html[Security privileges].
+
 ==== Example
 
 This example retrieves {ccr} stats:


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/35557

This PR adds authorization details for the remainder of the cross-cluster replication APIs.