### PR TITLE
Unit test for very large percentile aggs

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestStateTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestStateTests.java
@@ -1,0 +1,35 @@
+package org.elasticsearch.search.aggregations.metrics;
+
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class TDigestStateTests extends ESTestCase {
+    @Test
+    public void testMoreThan4BValues() {
+        // Regression test for #19528
+        // See https://github.com/tdunning/t-digest/pull/70/files#diff-4487072cee29b939694825647928f742R439
+        TDigestState digest = new TDigestState(100);
+        for (int i = 0; i < 1000; ++i) {
+            digest.add(randomDouble());
+        }
+        final int count = 1 << 29;
+        for (int i = 0; i < 10; ++i) {
+            digest.add(randomDouble(), count);
+        }
+        assertEquals(1000 + 10L * (1 << 29), digest.size());
+        assertTrue(digest.size() > 2 * Integer.MAX_VALUE);
+        final double[] quantiles = new double[] { 0, 0.1, 0.5, 0.9, 1, randomDouble()};
+        Arrays.sort(quantiles);
+        double prev = Double.NEGATIVE_INFINITY;
+        for (double q : quantiles) {
+            final double v = digest.quantile(q);
+            System.out.println("q=" + q + ", v=" + v);
+            assertTrue(v >= prev);
+            assertTrue("Unexpectedly low value: " + v, v >= 0.0);
+            assertTrue("Unexpectedly high value: " + v, v <= 1.0);
+            prev = v;
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestStateTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestStateTests.java
@@ -1,12 +1,30 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.test.ESTestCase;
-import org.junit.Test;
 
 import java.util.Arrays;
 
 public class TDigestStateTests extends ESTestCase {
-    @Test
+
     public void testMoreThan4BValues() {
         // Regression test for #19528
         // See https://github.com/tdunning/t-digest/pull/70/files#diff-4487072cee29b939694825647928f742R439
@@ -25,7 +43,7 @@ public class TDigestStateTests extends ESTestCase {
         double prev = Double.NEGATIVE_INFINITY;
         for (double q : quantiles) {
             final double v = digest.quantile(q);
-            System.out.println("q=" + q + ", v=" + v);
+            logger.trace("q=" + q + ", v=" + v);
             assertTrue(v >= prev);
             assertTrue("Unexpectedly low value: " + v, v >= 0.0);
             assertTrue("Unexpectedly high value: " + v, v <= 1.0);


### PR DESCRIPTION
This ports in a unit test for #19528 (which is really just the unit test @colings86 submitted to the upstream library last year, retouched for our randomized testing framework).  As far as I can tell, this issue has been fixed since we migrated to t-digest 3.2, and this test should just pass.  My recommendation is to include the test in our suite for regression testing, and close #19528 