### PR TITLE
Add docs on replicating APM Server or Beats indices

### DIFF
--- a/docs/reference/ccr/requirements.asciidoc
+++ b/docs/reference/ccr/requirements.asciidoc
@@ -43,3 +43,24 @@ on the underlying Lucene index yet retained up to the number of operations
 configured by this setting. The default value is `0`.
 
 For more information about index settings, see {ref}/index-modules.html[Index modules].
+
+[float]
+[[ccr-overview-beats]]
+==== Setting soft deletes on indices created by APM Server or Beats
+
+If you want to replicate indices created by APM Server or Beats, and are
+allowing APM Server or Beats to manage index templates you will want to add some
+settings to enable soft deletes. For example, you could make the following
+changes to the relevant APM Server or Beats configuration file.
+
+["source","yaml"]
+----------------------------------------------------------------------
+setup.template.overwrite: true
+setup.template.settings:
+  index.soft_deletes.enabled: true
+  index.soft_deletes.retention.operations: 1024
+----------------------------------------------------------------------
+
+For additional information on controlling the index templates managed by APM
+Server or Beats, see the relevant documentation on loading the Elasticsearch
+index template.

--- a/docs/reference/ccr/requirements.asciidoc
+++ b/docs/reference/ccr/requirements.asciidoc
@@ -49,9 +49,10 @@ For more information about index settings, see {ref}/index-modules.html[Index mo
 ==== Setting soft deletes on indices created by APM Server or Beats
 
 If you want to replicate indices created by APM Server or Beats, and are
-allowing APM Server or Beats to manage index templates you will want to add some
-settings to enable soft deletes. For example, you could make the following
-changes to the relevant APM Server or Beats configuration file.
+allowing APM Server or Beats to manage index templates, you need to enable
+soft deletes on the underlying index templates. To enable soft deletes on the
+underlying index templates, add the following changes to the relevant APM Server
+or Beats configuration file.
 
 ["source","yaml"]
 ----------------------------------------------------------------------


### PR DESCRIPTION
This commit adds a brief note to the documentation on how to manage the index templates that are used to create APM Server and Beats indices.
