### PR TITLE
Build Docker images if the binary exists

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -245,9 +245,16 @@ class BuildPlugin implements Plugin<Project> {
              *
              *  If either of these fail, we fail the build.
              */
+
+            // check if the Docker binary exists and record its path
+            final List<String> maybeDockerBinaries = ['/usr/bin/docker', '/usr/local/bin/docker']
+            final String dockerBinary = maybeDockerBinaries.find { it -> new File(it).exists() }
+
             final boolean buildDocker
             final String buildDockerProperty = System.getProperty("build.docker")
-            if (buildDockerProperty == null || buildDockerProperty == "true") {
+            if (buildDockerProperty == null) {
+                buildDocker = dockerBinary != null
+            } else if (buildDockerProperty == "true") {
                 buildDocker = true
             } else if (buildDockerProperty == "false") {
                 buildDocker = false
@@ -258,10 +265,6 @@ class BuildPlugin implements Plugin<Project> {
             rootProject.rootProject.ext.buildDocker = buildDocker
             rootProject.rootProject.ext.requiresDocker = []
             rootProject.gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
-                // check if the Docker binary exists and record its path
-                final List<String> maybeDockerBinaries = ['/usr/bin/docker', '/usr/local/bin/docker']
-                final String dockerBinary = maybeDockerBinaries.find { it -> new File(it).exists() }
-
                 int exitCode
                 String dockerErrorOutput
                 if (dockerBinary == null) {


### PR DESCRIPTION
This commit changes the Docker assemble tasks so that they attempt to build Docker if the Docker binaries exist, of if build.docker is set to true. If the Docker binaries do not exist, or if build.docker is set to false, then no attempt is made to build the Docker images.

Relates #36414