### PR TITLE
[ML] JIndex: Prevent updates to migrating configs and upgrade tests

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExceptionsHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExceptionsHelper.java
@@ -58,6 +58,10 @@ public class ExceptionsHelper {
         return new ElasticsearchStatusException(msg, RestStatus.BAD_REQUEST, args);
     }
 
+    public static ElasticsearchStatusException configHasNotBeenMigrated() {
+        return new ElasticsearchStatusException("the X is pending migration", RestStatus.SERVICE_UNAVAILABLE);
+    }
+
     /**
      * Creates an error message that explains there are shard failures, displays info
      * for the first failure (shard/reason) and kindly asks to see more info in the logs

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExceptionsHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExceptionsHelper.java
@@ -58,8 +58,9 @@ public class ExceptionsHelper {
         return new ElasticsearchStatusException(msg, RestStatus.BAD_REQUEST, args);
     }
 
-    public static ElasticsearchStatusException configHasNotBeenMigrated() {
-        return new ElasticsearchStatusException("the X is pending migration", RestStatus.SERVICE_UNAVAILABLE);
+    public static ElasticsearchStatusException configHasNotBeenMigrated(String verb, String id) {
+        return new ElasticsearchStatusException("cannot {} as the configuration [{}] is temporarily pending migration",
+                RestStatus.SERVICE_UNAVAILABLE, verb, id);
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
@@ -81,9 +81,6 @@ public class MlAssignmentNotifier implements ClusterStateListener, LocalNodeMast
         }
         PersistentTasksCustomMetaData previous = event.previousState().getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
         PersistentTasksCustomMetaData current = event.state().getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
-        if (Objects.equals(previous, current)) {
-            return;
-        }
 
         mlConfigMigrator.migrateConfigsWithoutTasks(event.state(), ActionListener.wrap(
                 response -> threadPool.executor(executorName()).execute(() -> auditChangesToMlTasks(current, previous, event.state())),
@@ -96,6 +93,10 @@ public class MlAssignmentNotifier implements ClusterStateListener, LocalNodeMast
 
     private void auditChangesToMlTasks(PersistentTasksCustomMetaData current, PersistentTasksCustomMetaData previous,
                                        ClusterState state) {
+
+        if (Objects.equals(previous, current)) {
+            return;
+        }
 
         for (PersistentTask<?> currentTask : current.tasks()) {
             Assignment currentAssignment = currentTask.getAssignment();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.ml;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
@@ -86,20 +85,13 @@ public class MlAssignmentNotifier implements ClusterStateListener, LocalNodeMast
             return;
         }
 
-        Version minNodeVersion = event.state().nodes().getMinNodeVersion();
-        if (minNodeVersion.onOrAfter(Version.V_6_6_0)) {
-            // ok to migrate
-            mlConfigMigrator.migrateConfigsWithoutTasks(event.state(), ActionListener.wrap(
-                    response -> threadPool.executor(executorName()).execute(() -> auditChangesToMlTasks(current, previous, event.state())),
-                    e -> {
-                        logger.error("error migrating ml configurations", e);
-                        threadPool.executor(executorName()).execute(() -> auditChangesToMlTasks(current, previous, event.state()));
-                    }
-            ));
-        } else {
-            threadPool.executor(executorName()).execute(() -> auditChangesToMlTasks(current, previous, event.state()));
-        }
-
+        mlConfigMigrator.migrateConfigsWithoutTasks(event.state(), ActionListener.wrap(
+                response -> threadPool.executor(executorName()).execute(() -> auditChangesToMlTasks(current, previous, event.state())),
+                e -> {
+                    logger.error("error migrating ml configurations", e);
+                    threadPool.executor(executorName()).execute(() -> auditChangesToMlTasks(current, previous, event.state()));
+                }
+        ));
     }
 
     private void auditChangesToMlTasks(PersistentTasksCustomMetaData current, PersistentTasksCustomMetaData previous,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
@@ -117,7 +117,7 @@ public class MlConfigMigrator {
             return;
         }
 
-        logger.trace("migrating ml configurations");
+        logger.debug("migrating ml configurations");
 
         Collection<DatafeedConfig> datafeedsToMigrate = stoppedDatafeedConfigs(clusterState);
         List<Job> jobsToMigrate = nonDeletingJobs(closedJobConfigs(clusterState)).stream()
@@ -431,7 +431,7 @@ public class MlConfigMigrator {
      * @param clusterState clusterstate
      * @return A boolean depending on the conditions listed above
      */
-    public static boolean datafeedIdEligibleForMigration(String datafeedId, ClusterState clusterState) {
+    public static boolean datafeedIsEligibleForMigration(String datafeedId, ClusterState clusterState) {
         Version minNodeVersion = clusterState.nodes().getMinNodeVersion();
         if (minNodeVersion.before(MIN_NODE_VERSION)) {
             return false;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
@@ -110,6 +110,7 @@ public class MlConfigMigrator {
         Version minNodeVersion = clusterState.nodes().getMinNodeVersion();
         if (minNodeVersion.before(MIN_NODE_VERSION)) {
             listener.onResponse(Boolean.FALSE);
+            return;
         }
 
         if (migrationInProgress.compareAndSet(false, true) == false) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.core.ml.action.IsolateDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.MlConfigMigrator;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
@@ -72,6 +73,12 @@ public class TransportDeleteDatafeedAction extends TransportMasterNodeAction<Del
     @Override
     protected void masterOperation(DeleteDatafeedAction.Request request, ClusterState state,
                                    ActionListener<AcknowledgedResponse> listener) {
+
+        if (MlConfigMigrator.datafeedIdEligibleForMigration(request.getDatafeedId(), state)) {
+            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated());
+            return;
+        }
+
         if (request.isForce()) {
             forceDeleteDatafeed(request, state, listener);
         } else {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
@@ -75,7 +75,7 @@ public class TransportDeleteDatafeedAction extends TransportMasterNodeAction<Del
                                    ActionListener<AcknowledgedResponse> listener) {
 
         if (MlConfigMigrator.datafeedIdEligibleForMigration(request.getDatafeedId(), state)) {
-            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated());
+            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated("delete datafeed", request.getDatafeedId()));
             return;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
@@ -74,7 +74,7 @@ public class TransportDeleteDatafeedAction extends TransportMasterNodeAction<Del
     protected void masterOperation(DeleteDatafeedAction.Request request, ClusterState state,
                                    ActionListener<AcknowledgedResponse> listener) {
 
-        if (MlConfigMigrator.datafeedIdEligibleForMigration(request.getDatafeedId(), state)) {
+        if (MlConfigMigrator.datafeedIsEligibleForMigration(request.getDatafeedId(), state)) {
             listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated("delete datafeed", request.getDatafeedId()));
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
@@ -150,7 +150,7 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
                                    ActionListener<AcknowledgedResponse> listener) {
 
         if (MlConfigMigrator.jobIsEligibleForMigration(request.getJobId(), state)) {
-            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated());
+            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated("delete job", request.getJobId()));
             return;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
@@ -64,6 +64,7 @@ import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.CategorizerS
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.Quantiles;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.MlConfigMigrator;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.job.JobManager;
 import org.elasticsearch.xpack.ml.job.persistence.JobDataDeleter;
@@ -147,6 +148,12 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
     @Override
     protected void masterOperation(Task task, DeleteJobAction.Request request, ClusterState state,
                                    ActionListener<AcknowledgedResponse> listener) {
+
+        if (MlConfigMigrator.jobIsEligibleForMigration(request.getJobId(), state)) {
+            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated());
+            return;
+        }
+
         logger.debug("Deleting job '{}'", request.getJobId());
 
         if (request.isForce() == false) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -530,7 +530,7 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
     @Override
     protected void masterOperation(OpenJobAction.Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener) {
         if (MlConfigMigrator.jobIsEligibleForMigration(request.getJobParams().getJobId(), state)) {
-            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated());
+            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated("open job", request.getJobParams().getJobId()));
             return;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -70,6 +70,7 @@ import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.MachineLearning;
+import org.elasticsearch.xpack.ml.MlConfigMigrator;
 import org.elasticsearch.xpack.ml.job.ClusterStateJobUpdate;
 import org.elasticsearch.xpack.ml.job.JobManager;
 import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
@@ -528,6 +529,11 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
 
     @Override
     protected void masterOperation(OpenJobAction.Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener) {
+        if (MlConfigMigrator.jobIsEligibleForMigration(request.getJobParams().getJobId(), state)) {
+            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated());
+            return;
+        }
+
         OpenJobAction.JobParams jobParams = request.getJobParams();
         if (licenseState.isMachineLearningAllowed()) {
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
@@ -70,7 +70,7 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
     protected void masterOperation(RevertModelSnapshotAction.Request request, ClusterState state,
                                    ActionListener<RevertModelSnapshotAction.Response> listener) {
         if (MlConfigMigrator.jobIsEligibleForMigration(request.getJobId(), state)) {
-            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated());
+            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated("revert model snapshot", request.getJobId()));
             return;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.RevertModelSnapshotAction;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
+import org.elasticsearch.xpack.ml.MlConfigMigrator;
 import org.elasticsearch.xpack.ml.job.persistence.JobDataDeleter;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
@@ -68,6 +69,11 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
     @Override
     protected void masterOperation(RevertModelSnapshotAction.Request request, ClusterState state,
                                    ActionListener<RevertModelSnapshotAction.Response> listener) {
+        if (MlConfigMigrator.jobIsEligibleForMigration(request.getJobId(), state)) {
+            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated());
+            return;
+        }
+
         logger.debug("Received request to revert to snapshot id '{}' for job '{}', deleting intervening results: {}",
                 request.getSnapshotId(), request.getJobId(), request.getDeleteInterveningResults());
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -140,7 +140,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
             return;
         }
 
-        if (MlConfigMigrator.datafeedIdEligibleForMigration(request.getParams().getDatafeedId(), state)) {
+        if (MlConfigMigrator.datafeedIsEligibleForMigration(request.getParams().getDatafeedId(), state)) {
             listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated("start datafeed", request.getParams().getDatafeedId()));
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -141,7 +141,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
         }
 
         if (MlConfigMigrator.datafeedIdEligibleForMigration(request.getParams().getDatafeedId(), state)) {
-            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated());
+            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated("start datafeed", request.getParams().getDatafeedId()));
             return;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -45,6 +45,7 @@ import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.MachineLearning;
+import org.elasticsearch.xpack.ml.MlConfigMigrator;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedConfigReader;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedManager;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedNodeSelector;
@@ -136,6 +137,11 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
         StartDatafeedAction.DatafeedParams params = request.getParams();
         if (licenseState.isMachineLearningAllowed() == false) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
+            return;
+        }
+
+        if (MlConfigMigrator.datafeedIdEligibleForMigration(request.getParams().getDatafeedId(), state)) {
+            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated());
             return;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDatafeedAction.java
@@ -71,7 +71,7 @@ public class TransportUpdateDatafeedAction extends TransportMasterNodeAction<Upd
                                    ActionListener<PutDatafeedAction.Response> listener) throws Exception {
 
         if (MlConfigMigrator.datafeedIdEligibleForMigration(request.getUpdate().getId(), state)) {
-            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated());
+            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated("update datafeed", request.getUpdate().getId()));
             return;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDatafeedAction.java
@@ -70,7 +70,7 @@ public class TransportUpdateDatafeedAction extends TransportMasterNodeAction<Upd
     protected void masterOperation(UpdateDatafeedAction.Request request, ClusterState state,
                                    ActionListener<PutDatafeedAction.Response> listener) throws Exception {
 
-        if (MlConfigMigrator.datafeedIdEligibleForMigration(request.getUpdate().getId(), state)) {
+        if (MlConfigMigrator.datafeedIsEligibleForMigration(request.getUpdate().getId(), state)) {
             listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated("update datafeed", request.getUpdate().getId()));
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -439,7 +439,7 @@ public class JobManager {
     public void updateJob(UpdateJobAction.Request request, ActionListener<PutJobAction.Response> actionListener) {
         ClusterState clusterState = clusterService.state();
         if (MlConfigMigrator.jobIsEligibleForMigration(request.getJobId(), clusterState)) {
-            actionListener.onFailure(ExceptionsHelper.configHasNotBeenMigrated());
+            actionListener.onFailure(ExceptionsHelper.configHasNotBeenMigrated("update job", request.getJobId()));
             return;
         }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigratorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigratorTests.java
@@ -11,6 +11,9 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
@@ -21,6 +24,7 @@ import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobTests;
 
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -211,6 +215,123 @@ public class MlConfigMigratorTests extends ESTestCase {
         assertThat(removalResult.removedDatafeedIds, empty());
     }
 
+    public void testJobIsEligibleForMigration_givenNodesNotUpToVersion() {
+        // mixed 6.5 and 6.6 nodes
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
+                .nodes(DiscoveryNodes.builder()
+                        .add(new DiscoveryNode("node_id1", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.V_6_5_0))
+                        .add(new DiscoveryNode("node_id2", new TransportAddress(InetAddress.getLoopbackAddress(), 9301), Version.V_6_6_0)))
+                .build();
+
+        assertFalse(MlConfigMigrator.jobIsEligibleForMigration("pre-min-version", clusterState));
+    }
+
+    public void testJobIsEligibleForMigration_givenJobNotInClusterState() {
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests")).build();
+        assertFalse(MlConfigMigrator.jobIsEligibleForMigration("not-in-state", clusterState));
+    }
+
+    public void testJobIsEligibleForMigration_givenDeletingJob() {
+        Job deletingJob = JobTests.buildJobBuilder("deleting-job").setDeleting(true).build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(deletingJob, false);
+
+        PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
+        tasksBuilder.addTask(MlTasks.jobTaskId(deletingJob.getId()),
+                MlTasks.JOB_TASK_NAME, new OpenJobAction.JobParams(deletingJob.getId()),
+                new PersistentTasksCustomMetaData.Assignment("node-1", "test assignment"));
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+                .metaData(MetaData.builder()
+                        .putCustom(MlMetadata.TYPE, mlMetadata.build())
+                        .putCustom(PersistentTasksCustomMetaData.TYPE, tasksBuilder.build())
+                )
+                .build();
+
+        assertFalse(MlConfigMigrator.jobIsEligibleForMigration(deletingJob.getId(), clusterState));
+    }
+
+    public void testJobIsEligibleForMigration_givenOpenJob() {
+        Job openJob = JobTests.buildJobBuilder("open-job").build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(openJob, false);
+
+        PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
+        tasksBuilder.addTask(MlTasks.jobTaskId(openJob.getId()), MlTasks.JOB_TASK_NAME, new OpenJobAction.JobParams(openJob.getId()),
+                new PersistentTasksCustomMetaData.Assignment("node-1", "test assignment"));
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+                .metaData(MetaData.builder()
+                        .putCustom(MlMetadata.TYPE, mlMetadata.build())
+                        .putCustom(PersistentTasksCustomMetaData.TYPE, tasksBuilder.build())
+                )
+                .build();
+
+        assertFalse(MlConfigMigrator.jobIsEligibleForMigration(openJob.getId(), clusterState));
+    }
+
+    public void testJobIsEligibleForMigration_givenClosedJob() {
+        Job closedJob = JobTests.buildJobBuilder("closed-job").build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(closedJob, false);
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+                .metaData(MetaData.builder()
+                        .putCustom(MlMetadata.TYPE, mlMetadata.build())
+                )
+                .build();
+
+        assertTrue(MlConfigMigrator.jobIsEligibleForMigration(closedJob.getId(), clusterState));
+    }
+
+    public void testDatafeedIsEligibleForMigration_givenNodesNotUpToVersion() {
+        // mixed 6.5 and 6.6 nodes
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
+                .nodes(DiscoveryNodes.builder()
+                        .add(new DiscoveryNode("node_id1", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.V_6_5_0))
+                        .add(new DiscoveryNode("node_id2", new TransportAddress(InetAddress.getLoopbackAddress(), 9301), Version.V_6_6_0)))
+                .build();
+
+        assertFalse(MlConfigMigrator.datafeedIdEligibleForMigration("pre-min-version", clusterState));
+    }
+
+    public void testDatafeedIsEligibleForMigration_givenDatafeedNotInClusterState() {
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests")).build();
+        assertFalse(MlConfigMigrator.datafeedIdEligibleForMigration("not-in-state", clusterState));
+    }
+
+    public void testDatafeedIsEligibleForMigration_givenStartedDatafeed() {
+        Job openJob = JobTests.buildJobBuilder("open-job").build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(openJob, false);
+        mlMetadata.putDatafeed(createCompatibleDatafeed(openJob.getId()), Collections.emptyMap());
+        String datafeedId = "df-" + openJob.getId();
+
+        PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
+        tasksBuilder.addTask(MlTasks.datafeedTaskId(datafeedId), MlTasks.DATAFEED_TASK_NAME,
+                new StartDatafeedAction.DatafeedParams(datafeedId, 0L),
+                new PersistentTasksCustomMetaData.Assignment("node-1", "test assignment"));
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+                .metaData(MetaData.builder()
+                        .putCustom(MlMetadata.TYPE, mlMetadata.build())
+                        .putCustom(PersistentTasksCustomMetaData.TYPE, tasksBuilder.build())
+                )
+                .build();
+
+        assertFalse(MlConfigMigrator.datafeedIdEligibleForMigration(datafeedId, clusterState));
+    }
+
+    public void testDatafeedIsEligibleForMigration_givenStoppedDatafeed() {
+        Job job = JobTests.buildJobBuilder("closed-job").build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(job, false);
+        mlMetadata.putDatafeed(createCompatibleDatafeed(job.getId()), Collections.emptyMap());
+        String datafeedId = "df-" + job.getId();
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+                .metaData(MetaData.builder()
+                        .putCustom(MlMetadata.TYPE, mlMetadata.build())
+                )
+                .build();
+
+        assertTrue(MlConfigMigrator.datafeedIdEligibleForMigration(datafeedId, clusterState));
+    }
 
     private DatafeedConfig createCompatibleDatafeed(String jobId) {
         // create a datafeed without aggregations or anything

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigratorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigratorTests.java
@@ -289,12 +289,12 @@ public class MlConfigMigratorTests extends ESTestCase {
                         .add(new DiscoveryNode("node_id2", new TransportAddress(InetAddress.getLoopbackAddress(), 9301), Version.V_6_6_0)))
                 .build();
 
-        assertFalse(MlConfigMigrator.datafeedIdEligibleForMigration("pre-min-version", clusterState));
+        assertFalse(MlConfigMigrator.datafeedIsEligibleForMigration("pre-min-version", clusterState));
     }
 
     public void testDatafeedIsEligibleForMigration_givenDatafeedNotInClusterState() {
         ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests")).build();
-        assertFalse(MlConfigMigrator.datafeedIdEligibleForMigration("not-in-state", clusterState));
+        assertFalse(MlConfigMigrator.datafeedIsEligibleForMigration("not-in-state", clusterState));
     }
 
     public void testDatafeedIsEligibleForMigration_givenStartedDatafeed() {
@@ -315,7 +315,7 @@ public class MlConfigMigratorTests extends ESTestCase {
                 )
                 .build();
 
-        assertFalse(MlConfigMigrator.datafeedIdEligibleForMigration(datafeedId, clusterState));
+        assertFalse(MlConfigMigrator.datafeedIsEligibleForMigration(datafeedId, clusterState));
     }
 
     public void testDatafeedIsEligibleForMigration_givenStoppedDatafeed() {
@@ -330,7 +330,7 @@ public class MlConfigMigratorTests extends ESTestCase {
                 )
                 .build();
 
-        assertTrue(MlConfigMigrator.datafeedIdEligibleForMigration(datafeedId, clusterState));
+        assertTrue(MlConfigMigrator.datafeedIsEligibleForMigration(datafeedId, clusterState));
     }
 
     private DatafeedConfig createCompatibleDatafeed(String jobId) {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.upgrades;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -68,6 +69,14 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
     }
 
     protected static final ClusterType CLUSTER_TYPE = ClusterType.parse(System.getProperty("tests.rest.suite"));
+    protected static final Version UPGRADED_FROM_VERSION;
+    static {
+        String versionProperty = System.getProperty("tests.upgrade_from_version");
+        if (versionProperty == null) {
+            throw new IllegalStateException("System property 'tests.upgrade_from_version' not set, cannot start tests");
+        }
+        UPGRADED_FROM_VERSION = Version.fromString(versionProperty);
+    }
 
     @Override
     protected Settings restClientSettings() {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMigrationIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMigrationIT.java
@@ -37,12 +37,12 @@ import static org.hamcrest.Matchers.not;
 
 public class MlMigrationIT extends AbstractUpgradeTestCase {
 
-    private static final String OLD_CLUSTER_OPEN_JOB_ID = "migration-old-cluster-open-job";
-    private static final String OLD_CLUSTER_STARTED_DATAFEED_ID = "migration-old-cluster-started-datafeed";
-    private static final String OLD_CLUSTER_CLOSED_JOB_ID = "migration-old-cluster-closed-job";
-    private static final String OLD_CLUSTER_STOPPED_DATAFEED_ID = "migration-old-cluster-stopped-datafeed";
-    private static final String OLD_CLUSTER_CLOSED_JOB_EXTRA_ID = "migration-old-cluster-closed-job-extra";
-    private static final String OLD_CLUSTER_STOPPED_DATAFEED_EXTRA_ID = "migration-old-cluster-stopped-datafeed-extra";
+    private static final String OLD_CLUSTER_OPEN_JOB_ID = "migration-it-old-cluster-open-job";
+    private static final String OLD_CLUSTER_STARTED_DATAFEED_ID = "migration-it-old-cluster-started-datafeed";
+    private static final String OLD_CLUSTER_CLOSED_JOB_ID = "migration-it-old-cluster-closed-job";
+    private static final String OLD_CLUSTER_STOPPED_DATAFEED_ID = "migration-it-old-cluster-stopped-datafeed";
+    private static final String OLD_CLUSTER_CLOSED_JOB_EXTRA_ID = "migration-it-old-cluster-closed-job-extra";
+    private static final String OLD_CLUSTER_STOPPED_DATAFEED_EXTRA_ID = "migration-it-old-cluster-stopped-datafeed-extra";
 
     @Override
     protected Collection<String> templatesToWaitFor() {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMigrationIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMigrationIT.java
@@ -37,12 +37,12 @@ import static org.hamcrest.Matchers.not;
 
 public class MlMigrationIT extends AbstractUpgradeTestCase {
 
-    private static final String OLD_CLUSTER_OPEN_JOB_ID = "migration-it-old-cluster-open-job";
-    private static final String OLD_CLUSTER_STARTED_DATAFEED_ID = "migration-it-old-cluster-started-datafeed";
-    private static final String OLD_CLUSTER_CLOSED_JOB_ID = "migration-it-old-cluster-closed-job";
-    private static final String OLD_CLUSTER_STOPPED_DATAFEED_ID = "migration-it-old-cluster-stopped-datafeed";
-    private static final String OLD_CLUSTER_CLOSED_JOB_EXTRA_ID = "migration-it-old-cluster-closed-job-extra";
-    private static final String OLD_CLUSTER_STOPPED_DATAFEED_EXTRA_ID = "migration-it-old-cluster-stopped-datafeed-extra";
+    private static final String OLD_CLUSTER_OPEN_JOB_ID = "ml-migration-it-old-cluster-open-job";
+    private static final String OLD_CLUSTER_STARTED_DATAFEED_ID = "ml-migration-it-old-cluster-started-datafeed";
+    private static final String OLD_CLUSTER_CLOSED_JOB_ID = "ml-migration-it-old-cluster-closed-job";
+    private static final String OLD_CLUSTER_STOPPED_DATAFEED_ID = "ml-migration-it-old-cluster-stopped-datafeed";
+    private static final String OLD_CLUSTER_CLOSED_JOB_EXTRA_ID = "ml-migration-it-old-cluster-closed-job-extra";
+    private static final String OLD_CLUSTER_STOPPED_DATAFEED_EXTRA_ID = "ml-migration-it-old-cluster-stopped-datafeed-extra";
 
     @Override
     protected Collection<String> templatesToWaitFor() {
@@ -83,7 +83,7 @@ public class MlMigrationIT extends AbstractUpgradeTestCase {
     }
 
     private void createTestIndex() throws IOException {
-        Request createTestIndex = new Request("PUT", "/airline-data");
+        Request createTestIndex = new Request("PUT", "/airline-responsetime-data");
         createTestIndex.setJsonEntity("{\"mappings\": { \"doc\": {\"properties\": {" +
                     "\"time\": {\"type\": \"date\"}," +
                     "\"airline\": {\"type\": \"keyword\"}," +
@@ -140,7 +140,7 @@ public class MlMigrationIT extends AbstractUpgradeTestCase {
         if (UPGRADED_FROM_VERSION.before(Version.V_6_6_0)) {
             dfBuilder.setDelayedDataCheckConfig(null);
         }
-        dfBuilder.setIndices(Collections.singletonList("airline-data"));
+        dfBuilder.setIndices(Collections.singletonList("airline-responsetime-data"));
         dfBuilder.setTypes(Collections.singletonList("doc"));
 
         Request putDatafeed = new Request("PUT", "_xpack/ml/datafeeds/" + OLD_CLUSTER_STARTED_DATAFEED_ID);
@@ -162,7 +162,7 @@ public class MlMigrationIT extends AbstractUpgradeTestCase {
         if (UPGRADED_FROM_VERSION.before(Version.V_6_6_0)) {
             stoppedDfBuilder.setDelayedDataCheckConfig(null);
         }
-        stoppedDfBuilder.setIndices(Collections.singletonList("airline-data"));
+        stoppedDfBuilder.setIndices(Collections.singletonList("airline-responsetime-data"));
 
         Request putStoppedDatafeed = new Request("PUT", "_xpack/ml/datafeeds/" + OLD_CLUSTER_STOPPED_DATAFEED_ID);
         putStoppedDatafeed.setJsonEntity(Strings.toString(stoppedDfBuilder.build()));

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMigrationIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMigrationIT.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.upgrades;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
+import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
+import org.elasticsearch.xpack.core.ml.job.config.Detector;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.test.rest.XPackRestTestHelper;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+
+public class MlMigrationIT extends AbstractUpgradeTestCase {
+
+    private static final String OLD_CLUSTER_OPEN_JOB_ID = "migration-old-cluster-open-job";
+    private static final String OLD_CLUSTER_STARTED_DATAFEED_ID = "migration-old-cluster-started-datafeed";
+    private static final String OLD_CLUSTER_CLOSED_JOB_ID = "migration-old-cluster-closed-job";
+    private static final String OLD_CLUSTER_STOPPED_DATAFEED_ID = "migration-old-cluster-stopped-datafeed";
+
+
+    @Override
+    protected Collection<String> templatesToWaitFor() {
+        List<String> templatesToWaitFor = XPackRestTestHelper.ML_POST_V660_TEMPLATES;
+
+        // If upgrading from a version prior to v6.6.0 the set of templates
+        // to wait for is different
+        if (CLUSTER_TYPE == ClusterType.OLD) {
+            String versionProperty = System.getProperty("tests.upgrade_from_version");
+            if (versionProperty == null) {
+                throw new IllegalStateException("System property 'tests.upgrade_from_version' not set, cannot start tests");
+            }
+
+            Version upgradeFromVersion = Version.fromString(versionProperty);
+            if (upgradeFromVersion.before(Version.V_6_6_0)) {
+                templatesToWaitFor = XPackRestTestHelper.ML_PRE_V660_TEMPLATES;
+            }
+        }
+
+        return templatesToWaitFor;
+    }
+
+    private void waitForClusterHealth() throws IOException {
+        switch (CLUSTER_TYPE) {
+            case OLD:
+            case MIXED:
+                Request waitForYellow = new Request("GET", "/_cluster/health");
+                waitForYellow.addParameter("wait_for_nodes", "3");
+                waitForYellow.addParameter("wait_for_status", "yellow");
+                client().performRequest(waitForYellow);
+                break;
+            case UPGRADED:
+                Request waitForGreen = new Request("GET", "/_cluster/health");
+                waitForGreen.addParameter("wait_for_nodes", "3");
+                waitForGreen.addParameter("wait_for_status", "green");
+                // wait for long enough that we give delayed unassigned shards to stop being delayed
+                waitForGreen.addParameter("timeout", "70s");
+                waitForGreen.addParameter("level", "shards");
+                client().performRequest(waitForGreen);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        }
+    }
+
+    private void createTestIndex() throws IOException {
+        Request createTestIndex = new Request("PUT", "/airline-data");
+        createTestIndex.setJsonEntity("{\"mappings\": { \"doc\": {\"properties\": {" +
+                    "\"time\": {\"type\": \"date\"}," +
+                    "\"airline\": {\"type\": \"keyword\"}," +
+                    "\"responsetime\": {\"type\": \"float\"}" +
+                "}}}}");
+        client().performRequest(createTestIndex);
+    }
+
+    public void testConfigMigration() throws IOException {
+        if (UPGRADED_FROM_VERSION.onOrAfter(Version.V_6_6_0)) {
+            // We are testing migration of ml config defined in the clusterstate
+            // in versions before V6.6.0. There is no point testing later versions
+            // as the config will be written to index documents
+            logger.info("Testing migration of ml config in version [" + UPGRADED_FROM_VERSION + "] is a no-op");
+            return;
+        }
+
+        waitForClusterHealth();
+
+        switch (CLUSTER_TYPE) {
+            case OLD:
+                createTestIndex();
+                oldClusterTests();
+                break;
+            case MIXED:
+                mixedClusterTests();
+                break;
+            case UPGRADED:
+                upgradedClusterTests();
+                break;
+            default:
+                throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        }
+    }
+
+    private void oldClusterTests() throws IOException {
+        Detector.Builder d = new Detector.Builder("metric", "responsetime");
+        d.setByFieldName("airline");
+        AnalysisConfig.Builder analysisConfig = new AnalysisConfig.Builder(Collections.singletonList(d.build()));
+        analysisConfig.setBucketSpan(TimeValue.timeValueMinutes(10));
+        Job.Builder openJob = new Job.Builder(OLD_CLUSTER_OPEN_JOB_ID);
+        openJob.setAnalysisConfig(analysisConfig);
+        openJob.setDataDescription(new DataDescription.Builder());
+
+        Request putOpenJob = new Request("PUT", "_xpack/ml/anomaly_detectors/" + OLD_CLUSTER_OPEN_JOB_ID);
+        putOpenJob.setJsonEntity(Strings.toString(openJob));
+        client().performRequest(putOpenJob);
+
+        Request openOpenJob = new Request("POST", "_xpack/ml/anomaly_detectors/" + OLD_CLUSTER_OPEN_JOB_ID + "/_open");
+        client().performRequest(openOpenJob);
+
+        DatafeedConfig.Builder dfBuilder = new DatafeedConfig.Builder(OLD_CLUSTER_STARTED_DATAFEED_ID, OLD_CLUSTER_OPEN_JOB_ID);
+        if (UPGRADED_FROM_VERSION.before(Version.V_6_6_0)) {
+            dfBuilder.setDelayedDataCheckConfig(null);
+        }
+        dfBuilder.setIndices(Collections.singletonList("airline-data"));
+        dfBuilder.setTypes(Collections.singletonList("doc"));
+
+        Request putDatafeed = new Request("PUT", "_xpack/ml/datafeeds/" + OLD_CLUSTER_STARTED_DATAFEED_ID);
+        putDatafeed.setJsonEntity(Strings.toString(dfBuilder.build()));
+        client().performRequest(putDatafeed);
+
+        Request startDatafeed = new Request("POST", "_xpack/ml/datafeeds/" + OLD_CLUSTER_STARTED_DATAFEED_ID + "/_start");
+        client().performRequest(startDatafeed);
+
+        Job.Builder closedJob = new Job.Builder(OLD_CLUSTER_CLOSED_JOB_ID);
+        closedJob.setAnalysisConfig(analysisConfig);
+        closedJob.setDataDescription(new DataDescription.Builder());
+
+        Request putClosedJob = new Request("PUT", "_xpack/ml/anomaly_detectors/" + OLD_CLUSTER_CLOSED_JOB_ID);
+        putClosedJob.setJsonEntity(Strings.toString(closedJob));
+        client().performRequest(putClosedJob);
+
+        DatafeedConfig.Builder stoppedDfBuilder = new DatafeedConfig.Builder(OLD_CLUSTER_STOPPED_DATAFEED_ID, OLD_CLUSTER_CLOSED_JOB_ID);
+        if (UPGRADED_FROM_VERSION.before(Version.V_6_6_0)) {
+            stoppedDfBuilder.setDelayedDataCheckConfig(null);
+        }
+        stoppedDfBuilder.setIndices(Collections.singletonList("airline-data"));
+
+        Request putStoppedDatafeed = new Request("PUT", "_xpack/ml/datafeeds/" + OLD_CLUSTER_STOPPED_DATAFEED_ID);
+        putStoppedDatafeed.setJsonEntity(Strings.toString(stoppedDfBuilder.build()));
+        client().performRequest(putStoppedDatafeed);
+
+        assertConfigInClusterState();
+    }
+
+    private void mixedClusterTests() throws IOException {
+        assertConfigInClusterState();
+        checkJobs();
+        checkDatafeeds();
+    }
+
+    private void upgradedClusterTests() throws IOException {
+        checkJobs();
+        checkDatafeeds();
+
+        // try to update and catch potential response exception
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private void checkJobs() throws IOException {
+        // Wildcard expansion of jobs and datafeeds was added in 6.1.0
+        if (UPGRADED_FROM_VERSION.before(Version.V_6_1_0) && CLUSTER_TYPE != ClusterType.UPGRADED) {
+            return;
+        }
+
+        Request getJobs = new Request("GET", "_xpack/ml/anomaly_detectors/migration*");
+        Response response = client().performRequest(getJobs);
+
+        Map<String, Object> jobs = entityAsMap(response);
+        List<Map<String, Object>> jobConfigs =
+                (List<Map<String, Object>>) XContentMapValues.extractValue("jobs", jobs);
+
+        assertThat(jobConfigs, hasSize(2));
+        assertEquals(OLD_CLUSTER_CLOSED_JOB_ID, jobConfigs.get(0).get("job_id"));
+        assertEquals(OLD_CLUSTER_OPEN_JOB_ID, jobConfigs.get(1).get("job_id"));
+
+        Request getJobStats = new Request("GET", "_xpack/ml/anomaly_detectors/migration*/_stats");
+        response = client().performRequest(getJobStats);
+
+        Map<String, Object> stats = entityAsMap(response);
+        List<Map<String, Object>> jobStats =
+                (List<Map<String, Object>>) XContentMapValues.extractValue("jobs", stats);
+        assertThat(jobStats, hasSize(2));
+
+        assertEquals(OLD_CLUSTER_CLOSED_JOB_ID, XContentMapValues.extractValue("job_id", jobStats.get(0)));
+        assertEquals("closed", XContentMapValues.extractValue("state", jobStats.get(0)));
+        assertThat((String)XContentMapValues.extractValue("assignment_explanation", jobStats.get(0)), isEmptyOrNullString());
+
+        assertEquals(OLD_CLUSTER_OPEN_JOB_ID, XContentMapValues.extractValue("job_id", jobStats.get(1)));
+        assertEquals("opened", XContentMapValues.extractValue("state", jobStats.get(1)));
+        assertThat((String)XContentMapValues.extractValue("assignment_explanation", jobStats.get(1)), isEmptyOrNullString());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void checkDatafeeds() throws IOException {
+        // Wildcard expansion of jobs and datafeeds was added in 6.1.0
+        if (UPGRADED_FROM_VERSION.before(Version.V_6_1_0) && CLUSTER_TYPE != ClusterType.UPGRADED) {
+            return;
+        }
+
+        Request getDatafeeds = new Request("GET", "_xpack/ml/datafeeds/migration*");
+        Response response = client().performRequest(getDatafeeds);
+        List<Map<String, Object>> configs =
+                (List<Map<String, Object>>) XContentMapValues.extractValue("datafeeds", entityAsMap(response));
+        assertThat(configs, hasSize(2));
+        assertEquals(OLD_CLUSTER_STARTED_DATAFEED_ID, XContentMapValues.extractValue("datafeed_id", configs.get(0)));
+        assertEquals(OLD_CLUSTER_STOPPED_DATAFEED_ID, XContentMapValues.extractValue("datafeed_id", configs.get(1)));
+
+        Request getDatafeedStats = new Request("GET", "_xpack/ml/datafeeds/migration*/_stats");
+        response = client().performRequest(getDatafeedStats);
+        configs = (List<Map<String, Object>>) XContentMapValues.extractValue("datafeeds", entityAsMap(response));
+        assertThat(configs, hasSize(2));
+        assertEquals(OLD_CLUSTER_STARTED_DATAFEED_ID, XContentMapValues.extractValue("datafeed_id", configs.get(0)));
+        assertEquals("started", XContentMapValues.extractValue("state", configs.get(0)));
+        assertEquals(OLD_CLUSTER_STOPPED_DATAFEED_ID, XContentMapValues.extractValue("datafeed_id", configs.get(1)));
+        assertEquals("stopped", XContentMapValues.extractValue("state", configs.get(1)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertConfigInClusterState() throws IOException {
+        Request getClusterState = new Request("GET", "/_cluster/state/metadata");
+        Response response = client().performRequest(getClusterState);
+
+        List<Map<String, Object>> jobs =
+                (List<Map<String, Object>>) XContentMapValues.extractValue("metadata.ml.jobs", entityAsMap(response));
+        assertThat(jobs, not(empty()));
+        Optional<Object> job = jobs.stream().map(map -> map.get("job_id")).filter(id -> id.equals(OLD_CLUSTER_OPEN_JOB_ID)).findFirst();
+        assertTrue(job.isPresent());
+        job = jobs.stream().map(map -> map.get("job_id")).filter(id -> id.equals(OLD_CLUSTER_CLOSED_JOB_ID)).findFirst();
+        assertTrue(job.isPresent());
+
+        List<Map<String, Object>> datafeeds =
+                (List<Map<String, Object>>) XContentMapValues.extractValue("metadata.ml.datafeeds", entityAsMap(response));
+        assertThat(datafeeds, not(empty()));
+        Optional<Object> datafeed = datafeeds.stream().map(map -> map.get("datafeed_id"))
+                .filter(id -> id.equals(OLD_CLUSTER_STARTED_DATAFEED_ID)).findFirst();
+        assertTrue(datafeed.isPresent());
+        datafeed = datafeeds.stream().map(map -> map.get("datafeed_id"))
+                .filter(id -> id.equals(OLD_CLUSTER_STOPPED_DATAFEED_ID)).findFirst();
+        assertTrue(datafeed.isPresent());
+    }
+
+
+}

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMigrationIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMigrationIT.java
@@ -242,7 +242,10 @@ public class MlMigrationIT extends AbstractUpgradeTestCase {
 
         checkJobsMarkedAsMigrated(Arrays.asList(OLD_CLUSTER_CLOSED_JOB_ID, OLD_CLUSTER_OPEN_JOB_ID));
 
-        // TODO delete
+        Request deleteJob = new Request("DELETE", "_xpack/ml/anomaly_detectors/" + OLD_CLUSTER_OPEN_JOB_ID);
+        client().performRequest(deleteJob);
+        Request deleteDatafeed = new Request("DELETE", "_xpack/ml/datafeeds/" + OLD_CLUSTER_STARTED_DATAFEED_ID);
+        client().performRequest(deleteDatafeed);
     }
 
     @SuppressWarnings("unchecked")
@@ -433,7 +436,8 @@ public class MlMigrationIT extends AbstractUpgradeTestCase {
     private boolean openMigratedJob(String jobId) throws IOException {
         // opening a job should be rejected prior to migration
         Request openJob = new Request("POST", "_xpack/ml/anomaly_detectors/" + jobId + "/_open");
-        return updateJobExpectingSuccessOr503(jobId, openJob, "cannot open job as the configuration [" + jobId + "] is temporarily pending migration", false);
+        return updateJobExpectingSuccessOr503(jobId, openJob, "cannot open job as the configuration [" +
+                jobId + "] is temporarily pending migration", false);
     }
 
     private boolean startMigratedDatafeed(String datafeedId) throws IOException {

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/60_ml_config_migration.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/60_ml_config_migration.yml
@@ -21,8 +21,6 @@
   - is_false: jobs.0.node
   - match: { jobs.1.job_id: migration-old-cluster-open-job}
   - match: { jobs.1.state: opened }
-#  TODO can't test for assignment here as the job may not be re-allocated yet
-#  - is_true: jobs.1.node
   - is_false: jobs.1.assignment_explanation
 
   - do:
@@ -39,8 +37,6 @@
         datafeed_id: migration*
   - match: { datafeeds.0.datafeed_id: migration-old-cluster-started-datafeed}
   - match: { datafeeds.0.state: started }
-#  TODO can't test for assignment here as the datafeed may not be re-allocated yet
-#  - is_true: datafeeds.0.node
   - match: { datafeeds.1.datafeed_id: migration-old-cluster-stopped-datafeed}
   - match: { datafeeds.1.state: stopped }
   - is_false: datafeeds.1.node

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/60_ml_config_migration.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/60_ml_config_migration.yml
@@ -25,8 +25,6 @@ setup:
   - is_false: jobs.0.node
   - match: { jobs.1.job_id: migration-old-cluster-open-job }
   - match: { jobs.1.state: opened }
-#  TODO can't test for assignment here as the job may not be re-allocated yet
-#  - is_true: jobs.1.node
   - is_false: jobs.1.assignment_explanation
 
   - do:
@@ -43,8 +41,6 @@ setup:
         datafeed_id: migration*
   - match: { datafeeds.0.datafeed_id: migration-old-cluster-started-datafeed }
   - match: { datafeeds.0.state: started }
-#  TODO can't test for assignment here as the datafeed may not be re-allocated yet
-#  - is_true: datafeeds.0.node
   - match: { datafeeds.1.datafeed_id: migration-old-cluster-stopped-datafeed }
   - match: { datafeeds.1.state: stopped }
   - is_false: datafeeds.1.node
@@ -61,35 +57,3 @@ setup:
       xpack.ml.get_jobs:
         job_id: migration-old-cluster-open-job
   - is_true: jobs.0.finished_time
-
-# TODO cannot test delete as config may be migrating
-#  - do:
-#      xpack.ml.delete_datafeed:
-#        datafeed_id: migration-old-cluster-started-datafeed
-#
-#  - do:
-#      xpack.ml.delete_job:
-#        job_id: migration-old-cluster-open-job
-#
-#  - do:
-#      catch: missing
-#      xpack.ml.get_jobs:
-#        job_id: migration-old-cluster-open-job
-#
-#  - do:
-#      xpack.ml.delete_datafeed:
-#        datafeed_id: migration-old-cluster-stopped-datafeed
-#
-#  - do:
-#      xpack.ml.delete_job:
-#        job_id: migration-old-cluster-closed-job
-#
-#  - do:
-#      xpack.ml.get_jobs:
-#          job_id: migration*
-#  - match: { count: 0 }
-#
-#  - do:
-#      xpack.ml.get_datafeeds:
-#        datafeed_id: migration*
-#  - match: { count: 0 }


### PR DESCRIPTION
Updates to jobs and datafeeds are blocked if the config is eligible for migration. The conditions that satisfy this criteria are:
1. All nodes are v6.6.0 or above
2. Config is in the clusterstate
3. Config does not have an associated persistent task

A 503 service unavailable status code is returned in this situation. 

Because of this the rolling upgrade tests which modify a job/datafeed must accept either a successful update or an 503 error as a test pass. This is impossible with the yml tests so I've created `MlMigrationIT` as a more flexible test. 