### PR TITLE
Support content type `application/x-ndjson` in DeprecationRestHandler

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/DeprecationRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/DeprecationRestHandler.java
@@ -62,6 +62,11 @@ public class DeprecationRestHandler implements RestHandler {
         handler.handleRequest(request, channel, client);
     }
 
+    @Override
+    public boolean supportsContentStream() {
+        return handler.supportsContentStream();
+    }
+
     /**
      * This does a very basic pass at validating that a header's value contains only expected characters according to RFC-5987, and those
      * that it references.

--- a/server/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
@@ -28,6 +28,7 @@ import org.mockito.InOrder;
 
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests {@link DeprecationRestHandler}.
@@ -112,6 +113,13 @@ public class DeprecationRestHandlerTests extends ESTestCase {
         assertFalse(DeprecationRestHandler.validHeaderValue(blank));
 
         expectThrows(IllegalArgumentException.class, () -> DeprecationRestHandler.requireValidHeader(blank));
+    }
+
+    public void testSupportsContentStream() {
+        DeprecationRestHandler deprecationRestHandler = new DeprecationRestHandler(handler, deprecationMessage, deprecationLogger);
+        when(handler.supportsContentStream()).thenReturn(true).thenReturn(false);
+        assertTrue(deprecationRestHandler.supportsContentStream());
+        assertFalse(deprecationRestHandler.supportsContentStream());
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.test.ESTestCase;
 
+import org.junit.Before;
 import org.mockito.InOrder;
 
 import static org.mockito.Mockito.inOrder;
@@ -35,12 +36,18 @@ import static org.mockito.Mockito.when;
  */
 public class DeprecationRestHandlerTests extends ESTestCase {
 
-    private final RestHandler handler = mock(RestHandler.class);
+    private RestHandler handler;
     /**
      * Note: Headers should only use US ASCII (and this inevitably becomes one!).
      */
     private final String deprecationMessage = randomAlphaOfLengthBetween(1, 30);
-    private final DeprecationLogger deprecationLogger = mock(DeprecationLogger.class);
+    private DeprecationLogger deprecationLogger;
+
+    @Before
+    public void setup() {
+        handler = mock(RestHandler.class);
+        deprecationLogger = mock(DeprecationLogger.class);
+    }
 
     public void testNullHandler() {
         expectThrows(NullPointerException.class, () -> new DeprecationRestHandler(null, deprecationMessage, deprecationLogger));
@@ -115,11 +122,14 @@ public class DeprecationRestHandlerTests extends ESTestCase {
         expectThrows(IllegalArgumentException.class, () -> DeprecationRestHandler.requireValidHeader(blank));
     }
 
-    public void testSupportsContentStream() {
-        DeprecationRestHandler deprecationRestHandler = new DeprecationRestHandler(handler, deprecationMessage, deprecationLogger);
-        when(handler.supportsContentStream()).thenReturn(true).thenReturn(false);
-        assertTrue(deprecationRestHandler.supportsContentStream());
-        assertFalse(deprecationRestHandler.supportsContentStream());
+    public void testSupportsContentStreamTrue() {
+        when(handler.supportsContentStream()).thenReturn(true);
+        assertTrue(new DeprecationRestHandler(handler, deprecationMessage, deprecationLogger).supportsContentStream());
+    }
+
+    public void testSupportsContentStreamFalse() {
+        when(handler.supportsContentStream()).thenReturn(false);
+        assertFalse(new DeprecationRestHandler(handler, deprecationMessage, deprecationLogger).supportsContentStream());
     }
 
     /**


### PR DESCRIPTION
org.elasticsearch.rest.RestController#hasContentType checks to see if the
RestHandler supports the `application/x-ndjson` Content-Type. DeprecationRestHandler
is a wrapper around the real RestHandler, and prior to this change
would always return `false` due to the interface's default supportsContentStream().
This prevents API's that use multi-line JSON from properly being deprecated
resulting in an HTTP 406 error.

This change ensures that the DeprecationRestHandler honors the
supportsContentStream() of the wrapped RestHandler.

Part of #35958
