### PR TITLE
[Tests] Fix third party tests with Gradle 5.0

### DIFF
--- a/plugins/repository-gcs/qa/google-cloud-storage/src/test/resources/rest-api-spec/test/repository_gcs/10_repository.yml
+++ b/plugins/repository-gcs/qa/google-cloud-storage/src/test/resources/rest-api-spec/test/repository_gcs/10_repository.yml
@@ -13,6 +13,19 @@ setup:
             client: "integration_test"
             base_path: "${base_path}"
 
+  # Remove the snapshots, if a previous test failed to delete them. This is
+  # useful for third party tests that runs the test against a real external service.
+  - do:
+      snapshot.delete:
+        repository: repository
+        snapshot: snapshot-one
+        ignore: 404
+  - do:
+      snapshot.delete:
+        repository: repository
+        snapshot: snapshot-two
+        ignore: 404
+
 ---
 "Snapshot/Restore with repository-gcs":
 

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -134,7 +134,10 @@ if (!s3EC2Bucket && !s3EC2BasePath && !s3ECSBucket && !s3ECSBasePath) {
   s3EC2BasePath = 'integration_test'
   s3ECSBucket = 'ecs-bucket-test'
   s3ECSBasePath = 'integration_test'
+} else if (!s3EC2Bucket || !s3EC2BasePath || !s3ECSBucket || !s3ECSBasePath) {
+  throw new IllegalArgumentException("not all options specified to run EC2/ECS tests are present")
 }
+
 
 final String minioVersion = 'RELEASE.2018-06-22T23-48-46Z'
 final String minioBinDir = "${buildDir}/minio/bin"

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -106,19 +106,11 @@ String s3ECSBasePath = System.getenv("amazon_s3_base_path_ecs")
 // If all these variables are missing then we are testing against the internal fixture instead, which has the following
 // credentials hard-coded in.
 
-if (!s3PermanentAccessKey && !s3PermanentSecretKey && !s3PermanentBucket && !s3PermanentBasePath
-        && !s3EC2Bucket && !s3EC2BasePath
-        && !s3ECSBucket && !s3ECSBasePath) {
+if (!s3PermanentAccessKey && !s3PermanentSecretKey && !s3PermanentBucket && !s3PermanentBasePath) {
   s3PermanentAccessKey = 's3_integration_test_permanent_access_key'
   s3PermanentSecretKey = 's3_integration_test_permanent_secret_key'
   s3PermanentBucket = 'permanent-bucket-test'
   s3PermanentBasePath = 'integration_test'
-
-  s3EC2Bucket = 'ec2-bucket-test'
-  s3EC2BasePath = 'integration_test'
-
-  s3ECSBucket = 'ecs-bucket-test'
-  s3ECSBasePath = 'integration_test'
 
   useFixture = true
 
@@ -135,6 +127,13 @@ if (!s3TemporaryAccessKey && !s3TemporarySecretKey && !s3TemporaryBucket && !s3T
 
 } else if (!s3TemporaryAccessKey || !s3TemporarySecretKey || !s3TemporaryBucket || !s3TemporaryBasePath || !s3TemporarySessionToken) {
   throw new IllegalArgumentException("not all options specified to run against external S3 service as temporary credentials are present")
+}
+
+if (!s3EC2Bucket && !s3EC2BasePath && !s3ECSBucket && !s3ECSBasePath) {
+  s3EC2Bucket = 'ec2-bucket-test'
+  s3EC2BasePath = 'integration_test'
+  s3ECSBucket = 'ecs-bucket-test'
+  s3ECSBasePath = 'integration_test'
 }
 
 final String minioVersion = 'RELEASE.2018-06-22T23-48-46Z'

--- a/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/20_repository_permanent_credentials.yml
+++ b/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/20_repository_permanent_credentials.yml
@@ -16,6 +16,19 @@ setup:
             canned_acl: private
             storage_class: standard
 
+  # Remove the snapshots, if a previous test failed to delete them. This is
+  # useful for third party tests that runs the test against a real external service.
+  - do:
+      snapshot.delete:
+        repository: repository_permanent
+        snapshot: snapshot-one
+        ignore: 404
+  - do:
+      snapshot.delete:
+        repository: repository_permanent
+        snapshot: snapshot-two
+        ignore: 404
+
 ---
 "Snapshot and Restore with repository-s3 using permanent credentials":
 


### PR DESCRIPTION
This pull request fixes the `build.gradle` file so that it works with the Gradle 5.0 update (#34263).

It also makes use of the `ignore: 404` header in REST tests so that previous snapshots are deleted as part of the test set up. This way each new test run with an external service should start with a fresh repository even if the previous test run failed and left snapshots in the repo.  (This is a best effort as it does not fix a corrupted repository)