### PR TITLE
[ILM] HLRC-ILM  Retry Lifecycle Policy docs

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
@@ -282,7 +282,7 @@ public class IndexLifecycleClient {
      * @return the response
      * @throws IOException in case there is a problem sending the request or parsing back the response
      */
-    public AcknowledgedResponse retryLifecycleStep(RetryLifecyclePolicyRequest request, RequestOptions options) throws IOException {
+    public AcknowledgedResponse retryLifecyclePolicy(RetryLifecyclePolicyRequest request, RequestOptions options) throws IOException {
         return restHighLevelClient.performRequestAndParseEntity(request, IndexLifecycleRequestConverters::retryLifecycle, options,
             AcknowledgedResponse::fromXContent, emptySet());
     }
@@ -295,8 +295,8 @@ public class IndexLifecycleClient {
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
      */
-    public void retryLifecycleStepAsync(RetryLifecyclePolicyRequest request, RequestOptions options,
-        ActionListener<AcknowledgedResponse> listener) {
+    public void retryLifecyclePolicyAsync(RetryLifecyclePolicyRequest request, RequestOptions options,
+                                          ActionListener<AcknowledgedResponse> listener) {
         restHighLevelClient.performRequestAsyncAndParseEntity(request, IndexLifecycleRequestConverters::retryLifecycle, options,
             AcknowledgedResponse::fromXContent, listener, emptySet());
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndexLifecycleIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndexLifecycleIT.java
@@ -272,8 +272,8 @@ public class IndexLifecycleIT extends ESRestHighLevelClientTestCase {
         RetryLifecyclePolicyRequest retryRequest = new RetryLifecyclePolicyRequest("retry");
         ElasticsearchStatusException ex = expectThrows(ElasticsearchStatusException.class,
             () -> execute(
-                retryRequest, highLevelClient().indexLifecycle()::retryLifecycleStep,
-                highLevelClient().indexLifecycle()::retryLifecycleStepAsync
+                retryRequest, highLevelClient().indexLifecycle()::retryLifecyclePolicy,
+                highLevelClient().indexLifecycle()::retryLifecyclePolicyAsync
             )
         );
         assertEquals(400, ex.status().getStatus());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
@@ -30,12 +30,9 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.AcknowledgedResponse;
 import org.elasticsearch.client.indexlifecycle.DeleteAction;
 import org.elasticsearch.client.indexlifecycle.DeleteLifecyclePolicyRequest;
-<<<<<<< HEAD
+import org.elasticsearch.client.indexlifecycle.ExplainLifecycleRequest;
 import org.elasticsearch.client.indexlifecycle.GetLifecyclePolicyRequest;
 import org.elasticsearch.client.indexlifecycle.GetLifecyclePolicyResponse;
-=======
-import org.elasticsearch.client.indexlifecycle.ExplainLifecycleRequest;
->>>>>>> [ILM] HLRC ILM Retry Documentation
 import org.elasticsearch.client.indexlifecycle.LifecycleAction;
 import org.elasticsearch.client.indexlifecycle.LifecyclePolicy;
 import org.elasticsearch.client.indexlifecycle.LifecyclePolicyMetadata;
@@ -44,12 +41,9 @@ import org.elasticsearch.client.indexlifecycle.PutLifecyclePolicyRequest;
 import org.elasticsearch.client.indexlifecycle.RetryLifecyclePolicyRequest;
 import org.elasticsearch.client.indexlifecycle.RolloverAction;
 import org.elasticsearch.client.indexlifecycle.ShrinkAction;
-<<<<<<< HEAD
-import org.elasticsearch.common.collect.ImmutableOpenMap;
-=======
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
->>>>>>> [ILM] HLRC ILM Retry Documentation
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
@@ -263,12 +263,14 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
         }
 
         // tag::ilm-retry-lifecycle-policy-request
-        RetryLifecyclePolicyRequest request = new RetryLifecyclePolicyRequest("my_index");
+        RetryLifecyclePolicyRequest request =
+            new RetryLifecyclePolicyRequest("my_index"); // <1>
         // end::ilm-retry-lifecycle-policy-request
 
 
         // tag::ilm-retry-lifecycle-policy-execute
-        AcknowledgedResponse response = client.indexLifecycle().retryLifecyclePolicy(request, RequestOptions.DEFAULT);
+        AcknowledgedResponse response = client.indexLifecycle()
+            .retryLifecyclePolicy(request, RequestOptions.DEFAULT);
         // end::ilm-retry-lifecycle-policy-execute
 
         // tag::ilm-retry-lifecycle-policy-response

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
@@ -206,7 +206,8 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
         ActionListener<GetLifecyclePolicyResponse> listener =
             new ActionListener<GetLifecyclePolicyResponse>() {
                 @Override
-                public void onResponse(GetLifecyclePolicyResponse response) {
+                public void onResponse(GetLifecyclePolicyResponse response)
+                {
                     ImmutableOpenMap<String, LifecyclePolicyMetadata>
                         policies = response.getPolicies(); // <1>
                 }
@@ -239,11 +240,6 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
             Map<String, LifecycleAction> warmActions = new HashMap<>();
             warmActions.put(ShrinkAction.NAME, new ShrinkAction(1));
             phases.put("warm", new Phase("warm", TimeValue.ZERO, warmActions));
-
-            Map<String, LifecycleAction> deleteActions =
-                Collections.singletonMap(DeleteAction.NAME, new DeleteAction());
-            phases.put("delete", new Phase("delete",
-                new TimeValue(90, TimeUnit.DAYS), deleteActions));
 
             LifecyclePolicy policy = new LifecyclePolicy("my_policy",
                 phases);

--- a/docs/java-rest/high-level/ilm/put_lifecycle_policy.asciidoc
+++ b/docs/java-rest/high-level/ilm/put_lifecycle_policy.asciidoc
@@ -31,7 +31,7 @@ The returned +{response}+ indicates if the put lifecycle policy request was rece
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> Whether or not the put lifecycle policy was acknowledge.
+<1> Whether or not the put lifecycle policy was acknowledged.
 
 include::../execution.asciidoc[]
 

--- a/docs/java-rest/high-level/ilm/retry_lifecycle_policy.asciidoc
+++ b/docs/java-rest/high-level/ilm/retry_lifecycle_policy.asciidoc
@@ -18,7 +18,7 @@ that encountered errors in certain indices.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> retries execution of `my_index`'s policy
+<1> Retries execution of `my_index`'s policy
 
 [id="{upid}-{api}-response"]
 ==== Response

--- a/docs/java-rest/high-level/ilm/retry_lifecycle_policy.asciidoc
+++ b/docs/java-rest/high-level/ilm/retry_lifecycle_policy.asciidoc
@@ -1,0 +1,36 @@
+--
+:api: ilm-retry-lifecycle-policy
+:request: RetryLifecyclePolicyRequest
+:response: AcknowledgedResponse
+--
+
+[id="{upid}-{api}"]
+=== Retry Lifecycle Policy API
+
+
+[id="{upid}-{api}-request"]
+==== Request
+
+The Retry Lifecycle Policy API allows you to invoke execution of policies
+that encountered errors in certain indices.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-request]
+--------------------------------------------------
+<1>
+
+[id="{upid}-{api}-response"]
+==== Response
+
+The returned +{response}+ indicates if the retry lifecycle policy request was received.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-response]
+--------------------------------------------------
+<1>
+
+include::../execution.asciidoc[]
+
+

--- a/docs/java-rest/high-level/ilm/retry_lifecycle_policy.asciidoc
+++ b/docs/java-rest/high-level/ilm/retry_lifecycle_policy.asciidoc
@@ -18,7 +18,7 @@ that encountered errors in certain indices.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1>
+<1> retries execution of `my_index`'s policy
 
 [id="{upid}-{api}-response"]
 ==== Response
@@ -29,7 +29,7 @@ The returned +{response}+ indicates if the retry lifecycle policy request was re
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1>
+<1> Whether or not the lifecycle policy retry was acknowledged.
 
 include::../execution.asciidoc[]
 

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -452,7 +452,8 @@ Management APIs:
 
 * <<{upid}-ilm-put-lifecycle-policy>>
 * <<{upid}-ilm-get-lifecycle-policy>>
+* <<{upid}-ilm-retry-lifecycle-policy>>
 
 include::ilm/put_lifecycle_policy.asciidoc[]
 include::ilm/get_lifecycle_policy.asciidoc[]
-
+include::ilm/retry_lifecycle_policy.asciidoc[]


### PR DESCRIPTION
adds HLRC documentation for the ILM retry lifecycle policy action

this PR also renames `retryLifecycleStep` to `retryLifecyclePolicy` in the index-lifecycle-client