### PR TITLE
[TEST] Fix painless negative scores yml test 

### DIFF
--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/30_search.yml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/30_search.yml
@@ -464,6 +464,7 @@
         catch: bad_request
         search:
             index: test
+            allow_partial_search_results: false
             body:
                 query:
                     function_score:


### PR DESCRIPTION
Add `allow_partial_search_results` to also throw an error if the number of shards is `>` 1

Closes #35904