### PR TITLE
MINOR: Simplify SnapshotShardService

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -110,10 +110,10 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
 
     private final Condition shutdownCondition = shutdownLock.newCondition();
 
-    private volatile Map<Snapshot, SnapshotShards> shardSnapshots = emptyMap();
+    private volatile Map<Snapshot, Map<ShardId, IndexShardSnapshotStatus>> shardSnapshots = emptyMap();
 
     private final SnapshotStateExecutor snapshotStateExecutor = new SnapshotStateExecutor();
-    private UpdateSnapshotStatusAction updateSnapshotStatusHandler;
+    private final UpdateSnapshotStatusAction updateSnapshotStatusHandler;
 
     @Inject
     public SnapshotShardsService(Settings settings, ClusterService clusterService, SnapshotsService snapshotsService, ThreadPool threadPool,
@@ -131,8 +131,8 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
         }
 
         // The constructor of UpdateSnapshotStatusAction will register itself to the TransportService.
-        this.updateSnapshotStatusHandler = new UpdateSnapshotStatusAction(UPDATE_SNAPSHOT_STATUS_ACTION_NAME,
-            transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver);
+        this.updateSnapshotStatusHandler =
+            new UpdateSnapshotStatusAction(transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver);
     }
 
     @Override
@@ -184,9 +184,9 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
     @Override
     public void beforeIndexShardClosed(ShardId shardId, @Nullable IndexShard indexShard, Settings indexSettings) {
         // abort any snapshots occurring on the soon-to-be closed shard
-        Map<Snapshot, SnapshotShards> snapshotShardsMap = shardSnapshots;
-        for (Map.Entry<Snapshot, SnapshotShards> snapshotShards : snapshotShardsMap.entrySet()) {
-            Map<ShardId, IndexShardSnapshotStatus> shards = snapshotShards.getValue().shards;
+        Map<Snapshot, Map<ShardId, IndexShardSnapshotStatus>> snapshotShardsMap = shardSnapshots;
+        for (Map.Entry<Snapshot, Map<ShardId, IndexShardSnapshotStatus>> snapshotShards : snapshotShardsMap.entrySet()) {
+            Map<ShardId, IndexShardSnapshotStatus> shards = snapshotShards.getValue();
             if (shards.containsKey(shardId)) {
                 logger.debug("[{}] shard closing, abort snapshotting for snapshot [{}]", shardId, snapshotShards.getKey().getSnapshotId());
                 shards.get(shardId).abortIfNotCompleted("shard is closing, aborting");
@@ -204,12 +204,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
      * @return map of shard id to snapshot status
      */
     public Map<ShardId, IndexShardSnapshotStatus> currentSnapshotShards(Snapshot snapshot) {
-        SnapshotShards snapshotShards = shardSnapshots.get(snapshot);
-        if (snapshotShards == null) {
-            return null;
-        } else {
-            return snapshotShards.shards;
-        }
+        return shardSnapshots.get(snapshot);
     }
 
     /**
@@ -219,9 +214,9 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
      */
     private void processIndexShardSnapshots(ClusterChangedEvent event) {
         SnapshotsInProgress snapshotsInProgress = event.state().custom(SnapshotsInProgress.TYPE);
-        Map<Snapshot, SnapshotShards> survivors = new HashMap<>();
+        Map<Snapshot, Map<ShardId, IndexShardSnapshotStatus>> survivors = new HashMap<>();
         // First, remove snapshots that are no longer there
-        for (Map.Entry<Snapshot, SnapshotShards> entry : shardSnapshots.entrySet()) {
+        for (Map.Entry<Snapshot, Map<ShardId, IndexShardSnapshotStatus>> entry : shardSnapshots.entrySet()) {
             final Snapshot snapshot = entry.getKey();
             if (snapshotsInProgress != null && snapshotsInProgress.snapshot(snapshot) != null) {
                 survivors.put(entry.getKey(), entry.getValue());
@@ -230,7 +225,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                 // this could happen if for some reason the cluster state update for aborting
                 // running shards is missed, then the snapshot is removed is a subsequent cluster
                 // state update, which is being processed here
-                for (IndexShardSnapshotStatus snapshotStatus : entry.getValue().shards.values()) {
+                for (IndexShardSnapshotStatus snapshotStatus : entry.getValue().values()) {
                     snapshotStatus.abortIfNotCompleted("snapshot has been removed in cluster state, aborting");
                 }
             }
@@ -248,11 +243,11 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                                     entry.indices().stream().collect(Collectors.toMap(IndexId::getName, Function.identity())));
                 if (entry.state() == State.STARTED) {
                     Map<ShardId, IndexShardSnapshotStatus> startedShards = new HashMap<>();
-                    SnapshotShards snapshotShards = shardSnapshots.get(entry.snapshot());
+                    Map<ShardId, IndexShardSnapshotStatus> snapshotShards = shardSnapshots.get(entry.snapshot());
                     for (ObjectObjectCursor<ShardId, ShardSnapshotStatus> shard : entry.shards()) {
                         // Add all new shards to start processing on
                         if (localNodeId.equals(shard.value.nodeId())) {
-                            if (shard.value.state() == State.INIT && (snapshotShards == null || !snapshotShards.shards.containsKey(shard.key))) {
+                            if (shard.value.state() == State.INIT && (snapshotShards == null || !snapshotShards.containsKey(shard.key))) {
                                 logger.trace("[{}] - Adding shard to the queue", shard.key);
                                 startedShards.put(shard.key, IndexShardSnapshotStatus.newInitializing());
                             }
@@ -264,23 +259,23 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                             // We already saw this snapshot but we need to add more started shards
                             Map<ShardId, IndexShardSnapshotStatus> shards = new HashMap<>();
                             // Put all shards that were already running on this node
-                            shards.putAll(snapshotShards.shards);
+                            shards.putAll(snapshotShards);
                             // Put all newly started shards
                             shards.putAll(startedShards);
-                            survivors.put(entry.snapshot(), new SnapshotShards(unmodifiableMap(shards)));
+                            survivors.put(entry.snapshot(), unmodifiableMap(shards));
                         } else {
                             // Brand new snapshot that we haven't seen before
-                            survivors.put(entry.snapshot(), new SnapshotShards(unmodifiableMap(startedShards)));
+                            survivors.put(entry.snapshot(), unmodifiableMap(startedShards));
                         }
                     }
                 } else if (entry.state() == State.ABORTED) {
                     // Abort all running shards for this snapshot
-                    SnapshotShards snapshotShards = shardSnapshots.get(entry.snapshot());
+                    Map<ShardId, IndexShardSnapshotStatus> snapshotShards = shardSnapshots.get(entry.snapshot());
                     if (snapshotShards != null) {
                         final String failure = "snapshot has been aborted";
                         for (ObjectObjectCursor<ShardId, ShardSnapshotStatus> shard : entry.shards()) {
 
-                            final IndexShardSnapshotStatus snapshotStatus = snapshotShards.shards.get(shard.key);
+                            final IndexShardSnapshotStatus snapshotStatus = snapshotShards.get(shard.key);
                             if (snapshotStatus != null) {
                                 final IndexShardSnapshotStatus.Copy lastSnapshotStatus = snapshotStatus.abortIfNotCompleted(failure);
                                 final Stage stage = lastSnapshotStatus.getStage();
@@ -448,17 +443,6 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
     }
 
     /**
-     * Stores the list of shards that has to be snapshotted on this node
-     */
-    private static class SnapshotShards {
-        private final Map<ShardId, IndexShardSnapshotStatus> shards;
-
-        private SnapshotShards(Map<ShardId, IndexShardSnapshotStatus> shards) {
-            this.shards = shards;
-        }
-    }
-
-    /**
      * Internal request that is used to send changes in snapshot status to master
      */
     public static class UpdateIndexShardSnapshotStatusRequest extends MasterNodeRequest<UpdateIndexShardSnapshotStatusRequest> {
@@ -617,10 +601,14 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
 
     }
 
-    class UpdateSnapshotStatusAction extends TransportMasterNodeAction<UpdateIndexShardSnapshotStatusRequest, UpdateIndexShardSnapshotStatusResponse> {
-        UpdateSnapshotStatusAction(String actionName, TransportService transportService, ClusterService clusterService,
-                                   ThreadPool threadPool, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
-            super(actionName, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, UpdateIndexShardSnapshotStatusRequest::new);
+    private class UpdateSnapshotStatusAction
+        extends TransportMasterNodeAction<UpdateIndexShardSnapshotStatusRequest, UpdateIndexShardSnapshotStatusResponse> {
+            UpdateSnapshotStatusAction(TransportService transportService, ClusterService clusterService,
+                ThreadPool threadPool, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+                    super(
+                        SnapshotShardsService.UPDATE_SNAPSHOT_STATUS_ACTION_NAME, transportService, clusterService, threadPool, actionFilters,
+                        indexNameExpressionResolver, UpdateIndexShardSnapshotStatusRequest::new
+                    );
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotState.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotState.java
@@ -45,11 +45,11 @@ public enum SnapshotState {
      */
     INCOMPATIBLE((byte) 4, true, false);
 
-    private byte value;
+    private final byte value;
 
-    private boolean completed;
+    private final boolean completed;
 
-    private boolean restorable;
+    private final boolean restorable;
 
     SnapshotState(byte value, boolean completed, boolean restorable) {
         this.value = value;


### PR DESCRIPTION
Extracted some cleanups from https://github.com/elastic/elasticsearch/compare/master...ywelsch:snapshot-refactored?expand=1

* Unwrapping `SnapshotShards`
* `final` on `UpdateSnapshotStatusAction` field

Also:

* Simplified `UpdateSnapshotStatusAction` constructor
* Make `SnapshotState` immutable