### PR TITLE
Scripting: Actually add joda time back to whitelist

### DIFF
--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/Whitelist.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/Whitelist.java
@@ -48,7 +48,8 @@ public final class Whitelist {
         "java.util.txt",
         "java.util.function.txt",
         "java.util.regex.txt",
-        "java.util.stream.txt"
+        "java.util.stream.txt",
+        "joda.time.txt"
     };
 
     public static final List<Whitelist> BASE_WHITELISTS =


### PR DESCRIPTION
This commit actually loads the joda whitelist, which was missed in #35915.