### PR TITLE
Core: Remove parseDefaulting from DateFormatter

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.common.time.DateMathParser;
-import org.elasticsearch.common.time.JavaDateMathParser;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -921,7 +920,7 @@ public class IndexNameExpressionResolver {
                                     dateFormatter = DateFormatters.forPattern(dateFormatterPattern);
                                 }
                                 DateFormatter formatter = dateFormatter.withZone(timeZone);
-                                DateMathParser dateMathParser = new JavaDateMathParser(formatter);
+                                DateMathParser dateMathParser = formatter.toDateMathParser();
                                 long millis = dateMathParser.parse(mathExpression, context::getStartTime, false, timeZone);
 
                                 String time = formatter.format(Instant.ofEpochMilli(millis));

--- a/server/src/main/java/org/elasticsearch/common/time/EpochMillisDateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/EpochMillisDateFormatter.java
@@ -25,9 +25,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
-import java.time.temporal.TemporalField;
 import java.util.Locale;
-import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
@@ -42,7 +40,8 @@ import java.util.regex.Pattern;
 class EpochMillisDateFormatter implements DateFormatter {
 
     private static final Pattern SPLIT_BY_DOT_PATTERN = Pattern.compile("\\.");
-    static DateFormatter INSTANCE = new EpochMillisDateFormatter();
+    static final DateFormatter INSTANCE = new EpochMillisDateFormatter();
+    static final DateMathParser DATE_MATH_INSTANCE = new JavaDateMathParser(INSTANCE, INSTANCE);
 
     private EpochMillisDateFormatter() {
     }
@@ -104,11 +103,6 @@ class EpochMillisDateFormatter implements DateFormatter {
     }
 
     @Override
-    public DateFormatter parseDefaulting(Map<TemporalField, Long> fields) {
-        return this;
-    }
-
-    @Override
     public Locale getLocale() {
         return Locale.ROOT;
     }
@@ -116,5 +110,10 @@ class EpochMillisDateFormatter implements DateFormatter {
     @Override
     public ZoneId getZone() {
         return ZoneOffset.UTC;
+    }
+
+    @Override
+    public DateMathParser toDateMathParser() {
+        return DATE_MATH_INSTANCE;
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/time/EpochSecondsDateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/EpochSecondsDateFormatter.java
@@ -25,14 +25,13 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
-import java.time.temporal.TemporalField;
 import java.util.Locale;
-import java.util.Map;
 import java.util.regex.Pattern;
 
 public class EpochSecondsDateFormatter implements DateFormatter {
 
     public static DateFormatter INSTANCE = new EpochSecondsDateFormatter();
+    static final DateMathParser DATE_MATH_INSTANCE = new JavaDateMathParser(INSTANCE, INSTANCE);
     private static final Pattern SPLIT_BY_DOT_PATTERN = Pattern.compile("\\.");
 
     private EpochSecondsDateFormatter() {}
@@ -92,6 +91,11 @@ public class EpochSecondsDateFormatter implements DateFormatter {
     }
 
     @Override
+    public DateMathParser toDateMathParser() {
+        return DATE_MATH_INSTANCE;
+    }
+
+    @Override
     public DateFormatter withZone(ZoneId zoneId) {
         if (zoneId.equals(ZoneOffset.UTC) == false) {
             throw new IllegalArgumentException(pattern() + " date formatter can only be in zone offset UTC");
@@ -104,11 +108,6 @@ public class EpochSecondsDateFormatter implements DateFormatter {
         if (Locale.ROOT.equals(locale) == false) {
             throw new IllegalArgumentException(pattern() + " date formatter can only be in locale ROOT");
         }
-        return this;
-    }
-
-    @Override
-    public DateFormatter parseDefaulting(Map<TemporalField, Long> fields) {
         return this;
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/time/JavaDateMathParser.java
+++ b/server/src/main/java/org/elasticsearch/common/time/JavaDateMathParser.java
@@ -31,10 +31,7 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalAdjusters;
-import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalQueries;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.LongSupplier;
 
@@ -47,24 +44,15 @@ import java.util.function.LongSupplier;
  */
 public class JavaDateMathParser implements DateMathParser {
 
-    // base fields which should be used for default parsing, when we round up
-    private static final Map<TemporalField, Long> ROUND_UP_BASE_FIELDS = new HashMap<>(6);
-    {
-        ROUND_UP_BASE_FIELDS.put(ChronoField.MONTH_OF_YEAR, 1L);
-        ROUND_UP_BASE_FIELDS.put(ChronoField.DAY_OF_MONTH, 1L);
-        ROUND_UP_BASE_FIELDS.put(ChronoField.HOUR_OF_DAY, 23L);
-        ROUND_UP_BASE_FIELDS.put(ChronoField.MINUTE_OF_HOUR, 59L);
-        ROUND_UP_BASE_FIELDS.put(ChronoField.SECOND_OF_MINUTE, 59L);
-        ROUND_UP_BASE_FIELDS.put(ChronoField.MILLI_OF_SECOND, 999L);
-    }
+
 
     private final DateFormatter formatter;
     private final DateFormatter roundUpFormatter;
 
-    public JavaDateMathParser(DateFormatter formatter) {
+    public JavaDateMathParser(DateFormatter formatter, DateFormatter roundUpFormatter) {
         Objects.requireNonNull(formatter);
         this.formatter = formatter;
-        this.roundUpFormatter = formatter.parseDefaulting(ROUND_UP_BASE_FIELDS);
+        this.roundUpFormatter = roundUpFormatter;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.is;
 public class JavaDateMathParserTests extends ESTestCase {
 
     private final DateFormatter formatter = DateFormatters.forPattern("dateOptionalTime||epoch_millis");
-    private final JavaDateMathParser parser = new JavaDateMathParser(formatter);
+    private final DateMathParser parser = formatter.toDateMathParser();
 
     public void testBasicDates() {
         assertDateMathEquals("2014", "2014-01-01T00:00:00.000");
@@ -139,7 +139,7 @@ public class JavaDateMathParserTests extends ESTestCase {
     public void testRoundingPreservesEpochAsBaseDate() {
         // If a user only specifies times, then the date needs to always be 1970-01-01 regardless of rounding
         DateFormatter formatter = DateFormatters.forPattern("HH:mm:ss");
-        JavaDateMathParser parser = new JavaDateMathParser(formatter);
+        DateMathParser parser = formatter.toDateMathParser();
         ZonedDateTime zonedDateTime = DateFormatters.toZonedDateTime(formatter.parse("04:52:20"));
         assertThat(zonedDateTime.getYear(), is(1970));
         long millisStart = zonedDateTime.toInstant().toEpochMilli();
@@ -165,7 +165,7 @@ public class JavaDateMathParserTests extends ESTestCase {
 
         // implicit rounding with explicit timezone in the date format
         DateFormatter formatter = DateFormatters.forPattern("yyyy-MM-ddXXX");
-        JavaDateMathParser parser = new JavaDateMathParser(formatter);
+        DateMathParser parser = formatter.toDateMathParser();
         long time = parser.parse("2011-10-09+01:00", () -> 0, false, (ZoneId) null);
         assertEquals(this.parser.parse("2011-10-09T00:00:00.000+01:00", () -> 0), time);
         time = parser.parse("2011-10-09+01:00", () -> 0, true, (ZoneId) null);
@@ -239,7 +239,7 @@ public class JavaDateMathParserTests extends ESTestCase {
         assertDateMathEquals("1418248078000||/m", "2014-12-10T21:47:00.000");
 
         // also check other time units
-        JavaDateMathParser parser = new JavaDateMathParser(DateFormatters.forPattern("epoch_second||dateOptionalTime"));
+        DateMathParser parser = DateFormatters.forPattern("epoch_second||dateOptionalTime").toDateMathParser();
         long datetime = parser.parse("1418248078", () -> 0);
         assertDateEquals(datetime, "1418248078", "2014-12-10T21:47:58.000");
 


### PR DESCRIPTION
This commit removes the parseDefaulting method from DateFormatter,
bringing it more inline with the joda equivalent
FormatDateTimeFormatter. This method was only needed for the java
time implementation of DateMathParser. Instead, a DateFormatter now
returns an implementation of DateMathParser for the given format,
allowing the java time implementation to construct the appropriate date
math parser internally.