### PR TITLE
Add support for assertWarnings() to ESRestTestCase

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
@@ -223,6 +223,19 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
             assertTrue(searchHit.getSourceAsMap().containsKey("num2"));
         }
     }
+    
+    public void testSearchNoQueryDeprecated() throws IOException {
+        SearchRequest searchRequest = new SearchRequest("index");
+        searchRequest.types("foo");
+        SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+        assertWarnings("[types removal] Specifying types in search requests is deprecated.");
+    }    
+    
+
+    @Override
+    protected boolean getStrictDeprecationMode() {
+        return false;
+    }
 
     public void testSearchMatchQuery() throws IOException {
         SearchRequest searchRequest = new SearchRequest("index");

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
@@ -52,6 +52,7 @@ public final class RestClientBuilder {
     private int maxRetryTimeout = DEFAULT_MAX_RETRY_TIMEOUT_MILLIS;
     private Header[] defaultHeaders = EMPTY_HEADERS;
     private RestClient.FailureListener failureListener;
+    private RestClient.WarningListener warningListener;
     private HttpClientConfigCallback httpClientConfigCallback;
     private RequestConfigCallback requestConfigCallback;
     private String pathPrefix;
@@ -101,6 +102,17 @@ public final class RestClientBuilder {
         this.failureListener = failureListener;
         return this;
     }
+    
+    /**
+     * Sets the {@link RestClient.WarningListener} to be notified for each request failure
+     *
+     * @throws NullPointerException if {@code warningListener} is {@code null}.
+     */
+    public RestClientBuilder setWarningListener(RestClient.WarningListener warningListener) {
+        Objects.requireNonNull(warningListener, "warningListener must not be null");
+        this.warningListener = warningListener;
+        return this;
+    }    
 
     /**
      * Sets the maximum timeout (in milliseconds) to honour in case of multiple retries of the same request.
@@ -209,7 +221,7 @@ public final class RestClientBuilder {
             }
         });
         RestClient restClient = new RestClient(httpClient, maxRetryTimeout, defaultHeaders, nodes,
-                pathPrefix, failureListener, nodeSelector, strictDeprecationMode);
+                pathPrefix, warningListener, failureListener, nodeSelector, strictDeprecationMode);
         httpClient.start();
         return restClient;
     }

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientMultipleHostsTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientMultipleHostsTests.java
@@ -115,7 +115,7 @@ public class RestClientMultipleHostsTests extends RestClientTestCase {
         }
         nodes = Collections.unmodifiableList(nodes);
         failureListener = new HostsTrackingFailureListener();
-        return new RestClient(httpClient, 10000, new Header[0], nodes, null, failureListener, nodeSelector, false);
+        return new RestClient(httpClient, 10000, new Header[0], nodes, null, null, failureListener, nodeSelector, false);
     }
 
     /**

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
@@ -153,7 +153,7 @@ public class RestClientSingleHostTests extends RestClientTestCase {
         failureListener = new HostsTrackingFailureListener();
         strictDeprecationMode = randomBoolean();
         restClient = new RestClient(httpClient, 10000, defaultHeaders,
-                singletonList(node), null, failureListener, NodeSelector.ANY, strictDeprecationMode);
+                singletonList(node), null, null, failureListener, NodeSelector.ANY, strictDeprecationMode);
     }
 
     /**

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientTests.java
@@ -57,7 +57,7 @@ public class RestClientTests extends RestClientTestCase {
     public void testCloseIsIdempotent() throws IOException {
         List<Node> nodes = singletonList(new Node(new HttpHost("localhost", 9200)));
         CloseableHttpAsyncClient closeableHttpAsyncClient = mock(CloseableHttpAsyncClient.class);
-        RestClient restClient = new RestClient(closeableHttpAsyncClient, 1_000, new Header[0], nodes, null, null, null, false);
+        RestClient restClient = new RestClient(closeableHttpAsyncClient, 1_000, new Header[0], nodes, null, null, null, null, false);
         restClient.close();
         verify(closeableHttpAsyncClient, times(1)).close();
         restClient.close();
@@ -345,7 +345,7 @@ public class RestClientTests extends RestClientTestCase {
     private static RestClient createRestClient() {
         List<Node> nodes = Collections.singletonList(new Node(new HttpHost("localhost", 9200)));
         return new RestClient(mock(CloseableHttpAsyncClient.class), randomLongBetween(1_000, 30_000),
-                new Header[] {}, nodes, null, null, null, false);
+                new Header[] {}, nodes, null, null, null, null, false);
     }
 
     public void testRoundRobin() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -52,7 +52,6 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 import org.junit.AfterClass;


### PR DESCRIPTION
Added a "WarningsListener" to RestClient and ESRestTestCase provides such a listener so that it can use a DeprecationLogger to record warnings returned in HTTP responses.
Logging deprecation warnings causes the existing ThreadLocal storage of warning messages to take effect meaning `EStTestCase.assertWarnings()` calls have something to inspect.
Added an example use of assertWarnings to SearchIT

Closes #36251 