### PR TITLE
Core: Rework multi date formatter merging (#36447)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/joda/Joda.java
+++ b/server/src/main/java/org/elasticsearch/common/joda/Joda.java
@@ -48,10 +48,6 @@ import java.util.Locale;
 
 public class Joda {
 
-    public static JodaDateFormatter forPattern(String input) {
-        return forPattern(input, Locale.ROOT);
-    }
-
     /**
      * Parses a joda based pattern, including some named ones (similar to the built in Joda ISO ones).
      */
@@ -231,27 +227,7 @@ public class Joda {
             formatter = StrictISODateTimeFormat.yearMonth();
         } else if ("strictYearMonthDay".equals(input) || "strict_year_month_day".equals(input)) {
             formatter = StrictISODateTimeFormat.yearMonthDay();
-        } else if (Strings.hasLength(input) && input.contains("||")) {
-                String[] formats = Strings.delimitedListToStringArray(input, "||");
-                DateTimeParser[] parsers = new DateTimeParser[formats.length];
 
-                if (formats.length == 1) {
-                    formatter = forPattern(input, locale).parser;
-                } else {
-                    DateTimeFormatter dateTimeFormatter = null;
-                    for (int i = 0; i < formats.length; i++) {
-                        JodaDateFormatter currentFormatter = forPattern(formats[i], locale);
-                        DateTimeFormatter currentParser = currentFormatter.parser;
-                        if (dateTimeFormatter == null) {
-                            dateTimeFormatter = currentFormatter.printer;
-                        }
-                        parsers[i] = currentParser.getParser();
-                    }
-
-                    DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder()
-                        .append(dateTimeFormatter.withZone(DateTimeZone.UTC).getPrinter(), parsers);
-                    formatter = builder.toFormatter();
-                }
         } else {
             try {
                 formatter = DateTimeFormat.forPattern(input);

--- a/server/src/main/java/org/elasticsearch/common/joda/JodaDateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/joda/JodaDateFormatter.java
@@ -47,7 +47,7 @@ public class JodaDateFormatter implements DateFormatter {
 
     @Override
     public TemporalAccessor parse(String input) {
-        DateTime dt = parser.parseDateTime(input);
+        final DateTime dt = parser.parseDateTime(input);
         return ZonedDateTime.ofInstant(Instant.ofEpochMilli(dt.getMillis()), DateUtils.dateTimeZoneToZoneId(dt.getZone()));
     }
 

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
@@ -19,17 +19,19 @@
 
 package org.elasticsearch.common.time;
 
-import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.joda.Joda;
 import org.joda.time.DateTime;
 
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 
 public interface DateFormatter {
 
@@ -85,7 +87,7 @@ public interface DateFormatter {
      * Return the given millis-since-epoch formatted with this format.
      */
     default String formatMillis(long millis) {
-        return format(Instant.ofEpochMilli(millis));
+        return format(ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC));
     }
 
     /**
@@ -123,94 +125,23 @@ public interface DateFormatter {
      */
     DateMathParser toDateMathParser();
 
-    /**
-     * Merge several date formatters into a single one. Useful if you need to have several formatters with
-     * different formats act as one, for example when you specify a
-     * format like <code>date_hour||epoch_millis</code>
-     *
-     * @param formatters The list of date formatters to be merged together
-     * @return           The new date formtter containing the specified date formatters
-     */
-    static DateFormatter merge(DateFormatter... formatters) {
-        return new MergedDateFormatter(formatters);
+    static DateFormatter forPattern(String input) {
+        return forPattern(input, Locale.ROOT);
     }
 
-    class MergedDateFormatter implements DateFormatter {
-
-        private final String format;
-        private final DateFormatter[] formatters;
-        private final DateMathParser[] dateMathParsers;
-
-        MergedDateFormatter(DateFormatter... formatters) {
-            this.formatters = formatters;
-            this.format = Arrays.stream(formatters).map(DateFormatter::pattern).collect(Collectors.joining("||"));
-            this.dateMathParsers = Arrays.stream(formatters).map(DateFormatter::toDateMathParser).toArray(DateMathParser[]::new);
+    static DateFormatter forPattern(String input, Locale locale) {
+        if (Strings.hasLength(input) == false) {
+            throw new IllegalArgumentException("No date pattern provided");
+        }
+        List<DateFormatter> formatters = new ArrayList<>();
+        for (String pattern : Strings.delimitedListToStringArray(input, "||")) {
+            formatters.add(Joda.forPattern(pattern, locale));
         }
 
-        @Override
-        public TemporalAccessor parse(String input) {
-            DateTimeParseException failure = null;
-            for (DateFormatter formatter : formatters) {
-                try {
-                    return formatter.parse(input);
-                } catch (DateTimeParseException e) {
-                    if (failure == null) {
-                        failure = e;
-                    } else {
-                        failure.addSuppressed(e);
-                    }
-                }
-            }
-            throw failure;
+        if (formatters.size() == 1) {
+            return formatters.get(0);
         }
+        return new DateFormatters.MergedDateFormatter(input, formatters);
 
-        @Override
-        public DateFormatter withZone(ZoneId zoneId) {
-            return new MergedDateFormatter(Arrays.stream(formatters).map(f -> f.withZone(zoneId)).toArray(DateFormatter[]::new));
-        }
-
-        @Override
-        public DateFormatter withLocale(Locale locale) {
-            return new MergedDateFormatter(Arrays.stream(formatters).map(f -> f.withLocale(locale)).toArray(DateFormatter[]::new));
-        }
-
-        @Override
-        public String format(TemporalAccessor accessor) {
-            return formatters[0].format(accessor);
-        }
-
-        @Override
-        public String pattern() {
-            return format;
-        }
-
-        @Override
-        public Locale locale() {
-            return formatters[0].locale();
-        }
-
-        @Override
-        public ZoneId zone() {
-            return formatters[0].zone();
-        }
-
-        @Override
-        public DateMathParser toDateMathParser() {
-            return (text, now, roundUp, tz) -> {
-                ElasticsearchParseException failure = null;
-                for (DateMathParser parser : dateMathParsers) {
-                    try {
-                        return parser.parse(text, now, roundUp, tz);
-                    } catch (ElasticsearchParseException e) {
-                        if (failure == null) {
-                            failure = e;
-                        } else {
-                            failure.addSuppressed(e);
-                        }
-                    }
-                }
-                throw failure;
-            };
-        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -19,16 +19,19 @@
 
 package org.elasticsearch.common.time;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Strings;
 
 import java.time.DateTimeException;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 import java.time.format.ResolverStyle;
 import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
@@ -36,7 +39,11 @@ import java.time.temporal.IsoFields;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalAdjusters;
 import java.time.temporal.WeekFields;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.DAY_OF_WEEK;
@@ -1442,12 +1449,12 @@ public class DateFormatters {
                 return forPattern(formats[0], locale);
             } else {
                 try {
-                    DateFormatter[] formatters = new DateFormatter[formats.length];
+                    List<DateFormatter> formatters = new ArrayList<>(formats.length);
                     for (int i = 0; i < formats.length; i++) {
-                        formatters[i] = forPattern(formats[i], locale);
+                        formatters.add(forPattern(formats[i], locale));
                     }
 
-                    return DateFormatter.merge(formatters);
+                    return new MergedDateFormatter(input, formatters);
                 } catch (IllegalArgumentException e) {
                     throw new IllegalArgumentException("Invalid format: [" + input + "]: " + e.getMessage(), e);
                 }
@@ -1458,6 +1465,91 @@ public class DateFormatters {
             } catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException("Invalid format: [" + input + "]: " + e.getMessage(), e);
             }
+        }
+    }
+
+    static class MergedDateFormatter implements DateFormatter {
+
+        private final String pattern;
+        private final List<DateFormatter> formatters;
+        private final List<DateMathParser> dateMathParsers;
+
+        MergedDateFormatter(String pattern, List<DateFormatter> formatters) {
+            assert formatters.size() > 0;
+            this.pattern = pattern;
+            this.formatters = Collections.unmodifiableList(formatters);
+            this.dateMathParsers = formatters.stream().map(DateFormatter::toDateMathParser).collect(Collectors.toList());
+        }
+
+        @Override
+        public TemporalAccessor parse(String input) {
+            IllegalArgumentException failure = null;
+            for (DateFormatter formatter : formatters) {
+                try {
+                    return formatter.parse(input);
+                    // TODO: remove DateTimeParseException when JavaDateFormatter throws IAE
+                } catch (IllegalArgumentException | DateTimeParseException e) {
+                    if (failure == null) {
+                        // wrap so the entire multi format is in the message
+                        failure = new IllegalArgumentException("failed to parse date field [" + input + "] with format [" + pattern + "]",
+                            e);
+                    } else {
+                        failure.addSuppressed(e);
+                    }
+                }
+            }
+            throw failure;
+        }
+
+        @Override
+        public DateFormatter withZone(ZoneId zoneId) {
+            return new MergedDateFormatter(pattern, formatters.stream().map(f -> f.withZone(zoneId)).collect(Collectors.toList()));
+        }
+
+        @Override
+        public DateFormatter withLocale(Locale locale) {
+            return new MergedDateFormatter(pattern, formatters.stream().map(f -> f.withLocale(locale)).collect(Collectors.toList()));
+        }
+
+        @Override
+        public String format(TemporalAccessor accessor) {
+            return formatters.get(0).format(accessor);
+        }
+
+        @Override
+        public String pattern() {
+            return pattern;
+        }
+
+        @Override
+        public Locale locale() {
+            return formatters.get(0).locale();
+        }
+
+        @Override
+        public ZoneId zone() {
+            return formatters.get(0).zone();
+        }
+
+        @Override
+        public DateMathParser toDateMathParser() {
+            return (text, now, roundUp, tz) -> {
+                ElasticsearchParseException failure = null;
+                for (DateMathParser parser : dateMathParsers) {
+                    try {
+                        return parser.parse(text, now, roundUp, tz);
+                    } catch (ElasticsearchParseException e) {
+                        if (failure == null) {
+                            // wrap so the entire multi format is in the message
+                            failure = new ElasticsearchParseException("failed to parse date field [" + text + "] with format ["
+                                + pattern + "]", e);
+                        } else {
+                            failure.addSuppressed(e);
+                        }
+                    }
+                }
+                throw failure;
+            };
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -37,7 +37,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.geo.ShapeRelation;
-import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateMathParser;
@@ -65,7 +64,7 @@ import static org.elasticsearch.index.mapper.TypeParsers.parseDateTimeFormatter;
 public class DateFieldMapper extends FieldMapper {
 
     public static final String CONTENT_TYPE = "date";
-    public static final DateFormatter DEFAULT_DATE_TIME_FORMATTER = Joda.forPattern(
+    public static final DateFormatter DEFAULT_DATE_TIME_FORMATTER = DateFormatter.forPattern(
             "strict_date_optional_time||epoch_millis", Locale.ROOT);
 
     public static class Defaults {
@@ -387,7 +386,7 @@ public class DateFieldMapper extends FieldMapper {
         public DocValueFormat docValueFormat(@Nullable String format, DateTimeZone timeZone) {
             DateFormatter dateTimeFormatter = this.dateTimeFormatter;
             if (format != null) {
-                dateTimeFormatter = Joda.forPattern(format);
+                dateTimeFormatter = DateFormatter.forPattern(format);
             }
             if (timeZone == null) {
                 timeZone = DateTimeZone.UTC;

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -24,7 +24,6 @@ import org.apache.lucene.index.IndexOptions;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Booleans;
-import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -355,7 +354,7 @@ public class TypeParsers {
 
     public static DateFormatter parseDateTimeFormatter(Object node) {
         if (node instanceof String) {
-            return Joda.forPattern((String) node);
+            return DateFormatter.forPattern((String) node);
         }
         throw new IllegalArgumentException("Invalid format: [" + node.toString() + "]: expected string value");
     }

--- a/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateMathParser;
@@ -106,7 +105,7 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
         timeZone = in.readOptionalTimeZone();
         String formatString = in.readOptionalString();
         if (formatString != null) {
-            format = Joda.forPattern(formatString);
+            format = DateFormatter.forPattern(formatString);
         }
         if (in.getVersion().onOrAfter(Version.V_5_2_0)) {
             String relationString = in.readOptionalString();
@@ -295,7 +294,7 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
         if (format == null) {
             throw new IllegalArgumentException("format cannot be null");
         }
-        this.format = Joda.forPattern(format);
+        this.format = DateFormatter.forPattern(format);
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -150,7 +150,7 @@ public final class QueryParserHelper {
                 } catch (QueryShardException |UnsupportedOperationException e) {
                     // field type is never searchable with term queries (eg. geo point): ignore
                     continue;
-                } catch (IllegalArgumentException |ElasticsearchParseException e) {
+                } catch (IllegalArgumentException | ElasticsearchParseException e) {
                     // other exceptions are parsing errors or not indexed fields: keep
                 }
             }

--- a/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.geo.GeoHashUtils;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.time.DateFormatter;
@@ -186,7 +185,7 @@ public interface DocValueFormat extends NamedWriteable {
         }
 
         public DateTime(StreamInput in) throws IOException {
-            this(Joda.forPattern(in.readString()), DateTimeZone.forID(in.readString()));
+            this(DateFormatter.forPattern(in.readString()), DateTimeZone.forID(in.readString()));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
@@ -25,9 +25,9 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.rounding.DateTimeUnit;
 import org.elasticsearch.common.rounding.Rounding;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ObjectParser;
@@ -72,7 +72,7 @@ import static java.util.Collections.unmodifiableMap;
 public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuilder<ValuesSource.Numeric, DateHistogramAggregationBuilder>
         implements MultiBucketAggregationBuilder {
     public static final String NAME = "date_histogram";
-    private static DateMathParser EPOCH_MILLIS_PARSER = Joda.forPattern("epoch_millis", Locale.ROOT).toDateMathParser();
+    private static DateMathParser EPOCH_MILLIS_PARSER = DateFormatter.forPattern("epoch_millis", Locale.ROOT).toDateMathParser();
 
     public static final Map<String, DateTimeUnit> DATE_FIELD_UNITS;
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
@@ -21,7 +21,7 @@ package org.elasticsearch.search.aggregations.support;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.joda.Joda;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
@@ -133,7 +133,7 @@ public class ValuesSourceConfig<VS extends ValuesSource> {
             valueFormat = new DocValueFormat.Decimal(format);
         }
         if (valueFormat instanceof DocValueFormat.DateTime && format != null) {
-            valueFormat = new DocValueFormat.DateTime(Joda.forPattern(format), tz != null ? tz : DateTimeZone.UTC);
+            valueFormat = new DocValueFormat.DateTime(DateFormatter.forPattern(format), tz != null ? tz : DateTimeZone.UTC);
         }
         return valueFormat;
     }

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -472,25 +472,32 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
     }
 
     public void testSeveralTimeFormats() {
-        assertSameDate("2018-12-12", "year_month_day||ordinal_date");
-        assertSameDate("2018-128", "year_month_day||ordinal_date");
+        DateFormatter jodaFormatter = DateFormatter.forPattern("year_month_day||ordinal_date");
+        DateFormatter javaFormatter = DateFormatters.forPattern("year_month_day||ordinal_date");
+        assertSameDate("2018-12-12", "year_month_day||ordinal_date", jodaFormatter, javaFormatter);
+        assertSameDate("2018-128", "year_month_day||ordinal_date", jodaFormatter, javaFormatter);
     }
 
     private void assertSamePrinterOutput(String format, ZonedDateTime javaDate, DateTime jodaDate) {
         assertThat(jodaDate.getMillis(), is(javaDate.toInstant().toEpochMilli()));
         String javaTimeOut = DateFormatters.forPattern(format).format(javaDate);
-        String jodaTimeOut = Joda.forPattern(format).formatJoda(jodaDate);
+        String jodaTimeOut = DateFormatter.forPattern(format).formatJoda(jodaDate);
         String message = String.format(Locale.ROOT, "expected string representation to be equal for format [%s]: joda [%s], java [%s]",
                 format, jodaTimeOut, javaTimeOut);
         assertThat(message, javaTimeOut, is(jodaTimeOut));
     }
 
     private void assertSameDate(String input, String format) {
-        DateFormatter jodaFormatter = Joda.forPattern(format);
+        DateFormatter jodaFormatter = Joda.forPattern(format, Locale.ROOT);
+        DateFormatter javaFormatter = DateFormatters.forPattern(format);
+
+        assertSameDate(input, format, jodaFormatter, javaFormatter);
+    }
+
+    private void assertSameDate(String input, String format, DateFormatter jodaFormatter, DateFormatter javaFormatter) {
         DateTime jodaDateTime = jodaFormatter.parseJoda(input);
 
-        DateFormatter javaTimeFormatter = DateFormatters.forPattern(format);
-        TemporalAccessor javaTimeAccessor = javaTimeFormatter.parse(input);
+        TemporalAccessor javaTimeAccessor = javaFormatter.parse(input);
         ZonedDateTime zonedDateTime = DateFormatters.toZonedDateTime(javaTimeAccessor);
 
         String msg = String.format(Locale.ROOT, "Input [%s] Format [%s] Joda [%s], Java [%s]", input, format, jodaDateTime,
@@ -505,7 +512,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
     }
 
     private void assertJodaParseException(String input, String format, String expectedMessage) {
-        DateFormatter jodaFormatter = Joda.forPattern(format);
+        DateFormatter jodaFormatter = Joda.forPattern(format, Locale.ROOT);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> jodaFormatter.parseJoda(input));
         assertThat(e.getMessage(), containsString(expectedMessage));
     }

--- a/server/src/test/java/org/elasticsearch/common/joda/JodaDateMathParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JodaDateMathParserTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.joda.time.DateTimeZone;
 
 import java.time.ZoneId;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.LongSupplier;
 
@@ -35,7 +36,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class JodaDateMathParserTests extends ESTestCase {
 
-    DateFormatter formatter = Joda.forPattern("dateOptionalTime||epoch_millis");
+    DateFormatter formatter = DateFormatter.forPattern("dateOptionalTime||epoch_millis");
     DateMathParser parser = formatter.toDateMathParser();
 
     void assertDateMathEquals(String toTest, String expected) {
@@ -160,7 +161,7 @@ public class JodaDateMathParserTests extends ESTestCase {
 
     public void testRoundingPreservesEpochAsBaseDate() {
         // If a user only specifies times, then the date needs to always be 1970-01-01 regardless of rounding
-        DateFormatter formatter = Joda.forPattern("HH:mm:ss");
+        DateFormatter formatter = DateFormatter.forPattern("HH:mm:ss");
         DateMathParser parser = formatter.toDateMathParser();
         assertEquals(
                 this.formatter.parseMillis("1970-01-01T04:52:20.000Z"),
@@ -185,7 +186,7 @@ public class JodaDateMathParserTests extends ESTestCase {
         assertDateMathEquals("2014-11-18T09:20", "2014-11-18T08:20:59.999Z", 0, true, DateTimeZone.forID("CET"));
 
         // implicit rounding with explicit timezone in the date format
-        DateFormatter formatter = Joda.forPattern("YYYY-MM-ddZ");
+        DateFormatter formatter = DateFormatter.forPattern("YYYY-MM-ddZ");
         DateMathParser parser = formatter.toDateMathParser();
         long time = parser.parse("2011-10-09+01:00", () -> 0, false, (ZoneId) null);
         assertEquals(this.parser.parse("2011-10-09T00:00:00.000+01:00", () -> 0), time);
@@ -260,7 +261,7 @@ public class JodaDateMathParserTests extends ESTestCase {
         assertDateMathEquals("1418248078000||/m", "2014-12-10T21:47:00.000");
 
         // also check other time units
-        JodaDateMathParser parser = new JodaDateMathParser(Joda.forPattern("epoch_second||dateOptionalTime"));
+        JodaDateMathParser parser = new JodaDateMathParser(Joda.forPattern("epoch_second", Locale.ROOT));
         long datetime = parser.parse("1418248078", () -> 0);
         assertDateEquals(datetime, "1418248078", "2014-12-10T21:47:58.000");
 
@@ -307,7 +308,7 @@ public class JodaDateMathParserTests extends ESTestCase {
     }
 
     public void testThatUnixTimestampMayNotHaveTimeZone() {
-        JodaDateMathParser parser = new JodaDateMathParser(Joda.forPattern("epoch_millis"));
+        JodaDateMathParser parser = new JodaDateMathParser(Joda.forPattern("epoch_millis", Locale.ROOT));
         try {
             parser.parse("1234567890123", () -> 42, false, ZoneId.of("CET"));
             fail("Expected ElasticsearchParseException");

--- a/server/src/test/java/org/elasticsearch/common/joda/JodaTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JodaTests.java
@@ -31,11 +31,11 @@ public class JodaTests extends ESTestCase {
 
 
     public void testBasicTTimePattern() {
-        DateFormatter formatter1 = Joda.forPattern("basic_t_time");
+        DateFormatter formatter1 = DateFormatter.forPattern("basic_t_time");
         assertEquals(formatter1.pattern(), "basic_t_time");
         assertEquals(formatter1.zone(), ZoneOffset.UTC);
 
-        DateFormatter formatter2 = Joda.forPattern("basicTTime");
+        DateFormatter formatter2 = DateFormatter.forPattern("basicTTime");
         assertEquals(formatter2.pattern(), "basicTTime");
         assertEquals(formatter2.zone(), ZoneOffset.UTC);
 
@@ -43,9 +43,9 @@ public class JodaTests extends ESTestCase {
         assertEquals("T102030.040Z", formatter1.formatJoda(dt));
         assertEquals("T102030.040Z", formatter1.formatJoda(dt));
 
-        expectThrows(IllegalArgumentException.class, () -> Joda.forPattern("basic_t_Time"));
-        expectThrows(IllegalArgumentException.class, () -> Joda.forPattern("basic_T_Time"));
-        expectThrows(IllegalArgumentException.class, () -> Joda.forPattern("basic_T_time"));
+        expectThrows(IllegalArgumentException.class, () -> DateFormatter.forPattern("basic_t_Time"));
+        expectThrows(IllegalArgumentException.class, () -> DateFormatter.forPattern("basic_T_Time"));
+        expectThrows(IllegalArgumentException.class, () -> DateFormatter.forPattern("basic_T_time"));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/common/joda/SimpleJodaTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/SimpleJodaTests.java
@@ -111,7 +111,7 @@ public class SimpleJodaTests extends ESTestCase {
         millis = formatter.parseMillis("1970/01/01 00:00:00");
         assertThat(millis, equalTo(0L));
 
-        DateFormatter formatter2 = Joda.forPattern("yyyy/MM/dd HH:mm:ss");
+        DateFormatter formatter2 = DateFormatter.forPattern("yyyy/MM/dd HH:mm:ss");
         millis = formatter2.parseMillis("1970/01/01 00:00:00");
         assertThat(millis, equalTo(0L));
     }
@@ -124,38 +124,34 @@ public class SimpleJodaTests extends ESTestCase {
     }
 
     public void testSlashInFormat() {
-        DateFormatter formatter = Joda.forPattern("MM/yyyy");
+        DateFormatter formatter = DateFormatter.forPattern("MM/yyyy");
         formatter.parseMillis("01/2001");
 
-        formatter = Joda.forPattern("yyyy/MM/dd HH:mm:ss");
-        long millis = formatter.parseMillis("1970/01/01 00:00:00");
-        formatter.formatMillis(millis);
+        DateFormatter formatter2 = DateFormatter.forPattern("yyyy/MM/dd HH:mm:ss");
+        long millis = formatter2.parseMillis("1970/01/01 00:00:00");
+        formatter2.formatMillis(millis);
 
-        try {
-            millis = formatter.parseMillis("1970/01/01");
-            fail();
-        } catch (IllegalArgumentException e) {
-            // it really can't parse this one
-        }
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
+            formatter2.parseMillis("1970/01/01"));
     }
 
     public void testMultipleFormats() {
-        DateFormatter formatter = Joda.forPattern("yyyy/MM/dd HH:mm:ss||yyyy/MM/dd");
+        DateFormatter formatter = DateFormatter.forPattern("yyyy/MM/dd HH:mm:ss||yyyy/MM/dd");
         long millis = formatter.parseMillis("1970/01/01 00:00:00");
         assertThat("1970/01/01 00:00:00", is(formatter.formatMillis(millis)));
     }
 
     public void testMultipleDifferentFormats() {
-        DateFormatter formatter = Joda.forPattern("yyyy/MM/dd HH:mm:ss||yyyy/MM/dd");
+        DateFormatter formatter = DateFormatter.forPattern("yyyy/MM/dd HH:mm:ss||yyyy/MM/dd");
         String input = "1970/01/01 00:00:00";
         long millis = formatter.parseMillis(input);
         assertThat(input, is(formatter.formatMillis(millis)));
 
-        Joda.forPattern("yyyy/MM/dd HH:mm:ss||yyyy/MM/dd||dateOptionalTime");
-        Joda.forPattern("dateOptionalTime||yyyy/MM/dd HH:mm:ss||yyyy/MM/dd");
-        Joda.forPattern("yyyy/MM/dd HH:mm:ss||dateOptionalTime||yyyy/MM/dd");
-        Joda.forPattern("date_time||date_time_no_millis");
-        Joda.forPattern(" date_time || date_time_no_millis");
+        DateFormatter.forPattern("yyyy/MM/dd HH:mm:ss||yyyy/MM/dd||dateOptionalTime");
+        DateFormatter.forPattern("dateOptionalTime||yyyy/MM/dd HH:mm:ss||yyyy/MM/dd");
+        DateFormatter.forPattern("yyyy/MM/dd HH:mm:ss||dateOptionalTime||yyyy/MM/dd");
+        DateFormatter.forPattern("date_time||date_time_no_millis");
+        DateFormatter.forPattern(" date_time || date_time_no_millis");
     }
 
     public void testInvalidPatterns() {
@@ -170,7 +166,7 @@ public class SimpleJodaTests extends ESTestCase {
 
     private void expectInvalidPattern(String pattern, String errorMessage) {
         try {
-            Joda.forPattern(pattern);
+            DateFormatter.forPattern(pattern);
             fail("Pattern " + pattern + " should have thrown an exception but did not");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString(errorMessage));
@@ -244,7 +240,7 @@ public class SimpleJodaTests extends ESTestCase {
         boolean parseMilliSeconds = randomBoolean();
 
         // epoch: 1433144433655 => date: Mon Jun  1 09:40:33.655 CEST 2015
-        DateFormatter formatter = Joda.forPattern(parseMilliSeconds ? "epoch_millis" : "epoch_second");
+        DateFormatter formatter = DateFormatter.forPattern(parseMilliSeconds ? "epoch_millis" : "epoch_second");
         DateTime dateTime = formatter.parseJoda(parseMilliSeconds ? "1433144433655" : "1433144433");
 
         assertThat(dateTime.getYear(), is(2015));
@@ -269,7 +265,7 @@ public class SimpleJodaTests extends ESTestCase {
     public void testThatNegativeEpochsCanBeParsed() {
         // problem: negative epochs can be arbitrary in size...
         boolean parseMilliSeconds = randomBoolean();
-        DateFormatter formatter = Joda.forPattern(parseMilliSeconds ? "epoch_millis" : "epoch_second");
+        DateFormatter formatter = DateFormatter.forPattern(parseMilliSeconds ? "epoch_millis" : "epoch_second");
         DateTime dateTime = formatter.parseJoda("-10000");
 
         assertThat(dateTime.getYear(), is(1969));
@@ -310,23 +306,17 @@ public class SimpleJodaTests extends ESTestCase {
     }
 
     public void testForInvalidDatesInEpochSecond() {
-        DateFormatter formatter = Joda.forPattern("epoch_second");
-        try {
-            formatter.parseJoda(randomFrom("invalid date", "12345678901234567", "12345678901234567890"));
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("Invalid format"));
-        }
+        DateFormatter formatter = DateFormatter.forPattern("epoch_second");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
+            formatter.parseJoda(randomFrom("invalid date", "12345678901234567", "12345678901234567890")));
+        assertThat(e.getMessage(), containsString("Invalid format"));
     }
 
     public void testForInvalidDatesInEpochMillis() {
-        DateFormatter formatter = Joda.forPattern("epoch_millis");
-        try {
-            formatter.parseJoda(randomFrom("invalid date", "12345678901234567890"));
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("Invalid format"));
-        }
+        DateFormatter formatter = DateFormatter.forPattern("epoch_millis");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
+            formatter.parseJoda(randomFrom("invalid date", "12345678901234567890")));
+        assertThat(e.getMessage(), containsString("Invalid format"));
     }
 
     public void testForInvalidTimeZoneWithEpochSeconds() {
@@ -337,12 +327,9 @@ public class SimpleJodaTests extends ESTestCase {
             .withLocale(Locale.ROOT);
         DateFormatter formatter =
             new JodaDateFormatter("epoch_seconds", dateTimeFormatter, dateTimeFormatter);
-        try {
-            formatter.parseJoda("1433144433655");
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("time_zone must be UTC"));
-        }
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
+            formatter.parseJoda("1433144433655"));
+        assertThat(e.getMessage(), containsString("time_zone must be UTC"));
     }
 
     public void testForInvalidTimeZoneWithEpochMillis() {
@@ -353,20 +340,17 @@ public class SimpleJodaTests extends ESTestCase {
             .withLocale(Locale.ROOT);
         DateFormatter formatter =
             new JodaDateFormatter("epoch_millis", dateTimeFormatter, dateTimeFormatter);
-        try {
-            formatter.parseJoda("1433144433");
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("time_zone must be UTC"));
-        }
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
+            formatter.parseJoda("1433144433"));
+        assertThat(e.getMessage(), containsString("time_zone must be UTC"));
     }
 
     public void testThatEpochParserIsPrinter() {
-        JodaDateFormatter formatter = Joda.forPattern("epoch_millis");
+        JodaDateFormatter formatter = Joda.forPattern("epoch_millis", Locale.ROOT);
         assertThat(formatter.parser.isPrinter(), is(true));
         assertThat(formatter.printer.isPrinter(), is(true));
 
-        JodaDateFormatter epochSecondFormatter = Joda.forPattern("epoch_second");
+        JodaDateFormatter epochSecondFormatter = Joda.forPattern("epoch_second", Locale.ROOT);
         assertThat(epochSecondFormatter.parser.isPrinter(), is(true));
         assertThat(epochSecondFormatter.printer.isPrinter(), is(true));
     }
@@ -389,7 +373,7 @@ public class SimpleJodaTests extends ESTestCase {
     }
 
     public void testThatEpochParserIsIdempotent() {
-        DateFormatter formatter = Joda.forPattern("epoch_millis");
+        DateFormatter formatter = DateFormatter.forPattern("epoch_millis");
         DateTime dateTime = formatter.parseJoda("1234567890123");
         assertThat(dateTime.getMillis(), is(1234567890123L));
         dateTime = formatter.parseJoda("1234567890456");
@@ -399,7 +383,7 @@ public class SimpleJodaTests extends ESTestCase {
         dateTime = formatter.parseJoda("1234567890123456789");
         assertThat(dateTime.getMillis(), is(1234567890123456789L));
 
-        DateFormatter secondsFormatter = Joda.forPattern("epoch_second");
+        DateFormatter secondsFormatter = DateFormatter.forPattern("epoch_second");
         DateTime secondsDateTime = secondsFormatter.parseJoda("1234567890");
         assertThat(secondsDateTime.getMillis(), is(1234567890000L));
         secondsDateTime = secondsFormatter.parseJoda("1234567890");
@@ -757,13 +741,13 @@ public class SimpleJodaTests extends ESTestCase {
     }
 
     private void assertValidDateFormatParsing(String pattern, String dateToParse, String expectedDate) {
-        DateFormatter formatter = Joda.forPattern(pattern);
+        DateFormatter formatter = DateFormatter.forPattern(pattern);
         assertThat(formatter.formatMillis(formatter.parseMillis(dateToParse)), is(expectedDate));
     }
 
     private void assertDateFormatParsingThrowingException(String pattern, String invalidDate) {
         try {
-            DateFormatter formatter = Joda.forPattern(pattern);
+            DateFormatter formatter = DateFormatter.forPattern(pattern);
             formatter.parseMillis(invalidDate);
             fail(String.format(Locale.ROOT, "Expected parsing exception for pattern [%s] with date [%s], but did not happen",
                 pattern, invalidDate));

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -121,7 +121,7 @@ public class DateFormattersTests extends ESTestCase {
     }
 
     public void testEpochMilliParsersWithDifferentFormatters() {
-        DateFormatter formatter = DateFormatters.forPattern("strict_date_optional_time||epoch_millis");
+        DateFormatter formatter = DateFormatter.forPattern("strict_date_optional_time||epoch_millis");
         TemporalAccessor accessor = formatter.parse("123");
         assertThat(DateFormatters.toZonedDateTime(accessor).toInstant().toEpochMilli(), is(123L));
         assertThat(formatter.pattern(), is("strict_date_optional_time||epoch_millis"));

--- a/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.is;
 
 public class JavaDateMathParserTests extends ESTestCase {
 
-    private final DateFormatter formatter = DateFormatters.forPattern("dateOptionalTime||epoch_millis");
+    private final DateFormatter formatter = DateFormatter.forPattern("dateOptionalTime||epoch_millis");
     private final DateMathParser parser = formatter.toDateMathParser();
 
     public void testBasicDates() {
@@ -252,12 +252,8 @@ public class JavaDateMathParserTests extends ESTestCase {
     }
 
     void assertParseException(String msg, String date, String exc) {
-        try {
-            parser.parse(date, () -> 0);
-            fail("Date: " + date + "\n" + msg);
-        } catch (ElasticsearchParseException e) {
-            assertThat(ExceptionsHelper.detailedMessage(e), containsString(exc));
-        }
+        ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () -> parser.parse(date, () -> 0));
+        assertThat(msg, ExceptionsHelper.detailedMessage(e), containsString(exc));
     }
 
     public void testIllegalMathFormat() {
@@ -270,7 +266,7 @@ public class JavaDateMathParserTests extends ESTestCase {
 
     public void testIllegalDateFormat() {
         assertParseException("Expected bad timestamp exception", Long.toString(Long.MAX_VALUE) + "0", "failed to parse date field");
-        assertParseException("Expected bad date format exception", "123bogus", "could not be parsed");
+        assertParseException("Expected bad date format exception", "123bogus", "Unrecognized chars at the end of [123bogus]");
     }
 
     public void testOnlyCallsNowIfNecessary() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -174,7 +174,7 @@ public class DateFieldMapperTests extends ESSingleNodeTestCase {
                         .endObject()),
                 XContentType.JSON));
         MapperParsingException e = expectThrows(MapperParsingException.class, runnable);
-        assertThat(e.getCause().getMessage(), containsString("Cannot parse \"2016-03-99\""));
+        assertThat(e.getCause().getMessage(), containsString("failed to parse date field [2016-03-99]"));
 
         mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("properties").startObject("field").field("type", "date")

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
@@ -31,8 +31,8 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.IndexSettings;
@@ -61,13 +61,13 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         addModifier(new Modifier("format", false) {
             @Override
             public void modify(MappedFieldType ft) {
-                ((DateFieldType) ft).setDateTimeFormatter(Joda.forPattern("basic_week_date", Locale.ROOT));
+                ((DateFieldType) ft).setDateTimeFormatter(DateFormatter.forPattern("basic_week_date", Locale.ROOT));
             }
         });
         addModifier(new Modifier("locale", false) {
             @Override
             public void modify(MappedFieldType ft) {
-                ((DateFieldType) ft).setDateTimeFormatter(Joda.forPattern("date_optional_time", Locale.CANADA));
+                ((DateFieldType) ft).setDateTimeFormatter(DateFormatter.forPattern("date_optional_time", Locale.CANADA));
             }
         });
         nowInMillis = randomNonNegativeLong();

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -34,7 +34,6 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.geo.ShapeRelation;
-import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
@@ -63,13 +62,13 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
             addModifier(new Modifier("format", true) {
                 @Override
                 public void modify(MappedFieldType ft) {
-                    ((RangeFieldType) ft).setDateTimeFormatter(Joda.forPattern("basic_week_date", Locale.ROOT));
+                    ((RangeFieldType) ft).setDateTimeFormatter(DateFormatter.forPattern("basic_week_date", Locale.ROOT));
                 }
             });
             addModifier(new Modifier("locale", true) {
                 @Override
                 public void modify(MappedFieldType ft) {
-                    ((RangeFieldType) ft).setDateTimeFormatter(Joda.forPattern("date_optional_time", Locale.CANADA));
+                    ((RangeFieldType) ft).setDateTimeFormatter(DateFormatter.forPattern("date_optional_time", Locale.CANADA));
                 }
             });
         }
@@ -122,7 +121,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
             ex.getMessage());
 
         // setting mapping format which is compatible with those dates
-        final DateFormatter formatter = Joda.forPattern("yyyy-dd-MM'T'HH:mm:ssZZ");
+        final DateFormatter formatter = DateFormatter.forPattern("yyyy-dd-MM'T'HH:mm:ssZZ");
         assertEquals(1465975790000L, formatter.parseMillis(from));
         assertEquals(1466062190000L, formatter.parseMillis(to));
 

--- a/server/src/test/java/org/elasticsearch/search/DocValueFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DocValueFormatTests.java
@@ -26,8 +26,8 @@ import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry.Entry;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.test.ESTestCase;
 import org.joda.time.DateTimeZone;
 
@@ -60,7 +60,8 @@ public class DocValueFormatTests extends ESTestCase {
         assertEquals(DocValueFormat.Decimal.class, vf.getClass());
         assertEquals("###.##", ((DocValueFormat.Decimal) vf).pattern);
 
-        DocValueFormat.DateTime dateFormat = new DocValueFormat.DateTime(Joda.forPattern("epoch_second"), DateTimeZone.forOffsetHours(1));
+        DocValueFormat.DateTime dateFormat =
+            new DocValueFormat.DateTime(DateFormatter.forPattern("epoch_second"), DateTimeZone.forOffsetHours(1));
         out = new BytesStreamOutput();
         out.writeNamedWriteable(dateFormat);
         in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), registry);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -201,7 +202,7 @@ public class DateHistogramIT extends ESIntegTestCase {
 
     private static String getBucketKeyAsString(DateTime key, DateTimeZone tz) {
         ZoneId zoneId = DateUtils.dateTimeZoneToZoneId(tz);
-        return Joda.forPattern(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern()).withZone(zoneId).formatJoda(key);
+        return DateFormatter.forPattern(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern()).withZone(zoneId).formatJoda(key);
     }
 
     public void testSingleValuedField() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeIT.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket;
 
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
@@ -52,6 +51,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -973,8 +973,8 @@ public class DateRangeIT extends ESIntegTestCase {
         Exception e = expectThrows(Exception.class, () -> client().prepareSearch(indexName).setSize(0)
                 .addAggregation(dateRange("date_range").field("date").addRange(1000000, 3000000).addRange(3000000, 4000000)).get());
         Throwable cause = e.getCause();
-        assertThat(cause, instanceOf(ElasticsearchParseException.class));
-        assertEquals("failed to parse date field [1000000] with format [strict_hour_minute_second]", cause.getMessage());
+        assertThat(cause.getMessage(),
+            containsString("failed to parse date field [1000000] with format [strict_hour_minute_second]"));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/InternalCompositeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/InternalCompositeTests.java
@@ -21,7 +21,7 @@ package org.elasticsearch.search.aggregations.bucket.composite;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.joda.Joda;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -58,7 +58,7 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
         if (isLong) {
             // we use specific format only for date histogram on a long/date field
             if (randomBoolean()) {
-                return new DocValueFormat.DateTime(Joda.forPattern("epoch_second"), DateTimeZone.forOffsetHours(1));
+                return new DocValueFormat.DateTime(DateFormatter.forPattern("epoch_second"), DateTimeZone.forOffsetHours(1));
             } else {
                 return DocValueFormat.RAW;
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/ExtendedBoundsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/ExtendedBoundsTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -104,7 +103,7 @@ public class ExtendedBoundsTests extends ESTestCase {
                 new IndexSettings(IndexMetaData.builder("foo").settings(indexSettings).build(), indexSettings), null, null, null, null,
                 null, xContentRegistry(), writableRegistry(), null, null, () -> now, null);
         when(context.getQueryShardContext()).thenReturn(qsc);
-        DateFormatter formatter = Joda.forPattern("dateOptionalTime");
+        DateFormatter formatter = DateFormatter.forPattern("dateOptionalTime");
         DocValueFormat format = new DocValueFormat.DateTime(formatter, DateTimeZone.UTC);
 
         ExtendedBounds expected = randomParsedExtendedBounds();

--- a/x-pack/license-tools/src/test/java/org/elasticsearch/license/licensor/TestUtils.java
+++ b/x-pack/license-tools/src/test/java/org/elasticsearch/license/licensor/TestUtils.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.license.licensor;
 
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.unit.TimeValue;
@@ -36,7 +35,7 @@ public class TestUtils {
     public static final String PRIVATE_KEY_RESOURCE = "/private.key";
 
     private static final DateFormatter formatDateTimeFormatter =
-            Joda.forPattern("yyyy-MM-dd");
+            DateFormatter.forPattern("yyyy-MM-dd");
     private static final DateMathParser dateMathParser = formatDateTimeFormatter.toDateMathParser();
 
     public static String dumpLicense(License license) throws Exception {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/DateUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/DateUtils.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.license;
 
-import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.time.DateFormatter;
 import org.joda.time.MutableDateTime;
 import org.joda.time.format.DateTimeFormatter;
@@ -15,7 +14,7 @@ import java.time.ZoneOffset;
 
 public class DateUtils {
 
-    private static final DateFormatter dateOnlyFormatter = Joda.forPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
+    private static final DateFormatter dateOnlyFormatter = DateFormatter.forPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
 
     private static final DateTimeFormatter dateTimeFormatter = ISODateTimeFormat.dateTime().withZoneUTC();
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
@@ -20,7 +20,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.component.Lifecycle;
-import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -115,7 +114,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
 
     public static final String LICENSE_JOB = "licenseJob";
 
-    private static final DateFormatter DATE_FORMATTER = Joda.forPattern("EEEE, MMMMM dd, yyyy", Locale.ROOT);
+    private static final DateFormatter DATE_FORMATTER = DateFormatter.forPattern("EEEE, MMMMM dd, yyyy", Locale.ROOT);
 
     private static final String ACKNOWLEDGEMENT_HEADER = "This license update requires acknowledgement. To acknowledge the license, " +
             "please read the following messages and update the license again, this time with the \"acknowledge=true\" parameter:";

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/TestUtils.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/TestUtils.java
@@ -10,7 +10,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateMathParser;
@@ -48,7 +47,7 @@ import static org.junit.Assert.assertThat;
 
 public class TestUtils {
 
-    private static final DateFormatter formatDateTimeFormatter = Joda.forPattern("yyyy-MM-dd");
+    private static final DateFormatter formatDateTimeFormatter = DateFormatter.forPattern("yyyy-MM-dd");
     private static final DateMathParser dateMathParser = formatDateTimeFormatter.toDateMathParser();
 
     public static String dateMathString(String time, final long now) {

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -29,8 +29,8 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchResponseSections;
 import org.elasticsearch.action.search.ShardSearchFailure;
-import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.rounding.Rounding;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.ContentPath;
@@ -489,7 +489,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
     private Map<String, MappedFieldType> createFieldTypes(RollupJobConfig job) {
         Map<String, MappedFieldType> fieldTypes = new HashMap<>();
         MappedFieldType fieldType = new DateFieldMapper.Builder(job.getGroupConfig().getDateHistogram().getField())
-                .dateTimeFormatter(Joda.forPattern(randomFrom("basic_date", "date_optional_time", "epoch_second")))
+                .dateTimeFormatter(DateFormatter.forPattern(randomFrom("basic_date", "date_optional_time", "epoch_second")))
                 .build(new Mapper.BuilderContext(settings.getSettings(), new ContentPath(0)))
                 .fieldType();
         fieldTypes.put(fieldType.name(), fieldType);
@@ -602,7 +602,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
             RangeQueryBuilder range = (RangeQueryBuilder) request.source().query();
             final DateTimeZone timeZone = range.timeZone() != null ? DateTimeZone.forID(range.timeZone()) : null;
             Query query = timestampField.rangeQuery(range.from(), range.to(), range.includeLower(), range.includeUpper(),
-                    null, timeZone, Joda.forPattern(range.format()).toDateMathParser(), queryShardContext);
+                    null, timeZone, DateFormatter.forPattern(range.format()).toDateMathParser(), queryShardContext);
 
             // extract composite agg
             assertThat(request.source().aggregations().getAggregatorFactories().size(), equalTo(1));


### PR DESCRIPTION
This commit moves the MergedDateFormatter to a package private class and
reworks joda DateFormatter instances to use that instead of a single
DateTimeFormatter with multiple parsers. This will allow the java and
joda multi formats to share the same format parsing method in a
followup.
