### PR TITLE
Fix deprecation of audit log settings

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/DeprecatedLoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/DeprecatedLoggingAuditTrail.java
@@ -98,9 +98,11 @@ public class DeprecatedLoggingAuditTrail extends AbstractComponent implements Au
             // always read before `localNodeInfo` and `includeRequestBody`.
             this.events = parse(LoggingAuditTrail.INCLUDE_EVENT_SETTINGS.get(newSettings),
                     LoggingAuditTrail.EXCLUDE_EVENT_SETTINGS.get(newSettings));
-        }, Arrays.asList(LoggingAuditTrail.EMIT_HOST_ADDRESS_SETTING, LoggingAuditTrail.EMIT_HOST_NAME_SETTING,
-                LoggingAuditTrail.EMIT_NODE_NAME_SETTING, LoggingAuditTrail.INCLUDE_EVENT_SETTINGS,
-                LoggingAuditTrail.EXCLUDE_EVENT_SETTINGS, LoggingAuditTrail.INCLUDE_REQUEST_BODY));
+        }, Arrays.asList(LoggingAuditTrail.EMIT_HOST_ADDRESS_SETTING, LoggingAuditTrail.DEPRECATED_EMIT_HOST_ADDRESS_SETTING,
+                LoggingAuditTrail.EMIT_HOST_NAME_SETTING, LoggingAuditTrail.DEPRECATED_EMIT_NODE_NAME_SETTING,
+                LoggingAuditTrail.EMIT_NODE_NAME_SETTING, LoggingAuditTrail.DEPRECATED_EMIT_NODE_NAME_SETTING,
+                LoggingAuditTrail.INCLUDE_EVENT_SETTINGS, LoggingAuditTrail.EXCLUDE_EVENT_SETTINGS,
+                LoggingAuditTrail.INCLUDE_REQUEST_BODY));
         clusterService.getClusterSettings().addAffixUpdateConsumer(LoggingAuditTrail.FILTER_POLICY_IGNORE_PRINCIPALS,
                 (policyName, filtersList) -> {
                     final Optional<EventFilterPolicy> policy = eventFilterPolicyRegistry.get(policyName);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -184,7 +184,8 @@ public class LoggingAuditTrail extends AbstractComponent implements AuditTrail, 
             // `entryCommonFields` and `includeRequestBody` writes happen-before! `events` is
             // always read before `entryCommonFields` and `includeRequestBody`.
             this.events = parse(INCLUDE_EVENT_SETTINGS.get(newSettings), EXCLUDE_EVENT_SETTINGS.get(newSettings));
-        }, Arrays.asList(EMIT_HOST_ADDRESS_SETTING, EMIT_HOST_NAME_SETTING, EMIT_NODE_NAME_SETTING, EMIT_NODE_ID_SETTING,
+        }, Arrays.asList(EMIT_HOST_ADDRESS_SETTING, DEPRECATED_EMIT_HOST_ADDRESS_SETTING, EMIT_HOST_NAME_SETTING,
+                DEPRECATED_EMIT_HOST_NAME_SETTING, EMIT_NODE_NAME_SETTING, DEPRECATED_EMIT_NODE_NAME_SETTING, EMIT_NODE_ID_SETTING,
                 INCLUDE_EVENT_SETTINGS, EXCLUDE_EVENT_SETTINGS, INCLUDE_REQUEST_BODY));
         clusterService.getClusterSettings().addAffixUpdateConsumer(FILTER_POLICY_IGNORE_PRINCIPALS, (policyName, filtersList) -> {
             final Optional<EventFilterPolicy> policy = eventFilterPolicyRegistry.get(policyName);
@@ -784,8 +785,11 @@ public class LoggingAuditTrail extends AbstractComponent implements AuditTrail, 
 
     public static void registerSettings(List<Setting<?>> settings) {
         settings.add(EMIT_HOST_ADDRESS_SETTING);
+        settings.add(DEPRECATED_EMIT_HOST_ADDRESS_SETTING);
         settings.add(EMIT_HOST_NAME_SETTING);
+        settings.add(DEPRECATED_EMIT_HOST_NAME_SETTING);
         settings.add(EMIT_NODE_NAME_SETTING);
+        settings.add(DEPRECATED_EMIT_NODE_NAME_SETTING);
         settings.add(EMIT_NODE_ID_SETTING);
         settings.add(INCLUDE_EVENT_SETTINGS);
         settings.add(EXCLUDE_EVENT_SETTINGS);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/AuditTrailSettingsUpdateTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/AuditTrailSettingsUpdateTests.java
@@ -65,7 +65,7 @@ public class AuditTrailSettingsUpdateTests extends SecurityIntegTestCase {
         settingsBuilder.put("xpack.security.audit.outputs", "logfile");
         // add only startup filter policies
         settingsBuilder.put(startupFilterSettings);
-        // we cannot test deprecated variants of these settings because they are overriden
+        // Remove non-deprecated version of prefix settings so that we can test the deprecated variant
         settingsBuilder.remove(LoggingAuditTrail.EMIT_HOST_ADDRESS_SETTING.getKey());
         settingsBuilder.remove(LoggingAuditTrail.EMIT_HOST_NAME_SETTING.getKey());
         settingsBuilder.remove(LoggingAuditTrail.EMIT_NODE_NAME_SETTING.getKey());
@@ -182,6 +182,13 @@ public class AuditTrailSettingsUpdateTests extends SecurityIntegTestCase {
         assertThat(loggingAuditTrail.entryCommonFields.commonFields.containsKey(LoggingAuditTrail.NODE_NAME_FIELD_NAME), is(false));
         assertThat(loggingAuditTrail.entryCommonFields.commonFields.containsKey(LoggingAuditTrail.HOST_ADDRESS_FIELD_NAME), is(false));
         assertThat(loggingAuditTrail.entryCommonFields.commonFields.containsKey(LoggingAuditTrail.HOST_NAME_FIELD_NAME), is(false));
+        settingsBuilder.put(LoggingAuditTrail.DEPRECATED_EMIT_HOST_NAME_SETTING.getKey(), true);
+        settingsBuilder.put(LoggingAuditTrail.DEPRECATED_EMIT_HOST_ADDRESS_SETTING.getKey(), true);
+        settingsBuilder.put(LoggingAuditTrail.DEPRECATED_EMIT_NODE_NAME_SETTING.getKey(), true);
+        updateSettings(settingsBuilder.build(), persistent);
+        assertThat(loggingAuditTrail.entryCommonFields.commonFields.get(LoggingAuditTrail.NODE_NAME_FIELD_NAME), startsWith("node_"));
+        assertThat(loggingAuditTrail.entryCommonFields.commonFields.get(LoggingAuditTrail.HOST_ADDRESS_FIELD_NAME), is("127.0.0.1"));
+        assertThat(loggingAuditTrail.entryCommonFields.commonFields.get(LoggingAuditTrail.HOST_NAME_FIELD_NAME), is("127.0.0.1"));
     }
 
     public void testDynamicRequestBodySettings() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/AuditTrailSettingsUpdateTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/AuditTrailSettingsUpdateTests.java
@@ -65,6 +65,10 @@ public class AuditTrailSettingsUpdateTests extends SecurityIntegTestCase {
         settingsBuilder.put("xpack.security.audit.outputs", "logfile");
         // add only startup filter policies
         settingsBuilder.put(startupFilterSettings);
+        // we cannot test deprecated variants of these settings because they are overriden
+        settingsBuilder.remove(LoggingAuditTrail.EMIT_HOST_ADDRESS_SETTING.getKey());
+        settingsBuilder.remove(LoggingAuditTrail.EMIT_HOST_NAME_SETTING.getKey());
+        settingsBuilder.remove(LoggingAuditTrail.EMIT_NODE_NAME_SETTING.getKey());
         return settingsBuilder.build();
     }
 
@@ -148,11 +152,11 @@ public class AuditTrailSettingsUpdateTests extends SecurityIntegTestCase {
     }
 
     public void testDynamicHostDeprecatedSettings() {
-        final boolean persistent = randomBoolean();
         final Settings.Builder settingsBuilder = Settings.builder();
-        settingsBuilder.put(LoggingAuditTrail.DEPRECATED_EMIT_HOST_ADDRESS_SETTING.getKey(), true);
         settingsBuilder.put(LoggingAuditTrail.DEPRECATED_EMIT_HOST_NAME_SETTING.getKey(), true);
+        settingsBuilder.put(LoggingAuditTrail.DEPRECATED_EMIT_HOST_ADDRESS_SETTING.getKey(), true);
         settingsBuilder.put(LoggingAuditTrail.DEPRECATED_EMIT_NODE_NAME_SETTING.getKey(), true);
+        final boolean persistent = randomBoolean();
         updateSettings(settingsBuilder.build(), persistent);
         final LoggingAuditTrail loggingAuditTrail = (LoggingAuditTrail) internalCluster().getInstances(AuditTrailService.class)
                 .iterator()
@@ -179,7 +183,7 @@ public class AuditTrailSettingsUpdateTests extends SecurityIntegTestCase {
         assertThat(loggingAuditTrail.entryCommonFields.commonFields.containsKey(LoggingAuditTrail.HOST_ADDRESS_FIELD_NAME), is(false));
         assertThat(loggingAuditTrail.entryCommonFields.commonFields.containsKey(LoggingAuditTrail.HOST_NAME_FIELD_NAME), is(false));
     }
-    
+
     public void testDynamicRequestBodySettings() {
         final boolean persistent = randomBoolean();
         final boolean enableRequestBody = randomBoolean();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/AuditTrailSettingsUpdateTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/AuditTrailSettingsUpdateTests.java
@@ -147,6 +147,39 @@ public class AuditTrailSettingsUpdateTests extends SecurityIntegTestCase {
         assertThat(loggingAuditTrail.entryCommonFields.commonFields.containsKey(LoggingAuditTrail.HOST_NAME_FIELD_NAME), is(false));
     }
 
+    public void testDynamicHostDeprecatedSettings() {
+        final boolean persistent = randomBoolean();
+        final Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put(LoggingAuditTrail.DEPRECATED_EMIT_HOST_ADDRESS_SETTING.getKey(), true);
+        settingsBuilder.put(LoggingAuditTrail.DEPRECATED_EMIT_HOST_NAME_SETTING.getKey(), true);
+        settingsBuilder.put(LoggingAuditTrail.DEPRECATED_EMIT_NODE_NAME_SETTING.getKey(), true);
+        updateSettings(settingsBuilder.build(), persistent);
+        final LoggingAuditTrail loggingAuditTrail = (LoggingAuditTrail) internalCluster().getInstances(AuditTrailService.class)
+                .iterator()
+                .next()
+                .getAuditTrails()
+                .iterator()
+                .next();
+        assertThat(loggingAuditTrail.entryCommonFields.commonFields.get(LoggingAuditTrail.NODE_NAME_FIELD_NAME), startsWith("node_"));
+        assertThat(loggingAuditTrail.entryCommonFields.commonFields.get(LoggingAuditTrail.HOST_ADDRESS_FIELD_NAME), is("127.0.0.1"));
+        assertThat(loggingAuditTrail.entryCommonFields.commonFields.get(LoggingAuditTrail.HOST_NAME_FIELD_NAME), is("127.0.0.1"));
+        settingsBuilder.put(LoggingAuditTrail.DEPRECATED_EMIT_HOST_ADDRESS_SETTING.getKey(), false);
+        updateSettings(settingsBuilder.build(), persistent);
+        assertThat(loggingAuditTrail.entryCommonFields.commonFields.get(LoggingAuditTrail.NODE_NAME_FIELD_NAME), startsWith("node_"));
+        assertThat(loggingAuditTrail.entryCommonFields.commonFields.containsKey(LoggingAuditTrail.HOST_ADDRESS_FIELD_NAME), is(false));
+        assertThat(loggingAuditTrail.entryCommonFields.commonFields.get(LoggingAuditTrail.HOST_NAME_FIELD_NAME), is("127.0.0.1"));
+        settingsBuilder.put(LoggingAuditTrail.DEPRECATED_EMIT_HOST_NAME_SETTING.getKey(), false);
+        updateSettings(settingsBuilder.build(), persistent);
+        assertThat(loggingAuditTrail.entryCommonFields.commonFields.get(LoggingAuditTrail.NODE_NAME_FIELD_NAME), startsWith("node_"));
+        assertThat(loggingAuditTrail.entryCommonFields.commonFields.containsKey(LoggingAuditTrail.HOST_ADDRESS_FIELD_NAME), is(false));
+        assertThat(loggingAuditTrail.entryCommonFields.commonFields.containsKey(LoggingAuditTrail.HOST_NAME_FIELD_NAME), is(false));
+        settingsBuilder.put(LoggingAuditTrail.DEPRECATED_EMIT_NODE_NAME_SETTING.getKey(), false);
+        updateSettings(settingsBuilder.build(), persistent);
+        assertThat(loggingAuditTrail.entryCommonFields.commonFields.containsKey(LoggingAuditTrail.NODE_NAME_FIELD_NAME), is(false));
+        assertThat(loggingAuditTrail.entryCommonFields.commonFields.containsKey(LoggingAuditTrail.HOST_ADDRESS_FIELD_NAME), is(false));
+        assertThat(loggingAuditTrail.entryCommonFields.commonFields.containsKey(LoggingAuditTrail.HOST_NAME_FIELD_NAME), is(false));
+    }
+    
     public void testDynamicRequestBodySettings() {
         final boolean persistent = randomBoolean();
         final boolean enableRequestBody = randomBoolean();


### PR DESCRIPTION
I have botched deprecating the "prefix" logfile audit settings in https://github.com/elastic/elasticsearch/pull/34475 , by not registering them.

This commit fixes this, and adds a test that these deprecated settings still work and are dynamic.

Closes https://github.com/elastic/elasticsearch/issues/36162