### PR TITLE
TESTS: Disable Snapshot Repo Verify in BwC Test

### DIFF
--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
@@ -3,6 +3,8 @@
   - do:
       snapshot.create_repository:
         repository: my_repo
+        # TODO: Reenable verify
+        verify: false
         body:
           type: url
           settings:


### PR DESCRIPTION
* Disable snapshot repo verification temporarily because it runs into HTTP-500 in 6.6.0-SNAPSHOT
* Relates #35874

