### PR TITLE
[ML] Jindex: Prefer index config documents to cluster state config

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
@@ -131,15 +131,21 @@ public class TransportDeleteDatafeedAction extends TransportMasterNodeAction<Del
             return;
         }
 
-        MlMetadata mlMetadata = MlMetadata.getMlMetadata(state);
-        if (mlMetadata.getDatafeed(request.getDatafeedId()) != null) {
-            deleteDatafeedFromMetadata(request, listener);
-        } else {
-            datafeedConfigProvider.deleteDatafeedConfig(request.getDatafeedId(), ActionListener.wrap(
-                    deleteResponse -> listener.onResponse(new AcknowledgedResponse(true)),
-                    listener::onFailure
-            ));
-        }
+
+        datafeedConfigProvider.deleteDatafeedConfig(request.getDatafeedId(), ActionListener.wrap(
+                deleteResponse -> listener.onResponse(new AcknowledgedResponse(true)),
+                e -> {
+                    if (e.getClass() == ResourceNotFoundException.class) {
+                        // is the datafeed in the clusterstate
+                        MlMetadata mlMetadata = MlMetadata.getMlMetadata(state);
+                        if (mlMetadata.getDatafeed(request.getDatafeedId()) != null) {
+                            deleteDatafeedFromMetadata(request, listener);
+                            return;
+                        }
+                    }
+                    listener.onFailure(e);
+                }
+        ));
     }
 
     private void deleteDatafeedFromMetadata(DeleteDatafeedAction.Request request, ActionListener<AcknowledgedResponse> listener) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.ml.datafeed;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
@@ -50,17 +51,22 @@ public class DatafeedConfigReader {
      * @param listener   DatafeedConfig listener
      */
     public void datafeedConfig(String datafeedId, ClusterState state, ActionListener<DatafeedConfig> listener) {
-        MlMetadata mlMetadata = MlMetadata.getMlMetadata(state);
-        DatafeedConfig config = mlMetadata.getDatafeed(datafeedId);
 
-        if (config != null) {
-            listener.onResponse(config);
-        } else {
-            datafeedConfigProvider.getDatafeedConfig(datafeedId, ActionListener.wrap(
-                    builder -> listener.onResponse(builder.build()),
-                    listener::onFailure
-            ));
-        }
+        datafeedConfigProvider.getDatafeedConfig(datafeedId, ActionListener.wrap(
+                builder -> listener.onResponse(builder.build()),
+                e -> {
+                    if (e.getClass() == ResourceNotFoundException.class) {
+                        // look in the clusterstate
+                        MlMetadata mlMetadata = MlMetadata.getMlMetadata(state);
+                        DatafeedConfig config = mlMetadata.getDatafeed(datafeedId);
+                        if (config != null) {
+                            listener.onResponse(config);
+                            return;
+                        }
+                    }
+                    listener.onFailure(e);
+                }
+        ));
     }
 
     /**
@@ -70,22 +76,15 @@ public class DatafeedConfigReader {
     public void expandDatafeedIds(String expression, boolean allowNoDatafeeds, ClusterState clusterState,
                                   ActionListener<SortedSet<String>> listener) {
 
-        Set<String> clusterStateDatafeedIds = MlMetadata.getMlMetadata(clusterState).expandDatafeedIds(expression);
         ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(expression, allowNoDatafeeds);
-        requiredMatches.filterMatchedIds(clusterStateDatafeedIds);
 
         datafeedConfigProvider.expandDatafeedIdsWithoutMissingCheck(expression, ActionListener.wrap(
                 expandedDatafeedIds -> {
-                    // Check for duplicate Ids
-                    expandedDatafeedIds.forEach(id -> {
-                        if (clusterStateDatafeedIds.contains(id)) {
-                            listener.onFailure(new IllegalStateException("Datafeed [" + id + "] configuration " +
-                                    "exists in both clusterstate and index"));
-                            return;
-                        }
-                    });
-
                     requiredMatches.filterMatchedIds(expandedDatafeedIds);
+
+                    // now read from the clusterstate
+                    Set<String> clusterStateDatafeedIds = MlMetadata.getMlMetadata(clusterState).expandDatafeedIds(expression);
+                    requiredMatches.filterMatchedIds(clusterStateDatafeedIds);
 
                     if (requiredMatches.hasUnmatchedIds()) {
                         listener.onFailure(ExceptionsHelper.missingDatafeedException(requiredMatches.unmatchedIdsString()));
@@ -105,25 +104,26 @@ public class DatafeedConfigReader {
     public void expandDatafeedConfigs(String expression, boolean allowNoDatafeeds, ClusterState clusterState,
                                       ActionListener<List<DatafeedConfig>> listener) {
 
-        Map<String, DatafeedConfig> clusterStateConfigs = expandClusterStateDatafeeds(expression, clusterState);
-
         ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(expression, allowNoDatafeeds);
-        requiredMatches.filterMatchedIds(clusterStateConfigs.keySet());
 
         datafeedConfigProvider.expandDatafeedConfigsWithoutMissingCheck(expression, ActionListener.wrap(
                 datafeedBuilders -> {
-                    // Check for duplicate Ids
-                    datafeedBuilders.forEach(datafeedBuilder -> {
-                        if (clusterStateConfigs.containsKey(datafeedBuilder.getId())) {
-                            listener.onFailure(new IllegalStateException("Datafeed [" + datafeedBuilder.getId() + "] configuration " +
-                                    "exists in both clusterstate and index"));
-                            return;
-                        }
-                    });
-
                     List<DatafeedConfig> datafeedConfigs = new ArrayList<>();
                     for (DatafeedConfig.Builder builder : datafeedBuilders) {
                         datafeedConfigs.add(builder.build());
+                    }
+
+                    Map<String, DatafeedConfig> clusterStateConfigs = expandClusterStateDatafeeds(expression, clusterState);
+
+                    // Duplicate configs existing in both the clusterstate and index documents are ok
+                    // this may occur during migration of configs.
+                    // Prefer the index configs and filter duplicates.
+                    for (String clusterStateDatafeedId : clusterStateConfigs.keySet()) {
+                        boolean isDuplicate = datafeedConfigs.stream()
+                                .anyMatch(datafeed -> datafeed.getId().equals(clusterStateDatafeedId));
+                        if (isDuplicate == false) {
+                            datafeedConfigs.add(clusterStateConfigs.get(clusterStateDatafeedId));
+                        }
                     }
 
                     requiredMatches.filterMatchedIds(datafeedConfigs.stream().map(DatafeedConfig::getId).collect(Collectors.toList()));
@@ -131,7 +131,6 @@ public class DatafeedConfigReader {
                     if (requiredMatches.hasUnmatchedIds()) {
                         listener.onFailure(ExceptionsHelper.missingDatafeedException(requiredMatches.unmatchedIdsString()));
                     } else {
-                        datafeedConfigs.addAll(clusterStateConfigs.values());
                         Collections.sort(datafeedConfigs, Comparator.comparing(DatafeedConfig::getId));
                         listener.onResponse(datafeedConfigs);
                     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReader.java
@@ -117,11 +117,10 @@ public class DatafeedConfigReader {
 
                     // Duplicate configs existing in both the clusterstate and index documents are ok
                     // this may occur during migration of configs.
-                    // Prefer the index configs and filter duplicates.
+                    // Prefer the index configs and filter duplicates from the clusterstate configs.
+                    Set<String> indexConfigIds = datafeedConfigs.stream().map(DatafeedConfig::getId).collect(Collectors.toSet());
                     for (String clusterStateDatafeedId : clusterStateConfigs.keySet()) {
-                        boolean isDuplicate = datafeedConfigs.stream()
-                                .anyMatch(datafeed -> datafeed.getId().equals(clusterStateDatafeedId));
-                        if (isDuplicate == false) {
+                        if (indexConfigIds.contains(clusterStateDatafeedId) == false) {
                             datafeedConfigs.add(clusterStateConfigs.get(clusterStateDatafeedId));
                         }
                     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
@@ -234,7 +234,11 @@ public class DatafeedConfigProvider {
             }
             @Override
             public void onFailure(Exception e) {
-                actionListener.onFailure(e);
+                if (e.getClass() == IndexNotFoundException.class) {
+                    actionListener.onFailure(ExceptionsHelper.missingDatafeedException(datafeedId));
+                } else {
+                    actionListener.onFailure(e);
+                }
             }
         });
     }
@@ -303,7 +307,11 @@ public class DatafeedConfigProvider {
 
             @Override
             public void onFailure(Exception e) {
-                updatedConfigListener.onFailure(e);
+                if (e.getClass() == IndexNotFoundException.class) {
+                    updatedConfigListener.onFailure(ExceptionsHelper.missingDatafeedException(datafeedId));
+                } else {
+                    updatedConfigListener.onFailure(e);
+                }
             }
         });
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -233,10 +233,10 @@ public class JobManager {
 
                     // Duplicate configs existing in both the clusterstate and index documents are ok
                     // this may occur during migration of configs.
-                    // Prefer the index configs and filter duplicates.
+                    // Prefer the index configs and filter duplicates from the clusterstate configs
                     Map<String, Job> clusterStateJobs = expandJobsFromClusterState(expression, clusterService.state());
                     for (String clusterStateJobId : clusterStateJobs.keySet()) {
-                        boolean isDuplicate = jobs.stream().anyMatch(job -> job.getId().equals(clusterStateJobId));
+                        boolean isDuplicate = jobAndGroupIds.contains(clusterStateJobId);
                         if (isDuplicate == false) {
                             Job csJob = clusterStateJobs.get(clusterStateJobId);
                             jobs.add(csJob);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -212,28 +212,10 @@ public class JobManager {
      * @param jobsListener The jobs listener
      */
     public void expandJobs(String expression, boolean allowNoJobs, ActionListener<QueryPage<Job>> jobsListener) {
-        Map<String, Job> clusterStateJobs = expandJobsFromClusterState(expression, clusterService.state());
         ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(expression, allowNoJobs);
-        requiredMatches.filterMatchedIds(clusterStateJobs.keySet());
-
-        // If expression contains a group Id it has been expanded to its
-        // constituent job Ids but Ids matcher needs to know the group
-        // has been matched
-        Set<String> groupIds = clusterStateJobs.values().stream()
-                .filter(job -> job.getGroups() != null).flatMap(j -> j.getGroups().stream()).collect(Collectors.toSet());
-        requiredMatches.filterMatchedIds(groupIds);
 
         jobConfigProvider.expandJobsWithoutMissingcheck(expression, false, ActionListener.wrap(
                 jobBuilders -> {
-                    // Check for duplicate jobs
-                    for (Job.Builder jb : jobBuilders) {
-                        if (clusterStateJobs.containsKey(jb.getId())) {
-                            jobsListener.onFailure(new IllegalStateException("Job [" + jb.getId() + "] configuration " +
-                                    "exists in both clusterstate and index"));
-                            return;
-                        }
-                    }
-
                     Set<String> jobAndGroupIds = new HashSet<>();
 
                     // Merge cluster state and index jobs
@@ -241,8 +223,25 @@ public class JobManager {
                     for (Job.Builder jb : jobBuilders) {
                         Job job = jb.build();
                         jobAndGroupIds.add(job.getId());
+                        // If expression contains a group Id it has been expanded to its
+                        // constituent job Ids but Ids matcher needs to know the group
+                        // has been matched
                         jobAndGroupIds.addAll(job.getGroups());
                         jobs.add(job);
+                    }
+
+                    // Duplicate configs existing in both the clusterstate and index documents are ok
+                    // this may occur during migration of configs.
+                    // Prefer the index configs and filter duplicates.
+                    Map<String, Job> clusterStateJobs = expandJobsFromClusterState(expression, clusterService.state());
+                    for (String clusterStateJobId : clusterStateJobs.keySet()) {
+                        boolean isDuplicate = jobs.stream().anyMatch(job -> job.getId().equals(clusterStateJobId));
+                        if (isDuplicate == false) {
+                            Job csJob = clusterStateJobs.get(clusterStateJobId);
+                            jobs.add(csJob);
+                            jobAndGroupIds.add(csJob.getId());
+                            jobAndGroupIds.addAll(csJob.getGroups());
+                        }
                     }
 
                     requiredMatches.filterMatchedIds(jobAndGroupIds);
@@ -250,7 +249,6 @@ public class JobManager {
                     if (requiredMatches.hasUnmatchedIds()) {
                         jobsListener.onFailure(ExceptionsHelper.missingJobException(requiredMatches.unmatchedIdsString()));
                     } else {
-                        jobs.addAll(clusterStateJobs.values());
                         Collections.sort(jobs, Comparator.comparing(Job::getId));
                         jobsListener.onResponse(new QueryPage<>(jobs, jobs.size(), Job.RESULTS_FIELD));
                     }
@@ -277,27 +275,21 @@ public class JobManager {
      * @param jobsListener The jobs listener
      */
     public void expandJobIds(String expression, boolean allowNoJobs, ActionListener<SortedSet<String>> jobsListener) {
-        Set<String> clusterStateJobIds = MlMetadata.getMlMetadata(clusterService.state()).expandJobIds(expression);
         ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(expression, allowNoJobs);
-        requiredMatches.filterMatchedIds(clusterStateJobIds);
-        // If expression contains a group Id it has been expanded to its
-        // constituent job Ids but Ids matcher needs to know the group
-        // has been matched
-        requiredMatches.filterMatchedIds(MlMetadata.getMlMetadata(clusterService.state()).expandGroupIds(expression));
+
 
         jobConfigProvider.expandJobsIdsWithoutMissingCheck(expression, false, ActionListener.wrap(
                 jobIdsAndGroups -> {
-                    // Check for duplicate job Ids
-                    for (String id : jobIdsAndGroups.getJobs()) {
-                        if (clusterStateJobIds.contains(id)) {
-                            jobsListener.onFailure(new IllegalStateException("Job [" + id + "] configuration " +
-                                    "exists in both clusterstate and index"));
-                            return;
-                        }
-                    }
-
                     requiredMatches.filterMatchedIds(jobIdsAndGroups.getJobs());
+
+                    Set<String> clusterStateJobIds = MlMetadata.getMlMetadata(clusterService.state()).expandJobIds(expression);
+                    requiredMatches.filterMatchedIds(clusterStateJobIds);
+                    // If expression contains a group Id it has been expanded to its
+                    // constituent job Ids but Ids matcher needs to know the group
+                    // has been matched
                     requiredMatches.filterMatchedIds(jobIdsAndGroups.getGroups());
+                    requiredMatches.filterMatchedIds(MlMetadata.getMlMetadata(clusterService.state()).expandGroupIds(expression));
+
                     if (requiredMatches.hasUnmatchedIds()) {
                         jobsListener.onFailure(ExceptionsHelper.missingJobException(requiredMatches.unmatchedIdsString()));
                     } else {
@@ -311,38 +303,48 @@ public class JobManager {
     }
 
     /**
-     * Mark the job as being deleted. First looks in the cluster state for the
-     * job configuration then the index
+     * Mark the job as being deleted. First looks in the ml-config index
+     * for the job configuration then the clusterstate
      *
      * @param jobId     To to mark
      * @param force     Allows an open job to be marked
      * @param listener  listener
      */
     public void markJobAsDeleting(String jobId, boolean force, ActionListener<Boolean> listener) {
-        if (ClusterStateJobUpdate.jobIsInClusterState(clusterService.state(), jobId)) {
-            ClusterStateJobUpdate.markJobAsDeleting(jobId, force, clusterService, listener);
-        } else {
-            jobConfigProvider.markJobAsDeleting(jobId, listener);
-        }
+        jobConfigProvider.markJobAsDeleting(jobId, ActionListener.wrap(
+                listener::onResponse,
+                e -> {
+                    if (e.getClass() == ResourceNotFoundException.class) {
+                        // is the config in the cluster state
+                        if (ClusterStateJobUpdate.jobIsInClusterState(clusterService.state(), jobId)) {
+                            ClusterStateJobUpdate.markJobAsDeleting(jobId, force, clusterService, listener);
+                            return;
+                        }
+                    }
+                    listener.onFailure(e);
+                }
+        ));
+
     }
 
     /**
-     * First try to delete the job from the cluster state, if it does not exist
-     * there try to  delete the index job.
+     * First try to delete the job document from ml-config, if it does not exist
+     * there try to the clusterstate.
      *
      * @param request   The delete job request
      * @param listener  Delete listener
      */
     public void deleteJob(DeleteJobAction.Request request, ActionListener<Boolean> listener) {
-
-        if (ClusterStateJobUpdate.jobIsInClusterState(clusterService.state(), request.getJobId())) {
-            ClusterStateJobUpdate.deleteJob(request, clusterService, listener);
-        } else {
-            jobConfigProvider.deleteJob(request.getJobId(), false, ActionListener.wrap(
-                    deleteResponse -> listener.onResponse(Boolean.TRUE),
-                    listener::onFailure
-            ));
-        }
+        jobConfigProvider.deleteJob(request.getJobId(), false, ActionListener.wrap(
+                deleteResponse -> listener.onResponse(Boolean.TRUE),
+                e -> {
+                    if (e.getClass() == ResourceNotFoundException.class) {
+                        if (ClusterStateJobUpdate.jobIsInClusterState(clusterService.state(), request.getJobId())) {
+                            ClusterStateJobUpdate.deleteJob(request, clusterService, listener);
+                        }
+                    }
+                    listener.onFailure(e);
+                }));
     }
 
     /**
@@ -462,18 +464,21 @@ public class JobManager {
     }
 
     public void updateJob(UpdateJobAction.Request request, ActionListener<PutJobAction.Response> actionListener) {
-        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterService.state());
-        if (ClusterStateJobUpdate.jobIsInMlMetadata(mlMetadata, request.getJobId())) {
-            updateJobClusterState(request, actionListener);
-        } else {
-            updateJobIndex(request, ActionListener.wrap(
-                    updatedJob -> {
-                        postJobUpdate(clusterService.state(), request);
-                        actionListener.onResponse(new PutJobAction.Response(updatedJob));
-                    },
-                    actionListener::onFailure
-            ));
-        }
+        updateJobIndex(request, ActionListener.wrap(
+                updatedJob -> {
+                    postJobUpdate(clusterService.state(), request);
+                    actionListener.onResponse(new PutJobAction.Response(updatedJob));
+                },
+                e -> {
+                    if (e.getClass() == ResourceNotFoundException.class) {
+                        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterService.state());
+                        if (ClusterStateJobUpdate.jobIsInMlMetadata(mlMetadata, request.getJobId())) {
+                            updateJobClusterState(request, actionListener);
+                            return;
+                        }
+                    }
+                    actionListener.onFailure(e);
+                }));
     }
 
     private void postJobUpdate(ClusterState clusterState, UpdateJobAction.Request request) {
@@ -658,16 +663,16 @@ public class JobManager {
                 indexJobs -> {
                     threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(() -> {
 
-                        List<Job> allJobs = new ArrayList<>();
-                        // Check for duplicate jobs
-                        for (Job indexJob : indexJobs) {
-                            if (clusterStateJobs.containsKey(indexJob.getId())) {
-                                logger.error("[" + indexJob.getId() + "] job configuration exists in both clusterstate and index");
-                            } else {
-                                allJobs.add(indexJob);
+                        List<Job> allJobs = new ArrayList<>(indexJobs);
+                        // Duplicate configs existing in both the clusterstate and index documents are ok
+                        // this may occur during migration of configs.
+                        // Filter the duplicates so we don't update twice for duplicated jobs
+                        for (String clusterStateJobId : clusterStateJobs.keySet()) {
+                            boolean isDuplicate = allJobs.stream().anyMatch(job -> job.getId().equals(clusterStateJobId));
+                            if (isDuplicate == false) {
+                                allJobs.add(clusterStateJobs.get(clusterStateJobId));
                             }
                         }
-                        allJobs.addAll(clusterStateJobs.values());
 
                         for (Job job: allJobs) {
                             Set<String> jobFilters = job.getAnalysisConfig().extractReferencedFilters();
@@ -740,7 +745,7 @@ public class JobManager {
         jobConfigProvider.expandGroupIds(calendarJobIds, ActionListener.wrap(
                 expandedIds -> {
                     threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(() -> {
-                        // Merge the expended group members with the request Ids which
+                        // Merge the expanded group members with the request Ids
                         // which are job ids rather than group Ids.
                         expandedIds.addAll(calendarJobIds);
 
@@ -798,39 +803,10 @@ public class JobManager {
 
         // Step 1. update the job
         // -------
-
-        Consumer<Long> updateJobHandler;
-
-        if (ClusterStateJobUpdate.jobIsInClusterState(clusterService.state(), request.getJobId())) {
-            updateJobHandler = response -> clusterService.submitStateUpdateTask("revert-snapshot-" + request.getJobId(),
-                    new AckedClusterStateUpdateTask<Boolean>(request, ActionListener.wrap(updateHandler, actionListener::onFailure)) {
-
-                        @Override
-                        protected Boolean newResponse(boolean acknowledged) {
-                            if (acknowledged) {
-                                auditor.info(request.getJobId(),
-                                        Messages.getMessage(Messages.JOB_AUDIT_REVERTED, modelSnapshot.getDescription()));
-                                return true;
-                            }
-                            actionListener.onFailure(new IllegalStateException("Could not revert modelSnapshot on job ["
-                                    + request.getJobId() + "], not acknowledged by master."));
-                            return false;
-                        }
-
-                        @Override
-                        public ClusterState execute(ClusterState currentState) {
-                            Job job = MlMetadata.getMlMetadata(currentState).getJobs().get(request.getJobId());
-                            Job.Builder builder = new Job.Builder(job);
-                            builder.setModelSnapshotId(modelSnapshot.getSnapshotId());
-                            builder.setEstablishedModelMemory(response);
-                            return ClusterStateJobUpdate.putJobInClusterState(builder.build(), true, currentState);
-                        }
-                    });
-        } else {
-            updateJobHandler = response -> {
+        Consumer<Long> establishedMemoryHandler = modelMem -> {
                 JobUpdate update = new JobUpdate.Builder(request.getJobId())
                         .setModelSnapshotId(modelSnapshot.getSnapshotId())
-                        .setEstablishedModelMemory(response)
+                        .setEstablishedModelMemory(modelMem)
                         .build();
 
                 jobConfigProvider.updateJob(request.getJobId(), update, maxModelMemoryLimit, ActionListener.wrap(
@@ -839,14 +815,53 @@ public class JobManager {
                                     Messages.getMessage(Messages.JOB_AUDIT_REVERTED, modelSnapshot.getDescription()));
                             updateHandler.accept(Boolean.TRUE);
                         },
-                        actionListener::onFailure
+                        e -> {
+                            if (e.getClass() == ResourceNotFoundException.class) {
+                                // Not found? maybe it's in the index
+                                if (ClusterStateJobUpdate.jobIsInClusterState(clusterService.state(), request.getJobId())) {
+                                    revertModelSnapshotClusterState(request, modelSnapshot, updateHandler, modelMem, actionListener);
+                                    return;
+                                }
+                            }
+                            actionListener.onFailure(e);
+                        }
                 ));
             };
-        }
 
         // Step 0. Find the appropriate established model memory for the reverted job
         // -------
-        jobResultsProvider.getEstablishedMemoryUsage(request.getJobId(), modelSizeStats.getTimestamp(), modelSizeStats, updateJobHandler,
-                actionListener::onFailure);
+        jobResultsProvider.getEstablishedMemoryUsage(request.getJobId(), modelSizeStats.getTimestamp(), modelSizeStats,
+                establishedMemoryHandler, actionListener::onFailure);
+    }
+
+    private void revertModelSnapshotClusterState(RevertModelSnapshotAction.Request request,
+                                                 ModelSnapshot modelSnapshot,
+                                                 CheckedConsumer<Boolean, Exception> updateHandler, Long modelMem,
+                                                 ActionListener<RevertModelSnapshotAction.Response> actionListener) {
+        clusterService.submitStateUpdateTask("revert-snapshot-" + request.getJobId(),
+                new AckedClusterStateUpdateTask<Boolean>(request, ActionListener.wrap(updateHandler, actionListener::onFailure)) {
+
+                    @Override
+                    protected Boolean newResponse(boolean acknowledged) {
+                        if (acknowledged) {
+                            auditor.info(request.getJobId(),
+                                    Messages.getMessage(Messages.JOB_AUDIT_REVERTED, modelSnapshot.getDescription()));
+                            return true;
+                        }
+                        // TODO is this an error? can actionListener.onFailure be called twice?
+                        actionListener.onFailure(new IllegalStateException("Could not revert modelSnapshot on job ["
+                                + request.getJobId() + "], not acknowledged by master."));
+                        return false;
+                    }
+
+                    @Override
+                    public ClusterState execute(ClusterState currentState) {
+                        Job job = MlMetadata.getMlMetadata(currentState).getJobs().get(request.getJobId());
+                        Job.Builder builder = new Job.Builder(job);
+                        builder.setModelSnapshotId(modelSnapshot.getSnapshotId());
+                        builder.setEstablishedModelMemory(modelMem);
+                        return ClusterStateJobUpdate.putJobInClusterState(builder.build(), true, currentState);
+                    }
+                });
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
@@ -209,7 +209,11 @@ public class JobConfigProvider {
 
             @Override
             public void onFailure(Exception e) {
-                listener.onFailure(e);
+                if (e.getClass() == IndexNotFoundException.class) {
+                    listener.onFailure(ExceptionsHelper.missingJobException(String.join(",", jobIds)));
+                } else {
+                    listener.onFailure(e);
+                }
             }
         }, client::multiGet);
     }
@@ -244,7 +248,11 @@ public class JobConfigProvider {
             }
             @Override
             public void onFailure(Exception e) {
-                actionListener.onFailure(e);
+                if (e.getClass() == IndexNotFoundException.class) {
+                    actionListener.onFailure(ExceptionsHelper.missingJobException(jobId));
+                } else {
+                    actionListener.onFailure(e);
+                }
             }
         });
     }
@@ -298,7 +306,11 @@ public class JobConfigProvider {
 
             @Override
             public void onFailure(Exception e) {
-                updatedJobListener.onFailure(e);
+                if (e.getClass() == IndexNotFoundException.class) {
+                    updatedJobListener.onFailure(ExceptionsHelper.missingJobException(jobId));
+                } else {
+                    updatedJobListener.onFailure(e);
+                }
             }
         });
     }
@@ -366,7 +378,11 @@ public class JobConfigProvider {
 
             @Override
             public void onFailure(Exception e) {
-                updatedJobListener.onFailure(e);
+                if (e.getClass() == IndexNotFoundException.class) {
+                    updatedJobListener.onFailure(ExceptionsHelper.missingJobException(jobId));
+                } else {
+                    updatedJobListener.onFailure(e);
+                }
             }
         });
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReaderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReaderTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.SortedSet;
@@ -22,6 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -132,9 +134,39 @@ public class DatafeedConfigReaderTests extends ESTestCase {
                 e -> fail(e.getMessage())
         ));
 
+        assertThat(configHolder.get(), hasSize(3));
         assertEquals("cs-df", configHolder.get().get(0).getId());
         assertEquals("index-df", configHolder.get().get(1).getId());
         assertEquals("ll-df", configHolder.get().get(2).getId());
+    }
+
+    public void testExpandDatafeedConfigs_DuplicateConfigReturnsIndexDocument() {
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder();
+        mlMetadata.putJob(buildJobBuilder("datafeed-in-clusterstate").build(), false);
+        mlMetadata.putDatafeed(createDatafeedConfig("df1", "datafeed-in-clusterstate"), Collections.emptyMap());
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("datafeedconfigreadertests"))
+                .metaData(MetaData.builder()
+                        .putCustom(MlMetadata.TYPE, mlMetadata.build()))
+                .build();
+
+        DatafeedConfig.Builder indexConfig1 = createDatafeedConfigBuilder("df1", "datafeed-in-index");
+        DatafeedConfig.Builder indexConfig2 = createDatafeedConfigBuilder("df2", "job-c");
+        DatafeedConfigProvider provider = mock(DatafeedConfigProvider.class);
+        mockProviderWithExpectedConfig(provider, "_all", Arrays.asList(indexConfig1, indexConfig2));
+
+        DatafeedConfigReader reader = new DatafeedConfigReader(provider);
+
+        AtomicReference<List<DatafeedConfig>> configHolder = new AtomicReference<>();
+        reader.expandDatafeedConfigs("_all", true, clusterState, ActionListener.wrap(
+                configHolder::set,
+                e -> fail(e.getMessage())
+        ));
+
+        assertThat(configHolder.get(), hasSize(2));
+        assertEquals("df1", configHolder.get().get(0).getId());
+        assertEquals("datafeed-in-index", configHolder.get().get(0).getJobId());
+        assertEquals("df2", configHolder.get().get(1).getId());
     }
 
     private ClusterState buildClusterStateWithJob(DatafeedConfig datafeed) {


### PR DESCRIPTION
During the migration of ml configs from the clusterstate to index documents there is a window where the config is extant in both clusterstate and index. In this case prefer the index so all updates must be made to the index doc. This also helps in the case where there is a failure removing config from the clusterstate after copying to the index.