### PR TITLE
Deprecation check for HTTP pipelining

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -40,6 +40,7 @@ public class DeprecationChecks {
         Collections.unmodifiableList(Arrays.asList(
             NodeDeprecationChecks::httpEnabledSettingRemoved,
             NodeDeprecationChecks::tribeNodeCheck,
+            NodeDeprecationChecks::httpPipeliningCheck,
             NodeDeprecationChecks::azureRepositoryChanges,
             NodeDeprecationChecks::gcsRepositoryChanges,
             NodeDeprecationChecks::fileDiscoveryPluginRemoved

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.deprecation;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.common.network.NetworkModule;
+import org.elasticsearch.http.HttpTransportSettings;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 
 import java.util.List;
@@ -45,6 +46,21 @@ public class NodeDeprecationChecks {
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
                     "#_tribe_node_removed",
                 "nodes with tribe node settings: " + nodesFound);
+        }
+        return null;
+    }
+
+    static DeprecationIssue httpPipeliningCheck(List<NodeInfo> nodeInfos, List<NodeStats> nodeStats) {
+        List<String> nodesFound = nodeInfos.stream()
+            .filter(nodeInfo -> nodeInfo.getSettings().hasValue(HttpTransportSettings.SETTING_PIPELINING.getKey()))
+            .map(nodeInfo -> nodeInfo.getNode().getName())
+            .collect(Collectors.toList());
+        if (nodesFound.size() > 0) {
+            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
+                "HTTP pipelining setting removed as pipelining is now mandatory",
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+                    "#remove-http-pipelining-setting",
+                "nodes with http.pipelining set: " + nodesFound);
         }
         return null;
     }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -78,6 +78,15 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         assertSettingsAndIssue(tribeSetting, randomAlphaOfLength(5), expected);
     }
 
+    public void testHttpPipeliningCheck() {
+        DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
+            "HTTP pipelining setting removed as pipelining is now mandatory",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+                "#remove-http-pipelining-setting",
+            "nodes with http.pipelining set: [node_check]");
+        assertSettingsAndIssue("http.pipelining", Boolean.toString(randomBoolean()), expected);
+    }
+
     public void testAzurePluginCheck() {
         Version esVersion = VersionUtils.randomVersionBetween(random(), Version.V_6_0_0, Version.CURRENT);
         PluginInfo deprecatedPlugin = new PluginInfo(


### PR DESCRIPTION
Adds a deprecation check for the removed HTTP pipelining toggle.

Relates to https://github.com/elastic/elasticsearch/issues/36024 and https://github.com/elastic/elasticsearch/pull/30695