### PR TITLE
[Docs] Fix query in docs

### DIFF
--- a/docs/reference/query-dsl/script-query.asciidoc
+++ b/docs/reference/query-dsl/script-query.asciidoc
@@ -11,7 +11,7 @@ GET /_search
 {
     "query": {
         "bool" : {
-            "must" : {
+            "filter" : {
                 "script" : {
                     "script" : {
                         "source": "doc['num1'].value > 1",
@@ -38,7 +38,7 @@ GET /_search
 {
     "query": {
         "bool" : {
-            "must" : {
+            "filter" : {
                 "script" : {
                     "script" : {
                         "source" : "doc['num1'].value > params.param1",


### PR DESCRIPTION
The docs are saying "They are typically used in a filter context", but a bool/must query was used
