### PR TITLE
Explicitly recommend to forceMerge before freezing

### DIFF
--- a/docs/reference/frozen-indices.asciidoc
+++ b/docs/reference/frozen-indices.asciidoc
@@ -31,7 +31,6 @@ Since indices that are eligible for freezing are unlikely to change in the futur
 
 It's highly recommended to <<indices-forcemerge,`_forcemerge`>> your indices prior to freezing to ensure that each shard has only a single
 segment on disk. This will not only provide much better compression but also simplify the data structures needed to service aggregation requests.
-aggregation to be build on every request.
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/frozen-indices.asciidoc
+++ b/docs/reference/frozen-indices.asciidoc
@@ -29,6 +29,17 @@ data structures on demand which can cause page faults and garbage collections, w
 
 Since indices that are eligible for freezing are unlikely to change in the future, disk space can be optimized as described in <<tune-for-disk-usage>>.
 
+It's highly recommended to <<indices-forcemerge,`_forcemerge`>> you indices prior to freezing them to ensure the indices only have a single
+segment on disk. This will provide much better compression but also prevents the need for additional data-structures required for
+aggregation to be build on every request.
+
+[source,js]
+--------------------------------------------------
+POST /twitter/_forcemerge?max_num_segments=1
+--------------------------------------------------
+// CONSOLE
+// TEST[setup:twitter]
+
 == Searching a frozen index
 
 Frozen indices are throttled in order to limit memory consumptions per node. The number of concurrently loaded frozen indices per node is

--- a/docs/reference/frozen-indices.asciidoc
+++ b/docs/reference/frozen-indices.asciidoc
@@ -30,7 +30,8 @@ data structures on demand which can cause page faults and garbage collections, w
 Since indices that are eligible for freezing are unlikely to change in the future, disk space can be optimized as described in <<tune-for-disk-usage>>.
 
 It's highly recommended to <<indices-forcemerge,`_forcemerge`>> your indices prior to freezing to ensure that each shard has only a single
-segment on disk. This will not only provide much better compression but also simplify the data structures needed to service aggregation requests.
+segment on disk. This not only provides much better compression but also simplifies the data structures needed to service aggregation
+or sorted search requests.
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/frozen-indices.asciidoc
+++ b/docs/reference/frozen-indices.asciidoc
@@ -29,7 +29,7 @@ data structures on demand which can cause page faults and garbage collections, w
 
 Since indices that are eligible for freezing are unlikely to change in the future, disk space can be optimized as described in <<tune-for-disk-usage>>.
 
-It's highly recommended to <<indices-forcemerge,`_forcemerge`>> you indices prior to freezing them to ensure the indices only have a single
+It's highly recommended to <<indices-forcemerge,`_forcemerge`>> your indices prior to freezing to ensure that each shard has only a single
 segment on disk. This will provide much better compression but also prevents the need for additional data-structures required for
 aggregation to be build on every request.
 

--- a/docs/reference/frozen-indices.asciidoc
+++ b/docs/reference/frozen-indices.asciidoc
@@ -30,7 +30,7 @@ data structures on demand which can cause page faults and garbage collections, w
 Since indices that are eligible for freezing are unlikely to change in the future, disk space can be optimized as described in <<tune-for-disk-usage>>.
 
 It's highly recommended to <<indices-forcemerge,`_forcemerge`>> your indices prior to freezing to ensure that each shard has only a single
-segment on disk. This will provide much better compression but also prevents the need for additional data-structures required for
+segment on disk. This will not only provide much better compression but also simplify the data structures needed to service aggregation requests.
 aggregation to be build on every request.
 
 [source,js]


### PR DESCRIPTION
given the benchmark results on #34352 it's important to recommend
users to `_force_merge` their indices to a single segment before freezing.