### PR TITLE
Clean up PutLicenseResponse

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/license/PutLicenseResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/license/PutLicenseResponse.java
@@ -6,82 +6,19 @@
 package org.elasticsearch.protocol.xpack.license;
 
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParseException;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.protocol.xpack.common.ProtocolUtils;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
-import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
-
 public class PutLicenseResponse extends AcknowledgedResponse {
-
-    private static final ConstructingObjectParser<PutLicenseResponse, Void> PARSER = new ConstructingObjectParser<>(
-        "put_license_response", true, (a, v) -> {
-        boolean acknowledged = (Boolean) a[0];
-        LicensesStatus licensesStatus = LicensesStatus.fromString((String) a[1]);
-        @SuppressWarnings("unchecked") Tuple<String, Map<String, String[]>> acknowledgements = (Tuple<String, Map<String, String[]>>) a[2];
-        if (acknowledgements == null) {
-            return new PutLicenseResponse(acknowledged, licensesStatus);
-        } else {
-            return new PutLicenseResponse(acknowledged, licensesStatus, acknowledgements.v1(), acknowledgements.v2());
-        }
-
-    });
-
-    static {
-        PARSER.declareBoolean(constructorArg(), new ParseField("acknowledged"));
-        PARSER.declareString(constructorArg(), new ParseField("license_status"));
-        PARSER.declareObject(optionalConstructorArg(), (parser, v) -> {
-                Map<String, String[]> acknowledgeMessages = new HashMap<>();
-                String message = null;
-                XContentParser.Token token;
-                String currentFieldName = null;
-                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                    if (token == XContentParser.Token.FIELD_NAME) {
-                        currentFieldName = parser.currentName();
-                    } else {
-                        if (currentFieldName == null) {
-                            throw new XContentParseException(parser.getTokenLocation(), "expected message header or acknowledgement");
-                        }
-                        if ("message".equals(currentFieldName)) {
-                            if (token != XContentParser.Token.VALUE_STRING) {
-                                throw new XContentParseException(parser.getTokenLocation(), "unexpected message header type");
-                            }
-                            message = parser.text();
-                        } else {
-                            if (token != XContentParser.Token.START_ARRAY) {
-                                throw new XContentParseException(parser.getTokenLocation(), "unexpected acknowledgement type");
-                            }
-                            List<String> acknowledgeMessagesList = new ArrayList<>();
-                            while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                                if (token != XContentParser.Token.VALUE_STRING) {
-                                    throw new XContentParseException(parser.getTokenLocation(), "unexpected acknowledgement text");
-                                }
-                                acknowledgeMessagesList.add(parser.text());
-                            }
-                            acknowledgeMessages.put(currentFieldName, acknowledgeMessagesList.toArray(new String[0]));
-                        }
-                    }
-                }
-                return new Tuple<>(message, acknowledgeMessages);
-            },
-            new ParseField("acknowledge"));
-    }
 
     private LicensesStatus status;
     private Map<String, String[]> acknowledgeMessages;
@@ -170,10 +107,6 @@ public class PutLicenseResponse extends AcknowledgedResponse {
         return Strings.toString(this, true, true);
     }
 
-    public static PutLicenseResponse fromXContent(XContentParser parser) throws IOException {
-        return PARSER.parse(parser, null);
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -190,6 +123,4 @@ public class PutLicenseResponse extends AcknowledgedResponse {
     public int hashCode() {
         return Objects.hash(super.hashCode(), status, ProtocolUtils.hashCode(acknowledgeMessages), acknowledgeHeader);
     }
-
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/xpack/license/PutLicenseResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/xpack/license/PutLicenseResponseTests.java
@@ -77,11 +77,6 @@ public class PutLicenseResponseTests extends
     }
 
     @Override
-    protected PutLicenseResponse doParseInstance(XContentParser parser) throws IOException {
-        return PutLicenseResponse.fromXContent(parser);
-    }
-
-    @Override
     protected PutLicenseResponse createBlankInstance() {
         return new PutLicenseResponse();
     }
@@ -120,5 +115,4 @@ public class PutLicenseResponseTests extends
     private LicensesStatus mutateStatus(LicensesStatus status) {
         return randomValueOtherThan(status, () -> randomFrom(LicensesStatus.values()));
     }
-
 }


### PR DESCRIPTION
This commit removes the parsing code from the PutLicenseResponse server variant.

Relates to #35547
