### PR TITLE
[ML] Prefer cluster state config to index documents

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -91,6 +91,8 @@ public final class Messages {
     public static final String JOB_AUDIT_MEMORY_STATUS_HARD_LIMIT = "Job memory status changed to hard_limit at {0}; adjust the " +
             "analysis_limits.model_memory_limit setting to ensure all data is analyzed";
 
+    public static final String JOB_CANNOT_CLOSE_BECAUSE_DATAFEED = "cannot close job datafeed [{0}] hasn''t been stopped";
+
     public static final String JOB_CONFIG_CATEGORIZATION_FILTERS_CONTAINS_DUPLICATES = "categorization_filters contain duplicates";
     public static final String JOB_CONFIG_CATEGORIZATION_FILTERS_CONTAINS_EMPTY =
             "categorization_filters are not allowed to contain empty strings";

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -11,7 +11,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceAlreadyExistsException;
-import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingAction;
@@ -693,53 +692,47 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
 
     private void clearJobFinishedTime(String jobId, ActionListener<AcknowledgedResponse> listener) {
 
-        JobUpdate update = new JobUpdate.Builder(jobId).setClearFinishTime(true).build();
+        boolean jobIsInClusterState = ClusterStateJobUpdate.jobIsInClusterState(clusterService.state(), jobId);
+        if (jobIsInClusterState) {
+            clusterService.submitStateUpdateTask("clearing-job-finish-time-for-" + jobId, new ClusterStateUpdateTask() {
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    MlMetadata mlMetadata = MlMetadata.getMlMetadata(currentState);
+                    MlMetadata.Builder mlMetadataBuilder = new MlMetadata.Builder(mlMetadata);
+                    Job.Builder jobBuilder = new Job.Builder(mlMetadata.getJobs().get(jobId));
+                    jobBuilder.setFinishedTime(null);
 
-        jobConfigProvider.updateJob(jobId, update, null, ActionListener.wrap(
-                job -> listener.onResponse(new AcknowledgedResponse(true)),
-                e -> {
-                    if (e.getClass() == ResourceNotFoundException.class) {
-                        // Maybe the config is in the clusterstate
-                        if (ClusterStateJobUpdate.jobIsInClusterState(clusterService.state(), jobId)) {
-                            clearJobFinishedTimeClusterState(jobId, listener);
-                            return;
-                        }
-                    }
-                    logger.error("[" + jobId + "] Failed to clear finished_time", e);
-                    // Not a critical error so continue
+                    mlMetadataBuilder.putJob(jobBuilder.build(), true);
+                    ClusterState.Builder builder = ClusterState.builder(currentState);
+                    return builder.metaData(new MetaData.Builder(currentState.metaData())
+                            .putCustom(MlMetadata.TYPE, mlMetadataBuilder.build()))
+                            .build();
+                }
+
+                @Override
+                public void onFailure(String source, Exception e) {
+                    logger.error("[" + jobId + "] Failed to clear finished_time; source [" + source + "]", e);
                     listener.onResponse(new AcknowledgedResponse(true));
                 }
-        ));
-    }
 
-    private void clearJobFinishedTimeClusterState(String jobId, ActionListener<AcknowledgedResponse> listener) {
-        clusterService.submitStateUpdateTask("clearing-job-finish-time-for-" + jobId, new ClusterStateUpdateTask() {
-            @Override
-            public ClusterState execute(ClusterState currentState) {
-                MlMetadata mlMetadata = MlMetadata.getMlMetadata(currentState);
-                MlMetadata.Builder mlMetadataBuilder = new MlMetadata.Builder(mlMetadata);
-                Job.Builder jobBuilder = new Job.Builder(mlMetadata.getJobs().get(jobId));
-                jobBuilder.setFinishedTime(null);
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState,
+                                                  ClusterState newState) {
+                    listener.onResponse(new AcknowledgedResponse(true));
+                }
+            });
+        } else {
+            JobUpdate update = new JobUpdate.Builder(jobId).setClearFinishTime(true).build();
 
-                mlMetadataBuilder.putJob(jobBuilder.build(), true);
-                ClusterState.Builder builder = ClusterState.builder(currentState);
-                return builder.metaData(new MetaData.Builder(currentState.metaData())
-                        .putCustom(MlMetadata.TYPE, mlMetadataBuilder.build()))
-                        .build();
-            }
-
-            @Override
-            public void onFailure(String source, Exception e) {
-                logger.error("[" + jobId + "] Failed to clear finished_time; source [" + source + "]", e);
-                listener.onResponse(new AcknowledgedResponse(true));
-            }
-
-            @Override
-            public void clusterStateProcessed(String source, ClusterState oldState,
-                                              ClusterState newState) {
-                listener.onResponse(new AcknowledgedResponse(true));
-            }
-        });
+            jobConfigProvider.updateJob(jobId, update, null, ActionListener.wrap(
+                    job -> listener.onResponse(new AcknowledgedResponse(true)),
+                    e -> {
+                        logger.error("[" + jobId + "] Failed to clear finished_time", e);
+                        // Not a critical error so continue
+                        listener.onResponse(new AcknowledgedResponse(true));
+                    }
+            ));
+        }
     }
 
     private void cancelJobStart(PersistentTasksCustomMetaData.PersistentTask<OpenJobAction.JobParams> persistentTask, Exception exception,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDatafeedAction.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.ml.action;
 
-import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
@@ -70,6 +69,19 @@ public class TransportUpdateDatafeedAction extends TransportMasterNodeAction<Upd
     protected void masterOperation(UpdateDatafeedAction.Request request, ClusterState state,
                                    ActionListener<PutDatafeedAction.Response> listener) throws Exception {
 
+        MlMetadata mlMetadata = MlMetadata.getMlMetadata(state);
+        boolean datafeedConfigIsInClusterState = mlMetadata.getDatafeed(request.getUpdate().getId()) != null;
+        if (datafeedConfigIsInClusterState) {
+            updateDatafeedInClusterState(request, listener);
+        } else {
+            updateDatafeedInIndex(request, state, listener);
+        }
+    }
+
+    private void updateDatafeedInIndex(UpdateDatafeedAction.Request request, ClusterState state,
+                                       ActionListener<PutDatafeedAction.Response> listener) throws Exception {
+        final Map<String, String> headers = threadPool.getThreadContext().getHeaders();
+
         // Check datafeed is stopped
         PersistentTasksCustomMetaData tasks = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
         if (MlTasks.getDatafeedTask(request.getUpdate().getId(), tasks) != null) {
@@ -79,12 +91,6 @@ public class TransportUpdateDatafeedAction extends TransportMasterNodeAction<Upd
             return;
         }
 
-        updateDatafeedInIndex(request, state, listener);
-    }
-
-    private void updateDatafeedInIndex(UpdateDatafeedAction.Request request, ClusterState state,
-                                       ActionListener<PutDatafeedAction.Response> listener) throws Exception {
-        final Map<String, String> headers = threadPool.getThreadContext().getHeaders();
         String datafeedId = request.getUpdate().getId();
 
         CheckedConsumer<Boolean, Exception> updateConsumer = ok -> {
@@ -92,17 +98,7 @@ public class TransportUpdateDatafeedAction extends TransportMasterNodeAction<Upd
                     jobConfigProvider::validateDatafeedJob,
                     ActionListener.wrap(
                             updatedConfig -> listener.onResponse(new PutDatafeedAction.Response(updatedConfig)),
-                            e -> {
-                                if (e.getClass() == ResourceNotFoundException.class) {
-                                    // try the clusterstate
-                                    MlMetadata mlMetadata = MlMetadata.getMlMetadata(state);
-                                    if (mlMetadata.getDatafeed(request.getUpdate().getId()) != null) {
-                                        updateDatafeedInClusterState(request, listener);
-                                        return;
-                                    }
-                                }
-                                listener.onFailure(e);
-                            }
+                            listener::onFailure
                     ));
         };
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -10,7 +10,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
@@ -724,7 +723,7 @@ public class JobManager {
         jobConfigProvider.expandGroupIds(calendarJobIds, ActionListener.wrap(
                 expandedIds -> {
                     threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(() -> {
-                        // Merge the expanded group members with the request Ids 
+                        // Merge the expanded group members with the request Ids
                         // which are job ids rather than group Ids.
                         expandedIds.addAll(calendarJobIds);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -213,35 +213,30 @@ public class JobManager {
      * @param jobsListener The jobs listener
      */
     public void expandJobs(String expression, boolean allowNoJobs, ActionListener<QueryPage<Job>> jobsListener) {
+        Map<String, Job> clusterStateJobs = expandJobsFromClusterState(expression, clusterService.state());
         ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(expression, allowNoJobs);
+        requiredMatches.filterMatchedIds(clusterStateJobs.keySet());
+
+        // If expression contains a group Id it has been expanded to its
+        // constituent job Ids but Ids matcher needs to know the group
+        // has been matched
+        requiredMatches.filterMatchedIds(MlMetadata.getMlMetadata(clusterService.state()).expandGroupIds(expression));
 
         jobConfigProvider.expandJobsWithoutMissingcheck(expression, false, ActionListener.wrap(
                 jobBuilders -> {
                     Set<String> jobAndGroupIds = new HashSet<>();
 
-                    // Merge cluster state and index jobs
-                    List<Job> jobs = new ArrayList<>();
-                    for (Job.Builder jb : jobBuilders) {
-                        Job job = jb.build();
-                        jobAndGroupIds.add(job.getId());
-                        // If expression contains a group Id it has been expanded to its
-                        // constituent job Ids but Ids matcher needs to know the group
-                        // has been matched
-                        jobAndGroupIds.addAll(job.getGroups());
-                        jobs.add(job);
-                    }
+                    List<Job> jobs = new ArrayList<>(clusterStateJobs.values());
 
                     // Duplicate configs existing in both the clusterstate and index documents are ok
                     // this may occur during migration of configs.
-                    // Prefer the index configs and filter duplicates from the clusterstate configs
-                    Map<String, Job> clusterStateJobs = expandJobsFromClusterState(expression, clusterService.state());
-                    for (String clusterStateJobId : clusterStateJobs.keySet()) {
-                        boolean isDuplicate = jobAndGroupIds.contains(clusterStateJobId);
-                        if (isDuplicate == false) {
-                            Job csJob = clusterStateJobs.get(clusterStateJobId);
-                            jobs.add(csJob);
-                            jobAndGroupIds.add(csJob.getId());
-                            jobAndGroupIds.addAll(csJob.getGroups());
+                    // Prefer the clusterstate configs and filter duplicates from the index
+                    for (Job.Builder jb : jobBuilders) {
+                        if (clusterStateJobs.containsKey(jb.getId()) == false) {
+                            Job job = jb.build();
+                            jobAndGroupIds.add(job.getId());
+                            jobAndGroupIds.addAll(job.getGroups());
+                            jobs.add(job);
                         }
                     }
 
@@ -276,21 +271,18 @@ public class JobManager {
      * @param jobsListener The jobs listener
      */
     public void expandJobIds(String expression, boolean allowNoJobs, ActionListener<SortedSet<String>> jobsListener) {
+        Set<String> clusterStateJobIds = MlMetadata.getMlMetadata(clusterService.state()).expandJobIds(expression);
         ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(expression, allowNoJobs);
-
+        requiredMatches.filterMatchedIds(clusterStateJobIds);
+        // If expression contains a group Id it has been expanded to its
+        // constituent job Ids but Ids matcher needs to know the group
+        // has been matched
+        requiredMatches.filterMatchedIds(MlMetadata.getMlMetadata(clusterService.state()).expandGroupIds(expression));
 
         jobConfigProvider.expandJobsIdsWithoutMissingCheck(expression, false, ActionListener.wrap(
                 jobIdsAndGroups -> {
                     requiredMatches.filterMatchedIds(jobIdsAndGroups.getJobs());
-
-                    Set<String> clusterStateJobIds = MlMetadata.getMlMetadata(clusterService.state()).expandJobIds(expression);
-                    requiredMatches.filterMatchedIds(clusterStateJobIds);
-                    // If expression contains a group Id it has been expanded to its
-                    // constituent job Ids but Ids matcher needs to know the group
-                    // has been matched
                     requiredMatches.filterMatchedIds(jobIdsAndGroups.getGroups());
-                    requiredMatches.filterMatchedIds(MlMetadata.getMlMetadata(clusterService.state()).expandGroupIds(expression));
-
                     if (requiredMatches.hasUnmatchedIds()) {
                         jobsListener.onFailure(ExceptionsHelper.missingJobException(requiredMatches.unmatchedIdsString()));
                     } else {
@@ -304,50 +296,37 @@ public class JobManager {
     }
 
     /**
-     * Mark the job as being deleted. First looks in the ml-config index
-     * for the job configuration then the clusterstate
+     * Mark the job as being deleted. First looks in the cluster state for the
+     * job configuration then the index
      *
      * @param jobId     To to mark
      * @param force     Allows an open job to be marked
      * @param listener  listener
      */
     public void markJobAsDeleting(String jobId, boolean force, ActionListener<Boolean> listener) {
-        jobConfigProvider.markJobAsDeleting(jobId, ActionListener.wrap(
-                listener::onResponse,
-                e -> {
-                    if (e.getClass() == ResourceNotFoundException.class) {
-                        // is the config in the cluster state
-                        if (ClusterStateJobUpdate.jobIsInClusterState(clusterService.state(), jobId)) {
-                            ClusterStateJobUpdate.markJobAsDeleting(jobId, force, clusterService, listener);
-                            return;
-                        }
-                    }
-                    listener.onFailure(e);
-                }
-        ));
-
+        if (ClusterStateJobUpdate.jobIsInClusterState(clusterService.state(), jobId)) {
+            ClusterStateJobUpdate.markJobAsDeleting(jobId, force, clusterService, listener);
+        } else {
+            jobConfigProvider.markJobAsDeleting(jobId, listener);
+        }
     }
 
     /**
-     * First try to delete the job document from ml-config, if it does not exist
-     * there try to the clusterstate.
+     * First try to delete the job from the cluster state, if it does not exist
+     * there try to  delete the index job.
      *
      * @param request   The delete job request
      * @param listener  Delete listener
      */
     public void deleteJob(DeleteJobAction.Request request, ActionListener<Boolean> listener) {
-        jobConfigProvider.deleteJob(request.getJobId(), false, ActionListener.wrap(
-                deleteResponse -> {
-                    if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
-                        if (ClusterStateJobUpdate.jobIsInClusterState(clusterService.state(), request.getJobId())) {
-                            ClusterStateJobUpdate.deleteJob(request, clusterService, listener);
-                        }
-                    } else {
-                        listener.onResponse(deleteResponse.getResult() == DocWriteResponse.Result.DELETED);
-                    }
-                },
-                listener::onFailure
-        ));
+        if (ClusterStateJobUpdate.jobIsInClusterState(clusterService.state(), request.getJobId())) {
+            ClusterStateJobUpdate.deleteJob(request, clusterService, listener);
+        } else {
+            jobConfigProvider.deleteJob(request.getJobId(), false, ActionListener.wrap(
+                    deleteResponse -> listener.onResponse(Boolean.TRUE),
+                    listener::onFailure
+            ));
+        }
     }
 
     /**
@@ -467,21 +446,18 @@ public class JobManager {
     }
 
     public void updateJob(UpdateJobAction.Request request, ActionListener<PutJobAction.Response> actionListener) {
-        updateJobIndex(request, ActionListener.wrap(
-                updatedJob -> {
-                    postJobUpdate(clusterService.state(), request);
-                    actionListener.onResponse(new PutJobAction.Response(updatedJob));
-                },
-                e -> {
-                    if (e.getClass() == ResourceNotFoundException.class) {
-                        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterService.state());
-                        if (ClusterStateJobUpdate.jobIsInMlMetadata(mlMetadata, request.getJobId())) {
-                            updateJobClusterState(request, actionListener);
-                            return;
-                        }
-                    }
-                    actionListener.onFailure(e);
-                }));
+        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterService.state());
+        if (ClusterStateJobUpdate.jobIsInMlMetadata(mlMetadata, request.getJobId())) {
+            updateJobClusterState(request, actionListener);
+        } else {
+            updateJobIndex(request, ActionListener.wrap(
+                    updatedJob -> {
+                        postJobUpdate(clusterService.state(), request);
+                        actionListener.onResponse(new PutJobAction.Response(updatedJob));
+                    },
+                    actionListener::onFailure
+            ));
+        }
     }
 
     private void postJobUpdate(ClusterState clusterState, UpdateJobAction.Request request) {
@@ -666,14 +642,14 @@ public class JobManager {
                 indexJobs -> {
                     threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(() -> {
 
-                        List<Job> allJobs = new ArrayList<>(indexJobs);
+                        List<Job> allJobs = new ArrayList<>(clusterStateJobs.values());
+
                         // Duplicate configs existing in both the clusterstate and index documents are ok
                         // this may occur during migration of configs.
                         // Filter the duplicates so we don't update twice for duplicated jobs
-                        for (String clusterStateJobId : clusterStateJobs.keySet()) {
-                            boolean isDuplicate = allJobs.stream().anyMatch(job -> job.getId().equals(clusterStateJobId));
-                            if (isDuplicate == false) {
-                                allJobs.add(clusterStateJobs.get(clusterStateJobId));
+                        for (Job indexJob : indexJobs) {
+                            if (clusterStateJobs.containsKey(indexJob.getId()) == false) {
+                                allJobs.add(indexJob);
                             }
                         }
 
@@ -748,7 +724,7 @@ public class JobManager {
         jobConfigProvider.expandGroupIds(calendarJobIds, ActionListener.wrap(
                 expandedIds -> {
                     threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(() -> {
-                        // Merge the expanded group members with the request Ids
+                        // Merge the expanded group members with the request Ids 
                         // which are job ids rather than group Ids.
                         expandedIds.addAll(calendarJobIds);
 
@@ -806,10 +782,39 @@ public class JobManager {
 
         // Step 1. update the job
         // -------
-        Consumer<Long> establishedMemoryHandler = modelMem -> {
+
+        Consumer<Long> updateJobHandler;
+
+        if (ClusterStateJobUpdate.jobIsInClusterState(clusterService.state(), request.getJobId())) {
+            updateJobHandler = response -> clusterService.submitStateUpdateTask("revert-snapshot-" + request.getJobId(),
+                    new AckedClusterStateUpdateTask<Boolean>(request, ActionListener.wrap(updateHandler, actionListener::onFailure)) {
+
+                        @Override
+                        protected Boolean newResponse(boolean acknowledged) {
+                            if (acknowledged) {
+                                auditor.info(request.getJobId(),
+                                        Messages.getMessage(Messages.JOB_AUDIT_REVERTED, modelSnapshot.getDescription()));
+                                return true;
+                            }
+                            actionListener.onFailure(new IllegalStateException("Could not revert modelSnapshot on job ["
+                                    + request.getJobId() + "], not acknowledged by master."));
+                            return false;
+                        }
+
+                        @Override
+                        public ClusterState execute(ClusterState currentState) {
+                            Job job = MlMetadata.getMlMetadata(currentState).getJobs().get(request.getJobId());
+                            Job.Builder builder = new Job.Builder(job);
+                            builder.setModelSnapshotId(modelSnapshot.getSnapshotId());
+                            builder.setEstablishedModelMemory(response);
+                            return ClusterStateJobUpdate.putJobInClusterState(builder.build(), true, currentState);
+                        }
+                    });
+        } else {
+            updateJobHandler = response -> {
                 JobUpdate update = new JobUpdate.Builder(request.getJobId())
                         .setModelSnapshotId(modelSnapshot.getSnapshotId())
-                        .setEstablishedModelMemory(modelMem)
+                        .setEstablishedModelMemory(response)
                         .build();
 
                 jobConfigProvider.updateJob(request.getJobId(), update, maxModelMemoryLimit, ActionListener.wrap(
@@ -818,53 +823,14 @@ public class JobManager {
                                     Messages.getMessage(Messages.JOB_AUDIT_REVERTED, modelSnapshot.getDescription()));
                             updateHandler.accept(Boolean.TRUE);
                         },
-                        e -> {
-                            if (e.getClass() == ResourceNotFoundException.class) {
-                                // Not found? maybe it's in the index
-                                if (ClusterStateJobUpdate.jobIsInClusterState(clusterService.state(), request.getJobId())) {
-                                    revertModelSnapshotClusterState(request, modelSnapshot, updateHandler, modelMem, actionListener);
-                                    return;
-                                }
-                            }
-                            actionListener.onFailure(e);
-                        }
+                        actionListener::onFailure
                 ));
             };
+        }
 
         // Step 0. Find the appropriate established model memory for the reverted job
         // -------
-        jobResultsProvider.getEstablishedMemoryUsage(request.getJobId(), modelSizeStats.getTimestamp(), modelSizeStats,
-                establishedMemoryHandler, actionListener::onFailure);
-    }
-
-    private void revertModelSnapshotClusterState(RevertModelSnapshotAction.Request request,
-                                                 ModelSnapshot modelSnapshot,
-                                                 CheckedConsumer<Boolean, Exception> updateHandler, Long modelMem,
-                                                 ActionListener<RevertModelSnapshotAction.Response> actionListener) {
-        clusterService.submitStateUpdateTask("revert-snapshot-" + request.getJobId(),
-                new AckedClusterStateUpdateTask<Boolean>(request, ActionListener.wrap(updateHandler, actionListener::onFailure)) {
-
-                    @Override
-                    protected Boolean newResponse(boolean acknowledged) {
-                        if (acknowledged) {
-                            auditor.info(request.getJobId(),
-                                    Messages.getMessage(Messages.JOB_AUDIT_REVERTED, modelSnapshot.getDescription()));
-                            return true;
-                        }
-                        // TODO is this an error? can actionListener.onFailure be called twice?
-                        actionListener.onFailure(new IllegalStateException("Could not revert modelSnapshot on job ["
-                                + request.getJobId() + "], not acknowledged by master."));
-                        return false;
-                    }
-
-                    @Override
-                    public ClusterState execute(ClusterState currentState) {
-                        Job job = MlMetadata.getMlMetadata(currentState).getJobs().get(request.getJobId());
-                        Job.Builder builder = new Job.Builder(job);
-                        builder.setModelSnapshotId(modelSnapshot.getSnapshotId());
-                        builder.setEstablishedModelMemory(modelMem);
-                        return ClusterStateJobUpdate.putJobInClusterState(builder.build(), true, currentState);
-                    }
-                });
+        jobResultsProvider.getEstablishedMemoryUsage(request.getJobId(), modelSizeStats.getTimestamp(), modelSizeStats, updateJobHandler,
+                actionListener::onFailure);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionActionTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -31,8 +32,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -43,17 +45,19 @@ public class TransportFinalizeJobExecutionActionTests extends ESTestCase {
 
     private ThreadPool threadPool;
     private Client client;
+    private ClusterService clusterService;
 
     @Before
     @SuppressWarnings("unchecked")
     private void setupMocks() {
         ExecutorService executorService = mock(ExecutorService.class);
         threadPool = mock(ThreadPool.class);
-        org.elasticsearch.mock.orig.Mockito.doAnswer(invocation -> {
+        doAnswer(invocation -> {
             ((Runnable) invocation.getArguments()[0]).run();
             return null;
         }).when(executorService).execute(any(Runnable.class));
         when(threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME)).thenReturn(executorService);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
 
         client = mock(Client.class);
         doAnswer( invocationOnMock -> {
@@ -61,14 +65,19 @@ public class TransportFinalizeJobExecutionActionTests extends ESTestCase {
             listener.onResponse(null);
             return null;
         }).when(client).execute(eq(UpdateAction.INSTANCE), any(), any());
-
         when(client.threadPool()).thenReturn(threadPool);
-        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+
+        clusterService = mock(ClusterService.class);
+
+        doAnswer( invocationOnMock -> {
+            ClusterStateUpdateTask updateTask = (ClusterStateUpdateTask)invocationOnMock.getArguments()[1];
+            updateTask.clusterStateProcessed(null, null, null);
+            return null;
+        }).when(clusterService).submitStateUpdateTask(anyString(), any());
     }
 
     public void testOperation_noJobsInClusterState() {
-        ClusterService clusterService = mock(ClusterService.class);
-        TransportFinalizeJobExecutionAction action = createAction(clusterService);
+        TransportFinalizeJobExecutionAction action = createAction();
 
         ClusterState clusterState = ClusterState.builder(new ClusterName("finalize-job-action-tests")).build();
 
@@ -85,8 +94,7 @@ public class TransportFinalizeJobExecutionActionTests extends ESTestCase {
     }
 
     public void testOperation_jobInClusterState() {
-        ClusterService clusterService = mock(ClusterService.class);
-        TransportFinalizeJobExecutionAction action = createAction(clusterService);
+        TransportFinalizeJobExecutionAction action = createAction();
 
         MlMetadata.Builder mlBuilder = new MlMetadata.Builder();
         mlBuilder.putJob(BaseMlIntegTestCase.createFareQuoteJob("cs-job").build(new Date()), false);
@@ -103,11 +111,37 @@ public class TransportFinalizeJobExecutionActionTests extends ESTestCase {
                 e -> fail(e.getMessage())
         ));
 
+        assertTrue(ack.get().isAcknowledged());
         verify(client, never()).execute(eq(UpdateAction.INSTANCE), any(), any());
         verify(clusterService, times(1)).submitStateUpdateTask(any(), any());
     }
 
-    private TransportFinalizeJobExecutionAction createAction(ClusterService clusterService) {
+    public void testOperation_jobsInBothClusterAndIndex() {
+        TransportFinalizeJobExecutionAction action = createAction();
+
+        MlMetadata.Builder mlBuilder = new MlMetadata.Builder();
+        mlBuilder.putJob(BaseMlIntegTestCase.createFareQuoteJob("cs-job").build(new Date()), false);
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("finalize-job-action-tests"))
+                .metaData(MetaData.builder()
+                        .putCustom(MlMetadata.TYPE, mlBuilder.build()))
+                .build();
+
+        FinalizeJobExecutionAction.Request request =
+                new FinalizeJobExecutionAction.Request(new String[]{"index-job", "cs-job"});
+        AtomicReference<AcknowledgedResponse> ack = new AtomicReference<>();
+        action.masterOperation(request, clusterState, ActionListener.wrap(
+                ack::set,
+                e -> assertNull(e.getMessage())
+        ));
+
+        assertTrue(ack.get().isAcknowledged());
+        // The job in the clusterstate should not be updated in the index
+        verify(client, times(1)).execute(eq(UpdateAction.INSTANCE), any(), any());
+        verify(clusterService, times(1)).submitStateUpdateTask(any(), any());
+    }
+
+    private TransportFinalizeJobExecutionAction createAction() {
         return new TransportFinalizeJobExecutionAction(Settings.EMPTY, mock(TransportService.class), clusterService,
                 threadPool, mock(ActionFilters.class), mock(IndexNameExpressionResolver.class), client);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReaderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigReaderTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.SortedSet;
@@ -23,7 +22,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -134,39 +132,9 @@ public class DatafeedConfigReaderTests extends ESTestCase {
                 e -> fail(e.getMessage())
         ));
 
-        assertThat(configHolder.get(), hasSize(3));
         assertEquals("cs-df", configHolder.get().get(0).getId());
         assertEquals("index-df", configHolder.get().get(1).getId());
         assertEquals("ll-df", configHolder.get().get(2).getId());
-    }
-
-    public void testExpandDatafeedConfigs_DuplicateConfigReturnsIndexDocument() {
-        MlMetadata.Builder mlMetadata = new MlMetadata.Builder();
-        mlMetadata.putJob(buildJobBuilder("datafeed-in-clusterstate").build(), false);
-        mlMetadata.putDatafeed(createDatafeedConfig("df1", "datafeed-in-clusterstate"), Collections.emptyMap());
-
-        ClusterState clusterState = ClusterState.builder(new ClusterName("datafeedconfigreadertests"))
-                .metaData(MetaData.builder()
-                        .putCustom(MlMetadata.TYPE, mlMetadata.build()))
-                .build();
-
-        DatafeedConfig.Builder indexConfig1 = createDatafeedConfigBuilder("df1", "datafeed-in-index");
-        DatafeedConfig.Builder indexConfig2 = createDatafeedConfigBuilder("df2", "job-c");
-        DatafeedConfigProvider provider = mock(DatafeedConfigProvider.class);
-        mockProviderWithExpectedConfig(provider, "_all", Arrays.asList(indexConfig1, indexConfig2));
-
-        DatafeedConfigReader reader = new DatafeedConfigReader(provider);
-
-        AtomicReference<List<DatafeedConfig>> configHolder = new AtomicReference<>();
-        reader.expandDatafeedConfigs("_all", true, clusterState, ActionListener.wrap(
-                configHolder::set,
-                e -> fail(e.getMessage())
-        ));
-
-        assertThat(configHolder.get(), hasSize(2));
-        assertEquals("df1", configHolder.get().get(0).getId());
-        assertEquals("datafeed-in-index", configHolder.get().get(0).getJobId());
-        assertEquals("df2", configHolder.get().get(1).getId());
     }
 
     private ClusterState buildClusterStateWithJob(DatafeedConfig datafeed) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
@@ -230,7 +230,9 @@ public class JobManagerTests extends ESTestCase {
     }
 
     public void testExpandJob_GivenDuplicateConfig() throws IOException {
-        Job csJob = buildJobBuilder("dupe").build();
+        Job csJob = buildJobBuilder("dupe")
+                .setCustomSettings(Collections.singletonMap("job-saved-in-clusterstate", Boolean.TRUE))
+                .build();
 
         MlMetadata.Builder mlMetadata = new MlMetadata.Builder();
         mlMetadata.putJob(csJob, false);
@@ -243,6 +245,7 @@ public class JobManagerTests extends ESTestCase {
 
         List<BytesReference> docsAsBytes = new ArrayList<>();
         Job.Builder indexJob = buildJobBuilder("dupe");
+        indexJob.setCustomSettings(Collections.singletonMap("job-saved-in-index", Boolean.TRUE));
         docsAsBytes.add(toBytesReference(indexJob.build()));
 
         MockClientBuilder mockClientBuilder = new MockClientBuilder("jobmanager-test");
@@ -256,9 +259,10 @@ public class JobManagerTests extends ESTestCase {
                 exceptionHolder::set
         ));
 
-        assertNull(jobsHolder.get());
-        assertThat(exceptionHolder.get(), instanceOf(IllegalStateException.class));
-        assertEquals("Job [dupe] configuration exists in both clusterstate and index", exceptionHolder.get().getMessage());
+        assertThat(jobsHolder.get().results(), hasSize(1));
+        Job foundJob = jobsHolder.get().results().get(0);
+        assertTrue((Boolean)foundJob.getCustomSettings().get("job-saved-in-clusterstate"));
+        assertNull(exceptionHolder.get());
     }
 
     public void testExpandJobs_SplitBetweenClusterStateAndIndex() throws IOException {
@@ -371,9 +375,8 @@ public class JobManagerTests extends ESTestCase {
                 exceptionHolder::set
         ));
 
-        assertNull(jobIdsHolder.get());
-        assertThat(exceptionHolder.get(), instanceOf(IllegalStateException.class));
-        assertEquals("Job [dupe] configuration exists in both clusterstate and index", exceptionHolder.get().getMessage());
+        assertThat(jobIdsHolder.get(), contains("dupe"));
+        assertNull(exceptionHolder.get());
     }
 
     public void testExpandJobIdsFromClusterStateAndIndex_GivenAll() {
@@ -870,6 +873,12 @@ public class JobManagerTests extends ESTestCase {
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
         JobConfigProvider jobConfigProvider = mock(JobConfigProvider.class);
+        doAnswer(invocationOnMock -> {
+            ActionListener listener = (ActionListener) invocationOnMock.getArguments()[3];
+            listener.onFailure(new ResourceNotFoundException("missing job"));
+            return null;
+        }).when(jobConfigProvider).updateJob(anyString(), any(), any(), any(ActionListener.class));
+
         JobManager jobManager = new JobManager(environment, environment.settings(), jobResultsProvider, clusterService,
                 auditor, threadPool, mock(Client.class), updateJobProcessNotifier, jobConfigProvider);
 


### PR DESCRIPTION
A partial revert of #35940 

Duplicate configs in both the clusterstate and index are still possible but now clusterstate config is preferred. 

After discussing the changes in #35940 it was decided that during a move operation the original should always be preferred to the new until the operation has completed. This revert also makes the code simpler to read. 

Alas the wasted time

@benwtrent you reviewed #35940 would you take a look at this please
 