### PR TITLE
[ILM] DOCS: clarify interaction between rollover and min_age

### DIFF
--- a/docs/reference/ilm/get-index-lifecycle-information.asciidoc
+++ b/docs/reference/ilm/get-index-lifecycle-information.asciidoc
@@ -1,7 +1,0 @@
-[role="xpack"]
-[[get-index-lifecycle-information]]
-== Get index lifecycle information
-
-Execution Model
-Discuss how actions are actually split up into discrete steps and how you can see more information about where an index is within a policy (info and all)
-Talk about the jump-to-step API

--- a/docs/reference/ilm/index.asciidoc
+++ b/docs/reference/ilm/index.asciidoc
@@ -62,8 +62,6 @@ include::using-policies-rollover.asciidoc[]
 
 include::update-lifecycle-policy.asciidoc[]
 
-// include::get-index-lifecycle-information.asciidoc[]
-
 include::error-handling.asciidoc[]
 
 include::start-stop-ilm.asciidoc[]

--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -71,6 +71,9 @@ index is rolled over, then `min_age` is the time elapsed from the time the index
 is rolled over. The intention here is to execute following phases and actions
 relative to when data was written last to a rolled over index.
 
+The previous phase's actions must complete before {ILM} will check `min_age` and
+transition into the next phase.
+
 === Actions
 
 beta[]
@@ -448,6 +451,41 @@ PUT _ilm/policy/my_policy
 --------------------------------------------------
 // CONSOLE
 
+
+===== Example: Rollover condition stalls phase transition
+
+The Rollover action will only complete once one of its conditions is
+met. This means that any proceeding phases will be blocked until Rollover
+succeeds.
+
+[source,js]
+--------------------------------------------------
+PUT /_ilm/rollover_policy
+{
+  "policy": {
+    "phases": {
+      "hot": {
+        "actions": {
+          "rollover": {
+            "max_size": "50G"
+          }
+        }
+      },
+      "delete": {
+        "min_age": "1d",
+        "actions": {
+          "delete": {}
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+// CONSOLE
+
+The above example illustrates a policy which attempts to delete an
+index one day after the index has been rolled over. It does not
+delete the index one day after it has been created.
 
 [[ilm-shrink-action]]
 ==== Shrink

--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -460,7 +460,7 @@ succeeds.
 
 [source,js]
 --------------------------------------------------
-PUT /_ilm/rollover_policy
+PUT /_ilm/policy/rollover_policy
 {
   "policy": {
     "phases": {


### PR DESCRIPTION
This adds an example to drive home the semantics of `min_age` and explain
how actions from one phase must complete before `min_age` is even tested

Closes #34020.