### PR TITLE
Fix mutator in GetRolesRequestTests

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/GetRolesRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/GetRolesRequestTests.java
@@ -47,6 +47,7 @@ public class GetRolesRequestTests extends ESTestCase {
     }
 
     private static GetRolesRequest mutateTestItem(GetRolesRequest original) {
-        return new GetRolesRequest(randomArray(0, 5, String[]::new, () -> randomAlphaOfLength(5)));
+        final int minRoles = original.getRoleNames().isEmpty() ? 1 : 0;
+        return new GetRolesRequest(randomArray(minRoles, 5, String[]::new, () -> randomAlphaOfLength(6)));
     }
 }


### PR DESCRIPTION
There was no guarantee that the mutated object would not be the same
as the original object (and was for seed 6A8C4CBF63B5AA63)
