### PR TITLE
BUILD: Use Containerized docker-compose

### DIFF
--- a/buildSrc/src/main/resources/org/elasticsearch/gradle/testfixtures/docker-compose
+++ b/buildSrc/src/main/resources/org/elasticsearch/gradle/testfixtures/docker-compose
@@ -1,0 +1,63 @@
+#!/bin/sh
+#
+# Run docker-compose in a container
+#
+# This script will attempt to mirror the host paths by using volumes for the
+# following paths:
+#   * $(pwd)
+#   * $(dirname $COMPOSE_FILE) if it's set
+#   * $HOME if it's set
+#
+# You can add additional volumes (or any docker run options) using
+# the $COMPOSE_OPTIONS environment variable.
+#
+
+
+set -e
+
+VERSION="1.23.1"
+IMAGE="docker/compose:$VERSION"
+
+
+# Setup options for connecting to docker host
+if [ -z "$DOCKER_HOST" ]; then
+    DOCKER_HOST="/var/run/docker.sock"
+fi
+if [ -S "$DOCKER_HOST" ]; then
+    DOCKER_ADDR="-v $DOCKER_HOST:$DOCKER_HOST -e DOCKER_HOST"
+else
+    DOCKER_ADDR="-e DOCKER_HOST -e DOCKER_TLS_VERIFY -e DOCKER_CERT_PATH"
+fi
+
+
+# Setup volume mounts for compose config and context
+if [ "$(pwd)" != '/' ]; then
+    VOLUMES="-v $(pwd):$(pwd)"
+fi
+if [ -n "$COMPOSE_FILE" ]; then
+    COMPOSE_OPTIONS="$COMPOSE_OPTIONS -e COMPOSE_FILE=$COMPOSE_FILE"
+    compose_dir=$(realpath $(dirname $COMPOSE_FILE))
+fi
+# TODO: also check --file argument
+if [ -n "$compose_dir" ]; then
+    VOLUMES="$VOLUMES -v $compose_dir:$compose_dir"
+fi
+if [ -n "$HOME" ]; then
+    VOLUMES="$VOLUMES -v $HOME:$HOME -v $HOME:/root" # mount $HOME in /root to share docker.config
+fi
+
+# Only allocate tty if we detect one
+if [ -t 0 ]; then
+    if [ -t 1 ]; then
+        DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS -t"
+    fi
+else
+    DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS -i"
+fi
+
+# Handle userns security
+if [ ! -z "$(docker info 2>/dev/null | grep userns)" ]; then
+    DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS --userns=host"
+fi
+
+exec docker run --rm $DOCKER_RUN_OPTIONS $DOCKER_ADDR $COMPOSE_OPTIONS $VOLUMES -w "$(pwd)" $IMAGE "$@"

--- a/buildSrc/src/main/resources/org/elasticsearch/gradle/testfixtures/docker-compose
+++ b/buildSrc/src/main/resources/org/elasticsearch/gradle/testfixtures/docker-compose
@@ -1,21 +1,7 @@
 #!/bin/sh
-#
-# Run docker-compose in a container
-#
-# This script will attempt to mirror the host paths by using volumes for the
-# following paths:
-#   * $(pwd)
-#   * $(dirname $COMPOSE_FILE) if it's set
-#   * $HOME if it's set
-#
-# You can add additional volumes (or any docker run options) using
-# the $COMPOSE_OPTIONS environment variable.
-#
-
-
 set -e
 
-VERSION="1.23.1"
+VERSION="1.23.2"
 IMAGE="docker/compose:$VERSION"
 
 
@@ -38,7 +24,7 @@ if [ -n "$COMPOSE_FILE" ]; then
     COMPOSE_OPTIONS="$COMPOSE_OPTIONS -e COMPOSE_FILE=$COMPOSE_FILE"
     compose_dir=$(realpath $(dirname $COMPOSE_FILE))
 fi
-# TODO: also check --file argument
+
 if [ -n "$compose_dir" ]; then
     VOLUMES="$VOLUMES -v $compose_dir:$compose_dir"
 fi


### PR DESCRIPTION
* Make the build more portable by only requiring `docker` and not `docker-compose`
* Use containerized `docker-compose`
