### PR TITLE
NETWORKING: USE Smaller Size Limit in HTTP Tests

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
@@ -48,7 +48,7 @@ import static org.hamcrest.Matchers.hasSize;
 @ClusterScope(scope = Scope.TEST, supportsDedicatedMasters = false, numClientNodes = 0, numDataNodes = 1, transportClientRatio = 0)
 public class Netty4HttpRequestSizeLimitIT extends ESNetty4IntegTestCase {
 
-    private static final ByteSizeValue LIMIT = new ByteSizeValue(2, ByteSizeUnit.KB);
+    private static final ByteSizeValue LIMIT = new ByteSizeValue(512, ByteSizeUnit.BYTES);
 
     @Override
     protected boolean addMockHttpTransport() {
@@ -110,7 +110,7 @@ public class Netty4HttpRequestSizeLimitIT extends ESNetty4IntegTestCase {
         ensureGreen();
 
         @SuppressWarnings("unchecked")
-        Tuple<String, CharSequence>[] requestUris = new Tuple[1500];
+        Tuple<String, CharSequence>[] requestUris = new Tuple[375];
         for (int i = 0; i < requestUris.length; i++) {
             requestUris[i] = Tuple.tuple("/_cluster/settings",
                 "{ \"transient\": {\"search.default_search_timeout\": \"40s\" } }");


### PR DESCRIPTION
* Scale all numbers down by a  factor of 4 to speed up the test almost 4x
* Fixes #36496 by significantly lowering the chance to run into the 30s request timeout in the failing test
