### PR TITLE
[ML-DataFrame] fix state persistence and load on startup

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportDeleteDataFrameJobAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportDeleteDataFrameJobAction.java
@@ -52,7 +52,7 @@ public class TransportDeleteDataFrameJobAction extends TransportTasksAction<Data
     @Override
     protected void taskOperation(Request request, DataFrameJobTask task, ActionListener<Response> listener) {
         assert task.getConfig().getId().equals(request.getId());
-        IndexerState state = task.getState().getJobState();
+        IndexerState state = task.getState().getIndexerState();
         if (state.equals(IndexerState.STOPPED)) {
             task.onCancelled();
             listener.onResponse(new Response(true));

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportGetDataFrameJobsAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportGetDataFrameJobsAction.java
@@ -17,7 +17,6 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -28,7 +27,6 @@ import org.elasticsearch.xpack.dataframe.job.DataFrameJobConfig;
 import org.elasticsearch.xpack.dataframe.job.DataFrameJobTask;
 import org.elasticsearch.xpack.dataframe.persistence.DataFramePersistentTaskUtils;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportStopDataFrameJobAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportStopDataFrameJobAction.java
@@ -14,13 +14,11 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.dataframe.job.DataFrameJobTask;
 
-import java.io.IOException;
 import java.util.List;
 
 public class TransportStopDataFrameJobAction extends

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJob.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJob.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.dataframe.job;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -21,7 +22,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
-public class DataFrameJob implements XPackPlugin.XPackPersistentTaskParams {
+public class DataFrameJob extends AbstractDiffable<DataFrameJob> implements XPackPlugin.XPackPersistentTaskParams {
 
     public static final ParseField ID = new ParseField("id");
     public static final String NAME = DataFrame.TASK_NAME;

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobState.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobState.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.persistent.PersistentTaskState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
+import org.elasticsearch.xpack.dataframe.DataFrame;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -30,7 +31,7 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constru
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 public class DataFrameJobState implements Task.Status, PersistentTaskState {
-    public static final String NAME = "xpack/data_frame/job_state";
+    public static final String NAME = DataFrame.TASK_NAME;
 
     private final IndexerState state;
 
@@ -73,7 +74,7 @@ public class DataFrameJobState implements Task.Status, PersistentTaskState {
         currentPosition = in.readBoolean() ? Collections.unmodifiableSortedMap(new TreeMap<>(in.readMap())) : null;
     }
 
-    public IndexerState getJobState() {
+    public IndexerState getIndexerState() {
         return state;
     }
 

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/support/JobValidatorTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/support/JobValidatorTests.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.dataframe.support;
 
+import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -157,8 +158,9 @@ public class JobValidatorTests extends ESTestCase {
                     }
                 }
 
-                final SearchResponseSections sections = new SearchResponseSections(new SearchHits(new SearchHit[0], 0, 0), null, null,
-                        false, null, null, 1);
+                final SearchResponseSections sections = new SearchResponseSections(
+                        new SearchHits(new SearchHit[0], new TotalHits(0L, TotalHits.Relation.EQUAL_TO), 0), null, null, false, null, null,
+                        1);
                 final SearchResponse response = new SearchResponse(sections, null, 10, searchFailures.size() > 0 ? 0 : 5, 0, 0,
                         searchFailures.toArray(new ShardSearchFailure[searchFailures.size()]), null);
 


### PR DESCRIPTION
**Feature Branch PR**

fix a couple of issues, namely
 - persistence of job state to/from cluster state on node restart
 - make start/stop/triggered synchronized