### PR TITLE
[ML] JIndex: Replace Version.CURRENT in streaming functions

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/OpenJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/OpenJobAction.java
@@ -174,7 +174,7 @@ public class OpenJobAction extends Action<AcknowledgedResponse> {
         public JobParams(StreamInput in) throws IOException {
             jobId = in.readString();
             timeout = TimeValue.timeValueMillis(in.readVLong());
-            if (in.getVersion().onOrAfter(Version.CURRENT)) {
+            if (in.getVersion().onOrAfter(Version.V_6_6_0)) {
                 job = in.readOptionalWriteable(Job::new);
             }
         }
@@ -213,7 +213,7 @@ public class OpenJobAction extends Action<AcknowledgedResponse> {
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(jobId);
             out.writeVLong(timeout.millis());
-            if (out.getVersion().onOrAfter(Version.CURRENT)) {
+            if (out.getVersion().onOrAfter(Version.V_6_6_0)) {
                 out.writeOptionalWriteable(job);
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
@@ -195,7 +195,7 @@ public class StartDatafeedAction extends Action<AcknowledgedResponse> {
             startTime = in.readVLong();
             endTime = in.readOptionalLong();
             timeout = TimeValue.timeValueMillis(in.readVLong());
-            if (in.getVersion().onOrAfter(Version.CURRENT)) {
+            if (in.getVersion().onOrAfter(Version.V_6_6_0)) {
                 jobId = in.readOptionalString();
                 datafeedIndices = in.readList(StreamInput::readString);
             }
@@ -272,7 +272,7 @@ public class StartDatafeedAction extends Action<AcknowledgedResponse> {
             out.writeVLong(startTime);
             out.writeOptionalLong(endTime);
             out.writeVLong(timeout.millis());
-            if (out.getVersion().onOrAfter(Version.CURRENT)) {
+            if (out.getVersion().onOrAfter(Version.V_6_6_0)) {
                 out.writeOptionalString(jobId);
                 out.writeStringList(datafeedIndices);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateJobAction.java
@@ -97,8 +97,7 @@ public class UpdateJobAction extends Action<PutJobAction.Response> {
             } else {
                 isInternal = false;
             }
-            // TODO jindex change CURRENT to specific version when feature branch is merged
-            if (in.getVersion().onOrAfter(Version.V_6_3_0) && in.getVersion().before(Version.CURRENT)) {
+            if (in.getVersion().onOrAfter(Version.V_6_3_0) && in.getVersion().before(Version.V_7_0_0)) {
                 in.readBoolean(); // was waitForAck
             }
         }
@@ -111,8 +110,7 @@ public class UpdateJobAction extends Action<PutJobAction.Response> {
             if (out.getVersion().onOrAfter(Version.V_6_2_2)) {
                 out.writeBoolean(isInternal);
             }
-            // TODO jindex change CURRENT to specific version when feature branch is merged
-            if (out.getVersion().onOrAfter(Version.V_6_3_0) && out.getVersion().before(Version.CURRENT)) {
+            if (out.getVersion().onOrAfter(Version.V_6_3_0) && out.getVersion().before(Version.V_7_0_0)) {
                 out.writeBoolean(false); // was waitForAck
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -809,7 +809,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             return this;
         }
 
-        public Builder setModelSnapshotMinVersion(String modelSnapshotMinVersion) {
+        Builder setModelSnapshotMinVersion(String modelSnapshotMinVersion) {
             this.modelSnapshotMinVersion = Version.fromString(modelSnapshotMinVersion);
             return this;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
@@ -140,15 +140,15 @@ public class JobUpdate implements Writeable, ToXContentObject {
         } else {
             jobVersion = null;
         }
+        if (in.getVersion().onOrAfter(Version.V_6_6_0)) {
+            clearJobFinishTime = in.readOptionalBoolean();
+        } else {
+            clearJobFinishTime = null;
+        }
         if (in.getVersion().onOrAfter(Version.V_7_0_0) && in.readBoolean()) {
             modelSnapshotMinVersion = Version.readVersion(in);
         } else {
             modelSnapshotMinVersion = null;
-        }
-        if (in.getVersion().onOrAfter(Version.CURRENT)) {  // NORELEASE change current to Jindex release version
-            clearJobFinishTime = in.readOptionalBoolean();
-        } else {
-            clearJobFinishTime = null;
         }
     }
 
@@ -188,6 +188,9 @@ public class JobUpdate implements Writeable, ToXContentObject {
                 out.writeBoolean(false);
             }
         }
+        if (out.getVersion().onOrAfter(Version.V_6_6_0)) {
+            out.writeOptionalBoolean(clearJobFinishTime);
+        }
         if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
             if (modelSnapshotMinVersion != null) {
                 out.writeBoolean(true);
@@ -195,9 +198,6 @@ public class JobUpdate implements Writeable, ToXContentObject {
             } else {
                 out.writeBoolean(false);
             }
-        }
-        if (out.getVersion().onOrAfter(Version.CURRENT)) { // NORELEASE change current to Jindex release version
-            out.writeOptionalBoolean(clearJobFinishTime);
         }
     }
 


### PR DESCRIPTION
Now that the release version is known replace Version.CURRENT with V_6_6_0 in the streaming functions for classes with new fields added. 