### PR TITLE
Try running CI against Zulu

### DIFF
--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -9,3 +9,5 @@ ES_RUNTIME_JAVA:
   - java8
   - java8fips
   - java11
+  - zulu8
+  - zulu11


### PR DESCRIPTION
This commit adds Zulu to the CI rotation. This commit only means that we are going to try running CI against Zulu, it does not carry any implications of support in the past, now, or in the future.
