### PR TITLE
Remove deprecated QueryStringQueryBuilder#splitOnWhiteSpace

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -586,22 +586,6 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         return this.escape;
     }
 
-    /**
-     * This setting is ignored, this query parser splits on operator only.
-     */
-    @Deprecated
-    public QueryStringQueryBuilder splitOnWhitespace(boolean value) {
-        return this;
-    }
-
-    /**
-     * This setting is ignored, this query parser splits on operator only.
-     */
-    @Deprecated
-    public boolean splitOnWhitespace() {
-        return false;
-    }
-
     public QueryStringQueryBuilder autoGenerateSynonymsPhraseQuery(boolean value) {
         this.autoGenerateSynonymsPhraseQuery = value;
         return this;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/query/QueryStringQuery.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/query/QueryStringQuery.java
@@ -51,7 +51,6 @@ public class QueryStringQuery extends LeafQuery {
         appliers.put("lenient", (qb, s) -> qb.lenient(Booleans.parseBoolean(s)));
         appliers.put("locale", (qb, s) -> {});
         appliers.put("time_zone", (qb, s) -> qb.timeZone(s));
-        appliers.put("split_on_whitespace", (qb, s) -> qb.splitOnWhitespace(Booleans.parseBoolean(s)));
         appliers.put("all_fields", (qb, s) -> qb.useAllFields(Booleans.parseBoolean(s)));
         appliers.put("type", (qb, s) -> qb.type(MultiMatchQueryBuilder.Type.parse(s, LoggingDeprecationHandler.INSTANCE)));
         appliers.put("auto_generate_synonyms_phrase_query", (qb, s) -> qb.autoGenerateSynonymsPhraseQuery(Booleans.parseBoolean(s)));


### PR DESCRIPTION
This parameter has been deprecated and was ignored since 6.0, so its Java API
methods can be removed.