### PR TITLE
Deprecate X-Pack centric SQL endpoints

### DIFF
--- a/docs/reference/sql/endpoints/rest.asciidoc
+++ b/docs/reference/sql/endpoints/rest.asciidoc
@@ -9,7 +9,7 @@ and returns the results. For example:
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/sql?format=txt
+POST /_sql?format=txt
 {
     "query": "SELECT * FROM library ORDER BY page_count DESC LIMIT 5"
 }
@@ -48,7 +48,7 @@ specified then the response is returned in the same format as the request.
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/sql?format=json
+POST /_sql?format=json
 {
     "query": "SELECT * FROM library ORDER BY page_count DESC",
     "fetch_size": 5
@@ -85,7 +85,7 @@ case of text format the cursor is returned as `Cursor` http header.
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/sql?format=json
+POST /_sql?format=json
 {
     "cursor": "sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWYUpOYklQMHhRUEtld3RsNnFtYU1hQQ==:BAFmBGRhdGUBZgVsaWtlcwFzB21lc3NhZ2UBZgR1c2Vy9f///w8="
 }
@@ -123,7 +123,7 @@ To clear the state earlier, you can use the clear cursor command:
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/sql/close
+POST /_sql/close
 {
     "cursor": "sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWYUpOYklQMHhRUEtld3RsNnFtYU1hQQ==:BAFmBGRhdGUBZgVsaWtlcwFzB21lc3NhZ2UBZgR1c2Vy9f///w8="
 }
@@ -152,7 +152,7 @@ parameter.
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/sql?format=txt
+POST /_sql?format=txt
 {
     "query": "SELECT * FROM library ORDER BY page_count DESC",
     "filter": {

--- a/docs/reference/sql/endpoints/translate.asciidoc
+++ b/docs/reference/sql/endpoints/translate.asciidoc
@@ -8,7 +8,7 @@ into native Elasticsearch queries. For example:
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/sql/translate
+POST /_sql/translate
 {
     "query": "SELECT * FROM library ORDER BY page_count DESC",
     "fetch_size": 10

--- a/docs/reference/sql/getting-started.asciidoc
+++ b/docs/reference/sql/getting-started.asciidoc
@@ -22,7 +22,7 @@ And now you can execute SQL using the <<sql-rest>> right away:
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/sql?format=txt
+POST /_sql?format=txt
 {
     "query": "SELECT * FROM library WHERE release_date < '2000-01-01'"
 }

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/XPackIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/XPackIT.java
@@ -61,7 +61,7 @@ public class XPackIT extends AbstractRollingTestCase {
         bulk.addParameter("refresh", "true");
         client().performRequest(bulk);
 
-        Request sql = new Request("POST", "/_xpack/sql");
+        Request sql = new Request("POST", "/_sql");
         sql.setJsonEntity("{\"query\": \"SELECT * FROM sql_test WHERE f > 1 ORDER BY f ASC\"}");
         String response = EntityUtils.toString(client().performRequest(sql).getEntity());
         assertEquals("{\"columns\":[{\"name\":\"f\",\"type\":\"text\"}],\"rows\":[[\"2\"]]}", response);

--- a/x-pack/plugin/sql/qa/multi-node/src/test/java/org/elasticsearch/xpack/sql/qa/multi_node/RestSqlMultinodeIT.java
+++ b/x-pack/plugin/sql/qa/multi-node/src/test/java/org/elasticsearch/xpack/sql/qa/multi_node/RestSqlMultinodeIT.java
@@ -110,7 +110,7 @@ public class RestSqlMultinodeIT extends ESRestTestCase {
         expected.put("columns", singletonList(columnInfo(mode, "COUNT(1)", "long", JDBCType.BIGINT, 20)));
         expected.put("rows", singletonList(singletonList(count)));
 
-        Request request = new Request("POST", "/_xpack/sql");
+        Request request = new Request("POST", "/_sql");
         if (false == mode.isEmpty()) {
             request.addParameter("mode", mode);
         }

--- a/x-pack/plugin/sql/qa/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/RestSqlSecurityIT.java
+++ b/x-pack/plugin/sql/qa/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/RestSqlSecurityIT.java
@@ -177,7 +177,7 @@ public class RestSqlSecurityIT extends SqlSecurityTestCase {
         }
 
         private static Map<String, Object> runSql(@Nullable String asUser, String mode, HttpEntity entity) throws IOException {
-            Request request = new Request("POST", "/_xpack/sql");
+            Request request = new Request("POST", "/_sql");
             if (false == mode.isEmpty()) {
                 request.addParameter("mode", mode);
             }

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
@@ -314,7 +314,7 @@ public abstract class RestSqlTestCase extends ESRestTestCase implements ErrorsTe
     }
 
     private Map<String, Object> runSql(String mode, HttpEntity sql, String suffix) throws IOException {
-        Request request = new Request("POST", "/_xpack/sql" + suffix);
+        Request request = new Request("POST", "/_sql" + suffix);
         request.addParameter("error_trace", "true");   // Helps with debugging in case something crazy happens on the server.
         request.addParameter("pretty", "true");        // Improves error reporting readability
         if (randomBoolean()) {
@@ -646,7 +646,7 @@ public abstract class RestSqlTestCase extends ESRestTestCase implements ErrorsTe
      * rather than the {@code format} parameter.
      */
     private Tuple<String, String> runSqlAsText(String suffix, HttpEntity entity, String accept) throws IOException {
-        Request request = new Request("POST", "/_xpack/sql" + suffix);
+        Request request = new Request("POST", "/_sql" + suffix);
         request.addParameter("error_trace", "true");
         request.setEntity(entity);
         RequestOptions.Builder options = request.getOptions().toBuilder();
@@ -664,7 +664,7 @@ public abstract class RestSqlTestCase extends ESRestTestCase implements ErrorsTe
      * rather than an {@code Accept} header.
      */
     private Tuple<String, String> runSqlAsTextFormat(String sql, String format) throws IOException {
-        Request request = new Request("POST", "/_xpack/sql");
+        Request request = new Request("POST", "/_sql");
         request.addParameter("error_trace", "true");
         request.addParameter("format", format);
         request.setJsonEntity("{\"query\":\"" + sql + "\"}");

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlUsageTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlUsageTestCase.java
@@ -223,7 +223,7 @@ public abstract class RestSqlUsageTestCase extends ESRestTestCase {
     }
     
     private Map<String, Object> getStats() throws UnsupportedOperationException, IOException {
-        Request request = new Request("GET", "/_xpack/sql/stats");
+        Request request = new Request("GET", "/_sql/stats");
         Map<String, Object> responseAsMap;
         try (InputStream content = client().performRequest(request).getEntity().getContent()) {
             responseAsMap = XContentHelper.convertToMap(JsonXContent.jsonXContent, content, false);
@@ -233,7 +233,7 @@ public abstract class RestSqlUsageTestCase extends ESRestTestCase {
     }
     
     private void runTranslate(String sql) throws IOException {
-        Request request = new Request("POST", "/_xpack/sql/translate");
+        Request request = new Request("POST", "/_sql/translate");
         if (randomBoolean()) {
             // We default to JSON but we force it randomly for extra coverage
             request.addParameter("format", "json");
@@ -267,7 +267,7 @@ public abstract class RestSqlUsageTestCase extends ESRestTestCase {
     }
     
     private void runSql(String mode, String restClient, String sql) throws IOException {
-        Request request = new Request("POST", "/_xpack/sql");
+        Request request = new Request("POST", "/_sql");
         request.addParameter("error_trace", "true");   // Helps with debugging in case something crazy happens on the server.
         request.addParameter("pretty", "true");        // Improves error reporting readability
         if (randomBoolean()) {

--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/JreHttpUrlConnection.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/JreHttpUrlConnection.java
@@ -47,7 +47,7 @@ public class JreHttpUrlConnection implements Closeable {
      * error.
      */
     public static final String SQL_STATE_BAD_SERVER = "bad_server";
-    private static final String SQL_NOT_AVAILABLE_ERROR_MESSAGE = "request [/_xpack/sql] contains unrecognized parameter: [mode]";
+    private static final String SQL_NOT_AVAILABLE_ERROR_MESSAGE = "request [/_sql] contains unrecognized parameter: [mode]";
 
     public static <R> R http(String path, String query, ConnectionConfiguration cfg, Function<JreHttpUrlConnection, R> handler) {
         final URI uriPath = cfg.baseUri().resolve(path);  // update path if needed

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/Protocol.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/Protocol.java
@@ -26,7 +26,10 @@ public final class Protocol {
     /**
      * SQL-related endpoints
      */
-    public static final String CLEAR_CURSOR_REST_ENDPOINT = "/_xpack/sql/close";
-    public static final String SQL_QUERY_REST_ENDPOINT = "/_xpack/sql";
-    public static final String SQL_STATS_REST_ENDPOINT = "/_xpack/sql/stats";
+    public static final String CLEAR_CURSOR_REST_ENDPOINT = "/_sql/close";
+    public static final String CLEAR_CURSOR_DEPRECATED_REST_ENDPOINT = "/_sql/close";
+    public static final String SQL_QUERY_REST_ENDPOINT = "/_sql";
+    public static final String SQL_QUERY_DEPRECATED_REST_ENDPOINT = "/_sql";
+    public static final String SQL_STATS_REST_ENDPOINT = "/_sql/stats";
+    public static final String SQL_STATS_DEPRECATED_REST_ENDPOINT = "/_sql/stats";
 }

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/Protocol.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/Protocol.java
@@ -27,9 +27,9 @@ public final class Protocol {
      * SQL-related endpoints
      */
     public static final String CLEAR_CURSOR_REST_ENDPOINT = "/_sql/close";
-    public static final String CLEAR_CURSOR_DEPRECATED_REST_ENDPOINT = "/_sql/close";
+    public static final String CLEAR_CURSOR_DEPRECATED_REST_ENDPOINT = "/_xpack/sql/close";
     public static final String SQL_QUERY_REST_ENDPOINT = "/_sql";
-    public static final String SQL_QUERY_DEPRECATED_REST_ENDPOINT = "/_sql";
+    public static final String SQL_QUERY_DEPRECATED_REST_ENDPOINT = "/_xpack/sql";
     public static final String SQL_STATS_REST_ENDPOINT = "/_sql/stats";
-    public static final String SQL_STATS_DEPRECATED_REST_ENDPOINT = "/_sql/stats";
+    public static final String SQL_STATS_DEPRECATED_REST_ENDPOINT = "/_xpack/sql/stats";
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlClearCursorAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlClearCursorAction.java
@@ -3,9 +3,12 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.sql.plugin;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -21,11 +24,16 @@ import java.io.IOException;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
-
 public class RestSqlClearCursorAction extends BaseRestHandler {
-    public RestSqlClearCursorAction(Settings settings, RestController controller) {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestSqlClearCursorAction.class));
+
+    RestSqlClearCursorAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(POST, Protocol.CLEAR_CURSOR_REST_ENDPOINT, this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                POST, Protocol.CLEAR_CURSOR_REST_ENDPOINT, this,
+                POST, Protocol.CLEAR_CURSOR_DEPRECATED_REST_ENDPOINT, deprecationLogger);
     }
 
     @Override
@@ -39,6 +47,7 @@ public class RestSqlClearCursorAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "xpack_sql_clear_cursor_action";
+        return "sql_clear_cursor";
     }
+
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlQueryAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlQueryAction.java
@@ -3,10 +3,13 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.sql.plugin;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -37,12 +40,21 @@ import static org.elasticsearch.xpack.sql.proto.RequestInfo.CANVAS;
 import static org.elasticsearch.xpack.sql.proto.RequestInfo.CLI;
 
 public class RestSqlQueryAction extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestSqlQueryAction.class));
+
     private static String CLIENT_ID = "client.id";
 
-    public RestSqlQueryAction(Settings settings, RestController controller) {
+    RestSqlQueryAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(GET, Protocol.SQL_QUERY_REST_ENDPOINT, this);
-        controller.registerHandler(POST, Protocol.SQL_QUERY_REST_ENDPOINT, this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                GET, Protocol.SQL_QUERY_REST_ENDPOINT, this,
+                GET, Protocol.SQL_QUERY_DEPRECATED_REST_ENDPOINT, deprecationLogger);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                POST, Protocol.SQL_QUERY_REST_ENDPOINT, this,
+                POST, Protocol.SQL_QUERY_DEPRECATED_REST_ENDPOINT, deprecationLogger);
     }
 
     @Override
@@ -131,6 +143,7 @@ public class RestSqlQueryAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "xpack_sql_query_action";
+        return "sql_query";
     }
+
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlStatsAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlStatsAction.java
@@ -6,7 +6,9 @@
 
 package org.elasticsearch.xpack.sql.plugin;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
@@ -20,14 +22,19 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestSqlStatsAction extends BaseRestHandler {
 
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestSqlStatsAction.class));
+
     protected RestSqlStatsAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(GET, Protocol.SQL_STATS_REST_ENDPOINT, this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                GET, Protocol.SQL_STATS_REST_ENDPOINT, this,
+                GET, Protocol.SQL_STATS_DEPRECATED_REST_ENDPOINT, deprecationLogger);
     }
 
     @Override
     public String getName() {
-        return "xpack_sql_stats_action";
+        return "sql_stats";
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlTranslateAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlTranslateAction.java
@@ -27,8 +27,8 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestSqlTranslateAction extends BaseRestHandler {
     public RestSqlTranslateAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(GET, "/_xpack/sql/translate", this);
-        controller.registerHandler(POST, "/_xpack/sql/translate", this);
+        controller.registerHandler(GET, "/_sql/translate", this);
+        controller.registerHandler(POST, "/_sql/translate", this);
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.sql.clear_cursor.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.sql.clear_cursor.json
@@ -3,8 +3,8 @@
     "documentation": "Clear SQL cursor",
     "methods": [ "POST"],
     "url": {
-      "path": "/_xpack/sql/close",
-      "paths": [ "/_xpack/sql/close" ],
+      "path": "/_sql/close",
+      "paths": [ "/_sql/close" ],
       "parts": {}
     },
     "body": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.sql.query.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.sql.query.json
@@ -3,8 +3,8 @@
       "documentation": "Execute SQL",
       "methods": [ "POST", "GET" ],
       "url": {
-        "path": "/_xpack/sql",
-        "paths": [ "/_xpack/sql" ],
+        "path": "/_sql",
+        "paths": [ "/_sql" ],
         "parts": {},
         "params": {
           "format": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.sql.translate.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.sql.translate.json
@@ -3,8 +3,8 @@
       "documentation": "Translate SQL into Elasticsearch queries",
       "methods": [ "POST", "GET" ],
       "url": {
-        "path": "/_xpack/sql/translate",
-        "paths": [ "/_xpack/sql/translate" ],
+        "path": "/_sql/translate",
+        "paths": [ "/_sql/translate" ],
         "parts": {},
         "params": {}
       },

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -428,7 +428,12 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             client().performRequest(doc2);
             return;
         }
-        Request sqlRequest = new Request("POST", "/_xpack/sql");
+        final Request sqlRequest;
+        if (isRunningAgainstOldCluster()) {
+            sqlRequest = new Request("POST", "/_xpack/sql");
+        } else {
+            sqlRequest = new Request("POST", "/_sql");
+        }
         sqlRequest.setJsonEntity("{\"query\":\"SELECT * FROM testsqlfailsonindexwithtwotypes\"}");
         ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(sqlRequest));
         assertEquals(400, e.getResponse().getStatusLine().getStatusCode());


### PR DESCRIPTION
This commit is part of our plan to deprecate and ultimately remove the use of _xpack in the REST APIs.

Relates #35958