### PR TITLE
Deprecate types in search and multi search templates.

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
@@ -62,8 +62,8 @@ public class RestMultiSearchTemplateAction extends BaseRestHandler {
     }
 
     @Override
-    public RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
-        MultiSearchTemplateRequest multiRequest = parseRequest(restRequest, allowExplicitIndex);
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        MultiSearchTemplateRequest multiRequest = parseRequest(request, allowExplicitIndex);
         return channel -> client.execute(MultiSearchTemplateAction.INSTANCE, multiRequest, new RestToXContentListener<>(channel));
     }
 

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequestTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequestTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.search.RestMultiSearchAction;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -77,6 +78,8 @@ public class MultiSearchTemplateRequestTests extends ESTestCase {
         assertEquals(1, request.requests().get(0).getScriptParams().size());
         assertEquals(1, request.requests().get(1).getScriptParams().size());
         assertEquals(1, request.requests().get(2).getScriptParams().size());
+
+        assertWarnings(RestMultiSearchAction.TYPES_DEPRECATION_MESSAGE);
     }
 
     public void testParseWithCarriageReturn() throws Exception {
@@ -105,10 +108,10 @@ public class MultiSearchTemplateRequestTests extends ESTestCase {
         expectThrows(IllegalArgumentException.class, () ->
                 request.maxConcurrentSearchRequests(randomIntBetween(Integer.MIN_VALUE, 0)));
     }
-    
+
     public void testMultiSearchTemplateToJson() throws Exception {
         final int numSearchRequests = randomIntBetween(1, 10);
-        MultiSearchTemplateRequest multiSearchTemplateRequest = new MultiSearchTemplateRequest();        
+        MultiSearchTemplateRequest multiSearchTemplateRequest = new MultiSearchTemplateRequest();
         for (int i = 0; i < numSearchRequests; i++) {
             // Create a random request.
             String[] indices = {"test"};
@@ -118,25 +121,25 @@ public class MultiSearchTemplateRequestTests extends ESTestCase {
             // batched reduce size is currently not set-able on a per-request basis as it is a query string parameter only
             searchRequest.setBatchedReduceSize(SearchRequest.DEFAULT_BATCHED_REDUCE_SIZE);
             SearchTemplateRequest searchTemplateRequest = new SearchTemplateRequest(searchRequest);
-    
+
             searchTemplateRequest.setScript("{\"query\": { \"match\" : { \"{{field}}\" : \"{{value}}\" }}}");
             searchTemplateRequest.setScriptType(ScriptType.INLINE);
             searchTemplateRequest.setProfile(randomBoolean());
-    
+
             Map<String, Object> scriptParams = new HashMap<>();
             scriptParams.put("field", "name");
             scriptParams.put("value", randomAlphaOfLengthBetween(2, 5));
             searchTemplateRequest.setScriptParams(scriptParams);
-    
-            multiSearchTemplateRequest.add(searchTemplateRequest);            
+
+            multiSearchTemplateRequest.add(searchTemplateRequest);
         }
 
         //Serialize the request
         String serialized = toJsonString(multiSearchTemplateRequest);
-        
+
         //Deserialize the request
         RestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry())
-                .withContent(new BytesArray(serialized), XContentType.JSON).build();        
+                .withContent(new BytesArray(serialized), XContentType.JSON).build();
         MultiSearchTemplateRequest deser = RestMultiSearchTemplateAction.parseRequest(restRequest, true);
 
         // For object equality purposes need to set the search requests' source to non-null
@@ -145,10 +148,10 @@ public class MultiSearchTemplateRequestTests extends ESTestCase {
             if (sr.source() == null) {
                 sr.source(new SearchSourceBuilder());
             }
-        }        
+        }
         // Compare the deserialized request object with the original request object
         assertEquals(multiSearchTemplateRequest, deser);
-        
+
         // Finally, serialize the deserialized request to compare JSON equivalence (in case Object.equals() fails to reveal a discrepancy)
         assertEquals(serialized, toJsonString(deser));
     }
@@ -156,6 +159,6 @@ public class MultiSearchTemplateRequestTests extends ESTestCase {
     protected String toJsonString(MultiSearchTemplateRequest multiSearchTemplateRequest) throws IOException {
         byte[] bytes = MultiSearchTemplateRequest.writeMultiLineFormat(multiSearchTemplateRequest, XContentType.JSON.xContent());
         return new String(bytes, StandardCharsets.UTF_8);
-    }    
+    }
 
 }

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateActionTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateActionTests.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.script.mustache;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.search.RestMultiSearchAction;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestChannel;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.usage.UsageService;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+
+public class RestMultiSearchTemplateActionTests extends ESTestCase {
+    private RestController controller;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        controller = new RestController(Collections.emptySet(), null,
+            mock(NodeClient.class),
+            new NoneCircuitBreakerService(),
+            new UsageService());
+        new RestMultiSearchTemplateAction(Settings.EMPTY, controller);
+    }
+
+    public void testTypeInPath() {
+        String content = "{ \"index\": \"some_index\" } \n" +
+            "{\"source\": {\"query\" : {\"match_all\" :{}}}} \n";
+        BytesArray bytesContent = new BytesArray(content.getBytes(StandardCharsets.UTF_8));
+
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.GET)
+            .withPath("/some_index/some_type/_msearch/template")
+            .withContent(bytesContent, XContentType.JSON)
+            .build();
+
+        performRequest(request);
+        assertWarnings(RestMultiSearchAction.TYPES_DEPRECATION_MESSAGE);
+    }
+
+    public void testTypeInBody() {
+        String content = "{ \"index\": \"some_index\", \"type\": \"some_type\" } \n" +
+            "{\"source\": {\"query\" : {\"match_all\" :{}}}} \n";
+        BytesArray bytesContent = new BytesArray(content.getBytes(StandardCharsets.UTF_8));
+
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withPath("/some_index/_msearch/template")
+            .withContent(bytesContent, XContentType.JSON)
+            .build();
+
+        performRequest(request);
+        assertWarnings(RestMultiSearchAction.TYPES_DEPRECATION_MESSAGE);
+    }
+
+    private void performRequest(RestRequest request) {
+        RestChannel channel = new FakeRestChannel(request, false, 1);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        controller.dispatchRequest(request, channel, threadContext);
+    }
+}

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestSearchTemplateActionTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestSearchTemplateActionTests.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.script.mustache;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.search.RestSearchAction;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestChannel;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.usage.UsageService;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+
+public class RestSearchTemplateActionTests extends ESTestCase {
+    private RestController controller;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        controller = new RestController(Collections.emptySet(), null,
+            mock(NodeClient.class),
+            new NoneCircuitBreakerService(),
+            new UsageService());
+        new RestSearchTemplateAction(Settings.EMPTY, controller);
+    }
+
+    public void testTypeInPath() {
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.GET)
+            .withPath("/some_index/some_type/_search/template")
+            .build();
+
+        performRequest(request);
+        assertWarnings(RestSearchAction.TYPES_DEPRECATION_MESSAGE);
+    }
+
+    public void testTypeParameter() {
+        Map<String, String> params = new HashMap<>();
+        params.put("type", "some_type");
+
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.GET)
+            .withPath("/some_index/_search/template")
+            .withParams(params)
+            .build();
+
+        performRequest(request);
+        assertWarnings(RestSearchAction.TYPES_DEPRECATION_MESSAGE);
+    }
+
+    private void performRequest(RestRequest request) {
+        RestChannel channel = new FakeRestChannel(request, false, 1);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        controller.dispatchRequest(request, channel, threadContext);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -48,12 +48,12 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 public class RestMultiSearchAction extends BaseRestHandler {
-    private static final Set<String> RESPONSE_PARAMS = Collections.singleton(RestSearchAction.TYPED_KEYS_PARAM);
-
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
         LogManager.getLogger(RestMultiSearchAction.class));
-    static final String TYPES_DEPRECATION_MESSAGE = "[types removal]" +
+    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal]" +
         " Specifying types in multi search requests is deprecated.";
+
+    private static final Set<String> RESPONSE_PARAMS = Collections.singleton(RestSearchAction.TYPED_KEYS_PARAM);
 
     private final boolean allowExplicitIndex;
 

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -58,7 +58,7 @@ public class RestSearchAction extends BaseRestHandler {
     private static final Set<String> RESPONSE_PARAMS = Collections.singleton(TYPED_KEYS_PARAM);
 
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestSearchAction.class));
-    static final String TYPES_DEPRECATION_MESSAGE = "[types removal]" +
+    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal]" +
         " Specifying types in search requests is deprecated.";
 
     public RestSearchAction(Settings settings, RestController controller) {


### PR DESCRIPTION
This PR adds deprecation warnings to the relevant `Rest*Action` classes, plus tests in `Rest*ActionTests`. No updates to REST tests, the Java HLRC, or documentation were necessary, since they didn't make use of types.