### PR TITLE
Scripting: Add back joda to whitelist

### DIFF
--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/joda.time.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/joda.time.txt
@@ -1,0 +1,60 @@
+#
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Painless definition file. This defines the hierarchy of classes,
+# what methods and fields they have, etc.
+#
+
+# NOTE: this just minimal whitelisting of joda time, just to provide
+# convenient access via the scripting API. classes are fully qualified to avoid
+# any confusion with java.time
+
+class org.joda.time.ReadableInstant {
+  boolean equals(Object)
+  long getMillis()
+  int hashCode()
+  boolean isAfter(org.joda.time.ReadableInstant)
+  boolean isBefore(org.joda.time.ReadableInstant)
+  boolean isEqual(org.joda.time.ReadableInstant)
+  String toString()
+}
+
+class org.joda.time.ReadableDateTime {
+  int getCenturyOfEra()
+  int getDayOfMonth()
+  int getDayOfWeek()
+  int getDayOfYear()
+  int getEra()
+  int getHourOfDay()
+  int getMillisOfDay()
+  int getMillisOfSecond()
+  int getMinuteOfDay()
+  int getMinuteOfHour()
+  int getMonthOfYear()
+  int getSecondOfDay()
+  int getSecondOfMinute()
+  int getWeekOfWeekyear()
+  int getWeekyear()
+  int getYear()
+  int getYearOfCentury()
+  int getYearOfEra()
+  String toString(String)
+  String toString(String,Locale)
+}


### PR DESCRIPTION
Watcher still exposes some dates as joda DateTime objects. This commit
adds back joda to the painless whitelist so they can still be accessed.

closes #35913