### PR TITLE
Remove X-Pack centric graph endpoints

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/GraphRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/GraphRequestConverters.java
@@ -29,7 +29,7 @@ final class GraphRequestConverters {
     private GraphRequestConverters() {}
 
     static Request explore(GraphExploreRequest exploreRequest) throws IOException {
-        String endpoint = RequestConverters.endpoint(exploreRequest.indices(), exploreRequest.types(), "_xpack/graph/_explore");
+        String endpoint = RequestConverters.endpoint(exploreRequest.indices(), exploreRequest.types(), "_graph/explore");
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
         request.setEntity(RequestConverters.createEntity(exploreRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/GrapRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/GrapRequestConvertersTests.java
@@ -20,12 +20,12 @@
 package org.elasticsearch.client;
 
 import org.apache.http.client.methods.HttpGet;
+import org.elasticsearch.client.graph.GraphExploreRequest;
+import org.elasticsearch.client.graph.Hop;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
-import org.elasticsearch.client.graph.GraphExploreRequest;
-import org.elasticsearch.client.graph.Hop;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.HashMap;
@@ -58,7 +58,7 @@ public class GrapRequestConvertersTests extends ESTestCase {
         }
         Request request = GraphRequestConverters.explore(graphExploreRequest);
         assertEquals(HttpGet.METHOD_NAME, request.getMethod());
-        assertEquals("/index1,index2/type1,type2/_xpack/graph/_explore", request.getEndpoint());
+        assertEquals("/index1,index2/type1,type2/_graph/explore", request.getEndpoint());
         assertEquals(expectedParams, request.getParameters());
         assertThat(request.getEntity().getContentType().getValue(), is(XContentType.JSON.mediaTypeWithoutParameters()));
         RequestConvertersTests.assertToXContentBody(graphExploreRequest, request.getEntity());

--- a/docs/reference/graph/explore.asciidoc
+++ b/docs/reference/graph/explore.asciidoc
@@ -18,7 +18,7 @@ For additional information about working with the explore API, see the Graph
 [float]
 === Request
 
-`POST <index>/_xpack/graph/_explore`
+`POST <index>/_graph/explore`
 
 [float]
 === Description
@@ -183,7 +183,7 @@ An initial search typically begins with a query to identify strongly related ter
 
 [source,js]
 --------------------------------------------------
-POST clicklogs/_xpack/graph/_explore
+POST clicklogs/_graph/explore
 {
     "query": { <1>
         "match": {
@@ -288,7 +288,7 @@ every document could be of interest, see the
 
 [source,js]
 --------------------------------------------------
-POST clicklogs/_xpack/graph/_explore
+POST clicklogs/_graph/explore
 {
     "query": {
         "match": {
@@ -375,7 +375,7 @@ out to find additional search terms associated with that product. The terms
 
 [source,js]
 --------------------------------------------------
-POST clicklogs/_xpack/graph/_explore
+POST clicklogs/_graph/explore
 {
    "vertices": [
       {

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
@@ -3,14 +3,15 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.graph.rest.action;
 
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -38,7 +39,8 @@ import static org.elasticsearch.xpack.core.graph.action.GraphExploreAction.INSTA
  * @see GraphExploreRequest
  */
 public class RestGraphAction extends XPackRestHandler {
-    private static final Logger logger = LogManager.getLogger(RestGraphAction.class);
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestGraphAction.class));
 
     public static final ParseField TIMEOUT_FIELD = new ParseField("timeout");
     public static final ParseField SIGNIFICANCE_FIELD = new ParseField("use_significance");
@@ -61,16 +63,27 @@ public class RestGraphAction extends XPackRestHandler {
 
     public RestGraphAction(Settings settings, RestController controller) {
         super(settings);
-
-        controller.registerHandler(GET, "/{index}" + URI_BASE + "/graph/_explore", this);
-        controller.registerHandler(POST, "/{index}" + URI_BASE + "/graph/_explore", this);
-        controller.registerHandler(GET, "/{index}/{type}" + URI_BASE + "/graph/_explore", this);
-        controller.registerHandler(POST, "/{index}/{type}" + URI_BASE + "/graph/_explore", this);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                GET, "/{index}" + URI_BASE + "/graph/_explore", this,
+                GET, "/{index}/_graph/explore", deprecationLogger);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                POST, "/{index}" + URI_BASE + "/graph/_explore", this,
+                POST, "/{index}/_graph/explore", deprecationLogger);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                GET, "/{index}/{type}" + URI_BASE + "/graph/_explore", this,
+                GET, "/{index}/{type}/_graph/explore", deprecationLogger);
+        // TODO: remove deprecated endpoint in 8.0.0
+        controller.registerWithDeprecatedHandler(
+                POST, "/{index}/{type}" + URI_BASE + "/graph/_explore", this,
+                POST, "/{index}/{type}/_graph/explore", deprecationLogger);
     }
 
     @Override
     public String getName() {
-        return "xpack_graph_action";
+        return "graph";
     }
 
     @Override
@@ -323,4 +336,5 @@ public class RestGraphAction extends XPackRestHandler {
             }
         }
     }
+
 }

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
@@ -65,20 +65,20 @@ public class RestGraphAction extends XPackRestHandler {
         super(settings);
         // TODO: remove deprecated endpoint in 8.0.0
         controller.registerWithDeprecatedHandler(
-                GET, "/{index}" + URI_BASE + "/graph/_explore", this,
-                GET, "/{index}/_graph/explore", deprecationLogger);
+                GET, "/{index}/_graph/explore", this,
+                GET, "/{index}" + URI_BASE + "/graph/_explore", deprecationLogger);
         // TODO: remove deprecated endpoint in 8.0.0
         controller.registerWithDeprecatedHandler(
-                POST, "/{index}" + URI_BASE + "/graph/_explore", this,
-                POST, "/{index}/_graph/explore", deprecationLogger);
+                POST, "/{index}/_graph/explore", this,
+                POST, "/{index}" + URI_BASE + "/graph/_explore", deprecationLogger);
         // TODO: remove deprecated endpoint in 8.0.0
         controller.registerWithDeprecatedHandler(
-                GET, "/{index}/{type}" + URI_BASE + "/graph/_explore", this,
-                GET, "/{index}/{type}/_graph/explore", deprecationLogger);
+                GET, "/{index}/{type}/_graph/explore", this,
+                GET, "/{index}/{type}" + URI_BASE + "/graph/_explore", deprecationLogger);
         // TODO: remove deprecated endpoint in 8.0.0
         controller.registerWithDeprecatedHandler(
-                POST, "/{index}/{type}" + URI_BASE + "/graph/_explore", this,
-                POST, "/{index}/{type}/_graph/explore", deprecationLogger);
+                POST, "/{index}/{type}/_graph/explore", this,
+                POST, "/{index}/{type}" + URI_BASE + "/graph/_explore", deprecationLogger);
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.graph.explore.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.graph.explore.json
@@ -3,8 +3,8 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/{index}/_xpack/graph/_explore",
-      "paths": ["/{index}/_xpack/graph/_explore", "/{index}/{type}/_xpack/graph/_explore"],
+      "path": "/{index}/_xpack/_graph/explore",
+      "paths": ["/{index}/_xpack/_graph/explore", "/{index}/{type}/_xpack/_graph/explore"],
       "parts" : {
         "index": {
          "type" : "list",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.graph.explore.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.graph.explore.json
@@ -3,8 +3,8 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/{index}/_xpack/_graph/explore",
-      "paths": ["/{index}/_xpack/_graph/explore", "/{index}/{type}/_xpack/_graph/explore"],
+      "path": "/{index}/_graph/explore",
+      "paths": ["/{index}/_graph/explore", "/{index}/{type}/_graph/explore"],
       "parts" : {
         "index": {
          "type" : "list",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/graph/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/graph/10_basic.yml
@@ -18,6 +18,7 @@ setup:
 "Test basic graph explore":
   - skip:
       version: " - 6.99.99"
+      reason: "graph endpoints changed in 7.0.0 to not include _xpack in the path but this is not supported in 6.x"
   - do:
       index:
           index:  test_1

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/graph/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/graph/10_basic.yml
@@ -16,6 +16,8 @@ setup:
 
 ---
 "Test basic graph explore":
+  - skip:
+      version: " - 6.99.99"
   - do:
       index:
           index:  test_1


### PR DESCRIPTION
This commit is part of our plan to deprecate and ultimately remove the use of _xpack in the REST APIs.

Relates #35958