### PR TITLE
Enhance multiple data path shard allocation strategy

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -79,7 +79,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -346,22 +346,9 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             }
 
             if (path == null) {
-                // TODO: we should, instead, hold a "bytes reserved" of how large we anticipate this shard will be, e.g. for a shard
-                // that's being relocated/replicated we know how large it will become once it's done copying:
-                // Count up how many shards are currently on each data path:
-                Map<Path, Integer> dataPathToShardCount = new HashMap<>();
-                for (IndexShard shard : this) {
-                    Path dataPath = shard.shardPath().getRootStatePath();
-                    Integer curCount = dataPathToShardCount.get(dataPath);
-                    if (curCount == null) {
-                        curCount = 0;
-                    }
-                    dataPathToShardCount.put(dataPath, curCount + 1);
-                }
                 path = ShardPath.selectNewPathForShard(nodeEnv, shardId, this.indexSettings,
                     routing.getExpectedShardSize() == ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE
-                        ? getAvgShardSizeInBytes() : routing.getExpectedShardSize(),
-                    dataPathToShardCount);
+                        ? getAvgShardSizeInBytes() : routing.getExpectedShardSize());
                 logger.debug("{} creating using a new path [{}]", shardId, path);
             } else {
                 logger.debug("{} creating using an existing path [{}]", shardId, path);


### PR DESCRIPTION
Current 6.x including master branch have issue with shard path allocation strategy in multiple data path scenario. If one of the path has most free space left, it will be allocated several times of shards compare to other path which would cause IO performance imbalance.

Current code logic tries to use three level compare to sort multiple paths during selecting path.
1. Shard count of current index on each data path.
2. Total shard count over all indices on each data path.
3. Free space on each data path.

But for second condition, **this count get from IndexService.java line 352-360, it's only count shard number for current index.** So the first and second condition should be the same.

I moved calculating shard count for each path logic into ShardPath.java, and work through data path to calculate shard count, current index shard count and free space for each path together.
NewPathForShardTests.java test case also has been updated, I think we don't need to pass dataPathToShardCount parameter anymore, instead we should calculate it internally. 

Thanks,
Howard