### PR TITLE
Inner hits fail to propagate doc-value format.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -371,7 +371,7 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
         if (docValueFields == null) {
             docValueFields = new ArrayList<>();
         }
-        docValueFields.add(new FieldAndFormat(field, null));
+        docValueFields.add(new FieldAndFormat(field, format));
         return this;
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
@@ -46,6 +46,7 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -279,4 +280,12 @@ public class InnerHitBuilderTests extends ESTestCase {
         return ESTestCase.copyWriteable(original, namedWriteableRegistry, InnerHitBuilder::new);
     }
 
+    public void testSetDocValueFormat() {
+        InnerHitBuilder innerHit = new InnerHitBuilder();
+        innerHit.addDocValueField("foo");
+        innerHit.addDocValueField("@timestamp", "epoch_millis");
+        assertEquals(
+                Arrays.asList(new FieldAndFormat("foo", null), new FieldAndFormat("@timestamp", "epoch_millis")),
+                innerHit.getDocValueFields());
+    }
 }


### PR DESCRIPTION
If you pass a doc-value format to inner hits, it gets ignored.