### PR TITLE
[ML] Add docs for ML info endpoint

### DIFF
--- a/docs/reference/ml/apis/get-ml-info.asciidoc
+++ b/docs/reference/ml/apis/get-ml-info.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [testenv="platinum"]
-[[ml-info]]
+[[get-ml-info]]
 === Get Machine Learning Info API
 ++++
 <titleabbrev>Get Machine Learning Info</titleabbrev>

--- a/docs/reference/ml/apis/ml-api.asciidoc
+++ b/docs/reference/ml/apis/ml-api.asciidoc
@@ -76,6 +76,12 @@ machine learning APIs and in advanced job configuration options in Kibana.
 
 * <<ml-find-file-structure,Find file structure>>
 
+[float]
+[[ml-api-ml-info-endpoint]]
+=== Info
+
+* <<ml-info,Machine learning info>>
+
 //ADD
 include::post-calendar-event.asciidoc[]
 include::put-calendar-job.asciidoc[]
@@ -115,6 +121,8 @@ include::get-snapshot.asciidoc[]
 include::get-calendar-event.asciidoc[]
 include::get-filter.asciidoc[]
 include::get-record.asciidoc[]
+//INFO
+include::ml-info.asciidoc[]
 //OPEN
 include::open-job.asciidoc[]
 //POST

--- a/docs/reference/ml/apis/ml-api.asciidoc
+++ b/docs/reference/ml/apis/ml-api.asciidoc
@@ -80,7 +80,7 @@ machine learning APIs and in advanced job configuration options in Kibana.
 [[ml-api-ml-info-endpoint]]
 === Info
 
-* <<ml-info,Machine learning info>>
+* <<get-ml-info,Machine learning info>>
 
 //ADD
 include::post-calendar-event.asciidoc[]
@@ -117,12 +117,11 @@ include::get-datafeed-stats.asciidoc[]
 include::get-influencer.asciidoc[]
 include::get-job.asciidoc[]
 include::get-job-stats.asciidoc[]
+include::get-ml-info.asciidoc[]
 include::get-snapshot.asciidoc[]
 include::get-calendar-event.asciidoc[]
 include::get-filter.asciidoc[]
 include::get-record.asciidoc[]
-//INFO
-include::ml-info.asciidoc[]
 //OPEN
 include::open-job.asciidoc[]
 //POST

--- a/docs/reference/ml/apis/ml-info.asciidoc
+++ b/docs/reference/ml/apis/ml-info.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-info]]
-=== Machine Learning Info API
+=== Get Machine Learning Info API
 ++++
-<titleabbrev>Machine Learning Info </titleabbrev>
+<titleabbrev>Get Machine Learning Info</titleabbrev>
 ++++
 
 Returns defaults and limits used by machine learning.
@@ -25,8 +25,8 @@ what those defaults are.
 You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API.  The `machine_learning_admin` and `machine_learning_user`
 roles provide these privileges. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges] and
-{xpack-ref}/built-in-roles.html[Built-in Roles].
+{stack-ov}/security-privileges.html[Security Privileges] and
+{stack-ov}/built-in-roles.html[Built-in Roles].
 
 
 ==== Examples

--- a/docs/reference/ml/apis/ml-info.asciidoc
+++ b/docs/reference/ml/apis/ml-info.asciidoc
@@ -1,0 +1,60 @@
+[role="xpack"]
+[testenv="platinum"]
+[[ml-info]]
+=== Machine Learning Info API
+++++
+<titleabbrev>Machine Learning Info </titleabbrev>
+++++
+
+Returns defaults and limits used by machine learning.
+
+==== Request
+
+`GET _xpack/ml/info`
+
+==== Description
+
+This endpoint is designed to be used by a user interface that needs to fully
+understand machine learning configurations where some options are not specified,
+meaning that the defaults should be used.  This endpoint may be used to find out
+what those defaults are.
+
+
+==== Authorization
+
+You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
+privileges to use this API.  The `machine_learning_admin` and `machine_learning_user`
+roles provide these privileges. For more information, see
+{xpack-ref}/security-privileges.html[Security Privileges] and
+{xpack-ref}/built-in-roles.html[Built-in Roles].
+
+
+==== Examples
+
+The endpoint takes no arguments:
+
+[source,js]
+--------------------------------------------------
+GET _xpack/ml/info
+--------------------------------------------------
+// CONSOLE
+// TEST
+
+This is a possible response:
+[source,js]
+----
+{
+  "defaults" : {
+    "anomaly_detectors" : {
+      "model_memory_limit" : "1gb",
+      "categorization_examples_limit" : 4,
+      "model_snapshot_retention_days" : 1
+    },
+    "datafeeds" : {
+      "scroll_size" : 1000
+    }
+  },
+  "limits" : { }
+}
+----
+// TESTRESPONSE


### PR DESCRIPTION
This endpoint was not previously documented as it was not
particularly useful to end users.  However, since the HLRC
will support the endpoint we need some documentation to
link to.

The purpose of the endpoint is to provide defaults and
limits used by ML.  These are needed to fully understand
configurations that have missing values because the missing
value means the default should be used.

Relates #35777