### PR TITLE
[DOCS] Adds PRs to 5.6.14 release notes

### DIFF
--- a/docs/reference/release-notes/5.6.14.asciidoc
+++ b/docs/reference/release-notes/5.6.14.asciidoc
@@ -3,4 +3,9 @@
 
 Also see <<breaking-changes-5.6>>.
 
-coming[5.6.14]
+[[bug-5.6.14]]
+[float]
+=== Bug fixes
+
+CRUD::
+* Fix DeleteRequest validation for nullable or empty id/type {pull}35314[#35314] (issue: {issue}35297[#35297])


### PR DESCRIPTION
This PR adds the 5.6.14 PRs to the Elasticsearch release notes. 
