### PR TITLE
Allow asynchronous block operations to be delayed in IndexShardOperationPermits

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -732,7 +732,6 @@ public class IndexShardTests extends IndexShardTestCase {
         return fut.get();
     }
 
-    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/35850")
     public void testOperationPermitOnReplicaShards() throws Exception {
         final ShardId shardId = new ShardId("test", "_na_", 0);
         final IndexShard indexShard;
@@ -1023,7 +1022,6 @@ public class IndexShardTests extends IndexShardTestCase {
         closeShards(replicaShard, primaryShard);
     }
 
-    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/35850")
     public void testRestoreLocalHistoryFromTranslogOnPromotion() throws IOException, InterruptedException {
         final IndexShard indexShard = newStartedShard(false);
         final int operations = 1024 - scaledRandomIntBetween(0, 1024);
@@ -1088,7 +1086,6 @@ public class IndexShardTests extends IndexShardTestCase {
         closeShard(indexShard, false);
     }
 
-    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/35850")
     public void testRollbackReplicaEngineOnPromotion() throws IOException, InterruptedException {
         final IndexShard indexShard = newStartedShard(false);
 


### PR DESCRIPTION
IndexShardOperationPermits provides two methods to execute an operation while holding all the index shard permits: `blockOperations()` and `asyncBlockOperations()`. When they are called concurrently, all synchronous and asynchronous operations are competing for the acquisition of all permits. The order of execution is defined by the fairness of the internal semaphore used to acquire/release permits, but since asynchronous block operations are executed on another thread on the generic thread pool (which can already be busy with other unrelated operations) the order of execution is actually undefined.

This behavior was OK until the merge of #35540, in which we allow transport replication write action to acquire all permits during the execution. This change caused tests failures like #35850 where the execution of the action is competing with a primary term bump for the acquisition of all permits (see https://github.com/elastic/elasticsearch/pull/35862#issuecomment-441570761 for a more complete explanation of the issue). Depending of which takes the precedence, the test failed or succeed.

This pull request changes the IndexShardOperationPermits so that asynchronous block operations are delayed like regular operations if another block operation already requested the delay of operations. As soon as a blocking operation is terminated, IndexShardOperationPermits checks if one or more operations were delayed and should be released, and releases async block operations first - one after the other. This way IndexShardOperationPermits can guarantee that async block operations are executed in the order they were requested, while regular operation are still delayed until all sync/async block operations are terminated.

Closes #35850 