### PR TITLE
Deprecation check for percolator.map_unmapped_fields_as_string

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -49,6 +49,7 @@ public class DeprecationChecks {
         Collections.unmodifiableList(Arrays.asList(
             IndexDeprecationChecks::oldIndicesCheck,
             IndexDeprecationChecks::delimitedPayloadFilterCheck,
+            IndexDeprecationChecks::percolatorUnmappedFieldsAsStringCheck,
             IndexDeprecationChecks::indexNameCheck
             ));
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -116,4 +116,17 @@ public class IndexDeprecationChecks {
         }
         return null;
     }
+
+    static DeprecationIssue percolatorUnmappedFieldsAsStringCheck(IndexMetaData indexMetaData) {
+        if (indexMetaData.getSettings().hasValue("index.percolator.map_unmapped_fields_as_text")) {
+            String settingValue = indexMetaData.getSettings().get("index.percolator.map_unmapped_fields_as_text");
+            return new DeprecationIssue(DeprecationIssue.Level.WARNING,
+                "Setting index.percolator.map_unmapped_fields_as_text has been renamed",
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                    "#_percolator",
+                "The index setting [index.percolator.map_unmapped_fields_as_text] currently set to [" + settingValue +
+                    "] been removed in favor of [index.percolator.map_unmapped_fields_as_text].");
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
Adds a deprecation check for the removed setting
`index.percolator.map_unmapped_fields_as_string`

Relates to https://github.com/elastic/elasticsearch/issues/36024 and https://github.com/elastic/elasticsearch/pull/28060