### PR TITLE
Add note about ILM and Snapshots

### DIFF
--- a/docs/reference/ilm/ilm-and-snapshots.asciidoc
+++ b/docs/reference/ilm/ilm-and-snapshots.asciidoc
@@ -8,19 +8,28 @@ beta[]
 When restoring a snapshot that contains indices managed by Index Lifecycle
 Management, the lifecycle will automatically continue to execute after the
 snapshot is restored. Notably, the `min_age` is relative to the original
-creation or rollover of the index, rather than when the index was restored.
+creation or rollover of the index, rather than when the index was restored. For
+example, a monthly index that is restored partway through its lifecycle after an
+accidental deletion will be continue through its lifecycle as expected: The
+index will be shrunk, reallocated to different nodes, or deleted on the same
+schedule whether or not it has been restored from a snapshot.
 
-In cases where the index uses a policy with a Delete phase, this may cause the
-restored index to be deleted by Index Lifecycle Management immediately after it
-is restored. To prevent this, before restoring the snapshot,
-<<start-stop-ilm,lifecycle policy execution can be paused>> to allow the policy
-to be removed.
+However, there may be cases where you need to restore an index from a snapshot,
+but do not want it to automatically continue through its lifecycle, particularly
+if the index would rapidly progress through lifecycle phases due to its age. For
+example, you may wish to add or update documents in an index before it is marked
+read only or shrunk, or prevent an index from automatically being deleted.
+
+To stop lifecycle policy execution on an index restored from a snapshot, before
+restoring the snapshot, <<start-stop-ilm,lifecycle policy execution can be
+paused>> to allow the policy to be removed.
 
 For example, the following workflow can be used in the above situation to
-prevent the deletion of the index after it is restored:
+prevent the execution of the lifecycle policy for an index:
 
-1. Pause execution of lifecycle policies using the <<ilm-stop,Stop ILM API>>
+1. Pause execution of all lifecycle policies using the <<ilm-stop,Stop ILM API>>
 2. Restore the snapshot.
-3. Remove the lifecycle policy from the index using the
+3. Perform whatever operations you wish before resuming lifecycle execution, or
+    remove the lifecycle policy from the index using the
     <<ilm-remove-policy,Remove Policy from Index API>>
 4. Resume execution of lifecycle policies using the <<ilm-start,Start ILM API>>

--- a/docs/reference/ilm/ilm-and-snapshots.asciidoc
+++ b/docs/reference/ilm/ilm-and-snapshots.asciidoc
@@ -1,0 +1,26 @@
+[role="xpack"]
+[testenv="basic"]
+[[index-lifecycle-and-snapshots]]
+== Restoring Snapshots of Managed Indices
+
+beta[]
+
+When restoring a snapshot that contains indices managed by Index Lifecycle
+Management, the lifecycle will automatically continue to execute after the
+snapshot is restored. Notably, the `min_age` is relative to the original
+creation or rollover of the index, rather than when the index was restored.
+
+In cases where the index uses a policy with a Delete phase, this may cause the
+restored index to be deleted by Index Lifecycle Management immediately after it
+is restored. To prevent this, before restoring the snapshot,
+<<start-stop-ilm,lifecycle policy execution can be paused>> to allow the policy
+to be removed.
+
+For example, the following workflow can be used in the above situation to
+prevent the deletion of the index after it is restored:
+
+1. Pause execution of lifecycle policies using the <<ilm-stop,Stop ILM API>>
+2. Restore the snapshot.
+3. Remove the lifecycle policy from the index using the
+    <<ilm-remove-policy,Remove Policy from Index API>>
+4. Resume execution of lifecycle policies using the <<ilm-start,Start ILM API>>

--- a/docs/reference/ilm/index.asciidoc
+++ b/docs/reference/ilm/index.asciidoc
@@ -64,4 +64,6 @@ include::update-lifecycle-policy.asciidoc[]
 
 include::error-handling.asciidoc[]
 
+include::ilm-and-snapshots.asciidoc[]
+
 include::start-stop-ilm.asciidoc[]


### PR DESCRIPTION
This commit documents a workaround for situations where an index
may be deleted by ILM immediately after it is restored from a snapshot.

Documents a workaround for https://github.com/elastic/elasticsearch/issues/35561