### PR TITLE
[test] generate unique user names

### DIFF
--- a/x-pack/plugin/sql/qa/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/UserFunctionIT.java
+++ b/x-pack/plugin/sql/qa/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/UserFunctionIT.java
@@ -59,11 +59,9 @@ public class UserFunctionIT extends ESRestTestCase {
     private void setUpUsers() throws IOException {
         int usersCount = name.getMethodName().startsWith("testSingle") ? 1 : randomIntBetween(5,  15);
         users = new ArrayList<String>(usersCount);
-        
-        for(int i = 0; i < usersCount; i++) {
-            String randomUserName = randomAlphaOfLengthBetween(1, 15);
-            users.add(randomUserName);
-            createUser(randomUserName, MINIMAL_ACCESS_ROLE);
+        users.addAll(randomUnique(() -> randomAlphaOfLengthBetween(1, 15), usersCount));
+        for (String user : users) {
+            createUser(user, MINIMAL_ACCESS_ROLE);
         }
     }
 


### PR DESCRIPTION
This fixes a test bug in `UserFunctionIT.testMultipleRandomUsersAccess` where the list of users it tries to create contains a duplicate, which causes the call to delete the duplicate user to 404

For https://github.com/elastic/elasticsearch/issues/36138