### PR TITLE
Add global and index level blocks to IndexSettings

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -447,8 +447,13 @@ public class MetaDataCreateIndexService {
                         "]: cannot be greater than number of shard copies [" +
                         (tmpImd.getNumberOfReplicas() + 1) + "]");
                 }
+
+                final ClusterBlocks clusterBlocks = currentState.blocks();
+                final Set<ClusterBlock> globalBlocks = clusterBlocks.global();
+                final Set<ClusterBlock> indexBlocks = clusterBlocks.indices().get(tmpImd.getIndex().getName());
+
                 // create the index here (on the master) to validate it can be created, as well as adding the mapping
-                final IndexService indexService = indicesService.createIndex(tmpImd, Collections.emptyList());
+                final IndexService indexService = indicesService.createIndex(tmpImd, globalBlocks, indexBlocks, Collections.emptyList());
                 createdIndex = indexService.index();
                 // now add the mappings
                 MapperService mapperService = indexService.mapperService();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
@@ -232,7 +232,7 @@ public class MetaDataIndexTemplateService {
                 .build();
 
             final IndexMetaData tmpIndexMetadata = IndexMetaData.builder(temporaryIndexName).settings(dummySettings).build();
-            IndexService dummyIndexService = indicesService.createIndex(tmpIndexMetadata, Collections.emptyList());
+            IndexService dummyIndexService = indicesService.createIndex(tmpIndexMetadata, null, null, Collections.emptyList());
             createdIndex = dummyIndexService.index();
 
             templateBuilder.order(request.order);

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -28,6 +28,7 @@ import org.elasticsearch.Assertions;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Nullable;
@@ -677,6 +678,11 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 rescheduleFsyncTask(durability);
             }
         }
+    }
+
+    @Override
+    public void updateBlocks(@Nullable final Set<ClusterBlock> globalBlocks, @Nullable final Set<ClusterBlock> indexBlocks) {
+        indexSettings.updateIndexBlocks(globalBlocks, indexBlocks);
     }
 
     private void rescheduleFsyncTask(Translog.Durability durability) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexCreationTaskTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexCreationTaskTests.java
@@ -457,6 +457,6 @@ public class IndexCreationTaskTests extends ESTestCase {
         when(service.getIndexSortSupplier()).thenReturn(supplier);
         when(service.getIndexEventListener()).thenReturn(mock(IndexEventListener.class));
 
-        when(indicesService.createIndex(anyObject(), anyObject())).thenReturn(service);
+        when(indicesService.createIndex(anyObject(), anyObject(), anyObject(), anyObject())).thenReturn(service);
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -84,6 +84,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptyList;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.cluster.shards.ClusterShardLimitIT.ShardCounts.forDataNodeCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -541,7 +542,7 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
                     .numberOfShards(1)
                     .numberOfReplicas(0)
                     .build();
-            final IndexService indexService = indicesService.createIndex(indexMetaData, Collections.emptyList());
+            final IndexService indexService = indicesService.createIndex(indexMetaData, null, null, emptyList());
             if (value != null && value) {
                 assertThat(indexService.getEngineFactory(), instanceOf(FooEnginePlugin.FooEngineFactory.class));
             } else {
@@ -550,7 +551,7 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
         }
     }
 
-    public void testConflictingEngineFactories() throws IOException {
+    public void testConflictingEngineFactories() {
         final String indexName = "foobar";
         final Index index = new Index(indexName, UUIDs.randomBase64UUID());
         final Settings settings = Settings.builder()
@@ -567,7 +568,7 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
 
         final IndicesService indicesService = getIndicesService();
         final IllegalStateException e =
-                expectThrows(IllegalStateException.class, () -> indicesService.createIndex(indexMetaData, Collections.emptyList()));
+                expectThrows(IllegalStateException.class, () -> indicesService.createIndex(indexMetaData, null, null, emptyList()));
         final String pattern =
                 ".*multiple engine factories provided for \\[foobar/.*\\]: \\[.*FooEngineFactory\\],\\[.*BarEngineFactory\\].*";
         assertThat(e, hasToString(new RegexMatcher(pattern)));

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -50,6 +50,7 @@ import org.elasticsearch.cluster.EmptyClusterInfoService;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction.FailedShardEntry;
 import org.elasticsearch.cluster.action.shard.ShardStateAction.StartedShardEntry;
+import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.metadata.AliasValidator;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -101,6 +102,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anySetOf;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -151,7 +153,8 @@ public class ClusterStateChanges {
         // MetaDataCreateIndexService creates indices using its IndicesService instance to check mappings -> fake it here
         try {
             @SuppressWarnings("unchecked") final List<IndexEventListener> listeners = anyList();
-            when(indicesService.createIndex(any(IndexMetaData.class), listeners))
+            when(indicesService
+                .createIndex(any(IndexMetaData.class), anySetOf(ClusterBlock.class), anySetOf(ClusterBlock.class), listeners))
                 .then(invocationOnMock -> {
                     IndexService indexService = mock(IndexService.class);
                     IndexMetaData indexMetaData = (IndexMetaData)invocationOnMock.getArguments()[0];


### PR DESCRIPTION
This pull request adds a new `getIndexBlocks()` method to the `IndexSettings` class. This method returns a `ClusterBlocks` object that can be used to retrieve the current global level and index level blocks set on the `IndexShard` object which the index settings belongs to.

While the purpose of such method has been discussed via another channel few weeks ago, it resurfaced recently after the merge of #35332 in which we added check for global/index blocks in the primary action of transport replication actions. This change caused some tests to fail on CI (see #35597):  the `TransportResyncReplicationAction` failed and the replica was never promoted to primary before the test timed out. The resync failed because the primary action in `TransportResyncReplicationAction` checks blocks using the cluster state from the `ClusterService`, which is not yet updated and in the case of this tests still contains a global "no master" block, whereas it should check blocks against the blocks from the incoming cluster state that is not yet applied. 

This pull request changes the `IndicesClusterStateService` so that blocks are updated and propagated to the `IndexSettings`. After #35332 has been recomited again (it was reverted to allow CI to pass), a follow up PR will change how blocks are checked in TransportReplicationAction so that it uses blocks from `indexShard.indexSettings().getIndexBlocks()`.