### PR TITLE
[Zen2] Reduce cluster scope in NodeDisconnectIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/client/transport/NodeDisconnectIT.java
+++ b/server/src/test/java/org/elasticsearch/client/transport/NodeDisconnectIT.java
@@ -22,6 +22,8 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.transport.MockTransportClient;
 import org.elasticsearch.transport.TransportService;
 
@@ -33,6 +35,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.client.transport.TransportClient.CLIENT_TRANSPORT_NODES_SAMPLER_INTERVAL;
 
+@ClusterScope(scope = Scope.TEST)
 public class NodeDisconnectIT  extends ESIntegTestCase {
 
     public void testNotifyOnDisconnect() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1070,6 +1070,9 @@ public final class InternalTestCluster extends TestCluster {
             wipePendingDataDirectories();
         }
 
+        assert nodes.isEmpty() || nodes.values().stream().anyMatch(NodeAndClient::isMasterEligible)
+            : "only master-ineligible nodes left in " + nodes;
+
         final int prevNodeCount = nodes.size();
 
         // start any missing node

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -164,6 +164,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -1070,8 +1071,8 @@ public final class InternalTestCluster extends TestCluster {
             wipePendingDataDirectories();
         }
 
-        assert nodes.isEmpty() || nodes.values().stream().anyMatch(NodeAndClient::isMasterEligible)
-            : "only master-ineligible nodes left in " + nodes;
+        assertTrue("expected at least one master-eligible node left in " + nodes,
+            nodes.isEmpty() || nodes.values().stream().anyMatch(NodeAndClient::isMasterEligible));
 
         final int prevNodeCount = nodes.size();
 


### PR DESCRIPTION
This test suite can stop all the shared master-eligible nodes, which breaks the
cluster since any non-shared master-eligible nodes are stopped first in the
reset process between tests.

Since this test suite can leave the cluster in this somewhat broken state, it
seems best that it uses a new cluster for each test.