### PR TITLE
Testing conventions task part 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -639,5 +639,20 @@ allprojects {
 }
 
 
+if (gradle.startParameter.taskNames.contains("check")) {
+  gradle.taskGraph.whenReady { tg ->
+    allprojects { project ->
+      tasks.withType(RandomizedTestingTask.class) { each ->
+        if (tg.hasTask(each) == false) {
+          throw new IllegalStateException(
+                  "Found that ${project.path}:check does not depend on testing task:${each.path}"
+          )
+        }
+      }
+    }
+  }
+}
+
+
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -639,20 +639,4 @@ allprojects {
 }
 
 
-if (gradle.startParameter.taskNames.contains("check")) {
-  gradle.taskGraph.whenReady { tg ->
-    allprojects { project ->
-      tasks.withType(RandomizedTestingTask.class) { each ->
-        if (tg.hasTask(each) == false) {
-          throw new IllegalStateException(
-                  "Found that ${project.path}:check does not depend on testing task:${each.path}"
-          )
-        }
-      }
-    }
-  }
-}
-
-
-
 

--- a/build.gradle
+++ b/build.gradle
@@ -640,3 +640,4 @@ allprojects {
 
 
 
+

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -174,12 +174,11 @@ if (project != rootProject) {
   jarHell.enabled = false
   thirdPartyAudit.enabled = false
 
-  // tests can't  be run with randomized test runner
-  // it's fine as we run them as part of :buildSrc
   test {
     include "**/*Tests.class"
     exclude "**/*IT.class"
   }
+
   // This can't be an RandomizedTestingTask because we can't yet reference it
   task integTest(type: Test) {
     // integration test requires the local testing repo for example plugin builds

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -147,10 +147,8 @@ if (project == rootProject) {
       mavenLocal()
     }
   }
-  test {
-    include "**/*Tests.class"
-    exclude "**/*IT.class"
-  }
+  // only run tests as build-tools
+  test.enabled = false
 }
 
 /*****************************************************************************
@@ -178,7 +176,11 @@ if (project != rootProject) {
 
   // tests can't  be run with randomized test runner
   // it's fine as we run them as part of :buildSrc
-  test.enabled = false
+  test {
+    include "**/*Tests.class"
+    exclude "**/*IT.class"
+  }
+  // This can't be an RandomizedTestingTask because we can't yet reference it
   task integTest(type: Test) {
     // integration test requires the local testing repo for example plugin builds
     dependsOn project.rootProject.allprojects.collect {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -777,6 +777,18 @@ class BuildPlugin implements Plugin<Project> {
             onNonEmptyWorkDirectory 'wipe'
             leaveTemporary true
 
+            if (name != "test") {
+                project.tasks.matching { it.name == "test"}.all { testTask ->
+                    task.testClassesDirs = testTask.testClassesDirs
+                    task.classpath = testTask.classpath
+                    task.shouldRunAfter testTask
+                    // no loose ends: check has to depend on all test tasks
+                    project.tasks.matching {it.name == "check"}.all {
+                        dependsOn(task)
+                    }
+                }
+            }
+
             // TODO: why are we not passing maxmemory to junit4?
             jvmArg '-Xmx' + System.getProperty('tests.heap.size', '512m')
             jvmArg '-Xms' + System.getProperty('tests.heap.size', '512m')

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -770,7 +770,7 @@ class BuildPlugin implements Plugin<Project> {
     }
 
     static void applyCommonTestConfig(Project project) {
-        project.tasks.withType(RandomizedTestingTask) {
+        project.tasks.withType(RandomizedTestingTask) {task ->
             jvm "${project.runtimeJavaHome}/bin/java"
             parallelism System.getProperty('tests.jvms', project.rootProject.ext.defaultParallel)
             ifNoTests System.getProperty('tests.ifNoTests', 'fail')

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -777,16 +777,17 @@ class BuildPlugin implements Plugin<Project> {
             onNonEmptyWorkDirectory 'wipe'
             leaveTemporary true
 
+            // Make sure all test tasks are configured properly
             if (name != "test") {
                 project.tasks.matching { it.name == "test"}.all { testTask ->
                     task.testClassesDirs = testTask.testClassesDirs
                     task.classpath = testTask.classpath
                     task.shouldRunAfter testTask
-                    // no loose ends: check has to depend on all test tasks
-                    project.tasks.matching {it.name == "check"}.all {
-                        dependsOn(task)
-                    }
                 }
+            }
+            // no loose ends: check has to depend on all test tasks
+            project.tasks.matching {it.name == "check"}.all {
+                dependsOn(task)
             }
 
             // TODO: why are we not passing maxmemory to junit4?

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -129,7 +129,6 @@ public class PluginBuildPlugin extends BuildPlugin {
         RestIntegTestTask integTest = project.tasks.create('integTest', RestIntegTestTask.class)
         integTest.mustRunAfter(project.precommit, project.test)
         project.integTestCluster.distribution = System.getProperty('tests.distribution', 'integ-test-zip')
-        project.check.dependsOn(integTest)
     }
 
     /**

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -61,6 +61,7 @@ public class RestIntegTestTask extends DefaultTask {
         clusterInit = project.tasks.create(name: "${name}Cluster#init", dependsOn: project.testClasses)
         runner.dependsOn(clusterInit)
         runner.classpath = project.sourceSets.test.runtimeClasspath
+        runner.testClassesDirs = project.sourceSets.test.output.classesDirs
         clusterConfig = project.extensions.create("${name}Cluster", ClusterConfiguration.class, project)
 
         // override/add more for rest tests

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -61,7 +61,6 @@ public class RestIntegTestTask extends DefaultTask {
         clusterInit = project.tasks.create(name: "${name}Cluster#init", dependsOn: project.testClasses)
         runner.dependsOn(clusterInit)
         runner.classpath = project.sourceSets.test.runtimeClasspath
-        runner.testClassesDirs = project.sourceSets.test.output.classesDirs
         clusterConfig = project.extensions.create("${name}Cluster", ClusterConfiguration.class, project)
 
         // override/add more for rest tests

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/TestingConventionsTasks.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/TestingConventionsTasks.java
@@ -157,14 +157,15 @@ public class TestingConventionsTasks extends DefaultTask {
 
     @Input
     public Map<String, Set<File>> classFilesPerRandomizedTestingTask(FileTree testClassFiles) {
-        return Stream.concat(
-            getProject().getTasks().withType(getRandomizedTestingTask()).stream(),
-            // Look at sub-projects too. As sometimes tests are implemented in parent but ran in sub-projects against
-            // different configurations
-            getProject().getSubprojects().stream().flatMap(subproject ->
-                subproject.getTasks().withType(getRandomizedTestingTask()).stream()
+        return
+            Stream.concat(
+                getProject().getTasks().withType(getRandomizedTestingTask()).stream(),
+                // Look at sub-projects too. As sometimes tests are implemented in parent but ran in sub-projects against
+                // different configurations
+                getProject().getSubprojects().stream().flatMap(subproject ->
+                    subproject.getTasks().withType(getRandomizedTestingTask()).stream()
+                )
             )
-        )
             .filter(Task::getEnabled)
             .collect(Collectors.toMap(
                 Task::getPath,

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/TestingConventionsTasks.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/TestingConventionsTasks.java
@@ -20,15 +20,19 @@ package org.elasticsearch.gradle.precommit;
 
 import org.elasticsearch.gradle.tool.Boilerplate;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileTree;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.util.PatternFilterable;
 
 import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
@@ -40,8 +44,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -57,7 +63,7 @@ public class TestingConventionsTasks extends DefaultTask {
      */
     private Boolean activeTestsExists;
 
-    private List<String> testClassNames;
+    private Map<String, File> testClassNames;
 
     public TestingConventionsTasks() {
         setDescription("Tests various testing conventions");
@@ -68,56 +74,113 @@ public class TestingConventionsTasks extends DefaultTask {
     @TaskAction
     public void doCheck() throws IOException {
         activeTestsExists = false;
-        final List<String> problems;
+        final Optional<String> problems;
 
         try (URLClassLoader isolatedClassLoader = new URLClassLoader(
             getTestsClassPath().getFiles().stream().map(this::fileToUrl).toArray(URL[]::new)
         )) {
-            List<? extends Class<?>> classes = getTestClassNames().stream()
-                .map(name -> loadClassWithoutInitializing(name, isolatedClassLoader))
-                .collect(Collectors.toList());
-
             Predicate<Class<?>> isStaticClass = clazz -> Modifier.isStatic(clazz.getModifiers());
             Predicate<Class<?>> isPublicClass = clazz -> Modifier.isPublic(clazz.getModifiers());
-            Predicate<Class<?>> implementsNamingConvention = clazz -> clazz.getName().endsWith(TEST_CLASS_SUFIX) ||
-                clazz.getName().endsWith(INTEG_TEST_CLASS_SUFIX);
+            Predicate<Class<?>> implementsNamingConvention = clazz ->
+                clazz.getName().endsWith(TEST_CLASS_SUFIX) ||
+                    clazz.getName().endsWith(INTEG_TEST_CLASS_SUFIX);
 
-            problems = Stream.concat(
+            Map<File, ? extends Class<?>> classes = getTestClassNames().entrySet().stream()
+                .collect(Collectors.toMap(
+                    Map.Entry::getValue,
+                    entry -> loadClassWithoutInitializing(entry.getKey(), isolatedClassLoader))
+                );
+
+            FileTree allClassFiles = getProject().files(
+                classes.values().stream()
+                    .filter(isStaticClass.negate())
+                    .filter(isPublicClass)
+                    .filter(implementsNamingConvention)
+                    .map(clazz -> testClassNames.get(clazz.getName()))
+                    .collect(Collectors.toList())
+            ).getAsFileTree();
+
+            final Map<String, Set<File>> filesPerTask = getProject().getTasks().withType(getRandomizedTestingTask()).stream()
+                .map(each -> (Task) each)
+                .collect(Collectors.toMap(
+                    Task::getName,
+                    task -> allClassFiles.matching(getRandomizedTestingPatternSet(task)).getFiles()
+                ));
+            
+            problems = collectProblems(
                 checkNoneExists(
                     "Test classes implemented by inner classes will not run",
-                    classes.stream()
+                    classes.values().stream()
                         .filter(isStaticClass)
                         .filter(implementsNamingConvention.or(this::seemsLikeATest))
-                ).stream(),
+                ),
                 checkNoneExists(
                     "Seem like test classes but don't match naming convention",
-                    classes.stream()
+                    classes.values().stream()
                         .filter(isStaticClass.negate())
                         .filter(isPublicClass)
                         .filter(this::seemsLikeATest)
                         .filter(implementsNamingConvention.negate())
-                ).stream()
-            ).collect(Collectors.toList());
+                ),
+                checkNoneExists(
+                    "Test classes are not included in any task",
+                    allClassFiles.getFiles().stream()
+                        .filter(testFile ->
+                            filesPerTask.values().stream()
+                                .anyMatch(fileSet -> fileSet.contains(testFile)) == false
+                        )
+                        .map(classes::get)
+                )
+            );
         }
 
-        if (problems.isEmpty()) {
+        if (problems.isPresent()) {
+            throw new IllegalStateException("Testing conventions are not honored:\n" + problems.get());
+        } else {
             getSuccessMarker().getParentFile().mkdirs();
             Files.write(getSuccessMarker().toPath(), new byte[]{}, StandardOpenOption.CREATE);
-        } else {
-            problems.forEach(getProject().getLogger()::error);
-            throw new IllegalStateException("Testing conventions are not honored");
+        }
+    }
+
+    private Optional<String> collectProblems(String... problems) {
+        return Stream.of(problems)
+            .filter(String::isBlank)
+            .map(each -> each + "\n")
+            .reduce(String::concat)
+            .map(String::trim);
+    }
+
+    private PatternFilterable getRandomizedTestingPatternSet(Task task) {
+        try {
+            if (getRandomizedTestingTask().isAssignableFrom(task.getClass()) == false) {
+                throw new IllegalStateException("Expected " + task + " to be RandomizedTestingTask but it was " + task.getClass());
+            }
+            Method getPatternSet = task.getClass().getMethod("getPatternSet");
+            return (PatternFilterable) getPatternSet.invoke(task);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Expecte task to have a `patternSet` " + task, e);
+        } catch (IllegalAccessException|InvocationTargetException e) {
+            throw new IllegalStateException("Failed to get pattern set from task" + task, e);
+        }
+    }
+
+    private Class<? extends Task> getRandomizedTestingTask() {
+        try {
+            return (Class<? extends Task>) Class.forName("com.carrotsearch.gradle.junit4.RandomizedTestingTask");
+        } catch (ClassNotFoundException|ClassCastException e) {
+            throw new IllegalStateException("Failed to load randomized testing class", e);
         }
     }
 
     @Input
     @SkipWhenEmpty
-    public List<String> getTestClassNames() {
+    public Map<String, File> getTestClassNames() {
         if (testClassNames == null) {
             testClassNames = Boilerplate.getJavaSourceSets(getProject()).getByName("test").getOutput().getClassesDirs()
                 .getFiles().stream()
                 .filter(File::exists)
-                .flatMap(testRoot -> walkPathAndLoadClasses(testRoot).stream())
-                .collect(Collectors.toList());
+                .flatMap(testRoot -> walkPathAndLoadClasses(testRoot).entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
         return testClassNames;
     }
@@ -127,16 +190,15 @@ public class TestingConventionsTasks extends DefaultTask {
         return new File(getProject().getBuildDir(), "markers/" + getName());
     }
 
-    private List<String> checkNoneExists(String message, Stream<? extends Class<?>> stream) {
-        List<String> problems = new ArrayList<>();
-        List<Class<?>> entries = stream.collect(Collectors.toList());
-        if (entries.isEmpty() == false) {
-            problems.add(message + ":");
-            entries.stream()
-                .map(each -> "  * " + each.getName())
-            .forEach(problems::add);
+    private String checkNoneExists(String message, Stream<? extends Class<?>> stream) {
+        String problem = stream
+            .map(each -> "  * " + each.getName())
+            .collect(Collectors.joining("\n"));
+        if (problem.isEmpty() == false) {
+            return message + ":\n" + problem;
+        } else{
+            return "";
         }
-        return problems;
     }
 
     private boolean seemsLikeATest(Class<?> clazz) {
@@ -197,8 +259,8 @@ public class TestingConventionsTasks extends DefaultTask {
         );
     }
 
-    private List<String> walkPathAndLoadClasses(File testRoot) {
-        List<String> classes = new ArrayList<>();
+    private Map<String, File> walkPathAndLoadClasses(File testRoot) {
+        Map<String, File> classes = new HashMap<>();
         try {
             Files.walkFileTree(testRoot.toPath(), new FileVisitor<Path>() {
                 private String packageName;
@@ -227,7 +289,7 @@ public class TestingConventionsTasks extends DefaultTask {
                     String filename = file.getFileName().toString();
                     if (filename.endsWith(".class")) {
                         String className = filename.substring(0, filename.length() - ".class".length());
-                        classes.add(packageName + className);
+                        classes.put(packageName + className, file.toFile());
                     }
                     return FileVisitResult.CONTINUE;
                 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/TestingConventionsTasks.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/TestingConventionsTasks.java
@@ -106,7 +106,7 @@ public class TestingConventionsTasks extends DefaultTask {
                     Task::getName,
                     task -> allClassFiles.matching(getRandomizedTestingPatternSet(task)).getFiles()
                 ));
-            
+
             problems = collectProblems(
                 checkNoneExists(
                     "Test classes implemented by inner classes will not run",

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/precommit/FilePermissionsTaskTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/precommit/FilePermissionsTaskTests.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.gradle.precommit;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.List;
@@ -32,12 +31,8 @@ import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
 
 public class FilePermissionsTaskTests extends GradleUnitTestCase {
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     public void testCheckPermissionsWhenAnExecutableFileExists() throws Exception {
         RandomizedTest.assumeFalse("Functionality is Unix specific", Os.isFamily(Os.FAMILY_WINDOWS));
@@ -93,11 +88,10 @@ public class FilePermissionsTaskTests extends GradleUnitTestCase {
         assertEquals("done", result.get(0));
 
         file.delete();
-
     }
 
-    private Project createProject() throws IOException {
-        Project project = ProjectBuilder.builder().withProjectDir(temporaryFolder.newFolder()).build();
+    private Project createProject() {
+        Project project = ProjectBuilder.builder().build();
         project.getPlugins().apply(JavaPlugin.class);
         return project;
     }
@@ -105,4 +99,5 @@ public class FilePermissionsTaskTests extends GradleUnitTestCase {
     private FilePermissionsTask createTask(Project project) {
         return project.getTasks().create("filePermissionsTask", FilePermissionsTask.class);
     }
+
 }

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -301,6 +301,7 @@ if (secureFixtureSupported) {
   // Security tests unsupported. Don't run these tests.
   integTestSecure.enabled = false
   integTestSecureHa.enabled = false
+  testingConventions.enabled = false
 }
 
 thirdPartyAudit.excludes = [

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -73,10 +73,7 @@ task testRepositoryCreds(type: RandomizedTestingTask) {
   include '**/RepositoryCredentialsTests.class'
   include '**/S3BlobStoreRepositoryTests.class'
   systemProperty 'es.allow_insecure_settings', 'true'
-  classpath = tasks.test.classpath
-  testClassesDirs = tasks.test.testClassesDirs
 }
-project.check.dependsOn(testRepositoryCreds)
 
 test {
   // these are tested explicitly in separate test tasks

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -320,10 +320,6 @@ if (isEclipse == false || project.path == ":server-tests") {
                  group: JavaBasePlugin.VERIFICATION_GROUP,
                  description: 'Multi-node tests',
                  dependsOn: test.dependsOn) {
-    classpath = project.test.classpath
-    testClassesDirs = project.test.testClassesDirs
     include '**/*IT.class'
   }
-  check.dependsOn integTest
-  integTest.mustRunAfter test
 }

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import com.carrotsearch.gradle.junit4.RandomizedTestingTask;
+
 dependencies {
   compile "org.elasticsearch.client:elasticsearch-rest-client:${version}"
   compile "org.elasticsearch.client:elasticsearch-rest-client-sniffer:${version}"
@@ -72,4 +74,8 @@ test.configure {
   systemProperty 'tests.gradle_index_compat_versions', bwcVersions.indexCompatible.join(',')
   systemProperty 'tests.gradle_wire_compat_versions', bwcVersions.wireCompatible.join(',')
   systemProperty 'tests.gradle_unreleased_versions', bwcVersions.unreleased.join(',')
+}
+
+task integTest(type: RandomizedTestingTask) {
+  include "**/*IT.class"
 }

--- a/test/framework/src/test/java/org/elasticsearch/test/disruption/NetworkDisruptionIT.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/disruption/NetworkDisruptionIT.java
@@ -40,6 +40,7 @@ public class NetworkDisruptionIT extends ESIntegTestCase {
         return Arrays.asList(MockTransportService.TestPlugin.class);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/35861")
     public void testNetworkPartitionWithNodeShutdown() throws IOException {
         internalCluster().ensureAtLeastNumDataNodes(2);
         String[] nodeNames = internalCluster().getNodeNames();

--- a/test/framework/src/test/java/org/elasticsearch/test/disruption/NetworkDisruptionIT.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/disruption/NetworkDisruptionIT.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.test.disruption;
 
+import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
@@ -34,13 +35,13 @@ import java.util.Set;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
+@AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/36205")
 public class NetworkDisruptionIT extends ESIntegTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Arrays.asList(MockTransportService.TestPlugin.class);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/35861")
     public void testNetworkPartitionWithNodeShutdown() throws IOException {
         internalCluster().ensureAtLeastNumDataNodes(2);
         String[] nodeNames = internalCluster().getNodeNames();

--- a/test/framework/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterIT.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterIT.java
@@ -41,6 +41,7 @@ public class SuiteScopeClusterIT extends ESIntegTestCase {
     @Test
     @SuppressForbidden(reason = "repeat is a feature here")
     @Repeat(iterations = 10, useConstantSeed = true)
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/36202")
     public void testReproducible() throws IOException {
         if (ITER++ == 0) {
             CLUSTER_SEED = cluster().seed();

--- a/test/framework/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterIT.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterIT.java
@@ -26,6 +26,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.equalTo;
+
 /**
  * This test ensures that the cluster initializion for suite scope is not influencing
  * the tests random sequence due to initializtion using the same random instance.
@@ -33,6 +35,7 @@ import java.io.IOException;
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)
 public class SuiteScopeClusterIT extends ESIntegTestCase {
     private static int ITER = 0;
+    private static long[] SEQUENCE = new long[100];
     private static Long CLUSTER_SEED = null;
 
     @Test
@@ -41,8 +44,14 @@ public class SuiteScopeClusterIT extends ESIntegTestCase {
     public void testReproducible() throws IOException {
         if (ITER++ == 0) {
             CLUSTER_SEED = cluster().seed();
+            for (int i = 0; i < SEQUENCE.length; i++) {
+                SEQUENCE[i] = randomLong();
+            }
         } else {
             assertEquals(CLUSTER_SEED, Long.valueOf(cluster().seed()));
+            for (int i = 0; i < SEQUENCE.length; i++) {
+                assertThat(SEQUENCE[i], equalTo(randomLong()));
+            }
         }
     }
 

--- a/test/framework/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterIT.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterIT.java
@@ -26,8 +26,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.hamcrest.Matchers.equalTo;
-
 /**
  * This test ensures that the cluster initializion for suite scope is not influencing
  * the tests random sequence due to initializtion using the same random instance.

--- a/test/framework/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterIT.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterIT.java
@@ -35,7 +35,6 @@ import static org.hamcrest.Matchers.equalTo;
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)
 public class SuiteScopeClusterIT extends ESIntegTestCase {
     private static int ITER = 0;
-    private static long[] SEQUENCE = new long[100];
     private static Long CLUSTER_SEED = null;
 
     @Test
@@ -44,14 +43,8 @@ public class SuiteScopeClusterIT extends ESIntegTestCase {
     public void testReproducible() throws IOException {
         if (ITER++ == 0) {
             CLUSTER_SEED = cluster().seed();
-            for (int i = 0; i < SEQUENCE.length; i++) {
-                SEQUENCE[i] = randomLong();
-            }
         } else {
             assertEquals(CLUSTER_SEED, Long.valueOf(cluster().seed()));
-            for (int i = 0; i < SEQUENCE.length; i++) {
-                assertThat(SEQUENCE[i], equalTo(randomLong()));
-            }
         }
     }
 

--- a/x-pack/plugin/ccr/build.gradle
+++ b/x-pack/plugin/ccr/build.gradle
@@ -24,14 +24,9 @@ task internalClusterTest(type: RandomizedTestingTask,
         group: JavaBasePlugin.VERIFICATION_GROUP,
         description: 'Java fantasy integration tests',
         dependsOn: test.dependsOn) {
-    classpath = project.test.classpath
-    testClassesDirs = project.test.testClassesDirs
     include '**/*IT.class'
     systemProperty 'es.set.netty.runtime.available.processors', 'false'
 }
-
-check.dependsOn internalClusterTest
-internalClusterTest.mustRunAfter test
 
 // add all sub-projects of the qa sub-project
 gradle.projectsEvaluated {

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -4,6 +4,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
+import com.carrotsearch.gradle.junit4.RandomizedTestingTask;
 
 apply plugin: 'elasticsearch.esplugin'
 apply plugin: 'nebula.maven-base-publish'
@@ -136,5 +137,10 @@ thirdPartyAudit.excludes = [
 
 // xpack modules are installed in real clusters as the meta plugin, so
 // installing them as individual plugins for integ tests doesn't make sense,
-// so we disable integ tests and there are no integ tests in xpack core module
+// so we disable integ tests
 integTest.enabled = false
+
+// There are some integ tests that don't require a cluster, we still want to run those
+task internalClusterTest(type: RandomizedTestingTask) {
+    include "**/*IT.class"
+}

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -98,14 +98,9 @@ task internalClusterTest(type: RandomizedTestingTask,
                          group: JavaBasePlugin.VERIFICATION_GROUP,
                          description: 'Multi-node tests',
                          dependsOn: test.dependsOn) {
-  classpath = project.test.classpath
-  testClassesDirs = project.test.testClassesDirs
   include '**/*IT.class'
   systemProperty 'es.set.netty.runtime.available.processors', 'false'
 }
-
-check.dependsOn internalClusterTest
-internalClusterTest.mustRunAfter test
 
 // add all sub-projects of the qa sub-project
 gradle.projectsEvaluated {

--- a/x-pack/plugin/monitoring/build.gradle
+++ b/x-pack/plugin/monitoring/build.gradle
@@ -60,13 +60,9 @@ task internalClusterTest(type: RandomizedTestingTask,
                          group: JavaBasePlugin.VERIFICATION_GROUP,
                          description: 'Multi-node tests',
                          dependsOn: test.dependsOn) {
-  classpath = project.test.classpath
-  testClassesDirs = project.test.testClassesDirs
   include '**/*IT.class'
   systemProperty 'es.set.netty.runtime.available.processors', 'false'
 }
-check.dependsOn internalClusterTest
-internalClusterTest.mustRunAfter test
 
 // also add an "alias" task to make typing on the command line easier task icTest {
 task icTest {

--- a/x-pack/plugin/upgrade/build.gradle
+++ b/x-pack/plugin/upgrade/build.gradle
@@ -33,13 +33,9 @@ task internalClusterTest(type: RandomizedTestingTask,
                          group: JavaBasePlugin.VERIFICATION_GROUP,
                          description: 'Multi-node tests',
                          dependsOn: test.dependsOn) {
-  classpath = project.test.classpath
-  testClassesDirs = project.test.testClassesDirs
   include '**/*IT.class'
   systemProperty 'es.set.netty.runtime.available.processors', 'false'
 }
-check.dependsOn internalClusterTest
-internalClusterTest.mustRunAfter test
 
 // also add an "alias" task to make typing on the command line easier
 task icTest {

--- a/x-pack/qa/kerberos-tests/build.gradle
+++ b/x-pack/qa/kerberos-tests/build.gradle
@@ -133,6 +133,7 @@ integTestRunner {
 
 if (project.rootProject.vagrantSupported == false) {
     integTest.enabled = false
+    testingConventions.enabled = false
 } else {
     project.sourceSets.test.output.dir(generatedResources)
     integTestCluster.dependsOn krb5AddPrincipals, krb5kdcFixture, copyKeytabToGeneratedResources

--- a/x-pack/qa/openldap-tests/build.gradle
+++ b/x-pack/qa/openldap-tests/build.gradle
@@ -27,6 +27,7 @@ if (project.rootProject.vagrantSupported) {
   test.finalizedBy idpFixtureProject.halt
 } else {
   test.enabled = false
+  testingConventions.enabled = false
 }
 
 namingConventions {

--- a/x-pack/qa/saml-idp-tests/build.gradle
+++ b/x-pack/qa/saml-idp-tests/build.gradle
@@ -28,6 +28,7 @@ if (project.rootProject.vagrantSupported) {
   integTest.finalizedBy idpFixtureProject.halt
 } else {
   integTest.enabled = false
+  testingConventions.enabled = false
 }
 
 integTestCluster {

--- a/x-pack/qa/third-party/active-directory/build.gradle
+++ b/x-pack/qa/third-party/active-directory/build.gradle
@@ -29,5 +29,3 @@ test {
   include '**/*Tests.class'
 }
 
-// these are just tests, no need to audit
-thirdPartyAudit.enabled = false

--- a/x-pack/qa/third-party/hipchat/build.gradle
+++ b/x-pack/qa/third-party/hipchat/build.gradle
@@ -29,4 +29,5 @@ integTestCluster {
 
 if (!integrationAccount && !userAccount && !v1Account) {
   integTest.enabled = false
+  testingConventions.enabled = false
 }

--- a/x-pack/qa/third-party/jira/build.gradle
+++ b/x-pack/qa/third-party/jira/build.gradle
@@ -47,6 +47,7 @@ task cleanJira(type: DefaultTask) {
 // require network access for this one, exit early instead of starting up the cluster if we dont have network
 if (!jiraUrl && !jiraUser && !jiraPassword && !jiraProject) {
     integTest.enabled = false
+    testingConventions.enabled = false
 } else {
     integTestRunner.finalizedBy cleanJira
 }

--- a/x-pack/qa/third-party/pagerduty/build.gradle
+++ b/x-pack/qa/third-party/pagerduty/build.gradle
@@ -18,5 +18,6 @@ integTestCluster {
 }
 
 if (!pagerDutyServiceKey) {
-    integTest.enabled = false
+  integTest.enabled = false
+  testingConventions.enabled = false
 }

--- a/x-pack/qa/third-party/slack/build.gradle
+++ b/x-pack/qa/third-party/slack/build.gradle
@@ -22,4 +22,5 @@ integTestCluster {
 
 if (!slackUrl) {
   integTest.enabled = false
+  testingConventions.enabled = false
 }


### PR DESCRIPTION
Closes #35435

Changes to verify that we don't have test classes which are not ran as part of `./gradlew check`

- make it easier to add additional testing tasks with the proper configuration and add some where they were missing. 
- mute or fix failing tests 
- add a check as part of testing conventions to find classes not included in any testing task. 