### PR TITLE
Joda-Time branch - Fix failing licence test

### DIFF
--- a/x-pack/license-tools/src/test/java/org/elasticsearch/license/licensor/TestUtils.java
+++ b/x-pack/license-tools/src/test/java/org/elasticsearch/license/licensor/TestUtils.java
@@ -21,6 +21,8 @@ import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomBoolean;
@@ -49,7 +51,7 @@ public class TestUtils {
     }
 
     public static String dateMathString(String time, final long now) {
-        return dateFormatter.format(dateMathParser.parse(time, () -> now));
+        return dateFormatter.format(dateMathParser.parse(time, () -> now).atZone(ZoneId.systemDefault()));
     }
 
     public static long dateMath(String time, final long now) {

--- a/x-pack/license-tools/src/test/java/org/elasticsearch/license/licensor/TestUtils.java
+++ b/x-pack/license-tools/src/test/java/org/elasticsearch/license/licensor/TestUtils.java
@@ -21,7 +21,6 @@ import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.UUID;
 
@@ -51,7 +50,7 @@ public class TestUtils {
     }
 
     public static String dateMathString(String time, final long now) {
-        return dateFormatter.format(dateMathParser.parse(time, () -> now).atZone(ZoneId.systemDefault()));
+        return dateFormatter.format(dateMathParser.parse(time, () -> now).atZone(ZoneOffset.UTC));
     }
 
     public static long dateMath(String time, final long now) {


### PR DESCRIPTION
the test is using System.currentMilliseconds and then tries to format
this. Adding default system zoneId to formatter will make the test pass
