### PR TITLE
Remove `TcpChannel#setSoLinger` method (#35924)

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.concurrent.CompletableContext;
 import org.elasticsearch.transport.TcpChannel;
 import org.elasticsearch.transport.TransportException;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 
 public class Netty4TcpChannel implements TcpChannel {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
@@ -20,9 +20,7 @@
 package org.elasticsearch.transport.netty4;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPromise;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
@@ -93,17 +91,6 @@ public class Netty4TcpChannel implements TcpChannel {
     @Override
     public void addConnectListener(ActionListener<Void> listener) {
         connectContext.addListener(ActionListener.toBiConsumer(listener));
-    }
-
-    @Override
-    public void setSoLinger(int value) throws IOException {
-        if (channel.isOpen()) {
-            try {
-                channel.config().setOption(ChannelOption.SO_LINGER, value);
-            } catch (ChannelException e) {
-                throw new IOException(e);
-            }
-        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpChannel.java
@@ -23,7 +23,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.network.CloseableChannel;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 
 
@@ -38,14 +37,6 @@ public interface TcpChannel extends CloseableChannel {
      * This returns the profile for this channel.
      */
     String getProfile();
-
-    /**
-     * This sets the low level socket option {@link java.net.StandardSocketOptions} SO_LINGER on a channel.
-     *
-     * @param value to set for SO_LINGER
-     * @throws IOException that can be throw by the low level socket implementation
-     */
-    void setSoLinger(int value) throws IOException;
 
     /**
      * Returns the local address for this channel.

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -348,24 +348,6 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         public void close() {
             if (isClosing.compareAndSet(false, true)) {
                 try {
-                    if (lifecycle.stopped()) {
-                        /* We set SO_LINGER timeout to 0 to ensure that when we shutdown the node we don't
-                         * have a gazillion connections sitting in TIME_WAIT to free up resources quickly.
-                         * This is really the only part where we close the connection from the server side
-                         * otherwise the client (node) initiates the TCP closing sequence which doesn't cause
-                         * these issues. Setting this by default from the beginning can have unexpected
-                         * side-effects an should be avoided, our protocol is designed in a way that clients
-                         * close connection which is how it should be*/
-
-                        channels.forEach(c -> {
-                            try {
-                                c.setSoLinger(0);
-                            } catch (IOException e) {
-                                logger.warn(new ParameterizedMessage("unexpected exception when setting SO_LINGER on channel {}", c), e);
-                            }
-                        });
-                    }
-
                     boolean block = lifecycle.stopped() && Transports.isTransportThread(Thread.currentThread()) == false;
                     CloseableChannel.closeChannels(channels, block);
                 } finally {

--- a/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
@@ -274,10 +274,6 @@ public class TcpTransportTests extends ESTestCase {
         }
 
         @Override
-        public void setSoLinger(int value) throws IOException {
-        }
-
-        @Override
         public boolean isOpen() {
             return false;
         }

--- a/test/framework/src/main/java/org/elasticsearch/transport/MockTcpTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/MockTcpTransport.java
@@ -400,13 +400,6 @@ public class MockTcpTransport extends TcpTransport {
         }
 
         @Override
-        public void setSoLinger(int value) throws IOException {
-            if (activeChannel != null && activeChannel.isClosed() == false) {
-                activeChannel.setSoLinger(true, value);
-            }
-        }
-
-        @Override
         public boolean isOpen() {
             return isOpen.get();
         }


### PR DESCRIPTION
This commit removes the dedicated `setSoLinger` method. This simplifies
the `TcpChannel` interface. This method has very little effect as the
SO_LINGER is not set prior to the channels being closed in the abstract
transport test case.