### PR TITLE
Fields are declared at the top of the class.

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupUtility.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupUtility.java
@@ -72,6 +72,21 @@ import java.util.Objects;
  * </ul>
  */
 public final class PainlessLookupUtility {
+    
+    /**
+     * The name for an anonymous class.
+     */
+    public static final String ANONYMOUS_CLASS_NAME = "$anonymous";
+
+    /**
+     * The def type name as specified in the source for a script.
+     */
+    public static final String DEF_CLASS_NAME = "def";
+
+    /**
+     * The method name for all constructors.
+     */
+    public static final String CONSTRUCTOR_NAME = "<init>";
 
     /**
      * Converts a canonical type name to a type based on the terminology specified as part of the documentation for
@@ -343,22 +358,7 @@ public final class PainlessLookupUtility {
     public static String buildPainlessFieldKey(String fieldName) {
         return fieldName;
     }
-
-    /**
-     * The name for an anonymous class.
-     */
-    public static final String ANONYMOUS_CLASS_NAME = "$anonymous";
-
-    /**
-     * The def type name as specified in the source for a script.
-     */
-    public static final String DEF_CLASS_NAME = "def";
-
-    /**
-     * The method name for all constructors.
-     */
-    public static final String CONSTRUCTOR_NAME = "<init>";
-
+    
     private PainlessLookupUtility() {
 
     }


### PR DESCRIPTION
According to Java Code Pattern :
Fields should be declared at the top of the class, before any method declarations, constructors, initializers or inner classes.