### PR TITLE
Add pointer to the index-phrases option in shingle filter docs

### DIFF
--- a/docs/reference/analysis/tokenfilters/shingle-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/shingle-tokenfilter.asciidoc
@@ -1,6 +1,10 @@
 [[analysis-shingle-tokenfilter]]
 === Shingle Token Filter
 
+NOTE: Shingles are generally used to help speed up phrase queries.  Rather
+than building filter chains by hand, you may find it easier to use the
+<<index-phrases,`index-phrases`>> option on a text field.
+
 A token filter of type `shingle` that constructs shingles (token
 n-grams) from a token stream. In other words, it creates combinations of
 tokens as a single token. For example, the sentence "please divide this

--- a/docs/reference/mapping/params.asciidoc
+++ b/docs/reference/mapping/params.asciidoc
@@ -21,6 +21,7 @@ The following mapping parameters are common to some or all field datatypes:
 * <<ignore-above,`ignore_above`>>
 * <<ignore-malformed,`ignore_malformed`>>
 * <<index-options,`index_options`>>
+* <<index-phrases,`index_phrases`>>
 * <<mapping-index,`index`>>
 * <<multi-fields,`fields`>>
 * <<norms,`norms`>>
@@ -62,6 +63,8 @@ include::params/ignore-malformed.asciidoc[]
 include::params/index.asciidoc[]
 
 include::params/index-options.asciidoc[]
+
+include::params/index-phrases.asciidoc[]
 
 include::params/multi-fields.asciidoc[]
 

--- a/docs/reference/mapping/params/index-phrases.asciidoc
+++ b/docs/reference/mapping/params/index-phrases.asciidoc
@@ -1,0 +1,8 @@
+[[index-phrases]]
+=== Index Phrases
+
+If enabled, two-term word combinations ('shingles') are indexed into a separate
+field.  This allows exact phrase queries (no slop) to run more efficiently, at the expense
+of a larger index.  Note that this works best when stopwords are not removed,
+as phrases containing stopwords will not use the subsidiary field and will fall
+back to a standard phrase query.  Accepts `true` or `false` (default).

--- a/docs/reference/mapping/types/text.asciidoc
+++ b/docs/reference/mapping/types/text.asciidoc
@@ -96,7 +96,7 @@ The following parameters are accepted by `text` fields:
     the expense of a larger index. Accepts an
     <<index-prefix-config,`index-prefix configuration block`>>
 
-`index_phrases`::
+<<index-phrases,`index_phrases`>>::
 
     If enabled, two-term word combinations ('shingles') are indexed into a separate
     field.  This allows exact phrase queries (no slop) to run more efficiently, at the expense


### PR DESCRIPTION
Prompted by this thread on the discuss list:

https://discuss.elastic.co/t/issue-with-shingles-and-stopwords/155525

We should be discouraging the use of shingle filters and instead pointing users to the index-phrases parameter on text fields.