### PR TITLE
Fix logic in dockerComposeSupported

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
@@ -103,10 +103,9 @@ public class TestFixturesPlugin implements Plugin<Project> {
     @Input
     public boolean dockerComposeSupported(Project project) {
         // Don't look for docker-compose on the PATH yet that would pick up on Windows as well
-        return
-            project.file("/usr/local/bin/docker-compose").exists() == false &&
-            project.file("/usr/bin/docker-compose").exists() == false &&
-            Boolean.parseBoolean(System.getProperty("tests.fixture.enabled", "true")) == false;
+        final boolean hasDockerCompose = project.file("/usr/local/bin/docker-compose").exists() ||
+            project.file("/usr/bin/docker-compose").exists();
+        return hasDockerCompose && Boolean.parseBoolean(System.getProperty("tests.fixture.enabled", "true"));
     }
 
     private void setSystemProperty(Task task, String name, Object value) {


### PR DESCRIPTION
The logic in the dockerComposeSupported method currently returns false
even when docker and docker compose are available on the build machine.
This change updates the check to see if docker compose is available in
one of the two paths and allows the `tests.fixture.enabled` property to
disable the tests even if docker compose is available.