### PR TITLE
Always return false from `refreshNeeded` on ReadOnlyEngine

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -1000,7 +1000,7 @@ public abstract class Engine implements Closeable {
      */
     public abstract List<Segment> segments(boolean verbose);
 
-    public final boolean refreshNeeded() {
+    public boolean refreshNeeded() {
         if (store.tryIncRef()) {
             /*
               we need to inc the store here since we acquire a searcher and that might keep a file open on the

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -419,4 +419,9 @@ public class ReadOnlyEngine extends Engine {
     protected void processReaders(IndexReader reader, IndexReader previousReader) {
         searcherFactory.processReaders(reader, previousReader);
     }
+
+    @Override
+    public boolean refreshNeeded() {
+        return false;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -531,8 +531,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 long afterQueryTime = System.nanoTime();
                 operationListener.onQueryPhase(context, afterQueryTime - time);
                 QueryFetchSearchResult fetchSearchResult = executeFetchPhase(context, operationListener, afterQueryTime);
-                return new ScrollQueryFetchSearchResult(fetchSearchResult,
-                    context.shardTarget());
+                return new ScrollQueryFetchSearchResult(fetchSearchResult, context.shardTarget());
             } catch (Exception e) {
                 logger.trace("Fetch phase failed", e);
                 processFailure(context, e);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
@@ -205,11 +205,12 @@ public final class FrozenEngine extends ReadOnlyEngine {
                     assert false : "this is a read-only engine";
                 case "doc_stats":
                     assert false : "doc_stats are overwritten";
+                case "refresh_needed":
+                    assert false : "refresh_needed is always false";
                 case "segments":
                 case "segments_stats":
                 case "completion_stats":
-                case "refresh_needed":
-                    assert false : "refresh_needed is always false";
+
                 case "can_match": // special case for can_match phase - we use the cached point values reader
                     maybeOpenReader = false;
                     break;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
@@ -210,7 +210,6 @@ public final class FrozenEngine extends ReadOnlyEngine {
                 case "segments":
                 case "segments_stats":
                 case "completion_stats":
-
                 case "can_match": // special case for can_match phase - we use the cached point values reader
                     maybeOpenReader = false;
                     break;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
@@ -209,6 +209,7 @@ public final class FrozenEngine extends ReadOnlyEngine {
                 case "segments_stats":
                 case "completion_stats":
                 case "refresh_needed":
+                    assert false : "refresh_needed is always false";
                 case "can_match": // special case for can_match phase - we use the cached point values reader
                     maybeOpenReader = false;
                     break;


### PR DESCRIPTION
Acquiring a searcher is unnecessary to determine if a refresh is
necessary since read-only engines never refresh.

Closes #35785