### PR TITLE
[CCR] Change get autofollow patterns API response format

### DIFF
--- a/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
@@ -87,15 +87,19 @@ The API returns the following result:
 [source,js]
 --------------------------------------------------
 {
-  "my_auto_follow_pattern" :
-  {
-    "remote_cluster" : "remote_cluster",
-    "leader_index_patterns" :
-    [
-      "leader_index*"
-    ],
-    "follow_index_pattern" : "{{leader_index}}-follower"
-  }
+  "patterns": [
+    {
+      "name": "my_auto_follow_pattern",
+      "pattern": {
+        "remote_cluster" : "remote_cluster",
+        "leader_index_patterns" :
+        [
+          "leader_index*"
+        ],
+        "follow_index_pattern" : "{{leader_index}}-follower"
+      }
+    }
+  ]
 }
 --------------------------------------------------
 // TESTRESPONSE

--- a/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/auto_follow.yml
+++ b/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/auto_follow.yml
@@ -31,15 +31,17 @@
   - do:
       ccr.get_auto_follow_pattern:
         name: my_pattern
-  - match: { my_pattern.remote_cluster: 'local' }
-  - match: { my_pattern.leader_index_patterns: ['logs-*'] }
-  - match: { my_pattern.max_outstanding_read_requests: 2 }
+  - match: { patterns.0.name: 'my_pattern' }
+  - match: { patterns.0.pattern.remote_cluster: 'local' }
+  - match: { patterns.0.pattern.leader_index_patterns: ['logs-*'] }
+  - match: { patterns.0.pattern.max_outstanding_read_requests: 2 }
 
   - do:
       ccr.get_auto_follow_pattern: {}
-  - match: { my_pattern.remote_cluster: 'local' }
-  - match: { my_pattern.leader_index_patterns: ['logs-*'] }
-  - match: { my_pattern.max_outstanding_read_requests: 2 }
+  - match: { patterns.0.name: 'my_pattern' }
+  - match: { patterns.0.pattern.remote_cluster: 'local' }
+  - match: { patterns.0.pattern.leader_index_patterns: ['logs-*'] }
+  - match: { patterns.0.pattern.max_outstanding_read_requests: 2 }
 
   - do:
       ccr.delete_auto_follow_pattern:

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/GetAutoFollowPatternAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/GetAutoFollowPatternAction.java
@@ -111,10 +111,21 @@ public class GetAutoFollowPatternAction extends Action<GetAutoFollowPatternActio
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            for (Map.Entry<String, AutoFollowPattern> entry : autoFollowPatterns.entrySet()) {
-                builder.startObject(entry.getKey());
-                entry.getValue().toXContent(builder, params);
-                builder.endObject();
+            {
+                builder.startArray("patterns");
+                for (Map.Entry<String, AutoFollowPattern> entry : autoFollowPatterns.entrySet()) {
+                    builder.startObject();
+                    {
+                        builder.field("name", entry.getKey());
+                        builder.startObject("pattern");
+                        {
+                            entry.getValue().toXContent(builder, params);
+                        }
+                        builder.endObject();
+                    }
+                    builder.endObject();
+                }
+                builder.endArray();
             }
             builder.endObject();
             return builder;


### PR DESCRIPTION
The current response format is:

```
{
    "pattern1": {
        ...
    },
    "pattern2": {
        ...
    }
}
```

The new format is:

```
{
    "patterns": [
        {
            "name": "pattern1",
            "pattern": {
                ...
            }
        },
        {
            "name": "pattern2",
            "pattern": {
                ...
            }
        }
    ]
}
```

This format is more structured and more friendly for parsing and generating specs.
This is a breaking change, but it is better to do this now while ccr
is still a beta feature than later.

Follow up from #36049