### PR TITLE
[Eclipse] set line lengths for comments equal to code

### DIFF
--- a/buildSrc/src/main/resources/eclipse.settings/org.eclipse.jdt.core.prefs
+++ b/buildSrc/src/main/resources/eclipse.settings/org.eclipse.jdt.core.prefs
@@ -16,6 +16,7 @@ eclipse.preferences.version=1
 # org.eclipse.jdt.core.compiler.problem.potentialNullReference=warning
 
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.formatter.comment.line_length=140
 org.eclipse.jdt.core.formatter.lineSplit=140
 org.eclipse.jdt.core.formatter.tabulation.char=space
 org.eclipse.jdt.core.formatter.tabulation.size=4


### PR DESCRIPTION
currently eclipse (default) wraps code comments at 80 characters, this change sets line length for code comments equal to code == 140.