### PR TITLE
Help Eclipse with type inference for functions

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/bootstrap/BootstrapConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/bootstrap/BootstrapConfigurationTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNode.Role;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.test.EqualsHashCodeTestUtils.CopyFunction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +41,9 @@ public class BootstrapConfigurationTests extends ESTestCase {
 
     public void testEqualsHashcodeSerialization() {
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(randomBootstrapConfiguration(),
-            bootstrapConfiguration -> copyWriteable(bootstrapConfiguration, writableRegistry(), BootstrapConfiguration::new), this::mutate);
+                (CopyFunction<BootstrapConfiguration>) bootstrapConfiguration -> copyWriteable(bootstrapConfiguration, writableRegistry(),
+                        BootstrapConfiguration::new),
+                this::mutate);
     }
 
     public void testNodeDescriptionResolvedByName() {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationMetaDataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationMetaDataTests.java
@@ -18,8 +18,8 @@
  */
 package org.elasticsearch.cluster.coordination;
 
-import org.elasticsearch.cluster.coordination.CoordinationMetaData.VotingConfiguration;
 import org.elasticsearch.cluster.coordination.CoordinationMetaData.VotingConfigExclusion;
+import org.elasticsearch.cluster.coordination.CoordinationMetaData.VotingConfiguration;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.util.set.Sets;
@@ -29,6 +29,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.test.EqualsHashCodeTestUtils.CopyFunction;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -85,8 +86,9 @@ public class CoordinationMetaDataTests extends ESTestCase {
     public void testVotingConfigurationSerializationEqualsHashCode() {
         VotingConfiguration initialConfig = randomVotingConfig();
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(initialConfig,
-            orig -> ESTestCase.copyWriteable(orig, new NamedWriteableRegistry(Collections.emptyList()), VotingConfiguration::new),
-            cfg -> randomlyChangeVotingConfiguration(cfg));
+                (CopyFunction<VotingConfiguration>) orig -> ESTestCase.copyWriteable(orig,
+                        new NamedWriteableRegistry(Collections.emptyList()), VotingConfiguration::new),
+                cfg -> randomlyChangeVotingConfiguration(cfg));
     }
 
     private static VotingConfiguration randomVotingConfig() {
@@ -96,7 +98,8 @@ public class CoordinationMetaDataTests extends ESTestCase {
     public void testVotingTombstoneSerializationEqualsHashCode() {
         VotingConfigExclusion tombstone = new VotingConfigExclusion(randomAlphaOfLength(10), randomAlphaOfLength(10));
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(tombstone,
-                orig -> ESTestCase.copyWriteable(orig, new NamedWriteableRegistry(Collections.emptyList()), VotingConfigExclusion::new),
+                (CopyFunction<VotingConfigExclusion>) orig -> ESTestCase.copyWriteable(orig,
+                        new NamedWriteableRegistry(Collections.emptyList()), VotingConfigExclusion::new),
                 orig -> randomlyChangeVotingTombstone(orig));
     }
 
@@ -149,7 +152,8 @@ public class CoordinationMetaDataTests extends ESTestCase {
         CoordinationMetaData initialMetaData = new CoordinationMetaData(randomNonNegativeLong(), randomVotingConfig(), randomVotingConfig(),
                 randomVotingTombstones());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(initialMetaData,
-            orig -> ESTestCase.copyWriteable(orig, new NamedWriteableRegistry(Collections.emptyList()), CoordinationMetaData::new),
+                (CopyFunction<CoordinationMetaData>) orig -> ESTestCase.copyWriteable(orig,
+                        new NamedWriteableRegistry(Collections.emptyList()), CoordinationMetaData::new),
             meta -> {
                 CoordinationMetaData.Builder builder = CoordinationMetaData.builder(meta);
                 switch (randomInt(3)) {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.test.EqualsHashCodeTestUtils.CopyFunction;
 import org.elasticsearch.test.transport.MockTransport;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.ConnectTransportException;
@@ -378,7 +379,7 @@ public class FollowersCheckerTests extends ESTestCase {
     public void testFollowerCheckRequestEqualsHashCodeSerialization() {
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(new FollowerCheckRequest(randomNonNegativeLong(),
                 new DiscoveryNode(randomAlphaOfLength(10), buildNewFakeTransportAddress(), Version.CURRENT)),
-            rq -> copyWriteable(rq, writableRegistry(), FollowerCheckRequest::new),
+            (CopyFunction<FollowerCheckRequest>) rq -> copyWriteable(rq, writableRegistry(), FollowerCheckRequest::new),
             rq -> {
                 if (randomBoolean()) {
                     return new FollowerCheckRequest(rq.getTerm(),

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.test.EqualsHashCodeTestUtils.CopyFunction;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.test.transport.MockTransport;
 import org.elasticsearch.threadpool.ThreadPool.Names;
@@ -388,7 +389,7 @@ public class LeaderCheckerTests extends ESTestCase {
         LeaderCheckRequest request = new LeaderCheckRequest(
             new DiscoveryNode(randomAlphaOfLength(10), buildNewFakeTransportAddress(), Version.CURRENT));
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(request,
-            rq -> copyWriteable(rq, writableRegistry(), LeaderCheckRequest::new),
+                (CopyFunction<LeaderCheckRequest>) rq -> copyWriteable(rq, writableRegistry(), LeaderCheckRequest::new),
             rq -> new LeaderCheckRequest(new DiscoveryNode(randomAlphaOfLength(10), buildNewFakeTransportAddress(), Version.CURRENT)));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/MessagesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/MessagesTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.test.EqualsHashCodeTestUtils.CopyFunction;
 
 import java.util.Optional;
 
@@ -38,7 +39,7 @@ public class MessagesTests extends ESTestCase {
             randomNonNegativeLong(),
             randomNonNegativeLong());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(initialJoin,
-            join -> copyWriteable(join, writableRegistry(), Join::new),
+            (CopyFunction<Join>) join -> copyWriteable(join, writableRegistry(), Join::new),
             join -> {
                 switch (randomInt(4)) {
                     case 0:
@@ -80,7 +81,7 @@ public class MessagesTests extends ESTestCase {
     public void testPublishResponseEqualsHashCodeSerialization() {
         PublishResponse initialPublishResponse = new PublishResponse(randomNonNegativeLong(), randomNonNegativeLong());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(initialPublishResponse,
-            publishResponse -> copyWriteable(publishResponse, writableRegistry(), PublishResponse::new),
+            (CopyFunction<PublishResponse>) publishResponse -> copyWriteable(publishResponse, writableRegistry(), PublishResponse::new),
             publishResponse -> {
                 switch (randomInt(1)) {
                     case 0:
@@ -105,7 +106,8 @@ public class MessagesTests extends ESTestCase {
         PublishWithJoinResponse initialPublishWithJoinResponse = new PublishWithJoinResponse(initialPublishResponse,
             randomBoolean() ? Optional.empty() : Optional.of(initialJoin));
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(initialPublishWithJoinResponse,
-            publishWithJoinResponse -> copyWriteable(publishWithJoinResponse, writableRegistry(), PublishWithJoinResponse::new),
+                (CopyFunction<PublishWithJoinResponse>) publishWithJoinResponse -> copyWriteable(publishWithJoinResponse,
+                        writableRegistry(), PublishWithJoinResponse::new),
             publishWithJoinResponse -> {
                 switch (randomInt(1)) {
                     case 0:
@@ -127,7 +129,8 @@ public class MessagesTests extends ESTestCase {
     public void testStartJoinRequestEqualsHashCodeSerialization() {
         StartJoinRequest initialStartJoinRequest = new StartJoinRequest(createNode(randomAlphaOfLength(10)), randomNonNegativeLong());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(initialStartJoinRequest,
-            startJoinRequest -> copyWriteable(startJoinRequest, writableRegistry(), StartJoinRequest::new),
+                (CopyFunction<StartJoinRequest>) startJoinRequest -> copyWriteable(startJoinRequest, writableRegistry(),
+                        StartJoinRequest::new),
             startJoinRequest -> {
                 switch (randomInt(1)) {
                     case 0:
@@ -147,7 +150,7 @@ public class MessagesTests extends ESTestCase {
         ApplyCommitRequest initialApplyCommit = new ApplyCommitRequest(createNode(randomAlphaOfLength(10)), randomNonNegativeLong(),
             randomNonNegativeLong());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(initialApplyCommit,
-            applyCommit -> copyWriteable(applyCommit, writableRegistry(), ApplyCommitRequest::new),
+                (CopyFunction<ApplyCommitRequest>) applyCommit -> copyWriteable(applyCommit, writableRegistry(), ApplyCommitRequest::new),
             applyCommit -> {
                 switch (randomInt(2)) {
                     case 0:
@@ -173,7 +176,7 @@ public class MessagesTests extends ESTestCase {
         JoinRequest initialJoinRequest = new JoinRequest(initialJoin.getSourceNode(),
             randomBoolean() ? Optional.empty() : Optional.of(initialJoin));
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(initialJoinRequest,
-            joinRequest -> copyWriteable(joinRequest, writableRegistry(), JoinRequest::new),
+                (CopyFunction<JoinRequest>) joinRequest -> copyWriteable(joinRequest, writableRegistry(), JoinRequest::new),
             joinRequest -> {
                 if (randomBoolean() && joinRequest.getOptionalJoin().isPresent() == false) {
                     return new JoinRequest(createNode(randomAlphaOfLength(20)), joinRequest.getOptionalJoin());
@@ -201,7 +204,7 @@ public class MessagesTests extends ESTestCase {
     public void testPreVoteRequestEqualsHashCodeSerialization() {
         PreVoteRequest initialPreVoteRequest = new PreVoteRequest(createNode(randomAlphaOfLength(10)), randomNonNegativeLong());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(initialPreVoteRequest,
-            preVoteRequest -> copyWriteable(preVoteRequest, writableRegistry(), PreVoteRequest::new),
+                (CopyFunction<PreVoteRequest>) preVoteRequest -> copyWriteable(preVoteRequest, writableRegistry(), PreVoteRequest::new),
             preVoteRequest -> {
                 if (randomBoolean()) {
                     return new PreVoteRequest(createNode(randomAlphaOfLength(10)), preVoteRequest.getCurrentTerm());
@@ -216,7 +219,7 @@ public class MessagesTests extends ESTestCase {
         PreVoteResponse initialPreVoteResponse
             = new PreVoteResponse(currentTerm, randomLongBetween(1, currentTerm), randomNonNegativeLong());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(initialPreVoteResponse,
-            preVoteResponse -> copyWriteable(preVoteResponse, writableRegistry(), PreVoteResponse::new),
+                (CopyFunction<PreVoteResponse>) preVoteResponse -> copyWriteable(preVoteResponse, writableRegistry(), PreVoteResponse::new),
             preVoteResponse -> {
                 switch (randomInt(2)) {
                     case 0:

--- a/server/src/test/java/org/elasticsearch/discovery/PeerFinderMessagesTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/PeerFinderMessagesTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.coordination.PeersResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.test.EqualsHashCodeTestUtils.CopyFunction;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,7 +46,7 @@ public class PeerFinderMessagesTests extends ESTestCase {
             Arrays.stream(generateRandomStringArray(10, 10, false)).map(this::createNode).collect(Collectors.toList()));
 
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(initialPeersRequest,
-            publishRequest -> copyWriteable(publishRequest, writableRegistry(), PeersRequest::new),
+                (CopyFunction<PeersRequest>) publishRequest -> copyWriteable(publishRequest, writableRegistry(), PeersRequest::new),
             in -> {
                 final List<DiscoveryNode> discoveryNodes = new ArrayList<>(in.getKnownPeers());
                 if (randomBoolean()) {
@@ -69,7 +70,7 @@ public class PeerFinderMessagesTests extends ESTestCase {
         }
 
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(initialPeersResponse,
-            publishResponse -> copyWriteable(publishResponse, writableRegistry(), PeersResponse::new),
+                (CopyFunction<PeersResponse>) publishResponse -> copyWriteable(publishResponse, writableRegistry(), PeersResponse::new),
             in -> {
                 final long term = in.getTerm();
                 if (randomBoolean()) {


### PR DESCRIPTION
The Eclipse IDE java compiler seems to need some special hints about what types
some functions used in the tests return. Correcting this for some test that were
newly merged to master.