### PR TITLE
Don't disable tasks based on the plugin

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
@@ -27,6 +27,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.plugins.BasePlugin;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskContainer;
 
 import java.lang.reflect.InvocationTargetException;
@@ -45,21 +46,18 @@ public class TestFixturesPlugin implements Plugin<Project> {
             "testFixtures", TestFixtureExtension.class, project
         );
 
-        // Don't look for docker-compose on the PATH yet that would pick up on Windows as well
-        if (project.file("/usr/local/bin/docker-compose").exists() == false &&
-            project.file("/usr/bin/docker-compose").exists() == false
-        ) {
-            project.getLogger().warn(
-                "Tests require docker-compose at /usr/local/bin/docker-compose or /usr/bin/docker-compose " +
-                    "but none could not be found so these will be skipped"
-            );
-            tasks.withType(getTaskClass("com.carrotsearch.gradle.junit4.RandomizedTestingTask"), task ->
-                task.setEnabled(false)
-            );
-            return;
-        }
-
         if (project.file(DOCKER_COMPOSE_YML).exists()) {
+            // convenience boilerplate with build plugin
+            // Can't reference tasks that are implemented in Groovy, use reflection  instead
+            disableTaskByType(tasks, getTaskClass("org.elasticsearch.gradle.precommit.LicenseHeadersTask"));
+            disableTaskByType(tasks, getTaskClass("com.carrotsearch.gradle.junit4.RandomizedTestingTask"));
+            disableTaskByType(tasks, ThirdPartyAuditTask.class);
+            disableTaskByType(tasks, JarHellTask.class);
+
+            if(dockerComposeSupported(project) == false) {
+                return;
+            }
+
             project.apply(spec -> spec.plugin(BasePlugin.class));
             project.apply(spec -> spec.plugin(DockerComposePlugin.class));
             ComposeExtension composeExtension = project.getExtensions().getByType(ComposeExtension.class);
@@ -71,14 +69,17 @@ public class TestFixturesPlugin implements Plugin<Project> {
             );
 
             project.getTasks().getByName("clean").dependsOn("composeDown");
-
-            // convenience boilerplate with build plugin
-            // Can't reference tasks that are implemented in Groovy, use reflection  instead
-            disableTaskByType(tasks, getTaskClass("org.elasticsearch.gradle.precommit.LicenseHeadersTask"));
-            disableTaskByType(tasks, getTaskClass("com.carrotsearch.gradle.junit4.RandomizedTestingTask"));
-            disableTaskByType(tasks, ThirdPartyAuditTask.class);
-            disableTaskByType(tasks, JarHellTask.class);
         } else {
+            if (dockerComposeSupported(project) == false) {
+                project.getLogger().warn(
+                    "Tests require docker-compose at /usr/local/bin/docker-compose or /usr/bin/docker-compose " +
+                        "but none could not be found so these will be skipped"
+                );
+                tasks.withType(getTaskClass("com.carrotsearch.gradle.junit4.RandomizedTestingTask"), task ->
+                    task.setEnabled(false)
+                );
+                return;
+            }
             tasks.withType(getTaskClass("com.carrotsearch.gradle.junit4.RandomizedTestingTask"), task ->
                 extension.fixtures.all(fixtureProject -> {
                     task.dependsOn(fixtureProject.getTasks().getByName("composeUp"));
@@ -99,6 +100,15 @@ public class TestFixturesPlugin implements Plugin<Project> {
         }
     }
 
+    @Input
+    public boolean dockerComposeSupported(Project project) {
+        // Don't look for docker-compose on the PATH yet that would pick up on Windows as well
+        return
+            project.file("/usr/local/bin/docker-compose").exists() == false &&
+            project.file("/usr/bin/docker-compose").exists() == false &&
+            Boolean.parseBoolean(System.getProperty("tests.fixture.enabled", "true")) == false;
+    }
+
     private void setSystemProperty(Task task, String name, Object value) {
         try {
             Method systemProperty = task.getClass().getMethod("systemProperty", String.class, Object.class);
@@ -111,10 +121,7 @@ public class TestFixturesPlugin implements Plugin<Project> {
     }
 
     private void disableTaskByType(TaskContainer tasks, Class<? extends Task> type) {
-        tasks.withType(type, task -> {
-            task.getLogger().info("test fixtures: Disabling tasks of type {}", type);
-            task.setEnabled(false);
-        });
+        tasks.withType(type, task -> task.setEnabled(false));
     }
 
     @SuppressWarnings("unchecked")

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
@@ -73,13 +73,11 @@ public class TestFixturesPlugin implements Plugin<Project> {
             project.getTasks().getByName("clean").dependsOn("composeDown");
 
             // convenience boilerplate with build plugin
-            project.getPluginManager().withPlugin("elasticsearch.build", (appliedPlugin) -> {
-                // Can't reference tasks that are implemented in Groovy, use reflection  instead
-                disableTaskByType(tasks, getTaskClass("org.elasticsearch.gradle.precommit.LicenseHeadersTask"));
-                disableTaskByType(tasks, getTaskClass("com.carrotsearch.gradle.junit4.RandomizedTestingTask"));
-                disableTaskByType(tasks, ThirdPartyAuditTask.class);
-                disableTaskByType(tasks, JarHellTask.class);
-            });
+            // Can't reference tasks that are implemented in Groovy, use reflection  instead
+            disableTaskByType(tasks, getTaskClass("org.elasticsearch.gradle.precommit.LicenseHeadersTask"));
+            disableTaskByType(tasks, getTaskClass("com.carrotsearch.gradle.junit4.RandomizedTestingTask"));
+            disableTaskByType(tasks, ThirdPartyAuditTask.class);
+            disableTaskByType(tasks, JarHellTask.class);
         } else {
             tasks.withType(getTaskClass("com.carrotsearch.gradle.junit4.RandomizedTestingTask"), task ->
                 extension.fixtures.all(fixtureProject -> {
@@ -113,7 +111,10 @@ public class TestFixturesPlugin implements Plugin<Project> {
     }
 
     private void disableTaskByType(TaskContainer tasks, Class<? extends Task> type) {
-        tasks.withType(type, task -> task.setEnabled(false));
+        tasks.withType(type, task -> {
+            task.getLogger().info("test fixtures: Disabling tasks of type {}", type);
+            task.setEnabled(false);
+        });
     }
 
     @SuppressWarnings("unchecked")

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
@@ -54,7 +54,7 @@ public class TestFixturesPlugin implements Plugin<Project> {
             disableTaskByType(tasks, ThirdPartyAuditTask.class);
             disableTaskByType(tasks, JarHellTask.class);
 
-            if(dockerComposeSupported(project) == false) {
+            if (dockerComposeSupported(project) == false) {
                 return;
             }
 
@@ -72,8 +72,8 @@ public class TestFixturesPlugin implements Plugin<Project> {
         } else {
             if (dockerComposeSupported(project) == false) {
                 project.getLogger().warn(
-                    "Tests require docker-compose at /usr/local/bin/docker-compose or /usr/bin/docker-compose " +
-                        "but none could not be found so these will be skipped"
+                    "Tests for {} require docker-compose at /usr/local/bin/docker-compose or /usr/bin/docker-compose " +
+                        "but none could not be found so these will be skipped", project.getPath()
                 );
                 tasks.withType(getTaskClass("com.carrotsearch.gradle.junit4.RandomizedTestingTask"), task ->
                     task.setEnabled(false)

--- a/x-pack/test/smb-fixture/build.gradle
+++ b/x-pack/test/smb-fixture/build.gradle
@@ -1,5 +1,2 @@
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.test.fixtures'
-
-// TODO: elasticsearch.test.fixtures should disable this but it sometimes doesn't
-jarHell.enabled  = false


### PR DESCRIPTION
Some times the test fixtures plugin did not correctly disable tasks
from the build plugin as it should.
The plugin manager and tasks both use domain name collections so
the previus conde should have worked.
I did not have trime to track it down, but suspect there's some race
condition in Gradle causing this. The plugin manager is still incubating.
Since the tasks are on the cp even if the plugin is not applyed, we
don't really  need to involve the plugin at all.

Closes #36041

