### PR TITLE
Add link to script score query in the top level docs

### DIFF
--- a/docs/reference/query-dsl/script-score-query.asciidoc
+++ b/docs/reference/query-dsl/script-score-query.asciidoc
@@ -39,7 +39,7 @@ GET /_search
 ==== Accessing the score of a document within a script
 
 Within a script, you can
-<<modules-scripting-fields#scripting-score, access>>
+{ref}/modules-scripting-fields.html#scripting-score[access] 
 the `_score` variable which represents the current relevance score of a
 document.
 
@@ -132,8 +132,8 @@ these unique values need to be loaded into memory.
 
 [[decay-functions]]
 ===== Decay functions for numeric fields
-You can read more about decay functions
-<<query-dsl-function-score-query#function-decay, here>>.
+You can read more about decay functions 
+{ref}/query-dsl-function-score-query.html#function-decay[here].
 
 * `double decayNumericLinear(double origin, double scale, double offset, double decay, double docValue)`
 * `double decayNumericExp(double origin, double scale, double offset, double decay, double docValue)`

--- a/docs/reference/query-dsl/special-queries.asciidoc
+++ b/docs/reference/query-dsl/special-queries.asciidoc
@@ -14,6 +14,10 @@ or collection of documents.
 This query allows a script to act as a filter.  Also see the
 <<query-dsl-function-score-query,`function_score` query>>.
 
+<<query-dsl-script-score-query,`script_score` query>>::
+
+A query that allows to modify the score of a sub-query with a script.
+
 <<query-dsl-percolate-query,`percolate` query>>::
 
 This query finds queries that are stored as documents that match with
@@ -31,6 +35,8 @@ A query that accepts other queries as json or yaml string.
 include::mlt-query.asciidoc[]
 
 include::script-query.asciidoc[]
+
+include::script-score-query.asciidoc[]
 
 include::percolate-query.asciidoc[]
 


### PR DESCRIPTION
The `script_score` query is not listed in the documentation. This change adds an entry for this query in the special queries section.