### PR TITLE
Core: Converge FormatDateTimeFormatter and DateFormatter apis

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/WatchStatusDateParser.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/WatchStatusDateParser.java
@@ -53,6 +53,6 @@ public final class WatchStatusDateParser {
     }
 
     public static DateTime parseDate(String text) {
-        return FORMATTER.parser().parseDateTime(text);
+        return FORMATTER.parseJoda(text);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
@@ -174,7 +174,7 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
         if (out.getVersion().before(Version.V_6_0_0_alpha1)) {
             // timestamp
             out.writeBoolean(false); // enabled
-            out.writeString(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.format());
+            out.writeString(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern());
             out.writeOptionalString("now"); // 5.x default
             out.writeOptionalBoolean(null);
         }

--- a/server/src/main/java/org/elasticsearch/common/joda/FormatDateTimeFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/joda/FormatDateTimeFormatter.java
@@ -89,7 +89,7 @@ public class FormatDateTimeFormatter {
         return parser.getLocale();
     }
 
-    public ZoneId zoneId() {
+    public ZoneId zone() {
         return DateUtils.dateTimeZoneToZoneId(parser.getZone());
     }
 

--- a/server/src/main/java/org/elasticsearch/common/joda/FormatDateTimeFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/joda/FormatDateTimeFormatter.java
@@ -20,10 +20,12 @@
 package org.elasticsearch.common.joda;
 
 import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.common.time.DateUtils;
+import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 
+import java.time.ZoneId;
 import java.util.Locale;
-import java.util.Objects;
 
 /**
  * A simple wrapper around {@link DateTimeFormatter} that retains the
@@ -31,27 +33,28 @@ import java.util.Objects;
  */
 public class FormatDateTimeFormatter {
 
-    private final String format;
+    private final String pattern;
 
     private final DateTimeFormatter parser;
 
     private final DateTimeFormatter printer;
 
-    private final Locale locale;
-
-    public FormatDateTimeFormatter(String format, DateTimeFormatter parser, Locale locale) {
-        this(format, parser, parser, locale);
+    public FormatDateTimeFormatter(String pattern, DateTimeFormatter parser, DateTimeFormatter printer) {
+        this.pattern = pattern;
+        this.printer = printer.withDefaultYear(1970);
+        this.parser = parser.withDefaultYear(1970);
     }
 
-    public FormatDateTimeFormatter(String format, DateTimeFormatter parser, DateTimeFormatter printer, Locale locale) {
-        this.format = format;
-        this.locale = Objects.requireNonNull(locale, "A locale is required as JODA otherwise uses the default locale");
-        this.printer = printer.withLocale(locale).withDefaultYear(1970);
-        this.parser = parser.withLocale(locale).withDefaultYear(1970);
+    public String pattern() {
+        return pattern;
     }
 
-    public String format() {
-        return format;
+    public long parseMillis(String input) {
+        return parser.parseMillis(input);
+    }
+
+    public DateTime parseJoda(String input) {
+        return parser.parseDateTime(input);
     }
 
     public DateTimeFormatter parser() {
@@ -62,8 +65,32 @@ public class FormatDateTimeFormatter {
         return this.printer;
     }
 
+    public String formatJoda(DateTime dateTime) {
+        return printer.print(dateTime);
+    }
+
+    public String formatMillis(long millis) {
+        return printer.print(millis);
+    }
+
+    public FormatDateTimeFormatter withZone(ZoneId zoneId) {
+        DateTimeFormatter parser = this.parser.withZone(DateUtils.zoneIdToDateTimeZone(zoneId));
+        DateTimeFormatter printer = this.printer.withZone(DateUtils.zoneIdToDateTimeZone(zoneId));
+        return new FormatDateTimeFormatter(pattern, parser, printer);
+    }
+
+    public FormatDateTimeFormatter withLocale(Locale locale) {
+        DateTimeFormatter parser = this.parser.withLocale(locale);
+        DateTimeFormatter printer = this.printer.withLocale(locale);
+        return new FormatDateTimeFormatter(this.pattern, parser, printer);
+    }
+
     public Locale locale() {
-        return locale;
+        return parser.getLocale();
+    }
+
+    public ZoneId zoneId() {
+        return DateUtils.dateTimeZoneToZoneId(parser.getZone());
     }
 
     public DateMathParser toDateMathParser() {

--- a/server/src/main/java/org/elasticsearch/common/joda/Joda.java
+++ b/server/src/main/java/org/elasticsearch/common/joda/Joda.java
@@ -105,8 +105,8 @@ public class Joda {
             // in this case, we have a separate parser and printer since the dataOptionalTimeParser can't print
             // this sucks we should use the root local by default and not be dependent on the node
             return new FormatDateTimeFormatter(input,
-                    ISODateTimeFormat.dateOptionalTimeParser().withZone(DateTimeZone.UTC),
-                    ISODateTimeFormat.dateTime().withZone(DateTimeZone.UTC), locale);
+                    ISODateTimeFormat.dateOptionalTimeParser().withLocale(locale).withZone(DateTimeZone.UTC),
+                    ISODateTimeFormat.dateTime().withLocale(locale).withZone(DateTimeZone.UTC));
         } else if ("dateTime".equals(input) || "date_time".equals(input)) {
             formatter = ISODateTimeFormat.dateTime();
         } else if ("dateTimeNoMillis".equals(input) || "date_time_no_millis".equals(input)) {
@@ -182,8 +182,8 @@ public class Joda {
             // in this case, we have a separate parser and printer since the dataOptionalTimeParser can't print
             // this sucks we should use the root local by default and not be dependent on the node
             return new FormatDateTimeFormatter(input,
-                    StrictISODateTimeFormat.dateOptionalTimeParser().withZone(DateTimeZone.UTC),
-                    StrictISODateTimeFormat.dateTime().withZone(DateTimeZone.UTC), locale);
+                    StrictISODateTimeFormat.dateOptionalTimeParser().withLocale(locale).withZone(DateTimeZone.UTC),
+                    StrictISODateTimeFormat.dateTime().withLocale(locale).withZone(DateTimeZone.UTC));
         } else if ("strictDateTime".equals(input) || "strict_date_time".equals(input)) {
             formatter = StrictISODateTimeFormat.dateTime();
         } else if ("strictDateTimeNoMillis".equals(input) || "strict_date_time_no_millis".equals(input)) {
@@ -259,7 +259,8 @@ public class Joda {
             }
         }
 
-        return new FormatDateTimeFormatter(input, formatter.withZone(DateTimeZone.UTC), locale);
+        formatter = formatter.withLocale(locale).withZone(DateTimeZone.UTC);
+        return new FormatDateTimeFormatter(input, formatter, formatter);
     }
 
     public static FormatDateTimeFormatter getStrictStandardDateFormatter() {
@@ -292,8 +293,8 @@ public class Joda {
         DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder().append(longFormatter.withZone(DateTimeZone.UTC).getPrinter(),
             new DateTimeParser[]{longFormatter.getParser(), shortFormatter.getParser(), new EpochTimeParser(true)});
 
-        return new FormatDateTimeFormatter("yyyy/MM/dd HH:mm:ss||yyyy/MM/dd||epoch_millis",
-            builder.toFormatter().withZone(DateTimeZone.UTC), Locale.ROOT);
+        DateTimeFormatter formatter = builder.toFormatter().withLocale(Locale.ROOT).withZone(DateTimeZone.UTC);
+        return new FormatDateTimeFormatter("yyyy/MM/dd HH:mm:ss||yyyy/MM/dd||epoch_millis", formatter, formatter);
     }
 
 

--- a/server/src/main/java/org/elasticsearch/common/joda/JodaDateMathParser.java
+++ b/server/src/main/java/org/elasticsearch/common/joda/JodaDateMathParser.java
@@ -211,7 +211,8 @@ public class JodaDateMathParser implements DateMathParser {
             }
             return date.getMillis();
         } catch (IllegalArgumentException e) {
-            throw new ElasticsearchParseException("failed to parse date field [{}] with format [{}]", e, value, dateTimeFormatter.format());
+            throw new ElasticsearchParseException("failed to parse date field [{}] with format [{}]", e, value,
+                dateTimeFormatter.pattern());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
@@ -20,9 +20,11 @@
 package org.elasticsearch.common.time;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.joda.time.DateTime;
 
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
@@ -40,8 +42,18 @@ public interface DateFormatter {
      */
     TemporalAccessor parse(String input);
 
+    /**
+     * Parse the given input into millis-since-epoch.
+     */
     default long parseMillis(String input) {
         return Instant.from(parse(input)).toEpochMilli();
+    }
+
+    /**
+     * Parse the given input into a Joda {@link DateTime}.
+     */
+    default DateTime parseJoda(String input) {
+        new DateTime()
     }
 
     /**
@@ -68,8 +80,19 @@ public interface DateFormatter {
      */
     String format(TemporalAccessor accessor);
 
+    /**
+     * Return the given millis-since-epoch formatted with this format.
+     */
     default String formatMillis(long millis) {
         return format(Instant.ofEpochMilli(millis));
+    }
+
+    /**
+     * Return the given Joda {@link DateTime} formatted with this format.
+     */
+    default String formatJoda(DateTime dateTime) {
+        return format(ZonedDateTime.ofInstant(Instant.ofEpochMilli(dateTime.getMillis()),
+            DateUtils.dateTimeZoneToZoneId(dateTime.getZone())));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.time;
 
 import org.elasticsearch.ElasticsearchParseException;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
@@ -38,6 +39,10 @@ public interface DateFormatter {
      * @return                        The java time object containing the parsed input
      */
     TemporalAccessor parse(String input);
+
+    default long parseMillis(String input) {
+        return Instant.from(parse(input)).toEpochMilli();
+    }
 
     /**
      * Create a copy of this formatter that is configured to parse dates in the specified time zone
@@ -63,6 +68,10 @@ public interface DateFormatter {
      */
     String format(TemporalAccessor accessor);
 
+    default String formatMillis(long millis) {
+        return format(Instant.ofEpochMilli(millis));
+    }
+
     /**
      * A name based format for this formatter. Can be one of the registered formatters like <code>epoch_millis</code> or
      * a configured format like <code>HH:mm:ss</code>
@@ -76,14 +85,14 @@ public interface DateFormatter {
      *
      * @return The locale of this formatter
      */
-    Locale getLocale();
+    Locale locale();
 
     /**
      * Returns the configured time zone of the date formatter
      *
      * @return The time zone of this formatter
      */
-    ZoneId getZone();
+    ZoneId zone();
 
     /**
      * Return a {@link DateMathParser} built from this formatter.
@@ -152,13 +161,13 @@ public interface DateFormatter {
         }
 
         @Override
-        public Locale getLocale() {
-            return formatters[0].getLocale();
+        public Locale locale() {
+            return formatters[0].locale();
         }
 
         @Override
-        public ZoneId getZone() {
-            return formatters[0].getZone();
+        public ZoneId zone() {
+            return formatters[0].zone();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
@@ -53,7 +53,8 @@ public interface DateFormatter {
      * Parse the given input into a Joda {@link DateTime}.
      */
     default DateTime parseJoda(String input) {
-        new DateTime()
+        ZonedDateTime dateTime = ZonedDateTime.from(parse(input));
+        return new DateTime(dateTime.toInstant().toEpochMilli(), DateUtils.zoneIdToDateTimeZone(dateTime.getZone()));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
@@ -61,6 +61,9 @@ public class DateUtils {
         if (timeZone == null) {
             return null;
         }
+        if (DateTimeZone.UTC.equals(timeZone)) {
+            return ZoneOffset.UTC;
+        }
 
         String deprecatedId = DEPRECATED_SHORT_TIMEZONES.get(timeZone.getID());
         if (deprecatedId != null) {

--- a/server/src/main/java/org/elasticsearch/common/time/EpochMillisDateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/EpochMillisDateFormatter.java
@@ -103,12 +103,12 @@ class EpochMillisDateFormatter implements DateFormatter {
     }
 
     @Override
-    public Locale getLocale() {
+    public Locale locale() {
         return Locale.ROOT;
     }
 
     @Override
-    public ZoneId getZone() {
+    public ZoneId zone() {
         return ZoneOffset.UTC;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/time/EpochSecondsDateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/EpochSecondsDateFormatter.java
@@ -81,12 +81,12 @@ public class EpochSecondsDateFormatter implements DateFormatter {
     }
 
     @Override
-    public Locale getLocale() {
+    public Locale locale() {
         return Locale.ROOT;
     }
 
     @Override
-    public ZoneId getZone() {
+    public ZoneId zone() {
         return ZoneOffset.UTC;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/time/JavaDateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/JavaDateFormatter.java
@@ -146,12 +146,12 @@ class JavaDateFormatter implements DateFormatter {
     }
 
     @Override
-    public Locale getLocale() {
+    public Locale locale() {
         return this.printer.getLocale();
     }
 
     @Override
-    public ZoneId getZone() {
+    public ZoneId zone() {
         return this.printer.getZone();
     }
 
@@ -162,7 +162,7 @@ class JavaDateFormatter implements DateFormatter {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getLocale(), printer.getZone(), format);
+        return Objects.hash(locale(), printer.getZone(), format);
     }
 
     @Override
@@ -173,12 +173,12 @@ class JavaDateFormatter implements DateFormatter {
         JavaDateFormatter other = (JavaDateFormatter) obj;
 
         return Objects.equals(format, other.format) &&
-               Objects.equals(getLocale(), other.getLocale()) &&
+               Objects.equals(locale(), other.locale()) &&
                Objects.equals(this.printer.getZone(), other.printer.getZone());
     }
 
     @Override
     public String toString() {
-        return String.format(Locale.ROOT, "format[%s] locale[%s]", format, getLocale());
+        return String.format(Locale.ROOT, "format[%s] locale[%s]", format, locale());
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -124,8 +124,7 @@ public class DateFieldMapper extends FieldMapper {
             super.setupFieldType(context);
             FormatDateTimeFormatter dateTimeFormatter = fieldType().dateTimeFormatter;
             if (!locale.equals(dateTimeFormatter.locale())) {
-                fieldType().setDateTimeFormatter( new FormatDateTimeFormatter(dateTimeFormatter.format(),
-                        dateTimeFormatter.parser(), dateTimeFormatter.printer(), locale));
+                fieldType().setDateTimeFormatter(dateTimeFormatter.withLocale(locale));
             }
         }
 
@@ -199,13 +198,13 @@ public class DateFieldMapper extends FieldMapper {
         public boolean equals(Object o) {
             if (!super.equals(o)) return false;
             DateFieldType that = (DateFieldType) o;
-            return Objects.equals(dateTimeFormatter.format(), that.dateTimeFormatter.format()) &&
+            return Objects.equals(dateTimeFormatter.pattern(), that.dateTimeFormatter.pattern()) &&
                    Objects.equals(dateTimeFormatter.locale(), that.dateTimeFormatter.locale());
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(super.hashCode(), dateTimeFormatter.format(), dateTimeFormatter.locale());
+            return Objects.hash(super.hashCode(), dateTimeFormatter.pattern(), dateTimeFormatter.locale());
         }
 
         @Override
@@ -217,7 +216,7 @@ public class DateFieldMapper extends FieldMapper {
         public void checkCompatibility(MappedFieldType fieldType, List<String> conflicts) {
             super.checkCompatibility(fieldType, conflicts);
             DateFieldType other = (DateFieldType) fieldType;
-            if (Objects.equals(dateTimeFormatter().format(), other.dateTimeFormatter().format()) == false) {
+            if (Objects.equals(dateTimeFormatter().pattern(), other.dateTimeFormatter().pattern()) == false) {
                 conflicts.add("mapper [" + name() + "] has different [format] values");
             }
             if (Objects.equals(dateTimeFormatter().locale(), other.dateTimeFormatter().locale()) == false) {
@@ -240,7 +239,7 @@ public class DateFieldMapper extends FieldMapper {
         }
 
         long parse(String value) {
-            return dateTimeFormatter().parser().parseMillis(value);
+            return dateTimeFormatter().parseMillis(value);
         }
 
         @Override
@@ -375,7 +374,7 @@ public class DateFieldMapper extends FieldMapper {
             if (val == null) {
                 return null;
             }
-            return dateTimeFormatter().printer().print(val);
+            return dateTimeFormatter().formatMillis(val);
         }
 
         @Override
@@ -489,8 +488,8 @@ public class DateFieldMapper extends FieldMapper {
         }
 
         if (includeDefaults
-                || fieldType().dateTimeFormatter().format().equals(DEFAULT_DATE_TIME_FORMATTER.format()) == false) {
-            builder.field("format", fieldType().dateTimeFormatter().format());
+                || fieldType().dateTimeFormatter().pattern().equals(DEFAULT_DATE_TIME_FORMATTER.pattern()) == false) {
+            builder.field("format", fieldType().dateTimeFormatter().pattern());
         }
         if (includeDefaults
                 || fieldType().dateTimeFormatter().locale() != Locale.ROOT) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -717,7 +717,7 @@ final class DocumentParser {
                 // `epoch_millis` or `YYYY`
                 for (FormatDateTimeFormatter dateTimeFormatter : context.root().dynamicDateTimeFormatters()) {
                     try {
-                        dateTimeFormatter.parser().parseMillis(text);
+                        dateTimeFormatter.parseMillis(text);
                     } catch (IllegalArgumentException e) {
                         // failure to parse this, continue
                         continue;

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -148,8 +148,7 @@ public class RangeFieldMapper extends FieldMapper {
             FormatDateTimeFormatter dateTimeFormatter = fieldType().dateTimeFormatter;
             if (fieldType().rangeType == RangeType.DATE) {
                 if (!locale.equals(dateTimeFormatter.locale())) {
-                    fieldType().setDateTimeFormatter(new FormatDateTimeFormatter(dateTimeFormatter.format(),
-                        dateTimeFormatter.parser(), dateTimeFormatter.printer(), locale));
+                    fieldType().setDateTimeFormatter(dateTimeFormatter.withLocale(locale));
                 }
             } else if (dateTimeFormatter != null) {
                 throw new IllegalArgumentException("field [" + name() + "] of type [" + fieldType().rangeType
@@ -236,7 +235,7 @@ public class RangeFieldMapper extends FieldMapper {
             RangeFieldType that = (RangeFieldType) o;
             return Objects.equals(rangeType, that.rangeType) &&
             (rangeType == RangeType.DATE) ?
-                Objects.equals(dateTimeFormatter.format(), that.dateTimeFormatter.format())
+                Objects.equals(dateTimeFormatter.pattern(), that.dateTimeFormatter.pattern())
                 && Objects.equals(dateTimeFormatter.locale(), that.dateTimeFormatter.locale())
                 : dateTimeFormatter == null && that.dateTimeFormatter == null;
         }
@@ -244,7 +243,7 @@ public class RangeFieldMapper extends FieldMapper {
         @Override
         public int hashCode() {
             return (dateTimeFormatter == null) ? Objects.hash(super.hashCode(), rangeType)
-                : Objects.hash(super.hashCode(), rangeType, dateTimeFormatter.format(), dateTimeFormatter.locale());
+                : Objects.hash(super.hashCode(), rangeType, dateTimeFormatter.pattern(), dateTimeFormatter.locale());
         }
 
         @Override
@@ -406,8 +405,8 @@ public class RangeFieldMapper extends FieldMapper {
 
         if (fieldType().rangeType == RangeType.DATE
                 && (includeDefaults || (fieldType().dateTimeFormatter() != null
-                && fieldType().dateTimeFormatter().format().equals(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.format()) == false))) {
-            builder.field("format", fieldType().dateTimeFormatter().format());
+                && fieldType().dateTimeFormatter().pattern().equals(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern()) == false))) {
+            builder.field("format", fieldType().dateTimeFormatter().pattern());
         }
         if (fieldType().rangeType == RangeType.DATE
                 && (includeDefaults || (fieldType().dateTimeFormatter() != null

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -303,7 +303,7 @@ public class RootObjectMapper extends ObjectMapper {
         if (dynamicDateTimeFormatters.explicit() || includeDefaults) {
             builder.startArray("dynamic_date_formats");
             for (FormatDateTimeFormatter dateTimeFormatter : dynamicDateTimeFormatters.value()) {
-                builder.value(dateTimeFormatter.format());
+                builder.value(dateTimeFormatter.pattern());
             }
             builder.endArray();
         }

--- a/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -133,7 +133,7 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
         out.writeOptionalTimeZone(timeZone);
         String formatString = null;
         if (this.format != null) {
-            formatString = this.format.format();
+            formatString = this.format.pattern();
         }
         out.writeOptionalString(formatString);
         String relationString = null;
@@ -298,7 +298,7 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
      * Gets the format field to parse the from/to fields
      */
     public String format() {
-        return this.format == null ? null : this.format.format();
+        return this.format == null ? null : this.format.pattern();
     }
 
     DateMathParser getForceDateParser() { // pkg private for testing
@@ -338,7 +338,7 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
             builder.field(TIME_ZONE_FIELD.getPreferredName(), timeZone.getID());
         }
         if (format != null) {
-            builder.field(FORMAT_FIELD.getPreferredName(), format.format());
+            builder.field(FORMAT_FIELD.getPreferredName(), format.pattern());
         }
         if (relation != null) {
             builder.field(RELATION_FIELD.getPreferredName(), relation.getRelationName());
@@ -533,14 +533,14 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
     @Override
     protected int doHashCode() {
         String timeZoneId = timeZone == null ? null : timeZone.getID();
-        String formatString = format == null ? null : format.format();
+        String formatString = format == null ? null : format.pattern();
         return Objects.hash(fieldName, from, to, timeZoneId, includeLower, includeUpper, formatString);
     }
 
     @Override
     protected boolean doEquals(RangeQueryBuilder other) {
         String timeZoneId = timeZone == null ? null : timeZone.getID();
-        String formatString = format == null ? null : format.format();
+        String formatString = format == null ? null : format.pattern();
         return Objects.equals(fieldName, other.fieldName) &&
                Objects.equals(from, other.from) &&
                Objects.equals(to, other.to) &&

--- a/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
@@ -39,6 +39,7 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.text.ParseException;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Locale;
@@ -174,11 +175,13 @@ public interface DocValueFormat extends NamedWriteable {
         final FormatDateTimeFormatter formatter;
         // TODO: change this to ZoneId, but will require careful change to serialization
         final DateTimeZone timeZone;
+        private final ZoneId zoneId;
         private final DateMathParser parser;
 
         public DateTime(FormatDateTimeFormatter formatter, DateTimeZone timeZone) {
             this.formatter = Objects.requireNonNull(formatter);
             this.timeZone = Objects.requireNonNull(timeZone);
+            this.zoneId = DateUtils.dateTimeZoneToZoneId(timeZone);
             this.parser = formatter.toDateMathParser();
         }
 
@@ -193,13 +196,13 @@ public interface DocValueFormat extends NamedWriteable {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeString(formatter.format());
+            out.writeString(formatter.pattern());
             out.writeString(timeZone.getID());
         }
 
         @Override
         public String format(long value) {
-            return formatter.printer().withZone(timeZone).print(value);
+            return formatter.withZone(zoneId).formatMillis(value);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -479,7 +479,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
     private void assertSamePrinterOutput(String format, ZonedDateTime javaDate, DateTime jodaDate) {
         assertThat(jodaDate.getMillis(), is(javaDate.toInstant().toEpochMilli()));
         String javaTimeOut = DateFormatters.forPattern(format).format(javaDate);
-        String jodaTimeOut = Joda.forPattern(format).printer().print(jodaDate);
+        String jodaTimeOut = Joda.forPattern(format).formatJoda(jodaDate);
         String message = String.format(Locale.ROOT, "expected string representation to be equal for format [%s]: joda [%s], java [%s]",
                 format, jodaTimeOut, javaTimeOut);
         assertThat(message, javaTimeOut, is(jodaTimeOut));
@@ -487,7 +487,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
 
     private void assertSameDate(String input, String format) {
         FormatDateTimeFormatter jodaFormatter = Joda.forPattern(format);
-        DateTime jodaDateTime = jodaFormatter.parser().parseDateTime(input);
+        DateTime jodaDateTime = jodaFormatter.parseJoda(input);
 
         DateFormatter javaTimeFormatter = DateFormatters.forPattern(format);
         TemporalAccessor javaTimeAccessor = javaTimeFormatter.parse(input);
@@ -506,7 +506,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
 
     private void assertJodaParseException(String input, String format, String expectedMessage) {
         FormatDateTimeFormatter jodaFormatter = Joda.forPattern(format);
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> jodaFormatter.parser().parseDateTime(input));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> jodaFormatter.parseJoda(input));
         assertThat(e.getMessage(), containsString(expectedMessage));
     }
 

--- a/server/src/test/java/org/elasticsearch/common/joda/JodaDateMathParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JodaDateMathParserTests.java
@@ -50,7 +50,7 @@ public class JodaDateMathParserTests extends ESTestCase {
         if (gotMillis != expectedMillis) {
             fail("Date math not equal\n" +
                 "Original              : " + original + "\n" +
-                "Parsed                : " + formatter.printer().print(gotMillis) + "\n" +
+                "Parsed                : " + formatter.formatMillis(gotMillis) + "\n" +
                 "Expected              : " + expected + "\n" +
                 "Expected milliseconds : " + expectedMillis + "\n" +
                 "Actual milliseconds   : " + gotMillis + "\n");
@@ -161,10 +161,10 @@ public class JodaDateMathParserTests extends ESTestCase {
         FormatDateTimeFormatter formatter = Joda.forPattern("HH:mm:ss");
         JodaDateMathParser parser = new JodaDateMathParser(formatter);
         assertEquals(
-                this.formatter.parser().parseMillis("1970-01-01T04:52:20.000Z"),
+                this.formatter.parseMillis("1970-01-01T04:52:20.000Z"),
                 parser.parse("04:52:20", () -> 0, false, (ZoneId) null));
         assertEquals(
-                this.formatter.parser().parseMillis("1970-01-01T04:52:20.999Z"),
+                this.formatter.parseMillis("1970-01-01T04:52:20.999Z"),
                 parser.parse("04:52:20", () -> 0, true, (ZoneId) null));
     }
 

--- a/server/src/test/java/org/elasticsearch/common/joda/JodaTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JodaTests.java
@@ -22,7 +22,8 @@ package org.elasticsearch.common.joda;
 import org.elasticsearch.test.ESTestCase;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormatter;
+
+import java.time.ZoneOffset;
 
 
 public class JodaTests extends ESTestCase {
@@ -30,20 +31,16 @@ public class JodaTests extends ESTestCase {
 
     public void testBasicTTimePattern() {
         FormatDateTimeFormatter formatter1 = Joda.forPattern("basic_t_time");
-        assertEquals(formatter1.format(), "basic_t_time");
-        DateTimeFormatter parser1 = formatter1.parser();
-
-        assertEquals(parser1.getZone(), DateTimeZone.UTC);
+        assertEquals(formatter1.pattern(), "basic_t_time");
+        assertEquals(formatter1.zoneId(), ZoneOffset.UTC);
 
         FormatDateTimeFormatter formatter2 = Joda.forPattern("basicTTime");
-        assertEquals(formatter2.format(), "basicTTime");
-        DateTimeFormatter parser2 = formatter2.parser();
-
-        assertEquals(parser2.getZone(), DateTimeZone.UTC);
+        assertEquals(formatter2.pattern(), "basicTTime");
+        assertEquals(formatter2.zoneId(), ZoneOffset.UTC);
 
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, DateTimeZone.UTC);
-        assertEquals("T102030.040Z", parser1.print(dt));
-        assertEquals("T102030.040Z", parser2.print(dt));
+        assertEquals("T102030.040Z", formatter1.formatJoda(dt));
+        assertEquals("T102030.040Z", formatter1.formatJoda(dt));
 
         expectThrows(IllegalArgumentException.class, () -> Joda.forPattern("basic_t_Time"));
         expectThrows(IllegalArgumentException.class, () -> Joda.forPattern("basic_T_Time"));

--- a/server/src/test/java/org/elasticsearch/common/joda/JodaTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JodaTests.java
@@ -32,11 +32,11 @@ public class JodaTests extends ESTestCase {
     public void testBasicTTimePattern() {
         FormatDateTimeFormatter formatter1 = Joda.forPattern("basic_t_time");
         assertEquals(formatter1.pattern(), "basic_t_time");
-        assertEquals(formatter1.zoneId(), ZoneOffset.UTC);
+        assertEquals(formatter1.zone(), ZoneOffset.UTC);
 
         FormatDateTimeFormatter formatter2 = Joda.forPattern("basicTTime");
         assertEquals(formatter2.pattern(), "basicTTime");
-        assertEquals(formatter2.zoneId(), ZoneOffset.UTC);
+        assertEquals(formatter2.zone(), ZoneOffset.UTC);
 
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, DateTimeZone.UTC);
         assertEquals("T102030.040Z", formatter1.formatJoda(dt));

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -128,9 +128,9 @@ public class DateFormattersTests extends ESTestCase {
     }
 
     public void testLocales() {
-        assertThat(DateFormatters.forPattern("strict_date_optional_time").getLocale(), is(Locale.ROOT));
+        assertThat(DateFormatters.forPattern("strict_date_optional_time").locale(), is(Locale.ROOT));
         Locale locale = randomLocale(random());
-        assertThat(DateFormatters.forPattern("strict_date_optional_time").withLocale(locale).getLocale(), is(locale));
+        assertThat(DateFormatters.forPattern("strict_date_optional_time").withLocale(locale).locale(), is(locale));
         if (locale.equals(Locale.ROOT)) {
             DateFormatter millisFormatter = DateFormatters.forPattern("epoch_millis");
             assertThat(millisFormatter.withLocale(locale), is(millisFormatter));
@@ -147,9 +147,9 @@ public class DateFormattersTests extends ESTestCase {
 
     public void testTimeZones() {
         // zone is null by default due to different behaviours between java8 and above
-        assertThat(DateFormatters.forPattern("strict_date_optional_time").getZone(), is(nullValue()));
+        assertThat(DateFormatters.forPattern("strict_date_optional_time").zone(), is(nullValue()));
         ZoneId zoneId = randomZone();
-        assertThat(DateFormatters.forPattern("strict_date_optional_time").withZone(zoneId).getZone(), is(zoneId));
+        assertThat(DateFormatters.forPattern("strict_date_optional_time").withZone(zoneId).zone(), is(zoneId));
         if (zoneId.equals(ZoneOffset.UTC)) {
             DateFormatter millisFormatter = DateFormatters.forPattern("epoch_millis");
             assertThat(millisFormatter.withZone(zoneId), is(millisFormatter));

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
@@ -110,8 +110,8 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
     public void testIsFieldWithinQuery() throws IOException {
         Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
-        long instant1 = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime("2015-10-12").getMillis();
-        long instant2 = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime("2016-04-03").getMillis();
+        long instant1 = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda("2015-10-12").getMillis();
+        long instant2 = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda("2016-04-03").getMillis();
         Document doc = new Document();
         LongPoint field = new LongPoint("my_date", instant1);
         doc.add(field);
@@ -138,7 +138,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
 
     public void testValueFormat() {
         MappedFieldType ft = createDefaultFieldType();
-        long instant = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime("2015-10-12T14:10:55").getMillis();
+        long instant = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda("2015-10-12T14:10:55").getMillis();
         assertEquals("2015-10-12T14:10:55.000Z",
                 ft.docValueFormat(null, DateTimeZone.UTC).format(instant));
         assertEquals("2015-10-12T15:10:55.000+01:00",
@@ -149,14 +149,14 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
                 ft.docValueFormat(null, DateTimeZone.UTC).parseLong("2015-10-12T14:10:55", false, null));
         assertEquals(instant + 999,
                 ft.docValueFormat(null, DateTimeZone.UTC).parseLong("2015-10-12T14:10:55", true, null));
-        assertEquals(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime("2015-10-13").getMillis() - 1,
+        assertEquals(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda("2015-10-13").getMillis() - 1,
                 ft.docValueFormat(null, DateTimeZone.UTC).parseLong("2015-10-12||/d", true, null));
     }
 
     public void testValueForSearch() {
         MappedFieldType ft = createDefaultFieldType();
         String date = "2015-10-12T12:09:55.000Z";
-        long instant = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(date).getMillis();
+        long instant = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda(date).getMillis();
         assertEquals(date, ft.valueForDisplay(instant));
     }
 
@@ -170,7 +170,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType ft = createDefaultFieldType();
         ft.setName("field");
         String date = "2015-10-12T14:10:55";
-        long instant = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(date).getMillis();
+        long instant = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda(date).getMillis();
         ft.setIndexOptions(IndexOptions.DOCS);
         Query expected = new IndexOrDocValuesQuery(
                 LongPoint.newRangeQuery("field", instant, instant + 999),
@@ -193,8 +193,8 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         ft.setName("field");
         String date1 = "2015-10-12T14:10:55";
         String date2 = "2016-04-28T11:33:52";
-        long instant1 = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(date1).getMillis();
-        long instant2 = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(date2).getMillis() + 999;
+        long instant1 = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda(date1).getMillis();
+        long instant2 = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda(date2).getMillis() + 999;
         ft.setIndexOptions(IndexOptions.DOCS);
         Query expected = new IndexOrDocValuesQuery(
                 LongPoint.newRangeQuery("field", instant1, instant2),

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -709,11 +709,11 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
         DateFieldMapper dateMapper2 = (DateFieldMapper) defaultMapper.mappers().getMapper("date2");
         DateFieldMapper dateMapper3 = (DateFieldMapper) defaultMapper.mappers().getMapper("date3");
         // inherited from dynamic date format
-        assertEquals("yyyy-MM-dd", dateMapper1.fieldType().dateTimeFormatter().format());
+        assertEquals("yyyy-MM-dd", dateMapper1.fieldType().dateTimeFormatter().pattern());
         // inherited from dynamic date format since the mapping in the template did not specify a format
-        assertEquals("yyyy-MM-dd", dateMapper2.fieldType().dateTimeFormatter().format());
+        assertEquals("yyyy-MM-dd", dateMapper2.fieldType().dateTimeFormatter().pattern());
         // not inherited from the dynamic date format since the template defined an explicit format
-        assertEquals("yyyy-MM-dd||epoch_millis", dateMapper3.fieldType().dateTimeFormatter().format());
+        assertEquals("yyyy-MM-dd||epoch_millis", dateMapper3.fieldType().dateTimeFormatter().pattern());
     }
 
     public void testDynamicTemplateOrder() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -123,8 +123,8 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
 
         // setting mapping format which is compatible with those dates
         final FormatDateTimeFormatter formatter = Joda.forPattern("yyyy-dd-MM'T'HH:mm:ssZZ");
-        assertEquals(1465975790000L, formatter.parser().parseMillis(from));
-        assertEquals(1466062190000L, formatter.parser().parseMillis(to));
+        assertEquals(1465975790000L, formatter.parseMillis(from));
+        assertEquals(1466062190000L, formatter.parseMillis(to));
 
         fieldType.setDateTimeFormatter(formatter);
         final Query query = fieldType.rangeQuery(from, to, true, true, relation, null, null, context);

--- a/server/src/test/java/org/elasticsearch/script/JodaCompatibleZonedDateTimeTests.java
+++ b/server/src/test/java/org/elasticsearch/script/JodaCompatibleZonedDateTimeTests.java
@@ -97,6 +97,14 @@ public class JodaCompatibleZonedDateTimeTests extends ESTestCase {
         assertDeprecation(assertions, "Use of the joda time method [" + oldMethod + "] is deprecated. Use [" + newMethod + "] instead.");
     }
 
+    public void testEquals() {
+        assertThat(javaTime, equalTo(javaTime));
+    }
+
+    public void testToString() {
+        assertThat(javaTime.toString(), equalTo(jodaTime.toString()));
+    }
+
     public void testDayOfMonth() {
         assertThat(javaTime.getDayOfMonth(), equalTo(jodaTime.getDayOfMonth()));
     }

--- a/server/src/test/java/org/elasticsearch/script/JodaCompatibleZonedDateTimeTests.java
+++ b/server/src/test/java/org/elasticsearch/script/JodaCompatibleZonedDateTimeTests.java
@@ -97,10 +97,6 @@ public class JodaCompatibleZonedDateTimeTests extends ESTestCase {
         assertDeprecation(assertions, "Use of the joda time method [" + oldMethod + "] is deprecated. Use [" + newMethod + "] instead.");
     }
 
-    public void testEquals() {
-        assertThat(javaTime, equalTo(javaTime));
-    }
-
     public void testToString() {
         assertThat(javaTime.toString(), equalTo(jodaTime.toString()));
     }

--- a/server/src/test/java/org/elasticsearch/search/DocValueFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DocValueFormatTests.java
@@ -66,7 +66,7 @@ public class DocValueFormatTests extends ESTestCase {
         in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), registry);
         vf = in.readNamedWriteable(DocValueFormat.class);
         assertEquals(DocValueFormat.DateTime.class, vf.getClass());
-        assertEquals("epoch_second", ((DocValueFormat.DateTime) vf).formatter.format());
+        assertEquals("epoch_second", ((DocValueFormat.DateTime) vf).formatter.pattern());
         assertEquals(DateTimeZone.forOffsetHours(1), ((DocValueFormat.DateTime) vf).timeZone);
 
         out = new BytesStreamOutput();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
@@ -50,6 +51,7 @@ import org.joda.time.format.DateTimeFormat;
 import org.junit.After;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -87,7 +89,7 @@ public class DateHistogramIT extends ESIntegTestCase {
     }
 
     private DateTime date(String date) {
-        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(date);
+        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda(date);
     }
 
     private static String format(DateTime date, String pattern) {
@@ -198,7 +200,8 @@ public class DateHistogramIT extends ESIntegTestCase {
     }
 
     private static String getBucketKeyAsString(DateTime key, DateTimeZone tz) {
-        return Joda.forPattern(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.format()).printer().withZone(tz).print(key);
+        ZoneId zoneId = DateUtils.dateTimeZoneToZoneId(tz);
+        return Joda.forPattern(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern()).withZone(zoneId).formatJoda(key);
     }
 
     public void testSingleValuedField() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramOffsetIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramOffsetIT.java
@@ -52,7 +52,7 @@ public class DateHistogramOffsetIT extends ESIntegTestCase {
     private static final String DATE_FORMAT = "yyyy-MM-dd:hh-mm-ss";
 
     private DateTime date(String date) {
-        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(date);
+        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda(date);
     }
 
     @Before

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
@@ -1835,6 +1835,6 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
     }
 
     private static long asLong(String dateTime) {
-        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(dateTime).getMillis();
+        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda(dateTime).getMillis();
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -455,6 +455,6 @@ public class DateHistogramAggregatorTests extends AggregatorTestCase {
     }
 
     private static long asLong(String dateTime) {
-        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(dateTime).getMillis();
+        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda(dateTime).getMillis();
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/AvgBucketAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/AvgBucketAggregatorTests.java
@@ -143,6 +143,6 @@ public class AvgBucketAggregatorTests extends AggregatorTestCase {
 
 
     private static long asLong(String dateTime) {
-        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(dateTime).getMillis();
+        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda(dateTime).getMillis();
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumAggregatorTests.java
@@ -307,6 +307,6 @@ public class CumulativeSumAggregatorTests extends AggregatorTestCase {
     }
 
     private static long asLong(String dateTime) {
-        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(dateTime).getMillis();
+        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda(dateTime).getMillis();
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/DateDerivativeIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/DateDerivativeIT.java
@@ -65,7 +65,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
     }
 
     private DateTime date(String date) {
-        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(date);
+        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda(date);
     }
 
     private static String format(DateTime date, String pattern) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/MovFnUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/MovFnUnitTests.java
@@ -160,6 +160,6 @@ public class MovFnUnitTests extends AggregatorTestCase {
     }
 
     private static long asLong(String dateTime) {
-        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(dateTime).getMillis();
+        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda(dateTime).getMillis();
     }
 }

--- a/x-pack/license-tools/src/test/java/org/elasticsearch/license/licensor/TestUtils.java
+++ b/x-pack/license-tools/src/test/java/org/elasticsearch/license/licensor/TestUtils.java
@@ -18,7 +18,6 @@ import org.elasticsearch.license.DateUtils;
 import org.elasticsearch.license.License;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.MatcherAssert;
-import org.joda.time.format.DateTimeFormatter;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -39,7 +38,6 @@ public class TestUtils {
     private static final FormatDateTimeFormatter formatDateTimeFormatter =
             Joda.forPattern("yyyy-MM-dd");
     private static final DateMathParser dateMathParser = formatDateTimeFormatter.toDateMathParser();
-    private static final DateTimeFormatter dateTimeFormatter = formatDateTimeFormatter.printer();
 
     public static String dumpLicense(License license) throws Exception {
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
@@ -52,7 +50,7 @@ public class TestUtils {
     }
 
     public static String dateMathString(String time, final long now) {
-        return dateTimeFormatter.print(dateMathParser.parse(time, () -> now));
+        return formatDateTimeFormatter.formatMillis(dateMathParser.parse(time, () -> now));
     }
 
     public static long dateMath(String time, final long now) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/DateUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/DateUtils.java
@@ -11,11 +11,11 @@ import org.joda.time.MutableDateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
+import java.time.ZoneOffset;
+
 public class DateUtils {
 
-    private static final FormatDateTimeFormatter formatDateOnlyFormatter = Joda.forPattern("yyyy-MM-dd");
-
-    private static final DateTimeFormatter dateOnlyFormatter = formatDateOnlyFormatter.parser().withZoneUTC();
+    private static final FormatDateTimeFormatter dateOnlyFormatter = Joda.forPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
 
     private static final DateTimeFormatter dateTimeFormatter = ISODateTimeFormat.dateTime().withZoneUTC();
 
@@ -25,7 +25,7 @@ public class DateUtils {
             return dateTimeFormatter.parseDateTime(date).getMillis();
         } catch (IllegalArgumentException ex) {
             // Fall back to the date only format
-            MutableDateTime dateTime = dateOnlyFormatter.parseMutableDateTime(date);
+            MutableDateTime dateTime = new MutableDateTime(dateOnlyFormatter.parseMillis(date));
             dateTime.millisOfDay().set(dateTime.millisOfDay().getMaximumValue());
             return dateTime.getMillis();
         }
@@ -37,7 +37,7 @@ public class DateUtils {
             return dateTimeFormatter.parseDateTime(date).getMillis();
         } catch (IllegalArgumentException ex) {
             // Fall back to the date only format
-            return dateOnlyFormatter.parseDateTime(date).getMillis();
+            return dateOnlyFormatter.parseMillis(date);
         }
 
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
@@ -140,7 +140,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
         String general = LoggerMessageFormat.format(null, "License [{}] on [{}].\n" +
                 "# If you have a new license, please update it. Otherwise, please reach out to\n" +
                 "# your support contact.\n" +
-                "# ", expiredMsg, DATE_FORMATTER.printer().print(expirationMillis));
+                "# ", expiredMsg, DATE_FORMATTER.formatMillis(expirationMillis));
         if (expired) {
             general = general.toUpperCase(Locale.ROOT);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/ActionStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/ActionStatus.java
@@ -244,7 +244,7 @@ public class ActionStatus implements ToXContentObject {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             return builder.startObject()
-                    .field(Field.TIMESTAMP.getPreferredName()).value(dateTimeFormatter.printer().print(timestamp))
+                    .field(Field.TIMESTAMP.getPreferredName()).value(dateTimeFormatter.formatJoda(timestamp))
                     .field(Field.ACK_STATUS_STATE.getPreferredName(), state.name().toLowerCase(Locale.ROOT))
                     .endObject();
         }
@@ -259,7 +259,7 @@ public class ActionStatus implements ToXContentObject {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
                 } else if (Field.TIMESTAMP.match(currentFieldName, parser.getDeprecationHandler())) {
-                    timestamp = dateTimeFormatter.parser().parseDateTime(parser.text());
+                    timestamp = dateTimeFormatter.parseJoda(parser.text());
                 } else if (Field.ACK_STATUS_STATE.match(currentFieldName, parser.getDeprecationHandler())) {
                     state = State.valueOf(parser.text().toUpperCase(Locale.ROOT));
                 } else {
@@ -342,7 +342,7 @@ public class ActionStatus implements ToXContentObject {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            builder.field(Field.TIMESTAMP.getPreferredName()).value(dateTimeFormatter.printer().print(timestamp));
+            builder.field(Field.TIMESTAMP.getPreferredName()).value(dateTimeFormatter.formatJoda(timestamp));
             builder.field(Field.EXECUTION_SUCCESSFUL.getPreferredName(), successful);
             if (reason != null) {
                 builder.field(Field.REASON.getPreferredName(), reason);
@@ -361,7 +361,7 @@ public class ActionStatus implements ToXContentObject {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
                 } else if (Field.TIMESTAMP.match(currentFieldName, parser.getDeprecationHandler())) {
-                    timestamp = dateTimeFormatter.parser().parseDateTime(parser.text());
+                    timestamp = dateTimeFormatter.parseJoda(parser.text());
                 } else if (Field.EXECUTION_SUCCESSFUL.match(currentFieldName, parser.getDeprecationHandler())) {
                     successful = parser.booleanValue();
                 } else if (Field.REASON.match(currentFieldName, parser.getDeprecationHandler())) {
@@ -442,7 +442,7 @@ public class ActionStatus implements ToXContentObject {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             return builder.startObject()
-                    .field(Field.TIMESTAMP.getPreferredName()).value(dateTimeFormatter.printer().print(timestamp))
+                    .field(Field.TIMESTAMP.getPreferredName()).value(dateTimeFormatter.formatJoda(timestamp))
                     .field(Field.REASON.getPreferredName(), reason)
                     .endObject();
         }
@@ -457,7 +457,7 @@ public class ActionStatus implements ToXContentObject {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
                 } else if (Field.TIMESTAMP.match(currentFieldName, parser.getDeprecationHandler())) {
-                    timestamp = dateTimeFormatter.parser().parseDateTime(parser.text());
+                    timestamp = dateTimeFormatter.parseJoda(parser.text());
                 } else if (Field.REASON.match(currentFieldName, parser.getDeprecationHandler())) {
                     reason = parser.text();
                 } else {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/WatcherDateTimeUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/WatcherDateTimeUtils.java
@@ -49,12 +49,12 @@ public class WatcherDateTimeUtils {
     }
 
     public static DateTime parseDate(String format, DateTimeZone timeZone) {
-        DateTime dateTime = dateTimeFormatter.parser().parseDateTime(format);
+        DateTime dateTime = dateTimeFormatter.parseJoda(format);
         return timeZone != null ? dateTime.toDateTime(timeZone) : dateTime;
     }
 
     public static String formatDate(DateTime date) {
-        return dateTimeFormatter.printer().print(date);
+        return dateTimeFormatter.formatJoda(date);
     }
 
     public static DateTime parseDateMath(String fieldName, XContentParser parser, DateTimeZone timeZone, Clock clock) throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/TestUtils.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/TestUtils.java
@@ -23,7 +23,6 @@ import org.elasticsearch.license.licensor.LicenseSigner;
 import org.elasticsearch.protocol.xpack.license.LicensesStatus;
 import org.elasticsearch.protocol.xpack.license.PutLicenseResponse;
 import org.hamcrest.MatcherAssert;
-import org.joda.time.format.DateTimeFormatter;
 import org.junit.Assert;
 
 import java.io.IOException;
@@ -51,10 +50,9 @@ public class TestUtils {
 
     private static final FormatDateTimeFormatter formatDateTimeFormatter = Joda.forPattern("yyyy-MM-dd");
     private static final DateMathParser dateMathParser = formatDateTimeFormatter.toDateMathParser();
-    private static final DateTimeFormatter dateTimeFormatter = formatDateTimeFormatter.printer();
 
     public static String dateMathString(String time, final long now) {
-        return dateTimeFormatter.print(dateMathParser.parse(time, () -> now));
+        return formatDateTimeFormatter.formatMillis(dateMathParser.parse(time, () -> now));
     }
 
     public static long dateMath(String time, final long now) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
@@ -108,8 +108,8 @@ class DatafeedJob {
         }
 
         String msg = Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_STARTED_FROM_TO,
-                DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.printer().print(lookbackStartTimeMs),
-                endTime == null ? "real-time" : DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.printer().print(lookbackEnd),
+                DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.formatMillis(lookbackStartTimeMs),
+                endTime == null ? "real-time" : DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.formatMillis(lookbackEnd),
                 TimeValue.timeValueMillis(frequencyMs).getStringRep());
         auditor.info(jobId, msg);
         LOGGER.info("[{}] {}", jobId, msg);

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -449,7 +449,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
     }
 
     private static long asLong(String dateTime) {
-        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parser().parseDateTime(dateTime).getMillis();
+        return DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseJoda(dateTime).getMillis();
     }
 
     /**


### PR DESCRIPTION
This commit makes FormatDateTimeFormatter and DateFormatter apis close
to each other, so that the former can be removed in favor of the latter.
This PR does not change the uses of FormatDateTimeFormatter yet, so that
that future change can be purely mechanical.
