### PR TITLE
Revert "Use more precise does S3 bucket exist method"

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
@@ -19,11 +19,9 @@
 
 package org.elasticsearch.repositories.s3;
 
-import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest.KeyVersion;
-import com.amazonaws.services.s3.model.HeadBucketRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.StorageClass;
@@ -68,23 +66,14 @@ class S3BlobStore extends AbstractComponent implements BlobStore {
 
         // Note: the method client.doesBucketExist() may return 'true' is the bucket exists
         // but we don't have access to it (ie, 403 Forbidden response code)
+        // Also, if invalid security credentials are used to execute this method, the
+        // client is not able to distinguish between bucket permission errors and
+        // invalid credential errors, and this method could return an incorrect result.
         try (AmazonS3Reference clientReference = clientReference()) {
             SocketAccess.doPrivilegedVoid(() -> {
-                try {
-                    clientReference.client().headBucket(new HeadBucketRequest(bucket));
-                } catch (final AmazonServiceException e) {
-                    if (e.getStatusCode() == 301) {
-                        throw new IllegalArgumentException("the bucket [" + bucket + "] is in a different region than you configured", e);
-                    } else if (e.getStatusCode() == 403) {
-                        throw new IllegalArgumentException("you do not have permissions to access the bucket [" + bucket + "]", e);
-                    } else if (e.getStatusCode() == 404) {
-                        throw new IllegalArgumentException(
-                                "the bucket [" + bucket + "] does not exist;"
-                                        + " please create it before creating an S3 snapshot repository backed by it",
-                                e);
-                    } else {
-                        throw new IllegalArgumentException("error checking the existence of bucket [" + bucket + "]", e);
-                    }
+                if (clientReference.client().doesBucketExist(bucket) == false) {
+                    throw new IllegalArgumentException("The bucket [" + bucket + "] does not exist. Please create it before "
+                            + " creating an s3 snapshot repository backed by it.");
                 }
             });
         }
@@ -169,9 +158,7 @@ class S3BlobStore extends AbstractComponent implements BlobStore {
         return cannedACL;
     }
 
-    public StorageClass getStorageClass() {
-        return storageClass;
-    }
+    public StorageClass getStorageClass() { return storageClass; }
 
     public static StorageClass initStorageClass(String storageClass) {
         if ((storageClass == null) || storageClass.equals("")) {

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.repositories.s3;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AbstractAmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
@@ -28,8 +27,6 @@ import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsResult;
 import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.HeadBucketRequest;
-import com.amazonaws.services.s3.model.HeadBucketResult;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -76,15 +73,8 @@ class MockAmazonS3 extends AbstractAmazonS3 {
     }
 
     @Override
-    public HeadBucketResult headBucket(final HeadBucketRequest headBucketRequest) throws SdkClientException, AmazonServiceException {
-        if (this.bucket.equalsIgnoreCase(headBucketRequest.getBucketName())) {
-            return new HeadBucketResult();
-        } else {
-            final AmazonServiceException e =
-                    new AmazonServiceException("bucket [" + headBucketRequest.getBucketName() + "] does not exist");
-            e.setStatusCode(404);
-            throw e;
-        }
+    public boolean doesBucketExist(final String bucket) {
+        return this.bucket.equalsIgnoreCase(bucket);
     }
 
     @Override

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/RepositoryCredentialsTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/RepositoryCredentialsTests.java
@@ -19,13 +19,9 @@
 
 package org.elasticsearch.repositories.s3;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.AmazonServiceException;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.HeadBucketRequest;
-import com.amazonaws.services.s3.model.HeadBucketResult;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.settings.MockSecureSettings;
@@ -61,10 +57,9 @@ public class RepositoryCredentialsTests extends ESTestCase {
             }
 
             @Override
-            public HeadBucketResult headBucket(HeadBucketRequest headBucketRequest) throws AmazonClientException, AmazonServiceException {
-                return new HeadBucketResult();
+            public boolean doesBucketExist(String bucketName) {
+                return true;
             }
-
         }
 
         static final class ProxyS3Service extends S3Service {

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
@@ -19,11 +19,7 @@
 
 package org.elasticsearch.repositories.s3;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AbstractAmazonS3;
-import com.amazonaws.services.s3.model.HeadBucketRequest;
-import com.amazonaws.services.s3.model.HeadBucketResult;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -46,8 +42,8 @@ public class S3RepositoryTests extends ESTestCase {
     private static class DummyS3Client extends AbstractAmazonS3 {
 
         @Override
-        public HeadBucketResult headBucket(final HeadBucketRequest request) throws SdkClientException, AmazonServiceException {
-            return new HeadBucketResult();
+        public boolean doesBucketExist(String bucketName) {
+            return true;
         }
 
         @Override


### PR DESCRIPTION
This reverts #34123 which breaks compatibility with our documented IAM policies (see #35703).
For 6.6 and beyond, I've opened #35731 that addresses this in a different way.