### PR TITLE
SNAPSHOT: Fix Leaking Snapshot Task in IT (#35657)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SnapshotIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SnapshotIT.java
@@ -144,6 +144,14 @@ public class SnapshotIT extends ESRestHighLevelClientTestCase {
 
         CreateSnapshotResponse response = createTestSnapshot(request);
         assertEquals(waitForCompletion ? RestStatus.OK : RestStatus.ACCEPTED, response.status());
+        if (waitForCompletion == false) {
+            // If we don't wait for the snapshot to complete we have to cancel it to not leak the snapshot task
+            AcknowledgedResponse deleteResponse = execute(
+                new DeleteSnapshotRequest(repository, snapshot),
+                highLevelClient().snapshot()::delete, highLevelClient().snapshot()::deleteAsync
+            );
+            assertTrue(deleteResponse.isAcknowledged());
+        }
     }
 
     public void testGetSnapshots() throws IOException {


### PR DESCRIPTION
* SNAPSHOT: Fix Leaking Snapshot Task in IT

* If the test randomization causes the request to not wait for snapshot completion
then the deleting of the still in progress snapshot could fail in the after hook
   * Fixed by deleting the snapshot in the test
* Closes #35642
