### PR TITLE
[Scripting] Use Number as a return value for BucketAggregationScript

### DIFF
--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
@@ -109,7 +109,7 @@ public class ExpressionScriptEngine implements ScriptEngine {
             BucketAggregationSelectorScript.Factory wrappedFactory = parameters -> new BucketAggregationSelectorScript(parameters) {
                 @Override
                 public boolean execute() {
-                    return factory.newInstance(getParams()).execute() == 1.0;
+                    return factory.newInstance(getParams()).execute().doubleValue() == 1.0;
                 }
             };
             return context.factoryClazz.cast(wrappedFactory);

--- a/server/src/main/java/org/elasticsearch/script/BucketAggregationScript.java
+++ b/server/src/main/java/org/elasticsearch/script/BucketAggregationScript.java
@@ -46,7 +46,7 @@ public abstract class BucketAggregationScript {
         return params;
     }
 
-    public abstract Double execute();
+    public abstract Number execute();
 
     public interface Factory {
         BucketAggregationScript newInstance(Map<String, Object> params);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptPipelineAggregator.java
@@ -108,13 +108,13 @@ public class BucketScriptPipelineAggregator extends PipelineAggregator {
             if (skipBucket) {
                 newBuckets.add(bucket);
             } else {
-                Double returned = factory.newInstance(vars).execute();
+                Number returned = factory.newInstance(vars).execute();
                 if (returned == null) {
                     newBuckets.add(bucket);
                 } else {
                     final List<InternalAggregation> aggs = StreamSupport.stream(bucket.getAggregations().spliterator(), false).map(
                         (p) -> (InternalAggregation) p).collect(Collectors.toList());
-                    aggs.add(new InternalSimpleValue(name(), returned, formatter, new ArrayList<>(), metaData()));
+                    aggs.add(new InternalSimpleValue(name(), returned.doubleValue(), formatter, new ArrayList<>(), metaData()));
                     InternalMultiBucketAggregation.InternalBucket newBucket = originalAgg.createBucket(new InternalAggregations(aggs),
                         bucket);
                     newBuckets.add(newBucket);


### PR DESCRIPTION
This change fixes https://github.com/elastic/elasticsearch/issues/35351.  Users were no longer able to return types of numbers other than doubles for bucket aggregation scripts.  This PR reverts to the previous behavior of being able to return any type of number and having it converted to a double outside of the script.