### PR TITLE
Deprecate the query filter context

### DIFF
--- a/docs/reference/migration/migrate_6_0/search.asciidoc
+++ b/docs/reference/migration/migrate_6_0/search.asciidoc
@@ -268,3 +268,13 @@ rewrite any prefix query on the field to a a single term query that matches the 
 
 Setting a negative `boost` in a query is deprecated and will throw an error in the next version.
 To deboost a specific query you can use a `boost` comprise between 0 and 1.
+
+[float]
+==== The filter context is deprecated
+
+ The `filter` context is deprecated in Elasticsearch's query builders,
+the distinction between queries and filters is decided in Lucene depending
+on whether queries need to access score or not. As a result `bool` queries with
+`should` clauses that don't need to access the score will issue a deprecation
+warning when they automatically set `minimum_should_match` to 1.
+This behavior will be removed in the next major version.

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -374,6 +374,10 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
 
     @Override
     public final String toString() {
-        return Strings.toString(this, true, true);
+        return toString(true);
+    }
+
+    public final String toString(boolean pretty) {
+        return Strings.toString(this, pretty, true);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -179,7 +179,10 @@ public class QueryShardContext extends QueryRewriteContext {
 
     /**
      * Return whether we are currently parsing a filter or a query.
+     * @deprecated The distinction between query and filter context is removed
+     * in the next major version.
      */
+    @Deprecated
     public boolean isFilter() {
         return isFilter;
     }

--- a/server/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
@@ -235,6 +235,9 @@ public class BoolQueryBuilderTests extends AbstractQueryTestCase<BoolQueryBuilde
         BooleanClause innerBooleanClause2 = innerBooleanQuery.clauses().get(1);
         assertThat(innerBooleanClause2.getOccur(), equalTo(BooleanClause.Occur.SHOULD));
         assertThat(innerBooleanClause2.getQuery(), instanceOf(MatchAllDocsQuery.class));
+        assertWarnings("Should clauses in the filter context will no longer automatically set the minimum should" +
+            " match to 1 in the next major version. You should group them in a [filter] clause or explicitly set" +
+            " [minimum_should_match] to 1 to restore this behavior in the next major version.");
     }
 
     public void testMinShouldMatchBiggerThanNumberOfShouldClauses() throws Exception {
@@ -440,5 +443,35 @@ public class BoolQueryBuilderTests extends AbstractQueryTestCase<BoolQueryBuilde
             .filter(new MatchNoneQueryBuilder()));
         rewritten = Rewriteable.rewrite(boolQueryBuilder, createShardContext());
         assertEquals(new MatchNoneQueryBuilder(), rewritten);
+    }
+
+    public void testShouldFilterContextDeprecation() throws Exception {
+        QueryShardContext context = createShardContext();
+        BoolQueryBuilder bq = new BoolQueryBuilder()
+            .should(new MatchAllQueryBuilder())
+            .filter(new TermQueryBuilder("foo", "bar"));
+        bq.doToQuery(context);
+        BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+        boolQueryBuilder.should(bq);
+        boolQueryBuilder.doToQuery(context);
+
+        boolQueryBuilder = new BoolQueryBuilder();
+        boolQueryBuilder.filter(bq);
+        boolQueryBuilder.doToQuery(context);
+        assertWarnings("Should clauses in the filter context will no longer automatically set the minimum should" +
+            " match to 1 in the next major version. You should group them in a [filter] clause or explicitly set" +
+            " [minimum_should_match] to 1 to restore this behavior in the next major version.");
+
+        ConstantScoreQueryBuilder query = new ConstantScoreQueryBuilder(bq);
+        query.doToQuery(context);
+        assertWarnings("Should clauses in the filter context will no longer automatically set the minimum should" +
+            " match to 1 in the next major version. You should group them in a [filter] clause or explicitly set" +
+            " [minimum_should_match] to 1 to restore this behavior in the next major version.");
+
+        bq = new BoolQueryBuilder()
+            .should(new MatchAllQueryBuilder());
+        boolQueryBuilder = new BoolQueryBuilder();
+        boolQueryBuilder.filter(bq);
+        boolQueryBuilder.doToQuery(context);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorTests.java
@@ -127,6 +127,5 @@ public class FilterAggregatorTests extends AggregatorTestCase {
         assertWarnings("Should clauses in the filter context will no longer automatically set the minimum should" +
             " match to 1 in the next major version. You should group them in a [filter] clause or explicitly set" +
             " [minimum_should_match] to 1 to restore this behavior in the next major version.");
-
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorTests.java
@@ -124,5 +124,9 @@ public class FilterAggregatorTests extends AggregatorTestCase {
         // means the bool query has been parsed as a filter, if it was a query minShouldMatch would
         // be 0
         assertEquals(1, ((BooleanQuery) parsedQuery).getMinimumNumberShouldMatch());
+        assertWarnings("Should clauses in the filter context will no longer automatically set the minimum should" +
+            " match to 1 in the next major version. You should group them in a [filter] clause or explicitly set" +
+            " [minimum_should_match] to 1 to restore this behavior in the next major version.");
+
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorTests.java
@@ -220,5 +220,8 @@ public class FiltersAggregatorTests extends AggregatorTestCase {
         // means the bool query has been parsed as a filter, if it was a query minShouldMatch would
         // be 0
         assertEquals(1, ((BooleanQuery) parsedQuery).getMinimumNumberShouldMatch());
+        assertWarnings("Should clauses in the filter context will no longer automatically set the minimum should" +
+            " match to 1 in the next major version. You should group them in a [filter] clause or explicitly set" +
+            " [minimum_should_match] to 1 to restore this behavior in the next major version.");
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorTests.java
@@ -106,6 +106,9 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
         // means the bool query has been parsed as a filter, if it was a query minShouldMatch would
         // be 0
         assertEquals(1, ((BooleanQuery) parsedQuery).getMinimumNumberShouldMatch());
+        assertWarnings("Should clauses in the filter context will no longer automatically set the minimum should" +
+            " match to 1 in the next major version. You should group them in a [filter] clause or explicitly set" +
+            " [minimum_should_match] to 1 to restore this behavior in the next major version.");
     }
 
     /**

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupResponseTranslationTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupResponseTranslationTests.java
@@ -443,8 +443,8 @@ public class RollupResponseTranslationTests extends AggregatorTestCase {
         fieldType.setIndexOptions(IndexOptions.DOCS);
         fieldType.setName("foo");
         QueryBuilder filter = QueryBuilders.boolQuery()
-                .must(QueryBuilders.termQuery("field", "foo"))
-                .should(QueryBuilders.termQuery("field", "bar"));
+                .filter(QueryBuilders.termQuery("field", "foo"))
+                .filter(QueryBuilders.termQuery("field", "bar"));
         SignificantTermsAggregationBuilder builder = new SignificantTermsAggregationBuilder(
                 "test", ValueType.STRING)
                 .field("field")


### PR DESCRIPTION
This change deprecates the Elasticsearch's filter context and adds a deprecation
warning to bool queries that automatically set their minimum should match to 1.

Relates #35354