### PR TITLE
DocValueFormat#format(BytesRef) to return String rather than Object

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -295,7 +295,7 @@ public class IpFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Object valueForDisplay(Object value) {
+        public String valueForDisplay(Object value) {
             if (value == null) {
                 return null;
             }

--- a/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
@@ -66,7 +66,7 @@ public interface DocValueFormat extends NamedWriteable {
     /** Format a binary value. This is used by terms aggregations to format
      *  keys for fields that use binary doc value representations such as the
      *  {@code keyword} and {@code ip} fields. */
-    default Object format(BytesRef value) {
+    default String format(BytesRef value) {
         throw new UnsupportedOperationException();
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -363,7 +363,7 @@ public class InternalComposite
      * If the format is equals to {@link DocValueFormat#RAW}, the object is returned as is
      * for numbers and a string for {@link BytesRef}s.
      */
-    static Object formatObject(Object obj, DocValueFormat format) {
+    private static Object formatObject(Object obj, DocValueFormat format) {
         if (obj == null) {
             return null;
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
@@ -83,7 +83,7 @@ public class SignificantStringTerms extends InternalMappedSignificantTerms<Signi
 
         @Override
         public String getKeyAsString() {
-            return format.format(termBytes).toString();
+            return format.format(termBytes);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
@@ -151,7 +151,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
     }
 
     public long getBackgroundFrequency(BytesRef termBytes) throws IOException {
-        String value = config.format().format(termBytes).toString();
+        String value = config.format().format(termBytes);
         return getBackgroundFrequency(value);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTextAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTextAggregatorFactory.java
@@ -139,7 +139,7 @@ public class SignificantTextAggregatorFactory extends AggregatorFactory<Signific
     }
 
     public long getBackgroundFrequency(BytesRef termBytes) throws IOException {
-        String value = format.format(termBytes).toString();
+        String value = format.format(termBytes);
         return getBackgroundFrequency(value);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
@@ -23,9 +23,9 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
-import org.elasticsearch.search.aggregations.BucketOrder;
 
 import java.io.IOException;
 import java.util.List;
@@ -80,7 +80,7 @@ public class StringTerms extends InternalMappedTerms<StringTerms, StringTerms.Bu
 
         @Override
         public String getKeyAsString() {
-            return format.format(termBytes).toString();
+            return format.format(termBytes);
         }
 
         @Override


### PR DESCRIPTION
All the implementors of this method return a `String`, hence the return type can change from `Object` to `String`. This is the case only for formatting `BytesRef`, while for other types (long and double) implementors may indeed return different types.

This is also more aligned with `parseBytesRef` which does the opposite and takes a `String` as an argument (the previously formatted value)