### PR TITLE
Clean up StartBasicResponse

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/license/StartBasicResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/license/StartBasicResponse.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -91,26 +90,16 @@ public class StartBasicResponse {
     private String acknowledgeMessage;
 
     public enum Status {
-        GENERATED_BASIC(true, null, RestStatus.OK),
-        ALREADY_USING_BASIC(false, "Operation failed: Current license is basic.", RestStatus.FORBIDDEN),
-        NEED_ACKNOWLEDGEMENT(false, "Operation failed: Needs acknowledgement.", RestStatus.OK);
+        GENERATED_BASIC(true, null),
+        ALREADY_USING_BASIC(false, "Operation failed: Current license is basic."),
+        NEED_ACKNOWLEDGEMENT(false, "Operation failed: Needs acknowledgement.");
 
         private final boolean isBasicStarted;
         private final String errorMessage;
-        private final RestStatus restStatus;
 
-        Status(boolean isBasicStarted, String errorMessage, RestStatus restStatus) {
+        Status(boolean isBasicStarted, String errorMessage) {
             this.isBasicStarted = isBasicStarted;
             this.errorMessage = errorMessage;
-            this.restStatus = restStatus;
-        }
-
-        String getErrorMessage() {
-            return errorMessage;
-        }
-
-        boolean isBasicStarted() {
-            return isBasicStarted;
         }
 
         static StartBasicResponse.Status fromErrorMessage(final String errorMessage) {
@@ -126,14 +115,11 @@ public class StartBasicResponse {
 
     private StartBasicResponse.Status status;
 
-    public StartBasicResponse() {
-    }
-
-    StartBasicResponse(StartBasicResponse.Status status) {
+    private StartBasicResponse(StartBasicResponse.Status status) {
         this(status, Collections.emptyMap(), null);
     }
 
-    StartBasicResponse(StartBasicResponse.Status status,
+    private StartBasicResponse(StartBasicResponse.Status status,
                               Map<String, String[]> acknowledgeMessages, String acknowledgeMessage) {
         this.status = status;
         this.acknowledgeMessages = acknowledgeMessages;
@@ -167,5 +153,4 @@ public class StartBasicResponse {
     public static StartBasicResponse fromXContent(XContentParser parser) throws IOException {
         return PARSER.parse(parser, null);
     }
-
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartBasicResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartBasicResponse.java
@@ -7,82 +7,24 @@ package org.elasticsearch.license;
 
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.StatusToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParseException;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.protocol.xpack.common.ProtocolUtils;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
-import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
-
-public class PostStartBasicResponse extends AcknowledgedResponse {
-
-    private static final ConstructingObjectParser<PostStartBasicResponse, Void> PARSER = new ConstructingObjectParser<>(
-        "start_basic_response", true, (a, v) -> {
-        boolean basicWasStarted = (Boolean) a[0];
-        String errorMessage = (String) a[1];
-
-        if (basicWasStarted) {
-            return new PostStartBasicResponse(Status.GENERATED_BASIC);
-        }
-        Status status = Status.fromErrorMessage(errorMessage);
-        @SuppressWarnings("unchecked") Tuple<String, Map<String, String[]>> acknowledgements = (Tuple<String, Map<String, String[]>>) a[2];
-        return new PostStartBasicResponse(status, acknowledgements.v2(), acknowledgements.v1());
-    });
+public class PostStartBasicResponse extends AcknowledgedResponse implements StatusToXContentObject {
 
     private static final ParseField BASIC_WAS_STARTED_FIELD = new ParseField("basic_was_started");
     private static final ParseField ERROR_MESSAGE_FIELD = new ParseField("error_message");
-    private static final ParseField ACKNOWLEDGE_FIELD = new ParseField("acknowledge");
     private static final ParseField MESSAGE_FIELD = new ParseField("message");
-
-    static {
-        PARSER.declareBoolean(constructorArg(), BASIC_WAS_STARTED_FIELD);
-        PARSER.declareString(optionalConstructorArg(), ERROR_MESSAGE_FIELD);
-        PARSER.declareObject(optionalConstructorArg(), (parser, v) -> {
-                Map<String, String[]> acknowledgeMessages = new HashMap<>();
-                String message = null;
-                XContentParser.Token token;
-                String currentFieldName = null;
-                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                    if (token == XContentParser.Token.FIELD_NAME) {
-                        currentFieldName = parser.currentName();
-                    } else {
-                        if (currentFieldName == null) {
-                            throw new XContentParseException(parser.getTokenLocation(), "expected message header or acknowledgement");
-                        }
-                        if (MESSAGE_FIELD.getPreferredName().equals(currentFieldName)) {
-                            ensureExpectedToken(XContentParser.Token.VALUE_STRING, token, parser::getTokenLocation);
-                            message = parser.text();
-                        } else {
-                            if (token != XContentParser.Token.START_ARRAY) {
-                                throw new XContentParseException(parser.getTokenLocation(), "unexpected acknowledgement type");
-                            }
-                            List<String> acknowledgeMessagesList = new ArrayList<>();
-                            while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                                ensureExpectedToken(XContentParser.Token.VALUE_STRING, token, parser::getTokenLocation);
-                                acknowledgeMessagesList.add(parser.text());
-                            }
-                            acknowledgeMessages.put(currentFieldName, acknowledgeMessagesList.toArray(new String[0]));
-                        }
-                    }
-                }
-                return new Tuple<>(message, acknowledgeMessages);
-            }, ACKNOWLEDGE_FIELD);
-    }
 
     private Map<String, String[]> acknowledgeMessages;
     private String acknowledgeMessage;
@@ -112,16 +54,6 @@ public class PostStartBasicResponse extends AcknowledgedResponse {
 
         RestStatus getRestStatus() {
             return restStatus;
-        }
-
-        static Status fromErrorMessage(final String errorMessage) {
-            final Status[] values = Status.values();
-            for (Status status : values) {
-                if (Objects.equals(status.errorMessage, errorMessage)) {
-                    return status;
-                }
-            }
-            throw new IllegalArgumentException("No status for error message ['" + errorMessage + "']");
         }
     }
 
@@ -201,8 +133,9 @@ public class PostStartBasicResponse extends AcknowledgedResponse {
         }
     }
 
-    public static PostStartBasicResponse fromXContent(XContentParser parser) throws IOException {
-        return PARSER.parse(parser, null);
+    @Override
+    public RestStatus status() {
+        return status.restStatus;
     }
 
     @Override
@@ -221,5 +154,4 @@ public class PostStartBasicResponse extends AcknowledgedResponse {
     public int hashCode() {
         return Objects.hash(super.hashCode(), status, ProtocolUtils.hashCode(acknowledgeMessages), acknowledgeMessage);
     }
-
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartBasicLicense.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartBasicLicense.java
@@ -6,13 +6,9 @@
 package org.elasticsearch.license;
 
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
-import org.elasticsearch.rest.action.RestBuilderListener;
+import org.elasticsearch.rest.action.RestStatusToXContentListener;
 import org.elasticsearch.xpack.core.XPackClient;
 import org.elasticsearch.xpack.core.rest.XPackRestHandler;
 
@@ -33,14 +29,7 @@ public class RestPostStartBasicLicense extends XPackRestHandler {
         startBasicRequest.acknowledge(request.paramAsBoolean("acknowledge", false));
         startBasicRequest.timeout(request.paramAsTime("timeout", startBasicRequest.timeout()));
         startBasicRequest.masterNodeTimeout(request.paramAsTime("master_timeout", startBasicRequest.masterNodeTimeout()));
-        return channel -> client.licensing().postStartBasic(startBasicRequest, new RestBuilderListener<PostStartBasicResponse>(channel) {
-            @Override
-            public RestResponse buildResponse(PostStartBasicResponse response, XContentBuilder builder) throws Exception {
-                PostStartBasicResponse.Status status = response.getStatus();
-                response.toXContent(builder, ToXContent.EMPTY_PARAMS);
-                return new BytesRestResponse(status.getRestStatus(), builder);
-            }
-        });
+        return channel -> client.licensing().postStartBasic(startBasicRequest, new RestStatusToXContentListener<>(channel));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/xpack/license/StartBasicResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/xpack/license/StartBasicResponseTests.java
@@ -31,11 +31,6 @@ public class StartBasicResponseTests extends
     }
 
     @Override
-    protected PostStartBasicResponse doParseInstance(XContentParser parser) throws IOException {
-        return PostStartBasicResponse.fromXContent(parser);
-    }
-
-    @Override
     protected PostStartBasicResponse createBlankInstance() {
         return new PostStartBasicResponse();
     }


### PR DESCRIPTION
This PR removes the parsing code from the PostStartBasicResponse server variant. It also makes the server response implement StatusToXContent which allows us to save a couple of lines of code in the corredponding REST action.

Relates to #35547