### PR TITLE
[ML-DataFrame] move common fields and string into a utility class

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameField.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.dataframe;
+
+import org.elasticsearch.common.ParseField;
+
+/*
+ * Utility class to hold common fields and strings for data frame.
+ */
+public final class DataFrameField {
+
+    // common parse fields
+    public static final ParseField ID = new ParseField("id");
+    public static final ParseField JOBS = new ParseField("jobs");
+    public static final ParseField COUNT = new ParseField("count");
+
+    // common strings
+    public static final String TASK_NAME = "data_frame/jobs";
+    public static final String REST_BASE_PATH = "/_data_frame/";
+    public static final String REST_BASE_PATH_JOBS_BY_ID = REST_BASE_PATH + "jobs/{id}/";
+
+    // note: this is used to match tasks
+    public static final String PERSISTENT_TASK_DESCRIPTION_PREFIX = "data_frame_";
+
+    private DataFrameField() {
+    }
+}

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataframePivotRestIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataframePivotRestIT.java
@@ -16,7 +16,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.test.rest.ESRestTestCase;
-import org.elasticsearch.xpack.dataframe.DataFrame;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.junit.AfterClass;
 import org.junit.Before;
 import java.io.IOException;
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class DataframePivotRestIT extends ESRestTestCase {
 
-    private static final String DATAFRAME_ENDPOINT = DataFrame.BASE_PATH + "jobs/";
+    private static final String DATAFRAME_ENDPOINT = DataFrameField.REST_BASE_PATH + "jobs/";
     private boolean indicesCreated = false;
 
     // preserve indices in order to reuse source indices in several test cases
@@ -236,7 +236,7 @@ public class DataframePivotRestIT extends ESRestTestCase {
     }
 
     private static void waitForPendingDataFrameTasks() throws Exception {
-        waitForPendingTasks(adminClient(), taskName -> taskName.startsWith(DataFrame.TASK_NAME) == false);
+        waitForPendingTasks(adminClient(), taskName -> taskName.startsWith(DataFrameField.TASK_NAME) == false);
     }
 
     private static void wipeIndices() throws IOException {

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrame.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrame.java
@@ -35,6 +35,7 @@ import org.elasticsearch.threadpool.FixedExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.dataframe.action.DeleteDataFrameJobAction;
 import org.elasticsearch.xpack.dataframe.action.GetDataFrameJobsAction;
@@ -73,9 +74,6 @@ import static java.util.Collections.emptyList;
 public class DataFrame extends Plugin implements ActionPlugin, PersistentTaskPlugin {
 
     public static final String NAME = "data_frame";
-    public static final String TASK_NAME = "data_frame/jobs";
-    public static final String BASE_PATH = "/_data_frame/";
-    public static final String BASE_PATH_JOBS_BY_ID = BASE_PATH + "jobs/{id}/";
     public static final String TASK_THREAD_POOL_NAME = "data_frame_indexing";
 
     // list of headers that will be stored when a job is created
@@ -172,7 +170,7 @@ public class DataFrame extends Plugin implements ActionPlugin, PersistentTaskPlu
             return emptyList();
         }
         return  Arrays.asList(
-                new NamedXContentRegistry.Entry(PersistentTaskParams.class, new ParseField(TASK_NAME),
+                new NamedXContentRegistry.Entry(PersistentTaskParams.class, new ParseField(DataFrameField.TASK_NAME),
                         DataFrameJob::fromXContent),
                 new NamedXContentRegistry.Entry(Task.Status.class, new ParseField(DataFrameJobState.NAME),
                         DataFrameJobState::fromXContent),

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/DataFrameJobStateAndStats.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/DataFrameJobStateAndStats.java
@@ -13,8 +13,8 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.dataframe.job.DataFrameIndexerJobStats;
-import org.elasticsearch.xpack.dataframe.job.DataFrameJob;
 import org.elasticsearch.xpack.dataframe.job.DataFrameJobState;
 
 import java.io.IOException;
@@ -34,7 +34,7 @@ public class DataFrameJobStateAndStats implements Writeable, ToXContentObject {
             a -> new DataFrameJobStateAndStats((String) a[0], (DataFrameJobState) a[1], (DataFrameIndexerJobStats) a[2]));
 
     static {
-        PARSER.declareString(ConstructingObjectParser.constructorArg(), DataFrameJob.ID);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), DataFrameField.ID);
         PARSER.declareObject(ConstructingObjectParser.constructorArg(), DataFrameJobState.PARSER::apply, STATE_FIELD);
         PARSER.declareObject(ConstructingObjectParser.constructorArg(), (p, c) -> DataFrameIndexerJobStats.fromXContent(p), STATS_FIELD);
     }
@@ -54,7 +54,7 @@ public class DataFrameJobStateAndStats implements Writeable, ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(DataFrameJob.ID.getPreferredName(), id);
+        builder.field(DataFrameField.ID.getPreferredName(), id);
         builder.field(STATE_FIELD.getPreferredName(), jobState);
         builder.field(STATS_FIELD.getPreferredName(), jobStats);
         builder.endObject();

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/DeleteDataFrameJobAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/DeleteDataFrameJobAction.java
@@ -20,8 +20,8 @@ import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
-import org.elasticsearch.xpack.dataframe.job.DataFrameJob;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -46,7 +46,7 @@ public class DeleteDataFrameJobAction extends Action<DeleteDataFrameJobAction.Re
         private String id;
 
         public Request(String id) {
-            this.id = ExceptionsHelper.requireNonNull(id, DataFrameJob.ID.getPreferredName());
+            this.id = ExceptionsHelper.requireNonNull(id, DataFrameField.ID.getPreferredName());
         }
 
         public Request() {
@@ -63,7 +63,7 @@ public class DeleteDataFrameJobAction extends Action<DeleteDataFrameJobAction.Re
 
         @Override
         public boolean match(Task task) {
-            return task.getDescription().equals(DataFrameJob.PERSISTENT_TASK_DESCRIPTION_PREFIX + id);
+            return task.getDescription().equals(DataFrameField.PERSISTENT_TASK_DESCRIPTION_PREFIX + id);
         }
 
         @Override
@@ -79,7 +79,7 @@ public class DeleteDataFrameJobAction extends Action<DeleteDataFrameJobAction.Re
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.field(DataFrameJob.ID.getPreferredName(), id);
+            builder.field(DataFrameField.ID.getPreferredName(), id);
             return builder;
         }
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/GetDataFrameJobsAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/GetDataFrameJobsAction.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.support.tasks.BaseTasksRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksResponse;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -24,7 +23,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.xpack.dataframe.job.DataFrameJob;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.dataframe.job.DataFrameJobConfig;
 
 import java.io.IOException;
@@ -36,8 +35,6 @@ public class GetDataFrameJobsAction extends Action<GetDataFrameJobsAction.Respon
 
     public static final GetDataFrameJobsAction INSTANCE = new GetDataFrameJobsAction();
     public static final String NAME = "cluster:monitor/data_frame/get";
-    public static final ParseField JOBS = new ParseField("jobs");
-    public static final ParseField COUNT = new ParseField("count");
 
     private GetDataFrameJobsAction() {
         super(NAME);
@@ -70,10 +67,10 @@ public class GetDataFrameJobsAction extends Action<GetDataFrameJobsAction.Respon
         public boolean match(Task task) {
             // If we are retrieving all the jobs, the task description does not contain the id
             if (id.equals(MetaData.ALL)) {
-                return task.getDescription().startsWith(DataFrameJob.PERSISTENT_TASK_DESCRIPTION_PREFIX);
+                return task.getDescription().startsWith(DataFrameField.PERSISTENT_TASK_DESCRIPTION_PREFIX);
             }
             // Otherwise find the task by ID
-            return task.getDescription().equals(DataFrameJob.PERSISTENT_TASK_DESCRIPTION_PREFIX + id);
+            return task.getDescription().equals(DataFrameField.PERSISTENT_TASK_DESCRIPTION_PREFIX + id);
         }
 
         public String getId() {
@@ -93,7 +90,7 @@ public class GetDataFrameJobsAction extends Action<GetDataFrameJobsAction.Respon
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.field(DataFrameJob.ID.getPreferredName(), id);
+            builder.field(DataFrameField.ID.getPreferredName(), id);
             return builder;
         }
 
@@ -165,9 +162,9 @@ public class GetDataFrameJobsAction extends Action<GetDataFrameJobsAction.Respon
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            builder.field(COUNT.getPreferredName(), jobConfigurations.size());
+            builder.field(DataFrameField.COUNT.getPreferredName(), jobConfigurations.size());
             // XContentBuilder does not support passing the params object for Iterables
-            builder.field(JOBS.getPreferredName());
+            builder.field(DataFrameField.JOBS.getPreferredName());
             builder.startArray();
             for (DataFrameJobConfig jobResponse : jobConfigurations) {
                 jobResponse.toXContent(builder, params);

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/GetDataFrameJobsStatsAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/GetDataFrameJobsStatsAction.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.support.tasks.BaseTasksRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksResponse;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -24,7 +23,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.xpack.dataframe.job.DataFrameJob;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -35,9 +34,6 @@ public class GetDataFrameJobsStatsAction extends Action<GetDataFrameJobsStatsAct
 
     public static final GetDataFrameJobsStatsAction INSTANCE = new GetDataFrameJobsStatsAction();
     public static final String NAME = "cluster:monitor/data_frame_stats/get";
-    public static final ParseField COUNT = new ParseField("count");
-    public static final ParseField JOBS = new ParseField("jobs");
-
     public GetDataFrameJobsStatsAction() {
         super(NAME);
     }
@@ -69,10 +65,10 @@ public class GetDataFrameJobsStatsAction extends Action<GetDataFrameJobsStatsAct
         public boolean match(Task task) {
             // If we are retrieving all the jobs, the task description does not contain the id
             if (id.equals(MetaData.ALL)) {
-                return task.getDescription().startsWith(DataFrameJob.PERSISTENT_TASK_DESCRIPTION_PREFIX);
+                return task.getDescription().startsWith(DataFrameField.PERSISTENT_TASK_DESCRIPTION_PREFIX);
             }
             // Otherwise find the task by ID
-            return task.getDescription().equals(DataFrameJob.PERSISTENT_TASK_DESCRIPTION_PREFIX + id);
+            return task.getDescription().equals(DataFrameField.PERSISTENT_TASK_DESCRIPTION_PREFIX + id);
         }
 
         public String getId() {
@@ -92,7 +88,7 @@ public class GetDataFrameJobsStatsAction extends Action<GetDataFrameJobsStatsAct
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.field(DataFrameJob.ID.getPreferredName(), id);
+            builder.field(DataFrameField.ID.getPreferredName(), id);
             return builder;
         }
 
@@ -164,8 +160,8 @@ public class GetDataFrameJobsStatsAction extends Action<GetDataFrameJobsStatsAct
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            builder.field(COUNT.getPreferredName(), jobsStateAndStats.size());
-            builder.field(JOBS.getPreferredName(), jobsStateAndStats);
+            builder.field(DataFrameField.COUNT.getPreferredName(), jobsStateAndStats.size());
+            builder.field(DataFrameField.JOBS.getPreferredName(), jobsStateAndStats);
             builder.endObject();
             return builder;
         }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/StartDataFrameJobAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/StartDataFrameJobAction.java
@@ -18,8 +18,8 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
-import org.elasticsearch.xpack.dataframe.job.DataFrameJob;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -43,7 +43,7 @@ public class StartDataFrameJobAction extends Action<StartDataFrameJobAction.Resp
         private String id;
 
         public Request(String id) {
-            this.id = ExceptionsHelper.requireNonNull(id, DataFrameJob.ID.getPreferredName());
+            this.id = ExceptionsHelper.requireNonNull(id, DataFrameField.ID.getPreferredName());
         }
 
         public Request() {
@@ -71,7 +71,7 @@ public class StartDataFrameJobAction extends Action<StartDataFrameJobAction.Resp
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.field(DataFrameJob.ID.getPreferredName(), id);
+            builder.field(DataFrameField.ID.getPreferredName(), id);
             return builder;
         }
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/StopDataFrameJobAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/StopDataFrameJobAction.java
@@ -19,8 +19,8 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
-import org.elasticsearch.xpack.dataframe.job.DataFrameJob;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -46,11 +46,11 @@ public class StopDataFrameJobAction extends Action<StopDataFrameJobAction.Respon
         public static ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
 
         static {
-            PARSER.declareString(Request::setId, DataFrameJob.ID);
+            PARSER.declareString(Request::setId, DataFrameField.ID);
         }
 
         public Request(String id) {
-            this.id = ExceptionsHelper.requireNonNull(id, DataFrameJob.ID.getPreferredName());
+            this.id = ExceptionsHelper.requireNonNull(id, DataFrameField.ID.getPreferredName());
         }
 
         public Request() {
@@ -82,7 +82,7 @@ public class StopDataFrameJobAction extends Action<StopDataFrameJobAction.Respon
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.field(DataFrameJob.ID.getPreferredName(), id);
+            builder.field(DataFrameField.ID.getPreferredName(), id);
             return builder;
         }
 
@@ -106,7 +106,7 @@ public class StopDataFrameJobAction extends Action<StopDataFrameJobAction.Respon
 
         @Override
         public boolean match(Task task) {
-            String expectedDescription = DataFrameJob.PERSISTENT_TASK_DESCRIPTION_PREFIX + id;
+            String expectedDescription = DataFrameField.PERSISTENT_TASK_DESCRIPTION_PREFIX + id;
 
             return task.getDescription().equals(expectedDescription);
         }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJob.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJob.java
@@ -15,7 +15,7 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.XPackPlugin;
-import org.elasticsearch.xpack.dataframe.DataFrame;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -24,11 +24,7 @@ import java.util.Objects;
 
 public class DataFrameJob extends AbstractDiffable<DataFrameJob> implements XPackPlugin.XPackPersistentTaskParams {
 
-    public static final ParseField ID = new ParseField("id");
-    public static final String NAME = DataFrame.TASK_NAME;
-
-    // note: this is used to match tasks
-    public static final String PERSISTENT_TASK_DESCRIPTION_PREFIX = "data_frame_";
+    public static final String NAME = DataFrameField.TASK_NAME;
 
     private DataFrameJobConfig config;
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobConfig.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobConfig.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Objects;
@@ -29,7 +30,6 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optiona
 public class DataFrameJobConfig implements NamedWriteable, ToXContentObject {
 
     private static final String NAME = "xpack/data_frame/jobconfig";
-    private static final ParseField ID = new ParseField("id");
     private static final ParseField INDEX_PATTERN = new ParseField("index_pattern");
     private static final ParseField DESTINATION_INDEX = new ParseField("destination_index");
     private static final ParseField SOURCES = new ParseField("sources");
@@ -52,7 +52,7 @@ public class DataFrameJobConfig implements NamedWriteable, ToXContentObject {
             });
 
     static {
-        PARSER.declareString(optionalConstructorArg(), ID);
+        PARSER.declareString(optionalConstructorArg(), DataFrameField.ID);
         PARSER.declareString(constructorArg(), INDEX_PATTERN);
         PARSER.declareString(constructorArg(), DESTINATION_INDEX);
         PARSER.declareObject(optionalConstructorArg(), (p, c) -> SourceConfig.fromXContent(p), SOURCES);
@@ -64,7 +64,7 @@ public class DataFrameJobConfig implements NamedWriteable, ToXContentObject {
                                         final String destinationIndex,
                                         final SourceConfig sourceConfig,
                                         final AggregationConfig aggregationConfig) {
-        this.id = ExceptionsHelper.requireNonNull(id, ID.getPreferredName());
+        this.id = ExceptionsHelper.requireNonNull(id, DataFrameField.ID.getPreferredName());
         this.indexPattern = ExceptionsHelper.requireNonNull(indexPattern, INDEX_PATTERN.getPreferredName());
         this.destinationIndex = ExceptionsHelper.requireNonNull(destinationIndex, DESTINATION_INDEX.getPreferredName());
 
@@ -115,7 +115,7 @@ public class DataFrameJobConfig implements NamedWriteable, ToXContentObject {
 
     public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
         builder.startObject();
-        builder.field(ID.getPreferredName(), id);
+        builder.field(DataFrameField.ID.getPreferredName(), id);
         builder.field(INDEX_PATTERN.getPreferredName(), indexPattern);
         builder.field(DESTINATION_INDEX.getPreferredName(), destinationIndex);
         if (sourceConfig != null) {

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobPersistentTasksExecutor.java
@@ -16,6 +16,7 @@ import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.persistent.PersistentTasksExecutor;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.dataframe.DataFrame;
 
@@ -31,7 +32,7 @@ public class DataFrameJobPersistentTasksExecutor extends PersistentTasksExecutor
 
     public DataFrameJobPersistentTasksExecutor(Client client, SchedulerEngine schedulerEngine,
             ThreadPool threadPool) {
-        super(DataFrame.TASK_NAME, DataFrame.TASK_THREAD_POOL_NAME);
+        super(DataFrameField.TASK_NAME, DataFrame.TASK_THREAD_POOL_NAME);
         this.client = client;
         this.schedulerEngine = schedulerEngine;
         this.threadPool = threadPool;

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobState.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobState.java
@@ -16,8 +16,8 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.persistent.PersistentTaskState;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
-import org.elasticsearch.xpack.dataframe.DataFrame;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -31,7 +31,7 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constru
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 public class DataFrameJobState implements Task.Status, PersistentTaskState {
-    public static final String NAME = DataFrame.TASK_NAME;
+    public static final String NAME = DataFrameField.TASK_NAME;
 
     private final IndexerState state;
     private final long generation;

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/job/DataFrameJobTask.java
@@ -21,10 +21,10 @@ import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine.Event;
-import org.elasticsearch.xpack.dataframe.DataFrame;
 import org.elasticsearch.xpack.dataframe.action.StartDataFrameJobAction;
 import org.elasticsearch.xpack.dataframe.action.StopDataFrameJobAction;
 import org.elasticsearch.xpack.dataframe.action.StartDataFrameJobAction.Response;
@@ -46,12 +46,12 @@ public class DataFrameJobTask extends AllocatedPersistentTask implements Schedul
     // 1: data frame complete, all data has been indexed
     private final AtomicReference<Long> generation;
 
-    static final String SCHEDULE_NAME = DataFrame.TASK_NAME + "/schedule";
+    static final String SCHEDULE_NAME = DataFrameField.TASK_NAME + "/schedule";
 
     public DataFrameJobTask(long id, String type, String action, TaskId parentTask, DataFrameJob job,
             DataFrameJobState state, Client client, SchedulerEngine schedulerEngine, ThreadPool threadPool,
             Map<String, String> headers) {
-        super(id, type, action, DataFrameJob.PERSISTENT_TASK_DESCRIPTION_PREFIX + job.getConfig().getId(), parentTask, headers);
+        super(id, type, action, DataFrameField.PERSISTENT_TASK_DESCRIPTION_PREFIX + job.getConfig().getId(), parentTask, headers);
         this.job = job;
         this.schedulerEngine = schedulerEngine;
         this.threadPool = threadPool;

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataFramePersistentTaskUtils.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataFramePersistentTaskUtils.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.dataframe.persistence;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
-import org.elasticsearch.xpack.dataframe.DataFrame;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 
 public final class DataFramePersistentTaskUtils {
 
@@ -29,7 +29,7 @@ public final class DataFramePersistentTaskUtils {
             // persistent tasks and see if at least once has a DataFrameJob param
             if (id.equals(MetaData.ALL)) {
                 hasJobs = pTasksMeta.tasks().stream()
-                        .anyMatch(persistentTask -> persistentTask.getTaskName().equals(DataFrame.TASK_NAME));
+                        .anyMatch(persistentTask -> persistentTask.getTaskName().equals(DataFrameField.TASK_NAME));
 
             } else if (pTasksMeta.getTask(id) != null) {
                 // If we're looking for a single job, we can just check directly

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestDeleteDataFrameJobAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestDeleteDataFrameJobAction.java
@@ -13,9 +13,8 @@ import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestToXContentListener;
-import org.elasticsearch.xpack.dataframe.DataFrame;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.dataframe.action.DeleteDataFrameJobAction;
-import org.elasticsearch.xpack.dataframe.job.DataFrameJob;
 
 import java.io.IOException;
 
@@ -23,12 +22,12 @@ public class RestDeleteDataFrameJobAction extends BaseRestHandler {
 
     public RestDeleteDataFrameJobAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.DELETE,  DataFrame.BASE_PATH_JOBS_BY_ID, this);
+        controller.registerHandler(RestRequest.Method.DELETE,  DataFrameField.REST_BASE_PATH_JOBS_BY_ID, this);
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
-        String id = restRequest.param(DataFrameJob.ID.getPreferredName());
+        String id = restRequest.param(DataFrameField.ID.getPreferredName());
         DeleteDataFrameJobAction.Request request = new DeleteDataFrameJobAction.Request(id);
 
         return channel -> client.execute(DeleteDataFrameJobAction.INSTANCE, request,

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestGetDataFrameJobsAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestGetDataFrameJobsAction.java
@@ -12,20 +12,19 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
-import org.elasticsearch.xpack.dataframe.DataFrame;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.dataframe.action.GetDataFrameJobsAction;
-import org.elasticsearch.xpack.dataframe.job.DataFrameJob;
 
 public class RestGetDataFrameJobsAction extends BaseRestHandler {
 
     public RestGetDataFrameJobsAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.GET, DataFrame.BASE_PATH_JOBS_BY_ID, this);
+        controller.registerHandler(RestRequest.Method.GET, DataFrameField.REST_BASE_PATH_JOBS_BY_ID, this);
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
-        String id = restRequest.param(DataFrameJob.ID.getPreferredName());
+        String id = restRequest.param(DataFrameField.ID.getPreferredName());
         GetDataFrameJobsAction.Request request = new GetDataFrameJobsAction.Request(id);
         return channel -> client.execute(GetDataFrameJobsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestGetDataFrameJobsStatsAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestGetDataFrameJobsStatsAction.java
@@ -12,20 +12,19 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
-import org.elasticsearch.xpack.dataframe.DataFrame;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.dataframe.action.GetDataFrameJobsStatsAction;
-import org.elasticsearch.xpack.dataframe.job.DataFrameJob;
 
 public class RestGetDataFrameJobsStatsAction extends BaseRestHandler {
 
     public RestGetDataFrameJobsStatsAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.GET, DataFrame.BASE_PATH_JOBS_BY_ID + "_stats", this);
+        controller.registerHandler(RestRequest.Method.GET, DataFrameField.REST_BASE_PATH_JOBS_BY_ID + "_stats", this);
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
-        String id = restRequest.param(DataFrameJob.ID.getPreferredName());
+        String id = restRequest.param(DataFrameField.ID.getPreferredName());
         GetDataFrameJobsStatsAction.Request request = new GetDataFrameJobsStatsAction.Request(id);
         return channel -> client.execute(GetDataFrameJobsStatsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestPutDataFrameJobAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestPutDataFrameJobAction.java
@@ -13,9 +13,8 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
-import org.elasticsearch.xpack.dataframe.DataFrame;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.dataframe.action.PutDataFrameJobAction;
-import org.elasticsearch.xpack.dataframe.job.DataFrameJob;
 
 import java.io.IOException;
 
@@ -23,7 +22,7 @@ public class RestPutDataFrameJobAction extends BaseRestHandler {
     
     public RestPutDataFrameJobAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.PUT, DataFrame.BASE_PATH_JOBS_BY_ID, this);
+        controller.registerHandler(RestRequest.Method.PUT, DataFrameField.REST_BASE_PATH_JOBS_BY_ID, this);
     }
 
     @Override
@@ -33,7 +32,7 @@ public class RestPutDataFrameJobAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
-        String id = restRequest.param(DataFrameJob.ID.getPreferredName());
+        String id = restRequest.param(DataFrameField.ID.getPreferredName());
         XContentParser parser = restRequest.contentParser();
 
         PutDataFrameJobAction.Request request = PutDataFrameJobAction.Request.fromXContent(parser, id);

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestStartDataFrameJobAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestStartDataFrameJobAction.java
@@ -12,8 +12,8 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.rollup.RollupField;
-import org.elasticsearch.xpack.dataframe.DataFrame;
 import org.elasticsearch.xpack.dataframe.action.StartDataFrameJobAction;
 
 import java.io.IOException;
@@ -22,7 +22,7 @@ public class RestStartDataFrameJobAction extends BaseRestHandler {
     
     public RestStartDataFrameJobAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.POST, DataFrame.BASE_PATH_JOBS_BY_ID + "_start", this);
+        controller.registerHandler(RestRequest.Method.POST, DataFrameField.REST_BASE_PATH_JOBS_BY_ID + "_start", this);
     }
     
     @Override

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestStopDataFrameJobAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestStopDataFrameJobAction.java
@@ -11,9 +11,8 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
-import org.elasticsearch.xpack.dataframe.DataFrame;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.dataframe.action.StopDataFrameJobAction;
-import org.elasticsearch.xpack.dataframe.job.DataFrameJob;
 
 import java.io.IOException;
 
@@ -21,12 +20,12 @@ public class RestStopDataFrameJobAction extends BaseRestHandler {
 
     public RestStopDataFrameJobAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.POST, DataFrame.BASE_PATH_JOBS_BY_ID + "_stop", this);
+        controller.registerHandler(RestRequest.Method.POST, DataFrameField.REST_BASE_PATH_JOBS_BY_ID + "_stop", this);
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
-        String id = restRequest.param(DataFrameJob.ID.getPreferredName());
+        String id = restRequest.param(DataFrameField.ID.getPreferredName());
         StopDataFrameJobAction.Request request = new StopDataFrameJobAction.Request(id);
 
         return channel -> client.execute(StopDataFrameJobAction.INSTANCE, request, new RestToXContentListener<>(channel));


### PR DESCRIPTION
move common fields and string into a utility class

Notes:
 - the new class is created in core although not necessary at the moment it needs to be eventually there for HLRC
 - changes are mostly mechanic, only DataFrameField is new, rest is re-factorings and 3 dedups
 - naming (DataFrameField) follows other plugins: ML, Rollup