### PR TITLE
Docs: DRY up indices docs

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -145,9 +145,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             request.indicesOptions(indicesOptions); // <4>
             // end::indices-exists-request-optionals
 
-            // tag::indices-exists-response
+            // tag::indices-exists-execute
             boolean exists = client.indices().exists(request, RequestOptions.DEFAULT);
-            // end::indices-exists-response
+            // end::indices-exists-execute
             assertTrue(exists);
         }
     }
@@ -182,9 +182,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             final CountDownLatch latch = new CountDownLatch(1);
             listener = new LatchedActionListener<>(listener, latch);
 
-            // tag::indices-exists-async
+            // tag::indices-exists-execute-async
             client.indices().existsAsync(request, RequestOptions.DEFAULT, listener); // <1>
-            // end::indices-exists-async
+            // end::indices-exists-execute-async
 
             assertTrue(latch.await(30L, TimeUnit.SECONDS));
         }
@@ -601,30 +601,30 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         }
 
         {
-            // tag::get-mapping-request
+            // tag::get-mappings-request
             GetMappingsRequest request = new GetMappingsRequest(); // <1>
             request.indices("twitter"); // <2>
             request.types("_doc"); // <3>
-            // end::get-mapping-request
+            // end::get-mappings-request
 
-            // tag::get-mapping-request-masterTimeout
+            // tag::get-mappings-request-masterTimeout
             request.masterNodeTimeout(TimeValue.timeValueMinutes(1)); // <1>
             request.masterNodeTimeout("1m"); // <2>
-            // end::get-mapping-request-masterTimeout
+            // end::get-mappings-request-masterTimeout
 
-            // tag::get-mapping-request-indicesOptions
+            // tag::get-mappings-request-indicesOptions
             request.indicesOptions(IndicesOptions.lenientExpandOpen()); // <1>
-            // end::get-mapping-request-indicesOptions
+            // end::get-mappings-request-indicesOptions
 
-            // tag::get-mapping-execute
+            // tag::get-mappings-execute
             GetMappingsResponse getMappingResponse = client.indices().getMapping(request, RequestOptions.DEFAULT);
-            // end::get-mapping-execute
+            // end::get-mappings-execute
 
-            // tag::get-mapping-response
+            // tag::get-mappings-response
             ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> allMappings = getMappingResponse.mappings(); // <1>
             MappingMetaData typeMapping = allMappings.get("twitter").get("_doc"); // <2>
             Map<String, Object> mapping = typeMapping.sourceAsMap(); // <3>
-            // end::get-mapping-response
+            // end::get-mappings-response
 
             Map<String, String> type = new HashMap<>();
             type.put("type", "text");
@@ -662,7 +662,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             request.indices("twitter");
             request.types("_doc");
 
-            // tag::get-mapping-execute-listener
+            // tag::get-mappings-execute-listener
             ActionListener<GetMappingsResponse> listener =
                 new ActionListener<GetMappingsResponse>() {
                     @Override
@@ -675,7 +675,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                         // <2>
                     }
                 };
-            // end::get-mapping-execute-listener
+            // end::get-mappings-execute-listener
 
             // Replace the empty listener by a blocking listener in test
             final CountDownLatch latch = new CountDownLatch(1);
@@ -698,9 +698,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                 fail("should not fail");
             });
 
-            // tag::get-mapping-execute-async
+            // tag::get-mappings-execute-async
             client.indices().getMappingAsync(request, RequestOptions.DEFAULT, listener); // <1>
-            // end::get-mapping-execute-async
+            // end::get-mappings-execute-async
 
             assertTrue(latch.await(30L, TimeUnit.SECONDS));
         }
@@ -731,29 +731,29 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             assertTrue(putMappingResponse.isAcknowledged());
         }
 
-        // tag::get-field-mapping-request
+        // tag::get-field-mappings-request
         GetFieldMappingsRequest request = new GetFieldMappingsRequest(); // <1>
         request.indices("twitter"); // <2>
         request.types("_doc"); // <3>
         request.fields("message", "timestamp"); // <4>
-        // end::get-field-mapping-request
+        // end::get-field-mappings-request
 
-        // tag::get-field-mapping-request-indicesOptions
+        // tag::get-field-mappings-request-indicesOptions
         request.indicesOptions(IndicesOptions.lenientExpandOpen()); // <1>
-        // end::get-field-mapping-request-indicesOptions
+        // end::get-field-mappings-request-indicesOptions
 
-        // tag::get-field-mapping-request-local
+        // tag::get-field-mappings-request-local
         request.local(true); // <1>
-        // end::get-field-mapping-request-local
+        // end::get-field-mappings-request-local
 
         {
 
-            // tag::get-field-mapping-execute
+            // tag::get-field-mappings-execute
             GetFieldMappingsResponse response =
                 client.indices().getFieldMapping(request, RequestOptions.DEFAULT);
-            // end::get-field-mapping-execute
+            // end::get-field-mappings-execute
 
-            // tag::get-field-mapping-response
+            // tag::get-field-mappings-response
             final Map<String, Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetaData>>> mappings =
                 response.mappings();// <1>
             final Map<String, GetFieldMappingsResponse.FieldMappingMetaData> typeMappings =
@@ -763,11 +763,11 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
 
             final String fullName = metaData.fullName();// <4>
             final Map<String, Object> source = metaData.sourceAsMap(); // <5>
-            // end::get-field-mapping-response
+            // end::get-field-mappings-response
         }
 
         {
-            // tag::get-field-mapping-execute-listener
+            // tag::get-field-mappings-execute-listener
             ActionListener<GetFieldMappingsResponse> listener =
                 new ActionListener<GetFieldMappingsResponse>() {
                     @Override
@@ -780,7 +780,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                         // <2>
                     }
                 };
-            // end::get-field-mapping-execute-listener
+            // end::get-field-mappings-execute-listener
 
             // Replace the empty listener by a blocking listener in test
             final CountDownLatch latch = new CountDownLatch(1);
@@ -800,9 +800,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                 fail("should not fail");
             });
 
-            // tag::get-field-mapping-execute-async
+            // tag::get-field-mappings-execute-async
             client.indices().getFieldMappingAsync(request, RequestOptions.DEFAULT, listener); // <1>
-            // end::get-field-mapping-execute-async
+            // end::get-field-mappings-execute-async
 
             assertTrue(latch.await(30L, TimeUnit.SECONDS));
         }
@@ -1002,7 +1002,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             // tag::flush-execute-listener
             ActionListener<FlushResponse> listener = new ActionListener<FlushResponse>() {
                 @Override
-                public void onResponse(FlushResponse refreshResponse) {
+                public void onResponse(FlushResponse flushResponse) {
                     // <1>
                 }
 
@@ -1571,7 +1571,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             // end::exists-alias-execute
             assertTrue(exists);
 
-            // tag::exists-alias-listener
+            // tag::exists-alias-execute-listener
             ActionListener<Boolean> listener = new ActionListener<Boolean>() {
                 @Override
                 public void onResponse(Boolean exists) {
@@ -1583,7 +1583,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                     // <2>
                 }
             };
-            // end::exists-alias-listener
+            // end::exists-alias-execute-listener
 
             // Replace the empty listener by a blocking listener in test
             final CountDownLatch latch = new CountDownLatch(1);
@@ -1844,44 +1844,44 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             client.indices().create(new CreateIndexRequest("index-1").alias(new Alias("alias")), RequestOptions.DEFAULT);
         }
 
-        // tag::rollover-request
+        // tag::rollover-index-request
         RolloverRequest request = new RolloverRequest("alias", "index-2"); // <1>
         request.addMaxIndexAgeCondition(new TimeValue(7, TimeUnit.DAYS)); // <2>
         request.addMaxIndexDocsCondition(1000); // <3>
         request.addMaxIndexSizeCondition(new ByteSizeValue(5, ByteSizeUnit.GB)); // <4>
-        // end::rollover-request
+        // end::rollover-index-request
 
-        // tag::rollover-request-timeout
+        // tag::rollover-index-request-timeout
         request.timeout(TimeValue.timeValueMinutes(2)); // <1>
         request.timeout("2m"); // <2>
-        // end::rollover-request-timeout
-        // tag::rollover-request-masterTimeout
+        // end::rollover-index-request-timeout
+        // tag::rollover-index-request-masterTimeout
         request.masterNodeTimeout(TimeValue.timeValueMinutes(1)); // <1>
         request.masterNodeTimeout("1m"); // <2>
-        // end::rollover-request-masterTimeout
-        // tag::rollover-request-dryRun
+        // end::rollover-index-request-masterTimeout
+        // tag::rollover-index-request-dryRun
         request.dryRun(true); // <1>
-        // end::rollover-request-dryRun
-        // tag::rollover-request-waitForActiveShards
+        // end::rollover-index-request-dryRun
+        // tag::rollover-index-request-waitForActiveShards
         request.getCreateIndexRequest().waitForActiveShards(2); // <1>
         request.getCreateIndexRequest().waitForActiveShards(ActiveShardCount.DEFAULT); // <2>
-        // end::rollover-request-waitForActiveShards
-        // tag::rollover-request-settings
+        // end::rollover-index-request-waitForActiveShards
+        // tag::rollover-index-request-settings
         request.getCreateIndexRequest().settings(Settings.builder()
                 .put("index.number_of_shards", 4)); // <1>
-        // end::rollover-request-settings
-        // tag::rollover-request-mapping
+        // end::rollover-index-request-settings
+        // tag::rollover-index-request-mapping
         request.getCreateIndexRequest().mapping("type", "field", "type=keyword"); // <1>
-        // end::rollover-request-mapping
-        // tag::rollover-request-alias
+        // end::rollover-index-request-mapping
+        // tag::rollover-index-request-alias
         request.getCreateIndexRequest().alias(new Alias("another_alias")); // <1>
-        // end::rollover-request-alias
+        // end::rollover-index-request-alias
 
-        // tag::rollover-execute
+        // tag::rollover-index-execute
         RolloverResponse rolloverResponse = client.indices().rollover(request, RequestOptions.DEFAULT);
-        // end::rollover-execute
+        // end::rollover-index-execute
 
-        // tag::rollover-response
+        // tag::rollover-index-response
         boolean acknowledged = rolloverResponse.isAcknowledged(); // <1>
         boolean shardsAcked = rolloverResponse.isShardsAcknowledged(); // <2>
         String oldIndex = rolloverResponse.getOldIndex(); // <3>
@@ -1889,7 +1889,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         boolean isRolledOver = rolloverResponse.isRolledOver(); // <5>
         boolean isDryRun = rolloverResponse.isDryRun(); // <6>
         Map<String, Boolean> conditionStatus = rolloverResponse.getConditionStatus();// <7>
-        // end::rollover-response
+        // end::rollover-index-response
         assertFalse(acknowledged);
         assertFalse(shardsAcked);
         assertEquals("index-1", oldIndex);
@@ -1898,7 +1898,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         assertTrue(isDryRun);
         assertEquals(3, conditionStatus.size());
 
-        // tag::rollover-execute-listener
+        // tag::rollover-index-execute-listener
         ActionListener<RolloverResponse> listener = new ActionListener<RolloverResponse>() {
             @Override
             public void onResponse(RolloverResponse rolloverResponse) {
@@ -1910,15 +1910,15 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                 // <2>
             }
         };
-        // end::rollover-execute-listener
+        // end::rollover-index-execute-listener
 
         // Replace the empty listener by a blocking listener in test
         final CountDownLatch latch = new CountDownLatch(1);
         listener = new LatchedActionListener<>(listener, latch);
 
-        // tag::rollover-execute-async
+        // tag::rollover-index-execute-async
         client.indices().rolloverAsync(request, RequestOptions.DEFAULT, listener); // <1>
-        // end::rollover-execute-async
+        // end::rollover-index-execute-async
 
         assertTrue(latch.await(30L, TimeUnit.SECONDS));
     }
@@ -1967,7 +1967,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             assertThat(response.getAliases().get("index").size(), equalTo(1));
             assertThat(response.getAliases().get("index").iterator().next().alias(), equalTo("alias"));
 
-            // tag::get-alias-listener
+            // tag::get-alias-execute-listener
             ActionListener<GetAliasesResponse> listener =
                     new ActionListener<GetAliasesResponse>() {
                         @Override
@@ -1980,7 +1980,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                             // <2>
                         }
             };
-            // end::get-alias-listener
+            // end::get-alias-execute-listener
 
             // Replace the empty listener by a blocking listener in test
             final CountDownLatch latch = new CountDownLatch(1);
@@ -2003,74 +2003,74 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             assertTrue(createIndexResponse.isAcknowledged());
         }
 
-        // tag::put-settings-request
+        // tag::indices-put-settings-request
         UpdateSettingsRequest request = new UpdateSettingsRequest("index1"); // <1>
         UpdateSettingsRequest requestMultiple =
                 new UpdateSettingsRequest("index1", "index2"); // <2>
         UpdateSettingsRequest requestAll = new UpdateSettingsRequest(); // <3>
-        // end::put-settings-request
+        // end::indices-put-settings-request
 
-        // tag::put-settings-create-settings
+        // tag::indices-put-settings-create-settings
         String settingKey = "index.number_of_replicas";
         int settingValue = 0;
         Settings settings =
                 Settings.builder()
                 .put(settingKey, settingValue)
                 .build(); // <1>
-        // end::put-settings-create-settings
-        // tag::put-settings-request-index-settings
+        // end::indices-put-settings-create-settings
+        // tag::indices-put-settings-request-index-settings
         request.settings(settings);
-        // end::put-settings-request-index-settings
+        // end::indices-put-settings-request-index-settings
 
         {
-            // tag::put-settings-settings-builder
+            // tag::indices-put-settings-settings-builder
             Settings.Builder settingsBuilder =
                     Settings.builder()
                     .put(settingKey, settingValue);
             request.settings(settingsBuilder); // <1>
-            // end::put-settings-settings-builder
+            // end::indices-put-settings-settings-builder
         }
         {
-            // tag::put-settings-settings-map
+            // tag::indices-put-settings-settings-map
             Map<String, Object> map = new HashMap<>();
             map.put(settingKey, settingValue);
             request.settings(map); // <1>
-            // end::put-settings-settings-map
+            // end::indices-put-settings-settings-map
         }
         {
-            // tag::put-settings-settings-source
+            // tag::indices-put-settings-settings-source
             request.settings(
                     "{\"index.number_of_replicas\": \"2\"}"
                     , XContentType.JSON); // <1>
-            // end::put-settings-settings-source
+            // end::indices-put-settings-settings-source
         }
 
-        // tag::put-settings-request-preserveExisting
+        // tag::indices-put-settings-request-preserveExisting
         request.setPreserveExisting(false); // <1>
-        // end::put-settings-request-preserveExisting
-        // tag::put-settings-request-timeout
+        // end::indices-put-settings-request-preserveExisting
+        // tag::indices-put-settings-request-timeout
         request.timeout(TimeValue.timeValueMinutes(2)); // <1>
         request.timeout("2m"); // <2>
-        // end::put-settings-request-timeout
-        // tag::put-settings-request-masterTimeout
+        // end::indices-put-settings-request-timeout
+        // tag::indices-put-settings-request-masterTimeout
         request.masterNodeTimeout(TimeValue.timeValueMinutes(1)); // <1>
         request.masterNodeTimeout("1m"); // <2>
-        // end::put-settings-request-masterTimeout
-        // tag::put-settings-request-indicesOptions
+        // end::indices-put-settings-request-masterTimeout
+        // tag::indices-put-settings-request-indicesOptions
         request.indicesOptions(IndicesOptions.lenientExpandOpen()); // <1>
-        // end::put-settings-request-indicesOptions
+        // end::indices-put-settings-request-indicesOptions
 
-        // tag::put-settings-execute
+        // tag::indices-put-settings-execute
         AcknowledgedResponse updateSettingsResponse =
                 client.indices().putSettings(request, RequestOptions.DEFAULT);
-        // end::put-settings-execute
+        // end::indices-put-settings-execute
 
-        // tag::put-settings-response
+        // tag::indices-put-settings-response
         boolean acknowledged = updateSettingsResponse.isAcknowledged(); // <1>
-        // end::put-settings-response
+        // end::indices-put-settings-response
         assertTrue(acknowledged);
 
-        // tag::put-settings-execute-listener
+        // tag::indices-put-settings-execute-listener
         ActionListener<AcknowledgedResponse> listener =
                 new ActionListener<AcknowledgedResponse>() {
 
@@ -2084,15 +2084,15 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                 // <2>
             }
         };
-        // end::put-settings-execute-listener
+        // end::indices-put-settings-execute-listener
 
         // Replace the empty listener by a blocking listener in test
         final CountDownLatch latch = new CountDownLatch(1);
         listener = new LatchedActionListener<>(listener, latch);
 
-        // tag::put-settings-execute-async
+        // tag::indices-put-settings-execute-async
         client.indices().putSettingsAsync(request, RequestOptions.DEFAULT, listener); // <1>
-        // end::put-settings-execute-async
+        // end::indices-put-settings-execute-async
 
         assertTrue(latch.await(30L, TimeUnit.SECONDS));
     }
@@ -2332,35 +2332,35 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         String index = "some_index";
         createIndex(index, Settings.EMPTY);
 
-        // tag::validate-query-request
+        // tag::indices-validate-query-request
         ValidateQueryRequest request = new ValidateQueryRequest(index); // <1>
-        // end::validate-query-request
+        // end::indices-validate-query-request
 
-        // tag::validate-query-request-query
+        // tag::indices-validate-query-request-query
         QueryBuilder builder = QueryBuilders
             .boolQuery() // <1>
             .must(QueryBuilders.queryStringQuery("*:*"))
             .filter(QueryBuilders.termQuery("user", "kimchy"));
         request.query(builder); // <2>
-        // end::validate-query-request-query
+        // end::indices-validate-query-request-query
 
-        // tag::validate-query-request-explain
+        // tag::indices-validate-query-request-explain
         request.explain(true); // <1>
-        // end::validate-query-request-explain
+        // end::indices-validate-query-request-explain
 
-        // tag::validate-query-request-allShards
+        // tag::indices-validate-query-request-allShards
         request.allShards(true); // <1>
-        // end::validate-query-request-allShards
+        // end::indices-validate-query-request-allShards
 
-        // tag::validate-query-request-rewrite
+        // tag::indices-validate-query-request-rewrite
         request.rewrite(true); // <1>
-        // end::validate-query-request-rewrite
+        // end::indices-validate-query-request-rewrite
 
-        // tag::validate-query-execute
+        // tag::indices-validate-query-execute
         ValidateQueryResponse response = client.indices().validateQuery(request, RequestOptions.DEFAULT); // <1>
-        // end::validate-query-execute
+        // end::indices-validate-query-execute
 
-        // tag::validate-query-response
+        // tag::indices-validate-query-response
         boolean isValid = response.isValid(); // <1>
         int totalShards = response.getTotalShards(); // <2>
         int successfulShards = response.getSuccessfulShards(); // <3>
@@ -2377,9 +2377,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             int shardId = explanation.getShard(); // <11>
             String explanationString = explanation.getExplanation(); // <12>
         }
-        // end::validate-query-response
+        // end::indices-validate-query-response
 
-        // tag::validate-query-execute-listener
+        // tag::indices-validate-query-execute-listener
         ActionListener<ValidateQueryResponse> listener =
             new ActionListener<ValidateQueryResponse>() {
                 @Override
@@ -2392,15 +2392,15 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                     // <2>
                 }
             };
-        // end::validate-query-execute-listener
+        // end::indices-validate-query-execute-listener
 
         // Replace the empty listener by a blocking listener in test
         final CountDownLatch latch = new CountDownLatch(1);
         listener = new LatchedActionListener<>(listener, latch);
 
-        // tag::validate-query-execute-async
+        // tag::indices-validate-query-execute-async
         client.indices().validateQueryAsync(request, RequestOptions.DEFAULT, listener); // <1>
-        // end::validate-query-execute-async
+        // end::indices-validate-query-execute-async
 
         assertTrue(latch.await(30L, TimeUnit.SECONDS));
     }
@@ -2444,9 +2444,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             request.attributes("keyword", "type");      // <2>
             // end::analyze-request-explain
 
-            // tag::analyze-request-sync
+            // tag::analyze-execute
             AnalyzeResponse response = client.indices().analyze(request, RequestOptions.DEFAULT);
-            // end::analyze-request-sync
+            // end::analyze-execute
 
             // tag::analyze-response-tokens
             List<AnalyzeResponse.AnalyzeToken> tokens = response.getTokens();   // <1>
@@ -2482,12 +2482,12 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             ActionListener<AnalyzeResponse> listener = new ActionListener<AnalyzeResponse>() {
                 @Override
                 public void onResponse(AnalyzeResponse analyzeTokens) {
-
+                    // <1>
                 }
 
                 @Override
                 public void onFailure(Exception e) {
-
+                    // <2>
                 }
             };
             // end::analyze-execute-listener
@@ -2501,9 +2501,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             final CountDownLatch latch = new CountDownLatch(1);
             listener = new LatchedActionListener<>(listener, latch);
 
-            // tag::analyze-request-async
-            client.indices().analyzeAsync(request, RequestOptions.DEFAULT, listener);
-            // end::analyze-request-async
+            // tag::analyze-execute-async
+            client.indices().analyzeAsync(request, RequestOptions.DEFAULT, listener); // <1>
+            // end::analyze-execute-async
 
             assertTrue(latch.await(30L, TimeUnit.SECONDS));
         }

--- a/docs/java-rest/high-level/indices/analyze.asciidoc
+++ b/docs/java-rest/high-level/indices/analyze.asciidoc
@@ -1,17 +1,23 @@
-[[java-rest-high-analyze]]
+--
+:api: analyze
+:request: AnalyzeRequest
+:response: AnalyzeResponse
+--
+
+[id="{upid}-{api}"]
 === Analyze API
 
-[[java-rest-high-analyze-request]]
+[id="{upid}-{api}-request"]
 ==== Analyze Request
 
-An `AnalyzeRequest` contains the text to analyze, and one of several options to
+An +{request}+ contains the text to analyze, and one of several options to
 specify how the analysis should be performed.
 
 The simplest version uses a built-in analyzer:
 
 ["source","java",subs="attributes,callouts,macros"]
 ---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-builtin-request]
+include-tagged::{doc-tests-file}[{api}-builtin-request]
 ---------------------------------------------------
 <1> The text to include.  Multiple strings are treated as a multi-valued field
 <2> A built-in analyzer
@@ -19,7 +25,7 @@ include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-builtin-re
 You can configure a custom analyzer:
 ["source","java",subs="attributes,callouts,macros"]
 ---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-custom-request]
+include-tagged::{doc-tests-file}[{api}-custom-request]
 ---------------------------------------------------
 <1> Configure char filters
 <2> Configure the tokenizer
@@ -31,13 +37,13 @@ You can also build a custom normalizer, by including only charfilters and
 tokenfilters:
 ["source","java",subs="attributes,callouts,macros"]
 ---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-custom-normalizer-request]
+include-tagged::{doc-tests-file}[{api}-custom-normalizer-request]
 ---------------------------------------------------
 
 You can analyze text using an analyzer defined in an existing index:
 ["source","java",subs="attributes,callouts,macros"]
 ---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-index-request]
+include-tagged::{doc-tests-file}[{api}-index-request]
 ---------------------------------------------------
 <1> The index containing the mappings
 <2> The analyzer defined on this index to use
@@ -45,7 +51,7 @@ include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-index-requ
 Or you can use a normalizer:
 ["source","java",subs="attributes,callouts,macros"]
 ---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-index-normalizer-request]
+include-tagged::{doc-tests-file}[{api}-index-normalizer-request]
 ---------------------------------------------------
 <1> The index containing the mappings
 <2> The normalizer defined on this index to use
@@ -53,7 +59,7 @@ include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-index-norm
 You can analyze text using the mappings for a particular field in an index:
 ["source","java",subs="attributes,callouts,macros"]
 ---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-field-request]
+include-tagged::{doc-tests-file}[{api}-field-request]
 ---------------------------------------------------
 
 ==== Optional arguments
@@ -61,50 +67,22 @@ The following arguments can also optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 ---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-request-explain]
+include-tagged::{doc-tests-file}[{api}-request-explain]
 ---------------------------------------------------
 <1> Setting `explain` to true will add further details to the response
 <2> Setting `attributes` allows you to return only token attributes that you are
 interested in
 
-[[java-rest-high-analyze-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
----------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-request-sync]
----------------------------------------------------
-
-[[java-rest-high-analyze-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of an analyze request requires both the `AnalyzeRequest`
-instance and an `ActionListener` instance to be passed to the asyncronous method:
-
-["source","java",subs="attributes,callouts,macros"]
----------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-request-async]
----------------------------------------------------
-
-The asynchronous method does not block and returns immediately.  Once it is
-completed the `ActionListener` is called back using the `onResponse` method if the
-execution successfully completed or using the `onFailure` method if it failed.
-
-A typical listener for `AnalyzeResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
----------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-execute-listener]
----------------------------------------------------
-
-[[java-rest-high-analyze-response]]
+[id="{upid}-{api}-response"]
 ==== Analyze Response
 
-The returned `AnalyzeResponse` allows you to retrieve details of the analysis as
+The returned +{response}+ allows you to retrieve details of the analysis as
 follows:
 ["source","java",subs="attributes,callouts,macros"]
 ---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-response-tokens]
+include-tagged::{doc-tests-file}[{api}-response-tokens]
 ---------------------------------------------------
 <1> `AnalyzeToken` holds information about the individual tokens produced by analysis
 
@@ -113,7 +91,7 @@ method:
 
 ["source","java",subs="attributes,callouts,macros"]
 ---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-response-detail]
+include-tagged::{doc-tests-file}[{api}-response-detail]
 ---------------------------------------------------
 <1> `DetailAnalyzeResponse` holds more detailed information about tokens produced by
 the various substeps in the analysis chain.

--- a/docs/java-rest/high-level/indices/clear_cache.asciidoc
+++ b/docs/java-rest/high-level/indices/clear_cache.asciidoc
@@ -1,15 +1,21 @@
-[[java-rest-high-clear-cache]]
+--
+:api: clear-cache
+:request: ClearIndicesCacheRequest
+:response: ClearIndicesCacheResponse
+--
+
+[id="{upid}-{api}"]
 === Clear Cache API
 
-[[java-rest-high-clear-cache-request]]
+[id="{upid}-{api}-request"]
 ==== Clear Cache Request
 
-A `ClearIndicesCacheRquest` can be applied to one or more indices, or even on
+A +{request}+ can be applied to one or more indices, or even on
 `_all` the indices:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[clear-cache-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Clears the cache of one index
 <2> Clears the cache of multiple indices
@@ -19,81 +25,46 @@ include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[clear-cache-reques
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[clear-cache-request-indicesOptions]
+include-tagged::{doc-tests-file}[{api}-request-indicesOptions]
 --------------------------------------------------
 <1> Setting `IndicesOptions` controls how unavailable indices are resolved and
 how wildcard expressions are expanded
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[clear-cache-request-query]
+include-tagged::{doc-tests-file}[{api}-request-query]
 --------------------------------------------------
 <1> Set the `query` flag to `true`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[clear-cache-request-fielddata]
+include-tagged::{doc-tests-file}[{api}-request-fielddata]
 --------------------------------------------------
 <1> Set the `fielddata` flag to `true`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[clear-cache-request-request]
+include-tagged::{doc-tests-file}[{api}-request-request]
 --------------------------------------------------
 <1> Set the `request` flag to `true`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[clear-cache-request-fields]
+include-tagged::{doc-tests-file}[{api}-request-fields]
 --------------------------------------------------
 <1> Set the `fields` parameter
 
-[[java-rest-high-clear-cache-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[clear-cache-execute]
---------------------------------------------------
-
-[[java-rest-high-clear-cache-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a clear cache request requires both the `ClearIndicesCacheRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[clear-cache-execute-async]
---------------------------------------------------
-<1> The `ClearIndicesCacheRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `ClearIndicesCacheResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[clear-cache-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-clear-cache-response]]
+[id="{upid}-{api}-response"]
 ==== Clear Cache Response
 
-The returned `ClearIndicesCacheResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[clear-cache-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Total number of shards hit by the clear cache request
 <2> Number of shards where the clear cache has succeeded
@@ -104,6 +75,6 @@ By default, if the indices were not found, an `ElasticsearchException` will be t
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[clear-cache-notfound]
+include-tagged::{doc-tests-file}[{api}-notfound]
 --------------------------------------------------
 <1> Do something if the indices to be cleared were not found

--- a/docs/java-rest/high-level/indices/close_index.asciidoc
+++ b/docs/java-rest/high-level/indices/close_index.asciidoc
@@ -1,14 +1,20 @@
-[[java-rest-high-close-index]]
+--
+:api: close-index
+:request: CloseIndexRequest
+:response: CloseIndexResponse
+--
+
+[id="{upid}-{api}"]
 === Close Index API
 
-[[java-rest-high-close-index-request]]
+[id="{upid}-{api}-request"]
 ==== Close Index Request
 
-A `CloseIndexRequest` requires an `index` argument:
+A +{request}+ requires an `index` argument:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[close-index-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> The index to close
 
@@ -17,7 +23,7 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[close-index-request-timeout]
+include-tagged::{doc-tests-file}[{api}-request-timeout]
 --------------------------------------------------
 <1> Timeout to wait for the all the nodes to acknowledge the index is closed
 as a `TimeValue`
@@ -26,63 +32,28 @@ as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[close-index-request-masterTimeout]
+include-tagged::{doc-tests-file}[{api}-request-masterTimeout]
 --------------------------------------------------
 <1> Timeout to connect to the master node as a `TimeValue`
 <2> Timeout to connect to the master node as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[close-index-request-indicesOptions]
+include-tagged::{doc-tests-file}[{api}-request-indicesOptions]
 --------------------------------------------------
 <1> Setting `IndicesOptions` controls how unavailable indices are resolved and
 how wildcard expressions are expanded
 
-[[java-rest-high-close-index-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[close-index-execute]
---------------------------------------------------
-
-[[java-rest-high-close-index-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a close index request requires both the `CloseIndexRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[close-index-execute-async]
---------------------------------------------------
-<1> The `CloseIndexRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `CloseIndexResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[close-index-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-close-index-response]]
+[id="{upid}-{api}-response"]
 ==== Close Index Response
 
-The returned `CloseIndexResponse` allows to retrieve information about the 
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[close-index-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Indicates whether all of the nodes have acknowledged the request

--- a/docs/java-rest/high-level/indices/create_index.asciidoc
+++ b/docs/java-rest/high-level/indices/create_index.asciidoc
@@ -1,14 +1,20 @@
-[[java-rest-high-create-index]]
+--
+:api: create-index
+:request: CreateIndexRequest
+:response: CreateIndexResponse
+--
+
+[id="{upid}-{api}"]
 === Create Index API
 
-[[java-rest-high-create-index-request]]
+[id="{upid}-{api}-request"]
 ==== Create Index Request
 
-A `CreateIndexRequest` requires an `index` argument:
+A +{request}+ requires an `index` argument:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[create-index-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> The index to create
 
@@ -17,7 +23,7 @@ Each index created can have specific settings associated with it.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[create-index-request-settings]
+include-tagged::{doc-tests-file}[{api}-request-settings]
 --------------------------------------------------
 <1> Settings for this index
 
@@ -27,7 +33,7 @@ An index may be created with mappings for its document types
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[create-index-request-mappings]
+include-tagged::{doc-tests-file}[{api}-request-mappings]
 --------------------------------------------------
 <1> The type to define
 <2> The mapping for this type, provided as a JSON string
@@ -37,21 +43,21 @@ The mapping source can be provided in different ways in addition to the
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[create-index-mappings-map]
+include-tagged::{doc-tests-file}[{api}-mappings-map]
 --------------------------------------------------
 <1> Mapping source provided as a `Map` which gets automatically converted
 to JSON format
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[create-index-mappings-xcontent]
+include-tagged::{doc-tests-file}[{api}-mappings-xcontent]
 --------------------------------------------------
 <1> Mapping source provided as an `XContentBuilder` object, the Elasticsearch
 built-in helpers to generate JSON content
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[create-index-mappings-shortcut]
+include-tagged::{doc-tests-file}[{api}-mappings-shortcut]
 --------------------------------------------------
 <1> Mapping source provided as `Object` key-pairs, which gets converted to
 JSON format
@@ -61,7 +67,7 @@ Aliases can be set at index creation time
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[create-index-request-aliases]
+include-tagged::{doc-tests-file}[{api}-request-aliases]
 --------------------------------------------------
 <1> The alias to define
 
@@ -72,7 +78,7 @@ can also be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[create-index-whole-source]
+include-tagged::{doc-tests-file}[{api}-whole-source]
 --------------------------------------------------
 <1> The source provided as a JSON string. It can also be provided as a `Map`
 or an `XContentBuilder`.
@@ -82,73 +88,38 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[create-index-request-timeout]
+include-tagged::{doc-tests-file}[{api}-request-timeout]
 --------------------------------------------------
 <1> Timeout to wait for the all the nodes to acknowledge the index creation as a `TimeValue`
 <2> Timeout to wait for the all the nodes to acknowledge the index creation as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[create-index-request-masterTimeout]
+include-tagged::{doc-tests-file}[{api}-request-masterTimeout]
 --------------------------------------------------
 <1> Timeout to connect to the master node as a `TimeValue`
 <2> Timeout to connect to the master node as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[create-index-request-waitForActiveShards]
+include-tagged::{doc-tests-file}[{api}-request-waitForActiveShards]
 --------------------------------------------------
 <1> The number of active shard copies to wait for before the create index API returns a
 response, as an `int`
 <2> The number of active shard copies to wait for before the create index API returns a
 response, as an `ActiveShardCount`
 
-[[java-rest-high-create-index-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[create-index-execute]
---------------------------------------------------
-
-[[java-rest-high-create-index-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a create index request requires both the `CreateIndexRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[create-index-execute-async]
---------------------------------------------------
-<1> The `CreateIndexRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `CreateIndexResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[create-index-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-create-index-response]]
+[id="{upid}-{api}-response"]
 ==== Create Index Response
 
-The returned `CreateIndexResponse` allows to retrieve information about the executed
+The returned +{response}+ allows to retrieve information about the executed
  operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[create-index-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Indicates whether all of the nodes have acknowledged the request
 <2> Indicates whether the requisite number of shard copies were started for each shard in the index before timing out

--- a/docs/java-rest/high-level/indices/delete_index.asciidoc
+++ b/docs/java-rest/high-level/indices/delete_index.asciidoc
@@ -1,14 +1,20 @@
-[[java-rest-high-delete-index]]
+--
+:api: delete-index
+:request: DeleteIndexRequest
+:response: DeleteIndexResponse
+--
+
+[id="{upid}-{api}"]
 === Delete Index API
 
-[[java-rest-high-delete-index-request]]
+[id="{upid}-{api}-request"]
 ==== Delete Index Request
 
-A `DeleteIndexRequest` requires an `index` argument:
+A +{request}+ requires an `index` argument:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[delete-index-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Index
 
@@ -17,71 +23,36 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[delete-index-request-timeout]
+include-tagged::{doc-tests-file}[{api}-request-timeout]
 --------------------------------------------------
 <1> Timeout to wait for the all the nodes to acknowledge the index deletion as a `TimeValue`
 <2> Timeout to wait for the all the nodes to acknowledge the index deletion as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[delete-index-request-masterTimeout]
+include-tagged::{doc-tests-file}[{api}-request-masterTimeout]
 --------------------------------------------------
 <1> Timeout to connect to the master node as a `TimeValue`
 <2> Timeout to connect to the master node as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[delete-index-request-indicesOptions]
+include-tagged::{doc-tests-file}[{api}-request-indicesOptions]
 --------------------------------------------------
 <1> Setting `IndicesOptions` controls how unavailable indices are resolved and
 how wildcard expressions are expanded
 
-[[java-rest-high-delete-index-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[delete-index-execute]
---------------------------------------------------
-
-[[java-rest-high-delete-index-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a delete index request requires both the `DeleteIndexRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[delete-index-execute-async]
---------------------------------------------------
-<1> The `DeleteIndexRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `DeleteIndexResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[delete-index-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-delete-index-response]]
+[id="{upid}-{api}-response"]
 ==== Delete Index Response
 
-The returned `DeleteIndexResponse` allows to retrieve information about the executed
+The returned +{response}+ allows to retrieve information about the executed
  operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[delete-index-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Indicates whether all of the nodes have acknowledged the request
 
@@ -89,6 +60,6 @@ If the index was not found, an `ElasticsearchException` will be thrown:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[delete-index-notfound]
+include-tagged::{doc-tests-file}[{api}-notfound]
 --------------------------------------------------
 <1> Do something if the index to be deleted was not found

--- a/docs/java-rest/high-level/indices/exists_alias.asciidoc
+++ b/docs/java-rest/high-level/indices/exists_alias.asciidoc
@@ -1,16 +1,22 @@
-[[java-rest-high-exists-alias]]
+--
+:api: exists-alias
+:request: GetAliasesRequest
+:response: Boolean
+--
+
+[id="{upid}-{api}"]
 === Exists Alias API
 
-[[java-rest-high-exists-alias-request]]
+[id="{upid}-{api}-request"]
 ==== Exists Alias Request
 
-The Exists Alias API uses `GetAliasesRequest` as its request object.
+The Exists Alias API uses +{request}+ as its request object.
 One or more aliases can be optionally provided either at construction
 time or later on through the relevant setter method.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[exists-alias-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 
 ==== Optional arguments
@@ -18,70 +24,35 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[exists-alias-request-alias]
+include-tagged::{doc-tests-file}[{api}-request-alias]
 --------------------------------------------------
 <1> One or more aliases to look for
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[exists-alias-request-indices]
+include-tagged::{doc-tests-file}[{api}-request-indices]
 --------------------------------------------------
 <1> The index or indices that the alias is associated with
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[exists-alias-request-indicesOptions]
+include-tagged::{doc-tests-file}[{api}-request-indicesOptions]
 --------------------------------------------------
 <1> Setting `IndicesOptions` controls how unavailable indices are resolved and
 how wildcard expressions are expanded
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[exists-alias-request-local]
+include-tagged::{doc-tests-file}[{api}-request-local]
 --------------------------------------------------
 <1> The `local` flag (defaults to `false`) controls whether the aliases need
 to be looked up in the local cluster state or in the cluster state held by
 the elected master node
 
-[[java-rest-high-exists-alias-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[exists-alias-execute]
---------------------------------------------------
-
-[[java-rest-high-exists-alias-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a exists alias request requires both a `GetAliasesRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[exists-alias-execute-async]
---------------------------------------------------
-<1> The `GetAliasesRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for the `Boolean` response looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[exists-alias-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-exists-alias-response]]
+[id="{upid}-{api}-response"]
 ==== Exists Alias Response
 
-The Exists Alias API returns a `boolean` that indicates whether the provided
+The Exists Alias API returns a +{response}+ that indicates whether the provided
 alias (or aliases) was found or not.

--- a/docs/java-rest/high-level/indices/flush.asciidoc
+++ b/docs/java-rest/high-level/indices/flush.asciidoc
@@ -1,14 +1,20 @@
-[[java-rest-high-flush]]
+--
+:api: flush
+:request: FlushRequest
+:response: FlushResponse
+--
+
+[id="{upid}-{api}"]
 === Flush API
 
-[[java-rest-high-flush-request]]
+[id="{upid}-{api}-request"]
 ==== Flush Request
 
-A `FlushRequest` can be applied to one or more indices, or even on `_all` the indices:
+A +{request}+ can be applied to one or more indices, or even on `_all` the indices:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Flush one index
 <2> Flush multiple indices
@@ -18,69 +24,34 @@ include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-request]
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-request-indicesOptions]
+include-tagged::{doc-tests-file}[{api}-request-indicesOptions]
 --------------------------------------------------
 <1> Setting `IndicesOptions` controls how unavailable indices are resolved and
 how wildcard expressions are expanded
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-request-wait]
+include-tagged::{doc-tests-file}[{api}-request-wait]
 --------------------------------------------------
 <1> Set the `wait_if_ongoing` flag to `true`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-request-force]
+include-tagged::{doc-tests-file}[{api}-request-force]
 --------------------------------------------------
 <1> Set the `force` flag to `true`
 
-[[java-rest-high-flush-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-execute]
---------------------------------------------------
-
-[[java-rest-high-flush-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a flush request requires both the `FlushRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-execute-async]
---------------------------------------------------
-<1> The `FlushRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `FlushResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-flush-response]]
+[id="{upid}-{api}-response"]
 ==== Flush Response
 
-The returned `FlushResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Total number of shards hit by the flush request
 <2> Number of shards where the flush has succeeded
@@ -91,6 +62,6 @@ By default, if the indices were not found, an `ElasticsearchException` will be t
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-notfound]
+include-tagged::{doc-tests-file}[{api}-notfound]
 --------------------------------------------------
 <1> Do something if the indices to be flushed were not found

--- a/docs/java-rest/high-level/indices/flush_synced.asciidoc
+++ b/docs/java-rest/high-level/indices/flush_synced.asciidoc
@@ -1,14 +1,20 @@
-[[java-rest-high-flush-synced]]
+--
+:api: flush-synced
+:request: SyncedFlushRequest
+:response: SyncedFlushResponse
+--
+
+[id="{upid}-{api}"]
 === Flush Synced API
 
-[[java-rest-high-flush-synced-request]]
+[id="{upid}-{api}-request"]
 ==== Flush Synced Request
 
-A `SyncedFlushRequest` can be applied to one or more indices, or even on `_all` the indices:
+A +{request}+ can be applied to one or more indices, or even on `_all` the indices:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-synced-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Flush synced one index
 <2> Flush synced multiple indices
@@ -18,57 +24,22 @@ include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-synced-reque
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-synced-request-indicesOptions]
+include-tagged::{doc-tests-file}[{api}-request-indicesOptions]
 --------------------------------------------------
 <1> Setting `IndicesOptions` controls how unavailable indices are resolved and
 how wildcard expressions are expanded
 
-[[java-rest-high-flush-synced-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-synced-execute]
---------------------------------------------------
-
-[[java-rest-high-flush-synced-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a flush request requires both the `SyncedFlushRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-synced-execute-async]
---------------------------------------------------
-<1> The `SyncedFlushRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `SyncedFlushResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-synced-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-flush-synced-response]]
+[id="{upid}-{api}-response"]
 ==== Flush Synced Response
 
-The returned `SyncedFlushResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-synced-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Total number of shards hit by the flush request
 <2> Number of shards where the flush has succeeded
@@ -86,6 +57,6 @@ By default, if the indices were not found, an `ElasticsearchException` will be t
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[flush-synced-notfound]
+include-tagged::{doc-tests-file}[{api}-notfound]
 --------------------------------------------------
 <1> Do something if the indices to be flushed were not found

--- a/docs/java-rest/high-level/indices/force_merge.asciidoc
+++ b/docs/java-rest/high-level/indices/force_merge.asciidoc
@@ -1,14 +1,20 @@
-[[java-rest-high-force-merge]]
+--
+:api: force-merge
+:request: ForceMergeRequest
+:response: ForceMergeResponse
+--
+
+[id="{upid}-{api}"]
 === Force Merge API
 
-[[java-rest-high-force-merge-request]]
+[id="{upid}-{api}-request"]
 ==== Force merge Request
 
-A `ForceMergeRequest` can be applied to one or more indices, or even on `_all` the indices:
+A +{request}+ can be applied to one or more indices, or even on `_all` the indices:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[force-merge-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Force merge one index
 <2> Force merge multiple indices
@@ -18,75 +24,40 @@ include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[force-merge-reques
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[force-merge-request-indicesOptions]
+include-tagged::{doc-tests-file}[{api}-request-indicesOptions]
 --------------------------------------------------
 <1> Setting `IndicesOptions` controls how unavailable indices are resolved and
 how wildcard expressions are expanded
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[force-merge-request-segments-num]
+include-tagged::{doc-tests-file}[{api}-request-segments-num]
 --------------------------------------------------
 <1> Set `max_num_segments` to control the number of segments to merge down to.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[force-merge-request-only-expunge-deletes]
+include-tagged::{doc-tests-file}[{api}-request-only-expunge-deletes]
 --------------------------------------------------
 <1> Set the `only_expunge_deletes` flag to `true`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[force-merge-request-flush]
+include-tagged::{doc-tests-file}[{api}-request-flush]
 --------------------------------------------------
 <1> Set the `flush` flag to `true`
 
-[[java-rest-high-force-merge-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[force-merge-execute]
---------------------------------------------------
-
-[[java-rest-high-force-merge-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a force merge request requires both the `ForceMergeRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[force-merge-execute-async]
---------------------------------------------------
-<1> The `ForceMergeRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `ForceMergeResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[force-merge-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-force-merge-response]]
+[id="{upid}-{api}-response"]
 ==== Force Merge Response
 
-The returned `ForceMergeResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[force-merge-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Total number of shards hit by the force merge request
 <2> Number of shards where the force merge has succeeded
@@ -97,6 +68,6 @@ By default, if the indices were not found, an `ElasticsearchException` will be t
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[force-merge-notfound]
+include-tagged::{doc-tests-file}[{api}-notfound]
 --------------------------------------------------
 <1> Do something if the indices to be force merged were not found

--- a/docs/java-rest/high-level/indices/get_alias.asciidoc
+++ b/docs/java-rest/high-level/indices/get_alias.asciidoc
@@ -1,16 +1,22 @@
-[[java-rest-high-get-alias]]
+--
+:api: get-alias
+:request: GetAliasesRequest
+:response: GetAliasesResponse
+--
+
+[id="{upid}-{api}"]
 === Get Alias API
 
-[[java-rest-high-get-alias-request]]
+[id="{upid}-{api}-request"]
 ==== Get Alias Request
 
-The Get Alias API uses `GetAliasesRequest` as its request object.
+The Get Alias API uses +{request}+ as its request object.
 One or more aliases can be optionally provided either at construction
 time or later on through the relevant setter method.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-alias-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 
 ==== Optional arguments
@@ -18,19 +24,19 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-alias-request-alias]
+include-tagged::{doc-tests-file}[{api}-request-alias]
 --------------------------------------------------
 <1> One or more aliases to retrieve
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-alias-request-indices]
+include-tagged::{doc-tests-file}[{api}-request-indices]
 --------------------------------------------------
 <1> The index or indices that the alias is associated with
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-alias-request-indicesOptions]
+include-tagged::{doc-tests-file}[{api}-request-indicesOptions]
 --------------------------------------------------
 <1> Setting `IndicesOptions` controls how unavailable indices are resolved and
 how wildcard expressions are expanded when looking for aliases that belong to
@@ -38,57 +44,22 @@ specified indices.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-alias-request-local]
+include-tagged::{doc-tests-file}[{api}-request-local]
 --------------------------------------------------
 <1> The `local` flag (defaults to `false`) controls whether the aliases need
 to be looked up in the local cluster state or in the cluster state held by
 the elected master node
 
-[[java-rest-high-get-alias-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-alias-execute]
---------------------------------------------------
-
-[[java-rest-high-get-alias-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a get alias request requires both a `GetAliasesRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-alias-execute-async]
---------------------------------------------------
-<1> The `GetAliasesRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for the `Boolean` response looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-alias-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-get-alias-response]]
+[id="{upid}-{api}-response"]
 ==== Get Alias Response
 
-The returned `GetAliasesResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-alias-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Retrieves a map of indices and their aliases

--- a/docs/java-rest/high-level/indices/get_field_mappings.asciidoc
+++ b/docs/java-rest/high-level/indices/get_field_mappings.asciidoc
@@ -1,14 +1,20 @@
-[[java-rest-high-get-field-mappings]]
+--
+:api: get-field-mappings
+:request: GetFieldMappingsRequest
+:response: GetFieldMappingsResponse
+--
+
+[id="{upid}-{api}"]
 === Get Field Mappings API
 
-[[java-rest-high-get-field-mappings-request]]
+[id="{upid}-{api}-request"]
 ==== Get Field Mappings Request
 
-A `GetFieldMappingsRequest` can have an optional list of indices, optional list of types and the list of fields:
+A +{request}+ can have an optional list of indices, optional list of types and the list of fields:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-field-mapping-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> An empty request
 <2> Setting the indices to fetch mapping for
@@ -20,63 +26,31 @@ The following arguments can also optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-field-mapping-request-indicesOptions]
+include-tagged::{doc-tests-file}[{api}-request-indicesOptions]
 --------------------------------------------------
 <1> Setting `IndicesOptions` controls how unavailable indices are resolved and
 how wildcard expressions are expanded
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-field-mapping-request-local]
+include-tagged::{doc-tests-file}[{api}-request-local]
 --------------------------------------------------
 <1> The `local` flag (defaults to `false`) controls whether the aliases need
 to be looked up in the local cluster state or in the cluster state held by
 the elected master node
 
-[[java-rest-high-get-field-mappings-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-field-mapping-execute]
---------------------------------------------------
+[id="{upid}-{api}-response"]
 
-[[java-rest-high-get-field-mapping-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a get mappings request requires both the
-`GetFieldMappingsRequest` instance and an `ActionListener` instance to be passed to
-the asynchronous method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-field-mapping-execute-async]
---------------------------------------------------
-<1> The `GetFieldMappingsRequest` to execute and the `ActionListener` to use when the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method if
-the execution successfully completed or using the `onFailure` method if it
-failed.
-
-A typical listener for `GetMappingsResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-field-mapping-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-get-field-mapping-response]]
 ==== Get Field Mappings Response
 
-The returned `GetFieldMappingsResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-field-mapping-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Returning all requested indices fields' mappings
 <2> Retrieving the mappings for a particular index and type

--- a/docs/java-rest/high-level/indices/get_index.asciidoc
+++ b/docs/java-rest/high-level/indices/get_index.asciidoc
@@ -1,14 +1,21 @@
+--
+:api: get-index
+:request: GetIndexRequest
+:response: GetIndexResponse
+--
+
+[id="{upid}-{api}"]
 [[java-rest-high-get-index]]
 === Get Index API
 
-[[java-rest-high-get-index-request]]
+[id="{upid}-{api}-request"]
 ==== Get Index Request
 
-A `GetIndexRequest` requires one or more `index` arguments:
+A +{request}+ requires one or more `index` arguments:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-index-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> The index whose information we want to retrieve
 
@@ -17,63 +24,28 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-index-request-includeDefaults]
+include-tagged::{doc-tests-file}[{api}-request-includeDefaults]
 --------------------------------------------------
 <1> If true, defaults will be returned for settings not explicitly set on the index
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-index-request-indicesOptions]
+include-tagged::{doc-tests-file}[{api}-request-indicesOptions]
 --------------------------------------------------
 <1> Setting `IndicesOptions` controls how unavailable indices are resolved and
 how wildcard expressions are expanded
 
-[[java-rest-high-get-index-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-index-execute]
---------------------------------------------------
-
-[[java-rest-high-get-index-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a Get Index request requires both the `GetIndexRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-index-execute-async]
---------------------------------------------------
-<1> The `GetIndexRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `GetIndexResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-index-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument.
-<2> Called in case of failure. The raised exception is provided as an argument.
-
-[[java-rest-high-get-index-response]]
+[id="{upid}-{api}-response"]
 ==== Get Index Response
 
-The returned `GetIndexResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-index-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Retrieve a Map of different types to `MappingMetadata` for `index`.
 <2> Retrieve a Map for the properties for document type `doc`.

--- a/docs/java-rest/high-level/indices/get_mappings.asciidoc
+++ b/docs/java-rest/high-level/indices/get_mappings.asciidoc
@@ -1,14 +1,20 @@
-[[java-rest-high-get-mappings]]
+--
+:api: get-mappings
+:request: GetMappingsRequest
+:response: GetMappingsResponse
+--
+
+[id="{upid}-{api}"]
 === Get Mappings API
 
-[[java-rest-high-get-mappings-request]]
+[id="{upid}-{api}-request"]
 ==== Get Mappings Request
 
-A `GetMappingsRequest` can have an optional list of indices and optional list of types:
+A +{request}+ can have an optional list of indices and optional list of types:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-mapping-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> An empty request that will return all indices and types
 <2> Setting the indices to fetch mapping for
@@ -19,61 +25,28 @@ The following arguments can also optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-mapping-request-masterTimeout]
+include-tagged::{doc-tests-file}[{api}-request-masterTimeout]
 --------------------------------------------------
 <1> Timeout to connect to the master node as a `TimeValue`
 <2> Timeout to connect to the master node as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-mapping-request-indicesOptions]
+include-tagged::{doc-tests-file}[{api}-request-indicesOptions]
 --------------------------------------------------
 <1> Options for expanding indices names
 
-[[java-rest-high-get-mappings-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-mapping-execute]
---------------------------------------------------
-
-[[java-rest-high-get-mapping-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a get mappings request requires both the
-`GetMappingsRequest` instance and an `ActionListener` instance to be passed to
-the asynchronous method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-mapping-execute-async]
---------------------------------------------------
-<1> The `GetMappingsRequest` to execute and the `ActionListener` to use when the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method if
-the execution successfully completed or using the `onFailure` method if it
-failed.
-
-A typical listener for `GetMappingsResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-mapping-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-get-mapping-response]]
+[id="{upid}-{api}-response"]
 ==== Get Mappings Response
 
-The returned `GetMappingsResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-mapping-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Returning all indices' mappings
 <2> Retrieving the mappings for a particular index and type

--- a/docs/java-rest/high-level/indices/get_settings.asciidoc
+++ b/docs/java-rest/high-level/indices/get_settings.asciidoc
@@ -1,14 +1,20 @@
-[[java-rest-high-get-settings]]
+--
+:api: get-settings
+:request: GetSettingsRequest
+:response: GetSettingsResponse
+--
+
+[id="{upid}-{api}"]
 === Get Settings API
 
-[[java-rest-high-get-settings-request]]
+[id="{upid}-{api}-request"]
 ==== Get Settings Request
 
-A `GetSettingsRequest` requires one or more `index` arguments:
+A +{request}+ requires one or more `index` arguments:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-settings-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> The index whose settings we should retrieve
 
@@ -17,80 +23,45 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-settings-request-names]
+include-tagged::{doc-tests-file}[{api}-request-names]
 --------------------------------------------------
 <1> One or more settings that be the only settings retrieved.  If unset, all settings will be retrieved
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-settings-request-include-defaults]
+include-tagged::{doc-tests-file}[{api}-request-include-defaults]
 --------------------------------------------------
 <1> If true, defaults will be returned for settings not explicitly set on the index
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-settings-request-indicesOptions]
+include-tagged::{doc-tests-file}[{api}-request-indicesOptions]
 --------------------------------------------------
 <1> Setting `IndicesOptions` controls how unavailable indices are resolved and
 how wildcard expressions are expanded
 
-[[java-rest-high-get-settings-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-settings-execute]
---------------------------------------------------
-
-[[java-rest-high-get-settings-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a Get Settings request requires both the `GetSettingsRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-settings-execute-async]
---------------------------------------------------
-<1> The `GetSettingsRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `GetSettingsResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-settings-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-get-settings-response]]
+[id="{upid}-{api}-response"]
 ==== Get Settings Response
 
-The returned `GetSettingsResponse` allows to retrieve information about the 
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-settings-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> We can retrieve the setting value for a particular index directly from the response as a string
 <2> We can also retrieve the Settings object for a particular index for further examination
 <3> The returned Settings object provides convenience methods for non String types
 
-If the `includeDefaults` flag was set to true in the `GetSettingsRequest`, the 
-behavior of `GetSettingsResponse` will differ somewhat.
+If the `includeDefaults` flag was set to true in the +{request}+ the
+behavior of +{response}+ will differ somewhat.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-settings-defaults-response]
+include-tagged::{doc-tests-file}[{api}-defaults-response]
 --------------------------------------------------
-<1> Individual default setting values may be retrieved directly from the `GetSettingsResponse`
+<1> Individual default setting values may be retrieved directly from the +{response}+
 <2> We may retrieve a Settings object for an index that contains those settings with default values

--- a/docs/java-rest/high-level/indices/get_templates.asciidoc
+++ b/docs/java-rest/high-level/indices/get_templates.asciidoc
@@ -1,16 +1,22 @@
-[[java-rest-high-get-templates]]
+--
+:api: get-templates
+:request: GetIndexTemplatesRequest
+:response: GetIndexTemplatesResponse
+--
+
+[id="{upid}-{api}"]
 === Get Templates API
 
 The Get Templates API allows to retrieve a list of index templates by name.
 
-[[java-rest-high-get-templates-request]]
+[id="{upid}-{api}-request"]
 ==== Get Index Templates Request
 
-A `GetIndexTemplatesRequest` specifies one or several names of the index templates to get.
+A +{request}+ specifies one or several names of the index templates to get.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-templates-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> A single index template name
 <2> Multiple index template names
@@ -18,56 +24,20 @@ include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-templates-requ
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-templates-request-masterTimeout]
+include-tagged::{doc-tests-file}[{api}-request-masterTimeout]
 --------------------------------------------------
 <1> Timeout to connect to the master node as a `TimeValue`
 <2> Timeout to connect to the master node as a `String`
 
-[[java-rest-high-get-templates-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-templates-execute]
---------------------------------------------------
-
-[[java-rest-high-get-templates-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a get index templates request requires a `GetTemplatesRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-templates-execute-async]
---------------------------------------------------
-<1> The `GetTemplatesRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `GetTemplatesResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-templates-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-get-templates-response]]
+[id="{upid}-{api}-response"]
 ==== Get Templates Response
 
-The returned `GetTemplatesResponse` consists a list of matching index templates.
+The returned +{response}+ consists a list of matching index templates.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[get-templates-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> A list of matching index templates
-

--- a/docs/java-rest/high-level/indices/indices_exists.asciidoc
+++ b/docs/java-rest/high-level/indices/indices_exists.asciidoc
@@ -1,70 +1,38 @@
-[[java-rest-high-indices-exists]]
+--
+:api: indices-exists
+:request: GetIndexRequest
+:response: boolean
+--
+
+[id="{upid}-{api}"]
 === Indices Exists API
 
-[[java-rest-high-indices-exists-request]]
+[id="{upid}-{api}-request"]
 ==== Indices Exists Request
 
-The high-level REST client uses a `GetIndexRequest` for Indices Exists API. The index name (or indices' names) are required.
+The high-level REST client uses a +{request}+ for Indices Exists API. The index name (or indices' names) are required.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[indices-exists-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Index
 
 [[java-rest-high-indices-exists-optional-args]]
 ==== Optional arguments
-Indices Exists API also accepts following optional arguments, through a `GetIndexRequest`:
+Indices Exists API also accepts following optional arguments, through a +{request}+:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[indices-exists-request-optionals]
+include-tagged::{doc-tests-file}[{api}-request-optionals]
 --------------------------------------------------
 <1> Whether to return local information or retrieve the state from master node
 <2> Return result in a format suitable for humans
 <3> Whether to return all default setting for each of the indices
 <4> Controls how unavailable indices are resolved and how wildcard expressions are expanded
 
-[[java-rest-high-indices-sync]]
-==== Synchronous Execution
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[indices-exists-response]
---------------------------------------------------
+include::../execution.asciidoc[]
 
-[[java-rest-high-indices-async]]
-==== Asynchronous Execution
-The asynchronous execution of an indices exists request requires both the
-`GetIndexRequest` instance and an `ActionListener` instance to be passed
-to the asynchronous method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[indices-exists-async]
---------------------------------------------------
-<1> The `GetIndexRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for the Indices Exists looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[indices-exists-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-indices-exists-response]]
+[id="{upid}-{api}-response"]
 ==== Response
-The response is a `boolean` value, indicating whether the index (or indices) exist:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[indices-exists-response]
---------------------------------------------------
+The response is a +{response}+ value, indicating whether the index (or indices) exist.

--- a/docs/java-rest/high-level/indices/open_index.asciidoc
+++ b/docs/java-rest/high-level/indices/open_index.asciidoc
@@ -1,14 +1,20 @@
-[[java-rest-high-open-index]]
+--
+:api: open-index
+:request: OpenIndexRequest
+:response: OpenIndexResponse
+--
+
+[id="{upid}-{api}"]
 === Open Index API
 
-[[java-rest-high-open-index-request]]
+[id="{upid}-{api}-request"]
 ==== Open Index Request
 
-An `OpenIndexRequest` requires an `index` argument:
+An +{request}+ requires an `index` argument:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[open-index-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> The index to open
 
@@ -17,7 +23,7 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[open-index-request-timeout]
+include-tagged::{doc-tests-file}[{api}-request-timeout]
 --------------------------------------------------
 <1> Timeout to wait for the all the nodes to acknowledge the index is opened
 as a `TimeValue`
@@ -26,14 +32,14 @@ as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[open-index-request-masterTimeout]
+include-tagged::{doc-tests-file}[{api}-request-masterTimeout]
 --------------------------------------------------
 <1> Timeout to connect to the master node as a `TimeValue`
 <2> Timeout to connect to the master node as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[open-index-request-waitForActiveShards]
+include-tagged::{doc-tests-file}[{api}-request-waitForActiveShards]
 --------------------------------------------------
 <1> The number of active shard copies to wait for before the open index API
 returns a response, as an `int`
@@ -42,57 +48,22 @@ returns a response, as an `ActiveShardCount`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[open-index-request-indicesOptions]
+include-tagged::{doc-tests-file}[{api}-request-indicesOptions]
 --------------------------------------------------
 <1> Setting `IndicesOptions` controls how unavailable indices are resolved and
 how wildcard expressions are expanded
 
-[[java-rest-high-open-index-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[open-index-execute]
---------------------------------------------------
-
-[[java-rest-high-open-index-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of an open index request requires both the `OpenIndexRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[open-index-execute-async]
---------------------------------------------------
-<1> The `OpenIndexRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `OpenIndexResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[open-index-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-open-index-response]]
+[id="{upid}-{api}-response"]
 ==== Open Index Response
 
-The returned `OpenIndexResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[open-index-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Indicates whether all of the nodes have acknowledged the request
 <2> Indicates whether the requisite number of shard copies were started for

--- a/docs/java-rest/high-level/indices/put_mapping.asciidoc
+++ b/docs/java-rest/high-level/indices/put_mapping.asciidoc
@@ -1,14 +1,20 @@
-[[java-rest-high-put-mapping]]
+--
+:api: put-mapping
+:request: PutMappingRequest
+:response: PutMappingResponse
+--
+
+[id="{upid}-{api}"]
 === Put Mapping API
 
-[[java-rest-high-put-mapping-request]]
+[id="{upid}-{api}-request"]
 ==== Put Mapping Request
 
-A `PutMappingRequest` requires an `index` argument, and a type:
+A +{request}+ requires an `index` argument, and a type:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-mapping-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> The index to add the mapping to
 <2> The type to create (or update)
@@ -18,7 +24,7 @@ A description of the fields to create on the mapping; if not defined, the mappin
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-mapping-request-source]
+include-tagged::{doc-tests-file}[{api}-request-source]
 --------------------------------------------------
 <1> Mapping source provided as a `String`
 
@@ -28,21 +34,21 @@ the `String` example shown above:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-mapping-map]
+include-tagged::{doc-tests-file}[{api}-map]
 --------------------------------------------------
 <1> Mapping source provided as a `Map` which gets automatically converted
 to JSON format
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-mapping-xcontent]
+include-tagged::{doc-tests-file}[{api}-xcontent]
 --------------------------------------------------
 <1> Mapping source provided as an `XContentBuilder` object, the Elasticsearch
 built-in helpers to generate JSON content
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-mapping-shortcut]
+include-tagged::{doc-tests-file}[{api}-shortcut]
 --------------------------------------------------
 <1> Mapping source provided as `Object` key-pairs, which gets converted to
 JSON format
@@ -52,63 +58,28 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-mapping-request-timeout]
+include-tagged::{doc-tests-file}[{api}-request-timeout]
 --------------------------------------------------
 <1> Timeout to wait for the all the nodes to acknowledge the index creation as a `TimeValue`
 <2> Timeout to wait for the all the nodes to acknowledge the index creation as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-mapping-request-masterTimeout]
+include-tagged::{doc-tests-file}[{api}-request-masterTimeout]
 --------------------------------------------------
 <1> Timeout to connect to the master node as a `TimeValue`
 <2> Timeout to connect to the master node as a `String`
 
-[[java-rest-high-put-mapping-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-mapping-execute]
---------------------------------------------------
-
-[[java-rest-high-put-mapping-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a put mappings request requires both the `PutMappingRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-mapping-execute-async]
---------------------------------------------------
-<1> The `PutMappingRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `PutMappingResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-mapping-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-put-mapping-response]]
+[id="{upid}-{api}-response"]
 ==== Put Mapping Response
 
-The returned `PutMappingResponse` allows to retrieve information about the executed
+The returned +{response}+ allows to retrieve information about the executed
  operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-mapping-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Indicates whether all of the nodes have acknowledged the request

--- a/docs/java-rest/high-level/indices/put_settings.asciidoc
+++ b/docs/java-rest/high-level/indices/put_settings.asciidoc
@@ -1,16 +1,22 @@
-[[java-rest-high-indices-put-settings]]
+--
+:api: indices-put-settings
+:request: UpdateSettingsRequest
+:response: UpdateSettingsResponse
+--
+
+[id="{upid}-{api}"]
 === Update Indices Settings API
 
 The Update Indices Settings API allows to change specific index level settings.
 
-[[java-rest-high-indices-put-settings-request]]
+[id="{upid}-{api}-request"]
 ==== Update Indices Settings Request
 
-An `UpdateSettingsRequest`:
+An +{request}+:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-settings-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Update settings for one index
 <2> Update settings for multiple indices
@@ -21,7 +27,7 @@ At least one setting to be updated must be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-settings-create-settings]
+include-tagged::{doc-tests-file}[{api}-create-settings]
 --------------------------------------------------
 <1> Sets the index settings to be applied
 
@@ -30,25 +36,25 @@ The settings to be applied can be provided in different ways:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-settings-create-settings]
+include-tagged::{doc-tests-file}[{api}-create-settings]
 --------------------------------------------------
 <1> Creates a setting as `Settings`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-settings-settings-builder]
+include-tagged::{doc-tests-file}[{api}-settings-builder]
 --------------------------------------------------
 <1> Settings provided as `Settings.Builder`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-settings-settings-source]
+include-tagged::{doc-tests-file}[{api}-settings-source]
 --------------------------------------------------
 <1> Settings provided as `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-settings-settings-map]
+include-tagged::{doc-tests-file}[{api}-settings-map]
 --------------------------------------------------
 <1> Settings provided as a `Map`
 
@@ -57,14 +63,14 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-settings-request-preserveExisting]
+include-tagged::{doc-tests-file}[{api}-request-preserveExisting]
 --------------------------------------------------
 <1> Whether to update existing settings. If set to `true` existing settings
 on an index remain unchanged, the default is `false`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-settings-request-timeout]
+include-tagged::{doc-tests-file}[{api}-request-timeout]
 --------------------------------------------------
 <1> Timeout to wait for the all the nodes to acknowledge the new setting
 as a `TimeValue`
@@ -73,63 +79,28 @@ as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-settings-request-masterTimeout]
+include-tagged::{doc-tests-file}[{api}-request-masterTimeout]
 --------------------------------------------------
 <1> Timeout to connect to the master node as a `TimeValue`
 <2> Timeout to connect to the master node as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-settings-request-indicesOptions]
+include-tagged::{doc-tests-file}[{api}-request-indicesOptions]
 --------------------------------------------------
 <1> Setting `IndicesOptions` controls how unavailable indices are resolved and
 how wildcard expressions are expanded
 
-[[java-rest-high-indices-put-settings-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-settings-execute]
---------------------------------------------------
-
-[[java-rest-high-indices-put-settings-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of an indices update settings requires both the
-`UpdateSettingsRequest` instance and an `ActionListener` instance to be
-passed to the asynchronous method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-settings-execute-async]
---------------------------------------------------
-<1> The `UpdateSettingsRequest` to execute and the `ActionListener`
-to use when the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `UpdateSettingsResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-settings-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of a failure. The raised exception is provided as an argument
-
-[[java-rest-high-indices-put-settings-response]]
+[id="{upid}-{api}-response"]
 ==== Update Indices Settings Response
 
-The returned `UpdateSettingsResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-settings-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Indicates whether all of the nodes have acknowledged the request

--- a/docs/java-rest/high-level/indices/put_template.asciidoc
+++ b/docs/java-rest/high-level/indices/put_template.asciidoc
@@ -1,15 +1,21 @@
-[[java-rest-high-put-template]]
+--
+:api: put-template
+:request: PutIndexTemplateRequest
+:response: PutIndexTemplateResponse
+--
+
+[id="{upid}-{api}"]
 === Put Template API
 
-[[java-rest-high-put-template-request]]
+[id="{upid}-{api}-request"]
 ==== Put Index Template Request
 
-A `PutIndexTemplateRequest` specifies the `name` of a template and `patterns`
+A +{request}+ specifies the `name` of a template and `patterns`
 which controls whether the template should be applied to the new index.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> The name of the template
 <2> The patterns of the template
@@ -20,7 +26,7 @@ template's patterns.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-request-settings]
+include-tagged::{doc-tests-file}[{api}-request-settings]
 --------------------------------------------------
 <1> Settings for this template
 
@@ -31,7 +37,7 @@ template's patterns.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-request-mappings-json]
+include-tagged::{doc-tests-file}[{api}-request-mappings-json]
 --------------------------------------------------
 <1> The type to define
 <2> The mapping for this type, provided as a JSON string
@@ -41,21 +47,21 @@ The mapping source can be provided in different ways in addition to the
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-request-mappings-map]
+include-tagged::{doc-tests-file}[{api}-request-mappings-map]
 --------------------------------------------------
 <1> Mapping source provided as a `Map` which gets automatically converted
 to JSON format
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-request-mappings-xcontent]
+include-tagged::{doc-tests-file}[{api}-request-mappings-xcontent]
 --------------------------------------------------
 <1> Mapping source provided as an `XContentBuilder` object, the Elasticsearch
 built-in helpers to generate JSON content
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-request-mappings-shortcut]
+include-tagged::{doc-tests-file}[{api}-request-mappings-shortcut]
 --------------------------------------------------
 <1> Mapping source provided as `Object` key-pairs, which gets converted to
 JSON format
@@ -66,7 +72,7 @@ template's patterns. A placeholder `{index}` can be used in an alias of a templa
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-request-aliases]
+include-tagged::{doc-tests-file}[{api}-request-aliases]
 --------------------------------------------------
 <1> The alias to define
 <2> The alias to define with placeholder
@@ -78,7 +84,7 @@ Templates with lower orders are applied first, and higher orders override them.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-request-order]
+include-tagged::{doc-tests-file}[{api}-request-order]
 --------------------------------------------------
 <1> The order of the template
 
@@ -88,7 +94,7 @@ management by external systems.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-request-version]
+include-tagged::{doc-tests-file}[{api}-request-version]
 --------------------------------------------------
 <1> The version number of the template
 
@@ -98,7 +104,7 @@ can also be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-whole-source]
+include-tagged::{doc-tests-file}[{api}-whole-source]
 --------------------------------------------------
 <1> The source provided as a JSON string. It can also be provided as a `Map`
 or an `XContentBuilder`.
@@ -108,61 +114,27 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-request-create]
+include-tagged::{doc-tests-file}[{api}-request-create]
 --------------------------------------------------
 <1> To force to only create a new template; do not overwrite the existing template
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-request-masterTimeout]
+include-tagged::{doc-tests-file}[{api}-request-masterTimeout]
 --------------------------------------------------
 <1> Timeout to connect to the master node as a `TimeValue`
 <2> Timeout to connect to the master node as a `String`
 
-[[java-rest-high-put-template-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-execute]
---------------------------------------------------
-
-[[java-rest-high-put-template-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a put template request requires both the `PutIndexTemplateRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-execute-async]
---------------------------------------------------
-<1> The `PutIndexTemplateRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `PutIndexTemplateResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-put-template-response]]
+[id="{upid}-{api}-response"]
 ==== Put Index Template Response
 
-The returned `PutIndexTemplateResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[put-template-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Indicates whether all of the nodes have acknowledged the request

--- a/docs/java-rest/high-level/indices/refresh.asciidoc
+++ b/docs/java-rest/high-level/indices/refresh.asciidoc
@@ -1,14 +1,20 @@
-[[java-rest-high-refresh]]
+--
+:api: refresh
+:request: RefreshRequest
+:response: RefreshResponse
+--
+
+[id="{upid}-{api}"]
 === Refresh API
 
-[[java-rest-high-refresh-request]]
+[id="{upid}-{api}-request"]
 ==== Refresh Request
 
-A `RefreshRequest` can be applied to one or more indices, or even on `_all` the indices:
+A +{request}+ can be applied to one or more indices, or even on `_all` the indices:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[refresh-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Refresh one index
 <2> Refresh multiple indices
@@ -18,57 +24,22 @@ include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[refresh-request]
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[refresh-request-indicesOptions]
+include-tagged::{doc-tests-file}[{api}-request-indicesOptions]
 --------------------------------------------------
 <1> Setting `IndicesOptions` controls how unavailable indices are resolved and
 how wildcard expressions are expanded
 
-[[java-rest-high-refresh-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[refresh-execute]
---------------------------------------------------
-
-[[java-rest-high-refresh-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a refresh request requires both the `RefreshRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[refresh-execute-async]
---------------------------------------------------
-<1> The `RefreshRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `RefreshResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[refresh-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-refresh-response]]
+[id="{upid}-{api}-response"]
 ==== Refresh Response
 
-The returned `RefreshResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[refresh-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Total number of shards hit by the refresh request
 <2> Number of shards where the refresh has succeeded
@@ -79,6 +50,6 @@ By default, if the indices were not found, an `ElasticsearchException` will be t
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[refresh-notfound]
+include-tagged::{doc-tests-file}[{api}-notfound]
 --------------------------------------------------
 <1> Do something if the indices to be refreshed were not found

--- a/docs/java-rest/high-level/indices/rollover.asciidoc
+++ b/docs/java-rest/high-level/indices/rollover.asciidoc
@@ -1,16 +1,22 @@
-[[java-rest-high-rollover-index]]
+--
+:api: rollover-index
+:request: RolloverRequest
+:response: RolloverResponse
+--
+
+[id="{upid}-{api}"]
 === Rollover Index API
 
-[[java-rest-high-rollover-request]]
+[id="{upid}-{api}-request"]
 ==== Rollover Request
 
-The Rollover Index API requires a `RolloverRequest` instance.
-A `RolloverRequest` requires two string arguments at construction time, and
+The Rollover Index API requires a +{request}+ instance.
+A +{request}+ requires two string arguments at construction time, and
 one or more conditions that determine when the index has to be rolled over:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[rollover-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> The alias (first argument) that points to the index to rollover, and
 optionally the name of the new index in case the rollover operation is performed
@@ -23,13 +29,13 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[rollover-request-dryRun]
+include-tagged::{doc-tests-file}[{api}-request-dryRun]
 --------------------------------------------------
 <1> Whether the rollover should be performed (default) or only simulated
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[rollover-request-timeout]
+include-tagged::{doc-tests-file}[{api}-request-timeout]
 --------------------------------------------------
 <1> Timeout to wait for the all the nodes to acknowledge the index is opened
 as a `TimeValue`
@@ -38,14 +44,14 @@ as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[rollover-request-masterTimeout]
+include-tagged::{doc-tests-file}[{api}-request-masterTimeout]
 --------------------------------------------------
 <1> Timeout to connect to the master node as a `TimeValue`
 <2> Timeout to connect to the master node as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[rollover-request-waitForActiveShards]
+include-tagged::{doc-tests-file}[{api}-request-waitForActiveShards]
 --------------------------------------------------
 <1> The number of active shard copies to wait for before the rollover index API
 returns a response, as an `int`
@@ -54,70 +60,35 @@ returns a response, as an `ActiveShardCount`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[rollover-request-settings]
+include-tagged::{doc-tests-file}[{api}-request-settings]
 --------------------------------------------------
 <1> Add the settings to apply to the new index, which include the number of
 shards to create for it
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[rollover-request-mapping]
+include-tagged::{doc-tests-file}[{api}-request-mapping]
 --------------------------------------------------
 <1> Add the mappings to associate the new index with. See <<java-rest-high-create-index-request-mappings>>
 for examples on the different ways to provide mappings
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[rollover-request-alias]
+include-tagged::{doc-tests-file}[{api}-request-alias]
 --------------------------------------------------
 <1> Add the aliases to associate the new index with
 
-[[java-rest-high-rollover-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[rollover-execute]
---------------------------------------------------
-
-[[java-rest-high-rollover-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a rollover request requires both the `RolloverRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[rollover-execute-async]
---------------------------------------------------
-<1> The `RolloverRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `RolloverResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[rollover-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-rollover-response]]
+[id="{upid}-{api}-response"]
 ==== Rollover Response
 
-The returned `RolloverResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[rollover-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Indicates whether all of the nodes have acknowledged the request
 <2> Indicates whether the requisite number of shard copies were started for

--- a/docs/java-rest/high-level/indices/shrink_index.asciidoc
+++ b/docs/java-rest/high-level/indices/shrink_index.asciidoc
@@ -1,15 +1,21 @@
-[[java-rest-high-shrink-index]]
+--
+:api: shrink-index
+:request: ResizeRequest
+:response: ResizeResponse
+--
+
+[id="{upid}-{api}"]
 === Shrink Index API
 
-[[java-rest-high-shrink-index-request]]
+[id="{upid}-{api}-request"]
 ==== Resize Request
 
-The Shrink API requires a `ResizeRequest` instance.
-A `ResizeRequest` requires two string arguments:
+The Shrink API requires a +{request}+ instance.
+A +{request}+ requires two string arguments:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[shrink-index-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> The target index (first argument) to shrink the source index (second argument) into
 
@@ -18,7 +24,7 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[shrink-index-request-timeout]
+include-tagged::{doc-tests-file}[{api}-request-timeout]
 --------------------------------------------------
 <1> Timeout to wait for the all the nodes to acknowledge the index is opened
 as a `TimeValue`
@@ -27,14 +33,14 @@ as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[shrink-index-request-masterTimeout]
+include-tagged::{doc-tests-file}[{api}-request-masterTimeout]
 --------------------------------------------------
 <1> Timeout to connect to the master node as a `TimeValue`
 <2> Timeout to connect to the master node as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[shrink-index-request-waitForActiveShards]
+include-tagged::{doc-tests-file}[{api}-request-waitForActiveShards]
 --------------------------------------------------
 <1> The number of active shard copies to wait for before the shrink index API
 returns a response, as an `int`
@@ -43,63 +49,28 @@ returns a response, as an `ActiveShardCount`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[shrink-index-request-settings]
+include-tagged::{doc-tests-file}[{api}-request-settings]
 --------------------------------------------------
 <1> The number of shards on the target of the shrink index request
 <2> Remove the allocation requirement copied from the source index
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[shrink-index-request-aliases]
+include-tagged::{doc-tests-file}[{api}-request-aliases]
 --------------------------------------------------
 <1> The aliases to associate the target index with
 
-[[java-rest-high-shrink-index-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[shrink-index-execute]
---------------------------------------------------
-
-[[java-rest-high-shrink-index-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a shrink index request requires both the `ResizeRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[shrink-index-execute-async]
---------------------------------------------------
-<1> The `ResizeRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `ResizeResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[shrink-index-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-shrink-index-response]]
+[id="{upid}-{api}-response"]
 ==== Shrink Index Response
 
-The returned `ResizeResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[shrink-index-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Indicates whether all of the nodes have acknowledged the request
 <2> Indicates whether the requisite number of shard copies were started for

--- a/docs/java-rest/high-level/indices/split_index.asciidoc
+++ b/docs/java-rest/high-level/indices/split_index.asciidoc
@@ -1,15 +1,21 @@
-[[java-rest-high-split-index]]
+--
+:api: split-index
+:request: ResizeRequest
+:response: ResizeResponse
+--
+
+[id="{upid}-{api}"]
 === Split Index API
 
-[[java-rest-high-split-index-request]]
+[id="{upid}-{api}-request"]
 ==== Resize Request
 
-The Split API requires a `ResizeRequest` instance.
-A `ResizeRequest` requires two string arguments:
+The Split API requires a +{request}+ instance.
+A +{request}+ requires two string arguments:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[split-index-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> The target index (first argument) to split the source index (second argument) into
 <2> The resize type needs to be set to `SPLIT`
@@ -19,7 +25,7 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[split-index-request-timeout]
+include-tagged::{doc-tests-file}[{api}-request-timeout]
 --------------------------------------------------
 <1> Timeout to wait for the all the nodes to acknowledge the index is opened
 as a `TimeValue`
@@ -28,14 +34,14 @@ as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[split-index-request-masterTimeout]
+include-tagged::{doc-tests-file}[{api}-request-masterTimeout]
 --------------------------------------------------
 <1> Timeout to connect to the master node as a `TimeValue`
 <2> Timeout to connect to the master node as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[split-index-request-waitForActiveShards]
+include-tagged::{doc-tests-file}[{api}-request-waitForActiveShards]
 --------------------------------------------------
 <1> The number of active shard copies to wait for before the split index API
 returns a response, as an `int`
@@ -44,63 +50,28 @@ returns a response, as an `ActiveShardCount`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[split-index-request-settings]
+include-tagged::{doc-tests-file}[{api}-request-settings]
 --------------------------------------------------
 <1> The settings to apply to the target index, which include the number of
 shards to create for it
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[split-index-request-aliases]
+include-tagged::{doc-tests-file}[{api}-request-aliases]
 --------------------------------------------------
 <1> The aliases to associate the target index with
 
-[[java-rest-high-split-index-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[split-index-execute]
---------------------------------------------------
-
-[[java-rest-high-split-index-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a split index request requires both the `ResizeRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[split-index-execute-async]
---------------------------------------------------
-<1> The `ResizeRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `ResizeResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[split-index-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-split-index-response]]
+[id="{upid}-{api}-response"]
 ==== Split Index Response
 
-The returned `ResizeResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[split-index-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Indicates whether all of the nodes have acknowledged the request
 <2> Indicates whether the requisite number of shard copies were started for

--- a/docs/java-rest/high-level/indices/update_aliases.asciidoc
+++ b/docs/java-rest/high-level/indices/update_aliases.asciidoc
@@ -1,17 +1,23 @@
-[[java-rest-high-update-aliases]]
+--
+:api: update-aliases
+:request: IndicesAliasesRequest
+:response: IndicesAliasesResponse
+--
+
+[id="{upid}-{api}"]
 === Index Aliases API
 
-[[java-rest-high-update-aliases-request]]
+[id="{upid}-{api}-request"]
 ==== Indices Aliases Request
 
 The Index Aliases API allows aliasing an index with a name, with all APIs
 automatically converting the alias name to the actual index name.
 
-An `IndicesAliasesRequest` must have at least one `AliasActions`:
+An +{request}+ must have at least one `AliasActions`:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[update-aliases-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Creates an `IndicesAliasesRequest`
 <2> Creates an `AliasActions` that aliases index `test1` with `alias1`
@@ -23,7 +29,7 @@ index.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[update-aliases-request2]
+include-tagged::{doc-tests-file}[{api}-request2]
 --------------------------------------------------
 <1> Creates an alias `alias1` with an optional filter on field `year`
 <2> Creates an alias `alias2` associated with two indices and with an optional routing
@@ -35,63 +41,28 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[update-aliases-request-timeout]
+include-tagged::{doc-tests-file}[{api}-request-timeout]
 --------------------------------------------------
 <1> Timeout to wait for the all the nodes to acknowledge the operation as a `TimeValue`
 <2> Timeout to wait for the all the nodes to acknowledge the operation as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[update-aliases-request-masterTimeout]
+include-tagged::{doc-tests-file}[{api}-request-masterTimeout]
 --------------------------------------------------
 <1> Timeout to connect to the master node as a `TimeValue`
 <2> Timeout to connect to the master node as a `String`
 
-[[java-rest-high-update-aliases-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[update-aliases-execute]
---------------------------------------------------
-
-[[java-rest-high-update-aliases-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of an update index aliases request requires both the `IndicesAliasesRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[update-aliases-execute-async]
---------------------------------------------------
-<1> The `IndicesAliasesRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `IndicesAliasesResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[update-aliases-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-update-aliases-response]]
+[id="{upid}-{api}-response"]
 ==== Indices Aliases Response
 
-The returned `IndicesAliasesResponse` allows to retrieve information about the
+The returned +{response}+ allows to retrieve information about the
 executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[update-aliases-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Indicates whether all of the nodes have acknowledged the request

--- a/docs/java-rest/high-level/indices/validate_query.asciidoc
+++ b/docs/java-rest/high-level/indices/validate_query.asciidoc
@@ -1,15 +1,21 @@
-[[java-rest-high-indices-validate-query]]
+--
+:api: indices-validate-query
+:request: ValidateQueryRequest
+:response: ValidateQueryResponse
+--
+
+[id="{upid}-{api}"]
 === Validate Query API
 
-[[java-rest-high-indices-validate-query-request]]
+[id="{upid}-{api}-request"]
 ==== Validate Query Request
 
-A `ValidateQueryRequest` requires one or more `indices` on which the query is validated. If no index
+A +{request}+ requires one or more `indices` on which the query is validated. If no index
 is provided the request is executed on all indices.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[validate-query-request]
+include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> The index on which to run the request.
 
@@ -18,7 +24,7 @@ The following code snippet builds a sample boolean query.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[validate-query-request-query]
+include-tagged::{doc-tests-file}[{api}-request-query]
 --------------------------------------------------
 <1> Build the desired query.
 <2> Set it to the request.
@@ -28,7 +34,7 @@ The following arguments can optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[validate-query-request-explain]
+include-tagged::{doc-tests-file}[{api}-request-explain]
 --------------------------------------------------
 <1> The explain parameter can be set to true to get more detailed information about why a query failed
 
@@ -38,7 +44,7 @@ query rewrite the `allShards` parameter should be used to get response from all 
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[validate-query-request-allShards]
+include-tagged::{doc-tests-file}[{api}-request-allShards]
 --------------------------------------------------
 <1> Set the allShards parameter.
 
@@ -47,57 +53,21 @@ the explanation is more detailed showing the actual Lucene query that will be ex
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[validate-query-request-rewrite]
+include-tagged::{doc-tests-file}[{api}-request-rewrite]
 --------------------------------------------------
 <1> Set the rewrite parameter.
 
-[[java-rest-high-indices-validate-query-sync]]
-==== Synchronous Execution
+include::../execution.asciidoc[]
 
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[validate-query-execute]
---------------------------------------------------
-<1> Execute the request and get back the response in a ValidateQueryResponse object.
-
-[[java-rest-high-indices-validate-query-async]]
-==== Asynchronous Execution
-
-The asynchronous execution of a validate query request requires both the `ValidateQueryRequest`
-instance and an `ActionListener` instance to be passed to the asynchronous
-method:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[validate-query-execute-async]
---------------------------------------------------
-<1> The `ValidateQueryRequest` to execute and the `ActionListener` to use when
-the execution completes
-
-The asynchronous method does not block and returns immediately. Once it is
-completed the `ActionListener` is called back using the `onResponse` method
-if the execution successfully completed or using the `onFailure` method if
-it failed.
-
-A typical listener for `ValidateQueryResponse` looks like:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[validate-query-execute-listener]
---------------------------------------------------
-<1> Called when the execution is successfully completed. The response is
-provided as an argument
-<2> Called in case of failure. The raised exception is provided as an argument
-
-[[java-rest-high-indices-validate-query-response]]
+[id="{upid}-{api}-response"]
 ==== Validate Query Response
 
-The returned `ValidateQueryResponse` allows to retrieve information about the executed
+The returned +{response}+ allows to retrieve information about the executed
  operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[validate-query-response]
+include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Check if the query is valid or not.
 <2> Get total number of shards.

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -85,36 +85,40 @@ include::miscellaneous/x-pack-usage.asciidoc[]
 
 == Indices APIs
 
+:upid: {mainid}
+:doc-tests-file: {doc-tests}/IndicesClientDocumentationIT.java
+
 The Java High Level REST Client supports the following Indices APIs:
 
 Index Management::
-* <<java-rest-high-create-index>>
-* <<java-rest-high-delete-index>>
-* <<java-rest-high-indices-exists>>
-* <<java-rest-high-open-index>>
-* <<java-rest-high-close-index>>
-* <<java-rest-high-shrink-index>>
-* <<java-rest-high-split-index>>
-* <<java-rest-high-refresh>>
-* <<java-rest-high-flush>>
-* <<java-rest-high-flush-synced>>
-* <<java-rest-high-clear-cache>>
-* <<java-rest-high-force-merge>>
-* <<java-rest-high-rollover-index>>
-* <<java-rest-high-indices-put-settings>>
-* <<java-rest-high-get-settings>>
-* <<java-rest-high-indices-validate-query>>
-* <<java-rest-high-get-index>>
+* <<{upid}-analyze>>
+* <<{upid}-create-index>>
+* <<{upid}-delete-index>>
+* <<{upid}-indices-exists>>
+* <<{upid}-open-index>>
+* <<{upid}-close-index>>
+* <<{upid}-shrink-index>>
+* <<{upid}-split-index>>
+* <<{upid}-refresh>>
+* <<{upid}-flush>>
+* <<{upid}-flush-synced>>
+* <<{upid}-clear-cache>>
+* <<{upid}-force-merge>>
+* <<{upid}-rollover-index>>
+* <<{upid}-indices-put-settings>>
+* <<{upid}-get-settings>>
+* <<{upid}-indices-validate-query>>
+* <<{upid}-get-index>>
 
 Mapping Management::
-* <<java-rest-high-put-mapping>>
-* <<java-rest-high-get-mappings>>
-* <<java-rest-high-get-field-mappings>>
+* <<{upid}-put-mapping>>
+* <<{upid}-get-mappings>>
+* <<{upid}-get-field-mappings>>
 
 Alias Management::
-* <<java-rest-high-update-aliases>>
-* <<java-rest-high-exists-alias>>
-* <<java-rest-high-get-alias>>
+* <<{upid}-update-aliases>>
+* <<{upid}-exists-alias>>
+* <<{upid}-get-alias>>
 
 include::indices/analyze.asciidoc[]
 include::indices/create_index.asciidoc[]


### PR DESCRIPTION
This commit DRYs up the indices folder as well as fixing a few minor
mishaps that were in the docs.