### PR TITLE
 Introduce `TransportLogger` for common logging

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/ESLoggingHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/ESLoggingHandler.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.transport.netty4;
 
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 
@@ -28,4 +29,9 @@ final class ESLoggingHandler extends LoggingHandler {
         super(LogLevel.TRACE);
     }
 
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        // We do not want to log read complete events because we log inbound messages in the TcpTransport.
+        ctx.fireChannelReadComplete();
+    }
 }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
@@ -156,5 +156,4 @@ public class Netty4Utils {
             throw closingExceptions;
         }
     }
-
 }

--- a/plugins/transport-nio/src/test/java/org/elasticsearch/transport/nio/NioTransportLoggingIT.java
+++ b/plugins/transport-nio/src/test/java/org/elasticsearch/transport/nio/NioTransportLoggingIT.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport.nio;
+
+import org.apache.logging.log4j.Level;
+import org.elasticsearch.NioIntegTestCase;
+import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsRequest;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.transport.TransportLogger;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 2)
+@TestLogging(value = "org.elasticsearch.transport.TransportLogger:trace")
+public class NioTransportLoggingIT extends NioIntegTestCase {
+
+    private MockLogAppender appender;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        appender = new MockLogAppender();
+        Loggers.addAppender(Loggers.getLogger(TransportLogger.class), appender);
+        appender.start();
+    }
+
+    public void tearDown() throws Exception {
+        Loggers.removeAppender(Loggers.getLogger(TransportLogger.class), appender);
+        appender.stop();
+        super.tearDown();
+    }
+
+    public void testLoggingHandler() throws IllegalAccessException {
+        final String writePattern =
+                ".*\\[length: \\d+" +
+                        ", request id: \\d+" +
+                        ", type: request" +
+                        ", version: .*" +
+                        ", action: cluster:monitor/nodes/hot_threads\\[n\\]\\]" +
+                        " WRITE: \\d+B";
+        final MockLogAppender.LoggingExpectation writeExpectation =
+                new MockLogAppender.PatternSeenEventExcpectation(
+                        "hot threads request", TransportLogger.class.getCanonicalName(), Level.TRACE, writePattern);
+
+        final String readPattern =
+                ".*\\[length: \\d+" +
+                        ", request id: \\d+" +
+                        ", type: request" +
+                        ", version: .*" +
+                        ", action: cluster:monitor/nodes/hot_threads\\[n\\]\\]" +
+                        " READ: \\d+B";
+
+        final MockLogAppender.LoggingExpectation readExpectation =
+                new MockLogAppender.PatternSeenEventExcpectation(
+                        "hot threads request", TransportLogger.class.getCanonicalName(), Level.TRACE, readPattern);
+
+        appender.addExpectation(writeExpectation);
+        appender.addExpectation(readExpectation);
+        client().admin().cluster().nodesHotThreads(new NodesHotThreadsRequest()).actionGet();
+        appender.assertAllExpectationsMatched();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/TransportLogger.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportLogger.java
@@ -19,13 +19,13 @@
 package org.elasticsearch.transport;
 
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.Compressor;
 import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.compress.NotCompressedException;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.internal.io.IOUtils;
@@ -34,12 +34,8 @@ import java.io.IOException;
 
 public final class TransportLogger {
 
-    private final Logger logger;
+    private static final Logger logger = LogManager.getLogger(TransportLogger.class);
     private static final int HEADER_SIZE = TcpHeader.MARKER_BYTES_SIZE + TcpHeader.MESSAGE_LENGTH_SIZE;
-
-    TransportLogger(Settings settings) {
-        logger = Loggers.getLogger(TransportLogger.class, settings);
-    }
 
     void logInboundMessage(TcpChannel channel, BytesReference message) {
         if (logger.isTraceEnabled()) {

--- a/server/src/main/java/org/elasticsearch/transport/TransportLogger.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportLogger.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.transport;
+
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.compress.Compressor;
+import org.elasticsearch.common.compress.CompressorFactory;
+import org.elasticsearch.common.compress.NotCompressedException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.internal.io.IOUtils;
+
+import java.io.IOException;
+
+public final class TransportLogger {
+
+    private final Logger logger;
+    private static final int HEADER_SIZE = TcpHeader.MARKER_BYTES_SIZE + TcpHeader.MESSAGE_LENGTH_SIZE;
+
+    TransportLogger(Settings settings) {
+        logger = Loggers.getLogger(TransportLogger.class, settings);
+    }
+
+    void logInboundMessage(TcpChannel channel, BytesReference message) {
+        if (logger.isTraceEnabled()) {
+            try {
+                String logMessage = format(channel, message, "READ");
+                logger.trace(logMessage);
+            } catch (IOException e) {
+                logger.trace("an exception occurred formatting a READ trace message", e);
+            }
+        }
+    }
+
+    void logOutboundMessage(TcpChannel channel, BytesReference message) {
+        if (logger.isTraceEnabled()) {
+            try {
+                BytesReference withoutHeader = message.slice(HEADER_SIZE, message.length() - HEADER_SIZE);
+                String logMessage = format(channel, withoutHeader, "WRITE");
+                logger.trace(logMessage);
+            } catch (IOException e) {
+                logger.trace("an exception occurred formatting a WRITE trace message", e);
+            }
+        }
+    }
+
+    private String format(TcpChannel channel, BytesReference message, String event) throws IOException {
+        final StringBuilder sb = new StringBuilder();
+        sb.append(channel);
+        int messageLengthWithHeader = HEADER_SIZE + message.length();
+        // This is a ping
+        if (message.length() == 0) {
+            sb.append(" [ping]").append(' ').append(event).append(": ").append(messageLengthWithHeader).append('B');
+        } else {
+            boolean success = false;
+            StreamInput streamInput = message.streamInput();
+            try {
+                final long requestId = streamInput.readLong();
+                final byte status = streamInput.readByte();
+                final boolean isRequest = TransportStatus.isRequest(status);
+                final String type = isRequest ? "request" : "response";
+                final String version = Version.fromId(streamInput.readInt()).toString();
+                sb.append(" [length: ").append(messageLengthWithHeader);
+                sb.append(", request id: ").append(requestId);
+                sb.append(", type: ").append(type);
+                sb.append(", version: ").append(version);
+
+                if (isRequest) {
+                    if (TransportStatus.isCompress(status)) {
+                        Compressor compressor;
+                        try {
+                            final int bytesConsumed = TcpHeader.REQUEST_ID_SIZE + TcpHeader.STATUS_SIZE + TcpHeader.VERSION_ID_SIZE;
+                            compressor = CompressorFactory.compressor(message.slice(bytesConsumed, message.length() - bytesConsumed));
+                        } catch (NotCompressedException ex) {
+                            throw new IllegalStateException(ex);
+                        }
+                        streamInput = compressor.streamInput(streamInput);
+                    }
+
+                    try (ThreadContext context = new ThreadContext(Settings.EMPTY)) {
+                        context.readHeaders(streamInput);
+                    }
+                    // now we decode the features
+                    if (streamInput.getVersion().onOrAfter(Version.V_6_3_0)) {
+                        streamInput.readStringArray();
+                    }
+                    sb.append(", action: ").append(streamInput.readString());
+                }
+                sb.append(']');
+                sb.append(' ').append(event).append(": ").append(messageLengthWithHeader).append('B');
+                success = true;
+            } finally {
+                if (success) {
+                    IOUtils.close(streamInput);
+                } else {
+                    IOUtils.closeWhileHandlingException(streamInput);
+                }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.transport;
 
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.stats.ClusterStatsAction;
 import org.elasticsearch.action.admin.cluster.stats.ClusterStatsRequest;
@@ -44,18 +45,18 @@ public class TransportLoggerTests extends ESTestCase {
     public void setUp() throws Exception {
         super.setUp();
         appender = new MockLogAppender();
-        Loggers.addAppender(Loggers.getLogger(TransportLogger.class), appender);
+        Loggers.addAppender(LogManager.getLogger(TransportLogger.class), appender);
         appender.start();
     }
 
     public void tearDown() throws Exception {
-        Loggers.removeAppender(Loggers.getLogger(TransportLogger.class), appender);
+        Loggers.removeAppender(LogManager.getLogger(TransportLogger.class), appender);
         appender.stop();
         super.tearDown();
     }
 
     public void testLoggingHandler() throws IOException {
-        TransportLogger transportLogger = new TransportLogger(Settings.EMPTY);
+        TransportLogger transportLogger = new TransportLogger();
 
         final String writePattern =
             ".*\\[length: \\d+" +

--- a/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.transport;
+
+import org.apache.logging.log4j.Level;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.stats.ClusterStatsAction;
+import org.elasticsearch.action.admin.cluster.stats.ClusterStatsRequest;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.CompositeBytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+
+@TestLogging(value = "org.elasticsearch.transport.TransportLogger:trace")
+public class TransportLoggerTests extends ESTestCase {
+
+    private MockLogAppender appender;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        appender = new MockLogAppender();
+        Loggers.addAppender(Loggers.getLogger(TransportLogger.class), appender);
+        appender.start();
+    }
+
+    public void tearDown() throws Exception {
+        Loggers.removeAppender(Loggers.getLogger(TransportLogger.class), appender);
+        appender.stop();
+        super.tearDown();
+    }
+
+    public void testLoggingHandler() throws IOException {
+        TransportLogger transportLogger = new TransportLogger(Settings.EMPTY);
+
+        final String writePattern =
+            ".*\\[length: \\d+" +
+                ", request id: \\d+" +
+                ", type: request" +
+                ", version: .*" +
+                ", action: cluster:monitor/stats]" +
+                " WRITE: \\d+B";
+        final MockLogAppender.LoggingExpectation writeExpectation =
+            new MockLogAppender.PatternSeenEventExcpectation(
+                "hot threads request", TransportLogger.class.getCanonicalName(), Level.TRACE, writePattern);
+
+        final String readPattern =
+            ".*\\[length: \\d+" +
+                ", request id: \\d+" +
+                ", type: request" +
+                ", version: .*" +
+                ", action: cluster:monitor/stats]" +
+                " READ: \\d+B";
+
+        final MockLogAppender.LoggingExpectation readExpectation =
+            new MockLogAppender.PatternSeenEventExcpectation(
+                "cluster monitor request", TransportLogger.class.getCanonicalName(), Level.TRACE, readPattern);
+
+        appender.addExpectation(writeExpectation);
+        appender.addExpectation(readExpectation);
+        BytesReference bytesReference = buildRequest();
+        transportLogger.logInboundMessage(mock(TcpChannel.class), bytesReference.slice(6, bytesReference.length() - 6));
+        transportLogger.logOutboundMessage(mock(TcpChannel.class), bytesReference);
+        appender.assertAllExpectationsMatched();
+    }
+
+    private BytesReference buildRequest() throws IOException {
+        try (BytesStreamOutput messageOutput = new BytesStreamOutput()) {
+            messageOutput.setVersion(Version.CURRENT);
+            try (ThreadContext context = new ThreadContext(Settings.EMPTY)) {
+                context.writeTo(messageOutput);
+            }
+            messageOutput.writeStringArray(new String[0]);
+            messageOutput.writeString(ClusterStatsAction.NAME);
+            new ClusterStatsRequest().writeTo(messageOutput);
+            BytesReference messageBody = messageOutput.bytes();
+            final BytesReference header = buildHeader(randomInt(30), messageBody.length());
+            return new CompositeBytesReference(header, messageBody);
+        }
+    }
+
+    private BytesReference buildHeader(long requestId, int length) throws IOException {
+        try (BytesStreamOutput headerOutput = new BytesStreamOutput(TcpHeader.HEADER_SIZE)) {
+            headerOutput.setVersion(Version.CURRENT);
+            TcpHeader.writeHeader(headerOutput, requestId, TransportStatus.setRequest((byte) 0), Version.CURRENT, length);
+            final BytesReference bytes = headerOutput.bytes();
+            assert bytes.length() == TcpHeader.HEADER_SIZE : "header size mismatch expected: " + TcpHeader.HEADER_SIZE + " but was: "
+                + bytes.length();
+            return bytes;
+        }
+    }
+}


### PR DESCRIPTION
Historically we have had a ESLoggingHandler in the netty module that
logs low-level connection operations. This class just extends the netty
logging handler with some (broken) message deserialization. This commit
fixes this message serialization and moves the class to server.

This new logger logs inbound and outbound messages. Eventually, we
should move other event logging to this class (connect, close, flush).
That way we will have consistent logging regards of which transport is
loaded.