### PR TITLE
Remove deprecated Graph endpoints

### DIFF
--- a/docs/reference/migration/migrate_7_0/api.asciidoc
+++ b/docs/reference/migration/migrate_7_0/api.asciidoc
@@ -113,3 +113,9 @@ The deprecated in 6.x url parameters are now removed. Use `_source_includes` and
 
 MultiSearchRequests issued through `_msearch` now validate all keys in the metadata section. Previously unknown keys were ignored
 while now an exception is thrown.
+
+[float]
+==== Deprecated graph endpoints removed
+
+The deprecated graph endpoints (those with `/_graph/_explore`) have been
+removed.

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
@@ -40,7 +40,6 @@ import static org.elasticsearch.xpack.core.graph.action.GraphExploreAction.INSTA
  */
 public class RestGraphAction extends XPackRestHandler {
     private static final Logger logger = LogManager.getLogger(RestGraphAction.class);
-    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
 
     public static final ParseField TIMEOUT_FIELD = new ParseField("timeout");
     public static final ParseField SIGNIFICANCE_FIELD = new ParseField("use_significance");

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
@@ -64,15 +64,10 @@ public class RestGraphAction extends XPackRestHandler {
     public RestGraphAction(Settings settings, RestController controller) {
         super(settings);
 
-        // @deprecated Remove in 7.0
-        controller.registerWithDeprecatedHandler(GET, "/{index}" + URI_BASE + "/graph/_explore", this,
-                                                 GET, "/{index}" + URI_BASE + "/_graph/_explore", deprecationLogger);
-        controller.registerWithDeprecatedHandler(POST, "/{index}" + URI_BASE + "/graph/_explore", this,
-                                                 POST, "/{index}" + URI_BASE + "/_graph/_explore", deprecationLogger);
-        controller.registerWithDeprecatedHandler(GET, "/{index}/{type}" + URI_BASE + "/graph/_explore", this,
-                                                 GET, "/{index}/{type}" + URI_BASE + "/_graph/_explore", deprecationLogger);
-        controller.registerWithDeprecatedHandler(POST, "/{index}/{type}" + URI_BASE + "/graph/_explore", this,
-                                                 POST, "/{index}/{type}" + URI_BASE + "/_graph/_explore", deprecationLogger);
+        controller.registerHandler(GET, "/{index}" + URI_BASE + "/graph/_explore", this);
+        controller.registerHandler(POST, "/{index}" + URI_BASE + "/graph/_explore", this);
+        controller.registerHandler(GET, "/{index}/{type}" + URI_BASE + "/graph/_explore", this);
+        controller.registerHandler(POST, "/{index}/{type}" + URI_BASE + "/graph/_explore", this);
     }
 
     @Override

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
@@ -5,20 +5,19 @@
  */
 package org.elasticsearch.xpack.graph.rest.action;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.protocol.xpack.graph.GraphExploreRequest;
+import org.elasticsearch.protocol.xpack.graph.GraphExploreRequest.TermBoost;
 import org.elasticsearch.protocol.xpack.graph.Hop;
 import org.elasticsearch.protocol.xpack.graph.VertexRequest;
-import org.elasticsearch.protocol.xpack.graph.GraphExploreRequest.TermBoost;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;


### PR DESCRIPTION
We had some endpoints in Graph that are deprecated for removal in 7.0.0. This commit removes these deprecated endpoints.