### PR TITLE
Deprecation check for File Discovery plugin

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -38,7 +38,8 @@ public class DeprecationChecks {
     static List<BiFunction<List<NodeInfo>, List<NodeStats>, DeprecationIssue>> NODE_SETTINGS_CHECKS =
         Collections.unmodifiableList(Arrays.asList(
             NodeDeprecationChecks::azureRepositoryChanges,
-            NodeDeprecationChecks::gcsRepositoryChanges
+            NodeDeprecationChecks::gcsRepositoryChanges,
+            NodeDeprecationChecks::fileDiscoveryPluginRemoved
         ));
 
     static List<Function<IndexMetaData, DeprecationIssue>> INDEX_SETTINGS_CHECKS =

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -49,4 +49,20 @@ public class NodeDeprecationChecks {
         }
         return null;
     }
+
+    static DeprecationIssue fileDiscoveryPluginRemoved(List<NodeInfo> nodeInfos, List<NodeStats> nodeStats) {
+        List<String> nodesFound = nodeInfos.stream()
+            .filter(nodeInfo ->
+                nodeInfo.getPlugins().getPluginInfos().stream()
+                    .anyMatch(pluginInfo -> "discovery-file".equals(pluginInfo.getName()))
+            ).map(nodeInfo -> nodeInfo.getNode().getName()).collect(Collectors.toList());
+        if (nodesFound.size() > 0) {
+            return new DeprecationIssue(DeprecationIssue.Level.WARNING,
+                "File-based discovery is no longer a plugin and uses a different path",
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+                    "#_file_based_discovery_plugin",
+                "nodes with discovery-file installed: " + nodesFound);
+        }
+        return null;
+    }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -88,4 +88,19 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             "nodes with repository-gcs installed: [node_check]");
         assertSettingsAndIssue("foo", "bar", expected);
     }
+
+    public void testFileDiscoveryPluginCheck() {
+        Version esVersion = VersionUtils.randomVersionBetween(random(), Version.V_6_0_0, Version.CURRENT);
+        PluginInfo deprecatedPlugin = new PluginInfo(
+            "discovery-file", "dummy plugin description", "dummy_plugin_version", esVersion,
+            "javaVersion", "DummyPluginName", Collections.emptyList(), false);
+        pluginsAndModules = new PluginsAndModules(Collections.singletonList(deprecatedPlugin), Collections.emptyList());
+
+        DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
+            "File-based discovery is no longer a plugin and uses a different path",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+                "#_file_based_discovery_plugin",
+            "nodes with discovery-file installed: [node_check]");
+        assertSettingsAndIssue("foo", "bar", expected);
+    }
 }


### PR DESCRIPTION
Adds a deprecation warning that the file discovery plugin is no longer
needed and that the path it uses has changed.

Relates to https://github.com/elastic/elasticsearch/issues/36024 and https://github.com/elastic/elasticsearch/pull/33257