### PR TITLE
Build: Fix jdbc jar pom to not include deps

### DIFF
--- a/x-pack/plugin/sql/jdbc/build.gradle
+++ b/x-pack/plugin/sql/jdbc/build.gradle
@@ -67,6 +67,10 @@ publishing {
     publications {
         nebula {
             artifactId = archivesBaseName
+            pom.withXml {
+                // Nebula is mistakenly including all dependencies that are already shadowed into the shadow jar
+                asNode().remove(asNode().dependencies)
+            }
         }
     }
 }


### PR DESCRIPTION
This commit adds back the exclusion of dependencies from the pom file
for the jdbc jar, which was accidentally lost in #32014