### PR TITLE
LLREST: Add PreferHasAttributeNodeSelector

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/PreferHasAttributeNodeSelector.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/PreferHasAttributeNodeSelector.java
@@ -25,8 +25,10 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * A {@link NodeSelector} that prefer to select nodes that have a particular value
- * for an attribute.
+ * Both {@link PreferHasAttributeNodeSelector} and {@link HasAttributeNodeSelector} will work the same
+ * if there is a {@link Node} with particular attribute in the attributes,
+ * but {@link PreferHasAttributeNodeSelector} will select another node even if there is no {@link Node} with particular attribute
+ * in the attributes.
  */
 public final class PreferHasAttributeNodeSelector implements NodeSelector {
     private final String key;

--- a/client/rest/src/main/java/org/elasticsearch/client/PreferHasAttributeNodeSelector.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/PreferHasAttributeNodeSelector.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A {@link NodeSelector} that prefer to select nodes that have a particular value
+ * for an attribute.
+ */
+public final class PreferHasAttributeNodeSelector implements NodeSelector {
+    private final String key;
+    private final String value;
+
+    public PreferHasAttributeNodeSelector(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override
+    public void select(Iterable<Node> nodes) {
+        boolean foundAtLeastOne = false;
+
+        for (Node node : nodes) {
+            Map<String, List<String>> attributes = node.getAttributes();
+
+            if (attributes == null) {
+                continue;
+            }
+
+            List<String> values = attributes.get(key);
+
+            if (values == null) {
+                continue;
+            }
+
+            if (values.contains(value)) {
+                foundAtLeastOne = true;
+                break;
+            }
+        }
+
+        if (foundAtLeastOne) {
+            Iterator<Node> nodeIterator = nodes.iterator();
+            while (nodeIterator.hasNext()) {
+                Map<String, List<String>> attributes = nodeIterator.next().getAttributes();
+
+                if (attributes == null) {
+                    continue;
+                }
+
+                List<String> values = attributes.get(key);
+
+                if (values == null || !values.contains(value)) {
+                    nodeIterator.remove();
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PreferHasAttributeNodeSelector that = (PreferHasAttributeNodeSelector) o;
+        return Objects.equals(key, that.key) &&
+            Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
+    }
+
+    @Override
+    public String toString() {
+        return key + "=" + value;
+    }
+}

--- a/client/rest/src/main/java/org/elasticsearch/client/PreferHasAttributeNodeSelector.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/PreferHasAttributeNodeSelector.java
@@ -27,8 +27,8 @@ import java.util.Objects;
 /**
  * Both {@link PreferHasAttributeNodeSelector} and {@link HasAttributeNodeSelector} will work the same
  * if there is a {@link Node} with particular attribute in the attributes,
- * but {@link PreferHasAttributeNodeSelector} will select another node even if there is no {@link Node} with particular attribute
- * in the attributes.
+ * but {@link PreferHasAttributeNodeSelector} will select another {@link Node}s even if there is no {@link Node}
+ * with particular attribute in the attributes.
  */
 public final class PreferHasAttributeNodeSelector implements NodeSelector {
     private final String key;

--- a/client/rest/src/test/java/org/elasticsearch/client/PreferHasAttributeNodeSelectorTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/PreferHasAttributeNodeSelectorTests.java
@@ -22,7 +22,11 @@ package org.elasticsearch.client;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.Node.Roles;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;

--- a/client/rest/src/test/java/org/elasticsearch/client/PreferHasAttributeNodeSelectorTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/PreferHasAttributeNodeSelectorTests.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.Node.Roles;
+
+import java.util.*;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+
+public class PreferHasAttributeNodeSelectorTests extends RestClientTestCase {
+    public void testFoundPreferHasAttribute() {
+        Node hasAttributeValue = dummyNode(singletonMap("attr", singletonList("val")));
+        Node hasAttributeButNotValue = dummyNode(singletonMap("attr", singletonList("notval")));
+        Node hasAttributeValueInList = dummyNode(singletonMap("attr", Arrays.asList("val", "notval")));
+        Node notHasAttribute = dummyNode(singletonMap("notattr", singletonList("val")));
+        List<Node> nodes = new ArrayList<>();
+        nodes.add(hasAttributeValue);
+        nodes.add(hasAttributeButNotValue);
+        nodes.add(hasAttributeValueInList);
+        nodes.add(notHasAttribute);
+        List<Node> expected = new ArrayList<>();
+        expected.add(hasAttributeValue);
+        expected.add(hasAttributeValueInList);
+        new PreferHasAttributeNodeSelector("attr", "val").select(nodes);
+        assertEquals(expected, nodes);
+    }
+
+    public void testNotFoundPreferHasAttribute() {
+        Node notHasAttribute = dummyNode(singletonMap("notattr", singletonList("val")));
+        List<Node> nodes = new ArrayList<>();
+        nodes.add(notHasAttribute);
+        List<Node> expected = new ArrayList<>();
+        expected.add(notHasAttribute);
+        new PreferHasAttributeNodeSelector("attr", "val").select(nodes);
+        assertEquals(expected, nodes);
+    }
+
+    private static Node dummyNode(Map<String, List<String>> attributes) {
+        return new Node(new HttpHost("dummy"), Collections.<HttpHost>emptySet(),
+            randomAsciiAlphanumOfLength(5), randomAsciiAlphanumOfLength(5),
+            new Roles(randomBoolean(), randomBoolean(), randomBoolean()),
+            attributes);
+    }
+}


### PR DESCRIPTION
Add PreferHasAttributeNodeSelector.
PreferHasAttributeNodeSelector and HasAttributeNodeSelector will work the same if there is a node with particular attribute in the attributes, but PreferHasAttributeNodeSelector will select another node even if there is no node with particular attribute in the attributes.
 
