### PR TITLE
Fix PrimaryAllocationIT#testForceStaleReplicaToBePromotedToPrimary

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -59,7 +59,6 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;

--- a/server/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -25,9 +25,11 @@ import org.elasticsearch.action.admin.indices.shards.IndicesShardStoresResponse;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.allocation.command.AllocateEmptyPrimaryAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.AllocateStalePrimaryAllocationCommand;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenIntMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
@@ -54,8 +56,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
@@ -212,14 +216,27 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
                 rerouteBuilder.add(new AllocateEmptyPrimaryAllocationCommand(idxName, shardId, storeStatus.getNode().getId(), true));
             }
         }
+
+        final AtomicReference<Set<String>> allocationIdsRef = new AtomicReference<>();
+        final CountDownLatch clusterStateChangeLatch = new CountDownLatch(1);
+        // grab in-sync set of the 1st cluster state change after reroute execution
+        final ClusterStateListener clusterStateListener = event -> {
+            allocationIdsRef.set(event.state().metaData().index(idxName).inSyncAllocationIds(0));
+            clusterStateChangeLatch.countDown();
+        };
+        final ClusterService clusterService = internalCluster().getInstance(ClusterService.class, master);
+        clusterService.addListener(clusterStateListener);
+
         rerouteBuilder.get();
 
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        clusterStateChangeLatch.await();
+        clusterService.removeListener(clusterStateListener);
 
         Set<String> expectedAllocationIds = useStaleReplica
             ? Collections.singleton(RecoverySource.ExistingStoreRecoverySource.FORCED_ALLOCATION_ID)
             : Collections.emptySet();
-        assertEquals(expectedAllocationIds, state.metaData().index(idxName).inSyncAllocationIds(0));
+
+        assertEquals(expectedAllocationIds, allocationIdsRef.get());
 
         logger.info("--> check that the stale primary shard gets allocated and that documents are available");
         ensureYellow(idxName);
@@ -235,7 +252,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         assertHitCount(client().prepareSearch(idxName).setSize(0).setQuery(matchAllQuery()).get(), useStaleReplica ? 1L : 0L);
 
         // allocation id of old primary was cleaned from the in-sync set
-        state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = client().admin().cluster().prepareState().get().getState();
 
         assertEquals(Collections.singleton(state.routingTable().index(idxName).shard(0).primary.allocationId().getId()),
             state.metaData().index(idxName).inSyncAllocationIds(0));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -226,13 +226,14 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
             if (expectedAllocationIds.equals(allocationIds)) {
                 clusterStateChangeLatch.countDown();
             }
+            logger.info("expected allocation ids: {} actual allocation ids: {}", expectedAllocationIds, allocationIds);
         };
         final ClusterService clusterService = internalCluster().getInstance(ClusterService.class, master);
         clusterService.addListener(clusterStateListener);
 
         rerouteBuilder.get();
 
-        assertThat(clusterStateChangeLatch.await(30, TimeUnit.SECONDS), equalTo(true));
+        assertTrue(clusterStateChangeLatch.await(30, TimeUnit.SECONDS));
         clusterService.removeListener(clusterStateListener);
 
         logger.info("--> check that the stale primary shard gets allocated and that documents are available");


### PR DESCRIPTION
Failure described in #35497 could be reproduced under load or just adding some delay in between reroute command execution and getting cluster state (allocation ids) - in that case recovery already passed and allocation ids contain actual node id rather expected allocation id right after command execution. 

The fix is to grab in-sync set of the 1st cluster state change after reroute execution from `ClusterService` of the node.

Closes #35497