### PR TITLE
Refactor an ambigious TermVectorsRequest constructor.

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/TermVectorsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/TermVectorsRequest.java
@@ -33,6 +33,8 @@ public class TermVectorsRequest implements ToXContentObject, Validatable {
     private final String index;
     private final String type;
     private String id = null;
+    private XContentBuilder docBuilder = null;
+
     private String routing = null;
     private String preference = null;
     private boolean realtime = true;
@@ -44,7 +46,6 @@ public class TermVectorsRequest implements ToXContentObject, Validatable {
     private boolean requestTermStatistics = false;
     private Map<String, String> perFieldAnalyzer = null;
     private Map<String, Integer> filterSettings = null;
-    private XContentBuilder docBuilder = null;
 
 
     /**
@@ -54,7 +55,8 @@ public class TermVectorsRequest implements ToXContentObject, Validatable {
      * @param docId - id of the document
      */
     public TermVectorsRequest(String index, String type, String docId) {
-        this(index, type);
+        this.index = index;
+        this.type = type;
         this.id = docId;
     }
 
@@ -62,10 +64,12 @@ public class TermVectorsRequest implements ToXContentObject, Validatable {
      * Constructs TermVectorRequest for an artificial document
      * @param index - index of the document
      * @param type - type of the document
+     * @param docBuilder - an artificial document
      */
-    public TermVectorsRequest(String index, String type) {
+    public TermVectorsRequest(String index, String type, XContentBuilder docBuilder) {
         this.index = index;
         this.type = type;
+        this.docBuilder = docBuilder;
     }
 
     /**

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -192,8 +192,8 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             assertFalse(execute(getRequest, highLevelClient()::exists, highLevelClient()::existsAsync));
         }
     }
-    
-    public void testSourceExists() throws IOException {     
+
+    public void testSourceExists() throws IOException {
         {
             GetRequest getRequest = new GetRequest("index", "type", "id");
             assertFalse(execute(getRequest, highLevelClient()::existsSource, highLevelClient()::existsSourceAsync));
@@ -215,8 +215,8 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             assertFalse(execute(getRequest, highLevelClient()::existsSource, highLevelClient()::existsSourceAsync));
         }
     }
-    
-    public void testSourceDoesNotExist() throws IOException {     
+
+    public void testSourceDoesNotExist() throws IOException {
         final String noSourceIndex = "no_source";
         {
             // Prepare
@@ -224,8 +224,8 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                 .put("number_of_shards", 1)
                 .put("number_of_replicas", 0)
                 .build();
-            String mapping = "\"_doc\": { \"_source\": {\n" + 
-                    "        \"enabled\": false\n" + 
+            String mapping = "\"_doc\": { \"_source\": {\n" +
+                    "        \"enabled\": false\n" +
                     "      }  }";
             createIndex(noSourceIndex, settings, mapping);
             assertEquals(
@@ -240,13 +240,13 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                     RequestOptions.DEFAULT
                 ).status()
             );
-        }        
+        }
         {
             GetRequest getRequest = new GetRequest(noSourceIndex, "_doc", "1");
             assertTrue(execute(getRequest, highLevelClient()::exists, highLevelClient()::existsAsync));
             assertFalse(execute(getRequest, highLevelClient()::existsSource, highLevelClient()::existsSourceAsync));
         }
-    }    
+    }
 
     public void testGet() throws IOException {
         {
@@ -1154,10 +1154,10 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
         }
         {
             // test _termvectors on artificial documents
-            TermVectorsRequest tvRequest = new TermVectorsRequest(sourceIndex, "_doc");
             XContentBuilder docBuilder = XContentFactory.jsonBuilder();
             docBuilder.startObject().field("field", "valuex").endObject();
-            tvRequest.setDoc(docBuilder);
+
+            TermVectorsRequest tvRequest = new TermVectorsRequest(sourceIndex, "_doc", docBuilder);
             TermVectorsResponse tvResponse = execute(tvRequest, highLevelClient()::termvectors, highLevelClient()::termvectorsAsync);
 
             TermVectorsResponse.TermVector.Token expectedToken = new TermVectorsResponse.TermVector.Token(0, 6, 0, null);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
@@ -1565,10 +1565,12 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
 
         {
             // tag::term-vectors-request-artificial
-            TermVectorsRequest request = new TermVectorsRequest("authors", "_doc");
+
             XContentBuilder docBuilder = XContentFactory.jsonBuilder();
             docBuilder.startObject().field("user", "guest-user").endObject();
-            request.setDoc(docBuilder); // <1>
+            TermVectorsRequest request = new TermVectorsRequest("authors",
+                "_doc",
+                docBuilder); // <1>
             // end::term-vectors-request-artificial
 
             // tag::term-vectors-request-optional-arguments


### PR DESCRIPTION
When we deprecate types, we'll want to introduce the constructor `TermVectorsRequest(String index, String id)`. However, this will clash with the current constructor `TermVectorsRequest(String index, String type)`, making it difficult to signal the migration path.

This PR refactors the constructor to avoid ambiguity. I don't think this change will have much effect on users, since the terms vector HLRC method isn't yet released.