### PR TITLE
For msearch templates, make sure to use the right name for deprecation logging.

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
@@ -41,7 +41,10 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 public class RestMultiSearchTemplateAction extends BaseRestHandler {
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
-        LogManager.getLogger(RestMultiSearchAction.class));
+        LogManager.getLogger(RestMultiSearchTemplateAction.class));
+    static final String TYPES_DEPRECATION_MESSAGE = "[types removal]" +
+        " Specifying types in multi search template requests is deprecated.";
+
     private static final Set<String> RESPONSE_PARAMS;
 
     static {
@@ -89,8 +92,7 @@ public class RestMultiSearchTemplateAction extends BaseRestHandler {
         RestMultiSearchAction.parseMultiLineRequest(restRequest, multiRequest.indicesOptions(), allowExplicitIndex,
                 (searchRequest, bytes) -> {
                     if (searchRequest.types().length > 0) {
-                        deprecationLogger.deprecatedAndMaybeLog("msearch_template_with_types",
-                            RestMultiSearchAction.TYPES_DEPRECATION_MESSAGE);
+                        deprecationLogger.deprecatedAndMaybeLog("msearch_template_with_types", TYPES_DEPRECATION_MESSAGE);
                     }
                     SearchTemplateRequest searchTemplateRequest = SearchTemplateRequest.fromXContent(bytes);
                     if (searchTemplateRequest.getScript() != null) {

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequestTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequestTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.search.RestMultiSearchAction;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -79,7 +78,7 @@ public class MultiSearchTemplateRequestTests extends ESTestCase {
         assertEquals(1, request.requests().get(1).getScriptParams().size());
         assertEquals(1, request.requests().get(2).getScriptParams().size());
 
-        assertWarnings(RestMultiSearchAction.TYPES_DEPRECATION_MESSAGE);
+        assertWarnings(RestMultiSearchTemplateAction.TYPES_DEPRECATION_MESSAGE);
     }
 
     public void testParseWithCarriageReturn() throws Exception {

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateActionTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateActionTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.search.RestMultiSearchAction;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.FakeRestChannel;
 import org.elasticsearch.test.rest.FakeRestRequest;
@@ -62,7 +61,7 @@ public class RestMultiSearchTemplateActionTests extends ESTestCase {
             .build();
 
         performRequest(request);
-        assertWarnings(RestMultiSearchAction.TYPES_DEPRECATION_MESSAGE);
+        assertWarnings(RestMultiSearchTemplateAction.TYPES_DEPRECATION_MESSAGE);
     }
 
     public void testTypeInBody() {
@@ -76,7 +75,7 @@ public class RestMultiSearchTemplateActionTests extends ESTestCase {
             .build();
 
         performRequest(request);
-        assertWarnings(RestMultiSearchAction.TYPES_DEPRECATION_MESSAGE);
+        assertWarnings(RestMultiSearchTemplateAction.TYPES_DEPRECATION_MESSAGE);
     }
 
     private void performRequest(RestRequest request) {

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -52,7 +52,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestMultiSearchAction extends BaseRestHandler {
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
         LogManager.getLogger(RestMultiSearchAction.class));
-    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal]" +
+    static final String TYPES_DEPRECATION_MESSAGE = "[types removal]" +
         " Specifying types in multi search requests is deprecated.";
 
     private static final Set<String> RESPONSE_PARAMS;


### PR DESCRIPTION
* Update the logger's class name to `RestMultiSearchTemplateAction`.
* Use a dedicated deprecation message in `RestMultiSearchTemplateAction`, as opposed to re-using the one from `RestMultiSearchAction`.