### PR TITLE
ActiveShardCount should not fail when closing the index

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/ActiveShardCount.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ActiveShardCount.java
@@ -162,6 +162,7 @@ public final class ActiveShardCount implements Writeable {
                 // and we can stop waiting
                 continue;
             }
+            assert indexRoutingTable != null;
             if (indexRoutingTable.allPrimaryShardsActive() == false) {
                 // all primary shards aren't active yet
                 return false;

--- a/server/src/main/java/org/elasticsearch/action/support/ActiveShardCount.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ActiveShardCount.java
@@ -156,7 +156,12 @@ public final class ActiveShardCount implements Writeable {
                 continue;
             }
             final IndexRoutingTable indexRoutingTable = clusterState.routingTable().index(indexName);
-            assert indexRoutingTable != null;
+            if (indexRoutingTable == null && indexMetaData.getState() == IndexMetaData.State.CLOSE) {
+                // its possible the index was closed while waiting for active shard copies,
+                // in this case, we'll just consider it that we have enough active shard copies
+                // and we can stop waiting
+                continue;
+            }
             if (indexRoutingTable.allPrimaryShardsActive() == false) {
                 // all primary shards aren't active yet
                 return false;

--- a/server/src/test/java/org/elasticsearch/action/support/ActiveShardCountTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ActiveShardCountTests.java
@@ -172,7 +172,7 @@ public class ActiveShardCountTests extends ESTestCase {
         final int numberOfReplicas = randomIntBetween(4, 7);
 
         final ClusterState clusterState = initializeWithClosedIndex(indexName, numberOfShards, numberOfReplicas);
-        for (ActiveShardCount waitForActiveShards : Arrays.asList(ActiveShardCount.DEFAULT,ActiveShardCount.ALL, ActiveShardCount.ONE)) {
+        for (ActiveShardCount waitForActiveShards : Arrays.asList(ActiveShardCount.DEFAULT, ActiveShardCount.ALL, ActiveShardCount.ONE)) {
             assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/support/ActiveShardCountTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ActiveShardCountTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 /**
  * Tests for the {@link ActiveShardCount} class
@@ -165,6 +166,17 @@ public class ActiveShardCountTests extends ESTestCase {
         assertEquals("activeShardCount cannot be negative", e.getMessage());
     }
 
+    public void testEnoughShardsActiveWithClosedIndex() {
+        final String indexName = "test-idx";
+        final int numberOfShards = randomIntBetween(1, 5);
+        final int numberOfReplicas = randomIntBetween(4, 7);
+
+        final ClusterState clusterState = initializeWithClosedIndex(indexName, numberOfShards, numberOfReplicas);
+        for (ActiveShardCount waitForActiveShards : Arrays.asList(ActiveShardCount.DEFAULT,ActiveShardCount.ALL, ActiveShardCount.ONE)) {
+            assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        }
+    }
+
     private void runTestForOneActiveShard(final ActiveShardCount activeShardCount) {
         final String indexName = "test-idx";
         final int numberOfShards = randomIntBetween(1, 5);
@@ -190,6 +202,18 @@ public class ActiveShardCountTests extends ESTestCase {
         final MetaData metaData = MetaData.builder().put(indexMetaData, true).build();
         final RoutingTable routingTable = RoutingTable.builder().addAsNew(indexMetaData).build();
         return ClusterState.builder(new ClusterName("test_cluster")).metaData(metaData).routingTable(routingTable).build();
+    }
+
+    private ClusterState initializeWithClosedIndex(final String indexName, final int numShards, final int numReplicas) {
+        final IndexMetaData indexMetaData = IndexMetaData.builder(indexName)
+            .settings(settings(Version.CURRENT)
+                .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID()))
+            .numberOfShards(numShards)
+            .numberOfReplicas(numReplicas)
+            .state(IndexMetaData.State.CLOSE)
+            .build();
+        final MetaData metaData = MetaData.builder().put(indexMetaData, true).build();
+        return ClusterState.builder(new ClusterName("test_cluster")).metaData(metaData).build();
     }
 
     private ClusterState startPrimaries(final ClusterState clusterState, final String indexName) {

--- a/server/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
@@ -22,12 +22,16 @@ package org.elasticsearch.indices.state;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.open.OpenIndexResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
@@ -39,6 +43,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_BLOCKS_METADATA;
@@ -315,6 +320,26 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
         assertBusy(() -> assertThat(client.admin().cluster().prepareState().get().getState().metaData().index("test").getState(),
             equalTo(IndexMetaData.State.OPEN)));
         ensureGreen("test");
+    }
+
+    public void testCloseUnassignedIndex() throws Exception {
+        final String index = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        final Settings indexSettings = Settings.builder().put("index.routing.allocation.include.tag", "does_not_exist").build();
+        final CreateIndexRequest createIndexRequest = new CreateIndexRequest(index).settings(indexSettings);
+
+        final PlainActionFuture<CreateIndexResponse> createIndexFuture = new PlainActionFuture<>();
+        client().admin().indices().create(createIndexRequest, createIndexFuture);
+
+        assertBusy(() -> {
+            assertIndexIsOpened(index);
+            ClusterHealthResponse healthResponse = client().admin().cluster().prepareHealth(index).get();
+            assertThat(healthResponse.isTimedOut(), is(false));
+            assertThat(healthResponse.getStatus(), is(ClusterHealthStatus.RED));
+        });
+        assertThat(createIndexFuture.isDone(), is(false));
+        assertAcked(client().admin().indices().prepareClose(index));
+        assertThat(createIndexFuture.isDone(), is(true));
+        assertAcked(createIndexFuture.get());
     }
 
     private void assertIndexIsOpened(String... indices) {


### PR DESCRIPTION
The `ActiveShardCount` is used by cluster state observers to wait for a given number of shards to be active before returning to the caller. The current implementation does not work when an index is closed while an observer is waiting on shards to be active. In this case, a NPE is thrown and the observer is never notified that the shards won't become active.

This pull request fixes the `ActiveShardCount.enoughShardsActive()` so that it returns "OK" when an index is closed, similarly to what is done when an index is deleted. It also adds a test that would have fail with the previous behavior.