### PR TITLE
Build: Fix gradle build for Mac OS

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -910,7 +910,7 @@ class BuildPlugin implements Plugin<Project> {
                 args '-n', 'hw.physicalcpu'
                 standardOutput = stdout
             }
-            return stdout.toString('UTF-8')
+            return stdout.toString('UTF-8').replace(System.lineSeparator(), "");
         }
         return 'auto';
     }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -910,7 +910,7 @@ class BuildPlugin implements Plugin<Project> {
                 args '-n', 'hw.physicalcpu'
                 standardOutput = stdout
             }
-            return stdout.toString('UTF-8').replace(System.lineSeparator(), "");
+            return stdout.toString('UTF-8').trim();
         }
         return 'auto';
     }


### PR DESCRIPTION
Remove trailing line feed from the output of the command to get
the number of CPUs.

Follow up to: #35789
