### PR TITLE
Types removal - PUT and GET IndexTemplates.

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
@@ -351,6 +351,7 @@ final class IndicesRequestConverters {
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
         RequestConverters.Params params = new RequestConverters.Params(request);
         params.withMasterTimeout(putIndexTemplateRequest.masterNodeTimeout());
+        params.putParam("include_type_name", Boolean.toString(putIndexTemplateRequest.isCustomTyped()));
         if (putIndexTemplateRequest.create()) {
             params.putParam("create", Boolean.TRUE.toString());
         }
@@ -395,6 +396,9 @@ final class IndicesRequestConverters {
         final RequestConverters.Params params = new RequestConverters.Params(request);
         params.withLocal(getIndexTemplatesRequest.isLocal());
         params.withMasterTimeout(getIndexTemplatesRequest.getMasterNodeTimeout());
+        if(getIndexTemplatesRequest.includeTypeNamesInResponse() == false) {
+            params.putParam("include_type_name", Boolean.toString(getIndexTemplatesRequest.includeTypeNamesInResponse()));            
+        }
         return request;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetIndexTemplatesRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetIndexTemplatesRequest.java
@@ -40,6 +40,7 @@ public class GetIndexTemplatesRequest implements Validatable {
 
     private TimeValue masterNodeTimeout = TimedRequest.DEFAULT_MASTER_NODE_TIMEOUT;
     private boolean local = false;
+    private boolean includeTypeNamesInResponse = true;
 
     /**
      * Create a request to read the content of one or more index templates. If no template names are provided, all templates will be read
@@ -96,4 +97,13 @@ public class GetIndexTemplatesRequest implements Validatable {
     public void setLocal(boolean local) {
         this.local = local;
     }
+    
+    
+    public boolean includeTypeNamesInResponse() {
+        return includeTypeNamesInResponse;
+    }
+
+    public void includeTypeNamesInResponse(boolean includeTypeNamesInResponse) {
+        this.includeTypeNamesInResponse = includeTypeNamesInResponse;
+    }    
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
@@ -817,14 +817,16 @@ public class IndicesRequestConvertersTests extends ESTestCase {
         if (ESTestCase.randomBoolean()) {
             putTemplateRequest.settings(Settings.builder().put("setting-" + ESTestCase.randomInt(), ESTestCase.randomTimeValue()));
         }
+        Map<String, String> expectedParams = new HashMap<>();
+        expectedParams.put("include_type_name", "false"); 
         if (ESTestCase.randomBoolean()) {
             putTemplateRequest.mapping("doc-" + ESTestCase.randomInt(),
                 "field-" + ESTestCase.randomInt(), "type=" + ESTestCase.randomFrom("text", "keyword"));
+            expectedParams.put("include_type_name", "true"); // Custom doc types will set the  "include_type_name" = true flag
         }
         if (ESTestCase.randomBoolean()) {
             putTemplateRequest.alias(new Alias("alias-" + ESTestCase.randomInt()));
         }
-        Map<String, String> expectedParams = new HashMap<>();
         if (ESTestCase.randomBoolean()) {
             expectedParams.put("create", Boolean.TRUE.toString());
             putTemplateRequest.create(true);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -2119,16 +2119,14 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
 
         {
             // tag::put-template-request-mappings-json
-            request.mapping("_doc", // <1>
+            request.mappingNoDocType(
                 "{\n" +
-                    "  \"_doc\": {\n" +
-                    "    \"properties\": {\n" +
-                    "      \"message\": {\n" +
-                    "        \"type\": \"text\"\n" +
-                    "      }\n" +
+                    "  \"properties\": {\n" +
+                    "    \"message\": {\n" +
+                    "      \"type\": \"text\"\n" +
                     "    }\n" +
                     "  }\n" +
-                    "}", // <2>
+                    "}", // <1>
                 XContentType.JSON);
             // end::put-template-request-mappings-json
             assertTrue(client.indices().putTemplate(request, RequestOptions.DEFAULT).isAcknowledged());
@@ -2136,14 +2134,16 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         {
             //tag::put-template-request-mappings-map
             Map<String, Object> jsonMap = new HashMap<>();
-            Map<String, Object> message = new HashMap<>();
-            message.put("type", "text");
-            Map<String, Object> properties = new HashMap<>();
-            properties.put("message", message);
-            Map<String, Object> mapping = new HashMap<>();
-            mapping.put("properties", properties);
-            jsonMap.put("_doc", mapping);
-            request.mapping("_doc", jsonMap); // <1>
+            {
+                Map<String, Object> properties = new HashMap<>();
+                {
+                    Map<String, Object> message = new HashMap<>();
+                    message.put("type", "text");
+                    properties.put("message", message);
+                }
+                jsonMap.put("properties", properties);                
+            }
+            request.mapping(jsonMap); // <1>
             //end::put-template-request-mappings-map
             assertTrue(client.indices().putTemplate(request, RequestOptions.DEFAULT).isAcknowledged());
         }
@@ -2152,28 +2152,24 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.startObject();
             {
-                builder.startObject("_doc");
+                builder.startObject("properties");
                 {
-                    builder.startObject("properties");
+                    builder.startObject("message");
                     {
-                        builder.startObject("message");
-                        {
-                            builder.field("type", "text");
-                        }
-                        builder.endObject();
+                        builder.field("type", "text");
                     }
                     builder.endObject();
                 }
                 builder.endObject();
             }
             builder.endObject();
-            request.mapping("_doc", builder); // <1>
+            request.mappingNoDocType(builder); // <1>
             //end::put-template-request-mappings-xcontent
             assertTrue(client.indices().putTemplate(request, RequestOptions.DEFAULT).isAcknowledged());
         }
         {
             //tag::put-template-request-mappings-shortcut
-            request.mapping("_doc", "message", "type=text"); // <1>
+            request.simplifiedMapping("message", "type=text"); // <1>
             //end::put-template-request-mappings-shortcut
             assertTrue(client.indices().putTemplate(request, RequestOptions.DEFAULT).isAcknowledged());
         }
@@ -2192,7 +2188,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         // end::put-template-request-version
 
         // tag::put-template-whole-source
-        request.source("{\n" +
+        request.sourceNoDocTypes("{\n" +
             "  \"index_patterns\": [\n" +
             "    \"log-*\",\n" +
             "    \"pattern-1\"\n" +
@@ -2202,11 +2198,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             "    \"number_of_shards\": 1\n" +
             "  },\n" +
             "  \"mappings\": {\n" +
-            "    \"_doc\": {\n" +
-            "      \"properties\": {\n" +
-            "        \"message\": {\n" +
-            "          \"type\": \"text\"\n" +
-            "        }\n" +
+            "    \"properties\": {\n" +
+            "      \"message\": {\n" +
+            "        \"type\": \"text\"\n" +
             "      }\n" +
             "    }\n" +
             "  },\n" +
@@ -2269,13 +2263,11 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest("my-template");
             putRequest.patterns(Arrays.asList("pattern-1", "log-*"));
             putRequest.settings(Settings.builder().put("index.number_of_shards", 3).put("index.number_of_replicas", 1));
-            putRequest.mapping("_doc",
+            putRequest.mappingNoDocType(
                     "{\n" +
-                    "  \"_doc\": {\n" +
-                    "    \"properties\": {\n" +
-                    "      \"message\": {\n" +
-                    "        \"type\": \"text\"\n" +
-                    "      }\n" +
+                    "  \"properties\": {\n" +
+                    "    \"message\": {\n" +
+                    "      \"type\": \"text\"\n" +
                     "    }\n" +
                     "  }\n" +
                     "}", XContentType.JSON);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
@@ -278,7 +278,7 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
             client.security().putUserAsync(request, RequestOptions.DEFAULT, listener); // <1>
             // end::put-user-execute-async
 
-            assertTrue(latch.await(30L, TimeUnit.SECONDS));
+            assertTrue(latch.await(30L, TimeUnit.SECONDS));            
         }
     }
 

--- a/docs/java-rest/high-level/indices/put_template.asciidoc
+++ b/docs/java-rest/high-level/indices/put_template.asciidoc
@@ -39,8 +39,7 @@ template's patterns.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request-mappings-json]
 --------------------------------------------------
-<1> The type to define
-<2> The mapping for this type, provided as a JSON string
+<1> The mapping for this type, provided as a JSON string
 
 The mapping source can be provided in different ways in addition to the
 `String` example shown above:

--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -16,25 +16,23 @@ For example:
 
 [source,js]
 --------------------------------------------------
-PUT _template/template_1
+PUT _template/template_1?include_type_name=false
 {
   "index_patterns": ["te*", "bar*"],
   "settings": {
     "number_of_shards": 1
   },
   "mappings": {
-    "_doc": {
-      "_source": {
-        "enabled": false
+    "_source": {
+      "enabled": false
+    },
+    "properties": {
+      "host_name": {
+        "type": "keyword"
       },
-      "properties": {
-        "host_name": {
-          "type": "keyword"
-        },
-        "created_at": {
-          "type": "date",
-          "format": "EEE MMM dd HH:mm:ss Z yyyy"
-        }
+      "created_at": {
+        "type": "date",
+        "format": "EEE MMM dd HH:mm:ss Z yyyy"
       }
     }
   }
@@ -49,6 +47,11 @@ everywhere in the JSON document except before the initial opening curly bracket.
 Defines a template named `template_1`, with a template pattern of `te*` or `bar*`.
 The settings and mappings will be applied to any index name that matches
 the `te*` or `bar*` pattern.
+
+NOTE: This mapping example uses a "typeless" format new to 7.0.
+Previous versions of elasticsearch included document type names in the "mappings"section 
+but here we have set the `include_type_name=false` parameter in the URL to use the new format.
+The old approach of including type names in mappings is still supported but is now deprecated.
 
 It is also possible to include aliases in an index template as follows:
 
@@ -149,7 +152,7 @@ orders overriding them. For example:
 
 [source,js]
 --------------------------------------------------
-PUT /_template/template_1
+PUT /_template/template_1?include_type_name=false
 {
     "index_patterns" : ["*"],
     "order" : 0,
@@ -157,13 +160,11 @@ PUT /_template/template_1
         "number_of_shards" : 1
     },
     "mappings" : {
-        "_doc" : {
-            "_source" : { "enabled" : false }
-        }
+        "_source" : { "enabled" : false }
     }
 }
 
-PUT /_template/template_2
+PUT /_template/template_2?include_type_name=false
 {
     "index_patterns" : ["te*"],
     "order" : 1,
@@ -171,9 +172,7 @@ PUT /_template/template_2
         "number_of_shards" : 1
     },
     "mappings" : {
-        "_doc" : {
-            "_source" : { "enabled" : true }
-        }
+        "_source" : { "enabled" : true }
     }
 }
 --------------------------------------------------
@@ -188,6 +187,11 @@ order templates, with lower order templates providing the basis.
 
 NOTE: Multiple matching templates with the same order value will 
 result in a non-deterministic merging order.
+
+NOTE: This mapping example uses the "typeless" format new to 7.0.
+Previous versions of elasticsearch included document type names in the "mappings"section 
+but here we have set the `include_type_name=false` parameter in the URL to use the new format.
+The old approach of including type names in mappings is still supported but is now deprecated.
 
 [float]
 [[versioning-templates]]

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.rest.action.admin.indices.RestPutIndexTemplateAction;
 import org.elasticsearch.rest.action.document.RestGetAction;
 import org.elasticsearch.rest.action.document.RestUpdateAction;
 import org.elasticsearch.rest.action.search.RestExplainAction;
@@ -899,8 +900,11 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         templateBuilder.endObject().endObject();
         Request createTemplateRequest = new Request("PUT", "/_template/test_template");
         createTemplateRequest.setJsonEntity(Strings.toString(templateBuilder));
+        createTemplateRequest.setOptions(expectWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE));
+        if (false == isRunningAgainstOldCluster()) {        
+            createTemplateRequest.addParameter("include_type_name", Boolean.TRUE.toString());
+        }
         client().performRequest(createTemplateRequest);
-
         if (isRunningAgainstOldCluster()) {
             // Create the repo
             XContentBuilder repoConfig = JsonXContent.contentBuilder().startObject(); {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
@@ -16,6 +16,10 @@
         }
       },
       "params": {
+        "include_type_name": {
+          "type" : "boolean",
+          "description" : "Whether a type should be returned in the body of the mappings. (default: true)"
+        },
         "flat_settings": {
           "type": "boolean",
           "description": "Return settings in flat format (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -33,6 +33,10 @@
         "flat_settings": {
            "type": "boolean",
            "description": "Return settings in flat format (default: false)"
+        },
+        "include_type_name": {
+          "type" : "boolean",
+          "description" : "Whether a type is included in the body of the mappings. (default: true)"
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_template/10_basic.yml
@@ -199,3 +199,79 @@
       indices.put_template:
         name: test
         body: {}
+
+---
+"Put template with mappings and doc type":
+  - do:
+      indices.put_template:
+        name: test
+        body:
+          index_patterns: test-*
+          mappings:
+            _doc:
+              properties:
+                description:
+                  type: "text"
+  - do:
+      indices.get_template:
+        name: test
+  - match: {test.index_patterns: ["test-*"]}
+  - match: {test.mappings._doc.properties.description.type: text}
+
+---
+"Put template with mappings and no doc type":
+  - skip:
+      version: " - 6.99.99"
+      reason:  this uses a new API that has been added in 7.0
+  - do:
+      indices.put_template:
+        name: test
+        include_type_name: false
+        body:
+          index_patterns: test-*
+          mappings:
+              properties:
+                description:
+                    type: "text"
+  - do:
+      indices.get_template:
+        name: test
+  - match: {test.index_patterns: ["test-*"]}
+  - match: {test.mappings._doc.properties.description.type: text}
+
+  # Also test we can GET without the type
+  - do:
+      indices.get_template:
+        name: test
+        include_type_name: false
+  - match: {test.index_patterns: ["test-*"]}
+  - match: {test.mappings.properties.description.type: text}
+
+---
+"Put template with mappings no doc type and no fields":
+  - skip:
+      version: " - 6.99.99"
+      reason:  this uses a new API that has been added in 7.0
+  - do:
+      indices.put_template:
+        name: test
+        include_type_name: false
+        body:
+          index_patterns: test-*
+          mappings:
+            _source:
+              enabled: false
+  - do:
+      indices.get_template:
+        name: test
+  - match: {test.index_patterns: ["test-*"]}
+  - match: {test.mappings._doc._source.enabled: false}
+
+  # Also test we can GET without the type
+  - do:
+      indices.get_template:
+        name: test
+        include_type_name: false
+  - match: {test.index_patterns: ["test-*"]}
+  - match: {test.mappings._source.enabled: false}
+

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
@@ -34,6 +34,8 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public class GetIndexTemplatesRequest extends MasterNodeReadRequest<GetIndexTemplatesRequest> {
 
     private String[] names;
+    
+    private boolean includeTypeNamesInResponse = true;
 
     public GetIndexTemplatesRequest() {
     }
@@ -45,6 +47,14 @@ public class GetIndexTemplatesRequest extends MasterNodeReadRequest<GetIndexTemp
     public GetIndexTemplatesRequest(StreamInput in) throws IOException {
         super(in);
         names = in.readStringArray();
+    }
+    
+    public boolean includeTypeNamesInResponse() {
+        return includeTypeNamesInResponse;
+    }
+
+    public void includeTypeNamesInResponse(boolean includeTypeNamesInResponse) {
+        this.includeTypeNamesInResponse = includeTypeNamesInResponse;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndexTemplateAction.java
@@ -58,8 +58,9 @@ public class RestGetIndexTemplateAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         final String[] names = Strings.splitStringByCommaToArray(request.param("name"));
-
+        
         final GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest(names);
+        getIndexTemplatesRequest.includeTypeNamesInResponse(request.paramAsBoolean("include_type_name", true));
         getIndexTemplatesRequest.local(request.paramAsBoolean("local", getIndexTemplatesRequest.local()));
         getIndexTemplatesRequest.masterNodeTimeout(request.paramAsTime("master_timeout", getIndexTemplatesRequest.masterNodeTimeout()));
 

--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/indexlifecycle/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/indexlifecycle/TimeSeriesLifecycleActionsIT.java
@@ -455,6 +455,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
         Request templateRequest = new Request("PUT", "_template/test");
+        templateRequest.addParameter("include_type_name", Boolean.FALSE.toString());
         templateRequest.setEntity(template);
         client().performRequest(templateRequest);
 


### PR DESCRIPTION
Add support for the `include_type_name` flag.
For HLRC support PutIndexTemplateRequest now includes checks to change the toXContent format if it looks like custom doc types are used in mappings.
