### PR TITLE
Security: treat the BwcXPackUser as internal

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/BwcXPackUser.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/BwcXPackUser.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.security.user;
+
+/**
+ * The representation of the XPackUser prior to version 5.6.1. This class should only be used for BWC purposes!
+ */
+@Deprecated
+public final class BwcXPackUser extends User {
+
+    public static final String NAME = XPackUser.NAME;
+    public static final String ROLE_NAME = "superuser";
+    public static final BwcXPackUser INSTANCE = new BwcXPackUser();
+
+    private BwcXPackUser() {
+        super(NAME, ROLE_NAME);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return INSTANCE == o;
+    }
+
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
+    }
+
+    public static boolean is(User user) {
+        return INSTANCE.equals(user);
+    }
+
+    public static boolean is(String principal) {
+        return NAME.equals(principal);
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/ServerTransportFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/ServerTransportFilter.java
@@ -27,6 +27,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.netty4.Netty4TcpChannel;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.user.BwcXPackUser;
 import org.elasticsearch.xpack.core.security.user.KibanaUser;
 import org.elasticsearch.xpack.core.security.user.SystemUser;
 import org.elasticsearch.xpack.core.security.user.User;
@@ -171,8 +172,7 @@ public interface ServerTransportFilter {
 
         private void executeAsOldVersionXPackUser(String securityAction, TransportRequest request, TransportChannel transportChannel,
                                                   ActionListener<Void> listener) {
-            final User xpackUser = new User(XPackUser.NAME, "superuser");
-            executeAsUser(xpackUser, securityAction, request, transportChannel, listener);
+            executeAsUser(BwcXPackUser.INSTANCE, securityAction, request, transportChannel, listener);
         }
 
         private void executeAsUser(User user, String securityAction, TransportRequest request, TransportChannel transportChannel,


### PR DESCRIPTION
This commit is a targeted fix for treating the backwards compatible
x-pack user as an internal user to avoid tripping an assertion during
tests. Previously, this user was created ad hoc when needed but this
change adds a dedicated user to ease checking if the current user is
this user. The XPackUser's permissions and role was changed in 5.6.1
so we need this backwards compatibility when interacting with versions
prior to that.

Closes #36199