### PR TITLE
[Zen2] Stop extra nodes after reinstating the old ones

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -818,7 +818,8 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 // there is no equals on cluster state, so we just serialize it to XContent and compare JSON representation
                 assert clusterChangedEvent.previousState() == coordinationState.get().getLastAcceptedState() ||
                     Strings.toString(clusterChangedEvent.previousState()).equals(
-                        Strings.toString(clusterStateWithNoMasterBlock(coordinationState.get().getLastAcceptedState())));
+                        Strings.toString(clusterStateWithNoMasterBlock(coordinationState.get().getLastAcceptedState())))
+                    : clusterChangedEvent.previousState() + " vs " + clusterStateWithNoMasterBlock(coordinationState.get().getLastAcceptedState());
 
                 final ClusterState clusterState = clusterChangedEvent.state();
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -819,7 +819,8 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 assert clusterChangedEvent.previousState() == coordinationState.get().getLastAcceptedState() ||
                     Strings.toString(clusterChangedEvent.previousState()).equals(
                         Strings.toString(clusterStateWithNoMasterBlock(coordinationState.get().getLastAcceptedState())))
-                    : clusterChangedEvent.previousState() + " vs " + clusterStateWithNoMasterBlock(coordinationState.get().getLastAcceptedState());
+                    : clusterChangedEvent.previousState() + " vs "
+                        + clusterStateWithNoMasterBlock(coordinationState.get().getLastAcceptedState());
 
                 final ClusterState clusterState = clusterChangedEvent.state();
 

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -157,7 +157,9 @@ public abstract class PeerFinder {
             final List<DiscoveryNode> knownPeers;
             if (active) {
                 assert leader.isPresent() == false : leader;
-                startProbe(peersRequest.getSourceNode().getAddress());
+                if (peersRequest.getSourceNode().isMasterNode()) {
+                    startProbe(peersRequest.getSourceNode().getAddress());
+                }
                 peersRequest.getKnownPeers().stream().map(DiscoveryNode::getAddress).forEach(this::startProbe);
                 knownPeers = getFoundPeersUnderLock();
             } else {

--- a/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
@@ -397,6 +397,20 @@ public class PeerFinderTests extends ESTestCase {
         assertFoundPeers(sourceNode, otherKnownNode);
     }
 
+    public void testDoesNotAddReachableNonMasterEligibleNodesFromIncomingRequests() {
+        final DiscoveryNode sourceNode = new DiscoveryNode("request-source", buildNewFakeTransportAddress(),
+            emptyMap(), emptySet(), Version.CURRENT);
+        final DiscoveryNode otherKnownNode = newDiscoveryNode("other-known-node");
+
+        transportAddressConnector.addReachableNode(otherKnownNode);
+
+        peerFinder.activate(lastAcceptedNodes);
+        peerFinder.handlePeersRequest(new PeersRequest(sourceNode, Collections.singletonList(otherKnownNode)));
+        runAllRunnableTasks();
+
+        assertFoundPeers(otherKnownNode);
+    }
+
     public void testDoesNotAddUnreachableNodesFromIncomingRequests() {
         final DiscoveryNode sourceNode = newDiscoveryNode("request-source");
         final DiscoveryNode otherKnownNode = newDiscoveryNode("other-known-node");

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1121,9 +1121,9 @@ public final class InternalTestCluster extends TestCluster {
             toStartAndPublish.add(nodeAndClient);
         }
 
-        logger.debug("starting nodes [{}]", toStartAndPublish.stream().map(NodeAndClient::getName).collect(Collectors.toList()));
+        logger.debug("starting nodes {}", toStartAndPublish.stream().map(NodeAndClient::getName).collect(Collectors.toList()));
         startAndPublishNodesAndClients(toStartAndPublish);
-        logger.debug("stopping nodes [{}]", toClose.stream().map(NodeAndClient::getName).collect(Collectors.toList()));
+        logger.debug("stopping nodes {}", toClose.stream().map(NodeAndClient::getName).collect(Collectors.toList()));
         stopNodesAndClients(toClose);
 
         // clean up what the nodes left that is unused


### PR DESCRIPTION
Today `InternalTestCluster#reset()` shuts down any extra nodes and then
reinstates any missing ones. However if the first step removes all the
master-eligible nodes then with Zen2 the cluster cannot re-form.

This change defers the shutdown of the extra nodes until after the new nodes
have started.

It also adds a check to avoids spurious `non-master-eligible node found`
exceptions in the cluster formation phase by not probing a node that just told
us it wasn't master-eligible.