### PR TITLE
Always set total hits to null when track total hits is false

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
@@ -761,7 +761,7 @@ public final class SearchPhaseController {
         TopDocsStats(boolean trackTotalHits) {
             this.trackTotalHits = trackTotalHits;
             this.totalHits = 0;
-            this.totalHitsRelation = trackTotalHits ? Relation.EQUAL_TO : Relation.GREATER_THAN_OR_EQUAL_TO;
+            this.totalHitsRelation = Relation.EQUAL_TO;
         }
 
         TotalHits getTotalHits() {

--- a/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -299,12 +299,17 @@ public class Lucene {
     }
 
     private static TotalHits readTotalHits(StreamInput in) throws IOException {
-        long totalHits = in.readVLong();
-        TotalHits.Relation totalHitsRelation = TotalHits.Relation.EQUAL_TO;
         if (in.getVersion().onOrAfter(org.elasticsearch.Version.V_7_0_0)) {
-            totalHitsRelation = in.readEnum(TotalHits.Relation.class);
+            if (in.readBoolean()) {
+                long totalHits = in.readVLong();
+                TotalHits.Relation totalHitsRelation = in.readEnum(TotalHits.Relation.class);
+                return new TotalHits(totalHits, totalHitsRelation);
+            } else {
+                return null;
+            }
+        } else {
+            return new TotalHits(in.readVLong(), TotalHits.Relation.EQUAL_TO);
         }
-        return new TotalHits(totalHits, totalHitsRelation);
     }
 
     public static TopDocsAndMaxScore readTopDocs(StreamInput in) throws IOException {
@@ -419,11 +424,24 @@ public class Lucene {
     private static final Class<?> GEO_DISTANCE_SORT_TYPE_CLASS = LatLonDocValuesField.newDistanceSort("some_geo_field", 0, 0).getClass();
 
     private static void writeTotalHits(StreamOutput out, TotalHits totalHits) throws IOException {
-        out.writeVLong(totalHits.value);
+        boolean hasTotalHits = totalHits != null;
         if (out.getVersion().onOrAfter(org.elasticsearch.Version.V_7_0_0)) {
-            out.writeEnum(totalHits.relation);
-        } else if (totalHits.value > 0 && totalHits.relation != TotalHits.Relation.EQUAL_TO) {
-            throw new IllegalArgumentException("Cannot serialize approximate total hit counts to nodes that are on a version < 7.0.0");
+            out.writeBoolean(hasTotalHits);
+            if (hasTotalHits) {
+                out.writeVLong(totalHits.value);
+                out.writeEnum(totalHits.relation);
+            }
+        } else {
+            if (hasTotalHits) {
+                out.writeVLong(totalHits.value);
+                if (totalHits.value > 0 && totalHits.relation != TotalHits.Relation.EQUAL_TO) {
+                    throw new IllegalArgumentException("Cannot serialize approximate total hit counts to nodes that " +
+                        "are on a version < 7.0.0");
+                }
+            } else {
+                // for bwc we use 0 but this will be translated to -1 by the coordinating node
+                out.writeVLong(0);
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/SearchHits.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHits.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -276,14 +277,7 @@ public final class SearchHits implements Streamable, ToXContentFragment, Iterabl
         final TotalHits in;
 
         Total(StreamInput in) throws IOException {
-            final long value = in.readVLong();
-            final Relation relation;
-            if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
-                relation = in.readEnum(Relation.class);
-            } else {
-                relation = Relation.EQUAL_TO;
-            }
-            this.in = new TotalHits(value, relation);
+            this.in = Lucene.readTotalHits(in);
         }
 
         Total(TotalHits in) {
@@ -306,12 +300,7 @@ public final class SearchHits implements Streamable, ToXContentFragment, Iterabl
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeVLong(in.value);
-            if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-                out.writeEnum(in.relation);
-            } else {
-                assert in.relation == Relation.EQUAL_TO;
-            }
+            Lucene.writeTotalHits(out, in);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/elasticsearch/search/query/TopDocsCollectorContext.java
@@ -221,7 +221,7 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
             } else {
                 topDocsCollector = createCollector(sortAndFormats, numHits, searchAfter, 1); // don't compute hit counts via the collector
                 topDocsSupplier = new CachedSupplier<>(topDocsCollector::topDocs);
-                if (hitCount == -1) {
+                if (trackTotalHits == false) {
                     totalHitsSupplier = () -> null;
                 } else {
                     totalHitsSupplier = () -> new TotalHits(hitCount, TotalHits.Relation.EQUAL_TO);

--- a/server/src/main/java/org/elasticsearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/elasticsearch/search/query/TopDocsCollectorContext.java
@@ -111,8 +111,7 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
                 }
             } else {
                 this.collector = new EarlyTerminatingCollector(new TotalHitCountCollector(), 0, false);
-                // for bwc hit count is set to 0, it will be converted to -1 by the coordinating node
-                this.hitCountSupplier = () -> new TotalHits(0, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
+                this.hitCountSupplier = () -> null;
             }
         }
 
@@ -223,8 +222,7 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
                 topDocsCollector = createCollector(sortAndFormats, numHits, searchAfter, 1); // don't compute hit counts via the collector
                 topDocsSupplier = new CachedSupplier<>(topDocsCollector::topDocs);
                 if (hitCount == -1) {
-                    assert trackTotalHits == false;
-                    totalHitsSupplier = () -> new TotalHits(0, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
+                    totalHitsSupplier = () -> null;
                 } else {
                     totalHitsSupplier = () -> new TotalHits(hitCount, TotalHits.Relation.EQUAL_TO);
                 }

--- a/server/src/main/java/org/elasticsearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/elasticsearch/search/query/TopDocsCollectorContext.java
@@ -107,11 +107,11 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
                     this.hitCountSupplier = () -> new TotalHits(hitCountCollector.getTotalHits(), TotalHits.Relation.EQUAL_TO);
                 } else {
                     this.collector = new EarlyTerminatingCollector(hitCountCollector, 0, false);
-                    this.hitCountSupplier = () -> new TotalHits(hitCount, TotalHits.Relation.EQUAL_TO);
+                    this.hitCountSupplier = () -> new TotalHits(hitCount, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
                 }
             } else {
                 this.collector = new EarlyTerminatingCollector(new TotalHitCountCollector(), 0, false);
-                this.hitCountSupplier = () -> null;
+                this.hitCountSupplier = () -> new TotalHits(0, TotalHits.Relation.EQUAL_TO);
             }
         }
 
@@ -222,7 +222,7 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
                 topDocsCollector = createCollector(sortAndFormats, numHits, searchAfter, 1); // don't compute hit counts via the collector
                 topDocsSupplier = new CachedSupplier<>(topDocsCollector::topDocs);
                 if (trackTotalHits == false) {
-                    totalHitsSupplier = () -> null;
+                    totalHitsSupplier = () -> new TotalHits(0, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
                 } else {
                     totalHitsSupplier = () -> new TotalHits(hitCount, TotalHits.Relation.EQUAL_TO);
                 }


### PR DESCRIPTION
This change ensures that shards don't set the total hits to an approximate value when the total number of hits is not tracked (track_total_hits is false). This is required to ensure that a node in 7 don't send an approximate total hits to a node in 6x. We have an assertion in the total hits serialization code that checks this and this caused some random failures during the bwc tests.

Closes #36284