### PR TITLE
HLRC: ML Delete event from Calendar

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
@@ -28,6 +28,7 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.client.RequestConverters.EndpointBuilder;
 import org.elasticsearch.client.ml.CloseJobRequest;
+import org.elasticsearch.client.ml.DeleteCalendarEventRequest;
 import org.elasticsearch.client.ml.DeleteCalendarJobRequest;
 import org.elasticsearch.client.ml.DeleteCalendarRequest;
 import org.elasticsearch.client.ml.DeleteDatafeedRequest;
@@ -552,6 +553,18 @@ final class MLRequestConverters {
             REQUEST_BODY_CONTENT_TYPE,
             PostCalendarEventRequest.EXCLUDE_CALENDAR_ID_PARAMS));
         return request;
+    }
+
+    static Request deleteCalendarEvent(DeleteCalendarEventRequest deleteCalendarEventRequest) {
+        String endpoint = new EndpointBuilder()
+            .addPathPartAsIs("_xpack")
+            .addPathPartAsIs("ml")
+            .addPathPartAsIs("calendars")
+            .addPathPart(deleteCalendarEventRequest.getCalendarId())
+            .addPathPartAsIs("events")
+            .addPathPart(deleteCalendarEventRequest.getEventId())
+            .build();
+        return new Request(HttpDelete.METHOD_NAME, endpoint);
     }
 
     static Request putFilter(PutFilterRequest putFilterRequest) throws IOException {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MachineLearningClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MachineLearningClient.java
@@ -22,6 +22,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.ml.CloseJobRequest;
 import org.elasticsearch.client.ml.CloseJobResponse;
+import org.elasticsearch.client.ml.DeleteCalendarEventRequest;
 import org.elasticsearch.client.ml.DeleteCalendarJobRequest;
 import org.elasticsearch.client.ml.DeleteCalendarRequest;
 import org.elasticsearch.client.ml.DeleteDatafeedRequest;
@@ -1423,6 +1424,48 @@ public final class MachineLearningClient {
             MLRequestConverters::postCalendarEvents,
             options,
             PostCalendarEventResponse::fromXContent,
+            listener,
+            Collections.emptySet());
+    }
+
+    /**
+     * Removes a Scheduled Event from a calendar
+     * <p>
+     * For additional info
+     * see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar-event.html">
+     * ML Delete calendar event documentation</a>
+     *
+     * @param request The request
+     * @param options Additional request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @return The {@link PutCalendarResponse} containing the updated calendar
+     * @throws IOException when there is a serialization issue sending the request or receiving the response
+     */
+    public AcknowledgedResponse deleteCalendarEvent(DeleteCalendarEventRequest request, RequestOptions options) throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(request,
+            MLRequestConverters::deleteCalendarEvent,
+            options,
+            AcknowledgedResponse::fromXContent,
+            Collections.emptySet());
+    }
+
+    /**
+     * Removes a Scheduled Event from a calendar, notifies listener when completed
+     * <p>
+     * For additional info
+     * see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar-event.html">
+     * ML Delete calendar event documentation</a>
+     *
+     * @param request  The request
+     * @param options  Additional request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @param listener Listener to be notified upon request completion
+     */
+    public void deleteCalendarEventAsync(DeleteCalendarEventRequest request,
+                                         RequestOptions options,
+                                         ActionListener<AcknowledgedResponse> listener) {
+        restHighLevelClient.performRequestAsyncAndParseEntity(request,
+            MLRequestConverters::deleteCalendarEvent,
+            options,
+            AcknowledgedResponse::fromXContent,
             listener,
             Collections.emptySet());
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/DeleteCalendarEventRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/DeleteCalendarEventRequest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.ml;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+
+import java.util.Objects;
+
+/**
+ * Request class for removing an event from an existing calendar
+ */
+public class DeleteCalendarEventRequest extends ActionRequest {
+
+    private final String eventId;
+    private final String calendarId;
+
+    /**
+     * Create a new request referencing an existing Calendar and which event to remove
+     * from it.
+     *
+     * @param calendarId The non-null ID of the calendar
+     * @param eventId Scheduled Event to remove from the calendar, Cannot be null.
+     */
+    public DeleteCalendarEventRequest(String calendarId, String eventId) {
+        this.calendarId = Objects.requireNonNull(calendarId, "[calendar_id] must not be null.");
+        this.eventId = Objects.requireNonNull(eventId, "[event_id] must not be null.");
+    }
+
+    public String getEventId() {
+        return eventId;
+    }
+
+    public String getCalendarId() {
+        return calendarId;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventId, calendarId);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        DeleteCalendarEventRequest that = (DeleteCalendarEventRequest) other;
+        return Objects.equals(eventId, that.eventId) &&
+            Objects.equals(calendarId, that.calendarId);
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MLRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MLRequestConvertersTests.java
@@ -24,6 +24,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.elasticsearch.client.ml.CloseJobRequest;
+import org.elasticsearch.client.ml.DeleteCalendarEventRequest;
 import org.elasticsearch.client.ml.DeleteCalendarJobRequest;
 import org.elasticsearch.client.ml.DeleteCalendarRequest;
 import org.elasticsearch.client.ml.DeleteDatafeedRequest;
@@ -605,6 +606,15 @@ public class MLRequestConvertersTests extends ESTestCase {
         XContentBuilder builder = JsonXContent.contentBuilder();
         builder = postCalendarEventRequest.toXContent(builder, PostCalendarEventRequest.EXCLUDE_CALENDAR_ID_PARAMS);
         assertEquals(Strings.toString(builder), requestEntityToString(request));
+    }
+
+    public void testDeleteCalendarEvent() {
+        String calendarId = randomAlphaOfLength(10);
+        String eventId = randomAlphaOfLength(5);
+        DeleteCalendarEventRequest deleteCalendarEventRequest = new DeleteCalendarEventRequest(calendarId, eventId);
+        Request request = MLRequestConverters.deleteCalendarEvent(deleteCalendarEventRequest);
+        assertEquals(HttpDelete.METHOD_NAME, request.getMethod());
+        assertEquals("/_xpack/ml/calendars/" + calendarId + "/events/" + eventId, request.getEndpoint());
     }
 
     public void testPutFilter() throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
@@ -999,8 +999,10 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         machineLearningClient.postCalendarEvent(new PostCalendarEventRequest(calendar.getId(), events), RequestOptions.DEFAULT);
         GetCalendarEventsResponse getCalendarEventsResponse =
             machineLearningClient.getCalendarEvents(new GetCalendarEventsRequest(calendar.getId()), RequestOptions.DEFAULT);
+
         assertThat(getCalendarEventsResponse.events().size(), equalTo(3));
         String deletedEvent = getCalendarEventsResponse.events().get(0).getEventId();
+
         DeleteCalendarEventRequest deleteCalendarEventRequest = new DeleteCalendarEventRequest(calendar.getId(), deletedEvent);
 
         AcknowledgedResponse response = execute(deleteCalendarEventRequest,
@@ -1011,9 +1013,13 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
         getCalendarEventsResponse =
             machineLearningClient.getCalendarEvents(new GetCalendarEventsRequest(calendar.getId()), RequestOptions.DEFAULT);
-        assertThat(getCalendarEventsResponse.events().size(), equalTo(2));
-        assertThat(getCalendarEventsResponse.events().stream().map(ScheduledEvent::getEventId).collect(Collectors.toList()),
-            not(hasItem(deletedEvent)));
+        List<String> remainingIds = getCalendarEventsResponse.events()
+            .stream()
+            .map(ScheduledEvent::getEventId)
+            .collect(Collectors.toList());
+
+        assertThat(remainingIds.size(), equalTo(2));
+        assertThat(remainingIds, not(hasItem(deletedEvent)));
     }
 
     public void testPutFilter() throws Exception {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
@@ -2522,17 +2522,19 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             "A calendar for public holidays");
         PutCalendarRequest putRequest = new PutCalendarRequest(calendar);
         client.machineLearning().putCalendar(putRequest, RequestOptions.DEFAULT);
+        List<ScheduledEvent> events = Arrays.asList(ScheduledEventTests.testInstance(calendar.getId(), null),
+            ScheduledEventTests.testInstance(calendar.getId(), null));
+        client.machineLearning().postCalendarEvent(new PostCalendarEventRequest("holidays", events), RequestOptions.DEFAULT);
+        GetCalendarEventsResponse getCalendarEventsResponse =
+            client.machineLearning().getCalendarEvents(new GetCalendarEventsRequest("holidays"), RequestOptions.DEFAULT);
         {
-            List<ScheduledEvent> events = Collections.singletonList(ScheduledEventTests.testInstance(calendar.getId(), null));
-            PostCalendarEventResponse postCalendarEventResponse = 
-                client.machineLearning().postCalendarEvent(new PostCalendarEventRequest("holidays", events), RequestOptions.DEFAULT);
-            
+
             // tag::delete-calendar-event-request
             DeleteCalendarEventRequest request = new DeleteCalendarEventRequest("holidays", // <1>
                 "EventId"); // <2>
             // end::delete-calendar-event-request
 
-            request = new DeleteCalendarEventRequest("holidays", events.get(0).getEventId());
+            request = new DeleteCalendarEventRequest("holidays", getCalendarEventsResponse.events().get(0).getEventId());
 
             // tag::delete-calendar-event-execute
             AcknowledgedResponse response = client.machineLearning().deleteCalendarEvent(request, RequestOptions.DEFAULT);
@@ -2545,10 +2547,8 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             assertThat(acknowledged, is(true));
         }
         {
-            List<ScheduledEvent> events = Collections.singletonList(ScheduledEventTests.testInstance(calendar.getId(), null));
-            PostCalendarEventResponse postCalendarEventResponse =
-                client.machineLearning().postCalendarEvent(new PostCalendarEventRequest("holidays", events), RequestOptions.DEFAULT);
-            DeleteCalendarEventRequest request = new DeleteCalendarEventRequest("holidays", events.get(0).getEventId());
+            DeleteCalendarEventRequest request = new DeleteCalendarEventRequest("holidays",
+                getCalendarEventsResponse.events().get(1).getEventId());
 
             // tag::delete-calendar-event-execute-listener
             ActionListener<AcknowledgedResponse> listener =

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/DeleteCalendarEventRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/DeleteCalendarEventRequestTests.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.ml;
+
+import org.elasticsearch.test.ESTestCase;
+
+public class DeleteCalendarEventRequestTests extends ESTestCase {
+
+    public void testWithNullId() {
+        NullPointerException ex = expectThrows(NullPointerException.class,
+            () -> new DeleteCalendarEventRequest(null, "event1"));
+        assertEquals("[calendar_id] must not be null.", ex.getMessage());
+    }
+
+    public void testWithNullEvent() {
+        NullPointerException ex = expectThrows(NullPointerException.class,
+            () ->new DeleteCalendarEventRequest("calendarId", null));
+        assertEquals("[event_id] must not be null.", ex.getMessage());
+    }
+}

--- a/docs/java-rest/high-level/ml/delete-calendar-event.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-calendar-event.asciidoc
@@ -1,36 +1,36 @@
 --
-:api: delete-calendar-job
-:request: DeleteCalendarJobRequest
-:response: PutCalendarResponse
+:api: delete-calendar-event
+:request: DeleteCalendarEventRequest
+:response: AcknowledgedResponse
 --
 [id="{upid}-{api}"]
-=== Delete Calendar Job API
-Removes {ml} jobs from an existing {ml} calendar.
+=== Delete Calendar Event API
+Removes a scheduled event from an existing {ml} calendar.
 The API accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Delete Calendar Job Request
+==== Delete Calendar Event Request
 
 A +{request}+ is constructed referencing a non-null
-calendar ID, and JobIDs which to remove from the calendar
+calendar ID, and eventId which to remove from the calendar
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> The ID of the calendar from which to remove the jobs
-<2> The JobIds to remove from the calendar
+<2> The eventId to remove from the calendar
 
 [id="{upid}-{api}-response"]
-====  Delete Calendar Job Response
+====  Delete Calendar Event Response
 
-The returned +{response}+ contains the updated Calendar:
+The returned +{response}+ acknowledges the success of the request:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> The updated Calendar with the jobs removed
+<1> Acknowledgement of the request and its success
 
 include::../execution.asciidoc[]

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -267,6 +267,7 @@ The Java High Level REST Client supports the following Machine Learning APIs:
 * <<{upid}-get-calendars>>
 * <<{upid}-put-calendar>>
 * <<{upid}-post-calendar-event>>
+* <<{upid}-delete-calendar-event>>
 * <<{upid}-put-calendar-job>>
 * <<{upid}-delete-calendar-job>>
 * <<{upid}-delete-calendar>>
@@ -305,6 +306,7 @@ include::ml/get-categories.asciidoc[]
 include::ml/get-calendars.asciidoc[]
 include::ml/put-calendar.asciidoc[]
 include::ml/post-calendar-event.asciidoc[]
+include::ml/delete-calendar-event.asciidoc[]
 include::ml/put-calendar-job.asciidoc[]
 include::ml/delete-calendar-job.asciidoc[]
 include::ml/delete-calendar.asciidoc[]


### PR DESCRIPTION
This adds the ML Api for deleting an event from a Calendar to the HLRC. 

Relates to #29827