### PR TITLE
Fix total hits serialization of the search response

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -298,7 +298,7 @@ public class Lucene {
         return false;
     }
 
-    private static TotalHits readTotalHits(StreamInput in) throws IOException {
+    public static TotalHits readTotalHits(StreamInput in) throws IOException {
         long totalHits = in.readVLong();
         TotalHits.Relation totalHitsRelation = TotalHits.Relation.EQUAL_TO;
         if (in.getVersion().onOrAfter(org.elasticsearch.Version.V_7_0_0)) {
@@ -418,7 +418,7 @@ public class Lucene {
 
     private static final Class<?> GEO_DISTANCE_SORT_TYPE_CLASS = LatLonDocValuesField.newDistanceSort("some_geo_field", 0, 0).getClass();
 
-    private static void writeTotalHits(StreamOutput out, TotalHits totalHits) throws IOException {
+    public static void writeTotalHits(StreamOutput out, TotalHits totalHits) throws IOException {
         out.writeVLong(totalHits.value);
         if (out.getVersion().onOrAfter(org.elasticsearch.Version.V_7_0_0)) {
             out.writeEnum(totalHits.relation);

--- a/server/src/main/java/org/elasticsearch/search/SearchHits.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHits.java
@@ -21,12 +21,12 @@ package org.elasticsearch.search;
 
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.TotalHits.Relation;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -276,14 +276,7 @@ public final class SearchHits implements Streamable, ToXContentFragment, Iterabl
         final TotalHits in;
 
         Total(StreamInput in) throws IOException {
-            final long value = in.readVLong();
-            final Relation relation;
-            if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
-                relation = in.readEnum(Relation.class);
-            } else {
-                relation = Relation.EQUAL_TO;
-            }
-            this.in = new TotalHits(value, relation);
+            this.in = Lucene.readTotalHits(in);
         }
 
         Total(TotalHits in) {
@@ -306,12 +299,7 @@ public final class SearchHits implements Streamable, ToXContentFragment, Iterabl
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeVLong(in.value);
-            if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-                out.writeEnum(in.relation);
-            } else {
-                assert in.relation == Relation.EQUAL_TO;
-            }
+            Lucene.writeTotalHits(out, in);
         }
 
         @Override


### PR DESCRIPTION
This change removes the custom serialization of the total hits
and reuses the shard's serialization of Lucene#read/writeTopDocs
in the client code. This also removes the incorrect assertion that
trips randomly in bwc tests.

Closes #36284