### PR TITLE
Add DEBUG/TRACE logs for LDAP bind

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapUtils.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapUtils.java
@@ -133,11 +133,13 @@ public final class LdapUtils {
             @SuppressForbidden(reason = "Bind allowed if forking of the LDAP Connection Reader Thread.")
             protected void doRun() throws Exception {
                 privilegedConnect(() -> ldapPool.bindAndRevertAuthentication(bind.duplicate()));
+                LOGGER.trace("LDAP bind [{}] succeeded for [{}]", bind, ldapPool);
                 runnable.run();
             }
 
             @Override
             public void onFailure(Exception e) {
+                LOGGER.debug("LDAP bind [{}] failed for [{}] - [{}]", bind, ldapPool, e.toString());
                 runnable.onFailure(e);
             }
 
@@ -178,11 +180,13 @@ public final class LdapUtils {
             @SuppressForbidden(reason = "Bind allowed if forking of the LDAP Connection Reader Thread.")
             protected void doRun() throws Exception {
                 privilegedConnect(() -> ldap.bind(bind.duplicate()));
+                LOGGER.trace("LDAP bind [{}] succeeded for [{}]", bind, ldap);
                 runnable.run();
             }
 
             @Override
             public void onFailure(Exception e) {
+                LOGGER.debug("LDAP bind [{}] failed for [{}] - [{}]", bind, ldap, e.toString());
                 runnable.onFailure(e);
             }
 


### PR DESCRIPTION
Introduces a debug log message when a bind fails and a trace message
when a bind succeeds.

It may seem strange to only debug a bind failure, but failures of this
nature are relatively common in some realm configurations (e.g. LDAP
realm with multiple user templates, or additional realms configured
after an LDAP realm).
