### PR TITLE
Auto skip license headers on no source

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/LicenseHeadersTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/LicenseHeadersTask.groovy
@@ -24,7 +24,9 @@ import org.apache.rat.license.SimpleLicenseFamily
 import org.elasticsearch.gradle.AntTask
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.SourceSet
 
 import java.nio.file.Files
@@ -38,12 +40,6 @@ public class LicenseHeadersTask extends AntTask {
 
     @OutputFile
     File reportFile = new File(project.buildDir, 'reports/licenseHeaders/rat.log')
-
-    /**
-     * The list of java files to check. protected so the afterEvaluate closure in the
-     * constructor can write to it.
-     */
-    protected List<FileCollection> javaFiles
 
     /** Allowed license families for this project. */
     @Input
@@ -65,11 +61,16 @@ public class LicenseHeadersTask extends AntTask {
 
     LicenseHeadersTask() {
         description = "Checks sources for missing, incorrect, or unacceptable license headers"
-        // Delay resolving the dependencies until after evaluation so we pick up generated sources
-        project.afterEvaluate {
-            javaFiles = project.sourceSets.collect({it.allJava})
-            inputs.files(javaFiles)
-        }
+    }
+
+    /**
+     * The list of java files to check. protected so the afterEvaluate closure in the
+     * constructor can write to it.
+     */
+    @InputFiles
+    @SkipWhenEmpty
+    public List<FileCollection> getJavaFiles() {
+        return project.sourceSets.collect({it.allJava})
     }
 
     /**
@@ -97,9 +98,8 @@ public class LicenseHeadersTask extends AntTask {
         Files.deleteIfExists(reportFile.toPath())
 
         // run rat, going to the file
-        List<FileCollection> input = javaFiles
         ant.ratReport(reportFile: reportFile.absolutePath, addDefaultLicenseMatchers: true) {
-            for (FileCollection dirSet : input) {
+            for (FileCollection dirSet : javaFiles) {
                for (File dir: dirSet.srcDirs) {
                    // sometimes these dirs don't exist, e.g. site-plugin has no actual java src/main...
                    if (dir.exists()) {

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/BuildExamplePluginsIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/BuildExamplePluginsIT.java
@@ -23,7 +23,6 @@ import org.apache.commons.io.FileUtils;
 import org.elasticsearch.gradle.test.GradleIntegrationTestCase;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
@@ -39,7 +38,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-@Ignore
 public class BuildExamplePluginsIT extends GradleIntegrationTestCase {
 
     private static List<File> EXAMPLE_PLUGINS = Collections.unmodifiableList(

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -4,4 +4,3 @@ apply plugin: 'nebula.maven-scm'
 
 test.enabled = false
 jarHell.enabled = false
-licenseHeaders.enabled = false

--- a/test/fixtures/krb5kdc-fixture/build.gradle
+++ b/test/fixtures/krb5kdc-fixture/build.gradle
@@ -74,7 +74,6 @@ task destroy(type: org.elasticsearch.gradle.vagrant.VagrantCommandTask) {
 }
 
 thirdPartyAudit.enabled = false
-licenseHeaders.enabled = false
 test.enabled = false
 
 // installKDC uses tabs in it for the Kerberos ACL file.

--- a/x-pack/plugin/ilm/qa/build.gradle
+++ b/x-pack/plugin/ilm/qa/build.gradle
@@ -16,5 +16,3 @@ subprojects {
     }
 }
 
-// the qa modules does not have any source files
-licenseHeaders.enabled = false

--- a/x-pack/test/idp-fixture/build.gradle
+++ b/x-pack/test/idp-fixture/build.gradle
@@ -38,6 +38,5 @@ task destroy(type: org.elasticsearch.gradle.vagrant.VagrantCommandTask) {
 }
 
 thirdPartyAudit.enabled = false
-licenseHeaders.enabled = false
 test.enabled = false
 jarHell.enabled = false

--- a/x-pack/test/smb-fixture/build.gradle
+++ b/x-pack/test/smb-fixture/build.gradle
@@ -38,6 +38,5 @@ task destroy(type: org.elasticsearch.gradle.vagrant.VagrantCommandTask) {
 }
 
 thirdPartyAudit.enabled = false
-licenseHeaders.enabled = false
 test.enabled = false
 jarHell.enabled = false


### PR DESCRIPTION
So there is no need to disable the task in build scripts. 
