### PR TITLE
[TEST] fixing ClusterApplierService#testClusterStateUpdateLogging()

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
@@ -131,7 +131,7 @@ public class ClusterApplierServiceTests extends ESTestCase {
         mockAppender.addExpectation(
             new MockLogAppender.SeenEventExpectation(
                 "test3",
-                clusterApplierService.getClass().getCanonicalName(),
+                ClusterApplierService.class.getCanonicalName(),
                 Level.DEBUG,
                 "*processing [test3]: took [0s] no change in cluster state*"));
 


### PR DESCRIPTION
Simple Test fix for a missed case from a previous merge. 

Relates to: https://github.com/elastic/elasticsearch/pull/35560