### PR TITLE
Align RolloverStep's name with other step names

### DIFF
--- a/docs/reference/ilm/apis/explain.asciidoc
+++ b/docs/reference/ilm/apis/explain.asciidoc
@@ -137,7 +137,7 @@ phase completes.
       "action": "rollover",
       "action_time_millis": 1538475653317,
       "action_time": "2018-10-15T13:45:22.577Z",
-      "step": "attempt_rollover",
+      "step": "attempt-rollover",
       "step_time_millis": 1538475653317,
       "step_time": "2018-10-15T13:45:22.577Z",
       "phase_execution": {
@@ -248,7 +248,7 @@ the step that failed and the step info provides information about the error.
       "step": "ERROR",
       "step_time_millis": 1538475653317,
       "step_time": "2018-10-15T13:45:22.577Z",
-      "failed_step": "attempt_rollover", <1>
+      "failed_step": "attempt-rollover", <1>
       "step_info": { <2>
         "type": "resource_already_exists_exception",
         "reason": "index [test-000057/H7lF9n36Rzqa-KfKcnGQMg] already exists",

--- a/docs/reference/ilm/getting-started-ilm.asciidoc
+++ b/docs/reference/ilm/getting-started-ilm.asciidoc
@@ -171,7 +171,7 @@ managed indices.
       "phase_time_millis": 1538475653317,
       "action": "rollover",                      <4>
       "action_time_millis": 1538475653317,
-      "step": "attempt_rollover",                <5>
+      "step": "attempt-rollover",                <5>
       "step_time_millis": 1538475653317,
       "phase_execution": {
         "policy": "datastream_policy",

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/RolloverStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/RolloverStep.java
@@ -19,7 +19,7 @@ import java.util.Objects;
  * Unconditionally rolls over an index using the Rollover API.
  */
 public class RolloverStep extends AsyncActionStep {
-    public static final String NAME = "attempt_rollover";
+    public static final String NAME = "attempt-rollover";
 
     public RolloverStep(StepKey key, StepKey nextStepKey, Client client) {
         super(key, nextStepKey, client);

--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/indexlifecycle/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/indexlifecycle/TimeSeriesLifecycleActionsIT.java
@@ -161,7 +161,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             "  \"next_step\": {\n" +
             "    \"phase\": \"hot\",\n" +
             "    \"action\": \"rollover\",\n" +
-            "    \"name\": \"attempt_rollover\"\n" +
+            "    \"name\": \"attempt-rollover\"\n" +
             "  }\n" +
             "}");
         client().performRequest(moveToStepRequest);


### PR DESCRIPTION
RolloverStep previously had a name of "attempt_rollover", which was
inconsistent with all other step names due it its use of an underscore
instead of a dash. This makes makes the step names consistent
across all steps.