### PR TITLE
Remove deprecated methods from QueryStringQueryBuilder

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -251,22 +251,6 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
     }
 
     /**
-     * This setting is deprecated, set {@link #defaultField(String)} to "*" instead.
-     */
-    @Deprecated
-    public QueryStringQueryBuilder useAllFields(Boolean useAllFields) {
-        if (useAllFields != null && useAllFields) {
-            this.defaultField = "*";
-        }
-        return this;
-    }
-
-    @Deprecated
-    public Boolean useAllFields() {
-        return defaultField == null ? null : Regex.isMatchAllPattern(defaultField);
-    }
-
-    /**
      * Adds a field to run the query string against. The field will be associated with the
      * default boost of {@link AbstractQueryBuilder#DEFAULT_BOOST}.
      * Use {@link #field(String, float)} to set a specific boost for the field.
@@ -303,22 +287,6 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
     public QueryStringQueryBuilder type(MultiMatchQueryBuilder.Type type) {
         this.type = type;
         return this;
-    }
-
-    /**
-     * Use {@link QueryStringQueryBuilder#tieBreaker} instead.
-     */
-    @Deprecated
-    public QueryStringQueryBuilder useDisMax(boolean useDisMax) {
-        return this;
-    }
-
-    /**
-     * Use {@link QueryStringQueryBuilder#tieBreaker} instead.
-     */
-    @Deprecated
-    public boolean useDisMax() {
-        return true;
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -158,9 +158,6 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             queryStringQueryBuilder.minimumShouldMatch(randomMinimumShouldMatch());
         }
         if (randomBoolean()) {
-            queryStringQueryBuilder.useDisMax(randomBoolean());
-        }
-        if (randomBoolean()) {
             queryStringQueryBuilder.timeZone(randomDateTimeZone().getID());
         }
         if (randomBoolean()) {

--- a/server/src/test/java/org/elasticsearch/search/query/QueryStringIT.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryStringIT.java
@@ -252,7 +252,6 @@ public class QueryStringIT extends ESIntegTestCase {
     public void testBooleanStrictQuery() throws Exception {
         Exception e = expectThrows(Exception.class,
                 () -> client().prepareSearch("test").setQuery(queryStringQuery("foo").field("f_bool")).get());
-        System.out.println(e);
         assertThat(ExceptionsHelper.unwrap(e, IllegalArgumentException.class).getMessage(),
                 containsString("Can't parse boolean value [foo], expected [true] or [false]"));
     }

--- a/server/src/test/java/org/elasticsearch/search/query/QueryStringIT.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryStringIT.java
@@ -250,10 +250,10 @@ public class QueryStringIT extends ESIntegTestCase {
     }
 
     public void testBooleanStrictQuery() throws Exception {
-        Exception e = expectThrows(Exception.class, () ->
-                client().prepareSearch("test").setQuery(
-                        queryStringQuery("foo").field("f_bool")).get());
-        assertThat(ExceptionsHelper.detailedMessage(e),
+        Exception e = expectThrows(Exception.class,
+                () -> client().prepareSearch("test").setQuery(queryStringQuery("foo").field("f_bool")).get());
+        System.out.println(e);
+        assertThat(ExceptionsHelper.unwrap(e, IllegalArgumentException.class).getMessage(),
                 containsString("Can't parse boolean value [foo], expected [true] or [false]"));
     }
 
@@ -261,8 +261,7 @@ public class QueryStringIT extends ESIntegTestCase {
         Exception e = expectThrows(Exception.class, () ->
                 client().prepareSearch("test").setQuery(
                         queryStringQuery("f_date:[now-2D TO now]").lenient(false)).get());
-        assertThat(ExceptionsHelper.detailedMessage(e),
-                containsString("unit [D] not supported for date math [-2D]"));
+        assertThat(e.getCause().getMessage(), containsString("unit [D] not supported for date math [-2D]"));
     }
 
     public void testLimitOnExpandedFields() throws Exception {
@@ -288,11 +287,11 @@ public class QueryStringIT extends ESIntegTestCase {
         Exception e = expectThrows(Exception.class, () -> {
                 QueryStringQueryBuilder qb = queryStringQuery("bar");
                 if (randomBoolean()) {
-                    qb.useAllFields(true);
+                    qb.defaultField("*");
                 }
                 client().prepareSearch("toomanyfields").setQuery(qb).get();
                 });
-        assertThat(ExceptionsHelper.detailedMessage(e),
+        assertThat(ExceptionsHelper.unwrap(e, IllegalArgumentException.class).getMessage(),
                 containsString("field expansion matches too many fields, limit: " + CLUSTER_MAX_CLAUSE_COUNT + ", got: "
                         + (CLUSTER_MAX_CLAUSE_COUNT + 1)));
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/query/QueryStringQuery.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/query/QueryStringQuery.java
@@ -37,7 +37,6 @@ public class QueryStringQuery extends LeafQuery {
         appliers.put("lowercase_expanded_terms", (qb, s) -> {});
         appliers.put("enable_position_increments", (qb, s) -> qb.enablePositionIncrements(Booleans.parseBoolean(s)));
         appliers.put("escape", (qb, s) -> qb.escape(Booleans.parseBoolean(s)));
-        appliers.put("use_dis_max", (qb, s) -> qb.useDisMax(Booleans.parseBoolean(s)));
         appliers.put("fuzzy_prefix_length", (qb, s) -> qb.fuzzyPrefixLength(Integer.valueOf(s)));
         appliers.put("fuzzy_max_expansions", (qb, s) -> qb.fuzzyMaxExpansions(Integer.valueOf(s)));
         appliers.put("fuzzy_rewrite", (qb, s) -> qb.fuzzyRewrite(s));
@@ -50,7 +49,6 @@ public class QueryStringQuery extends LeafQuery {
         appliers.put("lenient", (qb, s) -> qb.lenient(Booleans.parseBoolean(s)));
         appliers.put("locale", (qb, s) -> {});
         appliers.put("time_zone", (qb, s) -> qb.timeZone(s));
-        appliers.put("all_fields", (qb, s) -> qb.useAllFields(Booleans.parseBoolean(s)));
         appliers.put("type", (qb, s) -> qb.type(MultiMatchQueryBuilder.Type.parse(s, LoggingDeprecationHandler.INSTANCE)));
         appliers.put("auto_generate_synonyms_phrase_query", (qb, s) -> qb.autoGenerateSynonymsPhraseQuery(Booleans.parseBoolean(s)));
         appliers.put("fuzzy_transpositions", (qb, s) -> qb.fuzzyTranspositions(Booleans.parseBoolean(s)));


### PR DESCRIPTION
This change removes the deprecated useDisMax() and useAllFields() methods from
the QueryStringQueryBuilder and related tests. The disMax parameter has already
been a no-op since 6.0 and also the useAllFields has been deprecated since 6.0
and there is a direct replacement via defaultField, so it should be okay to
directly remove them.
