### PR TITLE
Add default methods to DocValueFormat

### DIFF
--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -54,7 +54,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.LongSupplier;
 
 public class ICUCollationKeywordFieldMapper extends FieldMapper {
 
@@ -187,17 +186,7 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
             }
 
             @Override
-            public void writeTo(StreamOutput out) throws IOException {
-            }
-
-            @Override
-            public String format(long value) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public String format(double value) {
-                throw new UnsupportedOperationException();
+            public void writeTo(StreamOutput out) {
             }
 
             @Override
@@ -206,16 +195,6 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
                 char[] encoded = new char[encodedLength];
                 IndexableBinaryStringTools.encode(value.bytes, value.offset, value.length, encoded, 0, encodedLength);
                 return new String(encoded, 0, encodedLength);
-            }
-
-            @Override
-            public long parseLong(String value, boolean roundUp, LongSupplier now) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public double parseDouble(String value, boolean roundUp, LongSupplier now) {
-                throw new UnsupportedOperationException();
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
@@ -52,29 +52,41 @@ public interface DocValueFormat extends NamedWriteable {
     /** Format a long value. This is used by terms and histogram aggregations
      *  to format keys for fields that use longs as a doc value representation
      *  such as the {@code long} and {@code date} fields. */
-    Object format(long value);
+    default Object format(long value) {
+        throw new UnsupportedOperationException();
+    }
 
     /** Format a double value. This is used by terms and stats aggregations
      *  to format keys for fields that use numbers as a doc value representation
      *  such as the {@code long}, {@code double} or {@code date} fields. */
-    Object format(double value);
+    default Object format(double value) {
+        throw new UnsupportedOperationException();
+    }
 
     /** Format a binary value. This is used by terms aggregations to format
      *  keys for fields that use binary doc value representations such as the
      *  {@code keyword} and {@code ip} fields. */
-    Object format(BytesRef value);
+    default Object format(BytesRef value) {
+        throw new UnsupportedOperationException();
+    }
 
     /** Parse a value that was formatted with {@link #format(long)} back to the
      *  original long value. */
-    long parseLong(String value, boolean roundUp, LongSupplier now);
+    default long parseLong(String value, boolean roundUp, LongSupplier now) {
+        throw new UnsupportedOperationException();
+    }
 
     /** Parse a value that was formatted with {@link #format(double)} back to
      *  the original double value. */
-    double parseDouble(String value, boolean roundUp, LongSupplier now);
+    default double parseDouble(String value, boolean roundUp, LongSupplier now) {
+        throw new UnsupportedOperationException();
+    }
 
     /** Parse a value that was formatted with {@link #format(BytesRef)} back
      *  to the original BytesRef. */
-    BytesRef parseBytesRef(String value);
+    default BytesRef parseBytesRef(String value) {
+        throw new UnsupportedOperationException();
+    }
 
     DocValueFormat RAW = new DocValueFormat() {
 
@@ -84,7 +96,7 @@ public interface DocValueFormat extends NamedWriteable {
         }
 
         @Override
-        public void writeTo(StreamOutput out) throws IOException {
+        public void writeTo(StreamOutput out) {
         }
 
         @Override
@@ -132,17 +144,7 @@ public interface DocValueFormat extends NamedWriteable {
         }
 
         @Override
-        public void writeTo(StreamOutput out) throws IOException {
-        }
-
-        @Override
-        public Object format(long value) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Object format(double value) {
-            throw new UnsupportedOperationException();
+        public void writeTo(StreamOutput out) {
         }
 
         @Override
@@ -150,16 +152,6 @@ public interface DocValueFormat extends NamedWriteable {
             return Base64.getEncoder()
                     .withoutPadding()
                     .encodeToString(Arrays.copyOfRange(value.bytes, value.offset, value.offset + value.length));
-        }
-
-        @Override
-        public long parseLong(String value, boolean roundUp, LongSupplier now) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public double parseDouble(String value, boolean roundUp, LongSupplier now) {
-            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -211,11 +203,6 @@ public interface DocValueFormat extends NamedWriteable {
         }
 
         @Override
-        public String format(BytesRef value) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public long parseLong(String value, boolean roundUp, LongSupplier now) {
             return parser.parse(value, now, roundUp, DateUtils.dateTimeZoneToZoneId(timeZone));
         }
@@ -223,11 +210,6 @@ public interface DocValueFormat extends NamedWriteable {
         @Override
         public double parseDouble(String value, boolean roundUp, LongSupplier now) {
             return parseLong(value, roundUp, now);
-        }
-
-        @Override
-        public BytesRef parseBytesRef(String value) {
-            throw new UnsupportedOperationException();
         }
     }
 
@@ -239,7 +221,7 @@ public interface DocValueFormat extends NamedWriteable {
         }
 
         @Override
-        public void writeTo(StreamOutput out) throws IOException {
+        public void writeTo(StreamOutput out) {
         }
 
         @Override
@@ -251,26 +233,6 @@ public interface DocValueFormat extends NamedWriteable {
         public String format(double value) {
             return format((long) value);
         }
-
-        @Override
-        public String format(BytesRef value) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long parseLong(String value, boolean roundUp, LongSupplier now) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public double parseDouble(String value, boolean roundUp, LongSupplier now) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public BytesRef parseBytesRef(String value) {
-            throw new UnsupportedOperationException();
-        }
     };
 
     DocValueFormat BOOLEAN = new DocValueFormat() {
@@ -281,22 +243,17 @@ public interface DocValueFormat extends NamedWriteable {
         }
 
         @Override
-        public void writeTo(StreamOutput out) throws IOException {
+        public void writeTo(StreamOutput out) {
         }
 
         @Override
         public Boolean format(long value) {
-            return java.lang.Boolean.valueOf(value != 0);
+            return value != 0;
         }
 
         @Override
         public Boolean format(double value) {
-            return java.lang.Boolean.valueOf(value != 0);
-        }
-
-        @Override
-        public String format(BytesRef value) {
-            throw new UnsupportedOperationException();
+            return value != 0;
         }
 
         @Override
@@ -314,11 +271,6 @@ public interface DocValueFormat extends NamedWriteable {
         public double parseDouble(String value, boolean roundUp, LongSupplier now) {
             return parseLong(value, roundUp, now);
         }
-
-        @Override
-        public BytesRef parseBytesRef(String value) {
-            throw new UnsupportedOperationException();
-        }
     };
 
     DocValueFormat IP = new DocValueFormat() {
@@ -329,17 +281,7 @@ public interface DocValueFormat extends NamedWriteable {
         }
 
         @Override
-        public void writeTo(StreamOutput out) throws IOException {
-        }
-
-        @Override
-        public String format(long value) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public String format(double value) {
-            throw new UnsupportedOperationException();
+        public void writeTo(StreamOutput out) {
         }
 
         @Override
@@ -347,16 +289,6 @@ public interface DocValueFormat extends NamedWriteable {
             byte[] bytes = Arrays.copyOfRange(value.bytes, value.offset, value.offset + value.length);
             InetAddress inet = InetAddressPoint.decode(bytes);
             return NetworkAddress.format(inet);
-        }
-
-        @Override
-        public long parseLong(String value, boolean roundUp, LongSupplier now) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public double parseDouble(String value, boolean roundUp, LongSupplier now) {
-            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -399,7 +331,7 @@ public interface DocValueFormat extends NamedWriteable {
 
         @Override
         public String format(double value) {
-            /**
+            /*
              * Explicitly check for NaN, since it formats to "�" or "NaN" depending on JDK version.
              *
              * Decimal formatter uses the JRE's default symbol list (via Locale.ROOT above).  In JDK8,
@@ -416,11 +348,6 @@ public interface DocValueFormat extends NamedWriteable {
                 return String.valueOf(Double.NaN);
             }
             return format.format(value);
-        }
-
-        @Override
-        public String format(BytesRef value) {
-            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -453,11 +380,6 @@ public interface DocValueFormat extends NamedWriteable {
                 throw new RuntimeException(e);
             }
             return n.doubleValue();
-        }
-
-        @Override
-        public BytesRef parseBytesRef(String value) {
-            throw new UnsupportedOperationException();
         }
 
         @Override


### PR DESCRIPTION
The different `DocValueFormat` implementors throw `UnsupportedOperationException` for methods that they don't support. That is perfectly fine, and quite common as not all implementors support all of the possible formats. This makes it hard though to trace back which implementors support which formats as they all implement the same methods.

This PR introduces default methods in the `DocValueFormat` interface so that all methods throw `UnsupportedOperationException` by default. This way implementors can override only the methods that they specifically support.