### PR TITLE
Core: Migrating from joda to java.time. ML package

### DIFF
--- a/x-pack/plugin/ml/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/ml/transforms/PainlessDomainSplitIT.java
+++ b/x-pack/plugin/ml/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/ml/transforms/PainlessDomainSplitIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.ml.MachineLearning;
 
+import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -267,7 +268,7 @@ public class PainlessDomainSplitIT extends ESRestTestCase {
                 "\"time\": { \"type\": \"date\" } } }");
 
         // Index some data
-        ZonedDateTime baseTime = ZonedDateTime.now().minusYears(1);
+        ZonedDateTime baseTime = ZonedDateTime.now(Clock.systemDefaultZone()).minusYears(1);
         TestConfiguration test = tests.get(randomInt(tests.size()-1));
 
         // domainSplit() tests had subdomain, testHighestRegisteredDomainCases() did not, so we need a special case for sub

--- a/x-pack/plugin/ml/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/ml/transforms/PainlessDomainSplitIT.java
+++ b/x-pack/plugin/ml/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/ml/transforms/PainlessDomainSplitIT.java
@@ -13,8 +13,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.ml.MachineLearning;
-import org.joda.time.DateTime;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -266,7 +267,7 @@ public class PainlessDomainSplitIT extends ESRestTestCase {
                 "\"time\": { \"type\": \"date\" } } }");
 
         // Index some data
-        DateTime baseTime = new DateTime().minusYears(1);
+        ZonedDateTime baseTime = ZonedDateTime.now().minusYears(1);
         TestConfiguration test = tests.get(randomInt(tests.size()-1));
 
         // domainSplit() tests had subdomain, testHighestRegisteredDomainCases() did not, so we need a special case for sub
@@ -276,18 +277,24 @@ public class PainlessDomainSplitIT extends ESRestTestCase {
 
         for (int i = 0; i < 100; i++) {
 
-            DateTime time = baseTime.plusHours(i);
+            ZonedDateTime time = baseTime.plusHours(i);
             if (i == 64) {
                 // Anomaly has 100 docs, but we don't care about the value
                 for (int j = 0; j < 100; j++) {
-                    Request createDocRequest = new Request("PUT", "/painless/test/" + time.toDateTimeISO() + "_" + j);
-                    createDocRequest.setJsonEntity("{\"domain\": \"" + "bar.bar.com\", \"time\": \"" + time.toDateTimeISO() + "\"}");
+                    String endpoint = "/painless/test/" + time.format(DateTimeFormatter.ISO_DATE_TIME) + "_" + j;
+                    Request createDocRequest = new Request("PUT", endpoint);
+                    String entity = "{\"domain\": \"" + "bar.bar.com\", \"time\": \"" + time.format(DateTimeFormatter.ISO_DATE_TIME) +
+                        "\"}";
+                    createDocRequest.setJsonEntity(entity);
                     client().performRequest(createDocRequest);
                 }
             } else {
                 // Non-anomalous values will be what's seen when the anomaly is reported
-                Request createDocRequest = new Request("PUT", "/painless/test/" + time.toDateTimeISO());
-                createDocRequest.setJsonEntity("{\"domain\": \"" + test.hostName + "\", \"time\": \"" + time.toDateTimeISO() + "\"}");
+                String endpoint = "/painless/test/" + time.format(DateTimeFormatter.ISO_DATE_TIME);
+                Request createDocRequest = new Request("PUT", endpoint);
+                String entity =
+                    "{\"domain\": \"" + test.hostName + "\", \"time\": \"" + time.format(DateTimeFormatter.ISO_DATE_TIME) + "\"}";
+                createDocRequest.setJsonEntity(entity);
                 client().performRequest(createDocRequest);
             }
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceService.java
@@ -16,9 +16,8 @@ import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction;
-import org.joda.time.DateTime;
-import org.joda.time.chrono.ISOChronology;
 
+import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.ScheduledFuture;
@@ -70,9 +69,14 @@ public class MlDailyMaintenanceService implements Releasable {
     private static TimeValue delayToNextTime(ClusterName clusterName) {
         Random random = new Random(clusterName.hashCode());
         int minutesOffset = random.ints(0, MAX_TIME_OFFSET_MINUTES).findFirst().getAsInt();
-        DateTime now = DateTime.now(ISOChronology.getInstance());
-        DateTime next = now.plusDays(1).withTimeAtStartOfDay().plusMinutes(30).plusMinutes(minutesOffset);
-        return TimeValue.timeValueMillis(next.getMillis() - now.getMillis());
+
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime next = now.plusDays(1)
+            .toLocalDate()
+            .atStartOfDay(now.getZone())
+            .plusMinutes(30)
+            .plusMinutes(minutesOffset);
+        return TimeValue.timeValueMillis(next.toInstant().toEpochMilli() - now.toInstant().toEpochMilli());
     }
 
     public void start() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceService.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction;
 
+import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.Random;
@@ -70,7 +71,7 @@ public class MlDailyMaintenanceService implements Releasable {
         Random random = new Random(clusterName.hashCode());
         int minutesOffset = random.ints(0, MAX_TIME_OFFSET_MINUTES).findFirst().getAsInt();
 
-        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime now = ZonedDateTime.now(Clock.systemDefaultZone());
         ZonedDateTime next = now.plusDays(1)
             .toLocalDate()
             .atStartOfDay(now.getZone())

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationToJsonProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationToJsonProcessor.java
@@ -20,7 +20,6 @@ import org.elasticsearch.search.aggregations.metrics.Percentile;
 import org.elasticsearch.search.aggregations.metrics.Percentiles;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
-import org.joda.time.DateTime;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -176,17 +175,15 @@ class AggregationToJsonProcessor {
     }
 
     /*
-     * Date Histograms have a {@link DateTime} object as the key,
+     * Date Histograms have a {@link ZonedDateTime} object as the key,
      * Histograms have either a Double or Long.
      */
     private long toHistogramKeyToEpoch(Object key) {
-        if (key instanceof DateTime) {
-            return ((DateTime)key).getMillis();
-        } else if (key instanceof ZonedDateTime) {
+        if (key instanceof ZonedDateTime) {
             return ((ZonedDateTime)key).toInstant().toEpochMilli();
         } else if (key instanceof Double) {
             return ((Double)key).longValue();
-        } else if (key instanceof Long){
+        } else if (key instanceof Long) {
             return (Long)key;
         } else {
             throw new IllegalStateException("Histogram key [" + key + "] cannot be converted to a timestamp");

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedField.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.datafeed.extractor.fields;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.subphase.DocValueFieldsContext;
-import org.joda.time.base.BaseDateTime;
 
 import java.util.List;
 import java.util.Map;
@@ -112,8 +111,6 @@ public abstract class ExtractedField {
             }
             if (value[0] instanceof String) { // doc_value field with the epoch_millis format
                 value[0] = Long.parseLong((String) value[0]);
-            } else if (value[0] instanceof BaseDateTime) { // script field
-                value[0] = ((BaseDateTime) value[0]).getMillis();
             } else if (value[0] instanceof Long == false) { // pre-6.0 field
                 throw new IllegalStateException("Unexpected value for a time field: " + value[0].getClass());
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
 import org.elasticsearch.xpack.ml.utils.VolatileCursorIterator;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -69,7 +70,7 @@ abstract class AbstractExpiredJobDataRemover implements MlDataRemover {
     }
 
     private long calcCutoffEpochMs(long retentionDays) {
-        long nowEpochMs = Instant.now().toEpochMilli();
+        long nowEpochMs = Instant.now(Clock.systemDefaultZone()).toEpochMilli();
         return nowEpochMs - new TimeValue(retentionDays, TimeUnit.DAYS).getMillis();
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
@@ -15,9 +15,8 @@ import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
 import org.elasticsearch.xpack.ml.utils.VolatileCursorIterator;
-import org.joda.time.DateTime;
-import org.joda.time.chrono.ISOChronology;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -70,7 +69,7 @@ abstract class AbstractExpiredJobDataRemover implements MlDataRemover {
     }
 
     private long calcCutoffEpochMs(long retentionDays) {
-        long nowEpochMs = DateTime.now(ISOChronology.getInstance()).getMillis();
+        long nowEpochMs = Instant.now().toEpochMilli();
         return nowEpochMs - new TimeValue(retentionDays, TimeUnit.DAYS).getMillis();
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredForecastsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredForecastsRemover.java
@@ -35,11 +35,10 @@ import org.elasticsearch.xpack.core.ml.job.results.Forecast;
 import org.elasticsearch.xpack.core.ml.job.results.ForecastRequestStats;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
 import org.elasticsearch.xpack.ml.MachineLearning;
-import org.joda.time.DateTime;
-import org.joda.time.chrono.ISOChronology;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -66,7 +65,7 @@ public class ExpiredForecastsRemover implements MlDataRemover {
     public ExpiredForecastsRemover(Client client, ThreadPool threadPool) {
         this.client = Objects.requireNonNull(client);
         this.threadPool = Objects.requireNonNull(threadPool);
-        this.cutoffEpochMs = DateTime.now(ISOChronology.getInstance()).getMillis();
+        this.cutoffEpochMs = Instant.now().toEpochMilli();
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredForecastsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredForecastsRemover.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xpack.ml.MachineLearning;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -65,7 +66,7 @@ public class ExpiredForecastsRemover implements MlDataRemover {
     public ExpiredForecastsRemover(Client client, ThreadPool threadPool) {
         this.client = Objects.requireNonNull(client);
         this.threadPool = Objects.requireNonNull(threadPool);
-        this.cutoffEpochMs = Instant.now().toEpochMilli();
+        this.cutoffEpochMs = Instant.now(Clock.systemDefaultZone()).toEpochMilli();
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedFieldTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedFieldTests.java
@@ -9,6 +9,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.subphase.DocValueFieldsContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ml.test.SearchHitBuilder;
+import org.joda.time.DateTime;
 
 import java.util.Arrays;
 
@@ -99,6 +100,13 @@ public class ExtractedFieldTests extends ESTestCase {
     public void testValueGivenStringTimeField() {
         final long millis = randomLong();
         final SearchHit hit = new SearchHitBuilder(randomInt()).addField("time", Long.toString(millis)).build();
+        final ExtractedField timeField = ExtractedField.newTimeField("time", ExtractedField.ExtractionMethod.DOC_VALUE);
+        assertThat(timeField.value(hit), equalTo(new Object[] { millis }));
+    }
+
+    public void testValueGivenLongTimeField() {
+        final long millis = randomLong();
+        final SearchHit hit = new SearchHitBuilder(randomInt()).addField("time", millis).build();
         final ExtractedField timeField = ExtractedField.newTimeField("time", ExtractedField.ExtractionMethod.DOC_VALUE);
         assertThat(timeField.value(hit), equalTo(new Object[] { millis }));
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedFieldTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedFieldTests.java
@@ -8,9 +8,7 @@ package org.elasticsearch.xpack.ml.datafeed.extractor.fields;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.subphase.DocValueFieldsContext;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.ml.datafeed.extractor.fields.ExtractedField;
 import org.elasticsearch.xpack.ml.test.SearchHitBuilder;
-import org.joda.time.DateTime;
 
 import java.util.Arrays;
 
@@ -96,13 +94,6 @@ public class ExtractedFieldTests extends ESTestCase {
 
     public void testNewTimeFieldGivenSource() {
         expectThrows(IllegalArgumentException.class, () -> ExtractedField.newTimeField("time", ExtractedField.ExtractionMethod.SOURCE));
-    }
-
-    public void testValueGivenTimeField() {
-        final long millis = randomLong();
-        final SearchHit hit = new SearchHitBuilder(randomInt()).addField("time", new DateTime(millis)).build();
-        final ExtractedField timeField = ExtractedField.newTimeField("time", ExtractedField.ExtractionMethod.DOC_VALUE);
-        assertThat(timeField.value(hit), equalTo(new Object[] { millis }));
     }
 
     public void testValueGivenStringTimeField() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedFieldTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedFieldTests.java
@@ -9,7 +9,6 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.subphase.DocValueFieldsContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ml.test.SearchHitBuilder;
-import org.joda.time.DateTime;
 
 import java.util.Arrays;
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/TimeBasedExtractedFieldsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/TimeBasedExtractedFieldsTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.ml.test.SearchHitBuilder;
-import org.joda.time.DateTime;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -62,13 +61,6 @@ public class TimeBasedExtractedFieldsTests extends ESTestCase {
         assertThat(extractedFields.getDocValueFields().stream().map(ExtractedField::getName).toArray(String[]::new),
             equalTo(new String[] {"time", "doc1", "doc2"}));
         assertThat(extractedFields.getSourceFields(), equalTo(new String[] {"src1", "src2"}));
-    }
-
-    public void testTimeFieldValue() {
-        long millis = randomLong();
-        SearchHit hit = new SearchHitBuilder(randomInt()).addField("time", new DateTime(millis)).build();
-        TimeBasedExtractedFields extractedFields = new TimeBasedExtractedFields(timeField, Collections.singletonList(timeField));
-        assertThat(extractedFields.timeFieldValue(hit), equalTo(millis));
     }
 
     public void testStringTimeFieldValue() {


### PR DESCRIPTION
merging against java-time branch to be able to test with elasticsearch already using java.time classes.

part of the migrating joda time work. The goal is to find usages of joda
time and refactor to use java.time.

closes: #35490
previous branch against master (on top of java-time)
relates: #35493
