### PR TITLE
Fix broken links in painless docs

### DIFF
--- a/docs/painless/painless-contexts/painless-similarity-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-similarity-context.asciidoc
@@ -49,7 +49,7 @@ documents in a query.
         document for the current field.
 
 Note that the `query`, `field`, and `term` variables are also available to the
-{ref}/painless-weight-context.html[weight context]. They are more efficiently used
+{painless}/painless-weight-context.html[weight context]. They are more efficiently used
 there, as they are constant for all documents.
 
 For queries that contain multiple terms, the script is called once for each

--- a/docs/painless/painless-contexts/painless-similarity-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-similarity-context.asciidoc
@@ -41,7 +41,7 @@ documents in a query.
 
 `doc.length` (`long`, read-only)::
         The number of tokens the current document has in the current field.  This
-        is decoded from the stored {ref}/norms[norms] and may be approximate for
+        is decoded from the stored {ref}/norms.html[norms] and may be approximate for
         long fields
 
 `doc.freq` (`long`, read-only)::
@@ -49,7 +49,7 @@ documents in a query.
         document for the current field.
 
 Note that the `query`, `field`, and `term` variables are also available to the
-{ref}/painless-weight-context[weight context]. They are more efficiently used
+{ref}/painless-weight-context.html[weight context]. They are more efficiently used
 there, as they are constant for all documents.
 
 For queries that contain multiple terms, the script is called once for each


### PR DESCRIPTION
This fixes two broken links in `painless-similarity-context.asciidoc`