### PR TITLE
[ML] Prevent potential NPE when reading the model memory limit

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -423,7 +423,11 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         if (establishedModelMemory != null && establishedModelMemory > 0) {
             return establishedModelMemory + PROCESS_MEMORY_OVERHEAD.getBytes();
         }
-        return ByteSizeUnit.MB.toBytes(analysisLimits.getModelMemoryLimit()) + PROCESS_MEMORY_OVERHEAD.getBytes();
+        long modelMemoryLimit = AnalysisLimits.PRE_6_1_DEFAULT_MODEL_MEMORY_LIMIT_MB;
+        if (analysisLimits != null && analysisLimits.getModelMemoryLimit() != null) {
+            modelMemoryLimit = analysisLimits.getModelMemoryLimit();
+        }
+        return ByteSizeUnit.MB.toBytes(modelMemoryLimit) + PROCESS_MEMORY_OVERHEAD.getBytes();
     }
 
     /**


### PR DESCRIPTION
This error is very hard to recreate and can only happen during a rolling upgrade from 5.6 or 6.0. This is impractical to unit test as it is impossible to create a situation where `analysisLimits` can be null in the current code base, this was possible in previous versions. 

v6.6.0 has changed to use a different mechanism to discover the model memory limit so this fix does not need to be forward ported to any other branches.