### PR TITLE
[ML] JIndex: Job exists and get job should read cluster state first.

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -348,6 +348,15 @@ public class JobManager {
             return;
         }
 
+        // and that the new job's groups are not job Ids
+        for (String group : job.getGroups()) {
+            if (currentMlMetadata.getJobs().containsKey(group)) {
+                actionListener.onFailure(new
+                        ResourceAlreadyExistsException(Messages.getMessage(Messages.JOB_AND_GROUP_NAMES_MUST_BE_UNIQUE, group)));
+                return;
+            }
+        }
+
         ActionListener<Boolean> putJobListener = new ActionListener<Boolean>() {
             @Override
             public void onResponse(Boolean indicesCreated) {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -397,6 +397,28 @@
             "description":"Can't update all description"
           }
 
+  - do:
+      xpack.ml.put_job:
+        job_id: job-crud-update-group-name-clash
+        body:  >
+          {
+            "analysis_config" : {
+                "bucket_span": "1h",
+                "detectors" :[{"function":"metric","field_name":"responsetime","by_field_name":"airline"}]
+            },
+            "data_description" : {
+            }
+          }
+
+  - do:
+      catch: "/job and group names must be unique/"
+      xpack.ml.update_job:
+        job_id: jobs-crud-update-job
+        body:  >
+          {
+            "groups": ["job-crud-update-group-name-clash"]
+          }
+
 ---
 "Test cannot decrease model_memory_limit below current usage":
   - skip:


### PR DESCRIPTION
Feature branch PR 

Changing methods missed in #36014 - get job and job exists. 
This also adds in a missing check on PUT job that the job Id is not the same as a group Id defined in clusterstate jobs and a another check on job update that the jobs groups are not job ids.