### PR TITLE
Allow HLRC/LLRC calls to list expected warnings.

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
@@ -75,14 +75,22 @@ public abstract class ESRestHighLevelClientTestCase extends ESRestTestCase {
      */
     protected static <Req, Resp> Resp execute(Req request, SyncMethod<Req, Resp> syncMethod,
                                        AsyncMethod<Req, Resp> asyncMethod) throws IOException {
+        return execute(request, syncMethod, asyncMethod, RequestOptions.DEFAULT);
+    }
+    
+    /**
+     * Executes the provided request using either the sync method or its async variant, both provided as functions
+     */
+    protected static <Req, Resp> Resp execute(Req request, SyncMethod<Req, Resp> syncMethod,
+                                       AsyncMethod<Req, Resp> asyncMethod, RequestOptions options) throws IOException {
         if (randomBoolean()) {
-            return syncMethod.execute(request, RequestOptions.DEFAULT);
+            return syncMethod.execute(request, options);
         } else {
             PlainActionFuture<Resp> future = PlainActionFuture.newFuture();
-            asyncMethod.execute(request, RequestOptions.DEFAULT, future);
+            asyncMethod.execute(request, options, future);
             return future.actionGet();
         }
-    }
+    }    
 
     /**
      * Executes the provided request using either the sync method or its async

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
@@ -223,6 +223,13 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
             assertTrue(searchHit.getSourceAsMap().containsKey("num2"));
         }
     }
+    
+    public void testSearchNoQueryDeprecated() throws IOException {
+        SearchRequest searchRequest = new SearchRequest("index");
+        searchRequest.types("foo");
+        SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync,
+                expectWarnings("[types removal] Specifying types in search requests is deprecated."));
+    }        
 
     public void testSearchMatchQuery() throws IOException {
         SearchRequest searchRequest = new SearchRequest("index");

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -29,6 +29,7 @@ import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksAction;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
@@ -805,6 +806,12 @@ public abstract class ESRestTestCase extends ESTestCase {
         return responseEntity;
     }
 
+    protected static RequestOptions expectWarnings(String... expectedWarnings) {
+        final RequestOptions.Builder builder = RequestOptions.DEFAULT.toBuilder();
+        builder.setExpectedWarnings(expectedWarnings);
+        return builder.build();
+    }    
+    
     /**
      * Is this template one that is automatically created by xpack?
      */


### PR DESCRIPTION
We're busy deprecating like crazy with types removal and what's concerning is the number of existing LLRC/HLRC tests where we're forced to switch off all warnings checks just to make tests pass.

* The answer is not to rewrite tests to use only new APIs because we want to test the deprecated APIs still work.
* The answer is not to turn off strict warning checks at class level (or method invocation level) because we go blind to any unanticipated warnings.

The answer is for tests to invoke known-deprecated APIs and list the warnings they expect to receive as a result. 

This PR adds a parameter in RequestOptions called "expectedWarnings" which lists expected messages. If supplied in strictDeprecationMode=true then LLRC: 
1) suppresses any exception-throwing for received warnings that were listed as expected
2) causes an exception if listed expected warnings were not received
