### PR TITLE
Option to use endpoints starting with _security

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/rest/RestGetCertificateInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/rest/RestGetCertificateInfoAction.java
@@ -31,6 +31,7 @@ public class RestGetCertificateInfoAction extends BaseRestHandler {
     public RestGetCertificateInfoAction(Settings settings, RestController controller) {
         super(settings);
         controller.registerHandler(GET, "/_xpack/ssl/certificates", this);
+        controller.registerHandler(GET, "/_ssl/certificates", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/RestAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/RestAuthenticateAction.java
@@ -40,6 +40,7 @@ public class RestAuthenticateAction extends SecurityBaseRestHandler {
         super(settings, licenseState);
         this.securityContext = securityContext;
         controller.registerHandler(GET, "/_xpack/security/_authenticate", this);
+        controller.registerHandler(GET, "/_security/_authenticate", this);
 
         // @deprecated: Remove in 6.0
         controller.registerAsDeprecatedHandler(GET, "/_shield/authenticate", this,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oauth2/RestGetTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oauth2/RestGetTokenAction.java
@@ -61,6 +61,7 @@ public final class RestGetTokenAction extends SecurityBaseRestHandler {
     public RestGetTokenAction(Settings settings, RestController controller, XPackLicenseState xPackLicenseState) {
         super(settings, xPackLicenseState);
         controller.registerHandler(POST, "/_xpack/security/oauth2/token", this);
+        controller.registerHandler(POST, "/_/security/oauth2/token", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oauth2/RestInvalidateTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oauth2/RestInvalidateTokenAction.java
@@ -44,6 +44,7 @@ public final class RestInvalidateTokenAction extends SecurityBaseRestHandler {
     public RestInvalidateTokenAction(Settings settings, RestController controller, XPackLicenseState xPackLicenseState) {
         super(settings, xPackLicenseState);
         controller.registerHandler(DELETE, "/_xpack/security/oauth2/token", this);
+        controller.registerHandler(DELETE, "/_security/oauth2/token", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/privilege/RestDeletePrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/privilege/RestDeletePrivilegesAction.java
@@ -34,6 +34,7 @@ public class RestDeletePrivilegesAction extends SecurityBaseRestHandler {
     public RestDeletePrivilegesAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(DELETE, "/_xpack/security/privilege/{application}/{privilege}", this);
+        controller.registerHandler(DELETE, "/_security/privilege/{application}/{privilege}", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/privilege/RestGetPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/privilege/RestGetPrivilegesAction.java
@@ -39,8 +39,11 @@ public class RestGetPrivilegesAction extends SecurityBaseRestHandler {
     public RestGetPrivilegesAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(GET, "/_xpack/security/privilege/", this);
+        controller.registerHandler(GET, "/_security/privilege/", this);
         controller.registerHandler(GET, "/_xpack/security/privilege/{application}", this);
+        controller.registerHandler(GET, "/_security/privilege/{application}", this);
         controller.registerHandler(GET, "/_xpack/security/privilege/{application}/{privilege}", this);
+        controller.registerHandler(GET, "/_security/privilege/{application}/{privilege}", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/privilege/RestPutPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/privilege/RestPutPrivilegesAction.java
@@ -39,7 +39,9 @@ public class RestPutPrivilegesAction extends SecurityBaseRestHandler {
     public RestPutPrivilegesAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(PUT, "/_xpack/security/privilege/", this);
+        controller.registerHandler(PUT, "/_security/privilege/", this);
         controller.registerHandler(POST, "/_xpack/security/privilege/", this);
+        controller.registerHandler(POST, "/_security/privilege/", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/realm/RestClearRealmCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/realm/RestClearRealmCacheAction.java
@@ -29,6 +29,7 @@ public final class RestClearRealmCacheAction extends SecurityBaseRestHandler {
     public RestClearRealmCacheAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(POST, "/_xpack/security/realm/{realms}/_clear_cache", this);
+        controller.registerHandler(POST, "/_security/realm/{realms}/_clear_cache", this);
 
         // @deprecated: Remove in 6.0
         controller.registerAsDeprecatedHandler(POST, "/_shield/realm/{realms}/_cache/clear", this,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/role/RestClearRolesCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/role/RestClearRolesCacheAction.java
@@ -29,6 +29,7 @@ public final class RestClearRolesCacheAction extends SecurityBaseRestHandler {
     public RestClearRolesCacheAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(POST, "/_xpack/security/role/{name}/_clear_cache", this);
+        controller.registerHandler(POST, "/_security/role/{name}/_clear_cache", this);
 
         // @deprecated: Remove in 6.0
         controller.registerAsDeprecatedHandler(POST, "/_shield/role/{name}/_clear_cache", this,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/role/RestDeleteRoleAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/role/RestDeleteRoleAction.java
@@ -36,6 +36,7 @@ public class RestDeleteRoleAction extends SecurityBaseRestHandler {
     public RestDeleteRoleAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(DELETE, "/_xpack/security/role/{name}", this);
+        controller.registerHandler(DELETE, "/_security/role/{name}", this);
 
         // @deprecated: Remove in 6.0
         controller.registerAsDeprecatedHandler(DELETE, "/_shield/role/{name}", this,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/role/RestGetRolesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/role/RestGetRolesAction.java
@@ -38,7 +38,9 @@ public class RestGetRolesAction extends SecurityBaseRestHandler {
     public RestGetRolesAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(GET, "/_xpack/security/role/", this);
+        controller.registerHandler(GET, "/_security/role/", this);
         controller.registerHandler(GET, "/_xpack/security/role/{name}", this);
+        controller.registerHandler(GET, "/_security/role/{name}", this);
 
         // @deprecated: Remove in 6.0
         controller.registerAsDeprecatedHandler(GET, "/_shield/role", this,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/role/RestPutRoleAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/role/RestPutRoleAction.java
@@ -38,7 +38,9 @@ public class RestPutRoleAction extends SecurityBaseRestHandler {
     public RestPutRoleAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(POST, "/_xpack/security/role/{name}", this);
+        controller.registerHandler(POST, "/_security/role/{name}", this);
         controller.registerHandler(PUT, "/_xpack/security/role/{name}", this);
+        controller.registerHandler(PUT, "/_security/role/{name}", this);
 
         // @deprecated: Remove in 6.0
         controller.registerAsDeprecatedHandler(POST, "/_shield/role/{name}", this,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/rolemapping/RestDeleteRoleMappingAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/rolemapping/RestDeleteRoleMappingAction.java
@@ -31,6 +31,7 @@ public class RestDeleteRoleMappingAction extends SecurityBaseRestHandler {
     public RestDeleteRoleMappingAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(DELETE, "/_xpack/security/role_mapping/{name}", this);
+        controller.registerHandler(DELETE, "/_security/role_mapping/{name}", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/rolemapping/RestGetRoleMappingsAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/rolemapping/RestGetRoleMappingsAction.java
@@ -32,7 +32,9 @@ public class RestGetRoleMappingsAction extends SecurityBaseRestHandler {
     public RestGetRoleMappingsAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(GET, "/_xpack/security/role_mapping/", this);
+        controller.registerHandler(GET, "/_security/role_mapping/", this);
         controller.registerHandler(GET, "/_xpack/security/role_mapping/{name}", this);
+        controller.registerHandler(GET, "/_security/role_mapping/{name}", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/rolemapping/RestPutRoleMappingAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/rolemapping/RestPutRoleMappingAction.java
@@ -35,7 +35,9 @@ public class RestPutRoleMappingAction extends SecurityBaseRestHandler {
     public RestPutRoleMappingAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(POST, "/_xpack/security/role_mapping/{name}", this);
+        controller.registerHandler(POST, "/_security/role_mapping/{name}", this);
         controller.registerHandler(PUT, "/_xpack/security/role_mapping/{name}", this);
+        controller.registerHandler(PUT, "/_security/role_mapping/{name}", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/RestSamlAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/RestSamlAuthenticateAction.java
@@ -59,6 +59,7 @@ public class RestSamlAuthenticateAction extends SamlBaseRestHandler implements R
                                       XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(POST, "/_xpack/security/saml/authenticate", this);
+        controller.registerHandler(POST, "/_security/saml/authenticate", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/RestSamlInvalidateSessionAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/RestSamlInvalidateSessionAction.java
@@ -44,6 +44,7 @@ public class RestSamlInvalidateSessionAction extends SamlBaseRestHandler {
     public RestSamlInvalidateSessionAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(POST, "/_xpack/security/saml/invalidate", this);
+        controller.registerHandler(POST, "/_security/saml/invalidate", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/RestSamlLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/RestSamlLogoutAction.java
@@ -44,6 +44,7 @@ public class RestSamlLogoutAction extends SamlBaseRestHandler {
     public RestSamlLogoutAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(POST, "/_xpack/security/saml/logout", this);
+        controller.registerHandler(POST, "/_security/saml/logout", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/RestSamlPrepareAuthenticationAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/RestSamlPrepareAuthenticationAction.java
@@ -45,6 +45,7 @@ public class RestSamlPrepareAuthenticationAction extends SamlBaseRestHandler {
     public RestSamlPrepareAuthenticationAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(POST, "/_xpack/security/saml/prepare", this);
+        controller.registerHandler(POST, "/_security/saml/prepare", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestChangePasswordAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestChangePasswordAction.java
@@ -42,9 +42,13 @@ public class RestChangePasswordAction extends SecurityBaseRestHandler implements
         this.securityContext = securityContext;
         passwordHasher = Hasher.resolve(XPackSettings.PASSWORD_HASHING_ALGORITHM.get(settings));
         controller.registerHandler(POST, "/_xpack/security/user/{username}/_password", this);
+        controller.registerHandler(POST, "/_security/user/{username}/_password", this);
         controller.registerHandler(PUT, "/_xpack/security/user/{username}/_password", this);
+        controller.registerHandler(PUT, "/_security/user/{username}/_password", this);
         controller.registerHandler(POST, "/_xpack/security/user/_password", this);
+        controller.registerHandler(POST, "/_security/user/_password", this);
         controller.registerHandler(PUT, "/_xpack/security/user/_password", this);
+        controller.registerHandler(PUT, "/_security/user/_password", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestDeleteUserAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestDeleteUserAction.java
@@ -36,6 +36,7 @@ public class RestDeleteUserAction extends SecurityBaseRestHandler {
     public RestDeleteUserAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(DELETE, "/_xpack/security/user/{username}", this);
+        controller.registerHandler(DELETE, "/_security/user/{username}", this);
 
         // @deprecated: Remove in 6.0
         controller.registerAsDeprecatedHandler(DELETE, "/_shield/user/{username}", this,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestGetUserPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestGetUserPrivilegesAction.java
@@ -45,6 +45,7 @@ public class RestGetUserPrivilegesAction extends SecurityBaseRestHandler {
         super(settings, licenseState);
         this.securityContext = securityContext;
         controller.registerHandler(GET, "/_xpack/security/user/_privileges", this);
+        controller.registerHandler(GET, "/_security/user/_privileges", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestGetUsersAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestGetUsersAction.java
@@ -38,7 +38,9 @@ public class RestGetUsersAction extends SecurityBaseRestHandler {
     public RestGetUsersAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(GET, "/_xpack/security/user/", this);
+        controller.registerHandler(GET, "/_security/user/", this);
         controller.registerHandler(GET, "/_xpack/security/user/{username}", this);
+        controller.registerHandler(GET, "/_security/user/{username}", this);
 
         // @deprecated: Remove in 6.0
         controller.registerAsDeprecatedHandler(GET, "/_shield/user", this,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestHasPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestHasPrivilegesAction.java
@@ -46,9 +46,13 @@ public class RestHasPrivilegesAction extends SecurityBaseRestHandler {
         super(settings, licenseState);
         this.securityContext = securityContext;
         controller.registerHandler(GET, "/_xpack/security/user/{username}/_has_privileges", this);
+        controller.registerHandler(GET, "/_security/user/{username}/_has_privileges", this);
         controller.registerHandler(POST, "/_xpack/security/user/{username}/_has_privileges", this);
+        controller.registerHandler(POST, "/_security/user/{username}/_has_privileges", this);
         controller.registerHandler(GET, "/_xpack/security/user/_has_privileges", this);
+        controller.registerHandler(GET, "/_security/user/_has_privileges", this);
         controller.registerHandler(POST, "/_xpack/security/user/_has_privileges", this);
+        controller.registerHandler(POST, "/_security/user/_has_privileges", this);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestPutUserAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestPutUserAction.java
@@ -47,7 +47,9 @@ public class RestPutUserAction extends SecurityBaseRestHandler implements RestRe
         super(settings, licenseState);
         passwordHasher = Hasher.resolve(XPackSettings.PASSWORD_HASHING_ALGORITHM.get(settings));
         controller.registerHandler(POST, "/_xpack/security/user/{username}", this);
+        controller.registerHandler(POST, "/_security/user/{username}", this);
         controller.registerHandler(PUT, "/_xpack/security/user/{username}", this);
+        controller.registerHandler(PUT, "/_security/user/{username}", this);
 
         // @deprecated: Remove in 6.0
         controller.registerAsDeprecatedHandler(POST, "/_shield/user/{username}", this,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestSetEnabledAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestSetEnabledAction.java
@@ -33,9 +33,13 @@ public class RestSetEnabledAction extends SecurityBaseRestHandler {
     public RestSetEnabledAction(Settings settings, RestController controller, XPackLicenseState licenseState) {
         super(settings, licenseState);
         controller.registerHandler(POST, "/_xpack/security/user/{username}/_enable", this);
+        controller.registerHandler(POST, "/_security/user/{username}/_enable", this);
         controller.registerHandler(PUT, "/_xpack/security/user/{username}/_enable", this);
+        controller.registerHandler(PUT, "/_security/user/{username}/_enable", this);
         controller.registerHandler(POST, "/_xpack/security/user/{username}/_disable", this);
+        controller.registerHandler(POST, "/_security/user/{username}/_disable", this);
         controller.registerHandler(PUT, "/_xpack/security/user/{username}/_disable", this);
+        controller.registerHandler(PUT, "/_security/user/{username}/_disable", this);
     }
 
     @Override


### PR DESCRIPTION
 #36293 deprecates the /_xpack/security/* endpoints in favor of
the /_security/* ones. This commit adds support for the /_security
endpoints in 6.x to facilitate tests and normal operations in a
mixed 6.x/7.x cluster
