### PR TITLE
Allow noop PutUser updates

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserRequest.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
@@ -179,5 +180,19 @@ public class PutUserRequest extends ActionRequest implements UserRequest, WriteR
             charBytesRef = new BytesArray(CharArrays.toUtf8Bytes(chars));
         }
         out.writeBytesReference(charBytesRef);
+    }
+
+    @Override
+    public String toString() {
+        return "PutUserRequest{" +
+            "username='" + username + '\'' +
+            ", roles=" + Arrays.toString(roles) +
+            ", fullName='" + fullName + '\'' +
+            ", email='" + email + '\'' +
+            ", metadata=" + metadata +
+            ", passwordHash=" + (passwordHash == null ? "<null>" : "<not-null>") +
+            ", enabled=" + enabled +
+            ", refreshPolicy=" + refreshPolicy +
+            '}';
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStore.java
@@ -341,7 +341,9 @@ public class NativeUsersStore {
                     new ActionListener<UpdateResponse>() {
                         @Override
                         public void onResponse(UpdateResponse updateResponse) {
-                            assert updateResponse.getResult() == DocWriteResponse.Result.UPDATED;
+                            assert updateResponse.getResult() == DocWriteResponse.Result.UPDATED
+                                || updateResponse.getResult() == DocWriteResponse.Result.NOOP
+                                : "Expected 'UPDATED' or 'NOOP' result [" + updateResponse + "] for request [" + putUserRequest + "]";
                             clearRealmCache(putUserRequest.username(), listener, false);
                         }
 


### PR DESCRIPTION
When assertions are enabled, a Put User action that has no effect (a
noop update) would trigger an assertion failure and shutdown the node.

This change accepts "noop" as an update result, and adds more
diagnostics to the assertion failure message.
