### PR TITLE
DOCS: remove bulk api global parameters section

### DIFF
--- a/docs/java-rest/high-level/document/bulk.asciidoc
+++ b/docs/java-rest/high-level/document/bulk.asciidoc
@@ -70,25 +70,6 @@ the index/update/delete operations.
 `ActiveShardCount.ALL`, `ActiveShardCount.ONE` or
 `ActiveShardCount.DEFAULT` (default)
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests-file}[{api}-request-pipeline]
---------------------------------------------------
-<1> Global pipelineId used on all sub requests, unless overridden on a sub request
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests-file}[{api}-request-routing]
---------------------------------------------------
-<1> Global routingId used on all sub requests, unless overridden on a sub request
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests-file}[{api}-request-index-type]
---------------------------------------------------
-<1> A bulk request with global index and type used on all sub requests, unless overridden on a sub request.
-Both parameters are @Nullable and can only be set during +{request}+ creation.
-
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]


### PR DESCRIPTION
The section had to be removed as the implementation was not merged from master yet. 
A new commit will follow with this section back and a backport of implementation.
