### PR TITLE
Make node field in JoinRequest private

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -112,7 +112,7 @@ public class JoinHelper {
 
         transportService.registerRequestHandler(MembershipAction.DISCOVERY_JOIN_ACTION_NAME, MembershipAction.JoinRequest::new,
             ThreadPool.Names.GENERIC, false, false,
-            (request, channel, task) -> joinHandler.accept(new JoinRequest(request.node, Optional.empty()), // treat as non-voting join
+            (request, channel, task) -> joinHandler.accept(new JoinRequest(request.getNode(), Optional.empty()), // treat as non-voting join
                 transportJoinCallback(request, channel)));
 
         transportService.registerRequestHandler(START_JOIN_ACTION_NAME, Names.GENERIC, false, false,

--- a/server/src/main/java/org/elasticsearch/discovery/zen/MembershipAction.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/MembershipAction.java
@@ -105,7 +105,11 @@ public class MembershipAction {
 
     public static class JoinRequest extends TransportRequest {
 
-        public DiscoveryNode node;
+        private DiscoveryNode node;
+
+        public DiscoveryNode getNode() {
+            return node;
+        }
 
         public JoinRequest() {
         }
@@ -132,7 +136,7 @@ public class MembershipAction {
 
         @Override
         public void messageReceived(final JoinRequest request, final TransportChannel channel, Task task) throws Exception {
-            listener.onJoin(request.node, new JoinCallback() {
+            listener.onJoin(request.getNode(), new JoinCallback() {
                 @Override
                 public void onSuccess() {
                     try {


### PR DESCRIPTION
This commit moves the node field in the JoinRequest object to be a private field, adding a dedicated accessor. This is a minor breaking change in that it is no longer possible for all callers to overwrite this field, but that is a feature.