### PR TITLE
Fix smb-docker fixture when runnig with aufs

### DIFF
--- a/x-pack/test/smb-fixture/src/main/resources/provision/installsmb.sh
+++ b/x-pack/test/smb-fixture/src/main/resources/provision/installsmb.sh
@@ -21,7 +21,7 @@ cat $SSL_DIR/ca.pem >> /etc/ssl/certs/ca-certificates.crt
 
 mv /etc/samba/smb.conf /etc/samba/smb.conf.orig
 
-samba-tool domain provision --server-role=dc --use-rfc2307 --dns-backend=SAMBA_INTERNAL --realm=AD.TEST.ELASTICSEARCH.COM --domain=ADES --adminpass=Passw0rd
+samba-tool domain provision --server-role=dc --use-rfc2307 --dns-backend=SAMBA_INTERNAL --realm=AD.TEST.ELASTICSEARCH.COM --domain=ADES --adminpass=Passw0rd --use-ntvfs
 
 cp /var/lib/samba/private/krb5.conf /etc/krb5.conf
 


### PR DESCRIPTION
Closes #36073

The problem showed up on debian 8 which uses `aufs` docker storage
driver by default as opposed to `overlay2` used on other distros.
`aufs` does not support acls and thus the failure.
The `--use-ntvfs` option instructs samba not to rely on acls.
From what I can tell this is an implementation detail that should not
affect the tests ( which continue to pass )
