### PR TITLE
Enable caching of roles from the api keys

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
@@ -68,7 +68,7 @@ import static org.elasticsearch.xpack.security.support.SecurityIndexManager.isMo
  */
 public class CompositeRolesStore {
 
-
+    private static final String ROLES_STORE_SOURCE = "roles_stores";
     private static final Setting<Integer> CACHE_SIZE_SETTING =
         Setting.intSetting("xpack.security.authz.store.roles.cache.max_size", 10000, Property.NodeScope);
     private static final Setting<Integer> NEGATIVE_LOOKUP_CACHE_SIZE_SETTING =
@@ -92,7 +92,8 @@ public class CompositeRolesStore {
     private final NativeRolesStore nativeRolesStore;
     private final NativePrivilegeStore privilegeStore;
     private final XPackLicenseState licenseState;
-    private final Cache<Set<String>, Role> roleCache;
+    private final FieldPermissionsCache fieldPermissionsCache;
+    private final Cache<RoleKey, Role> roleCache;
     private final Cache<String, Boolean> negativeLookupCache;
     private final ThreadContext threadContext;
     private final AtomicLong numInvalidation = new AtomicLong();
@@ -102,13 +103,14 @@ public class CompositeRolesStore {
     public CompositeRolesStore(Settings settings, FileRolesStore fileRolesStore, NativeRolesStore nativeRolesStore,
                                ReservedRolesStore reservedRolesStore, NativePrivilegeStore privilegeStore,
                                List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> rolesProviders,
-                               ThreadContext threadContext, XPackLicenseState licenseState) {
+                               ThreadContext threadContext, XPackLicenseState licenseState, FieldPermissionsCache fieldPermissionsCache) {
         this.fileRolesStore = fileRolesStore;
         fileRolesStore.addListener(this::invalidate);
         this.nativeRolesStore = nativeRolesStore;
         this.privilegeStore = privilegeStore;
         this.licenseState = licenseState;
-        CacheBuilder<Set<String>, Role> builder = CacheBuilder.builder();
+        this.fieldPermissionsCache = fieldPermissionsCache;
+        CacheBuilder<RoleKey, Role> builder = CacheBuilder.builder();
         final int cacheSize = CACHE_SIZE_SETTING.get(settings);
         if (cacheSize >= 0) {
             builder.setMaximumWeight(cacheSize);
@@ -133,8 +135,9 @@ public class CompositeRolesStore {
         }
     }
 
-    public void roles(Set<String> roleNames, FieldPermissionsCache fieldPermissionsCache, ActionListener<Role> roleActionListener) {
-        Role existing = roleCache.get(roleNames);
+    public void roles(Set<String> roleNames, ActionListener<Role> roleActionListener) {
+        final RoleKey roleKey = new RoleKey(roleNames, ROLES_STORE_SOURCE);
+        Role existing = roleCache.get(roleKey);
         if (existing != null) {
             roleActionListener.onResponse(existing);
         } else {
@@ -154,33 +157,53 @@ public class CompositeRolesStore {
                                     .filter((rd) -> rd.isUsingDocumentOrFieldLevelSecurity() == false)
                                     .collect(Collectors.toSet());
                         }
-                        logger.trace("Building role from descriptors [{}] for names [{}]", effectiveDescriptors, roleNames);
-                        buildRoleFromDescriptors(effectiveDescriptors, fieldPermissionsCache, privilegeStore, ActionListener.wrap(role -> {
-                            if (role != null && rolesRetrievalResult.isSuccess()) {
-                                try (ReleasableLock ignored = readLock.acquire()) {
-                                    /* this is kinda spooky. We use a read/write lock to ensure we don't modify the cache if we hold
-                                     * the write lock (fetching stats for instance - which is kinda overkill?) but since we fetching
-                                     * stuff in an async fashion we need to make sure that if the cache got invalidated since we
-                                     * started the request we don't put a potential stale result in the cache, hence the
-                                     * numInvalidation.get() comparison to the number of invalidation when we started. we just try to
-                                     * be on the safe side and don't cache potentially stale results
-                                     */
-                                    if (invalidationCounter == numInvalidation.get()) {
-                                        roleCache.computeIfAbsent(roleNames, (s) -> role);
-                                    }
-                                }
-
-                                for (String missingRole : rolesRetrievalResult.getMissingRoles()) {
-                                    negativeLookupCache.computeIfAbsent(missingRole, s -> Boolean.TRUE);
-                                }
-                            }
-                            roleActionListener.onResponse(role);
-                        }, roleActionListener::onFailure));
+                        buildThenMaybeCacheRole(roleKey, effectiveDescriptors, rolesRetrievalResult.getMissingRoles(),
+                            rolesRetrievalResult.isSuccess(), invalidationCounter, roleActionListener);
                     },
                     roleActionListener::onFailure));
         }
     }
 
+    public void buildAndCacheRoleFromDescriptors(Collection<RoleDescriptor> roleDescriptors, String source,
+                                                  ActionListener<Role> listener) {
+        if (ROLES_STORE_SOURCE.equals(source)) {
+            throw new IllegalArgumentException("source [" + ROLES_STORE_SOURCE + "] is reserved for internal use");
+        }
+        RoleKey roleKey = new RoleKey(roleDescriptors.stream().map(RoleDescriptor::getName).collect(Collectors.toSet()), source);
+        Role existing = roleCache.get(roleKey);
+        if (existing != null) {
+            listener.onResponse(existing);
+        } else {
+            final long invalidationCounter = numInvalidation.get();
+            buildThenMaybeCacheRole(roleKey, roleDescriptors, Collections.emptySet(), true, invalidationCounter, listener);
+        }
+    }
+
+    private void buildThenMaybeCacheRole(RoleKey roleKey, Collection<RoleDescriptor> roleDescriptors, Set<String> missing,
+                                         boolean tryCache, long invalidationCounter, ActionListener<Role> listener) {
+        logger.trace("Building role from descriptors [{}] for names [{}] from source [{}]", roleDescriptors, roleKey.names, roleKey.source);
+        buildRoleFromDescriptors(roleDescriptors, fieldPermissionsCache, privilegeStore, ActionListener.wrap(role -> {
+            if (role != null && tryCache) {
+                try (ReleasableLock ignored = readLock.acquire()) {
+                    /* this is kinda spooky. We use a read/write lock to ensure we don't modify the cache if we hold
+                     * the write lock (fetching stats for instance - which is kinda overkill?) but since we fetching
+                     * stuff in an async fashion we need to make sure that if the cache got invalidated since we
+                     * started the request we don't put a potential stale result in the cache, hence the
+                     * numInvalidation.get() comparison to the number of invalidation when we started. we just try to
+                     * be on the safe side and don't cache potentially stale results
+                     */
+                    if (invalidationCounter == numInvalidation.get()) {
+                        roleCache.computeIfAbsent(roleKey, (s) -> role);
+                    }
+                }
+
+                for (String missingRole : missing) {
+                    negativeLookupCache.computeIfAbsent(missingRole, s -> Boolean.TRUE);
+                }
+            }
+            listener.onResponse(role);
+        }, listener::onFailure));
+    }
     public void getRoleDescriptors(Set<String> roleNames, ActionListener<Set<RoleDescriptor>> listener) {
         roleDescriptors(roleNames, ActionListener.wrap(rolesRetrievalResult -> {
             if (rolesRetrievalResult.isSuccess()) {
@@ -239,11 +262,6 @@ public class CompositeRolesStore {
 
     private String names(Collection<RoleDescriptor> descriptors) {
         return descriptors.stream().map(RoleDescriptor::getName).collect(Collectors.joining(","));
-    }
-
-    public void buildRoleFromDescriptors(Collection<RoleDescriptor> roleDescriptors, FieldPermissionsCache fieldPermissionsCache,
-                                         ActionListener<Role> listener) {
-        buildRoleFromDescriptors(roleDescriptors, fieldPermissionsCache, privilegeStore, listener);
     }
 
     public static void buildRoleFromDescriptors(Collection<RoleDescriptor> roleDescriptors, FieldPermissionsCache fieldPermissionsCache,
@@ -346,10 +364,10 @@ public class CompositeRolesStore {
 
         // the cache cannot be modified while doing this operation per the terms of the cache iterator
         try (ReleasableLock ignored = writeLock.acquire()) {
-            Iterator<Set<String>> keyIter = roleCache.keys().iterator();
+            Iterator<RoleKey> keyIter = roleCache.keys().iterator();
             while (keyIter.hasNext()) {
-                Set<String> key = keyIter.next();
-                if (key.contains(role)) {
+                RoleKey key = keyIter.next();
+                if (key.names.contains(role)) {
                     keyIter.remove();
                 }
             }
@@ -362,10 +380,10 @@ public class CompositeRolesStore {
 
         // the cache cannot be modified while doing this operation per the terms of the cache iterator
         try (ReleasableLock ignored = writeLock.acquire()) {
-            Iterator<Set<String>> keyIter = roleCache.keys().iterator();
+            Iterator<RoleKey> keyIter = roleCache.keys().iterator();
             while (keyIter.hasNext()) {
-                Set<String> key = keyIter.next();
-                if (Sets.haveEmptyIntersection(key, roles) == false) {
+                RoleKey key = keyIter.next();
+                if (Sets.haveEmptyIntersection(key.names, roles) == false) {
                     keyIter.remove();
                 }
             }
@@ -458,6 +476,31 @@ public class CompositeRolesStore {
 
         private Set<String> getMissingRoles() {
             return missingRoles;
+        }
+    }
+
+    private static final class RoleKey {
+
+        private final Set<String> names;
+        private final String source;
+
+        private RoleKey(Set<String> names, String source) {
+            this.names = Objects.requireNonNull(names);
+            this.source = Objects.requireNonNull(source);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            RoleKey roleKey = (RoleKey) o;
+            return names.equals(roleKey.names) &&
+                source.equals(roleKey.source);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(names, source);
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
@@ -204,6 +204,7 @@ public class CompositeRolesStore {
             listener.onResponse(role);
         }, listener::onFailure));
     }
+
     public void getRoleDescriptors(Set<String> roleNames, ActionListener<Set<RoleDescriptor>> listener) {
         roleDescriptors(roleNames, ActionListener.wrap(rolesRetrievalResult -> {
             if (rolesRetrievalResult.isSuccess()) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -188,13 +188,13 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
                     );
                 }
                 return Void.TYPE;
-            }).when(rolesStore).roles(any(Set.class), any(FieldPermissionsCache.class), any(ActionListener.class));
+            }).when(rolesStore).roles(any(Set.class), any(ActionListener.class));
 
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
         authzService = new AuthorizationService(settings, rolesStore, clusterService,
                 mock(AuditTrailService.class), new DefaultAuthenticationFailureHandler(Collections.emptyMap()), mock(ThreadPool.class),
-                new AnonymousUser(settings), mock(ApiKeyService.class));
+                new AnonymousUser(settings), mock(ApiKeyService.class), new FieldPermissionsCache(settings));
         defaultIndicesResolver = new IndicesAndAliasesResolver(settings, clusterService);
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -169,7 +169,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         final FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
         doAnswer((i) -> {
                 ActionListener callback =
-                        (ActionListener) i.getArguments()[2];
+                        (ActionListener) i.getArguments()[1];
                 Set<String> names = (Set<String>) i.getArguments()[0];
                 assertNotNull(names);
                 Set<RoleDescriptor> roleDescriptors = new HashSet<>();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -79,6 +79,8 @@ public class CompositeRolesStoreTests extends ESTestCase {
             .put(XPackSettings.SECURITY_ENABLED.getKey(), true)
             .build();
 
+    private final FieldPermissionsCache cache = new FieldPermissionsCache(Settings.EMPTY);
+
     public void testRolesWhenDlsFlsUnlicensed() throws IOException {
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isDocumentAndFieldLevelSecurityAllowed()).thenReturn(false);
@@ -126,23 +128,22 @@ public class CompositeRolesStoreTests extends ESTestCase {
         when(fileRolesStore.roleDescriptors(Collections.singleton("no_fls_dls"))).thenReturn(Collections.singleton(noFlsDlsRole));
         CompositeRolesStore compositeRolesStore = new CompositeRolesStore(Settings.EMPTY, fileRolesStore, nativeRolesStore,
                 reservedRolesStore, mock(NativePrivilegeStore.class), Collections.emptyList(),
-                new ThreadContext(Settings.EMPTY), licenseState);
+                new ThreadContext(Settings.EMPTY), licenseState, cache);
 
-        FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
         PlainActionFuture<Role> roleFuture = new PlainActionFuture<>();
-        compositeRolesStore.roles(Collections.singleton("fls"), fieldPermissionsCache, roleFuture);
+        compositeRolesStore.roles(Collections.singleton("fls"), roleFuture);
         assertEquals(Role.EMPTY, roleFuture.actionGet());
 
         roleFuture = new PlainActionFuture<>();
-        compositeRolesStore.roles(Collections.singleton("dls"), fieldPermissionsCache, roleFuture);
+        compositeRolesStore.roles(Collections.singleton("dls"), roleFuture);
         assertEquals(Role.EMPTY, roleFuture.actionGet());
 
         roleFuture = new PlainActionFuture<>();
-        compositeRolesStore.roles(Collections.singleton("fls_dls"), fieldPermissionsCache, roleFuture);
+        compositeRolesStore.roles(Collections.singleton("fls_dls"), roleFuture);
         assertEquals(Role.EMPTY, roleFuture.actionGet());
 
         roleFuture = new PlainActionFuture<>();
-        compositeRolesStore.roles(Collections.singleton("no_fls_dls"), fieldPermissionsCache, roleFuture);
+        compositeRolesStore.roles(Collections.singleton("no_fls_dls"), roleFuture);
         assertNotEquals(Role.EMPTY, roleFuture.actionGet());
     }
 
@@ -192,23 +193,22 @@ public class CompositeRolesStoreTests extends ESTestCase {
         when(fileRolesStore.roleDescriptors(Collections.singleton("no_fls_dls"))).thenReturn(Collections.singleton(noFlsDlsRole));
         CompositeRolesStore compositeRolesStore = new CompositeRolesStore(Settings.EMPTY, fileRolesStore, nativeRolesStore,
                 reservedRolesStore, mock(NativePrivilegeStore.class), Collections.emptyList(),
-                new ThreadContext(Settings.EMPTY), licenseState);
+                new ThreadContext(Settings.EMPTY), licenseState, cache);
 
-        FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
         PlainActionFuture<Role> roleFuture = new PlainActionFuture<>();
-        compositeRolesStore.roles(Collections.singleton("fls"), fieldPermissionsCache, roleFuture);
+        compositeRolesStore.roles(Collections.singleton("fls"), roleFuture);
         assertNotEquals(Role.EMPTY, roleFuture.actionGet());
 
         roleFuture = new PlainActionFuture<>();
-        compositeRolesStore.roles(Collections.singleton("dls"), fieldPermissionsCache, roleFuture);
+        compositeRolesStore.roles(Collections.singleton("dls"), roleFuture);
         assertNotEquals(Role.EMPTY, roleFuture.actionGet());
 
         roleFuture = new PlainActionFuture<>();
-        compositeRolesStore.roles(Collections.singleton("fls_dls"), fieldPermissionsCache, roleFuture);
+        compositeRolesStore.roles(Collections.singleton("fls_dls"), roleFuture);
         assertNotEquals(Role.EMPTY, roleFuture.actionGet());
 
         roleFuture = new PlainActionFuture<>();
-        compositeRolesStore.roles(Collections.singleton("no_fls_dls"), fieldPermissionsCache, roleFuture);
+        compositeRolesStore.roles(Collections.singleton("no_fls_dls"), roleFuture);
         assertNotEquals(Role.EMPTY, roleFuture.actionGet());
     }
 
@@ -228,13 +228,12 @@ public class CompositeRolesStoreTests extends ESTestCase {
         final CompositeRolesStore compositeRolesStore =
                 new CompositeRolesStore(SECURITY_ENABLED_SETTINGS, fileRolesStore, nativeRolesStore, reservedRolesStore,
                         mock(NativePrivilegeStore.class), Collections.emptyList(), new ThreadContext(SECURITY_ENABLED_SETTINGS),
-                        new XPackLicenseState(SECURITY_ENABLED_SETTINGS));
+                        new XPackLicenseState(SECURITY_ENABLED_SETTINGS), cache);
         verify(fileRolesStore).addListener(any(Consumer.class)); // adds a listener in ctor
 
         final String roleName = randomAlphaOfLengthBetween(1, 10);
         PlainActionFuture<Role> future = new PlainActionFuture<>();
-        final FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
-        compositeRolesStore.roles(Collections.singleton(roleName), fieldPermissionsCache, future);
+        compositeRolesStore.roles(Collections.singleton(roleName), future);
         final Role role = future.actionGet();
         assertEquals(Role.EMPTY, role);
         verify(reservedRolesStore).accept(anySetOf(String.class), any(ActionListener.class));
@@ -250,7 +249,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
                 : Collections.singleton(roleName);
         for (int i = 0; i < numberOfTimesToCall; i++) {
             future = new PlainActionFuture<>();
-            compositeRolesStore.roles(names, fieldPermissionsCache, future);
+            compositeRolesStore.roles(names, future);
             future.actionGet();
         }
 
@@ -279,13 +278,12 @@ public class CompositeRolesStoreTests extends ESTestCase {
             .build();
         final CompositeRolesStore compositeRolesStore = new CompositeRolesStore(settings, fileRolesStore, nativeRolesStore,
             reservedRolesStore, mock(NativePrivilegeStore.class), Collections.emptyList(), new ThreadContext(settings),
-            new XPackLicenseState(settings));
+            new XPackLicenseState(settings), cache);
         verify(fileRolesStore).addListener(any(Consumer.class)); // adds a listener in ctor
 
         final String roleName = randomAlphaOfLengthBetween(1, 10);
         PlainActionFuture<Role> future = new PlainActionFuture<>();
-        final FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
-        compositeRolesStore.roles(Collections.singleton(roleName), fieldPermissionsCache, future);
+        compositeRolesStore.roles(Collections.singleton(roleName), future);
         final Role role = future.actionGet();
         assertEquals(Role.EMPTY, role);
         verify(reservedRolesStore).accept(anySetOf(String.class), any(ActionListener.class));
@@ -314,13 +312,12 @@ public class CompositeRolesStoreTests extends ESTestCase {
         final CompositeRolesStore compositeRolesStore =
             new CompositeRolesStore(SECURITY_ENABLED_SETTINGS, fileRolesStore, nativeRolesStore, reservedRolesStore,
                 mock(NativePrivilegeStore.class), Collections.emptyList(), new ThreadContext(SECURITY_ENABLED_SETTINGS),
-                new XPackLicenseState(SECURITY_ENABLED_SETTINGS));
+                new XPackLicenseState(SECURITY_ENABLED_SETTINGS), cache);
         verify(fileRolesStore).addListener(any(Consumer.class)); // adds a listener in ctor
 
         final String roleName = randomAlphaOfLengthBetween(1, 10);
         PlainActionFuture<Role> future = new PlainActionFuture<>();
-        final FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
-        compositeRolesStore.roles(Collections.singleton(roleName), fieldPermissionsCache, future);
+        compositeRolesStore.roles(Collections.singleton(roleName), future);
         final Role role = future.actionGet();
         assertEquals(Role.EMPTY, role);
         verify(reservedRolesStore).accept(anySetOf(String.class), any(ActionListener.class));
@@ -333,7 +330,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
         final Set<String> names = Collections.singleton(roleName);
         for (int i = 0; i < numberOfTimesToCall; i++) {
             future = new PlainActionFuture<>();
-            compositeRolesStore.roles(names, fieldPermissionsCache, future);
+            compositeRolesStore.roles(names, future);
             future.actionGet();
         }
 
@@ -392,12 +389,11 @@ public class CompositeRolesStoreTests extends ESTestCase {
         final CompositeRolesStore compositeRolesStore =
                 new CompositeRolesStore(SECURITY_ENABLED_SETTINGS, fileRolesStore, nativeRolesStore, reservedRolesStore,
                                 mock(NativePrivilegeStore.class), Arrays.asList(inMemoryProvider1, inMemoryProvider2),
-                                new ThreadContext(SECURITY_ENABLED_SETTINGS), new XPackLicenseState(SECURITY_ENABLED_SETTINGS));
+                                new ThreadContext(SECURITY_ENABLED_SETTINGS), new XPackLicenseState(SECURITY_ENABLED_SETTINGS), cache);
 
         final Set<String> roleNames = Sets.newHashSet("roleA", "roleB", "unknown");
         PlainActionFuture<Role> future = new PlainActionFuture<>();
-        final FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
-        compositeRolesStore.roles(roleNames, fieldPermissionsCache, future);
+        compositeRolesStore.roles(roleNames, future);
         final Role role = future.actionGet();
 
         // make sure custom roles providers populate roles correctly
@@ -414,7 +410,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
         final int numberOfTimesToCall = scaledRandomIntBetween(1, 8);
         for (int i = 0; i < numberOfTimesToCall; i++) {
             future = new PlainActionFuture<>();
-            compositeRolesStore.roles(Collections.singleton("unknown"), fieldPermissionsCache, future);
+            compositeRolesStore.roles(Collections.singleton("unknown"), future);
             future.actionGet();
         }
 
@@ -597,12 +593,11 @@ public class CompositeRolesStoreTests extends ESTestCase {
         final CompositeRolesStore compositeRolesStore =
             new CompositeRolesStore(SECURITY_ENABLED_SETTINGS, fileRolesStore, nativeRolesStore, reservedRolesStore,
                                     mock(NativePrivilegeStore.class), Arrays.asList(inMemoryProvider1, failingProvider),
-                                    new ThreadContext(SECURITY_ENABLED_SETTINGS), new XPackLicenseState(SECURITY_ENABLED_SETTINGS));
+                                    new ThreadContext(SECURITY_ENABLED_SETTINGS), new XPackLicenseState(SECURITY_ENABLED_SETTINGS), cache);
 
         final Set<String> roleNames = Sets.newHashSet("roleA", "roleB", "unknown");
         PlainActionFuture<Role> future = new PlainActionFuture<>();
-        final FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
-        compositeRolesStore.roles(roleNames, fieldPermissionsCache, future);
+        compositeRolesStore.roles(roleNames, future);
         try {
             future.get();
             fail("provider should have thrown a failure");
@@ -640,12 +635,11 @@ public class CompositeRolesStoreTests extends ESTestCase {
         xPackLicenseState.update(randomFrom(OperationMode.BASIC, OperationMode.GOLD, OperationMode.STANDARD), true, null);
         CompositeRolesStore compositeRolesStore = new CompositeRolesStore(
             Settings.EMPTY, fileRolesStore, nativeRolesStore, reservedRolesStore, mock(NativePrivilegeStore.class),
-            Arrays.asList(inMemoryProvider), new ThreadContext(Settings.EMPTY), xPackLicenseState);
+            Arrays.asList(inMemoryProvider), new ThreadContext(Settings.EMPTY), xPackLicenseState, cache);
 
         Set<String> roleNames = Sets.newHashSet("roleA");
         PlainActionFuture<Role> future = new PlainActionFuture<>();
-        FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
-        compositeRolesStore.roles(roleNames, fieldPermissionsCache, future);
+        compositeRolesStore.roles(roleNames, future);
         Role role = future.actionGet();
 
         // no roles should've been populated, as the license doesn't permit custom role providers
@@ -653,13 +647,12 @@ public class CompositeRolesStoreTests extends ESTestCase {
 
         compositeRolesStore = new CompositeRolesStore(
             Settings.EMPTY, fileRolesStore, nativeRolesStore, reservedRolesStore, mock(NativePrivilegeStore.class),
-            Arrays.asList(inMemoryProvider), new ThreadContext(Settings.EMPTY), xPackLicenseState);
+            Arrays.asList(inMemoryProvider), new ThreadContext(Settings.EMPTY), xPackLicenseState, cache);
         // these licenses allow custom role providers
         xPackLicenseState.update(randomFrom(OperationMode.PLATINUM, OperationMode.TRIAL), true, null);
         roleNames = Sets.newHashSet("roleA");
         future = new PlainActionFuture<>();
-        fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
-        compositeRolesStore.roles(roleNames, fieldPermissionsCache, future);
+        compositeRolesStore.roles(roleNames, future);
         role = future.actionGet();
 
         // roleA should've been populated by the custom role provider, because the license allows it
@@ -668,12 +661,11 @@ public class CompositeRolesStoreTests extends ESTestCase {
         // license expired, don't allow custom role providers
         compositeRolesStore = new CompositeRolesStore(
             Settings.EMPTY, fileRolesStore, nativeRolesStore, reservedRolesStore, mock(NativePrivilegeStore.class),
-            Arrays.asList(inMemoryProvider), new ThreadContext(Settings.EMPTY), xPackLicenseState);
+            Arrays.asList(inMemoryProvider), new ThreadContext(Settings.EMPTY), xPackLicenseState, cache);
         xPackLicenseState.update(randomFrom(OperationMode.PLATINUM, OperationMode.TRIAL), false, null);
         roleNames = Sets.newHashSet("roleA");
         future = new PlainActionFuture<>();
-        fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
-        compositeRolesStore.roles(roleNames, fieldPermissionsCache, future);
+        compositeRolesStore.roles(roleNames, future);
         role = future.actionGet();
         assertEquals(0, role.indices().groups().length);
     }
@@ -694,7 +686,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
         CompositeRolesStore compositeRolesStore = new CompositeRolesStore(
                 Settings.EMPTY, fileRolesStore, nativeRolesStore, reservedRolesStore,
                 mock(NativePrivilegeStore.class), Collections.emptyList(), new ThreadContext(Settings.EMPTY),
-                new XPackLicenseState(SECURITY_ENABLED_SETTINGS)) {
+                new XPackLicenseState(SECURITY_ENABLED_SETTINGS), cache) {
             @Override
             public void invalidateAll() {
                 numInvalidation.incrementAndGet();
@@ -746,7 +738,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
         CompositeRolesStore compositeRolesStore = new CompositeRolesStore(SECURITY_ENABLED_SETTINGS,
                 fileRolesStore, nativeRolesStore, reservedRolesStore,
                 mock(NativePrivilegeStore.class), Collections.emptyList(), new ThreadContext(SECURITY_ENABLED_SETTINGS),
-                new XPackLicenseState(SECURITY_ENABLED_SETTINGS)) {
+                new XPackLicenseState(SECURITY_ENABLED_SETTINGS), cache) {
             @Override
             public void invalidateAll() {
                 numInvalidation.incrementAndGet();


### PR DESCRIPTION
This commit enables api keys to share the same cache for roles that is
already in use for roles from other sources. In order to avoid the
possibility of a key collision with roles that do not belong to api
keys, the key for the roles cache now includes a source field that
prevents these collisions.