### PR TITLE
Extend field caps API to mark meta fields

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
@@ -1190,11 +1190,11 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
         assertEquals(2, ratingResponse.size());
 
         FieldCapabilities expectedKeywordCapabilities = new FieldCapabilities(
-            "rating", "keyword", true, true, new String[]{"index2"}, null, null);
+            "rating", "keyword", true, true, false, new String[]{"index2"}, null, null);
         assertEquals(expectedKeywordCapabilities, ratingResponse.get("keyword"));
 
         FieldCapabilities expectedLongCapabilities = new FieldCapabilities(
-            "rating", "long", true, true, new String[]{"index1"}, null, null);
+            "rating", "long", true, true, false, new String[]{"index1"}, null, null);
         assertEquals(expectedLongCapabilities, ratingResponse.get("long"));
 
         // Check the capabilities for the 'field' field.
@@ -1203,7 +1203,7 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
         assertEquals(1, fieldResponse.size());
 
         FieldCapabilities expectedTextCapabilities = new FieldCapabilities(
-            "field", "text", true, false);
+            "field", "text", true, false, false);
         assertEquals(expectedTextCapabilities, fieldResponse.get("text"));
     }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/field_caps/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/field_caps/10_basic.yml
@@ -264,3 +264,25 @@ setup:
   - match: {fields.geo.keyword.indices:                 ["test3"]}
   - is_false: fields.geo.keyword.non_searchable_indices
   - is_false: fields.geo.keyword.on_aggregatable_indices
+---
+"Get meta field information":
+  - skip:
+      version: " - 6.99.99"
+      reason: meta fields are returned since 7.0
+
+  - do:
+      field_caps:
+        index: 'test1,test2,test3'
+        fields: [text, _index]
+
+  - match: {fields.text.text.searchable:                true}
+  - match: {fields.text.text.aggregatable:              false}
+  - is_false: fields.text.text.indices
+  - is_false: fields.text.text.non_searchable_indices
+  - is_false: fields.text.text.non_aggregatable_indices
+  - match: {fields._index._index.searchable:            true}
+  - match: {fields._index._index.aggregatable:          true}
+  - match: {fields._index._index.meta:                  true}
+  - is_false: fields._index._index.indices
+  - is_false: fields._index._index.non_searchable_indices
+  - is_false: fields._index._index.non_aggregatable_indices

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -158,7 +158,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
             Map<String, FieldCapabilities.Builder> typeMap = responseMapBuilder.computeIfAbsent(field, f -> new HashMap<>());
             FieldCapabilities.Builder builder = typeMap.computeIfAbsent(fieldCap.getType(), key -> new FieldCapabilities.Builder(field,
                 key));
-            builder.add(indexName, fieldCap.isSearchable(), fieldCap.isAggregatable());
+            builder.add(indexName, fieldCap.isSearchable(), fieldCap.isAggregatable(), fieldCap.isMeta());
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -84,7 +84,8 @@ public class TransportFieldCapabilitiesIndexAction extends TransportSingleShardA
             MappedFieldType ft = mapperService.fullName(field);
             if (ft != null) {
                 if (indicesService.isMetaDataField(field) || fieldPredicate.test(ft.name())) {
-                    FieldCapabilities fieldCap = new FieldCapabilities(field, ft.typeName(), ft.isSearchable(), ft.isAggregatable());
+                    FieldCapabilities fieldCap = new FieldCapabilities(field, ft.typeName(), ft.isSearchable(), ft.isAggregatable(),
+                            indicesService.isMetaDataField(field));
                     responseMap.put(field, fieldCap);
                 } else {
                     continue;
@@ -102,7 +103,7 @@ public class TransportFieldCapabilitiesIndexAction extends TransportSingleShardA
                         // no field type, it must be an object field
                         ObjectMapper mapper = mapperService.getObjectMapper(parentField);
                         String type = mapper.nested().isNested() ? "nested" : "object";
-                        FieldCapabilities fieldCap = new FieldCapabilities(parentField, type, false, false);
+                        FieldCapabilities fieldCap = new FieldCapabilities(parentField, type, false, false, false);
                         responseMap.put(parentField, fieldCap);
                     }
                     dotIndex = parentField.lastIndexOf('.');

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
@@ -173,16 +173,16 @@ public class FieldCapabilitiesResponseTests extends AbstractStreamableXContentTe
 
     private static FieldCapabilitiesResponse createSimpleResponse() {
         Map<String, FieldCapabilities> titleCapabilities = new HashMap<>();
-        titleCapabilities.put("text", new FieldCapabilities("title", "text", true, false));
+        titleCapabilities.put("text", new FieldCapabilities("title", "text", true, false, false));
 
         Map<String, FieldCapabilities> ratingCapabilities = new HashMap<>();
         ratingCapabilities.put("long", new FieldCapabilities("rating", "long",
-            true, false,
+            true, false, false,
             new String[]{"index1", "index2"},
             null,
             new String[]{"index1"}));
         ratingCapabilities.put("keyword", new FieldCapabilities("rating", "keyword",
-            false, true,
+            false, true, false,
             new String[]{"index3", "index4"},
             new String[]{"index4"},
             null));

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesTests.java
@@ -48,14 +48,15 @@ public class FieldCapabilitiesTests extends AbstractSerializingTestCase<FieldCap
 
     public void testBuilder() {
         FieldCapabilities.Builder builder = new FieldCapabilities.Builder("field", "type");
-        builder.add("index1", true, false);
-        builder.add("index2", true, false);
-        builder.add("index3", true, false);
+        builder.add("index1", true, false, false);
+        builder.add("index2", true, false, true);
+        builder.add("index3", true, false, true);
 
         {
             FieldCapabilities cap1 = builder.build(false);
             assertThat(cap1.isSearchable(), equalTo(true));
             assertThat(cap1.isAggregatable(), equalTo(false));
+            assertThat(cap1.isMeta(), equalTo(false));
             assertNull(cap1.indices());
             assertNull(cap1.nonSearchableIndices());
             assertNull(cap1.nonAggregatableIndices());
@@ -63,6 +64,7 @@ public class FieldCapabilitiesTests extends AbstractSerializingTestCase<FieldCap
             FieldCapabilities cap2 = builder.build(true);
             assertThat(cap2.isSearchable(), equalTo(true));
             assertThat(cap2.isAggregatable(), equalTo(false));
+            assertThat(cap2.isMeta(), equalTo(false));
             assertThat(cap2.indices().length, equalTo(3));
             assertThat(cap2.indices(), equalTo(new String[]{"index1", "index2", "index3"}));
             assertNull(cap2.nonSearchableIndices());
@@ -70,13 +72,14 @@ public class FieldCapabilitiesTests extends AbstractSerializingTestCase<FieldCap
         }
 
         builder = new FieldCapabilities.Builder("field", "type");
-        builder.add("index1", false, true);
-        builder.add("index2", true, false);
-        builder.add("index3", false, false);
+        builder.add("index1", false, true, true);
+        builder.add("index2", true, false, true);
+        builder.add("index3", false, false, true);
         {
             FieldCapabilities cap1 = builder.build(false);
             assertThat(cap1.isSearchable(), equalTo(false));
             assertThat(cap1.isAggregatable(), equalTo(false));
+            assertThat(cap1.isMeta(), equalTo(true));
             assertNull(cap1.indices());
             assertThat(cap1.nonSearchableIndices(), equalTo(new String[]{"index1", "index3"}));
             assertThat(cap1.nonAggregatableIndices(), equalTo(new String[]{"index2", "index3"}));
@@ -84,6 +87,7 @@ public class FieldCapabilitiesTests extends AbstractSerializingTestCase<FieldCap
             FieldCapabilities cap2 = builder.build(true);
             assertThat(cap2.isSearchable(), equalTo(false));
             assertThat(cap2.isAggregatable(), equalTo(false));
+            assertThat(cap2.isMeta(), equalTo(true));
             assertThat(cap2.indices().length, equalTo(3));
             assertThat(cap2.indices(), equalTo(new String[]{"index1", "index2", "index3"}));
             assertThat(cap1.nonSearchableIndices(), equalTo(new String[]{"index1", "index3"}));
@@ -114,7 +118,7 @@ public class FieldCapabilitiesTests extends AbstractSerializingTestCase<FieldCap
             }
         }
         return new FieldCapabilities(fieldName,
-            randomAlphaOfLengthBetween(5, 20), randomBoolean(), randomBoolean(),
+                randomAlphaOfLengthBetween(5, 20), randomBoolean(), randomBoolean(), randomBoolean(),
             indices, nonSearchableIndices, nonAggregatableIndices);
     }
 
@@ -124,6 +128,7 @@ public class FieldCapabilitiesTests extends AbstractSerializingTestCase<FieldCap
         String type = instance.getType();
         boolean isSearchable = instance.isSearchable();
         boolean isAggregatable = instance.isAggregatable();
+        boolean isMetaData = instance.isMeta();
         String[] indices = instance.indices();
         String[] nonSearchableIndices = instance.nonSearchableIndices();
         String[] nonAggregatableIndices = instance.nonAggregatableIndices();
@@ -184,6 +189,7 @@ public class FieldCapabilitiesTests extends AbstractSerializingTestCase<FieldCap
             nonAggregatableIndices = newNonAggregatableIndices;
             break;
         }
-        return new FieldCapabilities(name, type, isSearchable, isAggregatable, indices, nonSearchableIndices, nonAggregatableIndices);
+        return new FieldCapabilities(name, type, isSearchable, isAggregatable, isMetaData, indices, nonSearchableIndices,
+                nonAggregatableIndices);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/test/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -38,6 +38,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 
 public class FieldCapabilitiesIT extends ESIntegTestCase {
 
+    @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
@@ -107,12 +108,12 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
 
         assertTrue(distance.containsKey("double"));
         assertEquals(
-            new FieldCapabilities("distance", "double", true, true, new String[] {"old_index"}, null, null),
+                new FieldCapabilities("distance", "double", true, true, false, new String[] { "old_index" }, null, null),
             distance.get("double"));
 
         assertTrue(distance.containsKey("text"));
         assertEquals(
-            new FieldCapabilities("distance", "text", true, false, new String[] {"new_index"}, null, null),
+                new FieldCapabilities("distance", "text", true, false, false, new String[] { "new_index" }, null, null),
             distance.get("text"));
 
         // Check the capabilities for the 'route_length_miles' alias.
@@ -121,7 +122,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
 
         assertTrue(routeLength.containsKey("double"));
         assertEquals(
-            new FieldCapabilities("route_length_miles", "double", true, true),
+                new FieldCapabilities("route_length_miles", "double", true, true, false),
             routeLength.get("double"));
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
@@ -179,7 +179,7 @@ public class IndexResolverTests extends ESTestCase {
         List<String> nonAggregatableIndices = new ArrayList<>();
 
         UpdateableFieldCapabilities(String name, String type, boolean isSearchable, boolean isAggregatable) {
-            super(name, type, isSearchable, isAggregatable);
+            super(name, type, isSearchable, isAggregatable, false);
         }
 
         @Override


### PR DESCRIPTION
Meta data fields are now marked accordingly in the field caps API
through the `meta` field returned in the response. For compatibility
purposes in the REST layer, this field is returned (as true) only when
needed.
