### PR TITLE
[ML-DataFrame] add generation to dataframe state

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobState.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobState.java
@@ -34,16 +34,18 @@ public class DataFrameJobState implements Task.Status, PersistentTaskState {
     public static final String NAME = DataFrame.TASK_NAME;
 
     private final IndexerState state;
+    private final long generation;
 
     @Nullable
     private final SortedMap<String, Object> currentPosition;
 
     private static final ParseField STATE = new ParseField("job_state");
     private static final ParseField CURRENT_POSITION = new ParseField("current_position");
+    private static final ParseField GENERATION = new ParseField("generation");
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<DataFrameJobState, Void> PARSER = new ConstructingObjectParser<>(NAME,
-            args -> new DataFrameJobState((IndexerState) args[0], (HashMap<String, Object>) args[1]));
+            args -> new DataFrameJobState((IndexerState) args[0], (HashMap<String, Object>) args[1], (long) args[2]));
 
     static {
         PARSER.declareField(constructorArg(), p -> {
@@ -62,16 +64,19 @@ public class DataFrameJobState implements Task.Status, PersistentTaskState {
             }
             throw new IllegalArgumentException("Unsupported token [" + p.currentToken() + "]");
         }, CURRENT_POSITION, ObjectParser.ValueType.VALUE_OBJECT_ARRAY);
+        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), GENERATION);
     }
 
-    public DataFrameJobState(IndexerState state, @Nullable Map<String, Object> position) {
+    public DataFrameJobState(IndexerState state, @Nullable Map<String, Object> position, long generation) {
         this.state = state;
         this.currentPosition = position == null ? null : Collections.unmodifiableSortedMap(new TreeMap<>(position));
+        this.generation = generation;
     }
 
     public DataFrameJobState(StreamInput in) throws IOException {
         state = IndexerState.fromStream(in);
         currentPosition = in.readBoolean() ? Collections.unmodifiableSortedMap(new TreeMap<>(in.readMap())) : null;
+        generation = in.readLong();
     }
 
     public IndexerState getIndexerState() {
@@ -80,6 +85,10 @@ public class DataFrameJobState implements Task.Status, PersistentTaskState {
 
     public Map<String, Object> getPosition() {
         return currentPosition;
+    }
+
+    public long getGeneration() {
+        return generation;
     }
 
     public static DataFrameJobState fromXContent(XContentParser parser) {
@@ -97,6 +106,7 @@ public class DataFrameJobState implements Task.Status, PersistentTaskState {
         if (currentPosition != null) {
             builder.field(CURRENT_POSITION.getPreferredName(), currentPosition);
         }
+        builder.field(GENERATION.getPreferredName(), generation);
         builder.endObject();
         return builder;
     }
@@ -113,6 +123,7 @@ public class DataFrameJobState implements Task.Status, PersistentTaskState {
         if (currentPosition != null) {
             out.writeMap(currentPosition);
         }
+        out.writeLong(generation);
     }
 
     @Override
@@ -127,11 +138,12 @@ public class DataFrameJobState implements Task.Status, PersistentTaskState {
 
         DataFrameJobState that = (DataFrameJobState) other;
 
-        return Objects.equals(this.state, that.state) && Objects.equals(this.currentPosition, that.currentPosition);
+        return Objects.equals(this.state, that.state) && Objects.equals(this.currentPosition, that.currentPosition)
+                && this.generation == that.generation;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(state, currentPosition);
+        return Objects.hash(state, currentPosition, generation);
     }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobTask.java
@@ -74,7 +74,7 @@ public class DataFrameJobTask extends AllocatedPersistentTask implements Schedul
         }
 
         this.indexer = new ClientDataFrameIndexer(job, new AtomicReference<>(initialState), initialPosition, client);
-        this.generation = new AtomicReference<>(0l);
+        this.generation = new AtomicReference<>(0L);
     }
 
     public DataFrameJobConfig getConfig() {
@@ -238,7 +238,7 @@ public class DataFrameJobTask extends AllocatedPersistentTask implements Schedul
 
             if(indexerState.equals(IndexerState.STARTED)) {
                 // if the indexer resets the state to started, it means it is done, so increment the generation
-                generation.compareAndSet(0l, 1l);
+                generation.compareAndSet(0L, 1L);
             }
 
             final DataFrameJobState state = new DataFrameJobState(indexerState, getPosition(), generation.get());

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobStateTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobStateTests.java
@@ -18,7 +18,7 @@ import java.util.Map;
 public class DataFrameJobStateTests extends AbstractSerializingTestCase<DataFrameJobState> {
 
     public static DataFrameJobState randomDataFrameJobState() {
-        return new DataFrameJobState(randomFrom(IndexerState.values()), randomPosition());
+        return new DataFrameJobState(randomFrom(IndexerState.values()), randomPosition(), randomLongBetween(0,10));
     }
 
     @Override


### PR DESCRIPTION
add a generation field to the dataframe state, the generation gets increased after every complete data frame indexing (aka builder run)

Notes:

 - for the first version, generation can be either 0 (not finished) or 1 (finished), so it's conceptually a boolean, but in future the idea is to inc it after every run
 - this is a prerequisite for https://github.com/elastic/elasticsearch/pull/34554
 - probably not the final design