### PR TITLE
Update Date example to actually match default format

### DIFF
--- a/docs/reference/mapping/types/date.asciidoc
+++ b/docs/reference/mapping/types/date.asciidoc
@@ -3,7 +3,7 @@
 
 JSON doesn't have a date datatype, so dates in Elasticsearch can either be:
 
-* strings containing formatted dates, e.g. `"2015-01-01"` or `"2015/01/01 12:10:30"`.
+* strings containing formatted dates, e.g. `"2015-01-01"` or `"2015-01-01T12:10:30"`.
 * a long number representing _milliseconds-since-the-epoch_.
 * an integer representing _seconds-since-the-epoch_.
 


### PR DESCRIPTION
The existing example is deceptive and misleading, because the default ISO8601 format doesn't even like slashes between y/m/d or spaces between date/time.