### PR TITLE
[DOCS] Replace deprecated ldap setting

### DIFF
--- a/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
@@ -52,7 +52,7 @@ xpack:
             bind_dn: "cn=ldapuser, ou=users, o=services, dc=example, dc=com"
             user_search:
               base_dn: "dc=example,dc=com"
-              attribute: cn
+              filter: cn
             group_search:
               base_dn: "dc=example,dc=com"
             files:

--- a/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
@@ -52,7 +52,7 @@ xpack:
             bind_dn: "cn=ldapuser, ou=users, o=services, dc=example, dc=com"
             user_search:
               base_dn: "dc=example,dc=com"
-              filter: cn
+              filter: "(cn={0})"
             group_search:
               base_dn: "dc=example,dc=com"
             files:

--- a/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
@@ -2,12 +2,12 @@
 [[configuring-ldap-realm]]
 === Configuring an LDAP realm
 
-You can configure {security} to communicate with a Lightweight Directory Access
-Protocol (LDAP) server to authenticate users. To integrate with LDAP, you
-configure an `ldap` realm and map LDAP groups to user roles.
+You can configure {es} to authenticate users by communicating with a Lightweight
+Directory Access Protocol (LDAP) server. To integrate with LDAP, you configure
+an `ldap` realm and map LDAP groups to user roles.
 
 For more information about LDAP realms, see 
-{xpack-ref}/ldap-realm.html[LDAP User Authentication].
+{stack-ov}/ldap-realm.html[LDAP User Authentication].
 
 . Determine which mode you want to use. The `ldap` realm supports two modes of 
 operation, a user search mode and a mode with specific templates for user DNs. 
@@ -115,12 +115,13 @@ All LDAP operations run as the authenticating user.
 
 --
 
-. (Optional) Configure how {security} should interact with multiple LDAP servers. 
+. (Optional) Configure how the {security-features} interact with multiple LDAP
+servers. 
 + 
 --
-The `load_balance.type` setting can be used at the realm level. {security} 
-supports both failover and load balancing modes of operation. See 
-<<ref-ldap-settings>>.
+The `load_balance.type` setting can be used at the realm level. The {es}
+{security-features} support both failover and load balancing modes of operation.
+See <<ref-ldap-settings>>.
 --
 
 . (Optional) To protect passwords, 
@@ -186,9 +187,9 @@ user:
 <3> The LDAP distinguished name (DN) of the `users` group.
 
 For more information, see 
-{xpack-ref}/ldap-realm.html#mapping-roles-ldap[Mapping LDAP Groups to Roles] 
+{stack-ov}/ldap-realm.html#mapping-roles-ldap[Mapping LDAP Groups to Roles] 
 and 
-{xpack-ref}/mapping-roles.html[Mapping Users and Groups to Roles].
+{stack-ov}/mapping-roles.html[Mapping Users and Groups to Roles].
 
 NOTE: The LDAP realm supports
 {stack-ov}/realm-chains.html#authorization_realms[authorization realms] as an
@@ -202,7 +203,7 @@ fields in the user's metadata.
 --
 By default, `ldap_dn` and `ldap_groups` are populated in the user's metadata. 
 For more information, see 
-{xpack-ref}/ldap-realm.html#ldap-user-metadata[User Metadata in LDAP Realms]. 
+{stack-ov}/ldap-realm.html#ldap-user-metadata[User Metadata in LDAP Realms]. 
 
 The example below includes the user's common name (`cn`) as an additional
 field in their metadata.


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/30735

Per https://www.elastic.co/guide/en/elasticsearch/reference/master/security-settings.html user_search.attribute was deprecated in 5.6 and replaced by user_search.filter.