### PR TITLE
Let TimeValue#toString use TimeValue#getStringRep()

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java
+++ b/libs/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java
@@ -182,63 +182,9 @@ public class TimeValue implements Comparable<TimeValue> {
         return daysFrac();
     }
 
-    /**
-     * Returns a {@link String} representation of the current {@link TimeValue}.
-     *
-     * Note that this method might produce fractional time values (ex 1.6m) which cannot be
-     * parsed by method like {@link TimeValue#parse(String, String, String)}.
-     */
     @Override
     public String toString() {
-        if (duration < 0) {
-            return Long.toString(duration);
-        }
-        long nanos = nanos();
-        if (nanos == 0) {
-            return "0s";
-        }
-        double value = nanos;
-        String suffix = "nanos";
-        if (nanos >= C6) {
-            value = daysFrac();
-            suffix = "d";
-        } else if (nanos >= C5) {
-            value = hoursFrac();
-            suffix = "h";
-        } else if (nanos >= C4) {
-            value = minutesFrac();
-            suffix = "m";
-        } else if (nanos >= C3) {
-            value = secondsFrac();
-            suffix = "s";
-        } else if (nanos >= C2) {
-            value = millisFrac();
-            suffix = "ms";
-        } else if (nanos >= C1) {
-            value = microsFrac();
-            suffix = "micros";
-        }
-        return formatDecimal(value) + suffix;
-    }
-
-    private static String formatDecimal(double value) {
-        String p = String.valueOf(value);
-        int ix = p.indexOf('.') + 1;
-        int ex = p.indexOf('E');
-        char fraction = p.charAt(ix);
-        if (fraction == '0') {
-            if (ex != -1) {
-                return p.substring(0, ix - 1) + p.substring(ex);
-            } else {
-                return p.substring(0, ix - 1);
-            }
-        } else {
-            if (ex != -1) {
-                return p.substring(0, ix) + fraction + p.substring(ex);
-            } else {
-                return p.substring(0, ix) + fraction;
-            }
-        }
+        return getStringRep();
     }
 
     public String getStringRep() {

--- a/libs/core/src/test/java/org/elasticsearch/common/unit/TimeValueTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/common/unit/TimeValueTests.java
@@ -41,15 +41,6 @@ public class TimeValueTests extends ESTestCase {
         assertThat(TimeUnit.DAYS.toDays(10), equalTo(new TimeValue(10, TimeUnit.DAYS).days()));
     }
 
-    public void testToString() {
-        assertThat("10ms", equalTo(new TimeValue(10, TimeUnit.MILLISECONDS).toString()));
-        assertThat("1.5s", equalTo(new TimeValue(1533, TimeUnit.MILLISECONDS).toString()));
-        assertThat("1.5m", equalTo(new TimeValue(90, TimeUnit.SECONDS).toString()));
-        assertThat("1.5h", equalTo(new TimeValue(90, TimeUnit.MINUTES).toString()));
-        assertThat("1.5d", equalTo(new TimeValue(36, TimeUnit.HOURS).toString()));
-        assertThat("1000d", equalTo(new TimeValue(1000, TimeUnit.DAYS).toString()));
-    }
-
     public void testMinusOne() {
         assertThat(new TimeValue(-1).nanos(), lessThan(0L));
     }
@@ -184,6 +175,14 @@ public class TimeValueTests extends ESTestCase {
         assertEquals("90m", new TimeValue(90, TimeUnit.MINUTES).getStringRep());
         assertEquals("36h", new TimeValue(36, TimeUnit.HOURS).getStringRep());
         assertEquals("1000d", new TimeValue(1000, TimeUnit.DAYS).getStringRep());
+    }
+
+    /**
+     * Just check that {@link TimeValue#toString()} uses {@link TimeValue#getStringRep()} under the hood.
+     */
+    public void testToString() {
+        TimeValue tv = new TimeValue(randomLong(), randomFrom(TimeUnit.values()));
+        assertEquals(tv.toString(), tv.getStringRep());
     }
 
     public void testCompareEquality() {


### PR DESCRIPTION
It is confusing that currently the output of TimeValue#toString is different
from TimeValue#getStringRep(), e.g. produces fractional values and is lossy in
the sense that its output cannot be parsed back to an equivalent TimeValue
instance (e.g. a "1523ms" instances toString() currently prints "1.5s" which
loses precision). We should use TimeValue#getStringRep() instead which always
uses the specified TimeUnit value and duration.