### PR TITLE
[ML] JIndex: Check group names against job Ids on update

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -397,6 +397,28 @@
             "description":"Can't update all description"
           }
 
+  - do:
+      xpack.ml.put_job:
+        job_id: job-crud-update-group-name-clash
+        body:  >
+          {
+            "analysis_config" : {
+                "bucket_span": "1h",
+                "detectors" :[{"function":"metric","field_name":"responsetime","by_field_name":"airline"}]
+            },
+            "data_description" : {
+            }
+          }
+
+  - do:
+      catch: "/job and group names must be unique/"
+      xpack.ml.update_job:
+        job_id: jobs-crud-update-job
+        body:  >
+          {
+            "groups": ["job-crud-update-group-name-clash"]
+          }
+
 ---
 "Test cannot decrease model_memory_limit below current usage":
   - skip:


### PR DESCRIPTION
A feature branch PR porting the relevant changes in #36305 to the master feature branch.

When a job's groups are updated a check must be made to ensure that the new group names are not the same as any existing job Ids. The same check is made on PUT job.

I made a refactoring extracting the post update actions to a new method which makes the diff very difficult to read sorry. 
