### PR TITLE
Docs: Mention that fields with dots do not work

### DIFF
--- a/x-pack/docs/en/watcher/condition/array-compare.asciidoc
+++ b/x-pack/docs/en/watcher/condition/array-compare.asciidoc
@@ -42,6 +42,9 @@ than or equal to 25:
 <4> The comparison value. Supports date math like the 
     <<compare-condition-date-math, compare condition>>.
 
+:NOTE: When using fieldnames that contain a dot this condition will not
+work, use a <<condition-script,script condition>> instead.
+
 ==== Array-Compare Condition Attributes
 
 [options="header"]

--- a/x-pack/docs/en/watcher/condition/array-compare.asciidoc
+++ b/x-pack/docs/en/watcher/condition/array-compare.asciidoc
@@ -42,7 +42,7 @@ than or equal to 25:
 <4> The comparison value. Supports date math like the 
     <<compare-condition-date-math, compare condition>>.
 
-:NOTE: When using fieldnames that contain a dot this condition will not
+NOTE: When using fieldnames that contain a dot this condition will not
 work, use a <<condition-script,script condition>> instead.
 
 ==== Array-Compare Condition Attributes


### PR DESCRIPTION
The dot is used as a splitting character internally for looking up
values in the array compare condition, thus the user should use the
script condition in such cases.

