### PR TITLE
Add non-X-Pack centric rollup endpoints

### DIFF
--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
@@ -80,8 +80,6 @@ import static java.util.Collections.emptyList;
 
 public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin {
 
-    public static final String BASE_PATH = "/_xpack/rollup/";
-
     // Introduced in ES version 6.3
     public static final int ROLLUP_VERSION_V1 = 1;
     // Introduced in ES Version 6.4

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestDeleteRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestDeleteRollupJobAction.java
@@ -3,8 +3,8 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-package org.elasticsearch.xpack.rollup.rest;
 
+package org.elasticsearch.xpack.rollup.rest;
 
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.ParseField;
@@ -20,11 +20,13 @@ import org.elasticsearch.xpack.rollup.Rollup;
 import java.io.IOException;
 
 public class RestDeleteRollupJobAction extends BaseRestHandler {
+
     public static final ParseField ID = new ParseField("id");
 
     public RestDeleteRollupJobAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.DELETE, Rollup.BASE_PATH +  "job/{id}/", this);
+        controller.registerHandler(RestRequest.Method.DELETE, "/_xpack/rollup/job/{id}/", this);
+        controller.registerHandler(RestRequest.Method.DELETE, "/_rollup/job/{id}/", this);
     }
 
     @Override
@@ -48,4 +50,5 @@ public class RestDeleteRollupJobAction extends BaseRestHandler {
     public String getName() {
         return "rollup_delete_job_action";
     }
+
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestDeleteRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestDeleteRollupJobAction.java
@@ -15,7 +15,6 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.rollup.action.DeleteRollupJobAction;
-import org.elasticsearch.xpack.rollup.Rollup;
 
 import java.io.IOException;
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupCapsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupCapsAction.java
@@ -3,6 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.rollup.rest;
 
 import org.elasticsearch.client.node.NodeClient;
@@ -13,16 +14,17 @@ import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.rollup.action.GetRollupCapsAction;
-import org.elasticsearch.xpack.rollup.Rollup;
 
 import java.io.IOException;
 
 public class RestGetRollupCapsAction extends BaseRestHandler {
+
     public static final ParseField ID = new ParseField("id");
 
     public RestGetRollupCapsAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.GET, Rollup.BASE_PATH +  "data/{id}/", this);
+        controller.registerHandler(RestRequest.Method.GET, "/_xpack/rollup/data/{id}/", this);
+        controller.registerHandler(RestRequest.Method.GET, "/_rollup/data/{id}/", this);
     }
 
     @Override
@@ -37,4 +39,5 @@ public class RestGetRollupCapsAction extends BaseRestHandler {
     public String getName() {
         return "rollup_get_caps_action";
     }
+
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupIndexCapsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupIndexCapsAction.java
@@ -3,6 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.rollup.rest;
 
 import org.elasticsearch.action.support.IndicesOptions;
@@ -17,11 +18,13 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.rollup.action.GetRollupIndexCapsAction;
 
 public class RestGetRollupIndexCapsAction extends BaseRestHandler {
+
     public static final ParseField INDEX = new ParseField("index");
 
     public RestGetRollupIndexCapsAction(Settings settings, RestController controller) {
         super(settings);
         controller.registerHandler(RestRequest.Method.GET, "/{index}/_xpack/rollup/data", this);
+        controller.registerHandler(RestRequest.Method.GET, "/{index}/_rollup/data", this);
     }
 
     @Override
@@ -37,4 +40,5 @@ public class RestGetRollupIndexCapsAction extends BaseRestHandler {
     public String getName() {
         return "rollup_get_caps_action";
     }
+
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupJobsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupJobsAction.java
@@ -3,6 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.rollup.rest;
 
 import org.elasticsearch.client.node.NodeClient;
@@ -13,14 +14,15 @@ import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.rollup.action.GetRollupJobsAction;
-import org.elasticsearch.xpack.rollup.Rollup;
 
 public class RestGetRollupJobsAction extends BaseRestHandler {
+
     public static final ParseField ID = new ParseField("id");
 
     public RestGetRollupJobsAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.GET, Rollup.BASE_PATH + "job/{id}/", this);
+        controller.registerHandler(RestRequest.Method.GET, "/_xpack/rollup/job/{id}/", this);
+        controller.registerHandler(RestRequest.Method.GET, "/_rollup/job/{id}/", this);
     }
 
     @Override
@@ -35,4 +37,5 @@ public class RestGetRollupJobsAction extends BaseRestHandler {
     public String getName() {
         return "rollup_get_job_action";
     }
+
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestPutRollupJobAction.java
@@ -3,8 +3,8 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-package org.elasticsearch.xpack.rollup.rest;
 
+package org.elasticsearch.xpack.rollup.rest;
 
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.settings.Settings;
@@ -13,7 +13,6 @@ import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.rollup.action.PutRollupJobAction;
-import org.elasticsearch.xpack.rollup.Rollup;
 
 import java.io.IOException;
 
@@ -21,7 +20,8 @@ public class RestPutRollupJobAction extends BaseRestHandler {
 
     public RestPutRollupJobAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.PUT, Rollup.BASE_PATH +  "job/{id}/", this);
+        controller.registerHandler(RestRequest.Method.PUT, "/_xpack/rollup/job/{id}/", this);
+        controller.registerHandler(RestRequest.Method.PUT, "/_rollup/job/{id}/", this);
     }
 
     @Override
@@ -35,4 +35,5 @@ public class RestPutRollupJobAction extends BaseRestHandler {
     public String getName() {
         return "rollup_put_job_action";
     }
+
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestStartRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestStartRollupJobAction.java
@@ -3,6 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.rollup.rest;
 
 import org.elasticsearch.client.node.NodeClient;
@@ -13,7 +14,6 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.rollup.RollupField;
 import org.elasticsearch.xpack.core.rollup.action.StartRollupJobAction;
-import org.elasticsearch.xpack.rollup.Rollup;
 
 import java.io.IOException;
 
@@ -21,7 +21,8 @@ public class RestStartRollupJobAction extends BaseRestHandler {
 
     public RestStartRollupJobAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.POST, Rollup.BASE_PATH +  "job/{id}/_start", this);
+        controller.registerHandler(RestRequest.Method.POST, "/_xpack/rollup/job/{id}/_start", this);
+        controller.registerHandler(RestRequest.Method.POST, "/_rollup/job/{id}/_start", this);
     }
 
     @Override
@@ -36,4 +37,5 @@ public class RestStartRollupJobAction extends BaseRestHandler {
     public String getName() {
         return "rollup_start_job_action";
     }
+
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestStopRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestStopRollupJobAction.java
@@ -3,6 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.rollup.rest;
 
 import org.elasticsearch.client.node.NodeClient;
@@ -14,13 +15,13 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.rollup.RollupField;
 import org.elasticsearch.xpack.core.rollup.action.StopRollupJobAction;
-import org.elasticsearch.xpack.rollup.Rollup;
 
 public class RestStopRollupJobAction extends BaseRestHandler {
 
     public RestStopRollupJobAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.POST, Rollup.BASE_PATH +  "job/{id}/_stop", this);
+        controller.registerHandler(RestRequest.Method.POST, "/_xpack/rollup/job/{id}/_stop", this);
+        controller.registerHandler(RestRequest.Method.POST, "/_rollup/job/{id}/_stop", this);
     }
 
     @Override
@@ -37,4 +38,5 @@ public class RestStopRollupJobAction extends BaseRestHandler {
     public String getName() {
         return "rollup_stop_job_action";
     }
+
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.delete_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.delete_job.json
@@ -4,7 +4,7 @@
     "methods": [ "DELETE" ],
     "url": {
       "path": "/_xpack/rollup/job/{id}",
-      "paths": [ "/_xpack/rollup/job/{id}" ],
+      "paths": [ "/_xpack/rollup/job/{id}", "/_rollup/job/{id}" ],
       "parts": {
         "id": {
           "type": "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.get_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.get_jobs.json
@@ -4,7 +4,7 @@
     "methods": [ "GET" ],
     "url": {
       "path": "/_xpack/rollup/job/{id}",
-      "paths": [ "/_xpack/rollup/job/{id}", "/_xpack/rollup/job/" ],
+      "paths": [ "/_xpack/rollup/job/{id}", "/_xpack/rollup/job/", "/_rollup/job/{id}", "/_rollup/job/"],
       "parts": {
         "id": {
           "type": "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.get_rollup_caps.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.get_rollup_caps.json
@@ -4,7 +4,7 @@
     "methods": [ "GET" ],
     "url": {
       "path": "/_xpack/rollup/data/{id}",
-      "paths": [ "/_xpack/rollup/data/{id}", "/_xpack/rollup/data/" ],
+      "paths": [ "/_xpack/rollup/data/{id}", "/_xpack/rollup/data/", "/_rollup/data/{id}", "/_rollup/data/" ],
       "parts": {
         "id": {
           "type": "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.get_rollup_index_caps.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.get_rollup_index_caps.json
@@ -4,7 +4,7 @@
     "methods": [ "GET" ],
     "url": {
       "path": "/{index}/_xpack/rollup/data",
-      "paths": [ "/{index}/_xpack/rollup/data" ],
+      "paths": [ "/{index}/_xpack/rollup/data", "/{index}/_rollup/data" ],
       "parts": {
         "index": {
           "type": "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.put_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.put_job.json
@@ -4,7 +4,7 @@
     "methods": [ "PUT" ],
     "url": {
       "path": "/_xpack/rollup/job/{id}",
-      "paths": [ "/_xpack/rollup/job/{id}" ],
+      "paths": [ "/_xpack/rollup/job/{id}", "/_rollup/job/{id}" ],
       "parts": {
         "id": {
           "type": "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.start_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.start_job.json
@@ -4,7 +4,7 @@
     "methods": [ "POST" ],
     "url": {
       "path": "/_xpack/rollup/job/{id}/_start",
-      "paths": [ "/_xpack/rollup/job/{id}/_start" ],
+      "paths": [ "/_xpack/rollup/job/{id}/_start", "/_rollup/job/{id}/_start" ],
       "parts": {
         "id": {
           "type": "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.stop_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.stop_job.json
@@ -4,7 +4,7 @@
     "methods": [ "POST" ],
     "url": {
       "path": "/_xpack/rollup/job/{id}/_stop",
-      "paths": [ "/_xpack/rollup/job/{id}/_stop" ],
+      "paths": [ "/_xpack/rollup/job/{id}/_stop", "/_ollup/job/{id}/_stop" ],
       "parts": {
         "id": {
           "type": "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.stop_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.rollup.stop_job.json
@@ -4,7 +4,7 @@
     "methods": [ "POST" ],
     "url": {
       "path": "/_xpack/rollup/job/{id}/_stop",
-      "paths": [ "/_xpack/rollup/job/{id}/_stop", "/_ollup/job/{id}/_stop" ],
+      "paths": [ "/_xpack/rollup/job/{id}/_stop", "/_rollup/job/{id}/_stop" ],
       "parts": {
         "id": {
           "type": "string",


### PR DESCRIPTION
This commit adds new endpoints for rollup that do not have _xpack in their path. The purpose for this change is to take these endpoints into 6.x as well so that they can be available in mixed cluster tests too. A follow-up change will deprecate the use of _xpack in the rollup endpoints. And finally, in the future, we would remove the _xpack endpoints.

Relates #35958
Relates #35962 
Relates 61c2db5ebbec9b32a02be79a8adce4728295b207