### PR TITLE
[Zen2] Do not probe non-master nodes back

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -818,7 +818,9 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 // there is no equals on cluster state, so we just serialize it to XContent and compare JSON representation
                 assert clusterChangedEvent.previousState() == coordinationState.get().getLastAcceptedState() ||
                     Strings.toString(clusterChangedEvent.previousState()).equals(
-                        Strings.toString(clusterStateWithNoMasterBlock(coordinationState.get().getLastAcceptedState())));
+                        Strings.toString(clusterStateWithNoMasterBlock(coordinationState.get().getLastAcceptedState())))
+                    : clusterChangedEvent.previousState() + " vs "
+                        + clusterStateWithNoMasterBlock(coordinationState.get().getLastAcceptedState());
 
                 final ClusterState clusterState = clusterChangedEvent.state();
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -819,8 +819,8 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 assert clusterChangedEvent.previousState() == coordinationState.get().getLastAcceptedState() ||
                     Strings.toString(clusterChangedEvent.previousState()).equals(
                         Strings.toString(clusterStateWithNoMasterBlock(coordinationState.get().getLastAcceptedState())))
-                    : clusterChangedEvent.previousState() + " vs "
-                        + clusterStateWithNoMasterBlock(coordinationState.get().getLastAcceptedState());
+                    : Strings.toString(clusterChangedEvent.previousState()) + " vs "
+                        + Strings.toString(clusterStateWithNoMasterBlock(coordinationState.get().getLastAcceptedState()));
 
                 final ClusterState clusterState = clusterChangedEvent.state();
 

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -157,7 +157,9 @@ public abstract class PeerFinder {
             final List<DiscoveryNode> knownPeers;
             if (active) {
                 assert leader.isPresent() == false : leader;
-                startProbe(peersRequest.getSourceNode().getAddress());
+                if (peersRequest.getSourceNode().isMasterNode()) {
+                    startProbe(peersRequest.getSourceNode().getAddress());
+                }
                 peersRequest.getKnownPeers().stream().map(DiscoveryNode::getAddress).forEach(this::startProbe);
                 knownPeers = getFoundPeersUnderLock();
             } else {

--- a/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
@@ -397,6 +397,20 @@ public class PeerFinderTests extends ESTestCase {
         assertFoundPeers(sourceNode, otherKnownNode);
     }
 
+    public void testDoesNotAddReachableNonMasterEligibleNodesFromIncomingRequests() {
+        final DiscoveryNode sourceNode = new DiscoveryNode("request-source", buildNewFakeTransportAddress(),
+            emptyMap(), emptySet(), Version.CURRENT);
+        final DiscoveryNode otherKnownNode = newDiscoveryNode("other-known-node");
+
+        transportAddressConnector.addReachableNode(otherKnownNode);
+
+        peerFinder.activate(lastAcceptedNodes);
+        peerFinder.handlePeersRequest(new PeersRequest(sourceNode, Collections.singletonList(otherKnownNode)));
+        runAllRunnableTasks();
+
+        assertFoundPeers(otherKnownNode);
+    }
+
     public void testDoesNotAddUnreachableNodesFromIncomingRequests() {
         final DiscoveryNode sourceNode = newDiscoveryNode("request-source");
         final DiscoveryNode otherKnownNode = newDiscoveryNode("other-known-node");


### PR DESCRIPTION
Today if a node `A` sends a peers request to another node `B` then `B` will
react by sending a peers request back to `A`. However if `A` is not
master-eligible then this reaction is pointless and fails with an exception
saying `non-master-eligible node found`, adding noise to the logs. This change
suppresses this response to non-master-eligible nodes.