### PR TITLE
[Zen2] VotingTombstone class

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequest.java
@@ -84,7 +84,8 @@ public class AddVotingTombstonesRequest extends MasterNodeRequest<AddVotingTombs
         return resolvedNodes;
     }
 
-    Set<VotingTombstone> resolveVotingTombstonesAndCheckMaximum(ClusterState currentState, int maxTombstoneCount, String maximumSettingKey) {
+    Set<VotingTombstone> resolveVotingTombstonesAndCheckMaximum(ClusterState currentState, int maxTombstoneCount,
+                                                                String maximumSettingKey) {
         final Set<VotingTombstone> resolvedNodes = resolveVotingTombstones(currentState);
 
         final int oldTombstoneCount = currentState.getVotingTombstones().size();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequest.java
@@ -70,7 +70,7 @@ public class AddVotingTombstonesRequest extends MasterNodeRequest<AddVotingTombs
         timeout = in.readTimeValue();
     }
 
-    Set<VotingTombstone> resolveNodes(ClusterState currentState) {
+    Set<VotingTombstone> resolveVotingTombstones(ClusterState currentState) {
         final DiscoveryNodes allNodes = currentState.nodes();
         final Set<VotingTombstone> resolvedNodes = Arrays.stream(allNodes.resolveNodes(nodeDescriptions))
                 .map(allNodes::get).filter(DiscoveryNode::isMasterNode).map(VotingTombstone::new).collect(Collectors.toSet());
@@ -84,8 +84,8 @@ public class AddVotingTombstonesRequest extends MasterNodeRequest<AddVotingTombs
         return resolvedNodes;
     }
 
-    Set<VotingTombstone> resolveNodesAndCheckMaximum(ClusterState currentState, int maxTombstoneCount, String maximumSettingKey) {
-        final Set<VotingTombstone> resolvedNodes = resolveNodes(currentState);
+    Set<VotingTombstone> resolveVotingTombstones(ClusterState currentState, int maxTombstoneCount, String maximumSettingKey) {
+        final Set<VotingTombstone> resolvedNodes = resolveVotingTombstones(currentState);
 
         final int oldTombstoneCount = currentState.getVotingTombstones().size();
         final int newTombstoneCount = resolvedNodes.size();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequest.java
@@ -84,7 +84,7 @@ public class AddVotingTombstonesRequest extends MasterNodeRequest<AddVotingTombs
         return resolvedNodes;
     }
 
-    Set<VotingTombstone> resolveVotingTombstones(ClusterState currentState, int maxTombstoneCount, String maximumSettingKey) {
+    Set<VotingTombstone> resolveVotingTombstonesAndCheckMaximum(ClusterState currentState, int maxTombstoneCount, String maximumSettingKey) {
         final Set<VotingTombstone> resolvedNodes = resolveVotingTombstones(currentState);
 
         final int oldTombstoneCount = currentState.getVotingTombstones().size();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequest.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.configuration;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.coordination.CoordinationMetaData.VotingTombstone;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -69,10 +70,10 @@ public class AddVotingTombstonesRequest extends MasterNodeRequest<AddVotingTombs
         timeout = in.readTimeValue();
     }
 
-    Set<DiscoveryNode> resolveNodes(ClusterState currentState) {
+    Set<VotingTombstone> resolveNodes(ClusterState currentState) {
         final DiscoveryNodes allNodes = currentState.nodes();
-        final Set<DiscoveryNode> resolvedNodes = Arrays.stream(allNodes.resolveNodes(nodeDescriptions))
-            .map(allNodes::get).filter(DiscoveryNode::isMasterNode).collect(Collectors.toSet());
+        final Set<VotingTombstone> resolvedNodes = Arrays.stream(allNodes.resolveNodes(nodeDescriptions))
+                .map(allNodes::get).filter(DiscoveryNode::isMasterNode).map(VotingTombstone::new).collect(Collectors.toSet());
 
         if (resolvedNodes.isEmpty()) {
             throw new IllegalArgumentException("add voting tombstones request for " + Arrays.asList(nodeDescriptions)
@@ -83,8 +84,8 @@ public class AddVotingTombstonesRequest extends MasterNodeRequest<AddVotingTombs
         return resolvedNodes;
     }
 
-    Set<DiscoveryNode> resolveNodesAndCheckMaximum(ClusterState currentState, int maxTombstoneCount, String maximumSettingKey) {
-        final Set<DiscoveryNode> resolvedNodes = resolveNodes(currentState);
+    Set<VotingTombstone> resolveNodesAndCheckMaximum(ClusterState currentState, int maxTombstoneCount, String maximumSettingKey) {
+        final Set<VotingTombstone> resolvedNodes = resolveNodes(currentState);
 
         final int oldTombstoneCount = currentState.getVotingTombstones().size();
         final int newTombstoneCount = resolvedNodes.size();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingTombstonesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingTombstonesAction.java
@@ -146,7 +146,7 @@ public class TransportAddVotingTombstonesAction extends TransportMasterNodeActio
     }
 
     private static Set<VotingTombstone> resolveVotingTombstonesAndCheckMaximum(AddVotingTombstonesRequest request, ClusterState state) {
-        return request.resolveVotingTombstones(state,
+        return request.resolveVotingTombstonesAndCheckMaximum(state,
             MAXIMUM_VOTING_TOMBSTONES_SETTING.get(state.metaData().settings()), MAXIMUM_VOTING_TOMBSTONES_SETTING.getKey());
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingTombstonesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingTombstonesAction.java
@@ -80,7 +80,7 @@ public class TransportAddVotingTombstonesAction extends TransportMasterNodeActio
     protected void masterOperation(AddVotingTombstonesRequest request, ClusterState state,
                                    ActionListener<AddVotingTombstonesResponse> listener) throws Exception {
 
-        resolveNodesAndCheckMaximum(request, state); // throws IllegalArgumentException if no nodes matched or maximum exceeded
+        resolveVotingTombstonesAndCheckMaximum(request, state); // throws IllegalArgumentException if no nodes matched or maximum exceeded
 
         clusterService.submitStateUpdateTask("add-voting-tombstones", new ClusterStateUpdateTask(Priority.URGENT) {
 
@@ -89,7 +89,7 @@ public class TransportAddVotingTombstonesAction extends TransportMasterNodeActio
             @Override
             public ClusterState execute(ClusterState currentState) {
                 assert resolvedNodes == null : resolvedNodes;
-                resolvedNodes = resolveNodesAndCheckMaximum(request, currentState);
+                resolvedNodes = resolveVotingTombstonesAndCheckMaximum(request, currentState);
 
                 final CoordinationMetaData.Builder builder = CoordinationMetaData.builder(currentState.coordinationMetaData());
                 resolvedNodes.forEach(builder::addVotingTombstone);
@@ -145,8 +145,8 @@ public class TransportAddVotingTombstonesAction extends TransportMasterNodeActio
         });
     }
 
-    private static Set<VotingTombstone> resolveNodesAndCheckMaximum(AddVotingTombstonesRequest request, ClusterState state) {
-        return request.resolveNodesAndCheckMaximum(state,
+    private static Set<VotingTombstone> resolveVotingTombstonesAndCheckMaximum(AddVotingTombstonesRequest request, ClusterState state) {
+        return request.resolveVotingTombstones(state,
             MAXIMUM_VOTING_TOMBSTONES_SETTING.get(state.metaData().settings()), MAXIMUM_VOTING_TOMBSTONES_SETTING.getKey());
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingTombstonesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingTombstonesAction.java
@@ -30,9 +30,9 @@ import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.coordination.CoordinationMetaData;
+import org.elasticsearch.cluster.coordination.CoordinationMetaData.VotingTombstone;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
@@ -84,7 +84,7 @@ public class TransportAddVotingTombstonesAction extends TransportMasterNodeActio
 
         clusterService.submitStateUpdateTask("add-voting-tombstones", new ClusterStateUpdateTask(Priority.URGENT) {
 
-            private Set<DiscoveryNode> resolvedNodes;
+            private Set<VotingTombstone> resolvedNodes;
 
             @Override
             public ClusterState execute(ClusterState currentState) {
@@ -110,7 +110,7 @@ public class TransportAddVotingTombstonesAction extends TransportMasterNodeActio
                 final ClusterStateObserver observer
                     = new ClusterStateObserver(clusterService, request.getTimeout(), logger, threadPool.getThreadContext());
 
-                final Set<String> resolvedNodeIds = resolvedNodes.stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
+                final Set<String> resolvedNodeIds = resolvedNodes.stream().map(VotingTombstone::getNodeId).collect(Collectors.toSet());
 
                 final Predicate<ClusterState> allNodesRemoved = clusterState -> {
                     final Set<String> votingNodeIds = clusterState.getLastCommittedConfiguration().getNodeIds();
@@ -145,7 +145,7 @@ public class TransportAddVotingTombstonesAction extends TransportMasterNodeActio
         });
     }
 
-    private static Set<DiscoveryNode> resolveNodesAndCheckMaximum(AddVotingTombstonesRequest request, ClusterState state) {
+    private static Set<VotingTombstone> resolveNodesAndCheckMaximum(AddVotingTombstonesRequest request, ClusterState state) {
         return request.resolveNodesAndCheckMaximum(state,
             MAXIMUM_VOTING_TOMBSTONES_SETTING.get(state.metaData().settings()), MAXIMUM_VOTING_TOMBSTONES_SETTING.getKey());
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingTombstonesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingTombstonesAction.java
@@ -30,9 +30,9 @@ import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.coordination.CoordinationMetaData;
+import org.elasticsearch.cluster.coordination.CoordinationMetaData.VotingTombstone;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
@@ -77,10 +77,10 @@ public class TransportClearVotingTombstonesAction
         final long startTimeMillis = threadPool.relativeTimeInMillis();
 
         final Predicate<ClusterState> allTombstonedNodesRemoved = newState -> {
-            for (DiscoveryNode tombstone : initialState.getVotingTombstones()) {
+            for (VotingTombstone tombstone : initialState.getVotingTombstones()) {
                 // NB checking for the existence of any node with this persistent ID, because persistent IDs are how votes are counted.
                 // Calling nodeExists(tombstone) is insufficient because this compares on the ephemeral ID.
-                if (newState.nodes().nodeExists(tombstone.getId())) {
+                if (newState.nodes().nodeExists(tombstone.getNodeId())) {
                     return false;
                 }
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingTombstonesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingTombstonesAction.java
@@ -79,7 +79,6 @@ public class TransportClearVotingTombstonesAction
         final Predicate<ClusterState> allTombstonedNodesRemoved = newState -> {
             for (VotingTombstone tombstone : initialState.getVotingTombstones()) {
                 // NB checking for the existence of any node with this persistent ID, because persistent IDs are how votes are counted.
-                // Calling nodeExists(tombstone) is insufficient because this compares on the ephemeral ID.
                 if (newState.nodes().nodeExists(tombstone.getNodeId())) {
                     return false;
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.coordination.CoordinationMetaData;
 import org.elasticsearch.cluster.coordination.CoordinationMetaData.VotingConfiguration;
+import org.elasticsearch.cluster.coordination.CoordinationMetaData.VotingTombstone;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
@@ -277,7 +278,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
         return coordinationMetaData().getLastCommittedConfiguration();
     }
 
-    public Set<DiscoveryNode> getVotingTombstones() {
+    public Set<VotingTombstone> getVotingTombstones() {
         return coordinationMetaData().getVotingTombstones();
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetaData.java
@@ -49,40 +49,48 @@ public class CoordinationMetaData implements Writeable, ToXContentFragment {
 
     private final VotingConfiguration lastAcceptedConfiguration;
 
-    private final Set<DiscoveryNode> votingTombstones;
+    private final Set<VotingTombstone> votingTombstones;
 
     private static final ParseField TERM_PARSE_FIELD = new ParseField("term");
     private static final ParseField LAST_COMMITTED_CONFIGURATION_FIELD = new ParseField("last_committed_config");
     private static final ParseField LAST_ACCEPTED_CONFIGURATION_FIELD = new ParseField("last_accepted_config");
+    private static final ParseField VOTING_TOMBSTONES_FIELD = new ParseField("voting_tombstones");
 
     private static long term(Object[] termAndConfigs) {
         return (long)termAndConfigs[0];
     }
 
     @SuppressWarnings("unchecked")
-    private static VotingConfiguration lastCommittedConfig(Object[] termAndConfig) {
-        List<String> nodeIds = (List<String>) termAndConfig[1];
+    private static VotingConfiguration lastCommittedConfig(Object[] fields) {
+        List<String> nodeIds = (List<String>) fields[1];
         return new VotingConfiguration(new HashSet<>(nodeIds));
     }
 
     @SuppressWarnings("unchecked")
-    private static VotingConfiguration lastAcceptedConfig(Object[] termAndConfig) {
-        List<String> nodeIds = (List<String>) termAndConfig[2];
+    private static VotingConfiguration lastAcceptedConfig(Object[] fields) {
+        List<String> nodeIds = (List<String>) fields[2];
         return new VotingConfiguration(new HashSet<>(nodeIds));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<VotingTombstone> votingTombstones(Object[] fields) {
+        Set<VotingTombstone> votingTombstones = new HashSet<>((List<VotingTombstone>) fields[3]);
+        return votingTombstones;
     }
 
     private static final ConstructingObjectParser<CoordinationMetaData, Void> PARSER = new ConstructingObjectParser<>(
             "coordination_metadata",
-            termAndConfigs -> new CoordinationMetaData(term(termAndConfigs), lastCommittedConfig(termAndConfigs),
-                    lastAcceptedConfig(termAndConfigs), Collections.emptySet()));
+            fields -> new CoordinationMetaData(term(fields), lastCommittedConfig(fields),
+                    lastAcceptedConfig(fields), votingTombstones(fields)));
     static {
         PARSER.declareLong(ConstructingObjectParser.constructorArg(), TERM_PARSE_FIELD);
         PARSER.declareStringArray(ConstructingObjectParser.constructorArg(), LAST_COMMITTED_CONFIGURATION_FIELD);
         PARSER.declareStringArray(ConstructingObjectParser.constructorArg(), LAST_ACCEPTED_CONFIGURATION_FIELD);
+        PARSER.declareObjectArray(ConstructingObjectParser.constructorArg(), VotingTombstone.PARSER, VOTING_TOMBSTONES_FIELD);
     }
 
     public CoordinationMetaData(long term, VotingConfiguration lastCommittedConfiguration, VotingConfiguration lastAcceptedConfiguration,
-        Set<DiscoveryNode> votingTombstones) {
+                                Set<VotingTombstone> votingTombstones) {
         this.term = term;
         this.lastCommittedConfiguration = lastCommittedConfiguration;
         this.lastAcceptedConfiguration = lastAcceptedConfiguration;
@@ -93,7 +101,7 @@ public class CoordinationMetaData implements Writeable, ToXContentFragment {
         term = in.readLong();
         lastCommittedConfiguration = new VotingConfiguration(in);
         lastAcceptedConfiguration = new VotingConfiguration(in);
-        votingTombstones = Collections.unmodifiableSet(in.readSet(DiscoveryNode::new));
+        votingTombstones = Collections.unmodifiableSet(in.readSet(VotingTombstone::new));
     }
 
     public static Builder builder() {
@@ -117,8 +125,8 @@ public class CoordinationMetaData implements Writeable, ToXContentFragment {
         return builder
             .field(TERM_PARSE_FIELD.getPreferredName(), term)
             .field(LAST_COMMITTED_CONFIGURATION_FIELD.getPreferredName(), lastCommittedConfiguration)
-            .field(LAST_ACCEPTED_CONFIGURATION_FIELD.getPreferredName(), lastAcceptedConfiguration);
-        // TODO include voting tombstones here
+                .field(LAST_ACCEPTED_CONFIGURATION_FIELD.getPreferredName(), lastAcceptedConfiguration)
+                .field(VOTING_TOMBSTONES_FIELD.getPreferredName(), votingTombstones);
     }
 
     public static CoordinationMetaData fromXContent(XContentParser parser) throws IOException {
@@ -137,7 +145,7 @@ public class CoordinationMetaData implements Writeable, ToXContentFragment {
         return lastCommittedConfiguration;
     }
 
-    public Set<DiscoveryNode> getVotingTombstones() {
+    public Set<VotingTombstone> getVotingTombstones() {
         return votingTombstones;
     }
 
@@ -177,7 +185,7 @@ public class CoordinationMetaData implements Writeable, ToXContentFragment {
         private long term = 0;
         private VotingConfiguration lastCommittedConfiguration = VotingConfiguration.EMPTY_CONFIG;
         private VotingConfiguration lastAcceptedConfiguration = VotingConfiguration.EMPTY_CONFIG;
-        private final Set<DiscoveryNode> votingTombstones = new HashSet<>();
+        private final Set<VotingTombstone> votingTombstones = new HashSet<>();
 
         public Builder() {
 
@@ -205,7 +213,7 @@ public class CoordinationMetaData implements Writeable, ToXContentFragment {
             return this;
         }
 
-        public Builder addVotingTombstone(DiscoveryNode tombstone) {
+        public Builder addVotingTombstone(VotingTombstone tombstone) {
             votingTombstones.add(tombstone);
             return this;
         }
@@ -218,6 +226,97 @@ public class CoordinationMetaData implements Writeable, ToXContentFragment {
         public CoordinationMetaData build() {
             return new CoordinationMetaData(term, lastCommittedConfiguration, lastAcceptedConfiguration, votingTombstones);
         }
+    }
+
+    public static class VotingTombstone implements Writeable, ToXContentFragment {
+        private String nodeId;
+        private String nodeName;
+
+        public VotingTombstone(DiscoveryNode node) {
+            this(node.getId(), node.getName());
+        }
+
+        public VotingTombstone(StreamInput in) throws IOException {
+            this.nodeId = in.readString();
+            this.nodeName = in.readString();
+        }
+
+        public VotingTombstone(String nodeId, String nodeName) {
+            this.nodeId = nodeId;
+            this.nodeName = nodeName;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(nodeId);
+            out.writeString(nodeName);
+        }
+
+        public String getNodeId() {
+            return nodeId;
+        }
+
+        public String getNodeName() {
+            return nodeName;
+        }
+
+        private static final ParseField NODE_ID_PARSE_FIELD = new ParseField("node_id");
+        private static final ParseField NODE_NAME_PARSE_FIELD = new ParseField("node_name");
+
+        private static String nodeId(Object[] nodeIdAndName) {
+            return (String) nodeIdAndName[0];
+        }
+
+        private static String nodeName(Object[] nodeIdAndName) {
+            return (String) nodeIdAndName[1];
+        }
+
+        private static final ConstructingObjectParser<VotingTombstone, Void> PARSER = new ConstructingObjectParser<>(
+                "voting_tombstone",
+                nodeIdAndName -> new VotingTombstone(nodeId(nodeIdAndName), nodeName(nodeIdAndName))
+        );
+
+        static {
+            PARSER.declareString(ConstructingObjectParser.constructorArg(), NODE_ID_PARSE_FIELD);
+            PARSER.declareString(ConstructingObjectParser.constructorArg(), NODE_NAME_PARSE_FIELD);
+        }
+
+        public static VotingTombstone fromXContent(XContentParser parser) throws IOException {
+            return PARSER.parse(parser, null);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder.startObject()
+                    .field(NODE_ID_PARSE_FIELD.getPreferredName(), nodeId)
+                    .field(NODE_NAME_PARSE_FIELD.getPreferredName(), nodeName)
+                    .endObject();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            VotingTombstone that = (VotingTombstone) o;
+            return Objects.equals(nodeId, that.nodeId) &&
+                    Objects.equals(nodeName, that.nodeName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(nodeId, nodeName);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append('{').append(nodeId).append('}');
+            if (nodeName.length() > 0) {
+                sb.append('{').append(nodeName).append('}');
+            }
+            return sb.toString();
+        }
+
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetaData.java
@@ -310,10 +310,10 @@ public class CoordinationMetaData implements Writeable, ToXContentFragment {
         @Override
         public String toString() {
             StringBuilder sb = new StringBuilder();
-            sb.append('{').append(nodeId).append('}');
             if (nodeName.length() > 0) {
                 sb.append('{').append(nodeName).append('}');
             }
+            sb.append('{').append(nodeId).append('}');
             return sb.toString();
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetaData.java
@@ -229,8 +229,8 @@ public class CoordinationMetaData implements Writeable, ToXContentFragment {
     }
 
     public static class VotingTombstone implements Writeable, ToXContentFragment {
-        private String nodeId;
-        private String nodeName;
+        private final String nodeId;
+        private final String nodeName;
 
         public VotingTombstone(DiscoveryNode node) {
             this(node.getId(), node.getName());

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetaData.java
@@ -125,8 +125,8 @@ public class CoordinationMetaData implements Writeable, ToXContentFragment {
         return builder
             .field(TERM_PARSE_FIELD.getPreferredName(), term)
             .field(LAST_COMMITTED_CONFIGURATION_FIELD.getPreferredName(), lastCommittedConfiguration)
-                .field(LAST_ACCEPTED_CONFIGURATION_FIELD.getPreferredName(), lastAcceptedConfiguration)
-                .field(VOTING_TOMBSTONES_FIELD.getPreferredName(), votingTombstones);
+            .field(LAST_ACCEPTED_CONFIGURATION_FIELD.getPreferredName(), lastAcceptedConfiguration)
+            .field(VOTING_TOMBSTONES_FIELD.getPreferredName(), votingTombstones);
     }
 
     public static CoordinationMetaData fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -33,6 +33,7 @@ import org.elasticsearch.cluster.ClusterStateTaskConfig;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.coordination.CoordinationMetaData.VotingConfiguration;
+import org.elasticsearch.cluster.coordination.CoordinationMetaData.VotingTombstone;
 import org.elasticsearch.cluster.coordination.FollowersChecker.FollowerCheckRequest;
 import org.elasticsearch.cluster.coordination.JoinHelper.InitialJoinAccumulator;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -654,7 +655,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         final Set<DiscoveryNode> liveNodes = StreamSupport.stream(clusterState.nodes().spliterator(), false)
             .filter(this::hasJoinVoteFrom).collect(Collectors.toSet());
         final VotingConfiguration newConfig = reconfigurator.reconfigure(liveNodes,
-            clusterState.getVotingTombstones().stream().map(DiscoveryNode::getId).collect(Collectors.toSet()),
+            clusterState.getVotingTombstones().stream().map(VotingTombstone::getNodeId).collect(Collectors.toSet()),
             clusterState.getLastAcceptedConfiguration());
         if (newConfig.equals(clusterState.getLastAcceptedConfiguration()) == false) {
             assert coordinationState.get().joinVotesHaveQuorumFor(newConfig);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequestTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.CoordinationMetaData;
+import org.elasticsearch.cluster.coordination.CoordinationMetaData.VotingTombstone;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNode.Role;
@@ -55,20 +56,27 @@ public class AddVotingTombstonesRequestTests extends ESTestCase {
     public void testResolve() {
         final DiscoveryNode localNode
             = new DiscoveryNode("local", "local", buildNewFakeTransportAddress(), emptyMap(), singleton(Role.MASTER), Version.CURRENT);
+        final VotingTombstone localNodeTombstone = new VotingTombstone(localNode);
         final DiscoveryNode otherNode1
             = new DiscoveryNode("other1", "other1", buildNewFakeTransportAddress(), emptyMap(), singleton(Role.MASTER), Version.CURRENT);
+        final VotingTombstone otherNode1Tombstone = new VotingTombstone(otherNode1);
         final DiscoveryNode otherNode2
             = new DiscoveryNode("other2", "other2", buildNewFakeTransportAddress(), emptyMap(), singleton(Role.MASTER), Version.CURRENT);
+        final VotingTombstone otherNode2Tombstone = new VotingTombstone(otherNode2);
         final DiscoveryNode otherDataNode
             = new DiscoveryNode("data", "data", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
 
         final ClusterState clusterState = ClusterState.builder(new ClusterName("cluster")).nodes(new Builder()
             .add(localNode).add(otherNode1).add(otherNode2).add(otherDataNode).localNodeId(localNode.getId())).build();
 
-        assertThat(makeRequest().resolveNodes(clusterState), containsInAnyOrder(localNode, otherNode1, otherNode2));
-        assertThat(makeRequest("_all").resolveNodes(clusterState), containsInAnyOrder(localNode, otherNode1, otherNode2));
-        assertThat(makeRequest("_local").resolveNodes(clusterState), contains(localNode));
-        assertThat(makeRequest("other*").resolveNodes(clusterState), containsInAnyOrder(otherNode1, otherNode2));
+        assertThat(makeRequest().resolveNodes(clusterState),
+                containsInAnyOrder(localNodeTombstone, otherNode1Tombstone, otherNode2Tombstone));
+        assertThat(makeRequest("_all").resolveNodes(clusterState),
+                containsInAnyOrder(localNodeTombstone, otherNode1Tombstone, otherNode2Tombstone));
+        assertThat(makeRequest("_local").resolveNodes(clusterState),
+                contains(localNodeTombstone));
+        assertThat(makeRequest("other*").resolveNodes(clusterState),
+                containsInAnyOrder(otherNode1Tombstone, otherNode2Tombstone));
 
         assertThat(expectThrows(IllegalArgumentException.class, () -> makeRequest("not-a-node").resolveNodes(clusterState)).getMessage(),
             equalTo("add voting tombstones request for [not-a-node] matched no master-eligible nodes"));
@@ -77,20 +85,24 @@ public class AddVotingTombstonesRequestTests extends ESTestCase {
     public void testResolveAndCheckMaximum() {
         final DiscoveryNode localNode
             = new DiscoveryNode("local", "local", buildNewFakeTransportAddress(), emptyMap(), singleton(Role.MASTER), Version.CURRENT);
+        final VotingTombstone localNodeTombstone = new VotingTombstone(localNode);
         final DiscoveryNode otherNode1
             = new DiscoveryNode("other1", "other1", buildNewFakeTransportAddress(), emptyMap(), singleton(Role.MASTER), Version.CURRENT);
+        final VotingTombstone otherNode1Tombstone = new VotingTombstone(otherNode1);
         final DiscoveryNode otherNode2
             = new DiscoveryNode("other2", "other2", buildNewFakeTransportAddress(), emptyMap(), singleton(Role.MASTER), Version.CURRENT);
+        final VotingTombstone otherNode2Tombstone = new VotingTombstone(otherNode2);
 
         final ClusterState.Builder builder = ClusterState.builder(new ClusterName("cluster")).nodes(new Builder()
             .add(localNode).add(otherNode1).add(otherNode2).localNodeId(localNode.getId()));
-        builder.metaData(MetaData.builder().coordinationMetaData(CoordinationMetaData.builder().addVotingTombstone(otherNode1).build()));
+        builder.metaData(MetaData.builder()
+                .coordinationMetaData(CoordinationMetaData.builder().addVotingTombstone(otherNode1Tombstone).build()));
         final ClusterState clusterState = builder.build();
 
         assertThat(makeRequest().resolveNodesAndCheckMaximum(clusterState, 3, "setting.name"),
-            containsInAnyOrder(localNode, otherNode2));
+                containsInAnyOrder(localNodeTombstone, otherNode2Tombstone));
         assertThat(makeRequest("_local").resolveNodesAndCheckMaximum(clusterState, 2, "setting.name"),
-            contains(localNode));
+                contains(localNodeTombstone));
 
         assertThat(expectThrows(IllegalArgumentException.class,
             () -> makeRequest().resolveNodesAndCheckMaximum(clusterState, 2, "setting.name")).getMessage(),

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequestTests.java
@@ -78,8 +78,9 @@ public class AddVotingTombstonesRequestTests extends ESTestCase {
         assertThat(makeRequest("other*").resolveVotingTombstones(clusterState),
                 containsInAnyOrder(otherNode1Tombstone, otherNode2Tombstone));
 
-        assertThat(expectThrows(IllegalArgumentException.class, () -> makeRequest("not-a-node").resolveVotingTombstones(clusterState)).getMessage(),
-            equalTo("add voting tombstones request for [not-a-node] matched no master-eligible nodes"));
+        assertThat(expectThrows(IllegalArgumentException.class,
+                () -> makeRequest("not-a-node").resolveVotingTombstones(clusterState)).getMessage(),
+                    equalTo("add voting tombstones request for [not-a-node] matched no master-eligible nodes"));
     }
 
     public void testResolveAndCheckMaximum() {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequestTests.java
@@ -99,17 +99,17 @@ public class AddVotingTombstonesRequestTests extends ESTestCase {
                 .coordinationMetaData(CoordinationMetaData.builder().addVotingTombstone(otherNode1Tombstone).build()));
         final ClusterState clusterState = builder.build();
 
-        assertThat(makeRequest().resolveVotingTombstones(clusterState, 3, "setting.name"),
+        assertThat(makeRequest().resolveVotingTombstonesAndCheckMaximum(clusterState, 3, "setting.name"),
                 containsInAnyOrder(localNodeTombstone, otherNode2Tombstone));
-        assertThat(makeRequest("_local").resolveVotingTombstones(clusterState, 2, "setting.name"),
+        assertThat(makeRequest("_local").resolveVotingTombstonesAndCheckMaximum(clusterState, 2, "setting.name"),
                 contains(localNodeTombstone));
 
         assertThat(expectThrows(IllegalArgumentException.class,
-            () -> makeRequest().resolveVotingTombstones(clusterState, 2, "setting.name")).getMessage(),
+            () -> makeRequest().resolveVotingTombstonesAndCheckMaximum(clusterState, 2, "setting.name")).getMessage(),
             equalTo("add voting tombstones request for [] would add [2] voting tombstones to the existing [1] which would exceed the " +
                 "maximum of [2] set by [setting.name]"));
         assertThat(expectThrows(IllegalArgumentException.class,
-            () -> makeRequest("_local").resolveVotingTombstones(clusterState, 1, "setting.name")).getMessage(),
+            () -> makeRequest("_local").resolveVotingTombstonesAndCheckMaximum(clusterState, 1, "setting.name")).getMessage(),
             equalTo("add voting tombstones request for [_local] would add [1] voting tombstones to the existing [1] which would exceed " +
                 "the maximum of [1] set by [setting.name]"));
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingTombstonesRequestTests.java
@@ -69,16 +69,16 @@ public class AddVotingTombstonesRequestTests extends ESTestCase {
         final ClusterState clusterState = ClusterState.builder(new ClusterName("cluster")).nodes(new Builder()
             .add(localNode).add(otherNode1).add(otherNode2).add(otherDataNode).localNodeId(localNode.getId())).build();
 
-        assertThat(makeRequest().resolveNodes(clusterState),
+        assertThat(makeRequest().resolveVotingTombstones(clusterState),
                 containsInAnyOrder(localNodeTombstone, otherNode1Tombstone, otherNode2Tombstone));
-        assertThat(makeRequest("_all").resolveNodes(clusterState),
+        assertThat(makeRequest("_all").resolveVotingTombstones(clusterState),
                 containsInAnyOrder(localNodeTombstone, otherNode1Tombstone, otherNode2Tombstone));
-        assertThat(makeRequest("_local").resolveNodes(clusterState),
+        assertThat(makeRequest("_local").resolveVotingTombstones(clusterState),
                 contains(localNodeTombstone));
-        assertThat(makeRequest("other*").resolveNodes(clusterState),
+        assertThat(makeRequest("other*").resolveVotingTombstones(clusterState),
                 containsInAnyOrder(otherNode1Tombstone, otherNode2Tombstone));
 
-        assertThat(expectThrows(IllegalArgumentException.class, () -> makeRequest("not-a-node").resolveNodes(clusterState)).getMessage(),
+        assertThat(expectThrows(IllegalArgumentException.class, () -> makeRequest("not-a-node").resolveVotingTombstones(clusterState)).getMessage(),
             equalTo("add voting tombstones request for [not-a-node] matched no master-eligible nodes"));
     }
 
@@ -99,17 +99,17 @@ public class AddVotingTombstonesRequestTests extends ESTestCase {
                 .coordinationMetaData(CoordinationMetaData.builder().addVotingTombstone(otherNode1Tombstone).build()));
         final ClusterState clusterState = builder.build();
 
-        assertThat(makeRequest().resolveNodesAndCheckMaximum(clusterState, 3, "setting.name"),
+        assertThat(makeRequest().resolveVotingTombstones(clusterState, 3, "setting.name"),
                 containsInAnyOrder(localNodeTombstone, otherNode2Tombstone));
-        assertThat(makeRequest("_local").resolveNodesAndCheckMaximum(clusterState, 2, "setting.name"),
+        assertThat(makeRequest("_local").resolveVotingTombstones(clusterState, 2, "setting.name"),
                 contains(localNodeTombstone));
 
         assertThat(expectThrows(IllegalArgumentException.class,
-            () -> makeRequest().resolveNodesAndCheckMaximum(clusterState, 2, "setting.name")).getMessage(),
+            () -> makeRequest().resolveVotingTombstones(clusterState, 2, "setting.name")).getMessage(),
             equalTo("add voting tombstones request for [] would add [2] voting tombstones to the existing [1] which would exceed the " +
                 "maximum of [2] set by [setting.name]"));
         assertThat(expectThrows(IllegalArgumentException.class,
-            () -> makeRequest("_local").resolveNodesAndCheckMaximum(clusterState, 1, "setting.name")).getMessage(),
+            () -> makeRequest("_local").resolveVotingTombstones(clusterState, 1, "setting.name")).getMessage(),
             equalTo("add voting tombstones request for [_local] would add [1] voting tombstones to the existing [1] which would exceed " +
                 "the maximum of [1] set by [setting.name]"));
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
@@ -87,7 +87,8 @@ public class ClusterRerouteResponseTests extends ESTestCase {
                     "      \"cluster_coordination\" : {\n" +
                     "        \"term\" : 0,\n" +
                     "        \"last_committed_config\" : [ ],\n" +
-                    "        \"last_accepted_config\" : [ ]\n" +
+                    "        \"last_accepted_config\" : [ ],\n" +
+                    "        \"voting_tombstones\" : [ ]\n" +
                     "      },\n" +
                     "      \"templates\" : { },\n" +
                     "      \"indices\" : {\n" +
@@ -181,7 +182,8 @@ public class ClusterRerouteResponseTests extends ESTestCase {
                     "      \"cluster_coordination\" : {\n" +
                     "        \"term\" : 0,\n" +
                     "        \"last_committed_config\" : [ ],\n" +
-                    "        \"last_accepted_config\" : [ ]\n" +
+                    "        \"last_accepted_config\" : [ ],\n" +
+                    "        \"voting_tombstones\" : [ ]\n" +
                     "      },\n" +
                     "      \"templates\" : { },\n" +
                     "      \"indices\" : {\n" +

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
@@ -23,6 +23,7 @@ import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.coordination.CoordinationMetaData;
+import org.elasticsearch.cluster.coordination.CoordinationMetaData.VotingTombstone;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexGraveyard;
 import org.elasticsearch.cluster.metadata.IndexGraveyardTests;
@@ -207,7 +208,7 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
                 new CoordinationMetaData.VotingConfiguration(Sets.newHashSet(generateRandomStringArray(10, 10, false))));
         }
         if (randomBoolean()) {
-            metaBuilder.addVotingTombstone(randomNode("node-" + randomAlphaOfLength(10)));
+            metaBuilder.addVotingTombstone(new VotingTombstone(randomNode("node-" + randomAlphaOfLength(10))));
         }
         return builder;
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
@@ -416,7 +416,7 @@ public class MetaDataTests extends ESTestCase {
     }
 
     private Set<VotingTombstone> randomVotingTombstones() {
-        final int size = randomIntBetween(1, 10);
+        final int size = randomIntBetween(0, 10);
         final Set<VotingTombstone> nodes = new HashSet<>(size);
         while (nodes.size() < size) {
             assertTrue(nodes.add(new VotingTombstone(randomAlphaOfLength(10), randomAlphaOfLength(10))));


### PR DESCRIPTION
Today voting tombstones are stored in `CoordinationMetaData` as
`Set<DiscoveryNode>`.
`DiscoveryNode` is not a lightweight object and have a lot of fields.
It also has `toXContent` method, but no `fromXContent` method and the
output of `toXContent` is not enough to re-create `DiscoveryNode`
object.
And `votingTombstone` set should be persisted as a part of `MetaData`.
On the other hand, the only thing required from the tombstone is the
`nodeId`. 
This PR adds `VotingTombstone` class for voting tombstones, which
consists of two fields for now - `nodeId` and `nodeName`. It could be
extended/shrank in the future if needed.
This PR also resolves TODO's related to the voting tombstones xcontent
story.
Example of `CoordinationMetaData.toXContent` with voting tombstones:
```
{
  "term": 1,
  "last_committed_config": [
    "fkwLdOBvXSlgRTBfgNAL",
    "tmQiPGHvUxXzPkkCDSJo",
    "HhOmtQBZAThpHIGWhxpz",
    "qZHWGpoDNPYRNIiqKsDl"
  ],
  "last_accepted_config": [
    "lhqacKmriwhHGFZcvqbx",
    "MYysmBuROkvJRlDcusyd"
  ],
  "voting_tombstones": [
    {
      "node_id": "McjbZbRkEz",
      "node_name": "pdKIWeNJUO"
    },
    {
      "node_id": "cpXkVibGwo",
      "node_name": "UnCvFgdVsc"
    },
    {
      "node_id": "EylRNOztbc",
      "node_name": "ohOhkbMWZX"
    }
  ]
}
```