### PR TITLE
[DOCS] Update sysctl instructions for Docker on Mac

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -93,11 +93,10 @@ The `vm.max_map_count` setting must be set within the xhyve virtual machine:
 
 ["source","sh"]
 --------------------------------------------
-$ screen ~/Library/Containers/com.docker.docker/Data/com.docker.driver.amd64-linux/tty
+$ screen ~/Library/Containers/com.docker.docker/Data/vms/0/tty
 --------------------------------------------
 
-Log in with 'root' and no password.
-Then configure the `sysctl` setting as you would for Linux:
+Just press enter and configure the `sysctl` setting as you would for Linux:
 
 ["source","sh"]
 --------------------------------------------


### PR DESCRIPTION
Recent Docker for Mac releases[1] have a different path to the tty for
accessing the console of the xhyve vm, required for altering the
`vm.max_map_count` sysctl.

Update instructions on how to enter the xhyve vm for altering the
`vm.max_map_count` sysctl setting on Docker for Mac.

[1]
https://forums.docker.com/t/is-it-possible-to-ssh-to-the-xhyve-machine/17426/13
