### PR TITLE
Cancel GetDiscoveredNodesAction when bootstrapped

### DIFF
--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -1008,7 +1008,9 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         TOO_MANY_BUCKETS_EXCEPTION(MultiBucketConsumerService.TooManyBucketsException.class,
             MultiBucketConsumerService.TooManyBucketsException::new, 149, Version.V_7_0_0),
         COORDINATION_STATE_REJECTED_EXCEPTION(org.elasticsearch.cluster.coordination.CoordinationStateRejectedException.class,
-            org.elasticsearch.cluster.coordination.CoordinationStateRejectedException::new, 150, Version.V_7_0_0);
+            org.elasticsearch.cluster.coordination.CoordinationStateRejectedException::new, 150, Version.V_7_0_0),
+        CLUSTER_ALREADY_BOOTSTRAPPED_EXCEPTION(org.elasticsearch.cluster.coordination.ClusterAlreadyBootstrappedException.class,
+            org.elasticsearch.cluster.coordination.ClusterAlreadyBootstrappedException::new, 151, Version.V_7_0_0);
 
         final Class<? extends ElasticsearchException> exceptionClass;
         final CheckedFunction<StreamInput, ? extends ElasticsearchException, IOException> constructor;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/bootstrap/BootstrapClusterAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/bootstrap/BootstrapClusterAction.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.io.stream.Writeable.Reader;
 
 public class BootstrapClusterAction extends Action<BootstrapClusterResponse> {
     public static final BootstrapClusterAction INSTANCE = new BootstrapClusterAction();
-    public static final String NAME = "cluster:admin/bootstrap_cluster";
+    public static final String NAME = "cluster:admin/bootstrap/set_voting_config";
 
     private BootstrapClusterAction() {
         super(NAME);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/bootstrap/GetDiscoveredNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/bootstrap/GetDiscoveredNodesAction.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.io.stream.Writeable.Reader;
 
 public class GetDiscoveredNodesAction extends Action<GetDiscoveredNodesResponse> {
     public static final GetDiscoveredNodesAction INSTANCE = new GetDiscoveredNodesAction();
-    public static final String NAME = "cluster:admin/get_bootstrap_discovered_nodes";
+    public static final String NAME = "cluster:admin/bootstrap/discover_nodes";
 
     private GetDiscoveredNodesAction() {
         super(NAME);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterAlreadyBootstrappedException.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterAlreadyBootstrappedException.java
@@ -16,26 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.action.admin.cluster.bootstrap;
+package org.elasticsearch.cluster.coordination;
 
-import org.elasticsearch.action.Action;
-import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
 
-public class GetDiscoveredNodesAction extends Action<GetDiscoveredNodesResponse> {
-    public static final GetDiscoveredNodesAction INSTANCE = new GetDiscoveredNodesAction();
-    public static final String NAME = "cluster:admin/get_bootstrap_discovered_nodes";
+import java.io.IOException;
 
-    private GetDiscoveredNodesAction() {
-        super(NAME);
+/**
+ * Exception thrown if trying to discovery nodes in order to perform cluster bootstrapping, but a cluster is formed before all the required
+ * nodes are discovered.
+ */
+public class ClusterAlreadyBootstrappedException extends ElasticsearchException {
+    public ClusterAlreadyBootstrappedException() {
+        super("node has already joined a bootstrapped cluster, bootstrapping is not required");
     }
 
-    @Override
-    public GetDiscoveredNodesResponse newResponse() {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-    }
-
-    @Override
-    public Reader<GetDiscoveredNodesResponse> getResponseReader() {
-        return GetDiscoveredNodesResponse::new;
+    public ClusterAlreadyBootstrappedException(StreamInput in) throws IOException {
+        super(in);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
@@ -117,7 +117,12 @@ public class ClusterBootstrapService {
 
                                 @Override
                                 public void handleException(TransportException exp) {
-                                    logger.warn("discovery attempt failed", exp);
+                                    final Throwable rootCause = exp.getRootCause();
+                                    if (rootCause instanceof ClusterAlreadyBootstrappedException) {
+                                        logger.debug(rootCause.getMessage(), rootCause);
+                                    } else {
+                                        logger.warn("discovery attempt failed", exp);
+                                    }
                                 }
 
                                 @Override

--- a/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.action.support.replication.ReplicationOperation;
 import org.elasticsearch.client.AbstractClientHeadersTestCase;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.coordination.ClusterAlreadyBootstrappedException;
 import org.elasticsearch.cluster.coordination.CoordinationStateRejectedException;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.IllegalShardRoutingStateException;
@@ -807,6 +808,7 @@ public class ExceptionSerializationTests extends ESTestCase {
         ids.put(148, UnknownNamedObjectException.class);
         ids.put(149, MultiBucketConsumerService.TooManyBucketsException.class);
         ids.put(150, CoordinationStateRejectedException.class);
+        ids.put(151, ClusterAlreadyBootstrappedException.class);
 
         Map<Class<? extends ElasticsearchException>, Integer> reverse = new HashMap<>();
         for (Map.Entry<Integer, Class<? extends ElasticsearchException>> entry : ids.entrySet()) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/SystemPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/SystemPrivilege.java
@@ -19,8 +19,7 @@ public final class SystemPrivilege extends Privilege {
             "internal:*",
             "indices:monitor/*", // added for monitoring
             "cluster:monitor/*",  // added for monitoring
-            "cluster:admin/get_bootstrap_discovered_nodes", // for the bootstrap service
-            "cluster:admin/bootstrap_cluster", // for the bootstrap service
+            "cluster:admin/bootstrap/*", // for the bootstrap service
             "cluster:admin/reroute", // added for DiskThresholdDecider.DiskListener
             "indices:admin/mapping/put", // needed for recovery and shrink api
             "indices:admin/template/put", // needed for the TemplateUpgradeService

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/SystemPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/SystemPrivilege.java
@@ -19,6 +19,7 @@ public final class SystemPrivilege extends Privilege {
             "internal:*",
             "indices:monitor/*", // added for monitoring
             "cluster:monitor/*",  // added for monitoring
+            "cluster:admin/get_bootstrap_discovered_nodes", // for the bootstrap service
             "cluster:admin/bootstrap_cluster", // for the bootstrap service
             "cluster:admin/reroute", // added for DiskThresholdDecider.DiskListener
             "indices:admin/mapping/put", // needed for recovery and shrink api

--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
@@ -9,7 +9,6 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.http.HttpStatus;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.admin.cluster.bootstrap.GetDiscoveredNodesAction;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.CheckedFunction;
@@ -256,9 +255,7 @@ public class XPackRestIT extends ESClientYamlSuiteTestCase {
             // it could be waiting for pending tasks while monitoring is still running).
             ESRestTestCase.waitForPendingTasks(adminClient(), task -> {
                     // Don't check rollup jobs because we clear them in the superclass.
-                    return task.contains(RollupJob.NAME)
-                        // Also ignore the zen2 discovery task
-                        || task.contains(GetDiscoveredNodesAction.NAME);
+                    return task.contains(RollupJob.NAME);
             });
         }
     }


### PR DESCRIPTION
Today the `GetDiscoveredNodesAction` waits, possibly indefinitely, to discover
enough nodes to bootstrap the cluster. However it is possible that the cluster
forms before a node has discovered the expected collection of nodes, in which
case the action will wait indefinitely despite the fact that it is no longer
required.

This commit changes the behaviour so that the action fails once a node receives
a cluster state with a nonempty configuration, indicating that the cluster has
been successfully bootstrapped and therefore the `GetDiscoveredNodesAction`
need wait no longer.

Relates #36380 and #36381; reverts 558f4ec27820e1a50660dc1f3437422150339af0.