### PR TITLE
[backport] Docs: Fix build for java-api 

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/BulkProcessorIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/BulkProcessorIT.java
@@ -303,7 +303,7 @@ public class BulkProcessorIT extends ESRestHighLevelClientTestCase {
             processor.add(new IndexRequest("blogs", "post_type", "1") // <2>
                 .source(XContentType.JSON, "title", "some title"));
         }
-        // end::bulk-request-mix-pipeline
+        // end::bulk-processor-mix-parameters
         latch.await();
 
         Iterable<SearchHit> hits = searchAll(new SearchRequest("tweets").routing("routing"));

--- a/docs/java-api/docs/bulk.asciidoc
+++ b/docs/java-api/docs/bulk.asciidoc
@@ -176,7 +176,7 @@ Global parameters can be specified on the BulkRequest as well as BulkProcessor, 
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/BulkProcessorIT.java[bulk-processor-mix-parameters]
+include-tagged::{hlrc-tests}/BulkProcessorIT.java[bulk-processor-mix-parameters]
 --------------------------------------------------
 <1> global parameters from the BulkRequest will be applied on a sub request
 <2> local pipeline parameter on a sub request will override global parameters from BulkRequest
@@ -184,7 +184,7 @@ include-tagged::{doc-tests}/BulkProcessorIT.java[bulk-processor-mix-parameters]
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/BulkRequestWithGlobalParametersIT.java[bulk-request-mix-pipeline]
+include-tagged::{hlrc-tests}/BulkRequestWithGlobalParametersIT.java[bulk-request-mix-pipeline]
 --------------------------------------------------
 <1> local pipeline parameter on a sub request will override global pipeline from the BulkRequest
 <2> global parameter from the BulkRequest will be applied on a sub request

--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -151,6 +151,7 @@ and add it as a dependency. As an example, we will use the `slf4j-simple` logger
 --------------------------------------------------
 
 :client-tests: {docdir}/../../server/src/test/java/org/elasticsearch/client/documentation
+:hlrc-tests: {docdir}/../../client/rest-high-level/src/test/java/org/elasticsearch/client
 
 :client-reindex-tests: {docdir}/../../modules/reindex/src/test/java/org/elasticsearch/client/documentation
 


### PR DESCRIPTION
The java-api docs had some broken references. Mostly because it is
difficult to build them so they are difficult to check.

Relates to #34528

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
