### PR TITLE
GCS Repository encryption with managed keys

### DIFF
--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
@@ -58,6 +58,8 @@ class GoogleCloudStorageRepository extends BlobStoreRepository {
     static final Setting<ByteSizeValue> CHUNK_SIZE =
             byteSizeSetting("chunk_size", MAX_CHUNK_SIZE, MIN_CHUNK_SIZE, MAX_CHUNK_SIZE, Property.NodeScope, Property.Dynamic);
     static final Setting<String> CLIENT_NAME = new Setting<>("client", "default", Function.identity());
+    // KMS_KEY_NAME in Google's lingo
+    static final Setting<String> ENCRYPTION_KEY_NAME = simpleString("encryption_key_name", Property.NodeScope, Property.Dynamic);
 
     private final Settings settings;
     private final GoogleCloudStorageService storageService;
@@ -66,6 +68,7 @@ class GoogleCloudStorageRepository extends BlobStoreRepository {
     private final ByteSizeValue chunkSize;
     private final String bucket;
     private final String clientName;
+    private final String encryptionKeyName;
 
     GoogleCloudStorageRepository(RepositoryMetaData metadata, Environment environment,
                                         NamedXContentRegistry namedXContentRegistry,
@@ -89,12 +92,14 @@ class GoogleCloudStorageRepository extends BlobStoreRepository {
         this.chunkSize = getSetting(CHUNK_SIZE, metadata);
         this.bucket = getSetting(BUCKET, metadata);
         this.clientName = CLIENT_NAME.get(metadata.settings());
-        logger.debug("using bucket [{}], base_path [{}], chunk_size [{}], compress [{}]", bucket, basePath, chunkSize, compress);
+        this.encryptionKeyName = ENCRYPTION_KEY_NAME.get(metadata.settings());
+        logger.debug("using bucket [{}], base_path [{}], chunk_size [{}], compress [{}], encryption_key_name [{}]", bucket, basePath,
+                chunkSize, compress, encryptionKeyName);
     }
 
     @Override
     protected GoogleCloudStorageBlobStore createBlobStore() {
-        return new GoogleCloudStorageBlobStore(bucket, clientName, storageService);
+        return new GoogleCloudStorageBlobStore(bucket, clientName, encryptionKeyName, storageService);
     }
 
     @Override

--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreContainerTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreContainerTests.java
@@ -35,12 +35,13 @@ public class GoogleCloudStorageBlobStoreContainerTests extends ESBlobStoreContai
     protected BlobStore newBlobStore() {
         final String bucketName = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
         final String clientName = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
+        final String encryptionKeyName = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
         final GoogleCloudStorageService storageService = mock(GoogleCloudStorageService.class);
         try {
             when(storageService.client(any(String.class))).thenReturn(new MockStorage(bucketName, new ConcurrentHashMap<>()));
         } catch (final Exception e) {
             throw new RuntimeException(e);
         }
-        return new GoogleCloudStorageBlobStore(bucketName, clientName, storageService);
+        return new GoogleCloudStorageBlobStore(bucketName, clientName, encryptionKeyName, storageService);
     }
 }

--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreTests.java
@@ -35,12 +35,13 @@ public class GoogleCloudStorageBlobStoreTests extends ESBlobStoreTestCase {
     protected BlobStore newBlobStore() {
         final String bucketName = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
         final String clientName = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
+        final String encryptionKeyName = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
         final GoogleCloudStorageService storageService = mock(GoogleCloudStorageService.class);
         try {
             when(storageService.client(any(String.class))).thenReturn(new MockStorage(bucketName, new ConcurrentHashMap<>()));
         } catch (final Exception e) {
             throw new RuntimeException(e);
         }
-        return new GoogleCloudStorageBlobStore(bucketName, clientName, storageService);
+        return new GoogleCloudStorageBlobStore(bucketName, clientName, encryptionKeyName, storageService);
     }
 }


### PR DESCRIPTION
Cloud providers (ms, ~google~, aws) have two ways to offer client side encryption (besides the encryption at rest and TLS in transit):
1. Using Customer Managed Keys
2. Using Customer Supplied Keys

The distinction between the two is whether the "key encryption key" is generated and stored locally (2) or managed by the cloud provider (1). They all use *envelope encryption*, encrypting data with randomly locally generated symmetric keys, and then encrypting this key with another key that can be managed by the cloud's provider key vault service (1) or be generated locally (2). The encrypted symmetric key is usually stored alongside the object, in it's metadata, together with the identifier name of the key required to decrypt it. This mechanism has the benefit that during a key rotation the decrypt and re-encrypt operations can be carried out over the data encryption keys only (not re-encrypting the data)

Implementation wise I think we should address both ways, although this PR only deals with (1).
Variant (1) allows for hustle free key rotation - you do it from the cloud provider's management console and you don't even need to change the setting value on ES (you can define automatic policies for this).
Variant (2) does all the encryption locally but rotation implies changing the setting on the ES cluster.

Encryption is done at file level (blob) and for all the files.

I have opened this to garner early feedback and concerns. I intend to push forward with implementing both variants + documentation.

Related https://github.com/elastic/elasticsearch/issues/34454 https://github.com/elastic/elasticsearch/issues/11128
Sibling of https://github.com/elastic/elasticsearch/pull/30513

CC @elastic/es-security 