### PR TITLE
[Docs] Align callouts in search.asciidoc

### DIFF
--- a/docs/java-api/search.asciidoc
+++ b/docs/java-api/search.asciidoc
@@ -210,12 +210,12 @@ To execute a stored templates, use `ScriptService.ScriptType.STORED`:
 [source,java]
 --------------------------------------------------
 SearchResponse sr = new SearchTemplateRequestBuilder(client)
-        .setScript("template_gender")                       <1>
+        .setScript("template_gender")         <1>
         .setScriptType(ScriptType.STORED)     <2>
-        .setScriptParams(template_params)                   <3>
-        .setRequest(new SearchRequest())                    <4>
-        .get()                                              <5>
-        .getResponse();                                     <6>
+        .setScriptParams(template_params)     <3>
+        .setRequest(new SearchRequest())      <4>
+        .get()                                <5>
+        .getResponse();                       <6>
 --------------------------------------------------
 <1> template name
 <2> template stored in the cluster state
@@ -229,7 +229,7 @@ You can also execute inline templates:
 [source,java]
 --------------------------------------------------
 sr = new SearchTemplateRequestBuilder(client)
-        .setScript("{\n" +                                  <1>
+        .setScript("{\n" +                   <1>
                 "        \"query\" : {\n" +
                 "            \"match\" : {\n" +
                 "                \"gender\" : \"{{param_gender}}\"\n" +
@@ -237,10 +237,10 @@ sr = new SearchTemplateRequestBuilder(client)
                 "        }\n" +
                 "}")
         .setScriptType(ScriptType.INLINE)    <2>
-        .setScriptParams(template_params)                  <3>
-        .setRequest(new SearchRequest())                   <4>
-        .get()                                             <5>
-        .getResponse();                                    <6>
+        .setScriptParams(template_params)    <3>
+        .setRequest(new SearchRequest())     <4>
+        .get()                               <5>
+        .getResponse();                      <6>
 --------------------------------------------------
 <1> template's body
 <2> template is passed inline


### PR DESCRIPTION
The callouts on the search page are bit messy. This aligns them.