### PR TITLE
Warn in multi-search on unknown keys in metadata

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -2067,6 +2067,8 @@ public class RestHighLevelClient implements Closeable {
         public void usedDeprecatedName(String usedName, String modernName) {}
         @Override
         public void usedDeprecatedField(String usedName, String replacedWith) {}
+        @Override
+        public void deprecated(String message, Object... params) {}
     };
 
     static List<NamedXContentRegistry.Entry> getDefaultNamedXContents() {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/RuleScope.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/RuleScope.java
@@ -66,6 +66,10 @@ public class RuleScope implements ToXContentObject {
 
         @Override
         public void usedDeprecatedField(String usedName, String replacedWith) {}
+
+        @Override
+        public void deprecated(String message, Object... params) {}
+
     };
 
     private final Map<String, FilterRef> scope;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/DeleteRoleMappingResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/DeleteRoleMappingResponseTests.java
@@ -43,6 +43,10 @@ public class DeleteRoleMappingResponseTests extends ESTestCase {
                     @Override
                     public void usedDeprecatedField(String usedName, String replacedWith) {
                     }
+
+                    @Override
+                    public void deprecated(String message, Object... params) {
+                    }
                 }, json));
         final DeleteRoleMappingResponse expectedResponse = new DeleteRoleMappingResponse(true);
         assertThat(response, equalTo(expectedResponse));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/ExpressionRoleMappingTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/ExpressionRoleMappingTests.java
@@ -58,6 +58,10 @@ public class ExpressionRoleMappingTests extends ESTestCase {
                     @Override
                     public void usedDeprecatedField(String usedName, String replacedWith) {
                     }
+
+                    @Override
+                    public void deprecated(String message, Object... params) {
+                    }
                 }, json), "example-role-mapping");
         final ExpressionRoleMapping expectedRoleMapping = new ExpressionRoleMapping("example-role-mapping", FieldRoleMapperExpression
                 .ofKeyValues("realm.name", "kerb1"), Collections.singletonList("superuser"), null, true);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/GetPrivilegesResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/GetPrivilegesResponseTests.java
@@ -88,6 +88,10 @@ public class GetPrivilegesResponseTests extends ESTestCase {
                 @Override
                 public void usedDeprecatedField(String usedName, String replacedWith) {
                 }
+
+                @Override
+                public void deprecated(String message, Object... params) {
+                }
             }, json));
 
         final ApplicationPrivilege readTestappPrivilege =

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/GetRoleMappingsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/GetRoleMappingsResponseTests.java
@@ -71,6 +71,10 @@ public class GetRoleMappingsResponseTests extends ESTestCase {
                     @Override
                     public void usedDeprecatedField(String usedName, String replacedWith) {
                     }
+
+                    @Override
+                    public void deprecated(String message, Object... params) {
+                    }
                 }, json));
         final List<ExpressionRoleMapping> expectedRoleMappingsList = new ArrayList<>();
         expectedRoleMappingsList.add(new ExpressionRoleMapping("kerberosmapping", FieldRoleMapperExpression.ofKeyValues("realm.name",

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/GetRolesResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/GetRolesResponseTests.java
@@ -71,6 +71,10 @@ public class GetRolesResponseTests extends ESTestCase {
                 @Override
                 public void usedDeprecatedField(String usedName, String replacedWith) {
                 }
+
+                @Override
+                public void deprecated(String message, Object... params) {
+                }
             }, json)));
         assertThat(response.getRoles().size(), equalTo(1));
         final Role role = response.getRoles().get(0);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/support/expressiondsl/parser/RoleMapperExpressionParserTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/support/expressiondsl/parser/RoleMapperExpressionParserTests.java
@@ -123,7 +123,11 @@ public class RoleMapperExpressionParserTests extends ESTestCase {
                     @Override
                     public void usedDeprecatedField(String usedName, String replacedWith) {
                     }
-                }, json));
+
+                    @Override
+                    public void deprecated(String message, Object... params) {
+                    }
+        }, json));
     }
 
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/user/privileges/ApplicationPrivilegeTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/user/privileges/ApplicationPrivilegeTests.java
@@ -58,6 +58,10 @@ public class ApplicationPrivilegeTests extends ESTestCase {
                 @Override
                 public void usedDeprecatedField(String usedName, String replacedWith) {
                 }
+
+                @Override
+                public void deprecated(String message, Object... params) {
+                }
             }, json));
         final Map<String, Object> metadata = new HashMap<>();
         metadata.put("description", "Read access to myapp");

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/DeprecationHandler.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/DeprecationHandler.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.common.xcontent;
 
+import java.util.Arrays;
+
 /**
  * Callback for notifying the creator of the {@link XContentParser} that
  * parsing hit a deprecated field.
@@ -41,6 +43,12 @@ public interface DeprecationHandler {
             throw new UnsupportedOperationException("deprecated fields not supported here but got ["
                 + usedName + "] which has been replaced with [" + modernName + "]");
         }
+
+        @Override
+        public void deprecated(String message, Object... params) {
+            throw new UnsupportedOperationException(
+                    "deprecations are not supported here but got [" + message + "] and " + Arrays.toString(params));
+        }
     };
 
     /**
@@ -57,4 +65,7 @@ public interface DeprecationHandler {
      * @param replacedWith the name of the field that replaced this field
      */
     void usedDeprecatedField(String usedName, String replacedWith);
+
+    void deprecated(String message, Object... params);
+
 }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/LoggingDeprecationHandler.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/LoggingDeprecationHandler.java
@@ -57,4 +57,10 @@ public class LoggingDeprecationHandler implements DeprecationHandler {
     public void usedDeprecatedField(String usedName, String replacedWith) {
         DEPRECATION_LOGGER.deprecated("Deprecated field [{}] used, replaced by [{}]", usedName, replacedWith);
     }
+
+    @Override
+    public void deprecated(final String message, final Object... params) {
+        DEPRECATION_LOGGER.deprecated(message, params);
+    }
+
 }

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -90,6 +90,15 @@ public class MultiSearchRequestTests extends ESTestCase {
         assertThat(request.requests().get(7).types().length, equalTo(0));
     }
 
+    public void testWarnWithUnknownKey() throws IOException {
+        final String requestContent = "{\"index\":\"test\", \"ignore_unavailable\" : true, \"unknown_key\" : \"open,closed\"}}\r\n" +
+                "{\"query\" : {\"match_all\" :{}}}\r\n";
+        final FakeRestRequest restRequest =
+                new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(requestContent), XContentType.JSON).build();
+        RestMultiSearchAction.parseRequest(restRequest, true);
+        assertWarnings("key [unknown_key] is not supported in the metadata section and will be rejected in 7.x");
+    }
+
     public void testSimpleAddWithCarriageReturn() throws Exception {
         final String requestContent = "{\"index\":\"test\", \"ignore_unavailable\" : true, \"expand_wildcards\" : \"open,closed\"}}\r\n" +
             "{\"query\" : {\"match_all\" :{}}}\r\n";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/LoggingDeprecationAccumulationHandler.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/LoggingDeprecationAccumulationHandler.java
@@ -41,6 +41,13 @@ public class LoggingDeprecationAccumulationHandler implements DeprecationHandler
             replacedWith));
     }
 
+    @Override
+    public void deprecated(final String message, final Object... params) {
+        final String formattedMessage = LoggerMessageFormat.format(message, params);
+        LoggingDeprecationHandler.INSTANCE.deprecated(formattedMessage);
+        deprecations.add(formattedMessage);
+    }
+
     /**
      * The collected deprecation warnings
      */


### PR DESCRIPTION
In the metadata section for each request in a multi-search request, we allow for only certain keys to be recognized and parsed. However, the parsing here is silently lenient, so that unknown keys can go undetected. In 7.x we will reject such keys. This commit deprecates this lenient behavior in 6.x to avoid surprising users when they upgrade.

Relates #35938

