### PR TITLE
[TEST] convert SearchHitsTests to AbstractStreamableXContentTestCase

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/SearchHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchHitsTests.java
@@ -21,36 +21,43 @@ package org.elasticsearch.search;
 
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.TestUtil;
-import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.test.AbstractStreamableXContentTestCase;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.function.Predicate;
 
-import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
-import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+public class SearchHitsTests extends AbstractStreamableXContentTestCase<SearchHits> {
 
-public class SearchHitsTests extends AbstractStreamableTestCase<SearchHits> {
     public static SearchHits createTestItem() {
-        int searchHits = randomIntBetween(0, 5);
-        SearchHit[] hits = new SearchHit[searchHits];
-        for (int i = 0; i < searchHits; i++) {
+        SearchHit[] searchHitArray = createSearchHitArray(randomIntBetween(0, 5));
+        float maxScore = frequently() ? randomFloat() : Float.NaN;
+        return new SearchHits(searchHitArray, frequently() ? randomTotalHits() : null, maxScore);
+    }
+
+    private static SearchHit[] createSearchHitArray(int size) {
+        SearchHit[] hits = new SearchHit[size];
+        for (int i = 0; i < hits.length; i++) {
             hits[i] = SearchHitTests.createTestItem(false); // creating random innerHits could create loops
         }
+        return hits;
+    }
+
+    private static TotalHits randomTotalHits() {
         long totalHits = TestUtil.nextLong(random(), 0, Long.MAX_VALUE);
         TotalHits.Relation relation = randomFrom(TotalHits.Relation.values());
-        float maxScore = frequently() ? randomFloat() : Float.NaN;
-
-        return new SearchHits(hits, frequently() ? new TotalHits(totalHits, relation) : null, maxScore);
+        return new TotalHits(totalHits, relation);
     }
 
     @Override
     protected SearchHits createBlankInstance() {
-        return new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        return new SearchHits();
     }
 
     @Override
@@ -58,51 +65,67 @@ public class SearchHitsTests extends AbstractStreamableTestCase<SearchHits> {
         return createTestItem();
     }
 
-    public void testFromXContent() throws IOException {
-        SearchHits searchHits = createTestItem();
-        XContentType xcontentType = randomFrom(XContentType.values());
-        boolean humanReadable = randomBoolean();
-        BytesReference originalBytes = toShuffledXContent(searchHits, xcontentType, ToXContent.EMPTY_PARAMS, humanReadable);
-        SearchHits parsed;
-        try (XContentParser parser = createParser(xcontentType.xContent(), originalBytes)) {
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertEquals(SearchHits.Fields.HITS, parser.currentName());
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            parsed = SearchHits.fromXContent(parser);
-            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
-            assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
-            assertNull(parser.nextToken());
-        }
-        assertToXContentEquivalent(originalBytes, toXContent(parsed, xcontentType, humanReadable), xcontentType);
+    @Override
+    protected void assertEqualInstances(SearchHits expectedInstance, SearchHits newInstance) {
+        //do nothing, rely on assertToXContentEquivalent: too many edge cases when parsing back _source and field values
     }
 
-    /**
-     * This test adds randomized fields on all json objects and checks that we
-     * can parse it to ensure the parsing is lenient for forward compatibility.
-     * We need to exclude json objects with the "highlight" and "fields" field
-     * name since these objects allow arbitrary keys (the field names that are
-     * queries). Also we want to exclude to add anything under "_source" since
-     * it is not parsed.
-     */
-    public void testFromXContentLenientParsing() throws IOException {
-        SearchHits searchHits = createTestItem();
-        XContentType xcontentType = randomFrom(XContentType.values());
-        BytesReference originalBytes = toXContent(searchHits, xcontentType, ToXContent.EMPTY_PARAMS, true);
-        Predicate<String> pathsToExclude = path -> (path.isEmpty() || path.endsWith("highlight") || path.endsWith("fields")
-                || path.contains("_source"));
-        BytesReference withRandomFields = insertRandomFields(xcontentType, originalBytes, pathsToExclude, random());
-        SearchHits parsed = null;
-        try (XContentParser parser = createParser(xcontentType.xContent(), withRandomFields)) {
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertEquals(SearchHits.Fields.HITS, parser.currentName());
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            parsed = SearchHits.fromXContent(parser);
-            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
-            assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
-            assertNull(parser.nextToken());
+    @Override
+    protected SearchHits doParseInstance(XContentParser parser) throws IOException {
+        assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+        assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+        assertEquals(SearchHits.Fields.HITS, parser.currentName());
+        assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+        SearchHits searchHits = SearchHits.fromXContent(parser);
+        assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+        assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
+        return searchHits;
+    }
+
+    @Override
+    protected Predicate<String> getRandomFieldsExcludeFilter() {
+        return path -> (path.isEmpty() || path.endsWith("highlight") || path.endsWith("fields") || path.contains("_source"));
+    }
+
+    @Override
+    protected SearchHits mutateInstance(SearchHits instance) {
+        switch (randomIntBetween(0, 2)) {
+            case 0:
+                return new SearchHits(createSearchHitArray(instance.getHits().length + 1), instance.getTotalHits(), instance.getMaxScore());
+            case 1:
+                final TotalHits totalHits;
+                if (instance.getTotalHits() == null) {
+                    totalHits = randomTotalHits();
+                } else {
+                    totalHits = null;
+                }
+                return new SearchHits(instance.getHits(), totalHits, instance.getMaxScore());
+            case 2:
+                final float maxScore;
+                if (Float.isNaN(instance.getMaxScore())) {
+                    maxScore = randomFloat();
+                } else {
+                    maxScore = Float.NaN;
+                }
+                return new SearchHits(instance.getHits(), instance.getTotalHits(), maxScore);
+            default:
+                throw new UnsupportedOperationException();
         }
-        assertToXContentEquivalent(originalBytes, toXContent(parsed, xcontentType, true), xcontentType);
+    }
+
+    public void testToXContent() throws IOException {
+        SearchHit[] hits = new SearchHit[] {
+            new SearchHit(1, "id1", new Text("type"), Collections.emptyMap()),
+            new SearchHit(2, "id2", new Text("type"), Collections.emptyMap()) };
+
+        float maxScore = 1.5f;
+        SearchHits searchHits = new SearchHits(hits, new TotalHits(1000, TotalHits.Relation.EQUAL_TO), maxScore);
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        builder.startObject();
+        searchHits.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        assertEquals("{\"hits\":{\"total\":{\"value\":1000,\"relation\":\"eq\"},\"max_score\":1.5," +
+            "\"hits\":[{\"_type\":\"type\",\"_id\":\"id1\",\"_score\":null},"+
+            "{\"_type\":\"type\",\"_id\":\"id2\",\"_score\":null}]}}", Strings.toString(builder));
     }
 }


### PR DESCRIPTION
Also implement mutateInstance for more coverage when testing equals and hashcode methods. And restored a recently deleted testToXContent method that looks useful and probably shouldn't have been removed.