### PR TITLE
Deprecate types in document delete requests.

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -97,24 +97,24 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             // Testing deletion
             String docId = "id";
             highLevelClient().index(
-                    new IndexRequest("index", "type", docId).source(Collections.singletonMap("foo", "bar")), RequestOptions.DEFAULT);
-            DeleteRequest deleteRequest = new DeleteRequest("index", "type", docId);
+                    new IndexRequest("index", "_doc", docId).source(Collections.singletonMap("foo", "bar")), RequestOptions.DEFAULT);
+            DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", docId);
             if (randomBoolean()) {
                 deleteRequest.version(1L);
             }
             DeleteResponse deleteResponse = execute(deleteRequest, highLevelClient()::delete, highLevelClient()::deleteAsync);
             assertEquals("index", deleteResponse.getIndex());
-            assertEquals("type", deleteResponse.getType());
+            assertEquals("_doc", deleteResponse.getType());
             assertEquals(docId, deleteResponse.getId());
             assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         }
         {
             // Testing non existing document
             String docId = "does_not_exist";
-            DeleteRequest deleteRequest = new DeleteRequest("index", "type", docId);
+            DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", docId);
             DeleteResponse deleteResponse = execute(deleteRequest, highLevelClient()::delete, highLevelClient()::deleteAsync);
             assertEquals("index", deleteResponse.getIndex());
-            assertEquals("type", deleteResponse.getType());
+            assertEquals("_doc", deleteResponse.getType());
             assertEquals(docId, deleteResponse.getId());
             assertEquals(DocWriteResponse.Result.NOT_FOUND, deleteResponse.getResult());
         }
@@ -122,12 +122,12 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             // Testing version conflict
             String docId = "version_conflict";
             highLevelClient().index(
-                    new IndexRequest("index", "type", docId).source(Collections.singletonMap("foo", "bar")), RequestOptions.DEFAULT);
-            DeleteRequest deleteRequest = new DeleteRequest("index", "type", docId).version(2);
+                    new IndexRequest("index", "_doc", docId).source(Collections.singletonMap("foo", "bar")), RequestOptions.DEFAULT);
+            DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", docId).version(2);
             ElasticsearchException exception = expectThrows(ElasticsearchException.class,
                 () -> execute(deleteRequest, highLevelClient()::delete, highLevelClient()::deleteAsync));
             assertEquals(RestStatus.CONFLICT, exception.status());
-            assertEquals("Elasticsearch exception [type=version_conflict_engine_exception, reason=[type][" + docId + "]: " +
+            assertEquals("Elasticsearch exception [type=version_conflict_engine_exception, reason=[_doc][" + docId + "]: " +
                 "version conflict, current version [1] is different than the one provided [2]]", exception.getMessage());
             assertEquals("index", exception.getMetadata("es.index").get(0));
         }
@@ -135,12 +135,12 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             // Testing version type
             String docId = "version_type";
             highLevelClient().index(
-                    new IndexRequest("index", "type", docId).source(Collections.singletonMap("foo", "bar"))
+                    new IndexRequest("index", "_doc", docId).source(Collections.singletonMap("foo", "bar"))
                 .versionType(VersionType.EXTERNAL).version(12), RequestOptions.DEFAULT);
-            DeleteRequest deleteRequest = new DeleteRequest("index", "type", docId).versionType(VersionType.EXTERNAL).version(13);
+            DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", docId).versionType(VersionType.EXTERNAL).version(13);
             DeleteResponse deleteResponse = execute(deleteRequest, highLevelClient()::delete, highLevelClient()::deleteAsync);
             assertEquals("index", deleteResponse.getIndex());
-            assertEquals("type", deleteResponse.getType());
+            assertEquals("_doc", deleteResponse.getType());
             assertEquals(docId, deleteResponse.getId());
             assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         }
@@ -148,26 +148,26 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             // Testing version type with a wrong version
             String docId = "wrong_version";
             highLevelClient().index(
-                    new IndexRequest("index", "type", docId).source(Collections.singletonMap("foo", "bar"))
+                    new IndexRequest("index", "_doc", docId).source(Collections.singletonMap("foo", "bar"))
                 .versionType(VersionType.EXTERNAL).version(12), RequestOptions.DEFAULT);
             ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class, () -> {
-                DeleteRequest deleteRequest = new DeleteRequest("index", "type", docId).versionType(VersionType.EXTERNAL).version(10);
+                DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", docId).versionType(VersionType.EXTERNAL).version(10);
                 execute(deleteRequest, highLevelClient()::delete, highLevelClient()::deleteAsync);
             });
             assertEquals(RestStatus.CONFLICT, exception.status());
-            assertEquals("Elasticsearch exception [type=version_conflict_engine_exception, reason=[type][" +
+            assertEquals("Elasticsearch exception [type=version_conflict_engine_exception, reason=[_doc][" +
                 docId + "]: version conflict, current version [12] is higher or equal to the one provided [10]]", exception.getMessage());
             assertEquals("index", exception.getMetadata("es.index").get(0));
         }
         {
             // Testing routing
             String docId = "routing";
-            highLevelClient().index(new IndexRequest("index", "type", docId).source(Collections.singletonMap("foo", "bar")).routing("foo"),
+            highLevelClient().index(new IndexRequest("index", "_doc", docId).source(Collections.singletonMap("foo", "bar")).routing("foo"),
                     RequestOptions.DEFAULT);
-            DeleteRequest deleteRequest = new DeleteRequest("index", "type", docId).routing("foo");
+            DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", docId).routing("foo");
             DeleteResponse deleteResponse = execute(deleteRequest, highLevelClient()::delete, highLevelClient()::deleteAsync);
             assertEquals("index", deleteResponse.getIndex());
-            assertEquals("type", deleteResponse.getType());
+            assertEquals("_doc", deleteResponse.getType());
             assertEquals(docId, deleteResponse.getId());
             assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         }
@@ -175,46 +175,46 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
 
     public void testExists() throws IOException {
         {
-            GetRequest getRequest = new GetRequest("index", "type", "id");
+            GetRequest getRequest = new GetRequest("index", "_doc", "id");
             assertFalse(execute(getRequest, highLevelClient()::exists, highLevelClient()::existsAsync));
         }
-        IndexRequest index = new IndexRequest("index", "type", "id");
+        IndexRequest index = new IndexRequest("index", "_doc", "id");
         index.source("{\"field1\":\"value1\",\"field2\":\"value2\"}", XContentType.JSON);
         index.setRefreshPolicy(RefreshPolicy.IMMEDIATE);
         highLevelClient().index(index, RequestOptions.DEFAULT);
         {
-            GetRequest getRequest = new GetRequest("index", "type", "id");
+            GetRequest getRequest = new GetRequest("index", "_doc", "id");
             assertTrue(execute(getRequest, highLevelClient()::exists, highLevelClient()::existsAsync));
         }
         {
-            GetRequest getRequest = new GetRequest("index", "type", "does_not_exist");
+            GetRequest getRequest = new GetRequest("index", "_doc", "does_not_exist");
             assertFalse(execute(getRequest, highLevelClient()::exists, highLevelClient()::existsAsync));
         }
         {
-            GetRequest getRequest = new GetRequest("index", "type", "does_not_exist").version(1);
+            GetRequest getRequest = new GetRequest("index", "_doc", "does_not_exist").version(1);
             assertFalse(execute(getRequest, highLevelClient()::exists, highLevelClient()::existsAsync));
         }
     }
 
     public void testSourceExists() throws IOException {
         {
-            GetRequest getRequest = new GetRequest("index", "type", "id");
+            GetRequest getRequest = new GetRequest("index", "_doc", "id");
             assertFalse(execute(getRequest, highLevelClient()::existsSource, highLevelClient()::existsSourceAsync));
         }
-        IndexRequest index = new IndexRequest("index", "type", "id");
+        IndexRequest index = new IndexRequest("index", "_doc", "id");
         index.source("{\"field1\":\"value1\",\"field2\":\"value2\"}", XContentType.JSON);
         index.setRefreshPolicy(RefreshPolicy.IMMEDIATE);
         highLevelClient().index(index, RequestOptions.DEFAULT);
         {
-            GetRequest getRequest = new GetRequest("index", "type", "id");
+            GetRequest getRequest = new GetRequest("index", "_doc", "id");
             assertTrue(execute(getRequest, highLevelClient()::existsSource, highLevelClient()::existsSourceAsync));
         }
         {
-            GetRequest getRequest = new GetRequest("index", "type", "does_not_exist");
+            GetRequest getRequest = new GetRequest("index", "_doc", "does_not_exist");
             assertFalse(execute(getRequest, highLevelClient()::existsSource, highLevelClient()::existsSourceAsync));
         }
         {
-            GetRequest getRequest = new GetRequest("index", "type", "does_not_exist").version(1);
+            GetRequest getRequest = new GetRequest("index", "_doc", "does_not_exist").version(1);
             assertFalse(execute(getRequest, highLevelClient()::existsSource, highLevelClient()::existsSourceAsync));
         }
     }
@@ -253,35 +253,35 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
 
     public void testGet() throws IOException {
         {
-            GetRequest getRequest = new GetRequest("index", "type", "id");
+            GetRequest getRequest = new GetRequest("index", "_doc", "id");
             ElasticsearchException exception = expectThrows(ElasticsearchException.class,
                     () -> execute(getRequest, highLevelClient()::get, highLevelClient()::getAsync));
             assertEquals(RestStatus.NOT_FOUND, exception.status());
             assertEquals("Elasticsearch exception [type=index_not_found_exception, reason=no such index [index]]", exception.getMessage());
             assertEquals("index", exception.getMetadata("es.index").get(0));
         }
-        IndexRequest index = new IndexRequest("index", "type", "id");
+        IndexRequest index = new IndexRequest("index", "_doc", "id");
         String document = "{\"field1\":\"value1\",\"field2\":\"value2\"}";
         index.source(document, XContentType.JSON);
         index.setRefreshPolicy(RefreshPolicy.IMMEDIATE);
         highLevelClient().index(index, RequestOptions.DEFAULT);
         {
-            GetRequest getRequest = new GetRequest("index", "type", "id").version(2);
+            GetRequest getRequest = new GetRequest("index", "_doc", "id").version(2);
             ElasticsearchException exception = expectThrows(ElasticsearchException.class,
                     () -> execute(getRequest, highLevelClient()::get, highLevelClient()::getAsync));
             assertEquals(RestStatus.CONFLICT, exception.status());
-            assertEquals("Elasticsearch exception [type=version_conflict_engine_exception, " + "reason=[type][id]: " +
+            assertEquals("Elasticsearch exception [type=version_conflict_engine_exception, " + "reason=[_doc][id]: " +
                     "version conflict, current version [1] is different than the one provided [2]]", exception.getMessage());
             assertEquals("index", exception.getMetadata("es.index").get(0));
         }
         {
-            GetRequest getRequest = new GetRequest("index", "type", "id");
+            GetRequest getRequest = new GetRequest("index", "_doc", "id");
             if (randomBoolean()) {
                 getRequest.version(1L);
             }
             GetResponse getResponse = execute(getRequest, highLevelClient()::get, highLevelClient()::getAsync);
             assertEquals("index", getResponse.getIndex());
-            assertEquals("type", getResponse.getType());
+            assertEquals("_doc", getResponse.getType());
             assertEquals("id", getResponse.getId());
             assertTrue(getResponse.isExists());
             assertFalse(getResponse.isSourceEmpty());
@@ -289,10 +289,10 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             assertEquals(document, getResponse.getSourceAsString());
         }
         {
-            GetRequest getRequest = new GetRequest("index", "type", "does_not_exist");
+            GetRequest getRequest = new GetRequest("index", "_doc", "does_not_exist");
             GetResponse getResponse = execute(getRequest, highLevelClient()::get, highLevelClient()::getAsync);
             assertEquals("index", getResponse.getIndex());
-            assertEquals("type", getResponse.getType());
+            assertEquals("_doc", getResponse.getType());
             assertEquals("does_not_exist", getResponse.getId());
             assertFalse(getResponse.isExists());
             assertEquals(-1, getResponse.getVersion());
@@ -300,11 +300,11 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             assertNull(getResponse.getSourceAsString());
         }
         {
-            GetRequest getRequest = new GetRequest("index", "type", "id");
+            GetRequest getRequest = new GetRequest("index", "_doc", "id");
             getRequest.fetchSourceContext(new FetchSourceContext(false, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY));
             GetResponse getResponse = execute(getRequest, highLevelClient()::get, highLevelClient()::getAsync);
             assertEquals("index", getResponse.getIndex());
-            assertEquals("type", getResponse.getType());
+            assertEquals("_doc", getResponse.getType());
             assertEquals("id", getResponse.getId());
             assertTrue(getResponse.isExists());
             assertTrue(getResponse.isSourceEmpty());
@@ -312,7 +312,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             assertNull(getResponse.getSourceAsString());
         }
         {
-            GetRequest getRequest = new GetRequest("index", "type", "id");
+            GetRequest getRequest = new GetRequest("index", "_doc", "id");
             if (randomBoolean()) {
                 getRequest.fetchSourceContext(new FetchSourceContext(true, new String[]{"field1"}, Strings.EMPTY_ARRAY));
             } else {
@@ -320,7 +320,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             }
             GetResponse getResponse = execute(getRequest, highLevelClient()::get, highLevelClient()::getAsync);
             assertEquals("index", getResponse.getIndex());
-            assertEquals("type", getResponse.getType());
+            assertEquals("_doc", getResponse.getType());
             assertEquals("id", getResponse.getId());
             assertTrue(getResponse.isExists());
             assertFalse(getResponse.isSourceEmpty());
@@ -334,15 +334,15 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
     public void testMultiGet() throws IOException {
         {
             MultiGetRequest multiGetRequest = new MultiGetRequest();
-            multiGetRequest.add("index", "type", "id1");
-            multiGetRequest.add("index", "type", "id2");
+            multiGetRequest.add("index", "_doc", "id1");
+            multiGetRequest.add("index", "_doc", "id2");
             MultiGetResponse response = execute(multiGetRequest, highLevelClient()::mget, highLevelClient()::mgetAsync);
             assertEquals(2, response.getResponses().length);
 
             assertTrue(response.getResponses()[0].isFailed());
             assertNull(response.getResponses()[0].getResponse());
             assertEquals("id1", response.getResponses()[0].getFailure().getId());
-            assertEquals("type", response.getResponses()[0].getFailure().getType());
+            assertEquals("_doc", response.getResponses()[0].getFailure().getType());
             assertEquals("index", response.getResponses()[0].getFailure().getIndex());
             assertEquals("Elasticsearch exception [type=index_not_found_exception, reason=no such index [index]]",
                     response.getResponses()[0].getFailure().getFailure().getMessage());
@@ -350,38 +350,38 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             assertTrue(response.getResponses()[1].isFailed());
             assertNull(response.getResponses()[1].getResponse());
             assertEquals("id2", response.getResponses()[1].getId());
-            assertEquals("type", response.getResponses()[1].getType());
+            assertEquals("_doc", response.getResponses()[1].getType());
             assertEquals("index", response.getResponses()[1].getIndex());
             assertEquals("Elasticsearch exception [type=index_not_found_exception, reason=no such index [index]]",
                     response.getResponses()[1].getFailure().getFailure().getMessage());
         }
         BulkRequest bulk = new BulkRequest();
         bulk.setRefreshPolicy(RefreshPolicy.IMMEDIATE);
-        IndexRequest index = new IndexRequest("index", "type", "id1");
+        IndexRequest index = new IndexRequest("index", "_doc", "id1");
         index.source("{\"field\":\"value1\"}", XContentType.JSON);
         bulk.add(index);
-        index = new IndexRequest("index", "type", "id2");
+        index = new IndexRequest("index", "_doc", "id2");
         index.source("{\"field\":\"value2\"}", XContentType.JSON);
         bulk.add(index);
         highLevelClient().bulk(bulk, RequestOptions.DEFAULT);
         {
             MultiGetRequest multiGetRequest = new MultiGetRequest();
-            multiGetRequest.add("index", "type", "id1");
-            multiGetRequest.add("index", "type", "id2");
+            multiGetRequest.add("index", "_doc", "id1");
+            multiGetRequest.add("index", "_doc", "id2");
             MultiGetResponse response = execute(multiGetRequest, highLevelClient()::mget, highLevelClient()::mgetAsync);
             assertEquals(2, response.getResponses().length);
 
             assertFalse(response.getResponses()[0].isFailed());
             assertNull(response.getResponses()[0].getFailure());
             assertEquals("id1", response.getResponses()[0].getId());
-            assertEquals("type", response.getResponses()[0].getType());
+            assertEquals("_doc", response.getResponses()[0].getType());
             assertEquals("index", response.getResponses()[0].getIndex());
             assertEquals(Collections.singletonMap("field", "value1"), response.getResponses()[0].getResponse().getSource());
 
             assertFalse(response.getResponses()[1].isFailed());
             assertNull(response.getResponses()[1].getFailure());
             assertEquals("id2", response.getResponses()[1].getId());
-            assertEquals("type", response.getResponses()[1].getType());
+            assertEquals("_doc", response.getResponses()[1].getType());
             assertEquals("index", response.getResponses()[1].getIndex());
             assertEquals(Collections.singletonMap("field", "value2"), response.getResponses()[1].getResponse().getSource());
         }
@@ -390,14 +390,14 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
     public void testIndex() throws IOException {
         final XContentType xContentType = randomFrom(XContentType.values());
         {
-            IndexRequest indexRequest = new IndexRequest("index", "type");
+            IndexRequest indexRequest = new IndexRequest("index", "_doc");
             indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("test", "test").endObject());
 
             IndexResponse indexResponse = execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
             assertEquals(RestStatus.CREATED, indexResponse.status());
             assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
             assertEquals("index", indexResponse.getIndex());
-            assertEquals("type", indexResponse.getType());
+            assertEquals("_doc", indexResponse.getType());
             assertTrue(Strings.hasLength(indexResponse.getId()));
             assertEquals(1L, indexResponse.getVersion());
             assertNotNull(indexResponse.getShardId());
@@ -411,41 +411,41 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             assertTrue(indexResponse.getShardInfo().getTotal() > 0);
         }
         {
-            IndexRequest indexRequest = new IndexRequest("index", "type", "id");
+            IndexRequest indexRequest = new IndexRequest("index", "_doc", "id");
             indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("version", 1).endObject());
 
             IndexResponse indexResponse = execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
             assertEquals(RestStatus.CREATED, indexResponse.status());
             assertEquals("index", indexResponse.getIndex());
-            assertEquals("type", indexResponse.getType());
+            assertEquals("_doc", indexResponse.getType());
             assertEquals("id", indexResponse.getId());
             assertEquals(1L, indexResponse.getVersion());
 
-            indexRequest = new IndexRequest("index", "type", "id");
+            indexRequest = new IndexRequest("index", "_doc", "id");
             indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("version", 2).endObject());
 
             indexResponse = execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
             assertEquals(RestStatus.OK, indexResponse.status());
             assertEquals("index", indexResponse.getIndex());
-            assertEquals("type", indexResponse.getType());
+            assertEquals("_doc", indexResponse.getType());
             assertEquals("id", indexResponse.getId());
             assertEquals(2L, indexResponse.getVersion());
 
             ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class, () -> {
-                IndexRequest wrongRequest = new IndexRequest("index", "type", "id");
+                IndexRequest wrongRequest = new IndexRequest("index", "_doc", "id");
                 wrongRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("field", "test").endObject());
                 wrongRequest.version(5L);
 
                 execute(wrongRequest, highLevelClient()::index, highLevelClient()::indexAsync);
             });
             assertEquals(RestStatus.CONFLICT, exception.status());
-            assertEquals("Elasticsearch exception [type=version_conflict_engine_exception, reason=[type][id]: " +
+            assertEquals("Elasticsearch exception [type=version_conflict_engine_exception, reason=[_doc][id]: " +
                          "version conflict, current version [2] is different than the one provided [5]]", exception.getMessage());
             assertEquals("index", exception.getMetadata("es.index").get(0));
         }
         {
             ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class, () -> {
-                IndexRequest indexRequest = new IndexRequest("index", "type", "missing_pipeline");
+                IndexRequest indexRequest = new IndexRequest("index", "_doc", "missing_pipeline");
                 indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("field", "test").endObject());
                 indexRequest.setPipeline("missing");
 
@@ -457,7 +457,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                          "reason=pipeline with id [missing] does not exist]", exception.getMessage());
         }
         {
-            IndexRequest indexRequest = new IndexRequest("index", "type", "external_version_type");
+            IndexRequest indexRequest = new IndexRequest("index", "_doc", "external_version_type");
             indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("field", "test").endObject());
             indexRequest.version(12L);
             indexRequest.versionType(VersionType.EXTERNAL);
@@ -465,19 +465,19 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             IndexResponse indexResponse = execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
             assertEquals(RestStatus.CREATED, indexResponse.status());
             assertEquals("index", indexResponse.getIndex());
-            assertEquals("type", indexResponse.getType());
+            assertEquals("_doc", indexResponse.getType());
             assertEquals("external_version_type", indexResponse.getId());
             assertEquals(12L, indexResponse.getVersion());
         }
         {
-            final IndexRequest indexRequest = new IndexRequest("index", "type", "with_create_op_type");
+            final IndexRequest indexRequest = new IndexRequest("index", "_doc", "with_create_op_type");
             indexRequest.source(XContentBuilder.builder(xContentType.xContent()).startObject().field("field", "test").endObject());
             indexRequest.opType(DocWriteRequest.OpType.CREATE);
 
             IndexResponse indexResponse = execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
             assertEquals(RestStatus.CREATED, indexResponse.status());
             assertEquals("index", indexResponse.getIndex());
-            assertEquals("type", indexResponse.getType());
+            assertEquals("_doc", indexResponse.getType());
             assertEquals("with_create_op_type", indexResponse.getId());
 
             ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class, () -> {
@@ -485,52 +485,52 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             });
 
             assertEquals(RestStatus.CONFLICT, exception.status());
-            assertEquals("Elasticsearch exception [type=version_conflict_engine_exception, reason=[type][with_create_op_type]: " +
+            assertEquals("Elasticsearch exception [type=version_conflict_engine_exception, reason=[_doc][with_create_op_type]: " +
                          "version conflict, document already exists (current version [1])]", exception.getMessage());
         }
     }
 
     public void testUpdate() throws IOException {
         {
-            UpdateRequest updateRequest = new UpdateRequest("index", "type", "does_not_exist");
+            UpdateRequest updateRequest = new UpdateRequest("index", "_doc", "does_not_exist");
             updateRequest.doc(singletonMap("field", "value"), randomFrom(XContentType.values()));
 
             ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class, () ->
                     execute(updateRequest, highLevelClient()::update, highLevelClient()::updateAsync));
             assertEquals(RestStatus.NOT_FOUND, exception.status());
-            assertEquals("Elasticsearch exception [type=document_missing_exception, reason=[type][does_not_exist]: document missing]",
+            assertEquals("Elasticsearch exception [type=document_missing_exception, reason=[_doc][does_not_exist]: document missing]",
                     exception.getMessage());
         }
         {
-            IndexRequest indexRequest = new IndexRequest("index", "type", "id");
+            IndexRequest indexRequest = new IndexRequest("index", "_doc", "id");
             indexRequest.source(singletonMap("field", "value"));
             IndexResponse indexResponse = highLevelClient().index(indexRequest, RequestOptions.DEFAULT);
             assertEquals(RestStatus.CREATED, indexResponse.status());
 
-            UpdateRequest updateRequest = new UpdateRequest("index", "type", "id");
+            UpdateRequest updateRequest = new UpdateRequest("index", "_doc", "id");
             updateRequest.doc(singletonMap("field", "updated"), randomFrom(XContentType.values()));
 
             UpdateResponse updateResponse = execute(updateRequest, highLevelClient()::update, highLevelClient()::updateAsync);
             assertEquals(RestStatus.OK, updateResponse.status());
             assertEquals(indexResponse.getVersion() + 1, updateResponse.getVersion());
 
-            UpdateRequest updateRequestConflict = new UpdateRequest("index", "type", "id");
+            UpdateRequest updateRequestConflict = new UpdateRequest("index", "_doc", "id");
             updateRequestConflict.doc(singletonMap("field", "with_version_conflict"), randomFrom(XContentType.values()));
             updateRequestConflict.version(indexResponse.getVersion());
 
             ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class, () ->
                     execute(updateRequestConflict, highLevelClient()::update, highLevelClient()::updateAsync));
             assertEquals(RestStatus.CONFLICT, exception.status());
-            assertEquals("Elasticsearch exception [type=version_conflict_engine_exception, reason=[type][id]: version conflict, " +
+            assertEquals("Elasticsearch exception [type=version_conflict_engine_exception, reason=[_doc][id]: version conflict, " +
                             "current version [2] is different than the one provided [1]]", exception.getMessage());
         }
         {
-            IndexRequest indexRequest = new IndexRequest("index", "type", "with_script");
+            IndexRequest indexRequest = new IndexRequest("index", "_doc", "with_script");
             indexRequest.source(singletonMap("counter", 12));
             IndexResponse indexResponse = highLevelClient().index(indexRequest, RequestOptions.DEFAULT);
             assertEquals(RestStatus.CREATED, indexResponse.status());
 
-            UpdateRequest updateRequest = new UpdateRequest("index", "type", "with_script");
+            UpdateRequest updateRequest = new UpdateRequest("index", "_doc", "with_script");
             Script script = new Script(ScriptType.INLINE, "painless", "ctx._source.counter += params.count", singletonMap("count", 8));
             updateRequest.script(script);
             updateRequest.fetchSource(true);
@@ -543,7 +543,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
 
         }
         {
-            IndexRequest indexRequest = new IndexRequest("index", "type", "with_doc");
+            IndexRequest indexRequest = new IndexRequest("index", "_doc", "with_doc");
             indexRequest.source("field_1", "one", "field_3", "three");
             indexRequest.version(12L);
             indexRequest.versionType(VersionType.EXTERNAL);
@@ -551,7 +551,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             assertEquals(RestStatus.CREATED, indexResponse.status());
             assertEquals(12L, indexResponse.getVersion());
 
-            UpdateRequest updateRequest = new UpdateRequest("index", "type", "with_doc");
+            UpdateRequest updateRequest = new UpdateRequest("index", "_doc", "with_doc");
             updateRequest.doc(singletonMap("field_2", "two"), randomFrom(XContentType.values()));
             updateRequest.fetchSource("field_*", "field_3");
 
@@ -567,13 +567,13 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             assertFalse(sourceAsMap.containsKey("field_3"));
         }
         {
-            IndexRequest indexRequest = new IndexRequest("index", "type", "noop");
+            IndexRequest indexRequest = new IndexRequest("index", "_doc", "noop");
             indexRequest.source("field", "value");
             IndexResponse indexResponse = highLevelClient().index(indexRequest, RequestOptions.DEFAULT);
             assertEquals(RestStatus.CREATED, indexResponse.status());
             assertEquals(1L, indexResponse.getVersion());
 
-            UpdateRequest updateRequest = new UpdateRequest("index", "type", "noop");
+            UpdateRequest updateRequest = new UpdateRequest("index", "_doc", "noop");
             updateRequest.doc(singletonMap("field", "value"), randomFrom(XContentType.values()));
 
             UpdateResponse updateResponse = execute(updateRequest, highLevelClient()::update, highLevelClient()::updateAsync);
@@ -589,7 +589,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             assertEquals(2L, updateResponse.getVersion());
         }
         {
-            UpdateRequest updateRequest = new UpdateRequest("index", "type", "with_upsert");
+            UpdateRequest updateRequest = new UpdateRequest("index", "_doc", "with_upsert");
             updateRequest.upsert(singletonMap("doc_status", "created"));
             updateRequest.doc(singletonMap("doc_status", "updated"));
             updateRequest.fetchSource(true);
@@ -597,14 +597,14 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             UpdateResponse updateResponse = execute(updateRequest, highLevelClient()::update, highLevelClient()::updateAsync);
             assertEquals(RestStatus.CREATED, updateResponse.status());
             assertEquals("index", updateResponse.getIndex());
-            assertEquals("type", updateResponse.getType());
+            assertEquals("_doc", updateResponse.getType());
             assertEquals("with_upsert", updateResponse.getId());
             GetResult getResult = updateResponse.getGetResult();
             assertEquals(1L, updateResponse.getVersion());
             assertEquals("created", getResult.sourceAsMap().get("doc_status"));
         }
         {
-            UpdateRequest updateRequest = new UpdateRequest("index", "type", "with_doc_as_upsert");
+            UpdateRequest updateRequest = new UpdateRequest("index", "_doc", "with_doc_as_upsert");
             updateRequest.doc(singletonMap("field", "initialized"));
             updateRequest.fetchSource(true);
             updateRequest.docAsUpsert(true);
@@ -612,14 +612,14 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             UpdateResponse updateResponse = execute(updateRequest, highLevelClient()::update, highLevelClient()::updateAsync);
             assertEquals(RestStatus.CREATED, updateResponse.status());
             assertEquals("index", updateResponse.getIndex());
-            assertEquals("type", updateResponse.getType());
+            assertEquals("_doc", updateResponse.getType());
             assertEquals("with_doc_as_upsert", updateResponse.getId());
             GetResult getResult = updateResponse.getGetResult();
             assertEquals(1L, updateResponse.getVersion());
             assertEquals("initialized", getResult.sourceAsMap().get("field"));
         }
         {
-            UpdateRequest updateRequest = new UpdateRequest("index", "type", "with_scripted_upsert");
+            UpdateRequest updateRequest = new UpdateRequest("index", "_doc", "with_scripted_upsert");
             updateRequest.fetchSource(true);
             updateRequest.script(new Script(ScriptType.INLINE, "painless", "ctx._source.level = params.test", singletonMap("test", "C")));
             updateRequest.scriptedUpsert(true);
@@ -628,7 +628,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             UpdateResponse updateResponse = execute(updateRequest, highLevelClient()::update, highLevelClient()::updateAsync);
             assertEquals(RestStatus.CREATED, updateResponse.status());
             assertEquals("index", updateResponse.getIndex());
-            assertEquals("type", updateResponse.getType());
+            assertEquals("_doc", updateResponse.getType());
             assertEquals("with_scripted_upsert", updateResponse.getId());
 
             GetResult getResult = updateResponse.getGetResult();
@@ -637,7 +637,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
         }
         {
             IllegalStateException exception = expectThrows(IllegalStateException.class, () -> {
-                UpdateRequest updateRequest = new UpdateRequest("index", "type", "id");
+                UpdateRequest updateRequest = new UpdateRequest("index", "_doc", "id");
                 updateRequest.doc(new IndexRequest().source(Collections.singletonMap("field", "doc"), XContentType.JSON));
                 updateRequest.upsert(new IndexRequest().source(Collections.singletonMap("field", "upsert"), XContentType.YAML));
                 execute(updateRequest, highLevelClient()::update, highLevelClient()::updateAsync);
@@ -664,35 +664,35 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                 if (erroneous == false) {
                     assertEquals(RestStatus.CREATED,
                             highLevelClient().index(
-                                    new IndexRequest("index", "test", id).source("field", -1), RequestOptions.DEFAULT).status());
+                                    new IndexRequest("index", "_doc", id).source("field", -1), RequestOptions.DEFAULT).status());
                 }
-                DeleteRequest deleteRequest = new DeleteRequest("index", "test", id);
+                DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", id);
                 bulkRequest.add(deleteRequest);
 
             } else {
                 BytesReference source = BytesReference.bytes(XContentBuilder.builder(xContentType.xContent())
                         .startObject().field("id", i).endObject());
                 if (opType == DocWriteRequest.OpType.INDEX) {
-                    IndexRequest indexRequest = new IndexRequest("index", "test", id).source(source, xContentType);
+                    IndexRequest indexRequest = new IndexRequest("index", "_doc", id).source(source, xContentType);
                     if (erroneous) {
                         indexRequest.version(12L);
                     }
                     bulkRequest.add(indexRequest);
 
                 } else if (opType == DocWriteRequest.OpType.CREATE) {
-                    IndexRequest createRequest = new IndexRequest("index", "test", id).source(source, xContentType).create(true);
+                    IndexRequest createRequest = new IndexRequest("index", "_doc", id).source(source, xContentType).create(true);
                     if (erroneous) {
                         assertEquals(RestStatus.CREATED, highLevelClient().index(createRequest, RequestOptions.DEFAULT).status());
                     }
                     bulkRequest.add(createRequest);
 
                 } else if (opType == DocWriteRequest.OpType.UPDATE) {
-                    UpdateRequest updateRequest = new UpdateRequest("index", "test", id)
+                    UpdateRequest updateRequest = new UpdateRequest("index", "_doc", id)
                             .doc(new IndexRequest().source(source, xContentType));
                     if (erroneous == false) {
                         assertEquals(RestStatus.CREATED,
                                 highLevelClient().index(
-                                        new IndexRequest("index", "test", id).source("field", -1), RequestOptions.DEFAULT).status());
+                                        new IndexRequest("index", "_doc", id).source("field", -1), RequestOptions.DEFAULT).status());
                     }
                     bulkRequest.add(updateRequest);
                 }
@@ -742,9 +742,9 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                 RestStatus.OK,
                 highLevelClient().bulk(
                     new BulkRequest()
-                        .add(new IndexRequest(sourceIndex, "type", "1")
+                        .add(new IndexRequest(sourceIndex, "_doc", "1")
                             .source(Collections.singletonMap("foo", 1), XContentType.JSON))
-                        .add(new IndexRequest(sourceIndex, "type", "2")
+                        .add(new IndexRequest(sourceIndex, "_doc", "2")
                             .source(Collections.singletonMap("foo", 2), XContentType.JSON))
                         .setRefreshPolicy(RefreshPolicy.IMMEDIATE),
                     RequestOptions.DEFAULT
@@ -755,7 +755,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             // test1: create one doc in dest
             UpdateByQueryRequest updateByQueryRequest = new UpdateByQueryRequest();
             updateByQueryRequest.indices(sourceIndex);
-            updateByQueryRequest.setQuery(new IdsQueryBuilder().addIds("1").types("type"));
+            updateByQueryRequest.setQuery(new IdsQueryBuilder().addIds("1").types("_doc"));
             updateByQueryRequest.setRefresh(true);
             BulkByScrollResponse bulkResponse =
                 execute(updateByQueryRequest, highLevelClient()::updateByQuery, highLevelClient()::updateByQueryAsync);
@@ -789,7 +789,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             assertEquals(0, bulkResponse.getSearchFailures().size());
             assertEquals(
                 3,
-                (int) (highLevelClient().get(new GetRequest(sourceIndex, "type", "2"), RequestOptions.DEFAULT)
+                (int) (highLevelClient().get(new GetRequest(sourceIndex, "_doc", "2"), RequestOptions.DEFAULT)
                     .getSourceAsMap().get("foo"))
             );
         }
@@ -797,7 +797,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             // test update-by-query rethrottling
             UpdateByQueryRequest updateByQueryRequest = new UpdateByQueryRequest();
             updateByQueryRequest.indices(sourceIndex);
-            updateByQueryRequest.setQuery(new IdsQueryBuilder().addIds("1").types("type"));
+            updateByQueryRequest.setQuery(new IdsQueryBuilder().addIds("1").types("_doc"));
             updateByQueryRequest.setRefresh(true);
 
             // this following settings are supposed to halt reindexing after first document
@@ -852,11 +852,11 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                 RestStatus.OK,
                 highLevelClient().bulk(
                     new BulkRequest()
-                        .add(new IndexRequest(sourceIndex, "type", "1")
+                        .add(new IndexRequest(sourceIndex, "_doc", "1")
                             .source(Collections.singletonMap("foo", 1), XContentType.JSON))
-                        .add(new IndexRequest(sourceIndex, "type", "2")
+                        .add(new IndexRequest(sourceIndex, "_doc", "2")
                             .source(Collections.singletonMap("foo", 2), XContentType.JSON))
-                        .add(new IndexRequest(sourceIndex, "type", "3")
+                        .add(new IndexRequest(sourceIndex, "_doc", "3")
                             .source(Collections.singletonMap("foo", 3), XContentType.JSON))
                         .setRefreshPolicy(RefreshPolicy.IMMEDIATE),
                     RequestOptions.DEFAULT
@@ -867,7 +867,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             // test1: delete one doc
             DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest();
             deleteByQueryRequest.indices(sourceIndex);
-            deleteByQueryRequest.setQuery(new IdsQueryBuilder().addIds("1").types("type"));
+            deleteByQueryRequest.setQuery(new IdsQueryBuilder().addIds("1").types("_doc"));
             deleteByQueryRequest.setRefresh(true);
             BulkByScrollResponse bulkResponse =
                 execute(deleteByQueryRequest, highLevelClient()::deleteByQuery, highLevelClient()::deleteByQueryAsync);
@@ -889,7 +889,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             // test delete-by-query rethrottling
             DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest();
             deleteByQueryRequest.indices(sourceIndex);
-            deleteByQueryRequest.setQuery(new IdsQueryBuilder().addIds("2", "3").types("type"));
+            deleteByQueryRequest.setQuery(new IdsQueryBuilder().addIds("2", "3").types("_doc"));
             deleteByQueryRequest.setRefresh(true);
 
             // this following settings are supposed to halt reindexing after first document
@@ -975,33 +975,33 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                     if (erroneous == false) {
                         assertEquals(RestStatus.CREATED,
                                 highLevelClient().index(
-                                        new IndexRequest("index", "test", id).source("field", -1), RequestOptions.DEFAULT).status());
+                                        new IndexRequest("index", "_doc", id).source("field", -1), RequestOptions.DEFAULT).status());
                     }
-                    DeleteRequest deleteRequest = new DeleteRequest("index", "test", id);
+                    DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", id);
                     processor.add(deleteRequest);
 
                 } else {
                     if (opType == DocWriteRequest.OpType.INDEX) {
-                        IndexRequest indexRequest = new IndexRequest("index", "test", id).source(xContentType, "id", i);
+                        IndexRequest indexRequest = new IndexRequest("index", "_doc", id).source(xContentType, "id", i);
                         if (erroneous) {
                             indexRequest.version(12L);
                         }
                         processor.add(indexRequest);
 
                     } else if (opType == DocWriteRequest.OpType.CREATE) {
-                        IndexRequest createRequest = new IndexRequest("index", "test", id).source(xContentType, "id", i).create(true);
+                        IndexRequest createRequest = new IndexRequest("index", "_doc", id).source(xContentType, "id", i).create(true);
                         if (erroneous) {
                             assertEquals(RestStatus.CREATED, highLevelClient().index(createRequest, RequestOptions.DEFAULT).status());
                         }
                         processor.add(createRequest);
 
                     } else if (opType == DocWriteRequest.OpType.UPDATE) {
-                        UpdateRequest updateRequest = new UpdateRequest("index", "test", id)
+                        UpdateRequest updateRequest = new UpdateRequest("index", "_doc", id)
                                 .doc(new IndexRequest().source(xContentType, "id", i));
                         if (erroneous == false) {
                             assertEquals(RestStatus.CREATED,
                                     highLevelClient().index(
-                                            new IndexRequest("index", "test", id).source("field", -1), RequestOptions.DEFAULT).status());
+                                            new IndexRequest("index", "_doc", id).source("field", -1), RequestOptions.DEFAULT).status());
                         }
                         processor.add(updateRequest);
                     }
@@ -1029,7 +1029,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
 
             assertEquals(i, bulkItemResponse.getItemId());
             assertEquals("index", bulkItemResponse.getIndex());
-            assertEquals("test", bulkItemResponse.getType());
+            assertEquals("_doc", bulkItemResponse.getType());
             assertEquals(String.valueOf(i), bulkItemResponse.getId());
 
             DocWriteRequest.OpType requestOpType = bulkRequest.requests().get(i).opType();
@@ -1051,37 +1051,37 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
         String expectedIndex = "logstash-" +
                 DateTimeFormat.forPattern("YYYY.MM.dd").print(new DateTime(DateTimeZone.UTC).monthOfYear().roundFloorCopy());
         {
-            IndexRequest indexRequest = new IndexRequest(indexPattern, "type", "id#1");
+            IndexRequest indexRequest = new IndexRequest(indexPattern, "_doc", "id#1");
             indexRequest.source("field", "value");
             IndexResponse indexResponse = highLevelClient().index(indexRequest, RequestOptions.DEFAULT);
             assertEquals(expectedIndex, indexResponse.getIndex());
-            assertEquals("type", indexResponse.getType());
+            assertEquals("_doc", indexResponse.getType());
             assertEquals("id#1", indexResponse.getId());
         }
         {
-            GetRequest getRequest = new GetRequest(indexPattern, "type", "id#1");
+            GetRequest getRequest = new GetRequest(indexPattern, "_doc", "id#1");
             GetResponse getResponse = highLevelClient().get(getRequest, RequestOptions.DEFAULT);
             assertTrue(getResponse.isExists());
             assertEquals(expectedIndex, getResponse.getIndex());
-            assertEquals("type", getResponse.getType());
+            assertEquals("_doc", getResponse.getType());
             assertEquals("id#1", getResponse.getId());
         }
 
         String docId = "this/is/the/id/中文";
         {
-            IndexRequest indexRequest = new IndexRequest("index", "type", docId);
+            IndexRequest indexRequest = new IndexRequest("index", "_doc", docId);
             indexRequest.source("field", "value");
             IndexResponse indexResponse = highLevelClient().index(indexRequest, RequestOptions.DEFAULT);
             assertEquals("index", indexResponse.getIndex());
-            assertEquals("type", indexResponse.getType());
+            assertEquals("_doc", indexResponse.getType());
             assertEquals(docId, indexResponse.getId());
         }
         {
-            GetRequest getRequest = new GetRequest("index", "type", docId);
+            GetRequest getRequest = new GetRequest("index", "_doc", docId);
             GetResponse getResponse = highLevelClient().get(getRequest, RequestOptions.DEFAULT);
             assertTrue(getResponse.isExists());
             assertEquals("index", getResponse.getIndex());
-            assertEquals("type", getResponse.getType());
+            assertEquals("_doc", getResponse.getType());
             assertEquals(docId, getResponse.getId());
         }
 
@@ -1092,20 +1092,20 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
         //parameters are encoded by the low-level client but let's test that everything works the same when we use the high-level one
         String routing = "routing/中文value#1?";
         {
-            IndexRequest indexRequest = new IndexRequest("index", "type", "id");
+            IndexRequest indexRequest = new IndexRequest("index", "_doc", "id");
             indexRequest.source("field", "value");
             indexRequest.routing(routing);
             IndexResponse indexResponse = highLevelClient().index(indexRequest, RequestOptions.DEFAULT);
             assertEquals("index", indexResponse.getIndex());
-            assertEquals("type", indexResponse.getType());
+            assertEquals("_doc", indexResponse.getType());
             assertEquals("id", indexResponse.getId());
         }
         {
-            GetRequest getRequest = new GetRequest("index", "type", "id").routing(routing);
+            GetRequest getRequest = new GetRequest("index", "_doc", "id").routing(routing);
             GetResponse getResponse = highLevelClient().get(getRequest, RequestOptions.DEFAULT);
             assertTrue(getResponse.isExists());
             assertEquals("index", getResponse.getIndex());
-            assertEquals("type", getResponse.getType());
+            assertEquals("_doc", getResponse.getType());
             assertEquals("id", getResponse.getId());
             assertEquals(routing, getResponse.getField("_routing").getValue());
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -98,7 +98,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             String docId = "id";
             highLevelClient().index(
                     new IndexRequest("index", "_doc", docId).source(Collections.singletonMap("foo", "bar")), RequestOptions.DEFAULT);
-            DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", docId);
+            DeleteRequest deleteRequest = new DeleteRequest("index", docId);
             if (randomBoolean()) {
                 deleteRequest.version(1L);
             }
@@ -111,7 +111,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
         {
             // Testing non existing document
             String docId = "does_not_exist";
-            DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", docId);
+            DeleteRequest deleteRequest = new DeleteRequest("index", docId);
             DeleteResponse deleteResponse = execute(deleteRequest, highLevelClient()::delete, highLevelClient()::deleteAsync);
             assertEquals("index", deleteResponse.getIndex());
             assertEquals("_doc", deleteResponse.getType());
@@ -123,7 +123,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             String docId = "version_conflict";
             highLevelClient().index(
                     new IndexRequest("index", "_doc", docId).source(Collections.singletonMap("foo", "bar")), RequestOptions.DEFAULT);
-            DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", docId).version(2);
+            DeleteRequest deleteRequest = new DeleteRequest("index", docId).version(2);
             ElasticsearchException exception = expectThrows(ElasticsearchException.class,
                 () -> execute(deleteRequest, highLevelClient()::delete, highLevelClient()::deleteAsync));
             assertEquals(RestStatus.CONFLICT, exception.status());
@@ -137,7 +137,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             highLevelClient().index(
                     new IndexRequest("index", "_doc", docId).source(Collections.singletonMap("foo", "bar"))
                 .versionType(VersionType.EXTERNAL).version(12), RequestOptions.DEFAULT);
-            DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", docId).versionType(VersionType.EXTERNAL).version(13);
+            DeleteRequest deleteRequest = new DeleteRequest("index",  docId).versionType(VersionType.EXTERNAL).version(13);
             DeleteResponse deleteResponse = execute(deleteRequest, highLevelClient()::delete, highLevelClient()::deleteAsync);
             assertEquals("index", deleteResponse.getIndex());
             assertEquals("_doc", deleteResponse.getType());
@@ -151,7 +151,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                     new IndexRequest("index", "_doc", docId).source(Collections.singletonMap("foo", "bar"))
                 .versionType(VersionType.EXTERNAL).version(12), RequestOptions.DEFAULT);
             ElasticsearchStatusException exception = expectThrows(ElasticsearchStatusException.class, () -> {
-                DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", docId).versionType(VersionType.EXTERNAL).version(10);
+                DeleteRequest deleteRequest = new DeleteRequest("index",  docId).versionType(VersionType.EXTERNAL).version(10);
                 execute(deleteRequest, highLevelClient()::delete, highLevelClient()::deleteAsync);
             });
             assertEquals(RestStatus.CONFLICT, exception.status());
@@ -164,7 +164,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             String docId = "routing";
             highLevelClient().index(new IndexRequest("index", "_doc", docId).source(Collections.singletonMap("foo", "bar")).routing("foo"),
                     RequestOptions.DEFAULT);
-            DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", docId).routing("foo");
+            DeleteRequest deleteRequest = new DeleteRequest("index",  docId).routing("foo");
             DeleteResponse deleteResponse = execute(deleteRequest, highLevelClient()::delete, highLevelClient()::deleteAsync);
             assertEquals("index", deleteResponse.getIndex());
             assertEquals("_doc", deleteResponse.getType());
@@ -666,7 +666,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                             highLevelClient().index(
                                     new IndexRequest("index", "_doc", id).source("field", -1), RequestOptions.DEFAULT).status());
                 }
-                DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", id);
+                DeleteRequest deleteRequest = new DeleteRequest("index", id);
                 bulkRequest.add(deleteRequest);
 
             } else {
@@ -977,7 +977,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                                 highLevelClient().index(
                                         new IndexRequest("index", "_doc", id).source("field", -1), RequestOptions.DEFAULT).status());
                     }
-                    DeleteRequest deleteRequest = new DeleteRequest("index", "_doc", id);
+                    DeleteRequest deleteRequest = new DeleteRequest("index", id);
                     processor.add(deleteRequest);
 
                 } else {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
@@ -116,7 +116,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             jsonMap.put("user", "kimchy");
             jsonMap.put("postDate", new Date());
             jsonMap.put("message", "trying out Elasticsearch");
-            IndexRequest indexRequest = new IndexRequest("posts", "doc", "1")
+            IndexRequest indexRequest = new IndexRequest("posts", "_doc", "1")
                     .source(jsonMap); // <1>
             //end::index-request-map
             IndexResponse indexResponse = client.index(indexRequest, RequestOptions.DEFAULT);
@@ -132,7 +132,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
                 builder.field("message", "trying out Elasticsearch");
             }
             builder.endObject();
-            IndexRequest indexRequest = new IndexRequest("posts", "doc", "1")
+            IndexRequest indexRequest = new IndexRequest("posts", "_doc", "1")
                     .source(builder);  // <1>
             //end::index-request-xcontent
             IndexResponse indexResponse = client.index(indexRequest, RequestOptions.DEFAULT);
@@ -140,7 +140,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         }
         {
             //tag::index-request-shortcut
-            IndexRequest indexRequest = new IndexRequest("posts", "doc", "1")
+            IndexRequest indexRequest = new IndexRequest("posts", "_doc", "1")
                     .source("user", "kimchy",
                             "postDate", new Date(),
                             "message", "trying out Elasticsearch"); // <1>
@@ -152,7 +152,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             //tag::index-request-string
             IndexRequest request = new IndexRequest(
                     "posts", // <1>
-                    "doc",  // <2>
+                    "_doc",  // <2>
                     "1");   // <3>
             String jsonString = "{" +
                     "\"user\":\"kimchy\"," +
@@ -190,7 +190,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             // end::index-response
         }
         {
-            IndexRequest request = new IndexRequest("posts", "doc", "1");
+            IndexRequest request = new IndexRequest("posts", "_doc", "1");
             // tag::index-request-routing
             request.routing("routing"); // <1>
             // end::index-request-routing
@@ -218,7 +218,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         }
         {
             // tag::index-conflict
-            IndexRequest request = new IndexRequest("posts", "doc", "1")
+            IndexRequest request = new IndexRequest("posts", "_doc", "1")
                     .source("field", "value")
                     .version(1);
             try {
@@ -232,7 +232,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         }
         {
             // tag::index-optype
-            IndexRequest request = new IndexRequest("posts", "doc", "1")
+            IndexRequest request = new IndexRequest("posts", "_doc", "1")
                     .source("field", "value")
                     .opType(DocWriteRequest.OpType.CREATE);
             try {
@@ -245,7 +245,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             // end::index-optype
         }
         {
-            IndexRequest request = new IndexRequest("posts", "doc", "async").source("field", "value");
+            IndexRequest request = new IndexRequest("posts", "_doc", "async").source("field", "value");
             ActionListener<IndexResponse> listener;
             // tag::index-execute-listener
             listener = new ActionListener<IndexResponse>() {
@@ -277,7 +277,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
     public void testUpdate() throws Exception {
         RestHighLevelClient client = highLevelClient();
         {
-            IndexRequest indexRequest = new IndexRequest("posts", "doc", "1").source("field", 0);
+            IndexRequest indexRequest = new IndexRequest("posts", "_doc", "1").source("field", 0);
             IndexResponse indexResponse = client.index(indexRequest, RequestOptions.DEFAULT);
             assertSame(RestStatus.CREATED, indexResponse.status());
 
@@ -296,7 +296,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             //tag::update-request
             UpdateRequest request = new UpdateRequest(
                     "posts", // <1>
-                    "doc",  // <2>
+                    "_doc",  // <2>
                     "1");   // <3>
             //end::update-request
             request.fetchSource(true);
@@ -311,7 +311,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             assertEquals(DocWriteResponse.Result.UPDATED, updateResponse.getResult());
             assertEquals(4, updateResponse.getGetResult().getSource().get("field"));
 
-            request = new UpdateRequest("posts", "doc", "1").fetchSource(true);
+            request = new UpdateRequest("posts", "_doc", "1").fetchSource(true);
             //tag::update-request-with-stored-script
             Script stored = new Script(
                     ScriptType.STORED, null, "increment-field", parameters);  // <1>
@@ -326,7 +326,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             Map<String, Object> jsonMap = new HashMap<>();
             jsonMap.put("updated", new Date());
             jsonMap.put("reason", "daily update");
-            UpdateRequest request = new UpdateRequest("posts", "doc", "1")
+            UpdateRequest request = new UpdateRequest("posts", "_doc", "1")
                     .doc(jsonMap); // <1>
             //end::update-request-with-doc-as-map
             UpdateResponse updateResponse = client.update(request, RequestOptions.DEFAULT);
@@ -341,7 +341,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
                 builder.field("reason", "daily update");
             }
             builder.endObject();
-            UpdateRequest request = new UpdateRequest("posts", "doc", "1")
+            UpdateRequest request = new UpdateRequest("posts", "_doc", "1")
                     .doc(builder);  // <1>
             //end::update-request-with-doc-as-xcontent
             UpdateResponse updateResponse = client.update(request, RequestOptions.DEFAULT);
@@ -349,7 +349,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         }
         {
             //tag::update-request-shortcut
-            UpdateRequest request = new UpdateRequest("posts", "doc", "1")
+            UpdateRequest request = new UpdateRequest("posts", "_doc", "1")
                     .doc("updated", new Date(),
                          "reason", "daily update"); // <1>
             //end::update-request-shortcut
@@ -358,7 +358,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         }
         {
             //tag::update-request-with-doc-as-string
-            UpdateRequest request = new UpdateRequest("posts", "doc", "1");
+            UpdateRequest request = new UpdateRequest("posts", "_doc", "1");
             String jsonString = "{" +
                     "\"updated\":\"2017-01-01\"," +
                     "\"reason\":\"daily update\"" +
@@ -415,7 +415,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         }
         {
             //tag::update-docnotfound
-            UpdateRequest request = new UpdateRequest("posts", "type", "does_not_exist")
+            UpdateRequest request = new UpdateRequest("posts", "_doc", "does_not_exist")
                     .doc("field", "value");
             try {
                 UpdateResponse updateResponse = client.update(
@@ -429,7 +429,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         }
         {
             // tag::update-conflict
-            UpdateRequest request = new UpdateRequest("posts", "doc", "1")
+            UpdateRequest request = new UpdateRequest("posts", "_doc", "1")
                     .doc("field", "value")
                     .version(1);
             try {
@@ -443,7 +443,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             // end::update-conflict
         }
         {
-            UpdateRequest request = new UpdateRequest("posts", "doc", "1").doc("reason", "no source");
+            UpdateRequest request = new UpdateRequest("posts", "_doc", "1").doc("reason", "no source");
             //tag::update-request-no-source
             request.fetchSource(true); // <1>
             //end::update-request-no-source
@@ -453,7 +453,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             assertEquals(3, updateResponse.getGetResult().sourceAsMap().size());
         }
         {
-            UpdateRequest request = new UpdateRequest("posts", "doc", "1").doc("reason", "source includes");
+            UpdateRequest request = new UpdateRequest("posts", "_doc", "1").doc("reason", "source includes");
             //tag::update-request-source-include
             String[] includes = new String[]{"updated", "r*"};
             String[] excludes = Strings.EMPTY_ARRAY;
@@ -468,7 +468,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             assertTrue(sourceAsMap.containsKey("updated"));
         }
         {
-            UpdateRequest request = new UpdateRequest("posts", "doc", "1").doc("reason", "source excludes");
+            UpdateRequest request = new UpdateRequest("posts", "_doc", "1").doc("reason", "source excludes");
             //tag::update-request-source-exclude
             String[] includes = Strings.EMPTY_ARRAY;
             String[] excludes = new String[]{"updated"};
@@ -483,7 +483,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             assertTrue(sourceAsMap.containsKey("field"));
         }
         {
-            UpdateRequest request = new UpdateRequest("posts", "doc", "id");
+            UpdateRequest request = new UpdateRequest("posts", "_doc", "id");
             // tag::update-request-routing
             request.routing("routing"); // <1>
             // end::update-request-routing
@@ -520,7 +520,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             // end::update-request-active-shards
         }
         {
-            UpdateRequest request = new UpdateRequest("posts", "doc", "async").doc("reason", "async update").docAsUpsert(true);
+            UpdateRequest request = new UpdateRequest("posts", "_doc", "async").doc("reason", "async update").docAsUpsert(true);
 
             ActionListener<UpdateResponse> listener;
             // tag::update-execute-listener
@@ -554,7 +554,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         RestHighLevelClient client = highLevelClient();
 
         {
-            IndexRequest indexRequest = new IndexRequest("posts", "doc", "1").source("field", "value");
+            IndexRequest indexRequest = new IndexRequest("posts", "_doc", "1").source("field", "value");
             IndexResponse indexResponse = client.index(indexRequest, RequestOptions.DEFAULT);
             assertSame(RestStatus.CREATED, indexResponse.status());
         }
@@ -563,7 +563,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             // tag::delete-request
             DeleteRequest request = new DeleteRequest(
                     "posts",    // <1>
-                    "doc",      // <2>
+                    "_doc",      // <2>
                     "1");       // <3>
             // end::delete-request
 
@@ -592,7 +592,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         }
 
         {
-            DeleteRequest request = new DeleteRequest("posts", "doc", "1");
+            DeleteRequest request = new DeleteRequest("posts", "_doc", "1");
             // tag::delete-request-routing
             request.routing("routing"); // <1>
             // end::delete-request-routing
@@ -614,7 +614,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
 
         {
             // tag::delete-notfound
-            DeleteRequest request = new DeleteRequest("posts", "doc", "does_not_exist");
+            DeleteRequest request = new DeleteRequest("posts", "_doc", "does_not_exist");
             DeleteResponse deleteResponse = client.delete(
                     request, RequestOptions.DEFAULT);
             if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
@@ -624,14 +624,14 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         }
 
         {
-            IndexResponse indexResponse = client.index(new IndexRequest("posts", "doc", "1").source("field", "value")
+            IndexResponse indexResponse = client.index(new IndexRequest("posts", "_doc", "1").source("field", "value")
                     , RequestOptions.DEFAULT);
             assertSame(RestStatus.CREATED, indexResponse.status());
 
             // tag::delete-conflict
             try {
                 DeleteResponse deleteResponse = client.delete(
-                        new DeleteRequest("posts", "doc", "1").version(2),
+                        new DeleteRequest("posts", "_doc", "1").version(2),
                         RequestOptions.DEFAULT);
             } catch (ElasticsearchException exception) {
                 if (exception.status() == RestStatus.CONFLICT) {
@@ -641,11 +641,11 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             // end::delete-conflict
         }
         {
-            IndexResponse indexResponse = client.index(new IndexRequest("posts", "doc", "async").source("field", "value"),
+            IndexResponse indexResponse = client.index(new IndexRequest("posts", "_doc", "async").source("field", "value"),
                     RequestOptions.DEFAULT);
             assertSame(RestStatus.CREATED, indexResponse.status());
 
-            DeleteRequest request = new DeleteRequest("posts", "doc", "async");
+            DeleteRequest request = new DeleteRequest("posts", "_doc", "async");
 
             ActionListener<DeleteResponse> listener;
             // tag::delete-execute-listener
@@ -680,11 +680,11 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         {
             // tag::bulk-request
             BulkRequest request = new BulkRequest(); // <1>
-            request.add(new IndexRequest("posts", "doc", "1")  // <2>
+            request.add(new IndexRequest("posts", "_doc", "1")  // <2>
                     .source(XContentType.JSON,"field", "foo"));
-            request.add(new IndexRequest("posts", "doc", "2")  // <3>
+            request.add(new IndexRequest("posts", "_doc", "2")  // <3>
                     .source(XContentType.JSON,"field", "bar"));
-            request.add(new IndexRequest("posts", "doc", "3")  // <4>
+            request.add(new IndexRequest("posts", "_doc", "3")  // <4>
                     .source(XContentType.JSON,"field", "baz"));
             // end::bulk-request
             // tag::bulk-execute
@@ -696,10 +696,10 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         {
             // tag::bulk-request-with-mixed-operations
             BulkRequest request = new BulkRequest();
-            request.add(new DeleteRequest("posts", "doc", "3")); // <1>
-            request.add(new UpdateRequest("posts", "doc", "2") // <2>
+            request.add(new DeleteRequest("posts", "_doc", "3")); // <1>
+            request.add(new UpdateRequest("posts", "_doc", "2") // <2>
                     .doc(XContentType.JSON,"other", "test"));
-            request.add(new IndexRequest("posts", "doc", "4")  // <3>
+            request.add(new IndexRequest("posts", "_doc", "4")  // <3>
                     .source(XContentType.JSON,"field", "baz"));
             // end::bulk-request-with-mixed-operations
             BulkResponse bulkResponse = client.bulk(request, RequestOptions.DEFAULT);
@@ -793,7 +793,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         RestHighLevelClient client = highLevelClient();
         {
             String mapping =
-                "\"doc\": {\n" +
+                "\"_doc\": {\n" +
                     "    \"properties\": {\n" +
                     "      \"user\": {\n" +
                     "        \"type\": \"text\"\n" +
@@ -826,7 +826,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             request.setConflicts("proceed"); // <1>
             // end::reindex-request-conflicts
             // tag::reindex-request-typeOrQuery
-            request.setSourceDocTypes("doc"); // <1>
+            request.setSourceDocTypes("_doc"); // <1>
             request.setSourceQuery(new TermQueryBuilder("user", "kimchy")); // <2>
             // end::reindex-request-typeOrQuery
             // tag::reindex-request-size
@@ -995,7 +995,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         RestHighLevelClient client = highLevelClient();
         {
             String mapping =
-                "\"doc\": {\n" +
+                "\"_doc\": {\n" +
                     "    \"properties\": {\n" +
                     "      \"user\": {\n" +
                     "        \"type\": \"text\"\n" +
@@ -1120,7 +1120,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         RestHighLevelClient client = highLevelClient();
         {
             String mapping =
-                "\"doc\": {\n" +
+                "\"_doc\": {\n" +
                     "    \"properties\": {\n" +
                     "      \"user\": {\n" +
                     "        \"type\": \"text\"\n" +
@@ -1236,7 +1236,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             createIndex.setJsonEntity(
                     "{\n" +
                     "    \"mappings\" : {\n" +
-                    "        \"doc\" : {\n" +
+                    "        \"_doc\" : {\n" +
                     "            \"properties\" : {\n" +
                     "                \"message\" : {\n" +
                     "                    \"type\": \"text\",\n" +
@@ -1249,7 +1249,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             Response response = client().performRequest(createIndex);
             assertEquals(200, response.getStatusLine().getStatusCode());
 
-            IndexRequest indexRequest = new IndexRequest("posts", "doc", "1")
+            IndexRequest indexRequest = new IndexRequest("posts", "_doc", "1")
                     .source("user", "kimchy",
                             "postDate", new Date(),
                             "message", "trying out Elasticsearch");
@@ -1260,7 +1260,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             //tag::get-request
             GetRequest getRequest = new GetRequest(
                     "posts", // <1>
-                    "doc",  // <2>
+                    "_doc",  // <2>
                     "1");   // <3>
             //end::get-request
 
@@ -1284,7 +1284,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             //end::get-response
         }
         {
-            GetRequest request = new GetRequest("posts", "doc", "1");
+            GetRequest request = new GetRequest("posts", "_doc", "1");
             //tag::get-request-no-source
             request.fetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE); // <1>
             //end::get-request-no-source
@@ -1292,7 +1292,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             assertNull(getResponse.getSourceInternal());
         }
         {
-            GetRequest request = new GetRequest("posts", "doc", "1");
+            GetRequest request = new GetRequest("posts", "_doc", "1");
             //tag::get-request-source-include
             String[] includes = new String[]{"message", "*Date"};
             String[] excludes = Strings.EMPTY_ARRAY;
@@ -1307,7 +1307,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             assertTrue(sourceAsMap.containsKey("postDate"));
         }
         {
-            GetRequest request = new GetRequest("posts", "doc", "1");
+            GetRequest request = new GetRequest("posts", "_doc", "1");
             //tag::get-request-source-exclude
             String[] includes = Strings.EMPTY_ARRAY;
             String[] excludes = new String[]{"message"};
@@ -1322,7 +1322,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             assertTrue(sourceAsMap.containsKey("postDate"));
         }
         {
-            GetRequest request = new GetRequest("posts", "doc", "1");
+            GetRequest request = new GetRequest("posts", "_doc", "1");
             //tag::get-request-stored
             request.storedFields("message"); // <1>
             GetResponse getResponse = client.get(request, RequestOptions.DEFAULT);
@@ -1333,7 +1333,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             assertNull(getResponse.getSourceInternal());
         }
         {
-            GetRequest request = new GetRequest("posts", "doc", "1");
+            GetRequest request = new GetRequest("posts", "_doc", "1");
             //tag::get-request-routing
             request.routing("routing"); // <1>
             //end::get-request-routing
@@ -1354,7 +1354,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             //end::get-request-version-type
         }
         {
-            GetRequest request = new GetRequest("posts", "doc", "1");
+            GetRequest request = new GetRequest("posts", "_doc", "1");
 
             // tag::get-execute-listener
             ActionListener<GetResponse> listener = new ActionListener<GetResponse>() {
@@ -1382,7 +1382,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         }
         {
             //tag::get-indexnotfound
-            GetRequest request = new GetRequest("does_not_exist", "doc", "1");
+            GetRequest request = new GetRequest("does_not_exist", "_doc", "1");
             try {
                 GetResponse getResponse = client.get(request, RequestOptions.DEFAULT);
             } catch (ElasticsearchException e) {
@@ -1395,7 +1395,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         {
             // tag::get-conflict
             try {
-                GetRequest request = new GetRequest("posts", "doc", "1").version(2);
+                GetRequest request = new GetRequest("posts", "_doc", "1").version(2);
                 GetResponse getResponse = client.get(request, RequestOptions.DEFAULT);
             } catch (ElasticsearchException exception) {
                 if (exception.status() == RestStatus.CONFLICT) {
@@ -1411,7 +1411,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         // tag::exists-request
         GetRequest getRequest = new GetRequest(
             "posts", // <1>
-            "doc",   // <2>
+            "_doc",   // <2>
             "1");    // <3>
         getRequest.fetchSourceContext(new FetchSourceContext(false)); // <4>
         getRequest.storedFields("_none_");                            // <5>
@@ -1480,13 +1480,13 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             assertNotNull(bulkProcessor);
 
             // tag::bulk-processor-add
-            IndexRequest one = new IndexRequest("posts", "doc", "1").
+            IndexRequest one = new IndexRequest("posts", "_doc", "1").
                     source(XContentType.JSON, "title",
                             "In which order are my Elasticsearch queries executed?");
-            IndexRequest two = new IndexRequest("posts", "doc", "2")
+            IndexRequest two = new IndexRequest("posts", "_doc", "2")
                     .source(XContentType.JSON, "title",
                             "Current status and upcoming changes in Elasticsearch");
-            IndexRequest three = new IndexRequest("posts", "doc", "3")
+            IndexRequest three = new IndexRequest("posts", "_doc", "3")
                     .source(XContentType.JSON, "title",
                             "The Future of Federated Search in Elasticsearch");
 
@@ -1756,7 +1756,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             createIndex.setJsonEntity(
                     "{\n" +
                     "    \"mappings\" : {\n" +
-                    "        \"type\" : {\n" +
+                    "        \"_doc\" : {\n" +
                     "            \"properties\" : {\n" +
                     "                \"foo\" : {\n" +
                     "                    \"type\": \"text\",\n" +
@@ -1774,7 +1774,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         source.put("foo", "val1");
         source.put("bar", "val2");
         source.put("baz", "val3");
-        client.index(new IndexRequest("index", "type", "example_id")
+        client.index(new IndexRequest("index", "_doc", "example_id")
             .source(source)
             .setRefreshPolicy(RefreshPolicy.IMMEDIATE), RequestOptions.DEFAULT);
 
@@ -1783,18 +1783,18 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             MultiGetRequest request = new MultiGetRequest();
             request.add(new MultiGetRequest.Item(
                 "index",         // <1>
-                "type",          // <2>
+                "_doc",          // <2>
                 "example_id"));  // <3>
-            request.add(new MultiGetRequest.Item("index", "type", "another_id")); // <4>
+            request.add(new MultiGetRequest.Item("index", "_doc", "another_id")); // <4>
             // end::multi-get-request
 
             // Add a missing index so we can test it.
-            request.add(new MultiGetRequest.Item("missing_index", "type", "id"));
+            request.add(new MultiGetRequest.Item("missing_index", "_doc", "id"));
 
             // tag::multi-get-request-item-extras
-            request.add(new MultiGetRequest.Item("index", "type", "with_routing")
+            request.add(new MultiGetRequest.Item("index", "_doc", "with_routing")
                 .routing("some_routing"));          // <1>
-            request.add(new MultiGetRequest.Item("index", "type", "with_version")
+            request.add(new MultiGetRequest.Item("index", "_doc", "with_version")
                 .versionType(VersionType.EXTERNAL)  // <2>
                 .version(10123L));                  // <3>
             // end::multi-get-request-item-extras
@@ -1867,7 +1867,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         {
             MultiGetRequest request = new MultiGetRequest();
             // tag::multi-get-request-no-source
-            request.add(new MultiGetRequest.Item("index", "type", "example_id")
+            request.add(new MultiGetRequest.Item("index", "_doc", "example_id")
                 .fetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE));  // <1>
             // end::multi-get-request-no-source
             MultiGetItemResponse item = unwrapAndAssertExample(client.mget(request, RequestOptions.DEFAULT));
@@ -1880,7 +1880,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             String[] excludes = Strings.EMPTY_ARRAY;
             FetchSourceContext fetchSourceContext =
                     new FetchSourceContext(true, includes, excludes);
-            request.add(new MultiGetRequest.Item("index", "type", "example_id")
+            request.add(new MultiGetRequest.Item("index", "_doc", "example_id")
                 .fetchSourceContext(fetchSourceContext));  // <1>
             // end::multi-get-request-source-include
             MultiGetItemResponse item = unwrapAndAssertExample(client.mget(request, RequestOptions.DEFAULT));
@@ -1895,7 +1895,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             String[] excludes = new String[] {"foo", "*r"};
             FetchSourceContext fetchSourceContext =
                     new FetchSourceContext(true, includes, excludes);
-            request.add(new MultiGetRequest.Item("index", "type", "example_id")
+            request.add(new MultiGetRequest.Item("index", "_doc", "example_id")
                 .fetchSourceContext(fetchSourceContext));  // <1>
             // end::multi-get-request-source-exclude
             MultiGetItemResponse item = unwrapAndAssertExample(client.mget(request, RequestOptions.DEFAULT));
@@ -1906,7 +1906,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         {
             MultiGetRequest request = new MultiGetRequest();
             // tag::multi-get-request-stored
-            request.add(new MultiGetRequest.Item("index", "type", "example_id")
+            request.add(new MultiGetRequest.Item("index", "_doc", "example_id")
                 .storedFields("foo"));  // <1>
             MultiGetResponse response = client.mget(request, RequestOptions.DEFAULT);
             MultiGetItemResponse item = response.getResponses()[0];
@@ -1918,7 +1918,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         {
             // tag::multi-get-conflict
             MultiGetRequest request = new MultiGetRequest();
-            request.add(new MultiGetRequest.Item("index", "type", "example_id")
+            request.add(new MultiGetRequest.Item("index", "_doc", "example_id")
                 .version(1000L));
             MultiGetResponse response = client.mget(request, RequestOptions.DEFAULT);
             MultiGetItemResponse item = response.getResponses()[0];
@@ -1939,7 +1939,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         assertThat(response.getResponses(), arrayWithSize(1));
         MultiGetItemResponse item = response.getResponses()[0];
         assertEquals("index", item.getIndex());
-        assertEquals("type", item.getType());
+        assertEquals("_doc", item.getType());
         assertEquals("example_id", item.getId());
         return item;
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
@@ -563,8 +563,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             // tag::delete-request
             DeleteRequest request = new DeleteRequest(
                     "posts",    // <1>
-                    "_doc",      // <2>
-                    "1");       // <3>
+                    "1");       // <2>
             // end::delete-request
 
             // tag::delete-execute
@@ -575,7 +574,6 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
 
             // tag::delete-response
             String index = deleteResponse.getIndex();
-            String type = deleteResponse.getType();
             String id = deleteResponse.getId();
             long version = deleteResponse.getVersion();
             ReplicationResponse.ShardInfo shardInfo = deleteResponse.getShardInfo();
@@ -592,7 +590,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         }
 
         {
-            DeleteRequest request = new DeleteRequest("posts", "_doc", "1");
+            DeleteRequest request = new DeleteRequest("posts", "1");
             // tag::delete-request-routing
             request.routing("routing"); // <1>
             // end::delete-request-routing
@@ -614,7 +612,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
 
         {
             // tag::delete-notfound
-            DeleteRequest request = new DeleteRequest("posts", "_doc", "does_not_exist");
+            DeleteRequest request = new DeleteRequest("posts", "does_not_exist");
             DeleteResponse deleteResponse = client.delete(
                     request, RequestOptions.DEFAULT);
             if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
@@ -631,7 +629,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             // tag::delete-conflict
             try {
                 DeleteResponse deleteResponse = client.delete(
-                        new DeleteRequest("posts", "_doc", "1").version(2),
+                        new DeleteRequest("posts", "1").version(2),
                         RequestOptions.DEFAULT);
             } catch (ElasticsearchException exception) {
                 if (exception.status() == RestStatus.CONFLICT) {
@@ -645,7 +643,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
                     RequestOptions.DEFAULT);
             assertSame(RestStatus.CREATED, indexResponse.status());
 
-            DeleteRequest request = new DeleteRequest("posts", "_doc", "async");
+            DeleteRequest request = new DeleteRequest("posts", "async");
 
             ActionListener<DeleteResponse> listener;
             // tag::delete-execute-listener
@@ -696,7 +694,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
         {
             // tag::bulk-request-with-mixed-operations
             BulkRequest request = new BulkRequest();
-            request.add(new DeleteRequest("posts", "_doc", "3")); // <1>
+            request.add(new DeleteRequest("posts", "3")); // <1>
             request.add(new UpdateRequest("posts", "_doc", "2") // <2>
                     .doc(XContentType.JSON,"other", "test"));
             request.add(new IndexRequest("posts", "_doc", "4")  // <3>

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MigrationDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MigrationDocumentationIT.java
@@ -82,7 +82,7 @@ public class MigrationDocumentationIT extends ESRestHighLevelClientTestCase {
         RestHighLevelClient client = highLevelClient();
         {
             //tag::migration-request-ctor
-            IndexRequest request = new IndexRequest("index", "doc", "id"); // <1>
+            IndexRequest request = new IndexRequest("index", "_doc", "id"); // <1>
             request.source("{\"field\":\"value\"}", XContentType.JSON);
             //end::migration-request-ctor
 
@@ -93,7 +93,7 @@ public class MigrationDocumentationIT extends ESRestHighLevelClientTestCase {
         }
         {
             //tag::migration-request-async-execution
-            DeleteRequest request = new DeleteRequest("index", "doc", "id"); // <1>
+            DeleteRequest request = new DeleteRequest("index", "id"); // <1>
             client.deleteAsync(request, RequestOptions.DEFAULT, new ActionListener<DeleteResponse>() { // <2>
                 @Override
                 public void onResponse(DeleteResponse deleteResponse) {
@@ -106,11 +106,11 @@ public class MigrationDocumentationIT extends ESRestHighLevelClientTestCase {
                 }
             });
             //end::migration-request-async-execution
-            assertBusy(() -> assertFalse(client.exists(new GetRequest("index", "doc", "id"), RequestOptions.DEFAULT)));
+            assertBusy(() -> assertFalse(client.exists(new GetRequest("index", "_doc", "id"), RequestOptions.DEFAULT)));
         }
         {
             //tag::migration-request-sync-execution
-            DeleteRequest request = new DeleteRequest("index", "doc", "id");
+            DeleteRequest request = new DeleteRequest("index", "id");
             DeleteResponse response = client.delete(request, RequestOptions.DEFAULT); // <1>
             //end::migration-request-sync-execution
             assertEquals(RestStatus.NOT_FOUND, response.status());

--- a/docs/java-rest/high-level/document/delete.asciidoc
+++ b/docs/java-rest/high-level/document/delete.asciidoc
@@ -10,15 +10,14 @@
 [id="{upid}-{api}-request"]
 ==== Delete Request
 
-A +{request}+ has no arguments
+A +{request}+ has two required arguments:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Index
-<2> Type
-<3> Document id
+<2> Document id
 
 ==== Optional arguments
 The following arguments can optionally be provided:

--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -1,9 +1,9 @@
 [[docs-delete]]
 == Delete API
 
-The delete API allows to delete a typed JSON document from a specific
+The delete API allows to delete a JSON document from a specific
 index based on its id. The following example deletes the JSON document
-from an index called `twitter`, under a type called `_doc`, with id `1`:
+from an index called `twitter` with ID `1`:
 
 [source,js]
 --------------------------------------------------
@@ -92,10 +92,7 @@ the request.
 If an <<docs-index_,external versioning variant>> is used,
 the delete operation automatically creates an index if it has not been
 created before (check out the <<indices-create-index,create index API>>
-for manually creating an index), and also automatically creates a
-dynamic type mapping for the specific type if it has not been created
-before (check out the <<indices-put-mapping,put mapping>>
-API for manually creating type mapping).
+for manually creating an index).
 
 [float]
 [[delete-distributed]]

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -129,13 +129,13 @@ public class IndexingIT extends AbstractRollingTestCase {
 
         if (CLUSTER_TYPE != ClusterType.OLD) {
             bulk("test_index", "_" + CLUSTER_TYPE, 5);
-            Request toBeDeleted = new Request("PUT", "/test_index/doc/to_be_deleted");
+            Request toBeDeleted = new Request("PUT", "/test_index/_doc/to_be_deleted");
             toBeDeleted.addParameter("refresh", "true");
             toBeDeleted.setJsonEntity("{\"f1\": \"delete-me\"}");
             client().performRequest(toBeDeleted);
             assertCount("test_index", expectedCount + 6);
 
-            Request delete = new Request("DELETE", "/test_index/doc/to_be_deleted");
+            Request delete = new Request("DELETE", "/test_index/_doc/to_be_deleted");
             delete.addParameter("refresh", "true");
             client().performRequest(delete);
 
@@ -146,7 +146,7 @@ public class IndexingIT extends AbstractRollingTestCase {
     private void bulk(String index, String valueSuffix, int count) throws IOException {
         StringBuilder b = new StringBuilder();
         for (int i = 0; i < count; i++) {
-            b.append("{\"index\": {\"_index\": \"").append(index).append("\", \"_type\": \"doc\"}}\n");
+            b.append("{\"index\": {\"_index\": \"").append(index).append("\", \"_type\": \"_doc\"}}\n");
             b.append("{\"f1\": \"v").append(i).append(valueSuffix).append("\", \"f2\": ").append(i).append("}\n");
         }
         Request bulk = new Request("POST", "/_bulk");

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
@@ -3,7 +3,7 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html",
     "methods": ["DELETE"],
     "url": {
-      "path": "/{index}/{type}/{id}",
+      "path": "/{index}/_doc/{id}",
       "paths": ["/{index}/{type}/{id}", "/{index}/_doc/{id}"],
       "parts": {
         "id": {

--- a/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -156,7 +156,10 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
 
     /**
      * The type of the document changed.
+     *
+     * @deprecated Types are in the process of being removed.
      */
+    @Deprecated
     public String getType() {
         return this.type;
     }

--- a/server/src/main/java/org/elasticsearch/action/delete/DeleteRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/delete/DeleteRequest.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
@@ -50,7 +51,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public class DeleteRequest extends ReplicatedWriteRequest<DeleteRequest>
         implements DocWriteRequest<DeleteRequest>, CompositeIndicesRequest {
 
-    private String type;
+    private String type = MapperService.SINGLE_MAPPING_NAME;
     private String id;
     @Nullable
     private String routing;
@@ -74,10 +75,24 @@ public class DeleteRequest extends ReplicatedWriteRequest<DeleteRequest>
      * @param index The index to get the document from
      * @param type  The type of the document
      * @param id    The id of the document
+     *
+     * @deprecated Types are in the process of being removed. Use {@link #DeleteRequest(String, String)} instead.
      */
+    @Deprecated
     public DeleteRequest(String index, String type, String id) {
         this.index = index;
         this.type = type;
+        this.id = id;
+    }
+
+    /**
+     * Constructs a new delete request against the specified index and id.
+     *
+     * @param index The index to get the document from
+     * @param id    The id of the document
+     */
+    public DeleteRequest(String index, String id) {
+        this.index = index;
         this.id = id;
     }
 
@@ -102,7 +117,10 @@ public class DeleteRequest extends ReplicatedWriteRequest<DeleteRequest>
 
     /**
      * The type of the document to delete.
+     *
+     * @deprecated Types are in the process of being removed.
      */
+    @Deprecated
     @Override
     public String type() {
         return type;
@@ -110,7 +128,10 @@ public class DeleteRequest extends ReplicatedWriteRequest<DeleteRequest>
 
     /**
      * Sets the type of the document to delete.
+     *
+     * @deprecated Types are in the process of being removed.
      */
+    @Deprecated
     @Override
     public DeleteRequest type(String type) {
         this.type = type;

--- a/server/src/main/java/org/elasticsearch/action/get/GetResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/get/GetResponse.java
@@ -149,7 +149,6 @@ public class GetResponse extends ActionResponse implements Iterable<DocumentFiel
      * @deprecated Use {@link GetResponse#getSource()} instead
      */
     @Deprecated
-    @Override
     public Iterator<DocumentField> iterator() {
         return getResult.iterator();
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestDeleteAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestDeleteAction.java
@@ -19,11 +19,14 @@
 
 package org.elasticsearch.rest.action.document;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -35,6 +38,11 @@ import java.io.IOException;
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 
 public class RestDeleteAction extends BaseRestHandler {
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
+        LogManager.getLogger(RestDeleteAction.class));
+    static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in " +
+        "document index requests is deprecated, use the /{index}/_doc/{id} endpoint instead.";
+
     public RestDeleteAction(Settings settings, RestController controller) {
         super(settings);
         controller.registerHandler(DELETE, "/{index}/{type}/{id}", this);
@@ -47,9 +55,12 @@ public class RestDeleteAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        DeleteRequest deleteRequest = new DeleteRequest(request.param("index"),
-            request.param("type"),
-            request.param("id"));
+        String type = request.param("type");
+        if (!type.equals(MapperService.SINGLE_MAPPING_NAME)) {
+            deprecationLogger.deprecated(TYPES_DEPRECATION_MESSAGE);
+        }
+
+        DeleteRequest deleteRequest = new DeleteRequest(request.param("index"), type, request.param("id"));
         deleteRequest.routing(request.param("routing"));
         deleteRequest.timeout(request.paramAsTime("timeout", DeleteRequest.DEFAULT_TIMEOUT));
         deleteRequest.setRefreshPolicy(request.param("refresh"));

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestDeleteActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestDeleteActionTests.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.document;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestRequest.Method;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestChannel;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.usage.UsageService;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+
+public class RestDeleteActionTests extends ESTestCase {
+    private RestController controller;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        controller = new RestController(Collections.emptySet(), null,
+            mock(NodeClient.class),
+            new NoneCircuitBreakerService(),
+            new UsageService());
+        new RestDeleteAction(Settings.EMPTY, controller);
+    }
+
+    public void testTypeInPath() {
+        RestRequest deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(Method.DELETE)
+            .withPath("/some_index/some_type/some_id")
+            .build();
+        performRequest(deprecatedRequest);
+        assertWarnings(RestDeleteAction.TYPES_DEPRECATION_MESSAGE);
+
+        RestRequest validRequest = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(Method.DELETE)
+            .withPath("/some_index/_doc/some_id")
+            .build();
+        performRequest(validRequest);
+    }
+
+    private void performRequest(RestRequest request) {
+        RestChannel channel = new FakeRestChannel(request, false, 1);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        controller.dispatchRequest(request, channel, threadContext);
+    }
+}

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -114,13 +114,13 @@ public class IndexingIT extends AbstractUpgradeTestCase {
 
         if (CLUSTER_TYPE != ClusterType.OLD) {
             bulk("test_index", "_" + CLUSTER_TYPE, 5);
-            Request toBeDeleted = new Request("PUT", "/test_index/doc/to_be_deleted");
+            Request toBeDeleted = new Request("PUT", "/test_index/_doc/to_be_deleted");
             toBeDeleted.addParameter("refresh", "true");
             toBeDeleted.setJsonEntity("{\"f1\": \"delete-me\"}");
             client().performRequest(toBeDeleted);
             assertCount("test_index", expectedCount + 6);
 
-            Request delete = new Request("DELETE", "/test_index/doc/to_be_deleted");
+            Request delete = new Request("DELETE", "/test_index/_doc/to_be_deleted");
             delete.addParameter("refresh", "true");
             client().performRequest(delete);
 
@@ -131,7 +131,7 @@ public class IndexingIT extends AbstractUpgradeTestCase {
     private void bulk(String index, String valueSuffix, int count) throws IOException {
         StringBuilder b = new StringBuilder();
         for (int i = 0; i < count; i++) {
-            b.append("{\"index\": {\"_index\": \"").append(index).append("\", \"_type\": \"doc\"}}\n");
+            b.append("{\"index\": {\"_index\": \"").append(index).append("\", \"_type\": \"_doc\"}}\n");
             b.append("{\"f1\": \"v").append(i).append(valueSuffix).append("\", \"f2\": ").append(i).append("}\n");
         }
         Request bulk = new Request("POST", "/_bulk");


### PR DESCRIPTION
The following updates were made:
- Add deprecation warnings to `RestDeleteAction`, plus a test in `RestDeleteActionTests`.
- Deprecate relevant methods on the Java HLRC requests/ responses.
- Update documentation (for both the REST API and Java HLRC).

Because of an earlier PR, the REST yml tests were already updated (one version without types, and another legacy version that retains types).
