### PR TITLE
Add origin_address to authentication_success

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/DeprecatedLoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/DeprecatedLoggingAuditTrail.java
@@ -138,12 +138,12 @@ public class DeprecatedLoggingAuditTrail extends AbstractComponent implements Au
         if (events.contains(AUTHENTICATION_SUCCESS) && (eventFilterPolicyRegistry.ignorePredicate()
                 .test(new AuditEventMetaInfo(Optional.of(user), Optional.of(realm), Optional.empty(), Optional.empty())) == false)) {
             if (includeRequestBody) {
-                logger.info("{}[rest] [authentication_success]\t{}, realm=[{}], uri=[{}], params=[{}]{}, request_body=[{}]",
-                        localNodeInfo.prefix, principal(user), realm, request.uri(), request.params(), opaqueId(),
+                logger.info("{}[rest] [authentication_success]\t{}, {}, realm=[{}], uri=[{}], params=[{}]{}, request_body=[{}]",
+                        localNodeInfo.prefix, hostAttributes(request), principal(user), realm, request.uri(), request.params(), opaqueId(),
                         restRequestContent(request));
             } else {
-                logger.info("{}[rest] [authentication_success]\t{}, realm=[{}], uri=[{}], params=[{}]{}", localNodeInfo.prefix,
-                        principal(user), realm, request.uri(), request.params(), opaqueId());
+                logger.info("{}[rest] [authentication_success]\t{}, {}, realm=[{}], uri=[{}], params=[{}]{}", localNodeInfo.prefix,
+                        hostAttributes(request), principal(user), realm, request.uri(), request.params(), opaqueId());
             }
         }
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/DeprecatedLoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/DeprecatedLoggingAuditTrailTests.java
@@ -680,8 +680,8 @@ public class DeprecatedLoggingAuditTrailTests extends ESTestCase {
                             + ", realm=[_realm], uri=[_uri], params=[" + params + "]" + opaqueId + ", request_body=[" + expectedMessage
                             + "]");
         } else {
-            assertMsg(logger, Level.INFO, prefix + "[rest] [authentication_success]\torigin_address=[" + NetworkAddress.format(address) + "], "
-                    + userInfo + ", realm=[_realm], uri=[_uri], params=[" + params + "]" + opaqueId);
+            assertMsg(logger, Level.INFO, prefix + "[rest] [authentication_success]\torigin_address=[" + NetworkAddress.format(address)
+                    + "], " + userInfo + ", realm=[_realm], uri=[_uri], params=[" + params + "]" + opaqueId);
         }
 
         // test disabled

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/DeprecatedLoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/DeprecatedLoggingAuditTrailTests.java
@@ -676,12 +676,12 @@ public class DeprecatedLoggingAuditTrailTests extends ESTestCase {
         auditTrail.authenticationSuccess(randomAlphaOfLength(12), realm, user, request);
         if (includeRequestBody) {
             assertMsg(logger, Level.INFO,
-                    prefix + "[rest] [authentication_success]\t" + userInfo + ", realm=[_realm], uri=[_uri], params=[" + params
-                    + "]" + opaqueId + ", request_body=[" + expectedMessage + "]");
+                    prefix + "[rest] [authentication_success]\torigin_address=[" + NetworkAddress.format(address) + "], " + userInfo
+                            + ", realm=[_realm], uri=[_uri], params=[" + params + "]" + opaqueId + ", request_body=[" + expectedMessage
+                            + "]");
         } else {
-            assertMsg(logger, Level.INFO,
-                    prefix + "[rest] [authentication_success]\t" + userInfo + ", realm=[_realm], uri=[_uri], params=[" + params
-                    + "]" + opaqueId);
+            assertMsg(logger, Level.INFO, prefix + "[rest] [authentication_success]\torigin_address=[" + NetworkAddress.format(address) + "], "
+                    + userInfo + ", realm=[_realm], uri=[_uri], params=[" + params + "]" + opaqueId);
         }
 
         // test disabled


### PR DESCRIPTION
The `origin_address` field should be present on all events (there is no reason not to), but it is missing in `authentication_success` events for the _deprecated logfile audit logging_.

It is easier to fix the code than the docs:
https://www.elastic.co/guide/en/elastic-stack-overview/6.5/audit-event-types.html#audit-event-attributes

(It was easier to write the docs in https://github.com/elastic/elasticsearch/pull/35510 the way they are, than to accommodate for this omission)