### PR TITLE
Scripting: Properly support no-offset date formatting

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/JodaCompatibleZonedDateTime.java
+++ b/server/src/main/java/org/elasticsearch/script/JodaCompatibleZonedDateTime.java
@@ -22,8 +22,8 @@ package org.elasticsearch.script;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.time.DateUtils;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -391,14 +391,14 @@ public class JodaCompatibleZonedDateTime {
     public String toString(String format) {
         logDeprecatedMethod("toString(String)", "a DateTimeFormatter");
         // TODO: replace with bwc formatter
-        return new DateTime(dt.toInstant().toEpochMilli(), DateTimeZone.forID(dt.getZone().getId())).toString(format);
+        return new DateTime(dt.toInstant().toEpochMilli(), DateUtils.zoneIdToDateTimeZone(dt.getZone())).toString(format);
     }
 
     @Deprecated
     public String toString(String format, Locale locale) {
         logDeprecatedMethod("toString(String,Locale)", "a DateTimeFormatter");
         // TODO: replace with bwc formatter
-        return new DateTime(dt.toInstant().toEpochMilli(), DateTimeZone.forID(dt.getZone().getId())).toString(format, locale);
+        return new DateTime(dt.toInstant().toEpochMilli(), DateUtils.zoneIdToDateTimeZone(dt.getZone())).toString(format, locale);
     }
 
     public DayOfWeek getDayOfWeekEnum() {

--- a/server/src/test/java/org/elasticsearch/script/JodaCompatibleZonedDateTimeTests.java
+++ b/server/src/test/java/org/elasticsearch/script/JodaCompatibleZonedDateTimeTests.java
@@ -237,4 +237,14 @@ public class JodaCompatibleZonedDateTimeTests extends ESTestCase {
     public void testDayOfWeekEnum() {
         assertThat(javaTime.getDayOfWeekEnum(), equalTo(DayOfWeek.of(jodaTime.getDayOfWeek())));
     }
+
+    public void testToStringWithLocaleAndZeroOffset() {
+        JodaCompatibleZonedDateTime dt = new JodaCompatibleZonedDateTime(Instant.EPOCH, ZoneOffset.ofTotalSeconds(0));
+        assertMethodDeprecation(() -> dt.toString("yyyy-MM-dd hh:mm", Locale.ROOT), "toString(String,Locale)", "a DateTimeFormatter");
+    }
+
+    public void testToStringAndZeroOffset() {
+        JodaCompatibleZonedDateTime dt = new JodaCompatibleZonedDateTime(Instant.EPOCH, ZoneOffset.ofTotalSeconds(0));
+        assertMethodDeprecation(() -> dt.toString("yyyy-MM-dd hh:mm"), "toString(String)", "a DateTimeFormatter");
+    }
 }


### PR DESCRIPTION
The conversion of timezones in JodaCompatibleZonedDateTime from joda to
java time requires the use of the DateUtils class to cater for corner
cases.

Closes #36306
