### PR TITLE
Deprecate X-Pack centric Migration endpoints

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MigrationRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MigrationRequestConverters.java
@@ -31,7 +31,7 @@ final class MigrationRequestConverters {
 
     static Request getMigrationAssistance(IndexUpgradeInfoRequest indexUpgradeInfoRequest) {
         RequestConverters.EndpointBuilder endpointBuilder = new RequestConverters.EndpointBuilder()
-            .addPathPartAsIs("_xpack", "migration", "assistance")
+            .addPathPartAsIs("_migration", "assistance")
             .addCommaSeparatedPathParts(indexUpgradeInfoRequest.indices());
         String endpoint = endpointBuilder.build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
@@ -50,7 +50,7 @@ final class MigrationRequestConverters {
 
     private static Request prepareMigrateRequest(IndexUpgradeRequest indexUpgradeRequest, boolean waitForCompletion) {
         String endpoint = new RequestConverters.EndpointBuilder()
-            .addPathPartAsIs("_xpack", "migration", "upgrade")
+            .addPathPartAsIs("_migration", "upgrade")
             .addPathPart(indexUpgradeRequest.index())
             .build();
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MigrationRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MigrationRequestConvertersTests.java
@@ -32,7 +32,7 @@ public class MigrationRequestConvertersTests extends ESTestCase {
 
     public void testGetMigrationAssistance() {
         IndexUpgradeInfoRequest upgradeInfoRequest = new IndexUpgradeInfoRequest();
-        String expectedEndpoint = "/_xpack/migration/assistance";
+        String expectedEndpoint = "/_migration/assistance";
         if (randomBoolean()) {
             String[] indices = RequestConvertersTests.randomIndicesNames(1, 5);
             upgradeInfoRequest.indices(indices);
@@ -52,7 +52,7 @@ public class MigrationRequestConvertersTests extends ESTestCase {
         String[] indices = RequestConvertersTests.randomIndicesNames(1, 1);
         IndexUpgradeRequest upgradeInfoRequest = new IndexUpgradeRequest(indices[0]);
 
-        String expectedEndpoint = "/_xpack/migration/upgrade/" + indices[0];
+        String expectedEndpoint = "/_migration/upgrade/" + indices[0];
         Map<String, String> expectedParams = new HashMap<>();
         expectedParams.put("wait_for_completion", Boolean.TRUE.toString());
 

--- a/docs/reference/migration/apis/assistance.asciidoc
+++ b/docs/reference/migration/apis/assistance.asciidoc
@@ -10,9 +10,9 @@ cluster can be upgraded to the next major version.
 [float]
 ==== Request
 
-`GET /_xpack/migration/assistance` +
+`GET /_migration/assistance` +
 
-`GET /_xpack/migration/assistance/<index_name>`
+`GET /_migration/assistance/<index_name>`
 
 //==== Description
 
@@ -31,11 +31,11 @@ cluster can be upgraded to the next major version.
 ==== Examples
 
 To see a list of indices that needs to be upgraded or reindexed, submit a GET
-request to the `/_xpack/migration/assistance` endpoint:
+request to the `/_migration/assistance` endpoint:
 
 [source,js]
 --------------------------------------------------
-GET /_xpack/migration/assistance
+GET /_migration/assistance
 --------------------------------------------------
 // CONSOLE
 // TEST[skip:cannot create an old index in docs test]
@@ -64,11 +64,11 @@ A successful call returns a list of indices that need to be updated or reindexed
 // NOTCONSOLE
 
 To check a particular index or set of indices, specify this index name or mask
-as the last part of the `/_xpack/migration/assistance/index_name` endpoint:
+as the last part of the `/_migration/assistance/index_name` endpoint:
 
 [source,js]
 --------------------------------------------------
-GET /_xpack/migration/assistance/my_*
+GET /_migration/assistance/my_*
 --------------------------------------------------
 // CONSOLE
 // TEST[skip:cannot create an old index in docs test]

--- a/docs/reference/migration/apis/deprecation.asciidoc
+++ b/docs/reference/migration/apis/deprecation.asciidoc
@@ -10,9 +10,9 @@ be removed or changed in the next major version.
 [float]
 ==== Request
 
-`GET /_xpack/migration/deprecations` +
+`GET /_migration/deprecations` +
 
-`GET /<index_name>/_xpack/migration/deprecations`
+`GET /<index_name>/_migration/deprecations`
 
 //=== Description
 
@@ -32,11 +32,11 @@ be removed or changed in the next major version.
 ==== Examples
 
 To see the list of offenders in your cluster, submit a GET request to the
-`_xpack/migration/deprecations` endpoint:
+`_migration/deprecations` endpoint:
 
 [source,js]
 --------------------------------------------------
-GET /_xpack/migration/deprecations
+GET /_migration/deprecations
 --------------------------------------------------
 // CONSOLE
 // TEST[skip:cannot assert tests have certain deprecations]
@@ -115,7 +115,7 @@ The following example request shows only index-level deprecations of all
 
 [source,js]
 --------------------------------------------------
-GET /logstash-*/_xpack/migration/deprecations
+GET /logstash-*/_migration/deprecations
 --------------------------------------------------
 // CONSOLE
 // TEST[skip:cannot assert tests have certain deprecations]

--- a/docs/reference/migration/apis/upgrade.asciidoc
+++ b/docs/reference/migration/apis/upgrade.asciidoc
@@ -9,7 +9,7 @@ compatible with the next major version.
 [float]
 ==== Request
 
-`POST /_xpack/migration/upgrade/<index_name>`
+`POST /_migration/upgrade/<index_name>`
 
 [float]
 ==== Description
@@ -35,11 +35,11 @@ Indices must be upgraded one at a time.
 ==== Examples
 
 The following example submits a POST request to the
-`/_xpack/migration/upgrade/<index_name>` endpoint:
+`/_migration/upgrade/<index_name>` endpoint:
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/migration/upgrade/.watches
+POST /_migration/upgrade/.watches
 --------------------------------------------------
 // CONSOLE
 // TEST[skip:cannot create an old index in docs test]
@@ -73,7 +73,7 @@ The following example upgrades a large index asynchronously by specifying the
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/migration/upgrade/.watches?wait_for_completion=false
+POST /_migration/upgrade/.watches?wait_for_completion=false
 --------------------------------------------------
 // CONSOLE
 // TEST[skip:cannot create an old index in docs test]

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/RestDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/RestDeprecationInfoAction.java
@@ -5,8 +5,11 @@
  */
 package org.elasticsearch.xpack.deprecation;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
@@ -18,15 +21,22 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationInfoAction.Request;
 import java.io.IOException;
 
 public class RestDeprecationInfoAction extends BaseRestHandler {
+    private static final Logger logger = LogManager.getLogger(RestDeprecationInfoAction.class);
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
+
     public RestDeprecationInfoAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.GET, "/_xpack/migration/deprecations", this);
-        controller.registerHandler(RestRequest.Method.GET, "/{index}/_xpack/migration/deprecations", this);
+        controller.registerWithDeprecatedHandler(
+            RestRequest.Method.GET, "/_migration/deprecations", this,
+            RestRequest.Method.GET, "/_xpack/migration/deprecations", deprecationLogger);
+        controller.registerWithDeprecatedHandler(
+            RestRequest.Method.GET, "/{index}/_migration/deprecations", this,
+            RestRequest.Method.GET, "/{index}/_xpack/migration/deprecations", deprecationLogger);
     }
 
     @Override
     public String getName() {
-        return "deprecation_info_action";
+        return "deprecation_info";
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.migration.deprecations.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.migration.deprecations.json
@@ -3,8 +3,8 @@
     "documentation": "http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/{index}/_xpack/migration/deprecations",
-      "paths": ["/_xpack/migration/deprecations", "/{index}/_xpack/migration/deprecations"],
+      "path": "/{index}/_migration/deprecations",
+      "paths": ["/_migration/deprecations", "/{index}/_migration/deprecations"],
       "parts": {
         "index": {
           "type" : "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.migration.get_assistance.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.migration.get_assistance.json
@@ -3,10 +3,10 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_xpack/migration/assistance",
+      "path": "/_migration/assistance",
       "paths": [
-        "/_xpack/migration/assistance",
-        "/_xpack/migration/assistance/{index}"
+        "/_migration/assistance",
+        "/_migration/assistance/{index}"
       ],
       "parts": {
         "index": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.migration.upgrade.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.migration.upgrade.json
@@ -3,9 +3,9 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_xpack/migration/upgrade/{index}",
+      "path": "/_migration/upgrade/{index}",
       "paths": [
-        "/_xpack/migration/upgrade/{index}"
+        "/_migration/upgrade/{index}"
       ],
       "parts": {
         "index": {

--- a/x-pack/plugin/upgrade/src/main/java/org/elasticsearch/xpack/upgrade/rest/RestIndexUpgradeAction.java
+++ b/x-pack/plugin/upgrade/src/main/java/org/elasticsearch/xpack/upgrade/rest/RestIndexUpgradeAction.java
@@ -5,10 +5,13 @@
  */
 package org.elasticsearch.xpack.upgrade.rest;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -31,20 +34,27 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
 public class RestIndexUpgradeAction extends BaseRestHandler {
+    private static final Logger logger = LogManager.getLogger(RestIndexUpgradeAction.class);
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
+
     public RestIndexUpgradeAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.POST, "_xpack/migration/upgrade/{index}", this);
+        controller.registerWithDeprecatedHandler(
+            POST, "_migration/upgrade/{index}", this,
+            POST, "_xpack/migration/upgrade/{index}", deprecationLogger);
     }
 
     @Override
     public String getName() {
-        return "xpack_migration_upgrade";
+        return "migration_upgrade";
     }
 
     @Override
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        if (request.method().equals(RestRequest.Method.POST)) {
+        if (request.method().equals(POST)) {
             return handlePost(request, client);
         } else {
             throw new IllegalArgumentException("illegal method [" + request.method() + "] for request [" + request.path() + "]");

--- a/x-pack/plugin/upgrade/src/main/java/org/elasticsearch/xpack/upgrade/rest/RestIndexUpgradeInfoAction.java
+++ b/x-pack/plugin/upgrade/src/main/java/org/elasticsearch/xpack/upgrade/rest/RestIndexUpgradeInfoAction.java
@@ -5,9 +5,13 @@
  */
 package org.elasticsearch.xpack.upgrade.rest;
 
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.protocol.xpack.migration.IndexUpgradeInfoRequest;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -18,22 +22,31 @@ import org.elasticsearch.xpack.core.upgrade.actions.IndexUpgradeInfoAction;
 
 import java.io.IOException;
 
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
 public class RestIndexUpgradeInfoAction extends BaseRestHandler {
+    private static final Logger logger = LogManager.getLogger(RestIndexUpgradeInfoAction.class);
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
 
     public RestIndexUpgradeInfoAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.GET, "/_xpack/migration/assistance", this);
-        controller.registerHandler(RestRequest.Method.GET, "/_xpack/migration/assistance/{index}", this);
+        controller.registerWithDeprecatedHandler(
+            GET, "_migration/assistance", this,
+            GET, "/_xpack/migration/assistance", deprecationLogger);
+
+        controller.registerWithDeprecatedHandler(
+            GET, "_migration/assistance/{index}", this,
+            GET, "/_xpack/migration/assistance/{index}", deprecationLogger);
     }
 
     @Override
     public String getName() {
-        return "xpack_migration_assistance";
+        return "migration_assistance";
     }
 
     @Override
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        if (request.method().equals(RestRequest.Method.GET)) {
+        if (request.method().equals(GET)) {
             return handleGet(request, client);
         } else {
             throw new IllegalArgumentException("illegal method [" + request.method() + "] for request [" + request.path() + "]");

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -132,7 +132,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                 }
                 // run upgrade API
                 Response upgradeResponse = client().performRequest(
-                        new Request("POST", "_xpack/migration/upgrade/" + concreteSecurityIndex));
+                        new Request("POST", "_migration/upgrade/" + concreteSecurityIndex));
                 logger.info("upgrade response:\n{}", toStr(upgradeResponse));
             }
 
@@ -176,7 +176,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             waitForYellow(".watches,bwc_watch_index,.watcher-history*");
 
             logger.info("checking if the upgrade procedure on the new cluster is required");
-            Map<String, Object> response = entityAsMap(client().performRequest(new Request("GET", "/_xpack/migration/assistance")));
+            Map<String, Object> response = entityAsMap(client().performRequest(new Request("GET", "/_migration/assistance")));
             logger.info(response);
 
             @SuppressWarnings("unchecked") Map<String, Object> indices = (Map<String, Object>) response.get("indices");
@@ -189,7 +189,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
                 logger.info("starting upgrade procedure on the new cluster");
 
-                Request migrationAssistantRequest = new Request("POST", "_xpack/migration/upgrade/.watches");
+                Request migrationAssistantRequest = new Request("POST", "_migration/upgrade/.watches");
                 migrationAssistantRequest.addParameter("error_trace", "true");
                 Map<String, Object> upgradeResponse = entityAsMap(client().performRequest(migrationAssistantRequest));
                 assertThat(upgradeResponse.get("timed_out"), equalTo(Boolean.FALSE));
@@ -198,7 +198,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
                 logger.info("checking that upgrade procedure on the new cluster is no longer required");
                 Map<String, Object> responseAfter = entityAsMap(client().performRequest(
-                        new Request("GET", "/_xpack/migration/assistance")));
+                        new Request("GET", "/_migration/assistance")));
                 @SuppressWarnings("unchecked") Map<String, Object> indicesAfter = (Map<String, Object>) responseAfter.get("indices");
                 assertNull(indicesAfter.get(".watches"));
             } else {


### PR DESCRIPTION
This commit is part of our plan to deprecate and remove the use of
_xpack in the REST API routes.

Relates to https://github.com/elastic/elasticsearch/issues/35958