### PR TITLE
Fix analyzed prefix query in query_string

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
@@ -484,10 +484,13 @@ public class QueryStringQueryParser extends XQueryParser {
         List<Query> queries = new ArrayList<>();
         for (Map.Entry<String, Float> entry : fields.entrySet()) {
             Query q = getPrefixQuerySingle(entry.getKey(), termStr);
-            assert q != null;
-            queries.add(applyBoost(q, entry.getValue()));
+            if (q != null) {
+                queries.add(applyBoost(q, entry.getValue()));
+            }
         }
-        if (queries.size() == 1) {
+        if (queries.isEmpty()) {
+            return null;
+        } else if (queries.size() == 1) {
             return queries.get(0);
         } else {
             float tiebreaker = groupTieBreaker == null ? type.tieBreaker() : groupTieBreaker;
@@ -561,7 +564,7 @@ public class QueryStringQueryParser extends XQueryParser {
         }
 
         if (tlist.size() == 0) {
-            return super.getPrefixQuery(field, termStr);
+            return null;
         }
 
         if (tlist.size() == 1 && tlist.get(0).size() == 1) {

--- a/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -1422,6 +1422,16 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         assertEquals(expected, query);
     }
 
+    public void testAnalyzedPrefix() throws Exception {
+        Query query = new QueryStringQueryBuilder("quick* @&*")
+            .field(STRING_FIELD_NAME)
+            .analyzer("standard")
+            .analyzeWildcard(true)
+            .toQuery(createShardContext());
+        Query expected = new PrefixQuery(new Term(STRING_FIELD_NAME, "quick"));
+        assertEquals(expected, query);
+    }
+
     private static IndexMetaData newIndexMeta(String name, Settings oldIndexSettings, Settings indexSettings) {
         Settings build = Settings.builder().put(oldIndexSettings)
             .put(indexSettings)


### PR DESCRIPTION
This change fixes analyzed prefix queries in `query_string` to be ignored
if all terms are removed during the analysis.

Closes #31702