### PR TITLE
Updated version to 6.5.2

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -1,4 +1,4 @@
-:version:               6.5.1
+:version:               6.5.2
 :major-version:         6.x
 :lucene_version:        7.5.0
 :lucene_version_path:   7_5_0


### PR DESCRIPTION
Updated the Elasticsearch docs version from 6.5.1 to 6.5.2.