### PR TITLE
fix MultiValuesSourceFieldConfig toXContent

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
@@ -207,7 +207,9 @@ public abstract class MultiValuesSourceAggregationBuilder<VS extends ValuesSourc
     public final XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         if (fields != null) {
-            builder.field(CommonFields.FIELDS.getPreferredName(), fields);
+            for (Map.Entry<String, MultiValuesSourceFieldConfig> fieldEntry : fields.entrySet()) {
+                builder.field(fieldEntry.getKey(), fieldEntry.getValue());
+            }
         }
         if (format != null) {
             builder.field(CommonFields.FORMAT.getPreferredName(), format);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceFieldConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceFieldConfig.java
@@ -25,16 +25,17 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ObjectParser;
-import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.script.Script;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.function.BiFunction;
 
-public class MultiValuesSourceFieldConfig implements Writeable, ToXContentFragment {
+public class MultiValuesSourceFieldConfig implements Writeable, ToXContentObject {
     private String fieldName;
     private Object missing;
     private Script script;
@@ -78,7 +79,7 @@ public class MultiValuesSourceFieldConfig implements Writeable, ToXContentFragme
     }
 
     public MultiValuesSourceFieldConfig(StreamInput in) throws IOException {
-        this.fieldName = in.readString();
+        this.fieldName = in.readOptionalString();
         this.missing = in.readGenericValue();
         this.script = in.readOptionalWriteable(Script::new);
         this.timeZone = in.readOptionalTimeZone();
@@ -102,7 +103,7 @@ public class MultiValuesSourceFieldConfig implements Writeable, ToXContentFragme
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(fieldName);
+        out.writeOptionalString(fieldName);
         out.writeGenericValue(missing);
         out.writeOptionalWriteable(script);
         out.writeOptionalTimeZone(timeZone);
@@ -110,6 +111,7 @@ public class MultiValuesSourceFieldConfig implements Writeable, ToXContentFragme
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
         if (missing != null) {
             builder.field(ParseField.CommonFields.MISSING.getPreferredName(), missing);
         }
@@ -120,9 +122,31 @@ public class MultiValuesSourceFieldConfig implements Writeable, ToXContentFragme
             builder.field(ParseField.CommonFields.FIELD.getPreferredName(), fieldName);
         }
         if (timeZone != null) {
-            builder.field(ParseField.CommonFields.TIME_ZONE.getPreferredName(), timeZone);
+            builder.field(ParseField.CommonFields.TIME_ZONE.getPreferredName(), timeZone.getID());
         }
+        builder.endObject();
         return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MultiValuesSourceFieldConfig that = (MultiValuesSourceFieldConfig) o;
+        return Objects.equals(fieldName, that.fieldName)
+            && Objects.equals(missing, that.missing)
+            && Objects.equals(script, that.script)
+            && Objects.equals(timeZone, that.timeZone);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldName, missing, script, timeZone);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
     }
 
     public static class Builder {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceFieldConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceFieldConfig.java
@@ -79,7 +79,7 @@ public class MultiValuesSourceFieldConfig implements Writeable, ToXContentObject
     }
 
     public MultiValuesSourceFieldConfig(StreamInput in) throws IOException {
-        this.fieldName = in.readOptionalString();
+        this.fieldName = in.readString();
         this.missing = in.readGenericValue();
         this.script = in.readOptionalWriteable(Script::new);
         this.timeZone = in.readOptionalTimeZone();
@@ -103,7 +103,7 @@ public class MultiValuesSourceFieldConfig implements Writeable, ToXContentObject
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeOptionalString(fieldName);
+        out.writeString(fieldName);
         out.writeGenericValue(missing);
         out.writeOptionalWriteable(script);
         out.writeOptionalTimeZone(timeZone);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/weighted_avg/WeightedAvgAggregationBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/weighted_avg/WeightedAvgAggregationBuilderTests.java
@@ -19,22 +19,21 @@
 
 package org.elasticsearch.search.aggregations.metrics.weighted_avg;
 
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchModule;
-import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.metrics.WeightedAvgAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.MultiValuesSourceFieldConfig;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Collections;
+
+import static org.hamcrest.Matchers.hasSize;
 
 public class WeightedAvgAggregationBuilderTests extends AbstractSerializingTestCase<WeightedAvgAggregationBuilder> {
     String aggregationName;
@@ -52,13 +51,14 @@ public class WeightedAvgAggregationBuilderTests extends AbstractSerializingTestC
 
     @Override
     protected WeightedAvgAggregationBuilder doParseInstance(XContentParser parser) throws IOException {
-        parser.nextToken();
-        AggregatorFactories.Builder builders = AggregatorFactories.parseAggregators(parser);
-        if (builders.getAggregatorFactories().size() == 1) {
-            AggregationBuilder builder = builders.getAggregatorFactories().iterator().next();
-            return (WeightedAvgAggregationBuilder) builder;
-        }
-        return null;
+        assertSame(XContentParser.Token.START_OBJECT, parser.nextToken());
+        AggregatorFactories.Builder parsed = AggregatorFactories.parseAggregators(parser);
+        assertThat(parsed.getAggregatorFactories(), hasSize(1));
+        assertThat(parsed.getPipelineAggregatorFactories(), hasSize(0));
+        WeightedAvgAggregationBuilder agg = (WeightedAvgAggregationBuilder) parsed.getAggregatorFactories().iterator().next();
+        assertNull(parser.nextToken());
+        assertNotNull(agg);
+        return agg;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/weighted_avg/WeightedAvgAggregationBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/weighted_avg/WeightedAvgAggregationBuilderTests.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.metrics.weighted_avg;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.support.MultiValuesSourceFieldConfig;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public class WeightedAvgAggregationBuilderTests extends AbstractSerializingTestCase<WeightedAvgAggregationBuilder> {
+    String aggregationName;
+
+    @Before
+    public void setupName() {
+        aggregationName = randomAlphaOfLength(10);
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, Collections.emptyList());
+        return new NamedXContentRegistry(searchModule.getNamedXContents());
+    }
+
+    @Override
+    protected WeightedAvgAggregationBuilder doParseInstance(XContentParser parser) throws IOException {
+        parser.nextToken();
+        AggregatorFactories.Builder builders = AggregatorFactories.parseAggregators(parser);
+        if (builders.getAggregatorFactories().size() == 1) {
+            AggregationBuilder builder = builders.getAggregatorFactories().iterator().next();
+            return (WeightedAvgAggregationBuilder) builder;
+        }
+        return null;
+    }
+
+    @Override
+    protected WeightedAvgAggregationBuilder createTestInstance() {
+        MultiValuesSourceFieldConfig valueConfig = new MultiValuesSourceFieldConfig.Builder().setFieldName("value_field").build();
+        MultiValuesSourceFieldConfig weightConfig = new MultiValuesSourceFieldConfig.Builder().setFieldName("weight_field").build();
+        WeightedAvgAggregationBuilder aggregationBuilder = new WeightedAvgAggregationBuilder(aggregationName)
+            .value(valueConfig)
+            .weight(weightConfig);
+        return aggregationBuilder;
+    }
+
+    @Override
+    protected Writeable.Reader<WeightedAvgAggregationBuilder> instanceReader() {
+        return WeightedAvgAggregationBuilder::new;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceFieldConfigTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceFieldConfigTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.test.AbstractSerializingTestCase;
-import org.elasticsearch.test.ESTestCase;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
@@ -39,13 +38,11 @@ public class MultiValuesSourceFieldConfigTests extends AbstractSerializingTestCa
 
     @Override
     protected MultiValuesSourceFieldConfig createTestInstance() {
-        boolean hasField = randomBoolean();
-        String field = hasField ? randomAlphaOfLength(10) : null;
-        Script script = hasField ? null : new Script("foo");
+        String field = randomAlphaOfLength(10);
         Object missing = randomBoolean() ? randomAlphaOfLength(10) : null;
         DateTimeZone timeZone = randomBoolean() ? randomDateTimeZone() : null;
         return new MultiValuesSourceFieldConfig.Builder()
-            .setFieldName(field).setMissing(missing).setScript(script).setTimeZone(timeZone).build();
+            .setFieldName(field).setMissing(missing).setScript(null).setTimeZone(timeZone).build();
     }
 
     @Override


### PR DESCRIPTION
This commit turns MultiValuesSourceFieldConfig into a proper
ToXContentObject for easy testing and verification of its
to/from XContent methods.

Closes #36474.