### PR TITLE
NETWORKING: Fix IpFiltering Test

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringIntegrationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringIntegrationTests.java
@@ -19,7 +19,6 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
@@ -69,7 +68,7 @@ public class IpFilteringIntegrationTests extends SecurityIntegTestCase {
 
     public void testThatIpFilteringIsAppliedForProfile() throws Exception {
         try (Socket socket = new Socket()){
-            trySocketConnection(socket, new InetSocketAddress(InetAddress.getLoopbackAddress(), getProfilePort("client")));
+            trySocketConnection(socket, getProfileAddress("client"));
             assertThat(socket.isClosed(), is(true));
         }
     }
@@ -86,9 +85,9 @@ public class IpFilteringIntegrationTests extends SecurityIntegTestCase {
         }
     }
 
-    private static int getProfilePort(String profile) {
+    private static InetSocketAddress getProfileAddress(String profile) {
         TransportAddress transportAddress =
                 randomFrom(internalCluster().getInstance(Transport.class).profileBoundAddresses().get(profile).boundAddresses());
-        return transportAddress.address().getPort();
+        return transportAddress.address();
     }
 }


### PR DESCRIPTION
* The port assigned to all loopback interfaces doesn't necessarily have to be the same  for ipv4 and ipv6
=> use actual address from profile instead of just port + loopback in test
* Closes #35584
