### PR TITLE
[ML-DataFrame]remove settings from transport actions

### DIFF
--- a/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/action/TransportDeleteFeatureIndexBuilderJobAction.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/action/TransportDeleteFeatureIndexBuilderJobAction.java
@@ -18,7 +18,6 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.persistent.PersistentTasksService;
@@ -36,9 +35,9 @@ public class TransportDeleteFeatureIndexBuilderJobAction
     private static final Logger logger = LogManager.getLogger(TransportDeleteFeatureIndexBuilderJobAction.class);
 
     @Inject
-    public TransportDeleteFeatureIndexBuilderJobAction(Settings settings, TransportService transportService, ThreadPool threadPool,
-                                          ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
-                                          PersistentTasksService persistentTasksService, ClusterService clusterService) {
+    public TransportDeleteFeatureIndexBuilderJobAction(TransportService transportService, ThreadPool threadPool,
+            ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
+            PersistentTasksService persistentTasksService, ClusterService clusterService) {
         super(DeleteFeatureIndexBuilderJobAction.NAME, transportService, clusterService, threadPool, actionFilters,
                 indexNameExpressionResolver, DeleteFeatureIndexBuilderJobAction.Request::new);
         this.persistentTasksService = persistentTasksService;

--- a/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/action/TransportPutFeatureIndexBuilderJobAction.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/action/TransportPutFeatureIndexBuilderJobAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.persistent.PersistentTasksService;
@@ -39,9 +38,9 @@ public class TransportPutFeatureIndexBuilderJobAction
     private final Client client;
 
     @Inject
-    public TransportPutFeatureIndexBuilderJobAction(Settings settings, TransportService transportService, ThreadPool threadPool,
-            ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver, ClusterService clusterService,
-            XPackLicenseState licenseState, PersistentTasksService persistentTasksService, Client client) {
+    public TransportPutFeatureIndexBuilderJobAction(TransportService transportService, ThreadPool threadPool, ActionFilters actionFilters,
+            IndexNameExpressionResolver indexNameExpressionResolver, ClusterService clusterService, XPackLicenseState licenseState,
+            PersistentTasksService persistentTasksService, Client client) {
         super(PutFeatureIndexBuilderJobAction.NAME, transportService, clusterService, threadPool, actionFilters,
                 indexNameExpressionResolver, PutFeatureIndexBuilderJobAction.Request::new);
         this.licenseState = licenseState;

--- a/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/action/TransportStartFeatureIndexBuilderJobAction.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/action/TransportStartFeatureIndexBuilderJobAction.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.Task;
@@ -35,7 +34,7 @@ public class TransportStartFeatureIndexBuilderJobAction extends
     private final XPackLicenseState licenseState;
 
     @Inject
-    public TransportStartFeatureIndexBuilderJobAction(Settings settings, TransportService transportService, ActionFilters actionFilters,
+    public TransportStartFeatureIndexBuilderJobAction(TransportService transportService, ActionFilters actionFilters,
             ClusterService clusterService, XPackLicenseState licenseState) {
         super(StartFeatureIndexBuilderJobAction.NAME, clusterService, transportService, actionFilters,
                 StartFeatureIndexBuilderJobAction.Request::new, StartFeatureIndexBuilderJobAction.Response::new, ThreadPool.Names.SAME);

--- a/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/action/TransportStopFeatureIndexBuilderJobAction.java
+++ b/x-pack/plugin/ml-feature-index-builder/src/main/java/org/elasticsearch/xpack/ml/featureindexbuilder/action/TransportStopFeatureIndexBuilderJobAction.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -29,7 +28,7 @@ public class TransportStopFeatureIndexBuilderJobAction extends
         StopFeatureIndexBuilderJobAction.Response, StopFeatureIndexBuilderJobAction.Response> {
 
     @Inject
-    public TransportStopFeatureIndexBuilderJobAction(Settings settings, TransportService transportService, ActionFilters actionFilters,
+    public TransportStopFeatureIndexBuilderJobAction(TransportService transportService, ActionFilters actionFilters,
             ClusterService clusterService) {
         super(StopFeatureIndexBuilderJobAction.NAME, clusterService, transportService, actionFilters,
                 StopFeatureIndexBuilderJobAction.Request::new, StopFeatureIndexBuilderJobAction.Response::new, ThreadPool.Names.SAME);


### PR DESCRIPTION
**Feature Branch PR**

remove settings from transport actions.


Note: cleanup after upstream re-factoring, see: https://github.com/elastic/elasticsearch/pull/35208