### PR TITLE
Rename internal repository actions to be internal

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/Ccr.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/Ccr.java
@@ -10,7 +10,6 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -151,7 +150,7 @@ public class Ccr extends Plugin implements ActionPlugin, PersistentTaskPlugin, E
             return emptyList();
         }
 
-        this.repositoryManager.set(new CcrRepositoryManager(settings, clusterService, (NodeClient) client));
+        this.repositoryManager.set(new CcrRepositoryManager(settings, clusterService, client));
 
         return Arrays.asList(
             ccrLicenseChecker,

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrRepositoryManager.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrRepositoryManager.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.ccr;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.transport.RemoteClusterAware;
@@ -22,9 +22,9 @@ import java.util.List;
 
 class CcrRepositoryManager extends RemoteClusterAware {
 
-    private final NodeClient client;
+    private final Client client;
 
-    CcrRepositoryManager(Settings settings, ClusterService clusterService, NodeClient client) {
+    CcrRepositoryManager(Settings settings, ClusterService clusterService, Client client) {
         super(settings);
         this.client = client;
         listenForUpdates(clusterService.getClusterSettings());
@@ -36,12 +36,12 @@ class CcrRepositoryManager extends RemoteClusterAware {
         if (addresses.isEmpty()) {
             DeleteInternalCcrRepositoryRequest request = new DeleteInternalCcrRepositoryRequest(repositoryName);
             PlainActionFuture<DeleteInternalCcrRepositoryAction.DeleteInternalCcrRepositoryResponse> f = PlainActionFuture.newFuture();
-            client.executeLocally(DeleteInternalCcrRepositoryAction.INSTANCE, request, f);
+            client.execute(DeleteInternalCcrRepositoryAction.INSTANCE, request, f);
             assert f.isDone() : "Should be completed as it is executed synchronously";
         } else {
             ActionRequest request = new PutInternalCcrRepositoryRequest(repositoryName, CcrRepository.TYPE);
             PlainActionFuture<PutInternalCcrRepositoryAction.PutInternalCcrRepositoryResponse> f = PlainActionFuture.newFuture();
-            client.executeLocally(PutInternalCcrRepositoryAction.INSTANCE, request, f);
+            client.execute(PutInternalCcrRepositoryAction.INSTANCE, request, f);
             assert f.isDone() : "Should be completed as it is executed synchronously";
         }
     }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/DeleteInternalCcrRepositoryAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/DeleteInternalCcrRepositoryAction.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 public class DeleteInternalCcrRepositoryAction extends Action<DeleteInternalCcrRepositoryAction.DeleteInternalCcrRepositoryResponse> {
 
     public static final DeleteInternalCcrRepositoryAction INSTANCE = new DeleteInternalCcrRepositoryAction();
-    public static final String NAME = "cluster:admin/ccr/internal_repository/delete";
+    public static final String NAME = "internal:admin/ccr/internal_repository/delete";
 
     private DeleteInternalCcrRepositoryAction() {
         super(NAME);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/PutInternalCcrRepositoryAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/PutInternalCcrRepositoryAction.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 public class PutInternalCcrRepositoryAction extends Action<PutInternalCcrRepositoryAction.PutInternalCcrRepositoryResponse> {
 
     public static final PutInternalCcrRepositoryAction INSTANCE = new PutInternalCcrRepositoryAction();
-    public static final String NAME = "cluster:admin/ccr/internal_repository/put";
+    public static final String NAME = "internal:admin/ccr/internal_repository/put";
 
     private PutInternalCcrRepositoryAction() {
         super(NAME);


### PR DESCRIPTION
This is a follow-up to #36086. It renames the internal repository
actions to be prefixed by "internal". This allows the system user to
execute the actions.

Additionally, this PR stops casting Client to NodeClient. The client we
have is a NodeClient so executing the actions will be local.
