### PR TITLE
[Tests] Fix creating ExplainLifecycleRequest with no indices

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/ExplainLifecycleRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/ExplainLifecycleRequestTests.java
@@ -29,7 +29,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class ExplainLifecycleRequestTests extends ESTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/35822")
     public void testEqualsAndHashcode() {
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(), this::copy, this::mutateInstance);
     }
@@ -55,7 +54,7 @@ public class ExplainLifecycleRequestTests extends ESTestCase {
         switch (between(0, 1)) {
         case 0:
             indices = randomValueOtherThanMany(i -> Arrays.equals(i, instance.getIndices()),
-                    () -> generateRandomStringArray(20, 10, false, true));
+                    () -> generateRandomStringArray(20, 10, false, false));
             break;
         case 1:
             indicesOptions = randomValueOtherThan(indicesOptions, () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ExplainLifecycleRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ExplainLifecycleRequestTests.java
@@ -19,7 +19,7 @@ public class ExplainLifecycleRequestTests extends AbstractWireSerializingTestCas
     protected ExplainLifecycleRequest createTestInstance() {
         ExplainLifecycleRequest request = new ExplainLifecycleRequest();
         if (randomBoolean()) {
-            request.indices(generateRandomStringArray(20, 20, false, true));
+            request.indices(generateRandomStringArray(20, 20, false, false));
         }
         if (randomBoolean()) {
             IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),


### PR DESCRIPTION
We didn't check that the ExplainLifecycleRequest was constructed with at least
one index before, now that we do we must also make sure the tests
mutateInstance() method used in equals/hashCode checks doesn't accidentally
create an empty index array.

Closes #35822