### PR TITLE
Deprecate X-Pack centric rollup endpoints

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RollupRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RollupRequestConverters.java
@@ -42,7 +42,7 @@ final class RollupRequestConverters {
 
     static Request putJob(final PutRollupJobRequest putRollupJobRequest) throws IOException {
         String endpoint = new RequestConverters.EndpointBuilder()
-            .addPathPartAsIs("_xpack", "rollup", "job")
+            .addPathPartAsIs("_rollup", "job")
             .addPathPart(putRollupJobRequest.getConfig().getId())
             .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
@@ -52,7 +52,7 @@ final class RollupRequestConverters {
 
     static Request startJob(final StartRollupJobRequest startRollupJobRequest) throws IOException {
         String endpoint = new RequestConverters.EndpointBuilder()
-            .addPathPartAsIs("_xpack", "rollup", "job")
+            .addPathPartAsIs("_rollup", "job")
             .addPathPart(startRollupJobRequest.getJobId())
             .addPathPartAsIs("_start")
             .build();
@@ -61,7 +61,7 @@ final class RollupRequestConverters {
 
     static Request stopJob(final StopRollupJobRequest stopRollupJobRequest) throws IOException {
         String endpoint = new RequestConverters.EndpointBuilder()
-            .addPathPartAsIs("_xpack", "rollup", "job")
+            .addPathPartAsIs("_rollup", "job")
             .addPathPart(stopRollupJobRequest.getJobId())
             .addPathPartAsIs("_stop")
             .build();
@@ -77,7 +77,7 @@ final class RollupRequestConverters {
 
     static Request getJob(final GetRollupJobRequest getRollupJobRequest) {
         String endpoint = new RequestConverters.EndpointBuilder()
-            .addPathPartAsIs("_xpack", "rollup", "job")
+            .addPathPartAsIs("_rollup", "job")
             .addPathPart(getRollupJobRequest.getJobId())
             .build();
         return new Request(HttpGet.METHOD_NAME, endpoint);
@@ -85,7 +85,7 @@ final class RollupRequestConverters {
 
     static Request deleteJob(final DeleteRollupJobRequest deleteRollupJobRequest) throws IOException {
         String endpoint = new RequestConverters.EndpointBuilder()
-            .addPathPartAsIs("_xpack", "rollup", "job")
+            .addPathPartAsIs("_rollup", "job")
             .addPathPart(deleteRollupJobRequest.getId())
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
@@ -95,7 +95,7 @@ final class RollupRequestConverters {
 
     static Request getRollupCaps(final GetRollupCapsRequest getRollupCapsRequest) throws IOException {
         String endpoint = new RequestConverters.EndpointBuilder()
-            .addPathPartAsIs("_xpack", "rollup", "data")
+            .addPathPartAsIs("_rollup", "data")
             .addPathPart(getRollupCapsRequest.getIndexPattern())
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
@@ -106,7 +106,7 @@ final class RollupRequestConverters {
     static Request getRollupIndexCaps(final GetRollupIndexCapsRequest getRollupIndexCapsRequest) throws IOException {
         String endpoint = new RequestConverters.EndpointBuilder()
             .addCommaSeparatedPathParts(getRollupIndexCapsRequest.indices())
-            .addPathPartAsIs("_xpack", "rollup", "data")
+            .addPathPartAsIs("_rollup", "data")
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
         request.setEntity(createEntity(getRollupIndexCapsRequest, REQUEST_BODY_CONTENT_TYPE));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RollupRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RollupRequestConvertersTests.java
@@ -45,7 +45,7 @@ public class RollupRequestConvertersTests extends ESTestCase {
         PutRollupJobRequest put = new PutRollupJobRequest(config);
 
         Request request = RollupRequestConverters.putJob(put);
-        assertThat(request.getEndpoint(), equalTo("/_xpack/rollup/job/" + job));
+        assertThat(request.getEndpoint(), equalTo("/_rollup/job/" + job));
         assertThat(HttpPut.METHOD_NAME, equalTo(request.getMethod()));
         assertThat(request.getParameters().keySet(), empty());
         RequestConvertersTests.assertToXContentBody(put, request.getEntity());
@@ -57,7 +57,7 @@ public class RollupRequestConvertersTests extends ESTestCase {
         StartRollupJobRequest startJob = new StartRollupJobRequest(jobId);
 
         Request request = RollupRequestConverters.startJob(startJob);
-        assertThat(request.getEndpoint(), equalTo("/_xpack/rollup/job/" + jobId + "/_start"));
+        assertThat(request.getEndpoint(), equalTo("/_rollup/job/" + jobId + "/_start"));
         assertThat(HttpPost.METHOD_NAME, equalTo(request.getMethod()));
         assertThat(request.getParameters().keySet(), empty());
         assertThat(request.getEntity(), nullValue());
@@ -81,7 +81,7 @@ public class RollupRequestConvertersTests extends ESTestCase {
         }
 
         Request request = RollupRequestConverters.stopJob(stopJob);
-        assertThat(request.getEndpoint(), equalTo("/_xpack/rollup/job/" + jobId + "/_stop"));
+        assertThat(request.getEndpoint(), equalTo("/_rollup/job/" + jobId + "/_stop"));
         assertThat(HttpPost.METHOD_NAME, equalTo(request.getMethod()));
         assertThat(request.getParameters().keySet().size(), equalTo(expectedParameters));
         assertThat(request.getParameters().get("timeout"), equalTo(expectedTimeOutString));
@@ -95,7 +95,7 @@ public class RollupRequestConvertersTests extends ESTestCase {
         GetRollupJobRequest get = getAll ? new GetRollupJobRequest() : new GetRollupJobRequest(job);
 
         Request request = RollupRequestConverters.getJob(get);
-        assertThat(request.getEndpoint(), equalTo("/_xpack/rollup/job/" + job));
+        assertThat(request.getEndpoint(), equalTo("/_rollup/job/" + job));
         assertThat(HttpGet.METHOD_NAME, equalTo(request.getMethod()));
         assertThat(request.getParameters().keySet(), empty());
         assertThat(request.getEntity(), nullValue());

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -625,7 +625,7 @@ buildRestTests.setups['sensor_rollup_job'] = '''
   - do:
       raw:
         method: PUT
-        path: _xpack/rollup/job/sensor
+        path: _rollup/job/sensor
         body:  >
             {
                 "index_pattern": "sensor-*",
@@ -696,7 +696,7 @@ buildRestTests.setups['sensor_started_rollup_job'] = '''
   - do:
       raw:
         method: PUT
-        path: _xpack/rollup/job/sensor
+        path: _rollup/job/sensor
         body:  >
             {
                 "index_pattern": "sensor-*",
@@ -727,7 +727,7 @@ buildRestTests.setups['sensor_started_rollup_job'] = '''
   - do:
       raw:
         method: POST
-        path: _xpack/rollup/job/sensor/_start
+        path: _rollup/job/sensor/_start
 '''
 
 buildRestTests.setups['sensor_index'] = '''

--- a/docs/reference/rollup/api-quickref.asciidoc
+++ b/docs/reference/rollup/api-quickref.asciidoc
@@ -9,7 +9,7 @@ Most {rollup} endpoints have the following base:
 
 [source,js]
 ----
-/_xpack/rollup/
+/_rollup/
 ----
 // NOTCONSOLE
 
@@ -17,18 +17,18 @@ Most {rollup} endpoints have the following base:
 [[rollup-api-jobs]]
 === /job/
 
-* {ref}/rollup-put-job.html[PUT /_xpack/rollup/job/<job_id+++>+++]: Create a job
-* {ref}/rollup-get-job.html[GET /_xpack/rollup/job]: List jobs
-* {ref}/rollup-get-job.html[GET /_xpack/rollup/job/<job_id+++>+++]: Get job details
-* {ref}/rollup-start-job.html[POST /_xpack/rollup/job/<job_id>/_start]: Start a job
-* {ref}/rollup-stop-job.html[POST /_xpack/rollup/job/<job_id>/_stop]: Stop a job
-* {ref}/rollup-delete-job.html[DELETE /_xpack/rollup/job/<job_id+++>+++]: Delete a job
+* {ref}/rollup-put-job.html[PUT /_rollup/job/<job_id+++>+++]: Create a job
+* {ref}/rollup-get-job.html[GET /_rollup/job]: List jobs
+* {ref}/rollup-get-job.html[GET /_rollup/job/<job_id+++>+++]: Get job details
+* {ref}/rollup-start-job.html[POST /_rollup/job/<job_id>/_start]: Start a job
+* {ref}/rollup-stop-job.html[POST /_rollup/job/<job_id>/_stop]: Stop a job
+* {ref}/rollup-delete-job.html[DELETE /_rollup/job/<job_id+++>+++]: Delete a job
 
 [float]
 [[rollup-api-data]]
 === /data/
 
-* {ref}/rollup-get-rollup-caps.html[GET /_xpack/rollup/data/<index_pattern+++>/_rollup_caps+++]: Get Rollup Capabilities
+* {ref}/rollup-get-rollup-caps.html[GET /_rollup/data/<index_pattern+++>/_rollup_caps+++]: Get Rollup Capabilities
 * {ref}/rollup-get-rollup-index-caps.html[GET /<index_name+++>/_rollup/data/+++]: Get Rollup Index Capabilities
 
 [float]

--- a/docs/reference/rollup/apis/delete-job.asciidoc
+++ b/docs/reference/rollup/apis/delete-job.asciidoc
@@ -39,7 +39,7 @@ POST my_rollup_index/_delete_by_query
 **********************************
 ==== Request
 
-`DELETE _xpack/rollup/job/<job_id>`
+`DELETE _rollup/job/<job_id>`
 
 //===== Description
 
@@ -66,7 +66,7 @@ If we have a rollup job named `sensor`, it can be deleted with:
 
 [source,js]
 --------------------------------------------------
-DELETE _xpack/rollup/job/sensor
+DELETE _rollup/job/sensor
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:sensor_rollup_job]
@@ -85,7 +85,7 @@ If however we try to delete a job which doesn't exist:
 
 [source,js]
 --------------------------------------------------
-DELETE _xpack/rollup/job/does_not_exist
+DELETE _rollup/job/does_not_exist
 --------------------------------------------------
 // CONSOLE
 // TEST[catch:missing]

--- a/docs/reference/rollup/apis/get-job.asciidoc
+++ b/docs/reference/rollup/apis/get-job.asciidoc
@@ -18,7 +18,7 @@ For details about a historical job, the <<rollup-get-rollup-caps,Rollup Capabili
 
 ==== Request
 
-`GET _xpack/rollup/job/<job_id>`
+`GET _rollup/job/<job_id>`
 
 //===== Description
 
@@ -44,7 +44,7 @@ If we have already created a rollup job named `sensor`, the details about the jo
 
 [source,js]
 --------------------------------------------------
-GET _xpack/rollup/job/sensor
+GET _rollup/job/sensor
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:sensor_rollup_job]
@@ -134,7 +134,7 @@ If we add another job, we can see how multi-job responses are handled:
 
 [source,js]
 --------------------------------------------------
-PUT _xpack/rollup/job/sensor2 <1>
+PUT _rollup/job/sensor2 <1>
 {
     "index_pattern": "sensor-*",
     "rollup_index": "sensor_rollup",
@@ -162,7 +162,7 @@ PUT _xpack/rollup/job/sensor2 <1>
     ]
 }
 
-GET _xpack/rollup/job/_all <2>
+GET _rollup/job/_all <2>
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:sensor_rollup_job]

--- a/docs/reference/rollup/apis/put-job.asciidoc
+++ b/docs/reference/rollup/apis/put-job.asciidoc
@@ -13,7 +13,7 @@ started with the <<rollup-start-job,Start Job API>>.
 
 ==== Request
 
-`PUT _xpack/rollup/job/<job_id>`
+`PUT _rollup/job/<job_id>`
 
 //===== Description
 
@@ -59,7 +59,7 @@ The following example creates a rollup job named "sensor", targeting the "sensor
 
 [source,js]
 --------------------------------------------------
-PUT _xpack/rollup/job/sensor
+PUT _rollup/job/sensor
 {
     "index_pattern": "sensor-*",
     "rollup_index": "sensor_rollup",

--- a/docs/reference/rollup/apis/rollup-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-caps.asciidoc
@@ -21,7 +21,7 @@ live?
 
 ==== Request
 
-`GET _xpack/rollup/data/{index}`
+`GET _rollup/data/{index}`
 
 //===== Description
 
@@ -50,7 +50,7 @@ this future scaling:
 
 [source,js]
 --------------------------------------------------
-PUT _xpack/rollup/job/sensor
+PUT _rollup/job/sensor
 {
     "index_pattern": "sensor-*",
     "rollup_index": "sensor_rollup",
@@ -85,7 +85,7 @@ We can then retrieve the rollup capabilities of that index pattern (`sensor-*`) 
 
 [source,js]
 --------------------------------------------------
-GET _xpack/rollup/data/sensor-*
+GET _rollup/data/sensor-*
 --------------------------------------------------
 // CONSOLE
 // TEST[continued]
@@ -155,7 +155,7 @@ We could also retrieve the same information with a request to `_all`:
 
 [source,js]
 --------------------------------------------------
-GET _xpack/rollup/data/_all
+GET _rollup/data/_all
 --------------------------------------------------
 // CONSOLE
 // TEST[continued]
@@ -164,7 +164,7 @@ But note that if we use the concrete index name (`sensor-1`), we'll retrieve no 
 
 [source,js]
 --------------------------------------------------
-GET _xpack/rollup/data/sensor-1
+GET _rollup/data/sensor-1
 --------------------------------------------------
 // CONSOLE
 // TEST[continued]

--- a/docs/reference/rollup/apis/rollup-index-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-index-caps.asciidoc
@@ -18,7 +18,7 @@ This API will allow you to determine:
 
 ==== Request
 
-`GET {index}/_xpack/rollup/data`
+`GET {index}/_rollup/data`
 
 //===== Description
 
@@ -44,7 +44,7 @@ will be a `sensor-2`, `sensor-3`, etc.  Let's create a Rollup job, which stores 
 
 [source,js]
 --------------------------------------------------
-PUT _xpack/rollup/job/sensor
+PUT _rollup/job/sensor
 {
     "index_pattern": "sensor-*",
     "rollup_index": "sensor_rollup",
@@ -80,7 +80,7 @@ Index API:
 
 [source,js]
 --------------------------------------------------
-GET /sensor_rollup/_xpack/rollup/data
+GET /sensor_rollup/_rollup/data
 --------------------------------------------------
 // CONSOLE
 // TEST[continued]
@@ -153,7 +153,7 @@ Like other APIs that interact with indices, you can specify index patterns inste
 
 [source,js]
 --------------------------------------------------
-GET /*_rollup/_xpack/rollup/data
+GET /*_rollup/_rollup/data
 --------------------------------------------------
 // CONSOLE
 // TEST[continued]

--- a/docs/reference/rollup/apis/rollup-job-config.asciidoc
+++ b/docs/reference/rollup/apis/rollup-job-config.asciidoc
@@ -15,7 +15,7 @@ A full job configuration might look like this:
 
 [source,js]
 --------------------------------------------------
-PUT _xpack/rollup/job/sensor
+PUT _rollup/job/sensor
 {
     "index_pattern": "sensor-*",
     "rollup_index": "sensor_rollup",

--- a/docs/reference/rollup/apis/rollup-search.asciidoc
+++ b/docs/reference/rollup/apis/rollup-search.asciidoc
@@ -52,7 +52,7 @@ Imagine we have an index named `sensor-1` full of raw data, and we have created 
 
 [source,js]
 --------------------------------------------------
-PUT _xpack/rollup/job/sensor
+PUT _rollup/job/sensor
 {
     "index_pattern": "sensor-*",
     "rollup_index": "sensor_rollup",

--- a/docs/reference/rollup/apis/start-job.asciidoc
+++ b/docs/reference/rollup/apis/start-job.asciidoc
@@ -13,7 +13,7 @@ Starting an already started job has no action.
 
 ==== Request
 
-`POST _xpack/rollup/job/<job_id>/_start`
+`POST _rollup/job/<job_id>/_start`
 
 //===== Description
 
@@ -39,7 +39,7 @@ If we have already created a rollup job named `sensor`, it can be started with:
 
 [source,js]
 --------------------------------------------------
-POST _xpack/rollup/job/sensor/_start
+POST _rollup/job/sensor/_start
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:sensor_rollup_job]
@@ -58,7 +58,7 @@ If however we try to start a job which doesn't exist:
 
 [source,js]
 --------------------------------------------------
-POST _xpack/rollup/job/does_not_exist/_start
+POST _rollup/job/does_not_exist/_start
 --------------------------------------------------
 // CONSOLE
 // TEST[catch:missing]

--- a/docs/reference/rollup/apis/stop-job.asciidoc
+++ b/docs/reference/rollup/apis/stop-job.asciidoc
@@ -13,7 +13,7 @@ Stopping an already stopped job has no action.
 
 ==== Request
 
-`POST _xpack/rollup/job/<job_id>/_stop`
+`POST _rollup/job/<job_id>/_stop`
 
 //===== Description
 
@@ -52,7 +52,7 @@ If we have an already-started rollup job named `sensor`, it can be stopped with:
 
 [source,js]
 --------------------------------------------------
-POST _xpack/rollup/job/sensor/_stop
+POST _rollup/job/sensor/_stop
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:sensor_started_rollup_job]
@@ -71,7 +71,7 @@ If however we try to stop a job which doesn't exist:
 
 [source,js]
 --------------------------------------------------
-POST _xpack/rollup/job/does_not_exist/_stop
+POST _rollup/job/does_not_exist/_stop
 --------------------------------------------------
 // CONSOLE
 // TEST[catch:missing]
@@ -106,7 +106,7 @@ stopped.  This is accomplished with the `wait_for_completion` query parameter, a
 
 [source,js]
 --------------------------------------------------
-POST _xpack/rollup/job/sensor/_stop?wait_for_completion=true&timeout=10s
+POST _rollup/job/sensor/_stop?wait_for_completion=true&timeout=10s
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:sensor_started_rollup_job]

--- a/docs/reference/rollup/rollup-getting-started.asciidoc
+++ b/docs/reference/rollup/rollup-getting-started.asciidoc
@@ -30,7 +30,7 @@ one hour or greater.  A rollup job might look like this:
 
 [source,js]
 --------------------------------------------------
-PUT _xpack/rollup/job/sensor
+PUT _rollup/job/sensor
 {
     "index_pattern": "sensor-*",
     "rollup_index": "sensor_rollup",
@@ -60,7 +60,7 @@ PUT _xpack/rollup/job/sensor
 // CONSOLE
 // TEST[setup:sensor_index]
 
-We give the job the ID of "sensor" (in the url: `PUT _xpack/rollup/job/sensor`), and tell it to rollup the index pattern `"sensor-*"`.
+We give the job the ID of "sensor" (in the url: `PUT _rollup/job/sensor`), and tell it to rollup the index pattern `"sensor-*"`.
 This job will find and rollup any index that matches that pattern. Rollup summaries are then stored in the `"sensor_rollup"` index.
 
 The `cron` parameter controls when and how often the job activates.  When a rollup job's cron schedule triggers, it will begin rolling up
@@ -114,7 +114,7 @@ To start the job, execute this command:
 
 [source,js]
 --------------------------------------------------
-POST _xpack/rollup/job/sensor/_start
+POST _rollup/job/sensor/_start
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:sensor_rollup_job]

--- a/docs/reference/rollup/understanding-groups.asciidoc
+++ b/docs/reference/rollup/understanding-groups.asciidoc
@@ -162,7 +162,7 @@ the best practice is to combine them into a single rollup job which covers both 
 
 [source,js]
 --------------------------------------------------
-PUT _xpack/rollup/job/combined
+PUT _rollup/job/combined
 {
     "index_pattern": "data-*",
     "rollup_index": "data_rollup",

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -474,7 +474,7 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     private void wipeRollupJobs() throws IOException, InterruptedException {
-        Response response = adminClient().performRequest(new Request("GET", "/_xpack/rollup/job/_all"));
+        Response response = adminClient().performRequest(new Request("GET", "/_rollup/job/_all"));
         Map<String, Object> jobs = entityAsMap(response);
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> jobConfigs =
@@ -487,7 +487,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         for (Map<String, Object> jobConfig : jobConfigs) {
             @SuppressWarnings("unchecked")
             String jobId = (String) ((Map<String, Object>) jobConfig.get("config")).get("id");
-            Request request = new Request("POST", "/_xpack/rollup/job/" + jobId + "/_stop");
+            Request request = new Request("POST", "/_rollup/job/" + jobId + "/_stop");
             request.addParameter("ignore", "404");
             request.addParameter("wait_for_completion", "true");
             request.addParameter("timeout", "10s");
@@ -498,7 +498,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         for (Map<String, Object> jobConfig : jobConfigs) {
             @SuppressWarnings("unchecked")
             String jobId = (String) ((Map<String, Object>) jobConfig.get("config")).get("id");
-            Request request = new Request("DELETE", "/_xpack/rollup/job/" + jobId);
+            Request request = new Request("DELETE", "/_rollup/job/" + jobId);
             request.addParameter("ignore", "404"); // Ignore 404s because they imply someone was racing us to delete this
             logger.debug("deleting rollup job [{}]", jobId);
             adminClient().performRequest(request);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsRestIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsRestIT.java
@@ -396,7 +396,7 @@ public class DatafeedJobsRestIT extends ESRestTestCase {
         client().performRequest(createJobRequest);
 
         String rollupJobId = "rollup-" + jobId;
-        Request createRollupRequest = new Request("PUT", "/_xpack/rollup/job/" + rollupJobId);
+        Request createRollupRequest = new Request("PUT", "/_rollup/job/" + rollupJobId);
         createRollupRequest.setJsonEntity("{\n"
             + "\"index_pattern\": \"airline-data-aggs\",\n"
             + "    \"rollup_index\": \"airline-data-aggs-rollup\",\n"
@@ -764,7 +764,7 @@ public class DatafeedJobsRestIT extends ESRestTestCase {
         client().performRequest(createJobRequest);
 
         String rollupJobId = "rollup-" + jobId;
-        Request createRollupRequest = new Request("PUT", "/_xpack/rollup/job/" + rollupJobId);
+        Request createRollupRequest = new Request("PUT", "/_rollup/job/" + rollupJobId);
         createRollupRequest.setJsonEntity("{\n"
             + "\"index_pattern\": \"airline-data-aggs\",\n"
             + "    \"rollup_index\": \"airline-data-aggs-rollup\",\n"
@@ -792,18 +792,18 @@ public class DatafeedJobsRestIT extends ESRestTestCase {
             + "    ]\n"
             + "}");
         client().performRequest(createRollupRequest);
-        client().performRequest(new Request("POST", "/_xpack/rollup/job/" + rollupJobId + "/_start"));
+        client().performRequest(new Request("POST", "/_rollup/job/" + rollupJobId + "/_start"));
 
         assertBusy(() -> {
-            Response getRollup = client().performRequest(new Request("GET", "/_xpack/rollup/job/" + rollupJobId));
+            Response getRollup = client().performRequest(new Request("GET", "/_rollup/job/" + rollupJobId));
             String body = EntityUtils.toString(getRollup.getEntity());
             assertThat(body, containsString("\"job_state\":\"started\""));
             assertThat(body, containsString("\"rollups_indexed\":4"));
         }, 60, TimeUnit.SECONDS);
 
-        client().performRequest(new Request("POST", "/_xpack/rollup/job/" + rollupJobId + "/_stop"));
+        client().performRequest(new Request("POST", "/_rollup/job/" + rollupJobId + "/_stop"));
         assertBusy(() -> {
-            Response getRollup = client().performRequest(new Request("GET", "/_xpack/rollup/job/" + rollupJobId));
+            Response getRollup = client().performRequest(new Request("GET", "/_rollup/job/" + rollupJobId));
             assertThat(EntityUtils.toString(getRollup.getEntity()), containsString("\"job_state\":\"stopped\""));
         }, 60, TimeUnit.SECONDS);
 
@@ -849,7 +849,7 @@ public class DatafeedJobsRestIT extends ESRestTestCase {
         client().performRequest(createJobRequest);
 
         String rollupJobId = "rollup-" + jobId;
-        Request createRollupRequest = new Request("PUT", "/_xpack/rollup/job/" + rollupJobId);
+        Request createRollupRequest = new Request("PUT", "/_rollup/job/" + rollupJobId);
         createRollupRequest.setJsonEntity("{\n"
             + "\"index_pattern\": \"airline-data-aggs\",\n"
             + "    \"rollup_index\": \"airline-data-aggs-rollup\",\n"

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
@@ -80,7 +80,7 @@ import static java.util.Collections.emptyList;
 
 public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin {
 
-    public static final String BASE_PATH = "/_rollup/";
+    public static final String BASE_PATH = "/_xpack/rollup/";
 
     // Introduced in ES version 6.3
     public static final int ROLLUP_VERSION_V1 = 1;

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
@@ -80,7 +80,7 @@ import static java.util.Collections.emptyList;
 
 public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin {
 
-    public static final String BASE_PATH = "/_xpack/rollup/";
+    public static final String BASE_PATH = "/_rollup/";
 
     // Introduced in ES version 6.3
     public static final int ROLLUP_VERSION_V1 = 1;

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestDeleteRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestDeleteRollupJobAction.java
@@ -3,11 +3,13 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.rollup.rest;
 
-
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
@@ -19,12 +21,20 @@ import org.elasticsearch.xpack.rollup.Rollup;
 
 import java.io.IOException;
 
+import static org.elasticsearch.rest.RestRequest.Method.DELETE;
+
 public class RestDeleteRollupJobAction extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestDeleteRollupJobAction.class));
+
     public static final ParseField ID = new ParseField("id");
 
     public RestDeleteRollupJobAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.DELETE, Rollup.BASE_PATH +  "job/{id}/", this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                DELETE, "/_rollup/job/{id}", this,
+                DELETE, Rollup.BASE_PATH +  "job/{id}/", deprecationLogger);
     }
 
     @Override
@@ -46,6 +56,7 @@ public class RestDeleteRollupJobAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "rollup_delete_job_action";
+        return "delete_rollup_job";
     }
+
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupCapsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupCapsAction.java
@@ -5,8 +5,10 @@
  */
 package org.elasticsearch.xpack.rollup.rest;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
@@ -17,12 +19,21 @@ import org.elasticsearch.xpack.rollup.Rollup;
 
 import java.io.IOException;
 
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
 public class RestGetRollupCapsAction extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestGetRollupCapsAction.class));
+
+
     public static final ParseField ID = new ParseField("id");
 
     public RestGetRollupCapsAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.GET, Rollup.BASE_PATH +  "data/{id}/", this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                GET, "/_rollup/data/{id}", this,
+                GET, Rollup.BASE_PATH +  "data/{id}/", deprecationLogger);
     }
 
     @Override
@@ -35,6 +46,7 @@ public class RestGetRollupCapsAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "rollup_get_caps_action";
+        return "get_rollup_caps";
     }
+
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupIndexCapsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupIndexCapsAction.java
@@ -3,12 +3,15 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.rollup.rest;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
@@ -16,12 +19,22 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.rollup.action.GetRollupIndexCapsAction;
 
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
 public class RestGetRollupIndexCapsAction extends BaseRestHandler {
-    public static final ParseField INDEX = new ParseField("index");
+
+    private static final DeprecationLogger deprecationLogger =
+            new DeprecationLogger(LogManager.getLogger(RestGetRollupIndexCapsAction.class));
+
+
+    static final ParseField INDEX = new ParseField("index");
 
     public RestGetRollupIndexCapsAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.GET, "/{index}/_xpack/rollup/data", this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                GET, "/{index}/_rollup/data", this,
+                GET, "/{index}/_xpack/rollup/data", deprecationLogger);
     }
 
     @Override
@@ -35,6 +48,7 @@ public class RestGetRollupIndexCapsAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "rollup_get_caps_action";
+        return "get_rollup_index_caps";
     }
+
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupJobsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupJobsAction.java
@@ -3,10 +3,13 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.rollup.rest;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
@@ -15,12 +18,20 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.rollup.action.GetRollupJobsAction;
 import org.elasticsearch.xpack.rollup.Rollup;
 
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
 public class RestGetRollupJobsAction extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestGetRollupJobsAction.class));
+
     public static final ParseField ID = new ParseField("id");
 
     public RestGetRollupJobsAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.GET, Rollup.BASE_PATH + "job/{id}/", this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                GET, "/_rollup/job/{id}", this,
+                GET, Rollup.BASE_PATH +  "job/{id}/", deprecationLogger);
     }
 
     @Override
@@ -33,6 +44,7 @@ public class RestGetRollupJobsAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "rollup_get_job_action";
+        return "get_rollup_job";
     }
+
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestPutRollupJobAction.java
@@ -3,10 +3,12 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.rollup.rest;
 
-
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
@@ -17,11 +19,18 @@ import org.elasticsearch.xpack.rollup.Rollup;
 
 import java.io.IOException;
 
+import static org.elasticsearch.rest.RestRequest.Method.PUT;
+
 public class RestPutRollupJobAction extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestPutRollupJobAction.class));
 
     public RestPutRollupJobAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.PUT, Rollup.BASE_PATH +  "job/{id}/", this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                PUT, "/_rollup/job/{id}", this,
+                PUT, Rollup.BASE_PATH +  "job/{id}", deprecationLogger);
     }
 
     @Override
@@ -33,6 +42,7 @@ public class RestPutRollupJobAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "rollup_put_job_action";
+        return "put_rollup_job";
     }
+
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestStartRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestStartRollupJobAction.java
@@ -3,9 +3,12 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.rollup.rest;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
@@ -17,11 +20,18 @@ import org.elasticsearch.xpack.rollup.Rollup;
 
 import java.io.IOException;
 
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
 public class RestStartRollupJobAction extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestStartRollupJobAction.class));
 
     public RestStartRollupJobAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.POST, Rollup.BASE_PATH +  "job/{id}/_start", this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                POST, "/_rollup/job/{id}/_start", this,
+                POST, Rollup.BASE_PATH +  "job/{id}/_start", deprecationLogger);
     }
 
     @Override
@@ -34,6 +44,7 @@ public class RestStartRollupJobAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "rollup_start_job_action";
+        return "start_rollup_job";
     }
+
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestStopRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestStopRollupJobAction.java
@@ -3,9 +3,12 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.rollup.rest;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -16,11 +19,18 @@ import org.elasticsearch.xpack.core.rollup.RollupField;
 import org.elasticsearch.xpack.core.rollup.action.StopRollupJobAction;
 import org.elasticsearch.xpack.rollup.Rollup;
 
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
 public class RestStopRollupJobAction extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestStopRollupJobAction.class));
 
     public RestStopRollupJobAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.POST, Rollup.BASE_PATH +  "job/{id}/_stop", this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                POST, "/_rollup/job/{id}/_stop", this,
+                POST, Rollup.BASE_PATH +  "job/{id}/_stop", deprecationLogger);
     }
 
     @Override
@@ -35,6 +45,7 @@ public class RestStopRollupJobAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "rollup_stop_job_action";
+        return "stop_rollup_job";
     }
+
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.delete_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.delete_job.json
@@ -3,8 +3,8 @@
     "documentation": "",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_xpack/rollup/job/{id}",
-      "paths": [ "/_xpack/rollup/job/{id}" ],
+      "path": "/_rollup/job/{id}",
+      "paths": [ "/_rollup/job/{id}" ],
       "parts": {
         "id": {
           "type": "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.get_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.get_jobs.json
@@ -3,8 +3,8 @@
     "documentation": "",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_xpack/rollup/job/{id}",
-      "paths": [ "/_xpack/rollup/job/{id}", "/_xpack/rollup/job/" ],
+      "path": "/_rollup/job/{id}",
+      "paths": [ "/_rollup/job/{id}", "/_rollup/job/" ],
       "parts": {
         "id": {
           "type": "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.get_rollup_caps.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.get_rollup_caps.json
@@ -3,8 +3,8 @@
     "documentation": "",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_xpack/rollup/data/{id}",
-      "paths": [ "/_xpack/rollup/data/{id}", "/_xpack/rollup/data/" ],
+      "path": "/_rollup/data/{id}",
+      "paths": [ "/_rollup/data/{id}", "/_rollup/data/" ],
       "parts": {
         "id": {
           "type": "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.get_rollup_index_caps.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.get_rollup_index_caps.json
@@ -3,8 +3,8 @@
     "documentation": "",
     "methods": [ "GET" ],
     "url": {
-      "path": "/{index}/_xpack/rollup/data",
-      "paths": [ "/{index}/_xpack/rollup/data" ],
+      "path": "/{index}/_rollup/data",
+      "paths": [ "/{index}/_rollup/data" ],
       "parts": {
         "index": {
           "type": "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.put_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.put_job.json
@@ -3,8 +3,8 @@
     "documentation": "",
     "methods": [ "PUT" ],
     "url": {
-      "path": "/_xpack/rollup/job/{id}",
-      "paths": [ "/_xpack/rollup/job/{id}" ],
+      "path": "/_rollup/job/{id}",
+      "paths": [ "/_rollup/job/{id}" ],
       "parts": {
         "id": {
           "type": "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.start_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.start_job.json
@@ -3,8 +3,8 @@
     "documentation": "",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_xpack/rollup/job/{id}/_start",
-      "paths": [ "/_xpack/rollup/job/{id}/_start" ],
+      "path": "/_rollup/job/{id}/_start",
+      "paths": [ "/_rollup/job/{id}/_start" ],
       "parts": {
         "id": {
           "type": "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.stop_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.stop_job.json
@@ -3,8 +3,8 @@
     "documentation": "",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_xpack/rollup/job/{id}/_stop",
-      "paths": [ "/_xpack/rollup/job/{id}/_stop" ],
+      "path": "/_rollup/job/{id}/_stop",
+      "paths": [ "/_rollup/job/{id}/_stop" ],
       "parts": {
         "id": {
           "type": "string",

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -261,7 +261,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             client().performRequest(bulkRequest);
 
             // create the rollup job
-            final Request createRollupJobRequest = new Request("PUT", "/_rollup/job/rollup-job-test");
+            final Request createRollupJobRequest = new Request("PUT", "/_xpack/rollup/job/rollup-job-test");
             createRollupJobRequest.setJsonEntity("{"
                     + "\"index_pattern\":\"rollup-*\","
                     + "\"rollup_index\":\"results-rollup\","
@@ -282,7 +282,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             assertThat(createRollupJobResponse.get("acknowledged"), equalTo(Boolean.TRUE));
 
             // start the rollup job
-            final Request startRollupJobRequest = new Request("POST", "_rollup/job/rollup-job-test/_start");
+            final Request startRollupJobRequest = new Request("POST", "/_xpack/rollup/job/rollup-job-test/_start");
             Map<String, Object> startRollupJobResponse = entityAsMap(client().performRequest(startRollupJobRequest));
             assertThat(startRollupJobResponse.get("started"), equalTo(Boolean.TRUE));
 
@@ -313,7 +313,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             client().performRequest(indexRequest);
 
             // create the rollup job
-            final Request createRollupJobRequest = new Request("PUT", "/_rollup/job/rollup-id-test");
+            final Request createRollupJobRequest = new Request("PUT", "/_xpack/rollup/job/rollup-id-test");
             createRollupJobRequest.setJsonEntity("{"
                 + "\"index_pattern\":\"id-test-rollup\","
                 + "\"rollup_index\":\"id-test-results-rollup\","
@@ -341,7 +341,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             assertThat(createRollupJobResponse.get("acknowledged"), equalTo(Boolean.TRUE));
 
             // start the rollup job
-            final Request startRollupJobRequest = new Request("POST", "_rollup/job/rollup-id-test/_start");
+            final Request startRollupJobRequest = new Request("POST", "/_xpack/rollup/job/rollup-id-test/_start");
             Map<String, Object> startRollupJobResponse = entityAsMap(client().performRequest(startRollupJobRequest));
             assertThat(startRollupJobResponse.get("started"), equalTo(Boolean.TRUE));
 
@@ -373,14 +373,14 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             assertRollUpJob("rollup-id-test");
 
             // stop the rollup job to force a state save, which will upgrade the ID
-            final Request stopRollupJobRequest = new Request("POST", "_rollup/job/rollup-id-test/_stop");
+            final Request stopRollupJobRequest = new Request("POST", "/_rollup/job/rollup-id-test/_stop");
             Map<String, Object> stopRollupJobResponse = entityAsMap(client().performRequest(stopRollupJobRequest));
             assertThat(stopRollupJobResponse.get("stopped"), equalTo(Boolean.TRUE));
 
             waitForRollUpJob("rollup-id-test", equalTo("stopped"));
 
             // start the rollup job again
-            final Request startRollupJobRequest = new Request("POST", "_rollup/job/rollup-id-test/_start");
+            final Request startRollupJobRequest = new Request("POST", "/_rollup/job/rollup-id-test/_start");
             Map<String, Object> startRollupJobResponse = entityAsMap(client().performRequest(startRollupJobRequest));
             assertThat(startRollupJobResponse.get("started"), equalTo(Boolean.TRUE));
 
@@ -617,7 +617,12 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         waitForRollUpJob(rollupJob, expectedStates);
 
         // check that the rollup job is started using the RollUp API
-        final Request getRollupJobRequest = new Request("GET", "_rollup/job/" + rollupJob);
+        final Request getRollupJobRequest;
+        if (isRunningAgainstOldCluster()) {
+            getRollupJobRequest = new Request("GET", "/_xpack/rollup/job/" + rollupJob);
+        } else {
+            getRollupJobRequest = new Request("GET", "/_rollup/job/" + rollupJob);
+        }
         Map<String, Object> getRollupJobResponse = entityAsMap(client().performRequest(getRollupJobRequest));
         Map<String, Object> job = getJob(getRollupJobResponse, rollupJob);
         if (job != null) {
@@ -663,7 +668,12 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
     private void waitForRollUpJob(final String rollupJob, final Matcher<?> expectedStates) throws Exception {
         assertBusy(() -> {
-            final Request getRollupJobRequest = new Request("GET", "_rollup/job/" + rollupJob);
+            final Request getRollupJobRequest;
+            if (isRunningAgainstOldCluster()) {
+                getRollupJobRequest = new Request("GET", "/_xpack/rollup/job/" + rollupJob);
+            } else {
+                getRollupJobRequest = new Request("GET", "/_rollup/job/" + rollupJob);
+            }
             Response getRollupJobResponse = client().performRequest(getRollupJobRequest);
             assertThat(getRollupJobResponse.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
 

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -261,7 +261,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             client().performRequest(bulkRequest);
 
             // create the rollup job
-            final Request createRollupJobRequest = new Request("PUT", "/_xpack/rollup/job/rollup-job-test");
+            final Request createRollupJobRequest = new Request("PUT", "/_rollup/job/rollup-job-test");
             createRollupJobRequest.setJsonEntity("{"
                     + "\"index_pattern\":\"rollup-*\","
                     + "\"rollup_index\":\"results-rollup\","
@@ -282,7 +282,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             assertThat(createRollupJobResponse.get("acknowledged"), equalTo(Boolean.TRUE));
 
             // start the rollup job
-            final Request startRollupJobRequest = new Request("POST", "_xpack/rollup/job/rollup-job-test/_start");
+            final Request startRollupJobRequest = new Request("POST", "_rollup/job/rollup-job-test/_start");
             Map<String, Object> startRollupJobResponse = entityAsMap(client().performRequest(startRollupJobRequest));
             assertThat(startRollupJobResponse.get("started"), equalTo(Boolean.TRUE));
 
@@ -313,7 +313,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             client().performRequest(indexRequest);
 
             // create the rollup job
-            final Request createRollupJobRequest = new Request("PUT", "/_xpack/rollup/job/rollup-id-test");
+            final Request createRollupJobRequest = new Request("PUT", "/_rollup/job/rollup-id-test");
             createRollupJobRequest.setJsonEntity("{"
                 + "\"index_pattern\":\"id-test-rollup\","
                 + "\"rollup_index\":\"id-test-results-rollup\","
@@ -341,7 +341,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             assertThat(createRollupJobResponse.get("acknowledged"), equalTo(Boolean.TRUE));
 
             // start the rollup job
-            final Request startRollupJobRequest = new Request("POST", "_xpack/rollup/job/rollup-id-test/_start");
+            final Request startRollupJobRequest = new Request("POST", "_rollup/job/rollup-id-test/_start");
             Map<String, Object> startRollupJobResponse = entityAsMap(client().performRequest(startRollupJobRequest));
             assertThat(startRollupJobResponse.get("started"), equalTo(Boolean.TRUE));
 
@@ -373,14 +373,14 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             assertRollUpJob("rollup-id-test");
 
             // stop the rollup job to force a state save, which will upgrade the ID
-            final Request stopRollupJobRequest = new Request("POST", "_xpack/rollup/job/rollup-id-test/_stop");
+            final Request stopRollupJobRequest = new Request("POST", "_rollup/job/rollup-id-test/_stop");
             Map<String, Object> stopRollupJobResponse = entityAsMap(client().performRequest(stopRollupJobRequest));
             assertThat(stopRollupJobResponse.get("stopped"), equalTo(Boolean.TRUE));
 
             waitForRollUpJob("rollup-id-test", equalTo("stopped"));
 
             // start the rollup job again
-            final Request startRollupJobRequest = new Request("POST", "_xpack/rollup/job/rollup-id-test/_start");
+            final Request startRollupJobRequest = new Request("POST", "_rollup/job/rollup-id-test/_start");
             Map<String, Object> startRollupJobResponse = entityAsMap(client().performRequest(startRollupJobRequest));
             assertThat(startRollupJobResponse.get("started"), equalTo(Boolean.TRUE));
 
@@ -617,7 +617,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         waitForRollUpJob(rollupJob, expectedStates);
 
         // check that the rollup job is started using the RollUp API
-        final Request getRollupJobRequest = new Request("GET", "_xpack/rollup/job/" + rollupJob);
+        final Request getRollupJobRequest = new Request("GET", "_rollup/job/" + rollupJob);
         Map<String, Object> getRollupJobResponse = entityAsMap(client().performRequest(getRollupJobRequest));
         Map<String, Object> job = getJob(getRollupJobResponse, rollupJob);
         if (job != null) {
@@ -663,7 +663,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
     private void waitForRollUpJob(final String rollupJob, final Matcher<?> expectedStates) throws Exception {
         assertBusy(() -> {
-            final Request getRollupJobRequest = new Request("GET", "_xpack/rollup/job/" + rollupJob);
+            final Request getRollupJobRequest = new Request("GET", "_rollup/job/" + rollupJob);
             Response getRollupJobResponse = client().performRequest(getRollupJobRequest);
             assertThat(getRollupJobResponse.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
 

--- a/x-pack/qa/multi-node/src/test/java/org/elasticsearch/multi_node/RollupIT.java
+++ b/x-pack/qa/multi-node/src/test/java/org/elasticsearch/multi_node/RollupIT.java
@@ -105,7 +105,7 @@ public class RollupIT extends ESRestTestCase {
         client().performRequest(bulkRequest);
 
         // create the rollup job
-        final Request createRollupJobRequest = new Request("PUT", "/_xpack/rollup/job/rollup-job-test");
+        final Request createRollupJobRequest = new Request("PUT", "/_rollup/job/rollup-job-test");
         int pageSize = randomIntBetween(2, 50);
         createRollupJobRequest.setJsonEntity("{"
             + "\"index_pattern\":\"rollup-*\","
@@ -127,7 +127,7 @@ public class RollupIT extends ESRestTestCase {
         assertThat(createRollupJobResponse.get("acknowledged"), equalTo(Boolean.TRUE));
 
         // start the rollup job
-        final Request startRollupJobRequest = new Request("POST", "_xpack/rollup/job/rollup-job-test/_start");
+        final Request startRollupJobRequest = new Request("POST", "_rollup/job/rollup-job-test/_start");
         Map<String, Object> startRollupJobResponse = toMap(client().performRequest(startRollupJobRequest));
         assertThat(startRollupJobResponse.get("started"), equalTo(Boolean.TRUE));
 
@@ -135,7 +135,7 @@ public class RollupIT extends ESRestTestCase {
 
         // Wait for the job to finish, by watching how many rollup docs we've indexed
         assertBusy(() -> {
-            final Request getRollupJobRequest = new Request("GET", "_xpack/rollup/job/rollup-job-test");
+            final Request getRollupJobRequest = new Request("GET", "_rollup/job/rollup-job-test");
             Response getRollupJobResponse = client().performRequest(getRollupJobRequest);
             assertThat(getRollupJobResponse.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
 
@@ -204,7 +204,7 @@ public class RollupIT extends ESRestTestCase {
         waitForRollUpJob(rollupJob, states);
 
         // check that the rollup job is started using the RollUp API
-        final Request getRollupJobRequest = new Request("GET", "_xpack/rollup/job/" + rollupJob);
+        final Request getRollupJobRequest = new Request("GET", "_rollup/job/" + rollupJob);
         Map<String, Object> getRollupJobResponse = toMap(client().performRequest(getRollupJobRequest));
         Map<String, Object> job = getJob(getRollupJobResponse, rollupJob);
         if (job != null) {
@@ -246,7 +246,7 @@ public class RollupIT extends ESRestTestCase {
 
     private void waitForRollUpJob(final String rollupJob, String[] expectedStates) throws Exception {
         assertBusy(() -> {
-            final Request getRollupJobRequest = new Request("GET", "_xpack/rollup/job/" + rollupJob);
+            final Request getRollupJobRequest = new Request("GET", "_rollup/job/" + rollupJob);
             Response getRollupJobResponse = client().performRequest(getRollupJobRequest);
             assertThat(getRollupJobResponse.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
 

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RollupIDUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RollupIDUpgradeIT.java
@@ -88,7 +88,7 @@ public class RollupIDUpgradeIT extends AbstractUpgradeTestCase {
             client().performRequest(indexRequest);
 
             // create the rollup job
-            final Request createRollupJobRequest = new Request("PUT", "/_xpack/rollup/job/rollup-id-test");
+            final Request createRollupJobRequest = new Request("PUT", "/_rollup/job/rollup-id-test");
             createRollupJobRequest.setJsonEntity("{"
                 + "\"index_pattern\":\"target\","
                 + "\"rollup_index\":\"rollup\","
@@ -120,7 +120,7 @@ public class RollupIDUpgradeIT extends AbstractUpgradeTestCase {
             client().performRequest(updateSettings);
 
             // start the rollup job
-            final Request startRollupJobRequest = new Request("POST", "_xpack/rollup/job/rollup-id-test/_start");
+            final Request startRollupJobRequest = new Request("POST", "_rollup/job/rollup-id-test/_start");
             Map<String, Object> startRollupJobResponse = entityAsMap(client().performRequest(startRollupJobRequest));
             assertThat(startRollupJobResponse.get("started"), equalTo(Boolean.TRUE));
 
@@ -225,7 +225,7 @@ public class RollupIDUpgradeIT extends AbstractUpgradeTestCase {
         waitForRollUpJob(rollupJob, expectedStates);
 
         // check that the rollup job is started using the RollUp API
-        final Request getRollupJobRequest = new Request("GET", "_xpack/rollup/job/" + rollupJob);
+        final Request getRollupJobRequest = new Request("GET", "_rollup/job/" + rollupJob);
         Map<String, Object> getRollupJobResponse = entityAsMap(client().performRequest(getRollupJobRequest));
         Map<String, Object> job = getJob(getRollupJobResponse, rollupJob);
         if (job != null) {
@@ -263,7 +263,7 @@ public class RollupIDUpgradeIT extends AbstractUpgradeTestCase {
 
     private void waitForRollUpJob(final String rollupJob, final Matcher<?> expectedStates) throws Exception {
         assertBusy(() -> {
-            final Request getRollupJobRequest = new Request("GET", "_xpack/rollup/job/" + rollupJob);
+            final Request getRollupJobRequest = new Request("GET", "_rollup/job/" + rollupJob);
             Response getRollupJobResponse = client().performRequest(getRollupJobRequest);
             assertThat(getRollupJobResponse.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
 


### PR DESCRIPTION
This commit is part of our plan to deprecate and ultimately remove the use of _xpack in the REST APIs.

Relates #35958
