### PR TITLE
Deprecate X-Pack centric license endpoints

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseRequestConverters.java
@@ -34,7 +34,7 @@ final class LicenseRequestConverters {
     private LicenseRequestConverters() {}
 
     static Request putLicense(PutLicenseRequest putLicenseRequest) {
-        String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_xpack", "license").build();
+        String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_license").build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
         RequestConverters.Params parameters = new RequestConverters.Params(request);
         parameters.withTimeout(putLicenseRequest.timeout());
@@ -47,7 +47,7 @@ final class LicenseRequestConverters {
     }
 
     static Request getLicense(GetLicenseRequest getLicenseRequest) {
-        String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_xpack", "license").build();
+        String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_license").build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
         RequestConverters.Params parameters = new RequestConverters.Params(request);
         parameters.withLocal(getLicenseRequest.isLocal());
@@ -55,7 +55,7 @@ final class LicenseRequestConverters {
     }
 
     static Request deleteLicense(DeleteLicenseRequest deleteLicenseRequest) {
-        String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_xpack", "license").build();
+        String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_license").build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
         RequestConverters.Params parameters = new RequestConverters.Params(request);
         parameters.withTimeout(deleteLicenseRequest.timeout());
@@ -64,7 +64,7 @@ final class LicenseRequestConverters {
     }
 
     static Request startTrial(StartTrialRequest startTrialRequest) {
-        final String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_xpack", "license", "start_trial").build();
+        final String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_license", "start_trial").build();
         final Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
         RequestConverters.Params parameters = new RequestConverters.Params(request);
@@ -77,7 +77,7 @@ final class LicenseRequestConverters {
 
     static Request startBasic(StartBasicRequest startBasicRequest) {
         String endpoint = new RequestConverters.EndpointBuilder()
-            .addPathPartAsIs("_xpack", "license", "start_basic")
+            .addPathPartAsIs("_license", "start_basic")
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
         RequestConverters.Params parameters = new RequestConverters.Params(request);
@@ -90,10 +90,11 @@ final class LicenseRequestConverters {
     }
 
     static Request getLicenseTrialStatus() {
-        return new Request(HttpGet.METHOD_NAME, "/_xpack/license/trial_status");
+        return new Request(HttpGet.METHOD_NAME, "/_license/trial_status");
     }
 
     static Request getLicenseBasicStatus() {
-        return new Request(HttpGet.METHOD_NAME, "/_xpack/license/basic_status");
+        return new Request(HttpGet.METHOD_NAME, "/_license/basic_status");
     }
+
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/LicenseRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/LicenseRequestConvertersTests.java
@@ -54,7 +54,7 @@ public class LicenseRequestConvertersTests extends ESTestCase {
 
         Request request = LicenseRequestConverters.getLicense(getLicenseRequest);
         assertThat(request.getMethod(), equalTo(HttpGet.METHOD_NAME));
-        assertThat(request.getEndpoint(), equalTo("/_xpack/license"));
+        assertThat(request.getEndpoint(), equalTo("/_license"));
         assertThat(request.getParameters(), equalTo(expectedParams));
         assertThat(request.getEntity(), is(nullValue()));
     }
@@ -72,7 +72,7 @@ public class LicenseRequestConvertersTests extends ESTestCase {
 
         Request request = LicenseRequestConverters.putLicense(putLicenseRequest);
         assertThat(request.getMethod(), equalTo(HttpPut.METHOD_NAME));
-        assertThat(request.getEndpoint(), equalTo("/_xpack/license"));
+        assertThat(request.getEndpoint(), equalTo("/_license"));
         assertThat(request.getParameters(), equalTo(expectedParams));
         assertThat(request.getEntity(), is(nullValue()));
     }
@@ -85,7 +85,7 @@ public class LicenseRequestConvertersTests extends ESTestCase {
 
         Request request = LicenseRequestConverters.deleteLicense(deleteLicenseRequest);
         assertThat(request.getMethod(), equalTo(HttpDelete.METHOD_NAME));
-        assertThat(request.getEndpoint(), equalTo("/_xpack/license"));
+        assertThat(request.getEndpoint(), equalTo("/_license"));
         assertThat(request.getParameters(), equalTo(expectedParams));
         assertThat(request.getEntity(), is(nullValue()));
     }
@@ -106,7 +106,7 @@ public class LicenseRequestConvertersTests extends ESTestCase {
         final Request restRequest = LicenseRequestConverters.startTrial(hlrcRequest);
 
         assertThat(restRequest.getMethod(), equalTo(HttpPost.METHOD_NAME));
-        assertThat(restRequest.getEndpoint(), equalTo("/_xpack/license/start_trial"));
+        assertThat(restRequest.getEndpoint(), equalTo("/_license/start_trial"));
         assertThat(restRequest.getParameters(), equalTo(expectedParams));
         assertThat(restRequest.getEntity(), nullValue());
     }
@@ -124,7 +124,7 @@ public class LicenseRequestConvertersTests extends ESTestCase {
         Request request = LicenseRequestConverters.startBasic(startBasicRequest);
 
         assertThat(request.getMethod(), equalTo(HttpPost.METHOD_NAME));
-        assertThat(request.getEndpoint(), equalTo("/_xpack/license/start_basic"));
+        assertThat(request.getEndpoint(), equalTo("/_license/start_basic"));
         assertThat(request.getParameters(), equalTo(expectedParams));
         assertThat(request.getEntity(), is(nullValue()));
     }
@@ -132,7 +132,7 @@ public class LicenseRequestConvertersTests extends ESTestCase {
     public void testGetLicenseTrialStatus() {
         Request request = LicenseRequestConverters.getLicenseTrialStatus();
         assertEquals(HttpGet.METHOD_NAME, request.getMethod());
-        assertEquals("/_xpack/license/trial_status", request.getEndpoint());
+        assertEquals("/_license/trial_status", request.getEndpoint());
         assertEquals(request.getParameters().size(), 0);
         assertNull(request.getEntity());
     }
@@ -140,7 +140,7 @@ public class LicenseRequestConvertersTests extends ESTestCase {
     public void testGetLicenseBasicStatus() {
         Request request = LicenseRequestConverters.getLicenseBasicStatus();
         assertEquals(HttpGet.METHOD_NAME, request.getMethod());
-        assertEquals("/_xpack/license/basic_status", request.getEndpoint());
+        assertEquals("/_license/basic_status", request.getEndpoint());
         assertEquals(request.getParameters().size(), 0);
         assertNull(request.getEntity());
     }

--- a/docs/reference/licensing/delete-license.asciidoc
+++ b/docs/reference/licensing/delete-license.asciidoc
@@ -8,7 +8,7 @@ This API enables you to delete licensing information.
 [float]
 ==== Request
 
-`DELETE /_xpack/license`
+`DELETE /_license`
 
 [float]
 ==== Description
@@ -30,7 +30,7 @@ The following example queries the info API:
 
 [source,js]
 ------------------------------------------------------------
-DELETE _xpack/license
+DELETE /_license
 ------------------------------------------------------------
 // CONSOLE
 // TEST[skip:license testing issues]

--- a/docs/reference/licensing/get-basic-status.asciidoc
+++ b/docs/reference/licensing/get-basic-status.asciidoc
@@ -8,7 +8,7 @@ This API enables you to check the status of your basic license.
 [float]
 ==== Request
 
-`GET _xpack/license/basic_status`
+`GET /_license/basic_status`
 
 [float]
 ==== Description
@@ -32,7 +32,7 @@ The following example checks whether you are eligible to start a basic:
 
 [source,js]
 ------------------------------------------------------------
-GET _xpack/license/basic_status
+GET /_license/basic_status
 ------------------------------------------------------------
 // CONSOLE
 

--- a/docs/reference/licensing/get-license.asciidoc
+++ b/docs/reference/licensing/get-license.asciidoc
@@ -8,7 +8,7 @@ This API enables you to retrieve licensing information.
 [float]
 ==== Request
 
-`GET /_xpack/license`
+`GET /_license`
 
 [float]
 ==== Description
@@ -43,7 +43,7 @@ The following example provides information about a trial license:
 
 [source,js]
 --------------------------------------------------
-GET _xpack/license
+GET /_license
 --------------------------------------------------
 // CONSOLE
 

--- a/docs/reference/licensing/get-trial-status.asciidoc
+++ b/docs/reference/licensing/get-trial-status.asciidoc
@@ -8,7 +8,7 @@ This API enables you to check the status of your trial license.
 [float]
 ==== Request
 
-`GET _xpack/license/trial_status`
+`GET /_license/trial_status`
 
 [float]
 ==== Description
@@ -38,7 +38,7 @@ The following example checks whether you are eligible to start a trial:
 
 [source,js]
 ------------------------------------------------------------
-GET _xpack/license/trial_status
+GET /_license/trial_status
 ------------------------------------------------------------
 // CONSOLE
 

--- a/docs/reference/licensing/start-basic.asciidoc
+++ b/docs/reference/licensing/start-basic.asciidoc
@@ -8,7 +8,7 @@ This API starts an indefinite basic license.
 [float]
 ==== Request
 
-`POST _xpack/license/start_basic`
+`POST /_license/start_basic`
 
 [float]
 ==== Description
@@ -38,7 +38,7 @@ The following example starts a basic license if you do not currently have a lice
 
 [source,js]
 ------------------------------------------------------------
-POST _xpack/license/start_basic
+POST /_license/start_basic
 ------------------------------------------------------------
 // CONSOLE
 // TEST[skip:license testing issues]
@@ -59,7 +59,7 @@ parameter:
 
 [source,js]
 ------------------------------------------------------------
-POST _xpack/license/start_basic?acknowledge=true
+POST /_license/start_basic?acknowledge=true
 ------------------------------------------------------------
 // CONSOLE
 // TEST[skip:license testing issues]

--- a/docs/reference/licensing/start-trial.asciidoc
+++ b/docs/reference/licensing/start-trial.asciidoc
@@ -8,7 +8,7 @@ This API starts a 30-day trial license.
 [float]
 ==== Request
 
-`POST _xpack/license/start_trial`
+`POST /_license/start_trial`
 
 [float]
 ==== Description
@@ -42,7 +42,7 @@ parameter is required as you are initiating a license that will expire.
 
 [source,js]
 ------------------------------------------------------------
-POST _xpack/license/start_trial?acknowledge=true
+POST /_license/start_trial?acknowledge=true
 ------------------------------------------------------------
 // CONSOLE
 // TEST[skip:license testing issues]

--- a/docs/reference/licensing/update-license.asciidoc
+++ b/docs/reference/licensing/update-license.asciidoc
@@ -8,7 +8,7 @@ This API enables you to update your license.
 [float]
 ==== Request
 
-`PUT _xpack/license`
+`PUT /_license`
 
 [float]
 ==== Description
@@ -54,7 +54,7 @@ The following example updates to a basic license:
 
 [source,js]
 ------------------------------------------------------------
-POST _xpack/license
+POST /_license
 {
   "licenses": [
     {
@@ -81,7 +81,7 @@ You can alternatively use a `curl` command, for example:
 [source,js]
 [source,shell]
 ------------------------------------------------------------
-curl -XPUT -u <user> 'http://<host>:<port>/_xpack/license' -H "Content-Type: application/json" -d @license.json
+curl -XPUT -u <user> 'http://<host>:<port>/_license' -H "Content-Type: application/json" -d @license.json
 ------------------------------------------------------------
 // NOTCONSOLE
 
@@ -89,7 +89,7 @@ On Windows machine, use the following command:
 
 [source,shell]
 ------------------------------------------------------------
-gc .\license.json |  Invoke-WebRequest -uri http://<host>:<port>/_xpack/license -Credential elastic -Method Put -ContentType "application/json"
+gc .\license.json |  Invoke-WebRequest -uri http://<host>:<port>/_license -Credential elastic -Method Put -ContentType "application/json"
 ------------------------------------------------------------
 
 In these examples,
@@ -131,7 +131,7 @@ To complete the update, you must re-submit the API request and set the
 
 [source,js]
 ------------------------------------------------------------
-POST _xpack/license?acknowledge=true
+POST /_license?acknowledge=true
 {
   "licenses": [
     {
@@ -154,7 +154,7 @@ Alternatively:
 
 [source,sh]
 ------------------------------------------------------------
-curl -XPUT -u elastic 'http://<host>:<port>/_xpack/license?acknowledge=true' -H "Content-Type: application/json" -d @license.json
+curl -XPUT -u elastic 'http://<host>:<port>/_license?acknowledge=true' -H "Content-Type: application/json" -d @license.json
 ------------------------------------------------------------
 // NOTCONSOLE
 

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/XPackIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/XPackIT.java
@@ -78,7 +78,7 @@ public class XPackIT extends AbstractRollingTestCase {
      * trial license a little bit to make sure that it works.
      */
     public void testTrialLicense() throws IOException {
-        Request startTrial = new Request("POST", "/_xpack/license/start_trial");
+        Request startTrial = new Request("POST", "/_license/start_trial");
         startTrial.addParameter("acknowledge", "true");
         client().performRequest(startTrial);
 

--- a/x-pack/plugin/ccr/qa/multi-cluster-downgraded-to-basic-license/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster-downgraded-to-basic-license/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexIT.java
@@ -50,7 +50,7 @@ public class FollowIndexIT extends ESCCRRestTestCase {
 
         String index2 = "logs-20190102";
         try (RestClient leaderClient = buildLeaderClient()) {
-            Request request = new Request("POST", "/_xpack/license/start_basic");
+            Request request = new Request("POST", "/_license/start_basic");
             request.addParameter("acknowledge", "true");
             Map<?, ?> response = toMap(leaderClient.performRequest(request));
             assertThat(response.get("basic_was_started"), is(true));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestDeleteLicenseAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestDeleteLicenseAction.java
@@ -3,8 +3,11 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.license;
 
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.protocol.xpack.license.DeleteLicenseRequest;
 import org.elasticsearch.rest.RestController;
@@ -18,14 +21,20 @@ import java.io.IOException;
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 
 public class RestDeleteLicenseAction extends XPackRestHandler {
-    public RestDeleteLicenseAction(Settings settings, RestController controller) {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestDeleteLicenseAction.class));
+
+    RestDeleteLicenseAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(DELETE, URI_BASE + "/license", this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                DELETE, "/_license", this,
+                DELETE, URI_BASE + "/license", deprecationLogger);
     }
 
     @Override
     public String getName() {
-        return "xpack_delete_license_action";
+        return "delete_license";
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetBasicStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetBasicStatus.java
@@ -3,8 +3,11 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.license;
 
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -16,9 +19,14 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestGetBasicStatus extends XPackRestHandler {
 
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestGetBasicStatus.class));
+
     RestGetBasicStatus(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(GET, URI_BASE + "/license/basic_status", this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                GET, "/_license/basic_status", this,
+                GET, URI_BASE + "/license/basic_status", deprecationLogger);
     }
 
     @Override
@@ -28,6 +36,7 @@ public class RestGetBasicStatus extends XPackRestHandler {
 
     @Override
     public String getName() {
-        return "xpack_basic_status_action";
+        return "get_basic_status";
     }
+
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetLicenseAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetLicenseAction.java
@@ -3,9 +3,12 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.license;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -28,15 +31,19 @@ import static org.elasticsearch.rest.RestStatus.OK;
 
 public class RestGetLicenseAction extends XPackRestHandler {
 
-    @Inject
-    public RestGetLicenseAction(Settings settings, RestController controller) {
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestGetLicenseAction.class));
+
+    RestGetLicenseAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(GET,  URI_BASE + "/license", this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                GET, "/_license", this,
+                GET,  URI_BASE + "/license", deprecationLogger);
     }
 
     @Override
     public String getName() {
-        return "xpack_get_license_action";
+        return "get_license";
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetLicenseAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetLicenseAction.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.license;
 
 import org.apache.logging.log4j.LogManager;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetTrialStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetTrialStatus.java
@@ -3,8 +3,11 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.license;
 
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -16,9 +19,14 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestGetTrialStatus extends XPackRestHandler {
 
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestGetTrialStatus.class));
+
     RestGetTrialStatus(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(GET, URI_BASE + "/license/trial_status", this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                GET, "/_license/trial_status", this,
+                GET, URI_BASE + "/license/trial_status", deprecationLogger);
     }
 
     @Override
@@ -28,6 +36,7 @@ public class RestGetTrialStatus extends XPackRestHandler {
 
     @Override
     public String getName() {
-        return "xpack_trial_status_action";
+        return "get_trial_status";
     }
+
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartBasicLicense.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartBasicLicense.java
@@ -3,8 +3,11 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.license;
 
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -18,9 +21,14 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 public class RestPostStartBasicLicense extends XPackRestHandler {
 
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestPostStartBasicLicense.class));
+
     RestPostStartBasicLicense(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(POST, URI_BASE + "/license/start_basic", this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                POST, "/_license/start_basis", this,
+                POST, URI_BASE + "/license/start_basic", deprecationLogger);
     }
 
     @Override
@@ -34,6 +42,7 @@ public class RestPostStartBasicLicense extends XPackRestHandler {
 
     @Override
     public String getName() {
-        return "xpack_start_basic_action";
+        return "post_start_basic";
     }
+
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartBasicLicense.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartBasicLicense.java
@@ -27,7 +27,7 @@ public class RestPostStartBasicLicense extends XPackRestHandler {
         super(settings);
         // TODO: remove deprecated endpoint in 8.0.0
         controller.registerWithDeprecatedHandler(
-                POST, "/_license/start_basis", this,
+                POST, "/_license/start_basic", this,
                 POST, URI_BASE + "/license/start_basic", deprecationLogger);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartTrialLicense.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartTrialLicense.java
@@ -3,8 +3,11 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.license;
 
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.BytesRestResponse;
@@ -22,9 +25,14 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 public class RestPostStartTrialLicense extends XPackRestHandler {
 
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestPostStartTrialLicense.class));
+
     RestPostStartTrialLicense(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(POST, URI_BASE + "/license/start_trial", this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                POST, "/_license/start_trial", this,
+                POST, URI_BASE + "/license/start_trial", deprecationLogger);
     }
 
     @Override
@@ -68,6 +76,7 @@ public class RestPostStartTrialLicense extends XPackRestHandler {
 
     @Override
     public String getName() {
-        return "xpack_upgrade_to_trial_action";
+        return "post_start_trial";
     }
+
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/StartBasicLicenseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/StartBasicLicenseTests.java
@@ -68,12 +68,12 @@ public class StartBasicLicenseTests extends AbstractLicensesIntegrationTestCase 
         }
 
         RestClient restClient = getRestClient();
-        Response response = restClient.performRequest(new Request("GET", "/_xpack/license/basic_status"));
+        Response response = restClient.performRequest(new Request("GET", "/_license/basic_status"));
         String body = Streams.copyToString(new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8));
         assertEquals(200, response.getStatusLine().getStatusCode());
         assertEquals("{\"eligible_to_start_basic\":true}", body);
 
-        Request ackRequest = new Request("POST", "/_xpack/license/start_basic");
+        Request ackRequest = new Request("POST", "/_license/start_basic");
         ackRequest.addParameter("acknowledge", "true");
         Response response2 = restClient.performRequest(ackRequest);
         String body2 = Streams.copyToString(new InputStreamReader(response2.getEntity().getContent(), StandardCharsets.UTF_8));
@@ -89,19 +89,19 @@ public class StartBasicLicenseTests extends AbstractLicensesIntegrationTestCase 
         long expirationMillis = licensingClient.prepareGetLicense().get().license().expiryDate();
         assertEquals(LicenseService.BASIC_SELF_GENERATED_LICENSE_EXPIRATION_MILLIS, expirationMillis);
 
-        Response response3 = restClient.performRequest(new Request("GET", "/_xpack/license"));
+        Response response3 = restClient.performRequest(new Request("GET", "/_license"));
         String body3 = Streams.copyToString(new InputStreamReader(response3.getEntity().getContent(), StandardCharsets.UTF_8));
         assertTrue(body3.contains("\"type\" : \"basic\""));
         assertFalse(body3.contains("expiry_date"));
         assertFalse(body3.contains("expiry_date_in_millis"));
 
-        Response response4 = restClient.performRequest(new Request("GET", "/_xpack/license/basic_status"));
+        Response response4 = restClient.performRequest(new Request("GET", "/_license/basic_status"));
         String body4 = Streams.copyToString(new InputStreamReader(response4.getEntity().getContent(), StandardCharsets.UTF_8));
         assertEquals(200, response3.getStatusLine().getStatusCode());
         assertEquals("{\"eligible_to_start_basic\":false}", body4);
 
         ResponseException ex = expectThrows(ResponseException.class,
-                () -> restClient.performRequest(new Request("POST", "/_xpack/license/start_basic")));
+                () -> restClient.performRequest(new Request("POST", "/_license/start_basic")));
         Response response5 = ex.getResponse();
         String body5 = Streams.copyToString(new InputStreamReader(response5.getEntity().getContent(), StandardCharsets.UTF_8));
         assertEquals(403, response5.getStatusLine().getStatusCode());
@@ -120,7 +120,7 @@ public class StartBasicLicenseTests extends AbstractLicensesIntegrationTestCase 
             assertEquals("trial", getLicenseResponse.license().type());
         });
 
-        Response response2 = getRestClient().performRequest(new Request("POST", "/_xpack/license/start_basic"));
+        Response response2 = getRestClient().performRequest(new Request("POST", "/_license/start_basic"));
         String body2 = Streams.copyToString(new InputStreamReader(response2.getEntity().getContent(), StandardCharsets.UTF_8));
         assertEquals(200, response2.getStatusLine().getStatusCode());
         assertTrue(body2.contains("\"acknowledged\":false"));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/StartTrialLicenseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/StartTrialLicenseTests.java
@@ -55,13 +55,13 @@ public class StartTrialLicenseTests extends AbstractLicensesIntegrationTestCase 
         ensureStartingWithBasic();
 
         RestClient restClient = getRestClient();
-        Response response = restClient.performRequest(new Request("GET", "/_xpack/license/trial_status"));
+        Response response = restClient.performRequest(new Request("GET", "/_license/trial_status"));
         String body = Streams.copyToString(new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8));
         assertEquals(200, response.getStatusLine().getStatusCode());
         assertEquals("{\"eligible_to_start_trial\":true}", body);
 
         // Test that starting will fail without acknowledgement
-        Response response2 = restClient.performRequest(new Request("POST", "/_xpack/license/start_trial"));
+        Response response2 = restClient.performRequest(new Request("POST", "/_license/start_trial"));
         String body2 = Streams.copyToString(new InputStreamReader(response2.getEntity().getContent(), StandardCharsets.UTF_8));
         assertEquals(200, response2.getStatusLine().getStatusCode());
         assertTrue(body2.contains("\"trial_was_started\":false"));
@@ -75,7 +75,7 @@ public class StartTrialLicenseTests extends AbstractLicensesIntegrationTestCase 
 
         String type = randomFrom(LicenseService.VALID_TRIAL_TYPES);
 
-        Request ackRequest = new Request("POST", "/_xpack/license/start_trial");
+        Request ackRequest = new Request("POST", "/_license/start_trial");
         ackRequest.addParameter("acknowledge", "true");
         ackRequest.addParameter("type", type);
         Response response3 = restClient.performRequest(ackRequest);
@@ -90,14 +90,14 @@ public class StartTrialLicenseTests extends AbstractLicensesIntegrationTestCase 
             assertEquals(type, postTrialLicenseResponse.license().type());
         });
 
-        Response response4 = restClient.performRequest(new Request("GET", "/_xpack/license/trial_status"));
+        Response response4 = restClient.performRequest(new Request("GET", "/_license/trial_status"));
         String body4 = Streams.copyToString(new InputStreamReader(response4.getEntity().getContent(), StandardCharsets.UTF_8));
         assertEquals(200, response4.getStatusLine().getStatusCode());
         assertEquals("{\"eligible_to_start_trial\":false}", body4);
 
         String secondAttemptType = randomFrom(LicenseService.VALID_TRIAL_TYPES);
 
-        Request startTrialWhenStartedRequest = new Request("POST", "/_xpack/license/start_trial");
+        Request startTrialWhenStartedRequest = new Request("POST", "/_license/start_trial");
         startTrialWhenStartedRequest.addParameter("acknowledge", "true");
         startTrialWhenStartedRequest.addParameter("type", secondAttemptType);
         ResponseException ex = expectThrows(ResponseException.class, () -> restClient.performRequest(startTrialWhenStartedRequest));
@@ -111,7 +111,7 @@ public class StartTrialLicenseTests extends AbstractLicensesIntegrationTestCase 
     public void testInvalidType() throws Exception {
         ensureStartingWithBasic();
 
-        Request request = new Request("POST", "/_xpack/license/start_trial");
+        Request request = new Request("POST", "/_license/start_trial");
         request.addParameter("type", "basic");
         ResponseException ex = expectThrows(ResponseException.class, () -> getRestClient().performRequest(request));
         Response response = ex.getResponse();

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.delete.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.delete.json
@@ -3,8 +3,8 @@
     "documentation": "https://www.elastic.co/guide/en/x-pack/current/license-management.html",
     "methods": ["DELETE"],
     "url": {
-      "path": "/_xpack/license",
-      "paths": ["/_xpack/license"],
+      "path": "/_license",
+      "paths": ["/_license"],
       "parts" : {}
     },
     "body": null

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.get.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.get.json
@@ -3,8 +3,8 @@
     "documentation": "https://www.elastic.co/guide/en/x-pack/current/license-management.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_xpack/license",
-      "paths": ["/_xpack/license"],
+      "path": "/_license",
+      "paths": ["/_license"],
       "parts" : {
       },
       "params": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.get_basic_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.get_basic_status.json
@@ -3,8 +3,8 @@
     "documentation": "https://www.elastic.co/guide/en/x-pack/current/license-management.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_xpack/license/basic_status",
-      "paths": ["/_xpack/license/basic_status"],
+      "path": "/_license/basic_status",
+      "paths": ["/_license/basic_status"],
       "parts" : {
       },
       "params": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.get_trial_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.get_trial_status.json
@@ -3,8 +3,8 @@
     "documentation": "https://www.elastic.co/guide/en/x-pack/current/license-management.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_xpack/license/trial_status",
-      "paths": ["/_xpack/license/trial_status"],
+      "path": "/_license/trial_status",
+      "paths": ["/_license/trial_status"],
       "parts" : {
       },
       "params": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.post.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.post.json
@@ -3,8 +3,8 @@
     "documentation": "https://www.elastic.co/guide/en/x-pack/current/license-management.html",
     "methods": ["PUT", "POST"],
     "url": {
-      "path": "/_xpack/license",
-      "paths": ["/_xpack/license"],
+      "path": "/_license",
+      "paths": ["/_license"],
       "parts" : {
       },
       "params": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.post_start_basic.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.post_start_basic.json
@@ -3,8 +3,8 @@
     "documentation": "https://www.elastic.co/guide/en/x-pack/current/license-management.html",
     "methods": ["POST"],
     "url": {
-      "path": "/_xpack/license/start_basic",
-      "paths": ["/_xpack/license/start_basic"],
+      "path": "/_license/start_basic",
+      "paths": ["/_license/start_basic"],
       "parts" : {
       },
       "params": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.post_start_trial.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.post_start_trial.json
@@ -3,8 +3,8 @@
     "documentation": "https://www.elastic.co/guide/en/x-pack/current/license-management.html",
     "methods": ["POST"],
     "url": {
-      "path": "/_xpack/license/start_trial",
-      "paths": ["/_xpack/license/start_trial"],
+      "path": "/_license/start_trial",
+      "paths": ["/_license/start_trial"],
       "parts" : {
       },
       "params": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/license/20_put_license.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/license/20_put_license.yml
@@ -102,7 +102,7 @@ teardown:
         body: |
           {"license":{"uid":"893361dc-9749-4997-93cb-802e3d7fa4a8","type":"basic","issue_date_in_millis":1411948800000,"expiry_date_in_millis":1914278399999,"max_nodes":1,"issued_to":"issuedTo","issuer":"issuer","signature":"AAAAAgAAAA0lKPZ0a7aZquUltho/AAABmC9ZN0hjZDBGYnVyRXpCOW5Bb3FjZDAxOWpSbTVoMVZwUzRxVk1PSmkxakxZdW5IMlhlTHNoN1N2MXMvRFk4d3JTZEx3R3RRZ0pzU3lobWJKZnQvSEFva0ppTHBkWkprZWZSQi9iNmRQNkw1SlpLN0lDalZCS095MXRGN1lIZlpYcVVTTnFrcTE2dzhJZmZrdFQrN3JQeGwxb0U0MXZ0dDJHSERiZTVLOHNzSDByWnpoZEphZHBEZjUrTVBxRENNSXNsWWJjZllaODdzVmEzUjNiWktNWGM5TUhQV2plaUo4Q1JOUml4MXNuL0pSOEhQaVB2azhmUk9QVzhFeTFoM1Q0RnJXSG53MWk2K055c28zSmRnVkF1b2JSQkFLV2VXUmVHNDZ2R3o2VE1qbVNQS2lxOHN5bUErZlNIWkZSVmZIWEtaSU9wTTJENDVvT1NCYklacUYyK2FwRW9xa0t6dldMbmMzSGtQc3FWOTgzZ3ZUcXMvQkt2RUZwMFJnZzlvL2d2bDRWUzh6UG5pdENGWFRreXNKNkE9PQAAAQAALuQ44S3IG6SzolcXVJ6Z4CIXORDrYQ+wdLCeey0XdujTslAOj+k+vNgo6wauc7Uswi01esHu4lb5IgpvKy7RRCbh5bj/z2ubu2qMJqopp9BQyD7VQjVfqmG6seUMJwJ1a5Avvm9r41YPSPcrii3bKK2e1l6jK6N8ibCvnTyY/XkYGCJrBWTSJePDbg6ErbyodrZ37x1StLbPWcNAkmweyHjDJnvYnbeZZO7A3NmubXZjW7Ttf8/YwQyE00PqMcl7fVPY3hkKpAeHf8aaJbqkKYbqZuER3EWJX7ZvLVb1dNdNg8aXRn7YrkQcYwWgptYQpfV+D7yEJ4j5muAEoler"}}
 
-  - match: { error.root_cause.0.reason: 'Installing basic licenses is no longer allowed. Use the POST /_xpack/license/start_basic API to install a basic license that does not expire.' }
+  - match: { error.root_cause.0.reason: 'Installing basic licenses is no longer allowed. Use the POST /_license/start_basic API to install a basic license that does not expire.' }
 ---
 "Should fail gracefully when body content is not provided":
 

--- a/x-pack/qa/rolling-upgrade-basic/src/test/java/org/elasticsearch/upgrades/BasicLicenseUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade-basic/src/test/java/org/elasticsearch/upgrades/BasicLicenseUpgradeIT.java
@@ -23,7 +23,7 @@ public class BasicLicenseUpgradeIT extends AbstractUpgradeTestCase {
     }
 
     private void checkBasicLicense() throws Exception {
-        Response licenseResponse = client().performRequest(new Request("GET", "/_xpack/license"));
+        Response licenseResponse = client().performRequest(new Request("GET", "/_license"));
         Map<String, Object> licenseResponseMap = entityAsMap(licenseResponse);
         Map<String, Object> licenseMap = (Map<String, Object>) licenseResponseMap.get("license");
         assertEquals("basic", licenseMap.get("type"));
@@ -31,7 +31,7 @@ public class BasicLicenseUpgradeIT extends AbstractUpgradeTestCase {
     }
 
     private void checkNonExpiringBasicLicense() throws Exception {
-        Response licenseResponse = client().performRequest(new Request("GET", "/_xpack/license"));
+        Response licenseResponse = client().performRequest(new Request("GET", "/_license"));
         Map<String, Object> licenseResponseMap = entityAsMap(licenseResponse);
         Map<String, Object> licenseMap = (Map<String, Object>) licenseResponseMap.get("license");
         assertEquals("basic", licenseMap.get("type"));


### PR DESCRIPTION
This commit is part of our plan to deprecate and ultimately remove the use of _xpack in the REST APIs.

Relates #35958
