### PR TITLE
[Zen2] Manage DiscoveryModule with Guice

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/NodeService.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeService.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.node;
 
+import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
@@ -61,7 +62,8 @@ public class NodeService implements Closeable {
 
     private final Discovery discovery;
 
-    NodeService(Settings settings, ThreadPool threadPool, MonitorService monitorService, Discovery discovery,
+    @Inject
+    public NodeService(Settings settings, ThreadPool threadPool, MonitorService monitorService, Discovery discovery,
                 TransportService transportService, IndicesService indicesService, PluginsService pluginService,
                 CircuitBreakerService circuitBreakerService, ScriptService scriptService,
                 @Nullable HttpServerTransport httpServerTransport, IngestService ingestService, ClusterService clusterService,


### PR DESCRIPTION
Today `DiscoveryModule` object is instantiated manually inside `Node`
class. 
Manually instantiated objects have a problem, that all of the
dependencies of these classes should be created manually.
Sadly, it's not always possible with current Elasticsearch
architecture. For example, in order to implement proper state recovery,
`GatewayService` should behave differently based on `DiscoveryType`. If
`Zen` discovery is used old behaviour is acceptable, if `Zen2`
discovery is used it should be different. So there're the following
options:
1. No DI, `ZenDiscovery` and `Coordinator` are responsible for their
own `GatewayService` instance creation. How to satisfy `GatewayService`
dependencies in this case? (for zen)
2. `GatewayService` accepts `Discovery` object as a parameter and
performs explicit `instanceof` to choose the behaviour. It's not clean,
`GatewayService` should know about different discovery types.
3. `GatewayService` accepts `Discovery` object as a parameter and asks
`Discovery` object to return a function that accepts gateway and can
perform recovery. In this case, we should add a method that returns
such function to `Discovery` interface, that is not acceptable.
4. Use DI for `DiscoveryModule`.

This PR examines 4th approach.