### PR TITLE
Remove NPE from IndexFollowingIT

### DIFF
--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
@@ -807,7 +807,7 @@ public class IndexFollowingIT extends CcrIntegTestCase {
         AtomicBoolean closed = new AtomicBoolean(false);
         clusterService.addListener(event -> {
             IndexMetaData indexMetaData = event.state().metaData().index(indexName);
-            if (indexMetaData.getState() == IndexMetaData.State.CLOSE) {
+            if (indexMetaData != null  && indexMetaData.getState() == IndexMetaData.State.CLOSE) {
                 closed.set(true);
             }
         });


### PR DESCRIPTION
Currently there is a common NPE in the IndexFollowingIT that does not
indicate the test failing. This is when a cluster state listener is
called and certain index metadata is not yet available.

This commit checks that the metadata is not null before performing the
logic that depends on the metadata.