### PR TITLE
Deprecation check for `:` in Cluster/Index name

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -18,7 +18,7 @@ public class ClusterDeprecationChecks {
         int maxShardsInCluster = shardsPerNode * nodeCount;
         int currentOpenShards = state.getMetaData().getTotalOpenIndexShards();
 
-        if (nodeCount != 0 && currentOpenShards >= maxShardsInCluster) {
+        if (nodeCount > 0 && currentOpenShards >= maxShardsInCluster) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "Number of open shards exceeds cluster soft limit",
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html",

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -18,12 +18,24 @@ public class ClusterDeprecationChecks {
         int maxShardsInCluster = shardsPerNode * nodeCount;
         int currentOpenShards = state.getMetaData().getTotalOpenIndexShards();
 
-        if (currentOpenShards >= maxShardsInCluster) {
+        if (nodeCount != 0 && currentOpenShards >= maxShardsInCluster) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "Number of open shards exceeds cluster soft limit",
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html",
                 "There are [" + currentOpenShards + "] open shards in this cluster, but the cluster is limited to [" +
                     shardsPerNode + "] per data node, for [" + maxShardsInCluster + "] maximum.");
+        }
+        return null;
+    }
+
+    static DeprecationIssue checkClusterName(ClusterState state) {
+        String clusterName = state.getClusterName().value();
+        if (clusterName.contains(":")) {
+            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
+                "Cluster name cannot contain ':'",
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                    "#_literal_literal_is_no_longer_allowed_in_cluster_name",
+                "This cluster is named [" + clusterName + "], which contains the illegal character ':'.");
         }
         return null;
     }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -32,7 +32,8 @@ public class DeprecationChecks {
 
     static List<Function<ClusterState, DeprecationIssue>> CLUSTER_SETTINGS_CHECKS =
         Collections.unmodifiableList(Arrays.asList(
-            ClusterDeprecationChecks::checkShardLimit
+            ClusterDeprecationChecks::checkShardLimit,
+            ClusterDeprecationChecks::checkClusterName
         ));
 
     static List<BiFunction<List<NodeInfo>, List<NodeStats>, DeprecationIssue>> NODE_SETTINGS_CHECKS =
@@ -44,7 +45,9 @@ public class DeprecationChecks {
     static List<Function<IndexMetaData, DeprecationIssue>> INDEX_SETTINGS_CHECKS =
         Collections.unmodifiableList(Arrays.asList(
             IndexDeprecationChecks::oldIndicesCheck,
-            IndexDeprecationChecks::delimitedPayloadFilterCheck));
+            IndexDeprecationChecks::delimitedPayloadFilterCheck,
+            IndexDeprecationChecks::indexNameCheck
+            ));
 
     /**
      * helper utility function to reduce repeat of running a specific {@link Set} of checks.

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -108,7 +108,7 @@ public class IndexDeprecationChecks {
     static DeprecationIssue indexNameCheck(IndexMetaData indexMetaData) {
         String clusterName = indexMetaData.getIndex().getName();
         if (clusterName.contains(":")) {
-            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
+            return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "Index name cannot contain ':'",
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#_literal_literal_is_no_longer_allowed_in_index_name",

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -104,4 +104,16 @@ public class IndexDeprecationChecks {
         }
         return null;
     }
+
+    static DeprecationIssue indexNameCheck(IndexMetaData indexMetaData) {
+        String clusterName = indexMetaData.getIndex().getName();
+        if (clusterName.contains(":")) {
+            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
+                "Index name cannot contain ':'",
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                    "#_literal_literal_is_no_longer_allowed_in_index_name",
+                "This index is named [" + clusterName + "], which contains the illegal character ':'.");
+        }
+        return null;
+    }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -51,4 +51,29 @@ public class IndexDeprecationChecksTests extends ESTestCase {
         List<DeprecationIssue> issues = DeprecationInfoAction.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(indexMetaData));
         assertEquals(singletonList(expected), issues);
     }
+
+    public void testIndexNameCheck(){
+        final String badIndexName = randomAlphaOfLengthBetween(0, 10) + ":" + randomAlphaOfLengthBetween(0, 10);
+        final IndexMetaData badIndex = IndexMetaData.builder(badIndexName)
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(randomIntBetween(1,100))
+            .numberOfReplicas(randomIntBetween(1,15))
+            .build();
+
+        DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.CRITICAL, "Index name cannot contain ':'",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                "#_literal_literal_is_no_longer_allowed_in_index_name",
+            "This index is named [" + badIndexName + "], which contains the illegal character ':'.");
+        List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(badIndex));
+        assertEquals(singletonList(expected), issues);
+
+        final String goodIndexName = randomAlphaOfLengthBetween(1,30);
+        final IndexMetaData goodIndex = IndexMetaData.builder(goodIndexName)
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(randomIntBetween(1,100))
+            .numberOfReplicas(randomIntBetween(1,15))
+            .build();
+        List<DeprecationIssue> noIssues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(goodIndex));
+        assertTrue(noIssues.isEmpty());
+    }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -60,7 +60,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             .numberOfReplicas(randomIntBetween(1,15))
             .build();
 
-        DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.CRITICAL, "Index name cannot contain ':'",
+        DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING, "Index name cannot contain ':'",
             "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                 "#_literal_literal_is_no_longer_allowed_in_index_name",
             "This index is named [" + badIndexName + "], which contains the illegal character ':'.");


### PR DESCRIPTION
Adds a deprecation check for cluster and index names that contain `:`,
which is illegal in 7.0.

Relates to https://github.com/elastic/elasticsearch/issues/36024 and https://github.com/elastic/elasticsearch/pull/26247