### PR TITLE
Docs: Fix release-state check for oss repositories

### DIFF
--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -105,7 +105,7 @@ endif::[]
 
 include::skip-set-kernel-parameters.asciidoc[]
 
-ifeval::["{release-state}"=="released"]
+ifeval::["{release-state}"!="unreleased"]
 
 [NOTE]
 ==================================================

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -90,7 +90,7 @@ sudo zypper install elasticsearch <3>
 
 endif::[]
 
-ifeval::["{release-state}"=="released"]
+ifeval::["{release-state}"!="unreleased"]
 
 [NOTE]
 ==================================================


### PR DESCRIPTION
To get the newly added oss apt/yum sections to get rendered for
`released` and `prerelease` versions the condition needs to be modified.
