### PR TITLE
Undeprecate /_license endpoints

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestDeleteLicenseAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestDeleteLicenseAction.java
@@ -26,9 +26,8 @@ public class RestDeleteLicenseAction extends XPackRestHandler {
 
     public RestDeleteLicenseAction(Settings settings, RestController controller) {
         super(settings);
-        // @deprecated Remove deprecations in 6.0
-        controller.registerWithDeprecatedHandler(DELETE, URI_BASE + "/license", this,
-                                                 DELETE, "/_license", deprecationLogger);
+        controller.registerHandler(DELETE, URI_BASE + "/license", this);
+        controller.registerHandler(DELETE, "/_license", this);
 
         // Remove _licenses support entirely in 6.0
         controller.registerAsDeprecatedHandler(DELETE, "/_licenses", this,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetLicenseAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetLicenseAction.java
@@ -34,9 +34,8 @@ public class RestGetLicenseAction extends XPackRestHandler {
 
     public RestGetLicenseAction(Settings settings, RestController controller) {
         super(settings);
-        // @deprecated Remove deprecations in 6.0
-        controller.registerWithDeprecatedHandler(GET,  URI_BASE + "/license", this,
-                                                 GET, "/_license", deprecationLogger);
+        controller.registerHandler(GET,  URI_BASE + "/license", this);
+        controller.registerHandler(GET,  "/_license", this);
 
         // Remove _licenses support entirely in 6.0
         controller.registerAsDeprecatedHandler(GET, "/_licenses", this,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPutLicenseAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPutLicenseAction.java
@@ -26,11 +26,10 @@ public class RestPutLicenseAction extends XPackRestHandler {
 
     public RestPutLicenseAction(Settings settings, RestController controller) {
         super(settings);
-        // @deprecated Remove deprecations in 6.0
-        controller.registerWithDeprecatedHandler(POST, URI_BASE + "/license", this,
-                                                 POST, "/_license", deprecationLogger);
-        controller.registerWithDeprecatedHandler(PUT, URI_BASE + "/license", this,
-                                                 PUT, "/_license", deprecationLogger);
+        controller.registerHandler(POST, URI_BASE + "/license", this);
+        controller.registerHandler(POST, "/_license", this);
+        controller.registerHandler(PUT, URI_BASE + "/license", this);
+        controller.registerHandler(PUT, "/_license", this);
 
         // Remove _licenses support entirely in 6.0
         controller.registerAsDeprecatedHandler(POST, "/_licenses", this,


### PR DESCRIPTION
We deprecated these awhile ago in favor of /_xpack/license endpoints. Yet, this is no longer the direction that we want to go in, instead we want to remove the /_xpack namespace. This commit undeprecates the /_license endpoint.

Relates #35959
