### PR TITLE
[ILM] fix ilm.remove_policy rest-spec

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.remove_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.remove_policy.json
@@ -4,7 +4,7 @@
     "methods": [ "POST" ],
     "url": {
       "path": "/{index}/_ilm/remove",
-      "paths": ["/{index}/_ilm/remove", "/_ilm/remove"],
+      "paths": ["/{index}/_ilm/remove"],
       "parts": {
         "index": {
           "type" : "string",


### PR DESCRIPTION
The rest interface for remove-policy-from-index API does not support
`_ilm/remove`, it requires that an `{index}` pattern be defined in
the URL path. This fixes the rest-api-spec to reflect the implementation

reference: https://github.com/elastic/elasticsearch/blob/a85b4f42ca3965e1c94f621948b3b48fa66611fb/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/RestRemoveIndexLifecyclePolicyAction.java#L25