### PR TITLE
[Kerberos] Find if port is available before using it for Kdc server

### DIFF
--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SimpleKdcLdapServer.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SimpleKdcLdapServer.java
@@ -238,13 +238,13 @@ public class SimpleKdcLdapServer {
         if (transport != null && transport.trim().equalsIgnoreCase("tcp")) {
             try (ServerSocket serverSocket = ServerSocketFactory.getDefault().createServerSocket(port, 1,
                     InetAddress.getByName("127.0.0.1"))) {
-                return true;
+                return serverSocket.isBound();
             } catch (Exception ex) {
                 return false;
             }
         } else if (transport != null && transport.trim().equalsIgnoreCase("udp")) {
             try (DatagramSocket socket = new DatagramSocket(port, InetAddress.getByName("127.0.0.1"))) {
-                return true;
+                return socket.isBound();
             } catch (Exception ex) {
                 return false;
             }

--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SimpleKdcLdapServer.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SimpleKdcLdapServer.java
@@ -135,10 +135,10 @@ public class SimpleKdcLdapServer {
             if (kdcPort == 0) {
                 kdcPort = getServerPort(transport);
             }
-            if (transport.trim().equals("TCP")) {
+            if (transport.trim().equalsIgnoreCase("TCP")) {
                 simpleKdc.setKdcTcpPort(kdcPort);
                 simpleKdc.setAllowUdp(false);
-            } else if (transport.trim().equals("UDP")) {
+            } else if (transport.trim().equalsIgnoreCase("UDP")) {
                 simpleKdc.setKdcUdpPort(kdcPort);
                 simpleKdc.setAllowTcp(false);
             } else {
@@ -226,18 +226,18 @@ public class SimpleKdcLdapServer {
     }
 
     private static int getServerPort(String transport) {
-        if (transport != null && transport.trim().equalsIgnoreCase("tcp")) {
+        if (transport != null && transport.trim().equalsIgnoreCase("TCP")) {
             try (ServerSocket serverSocket = ServerSocketFactory.getDefault().createServerSocket(0, 1,
                     InetAddress.getByName("127.0.0.1"))) {
                 return serverSocket.getLocalPort();
             } catch (Exception ex) {
-                throw new RuntimeException("Failed to get a tcp server socket point");
+                throw new RuntimeException("Failed to get a TCP server socket point");
             }
-        } else if (transport != null && transport.trim().equalsIgnoreCase("udp")) {
+        } else if (transport != null && transport.trim().equalsIgnoreCase("UDP")) {
             try (DatagramSocket socket = new DatagramSocket(0, InetAddress.getByName("127.0.0.1"))) {
                 return socket.getLocalPort();
             } catch (Exception ex) {
-                throw new RuntimeException("Failed to get a udp server socket point");
+                throw new RuntimeException("Failed to get a UDP server socket point");
             }
         }
         throw new IllegalArgumentException("Invalid transport: " + transport);

--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SimpleKdcLdapServer.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SimpleKdcLdapServer.java
@@ -233,6 +233,7 @@ public class SimpleKdcLdapServer {
                 throw new IllegalArgumentException("Could not find available port for KDC server");
             }
             port = ESTestCase.randomIntBetween(1024, 65535);
+            tries++;
         } while (isPortAvailable(port, transport) == false);
         return port;
     }


### PR DESCRIPTION
If the randomly selected port was already in use the Kerberos
tests would fail. This commit adds check to see if the network
port is available and if not continue to find one for KDC server.
If it does not find port after 100 retries it throws an exception.

Closes #34261