### PR TITLE
 Reduce composite references at network level

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/bytes/ByteBufferReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ByteBufferReference.java
@@ -25,8 +25,8 @@ import java.nio.ByteBuffer;
 
 /**
  * This is a {@link BytesReference} backed by a {@link ByteBuffer}. The byte buffer can either be a heap or
- * direct byte buffer. The reference is composed of the space between the {@link ByteBuffer#position} and
- * {@link ByteBuffer#limit} at construction time. If the position or limit of the underlying byte buffer is
+ * direct byte buffer. The reference is composed of the space between the {@link ByteBuffer#position()} and
+ * {@link ByteBuffer#limit()} at construction time. If the position or limit of the underlying byte buffer is
  * changed, those changes will not be reflected in this reference. However, modifying the limit or position
  * of the underlying byte buffer is not recommended as those can be used during {@link ByteBuffer#get()}
  * bounds checks. Use {@link ByteBuffer#duplicate()} at creation time if you plan on modifying the markers of

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
@@ -195,12 +195,19 @@ public abstract class BytesReference implements Comparable<BytesReference>, ToXC
      * Returns BytesReference composed of the provided ByteBuffers.
      */
     public static BytesReference fromByteBuffers(ByteBuffer[] buffers) {
-        ByteBufferReference[] references = new ByteBufferReference[buffers.length];
-        for (int i = 0; i < references.length; ++i) {
-            references[i] = new ByteBufferReference(buffers[i]);
-        }
+        int bufferCount = buffers.length;
+        if (bufferCount == 0) {
+            return BytesArray.EMPTY;
+        } else if (bufferCount == 1) {
+            return new ByteBufferReference(buffers[0]);
+        } else {
+            ByteBufferReference[] references = new ByteBufferReference[bufferCount];
+            for (int i = 0; i < bufferCount; ++i) {
+                references[i] = new ByteBufferReference(buffers[i]);
+            }
 
-        return new CompositeBytesReference(references);
+            return new CompositeBytesReference(references);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
@@ -212,7 +212,7 @@ public abstract class BytesReference implements Comparable<BytesReference>, ToXC
 
     @Override
     public int compareTo(final BytesReference other) {
-        return compareIterators(this, other, (a, b) -> a.compareTo(b));
+        return compareIterators(this, other, BytesRef::compareTo);
     }
 
     /**


### PR DESCRIPTION
Creating `CompositeBytesReference` has more overhead than a single
`ByteBufferReference`. Many of our messages will be contained to a
single `ByteBuffer`. This commit avoids creating composite instances
when there is 0 or 1  underlying `ByteBuffers`.