### PR TITLE
Make credentials mandatory when launching xpack/migrate

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/ESNativeRealmMigrateTool.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/ESNativeRealmMigrateTool.java
@@ -104,10 +104,10 @@ public class ESNativeRealmMigrateTool extends LoggingAwareMultiCommand {
             super("Migrates users or roles from file to native realm");
             this.username = parser.acceptsAll(Arrays.asList("u", "username"),
                     "User used to authenticate with Elasticsearch")
-                    .withRequiredArg();
+                    .withRequiredArg().required();
             this.password = parser.acceptsAll(Arrays.asList("p", "password"),
                     "Password used to authenticate with Elasticsearch")
-                    .withRequiredArg();
+                    .withRequiredArg().required();
             this.url = parser.acceptsAll(Arrays.asList("U", "url"),
                     "URL of Elasticsearch host")
                     .withRequiredArg();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/ESNativeMigrateToolTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/ESNativeMigrateToolTests.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.security.authc.esnative;
 
+import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import org.elasticsearch.cli.MockTerminal;
@@ -24,6 +25,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -154,5 +156,14 @@ public class ESNativeMigrateToolTests extends NativeRealmIntegTestCase {
         for (String r : addedRoles) {
             assertThat("expected list to contain: " + r, roles.contains(r), is(true));
         }
+    }
+
+    public void testMissingPasswordParameter() {
+        ESNativeRealmMigrateTool.MigrateUserOrRoles muor = new ESNativeRealmMigrateTool.MigrateUserOrRoles();
+
+        final OptionException ex = expectThrows(OptionException.class,
+            () -> muor.getParser().parse("-u", "elastic", "-U", "http://localhost:9200"));
+
+        assertThat(ex.getMessage(), containsString("password"));
     }
 }


### PR DESCRIPTION
Made credentials mandatory for xpack migrate tool.
Closes #29847.

The x-pack user and roles APIs aren't available unless security is enabled, so the tool should always be called with the -u and -p options specified.

Relates: #33972