### PR TITLE
[Zen2] testMarkAcceptedConfigAsCommitted fix

### DIFF
--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -221,7 +221,12 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
     public void testMarkAcceptedConfigAsCommitted() throws IOException {
         GatewayMetaStateUT gateway = newGateway();
 
-        CoordinationMetaData coordinationMetaData = createCoordinationMetaData(randomNonNegativeLong());
+        //generate random coordinationMetaData with different lastAcceptedConfiguration and lastCommittedConfiguration
+        CoordinationMetaData coordinationMetaData;
+        do {
+            coordinationMetaData = createCoordinationMetaData(randomNonNegativeLong());
+        } while (coordinationMetaData.getLastAcceptedConfiguration().equals(coordinationMetaData.getLastCommittedConfiguration()));
+
         ClusterState state = createClusterState(randomNonNegativeLong(),
                 MetaData.builder().coordinationMetaData(coordinationMetaData).build());
         gateway.setLastAcceptedState(state);


### PR DESCRIPTION
This PR fixes test failure, which is caused by equal randomly generated lastAcceptedConfiguration and lastCommittedConfguration.

```
> Task :server:test
   [junit4] <JUnit4> says مرحبا! Master seed: 34F00E75F669956A
==> Test Info: seed=34F00E75F669956A; jvm=1; suite=1

  1> [2018-11-29T01:22:34,505][INFO ][o.e.g.GatewayMetaStatePersistedStateTests] [testMarkAcceptedConfigAsCommitted] after test
  2> REPRODUCE WITH: ./gradlew :server:test -Dtests.seed=34F00E75F669956A -Dtests.class=org.elasticsearch.gateway.GatewayMetaStatePersistedStateTests -Dtests.method="testMarkAcceptedConfigAsCommitted" -Dtests.security.manager=true -Dtests.locale=es -Dtests.timezone=MIT -Dcompiler.java=11 -Druntime.java=11
FAILURE 0.44s | GatewayMetaStatePersistedStateTests.testMarkAcceptedConfigAsCommitted <<< FAILURES!
   > Throwable #1: java.lang.AssertionError: 
   > Expected: not <VotingConfiguration{}>
   >      but: was <VotingConfiguration{}>
   >    at __randomizedtesting.SeedInfo.seed([34F00E75F669956A:86F105F27B9119A]:0)
   >    at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
   >    at org.elasticsearch.gateway.GatewayMetaStatePersistedStateTests.testMarkAcceptedConfigAsCommitted(GatewayMetaStatePersistedStateTests.java:230)
   >    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
   >    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
   >    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
   >    at java.base/java.lang.reflect.Method.invoke(Method.java:566)
   >    at java.base/java.lang.Thread.run(Thread.java:834)
  2> NOTE: leaving temporary files on disk at: /home/brownbear/src/elasticsearch/server/build/testrun/test/J0/temp/org.elasticsearch.gateway.GatewayMetaStatePersistedStateTests_34F00E75F669956A-001
  2> NOTE: test params are: codec=Asserting(Lucene80): {}, docValues:{}, maxPointsInLeafNode=1032, maxMBSortInHeap=7.369019415389653, sim=Asserting(org.apache.lucene.search.similarities.AssertingSimilarity@4ab395ea), locale=es, timezone=MIT
  2> NOTE: Linux 4.18.0-11-generic amd64/Oracle Corporation 11.0.1 (64-bit)/cpus=16,threads=1,free=353516760,total=536870912
  2> NOTE: All tests run in this JVM: [GatewayMetaStatePersistedStateTests]
Completed [1/1] in 1.46s, 1 test, 1 failure <<< FAILURES!
```
