### PR TITLE
TEST: Enable skipped Rest test for upgrades

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/upgrade/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/upgrade/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: "all"
-      reason: "AwaitsFix'ing, see https://github.com/elastic/elasticsearch/issues/29890"
   - do:
       xpack.license.post:
         body: >


### PR DESCRIPTION
This test was skipped due to infr complications during the work
to open x-pack, but wasn't enabled again when the issue was resolved.

Relates: #29890
