### PR TITLE
[refactor] add Environment in BootstrapContext

### DIFF
--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
@@ -21,9 +21,8 @@ package org.elasticsearch.bootstrap;
 
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.SuppressForbidden;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.NodeValidationException;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
@@ -40,7 +39,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class EvilBootstrapChecksTests extends ESTestCase {
+public class EvilBootstrapChecksTests extends AbstractBootstrapCheckTestCase {
 
     private String esEnforceBootstrapChecks = System.getProperty(ES_ENFORCE_BOOTSTRAP_CHECKS);
 
@@ -65,7 +64,7 @@ public class EvilBootstrapChecksTests extends ESTestCase {
 
         final NodeValidationException e = expectThrows(
                 NodeValidationException.class,
-                () -> BootstrapChecks.check(new BootstrapContext(Settings.EMPTY, null), false, checks, logger));
+                () -> BootstrapChecks.check(emptyContext, false, checks, logger));
         final Matcher<String> allOf =
                 allOf(containsString("bootstrap checks failed"), containsString("error"));
         assertThat(e, hasToString(allOf));
@@ -77,7 +76,7 @@ public class EvilBootstrapChecksTests extends ESTestCase {
         setEsEnforceBootstrapChecks(null);
         final Logger logger = mock(Logger.class);
         // nothing should happen
-        BootstrapChecks.check(new BootstrapContext(Settings.EMPTY, null), false, emptyList(), logger);
+        BootstrapChecks.check(emptyContext, false, emptyList(), logger);
         verifyNoMoreInteractions(logger);
     }
 
@@ -87,7 +86,7 @@ public class EvilBootstrapChecksTests extends ESTestCase {
         final boolean enforceLimits = randomBoolean();
         final IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,
-                () -> BootstrapChecks.check(new BootstrapContext(Settings.EMPTY, null), enforceLimits, emptyList()));
+                () -> BootstrapChecks.check(emptyContext, enforceLimits, emptyList()));
         final Matcher<String> matcher = containsString(
                 "[es.enforce.bootstrap.checks] must be [true] but was [" + value + "]");
         assertThat(e, hasToString(matcher));

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -81,7 +81,7 @@ final class BootstrapChecks {
         final List<BootstrapCheck> combinedChecks = new ArrayList<>(builtInChecks);
         combinedChecks.addAll(additionalChecks);
         check(  context,
-                enforceLimits(boundTransportAddress, DiscoveryModule.DISCOVERY_TYPE_SETTING.get(context.settings)),
+                enforceLimits(boundTransportAddress, DiscoveryModule.DISCOVERY_TYPE_SETTING.get(context.getSettings())),
                 Collections.unmodifiableList(combinedChecks));
     }
 
@@ -302,7 +302,7 @@ final class BootstrapChecks {
 
         @Override
         public BootstrapCheckResult check(BootstrapContext context) {
-            if (BootstrapSettings.MEMORY_LOCK_SETTING.get(context.settings) && !isMemoryLocked()) {
+            if (BootstrapSettings.MEMORY_LOCK_SETTING.get(context.getSettings()) && !isMemoryLocked()) {
                 return BootstrapCheckResult.failure("memory locking requested for elasticsearch process but memory is not locked");
             } else {
                 return BootstrapCheckResult.success();
@@ -408,7 +408,7 @@ final class BootstrapChecks {
         @Override
         public BootstrapCheckResult check(final BootstrapContext context) {
             // we only enforce the check if mmapfs is an allowed store type
-            if (IndexModule.NODE_STORE_ALLOW_MMAPFS.get(context.settings)) {
+            if (IndexModule.NODE_STORE_ALLOW_MMAPFS.get(context.getSettings())) {
                 if (getMaxMapCount() != -1 && getMaxMapCount() < LIMIT) {
                     final String message = String.format(
                             Locale.ROOT,
@@ -525,7 +525,7 @@ final class BootstrapChecks {
 
         @Override
         public BootstrapCheckResult check(BootstrapContext context) {
-            if (BootstrapSettings.SYSTEM_CALL_FILTER_SETTING.get(context.settings) && !isSystemCallFilterInstalled()) {
+            if (BootstrapSettings.SYSTEM_CALL_FILTER_SETTING.get(context.getSettings()) && !isSystemCallFilterInstalled()) {
                 final String message =  "system call filters failed to install; " +
                         "check the logs and fix your configuration or disable system call filters at your own risk";
                 return BootstrapCheckResult.failure(message);
@@ -725,10 +725,10 @@ final class BootstrapChecks {
     static class DiscoveryConfiguredCheck implements BootstrapCheck {
         @Override
         public BootstrapCheckResult check(BootstrapContext context) {
-            if (DiscoveryModule.ZEN2_DISCOVERY_TYPE.equals(DiscoveryModule.DISCOVERY_TYPE_SETTING.get(context.settings)) == false) {
+            if (DiscoveryModule.ZEN2_DISCOVERY_TYPE.equals(DiscoveryModule.DISCOVERY_TYPE_SETTING.get(context.getSettings())) == false) {
                 return BootstrapCheckResult.success();
             }
-            if (ClusterBootstrapService.discoveryIsConfigured(context.settings)) {
+            if (ClusterBootstrapService.discoveryIsConfigured(context.getSettings())) {
                 return BootstrapCheckResult.success();
             }
 

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -81,7 +81,7 @@ final class BootstrapChecks {
         final List<BootstrapCheck> combinedChecks = new ArrayList<>(builtInChecks);
         combinedChecks.addAll(additionalChecks);
         check(  context,
-                enforceLimits(boundTransportAddress, DiscoveryModule.DISCOVERY_TYPE_SETTING.get(context.getSettings())),
+                enforceLimits(boundTransportAddress, DiscoveryModule.DISCOVERY_TYPE_SETTING.get(context.settings())),
                 Collections.unmodifiableList(combinedChecks));
     }
 
@@ -302,7 +302,7 @@ final class BootstrapChecks {
 
         @Override
         public BootstrapCheckResult check(BootstrapContext context) {
-            if (BootstrapSettings.MEMORY_LOCK_SETTING.get(context.getSettings()) && !isMemoryLocked()) {
+            if (BootstrapSettings.MEMORY_LOCK_SETTING.get(context.settings()) && !isMemoryLocked()) {
                 return BootstrapCheckResult.failure("memory locking requested for elasticsearch process but memory is not locked");
             } else {
                 return BootstrapCheckResult.success();
@@ -408,7 +408,7 @@ final class BootstrapChecks {
         @Override
         public BootstrapCheckResult check(final BootstrapContext context) {
             // we only enforce the check if mmapfs is an allowed store type
-            if (IndexModule.NODE_STORE_ALLOW_MMAPFS.get(context.getSettings())) {
+            if (IndexModule.NODE_STORE_ALLOW_MMAPFS.get(context.settings())) {
                 if (getMaxMapCount() != -1 && getMaxMapCount() < LIMIT) {
                     final String message = String.format(
                             Locale.ROOT,
@@ -525,7 +525,7 @@ final class BootstrapChecks {
 
         @Override
         public BootstrapCheckResult check(BootstrapContext context) {
-            if (BootstrapSettings.SYSTEM_CALL_FILTER_SETTING.get(context.getSettings()) && !isSystemCallFilterInstalled()) {
+            if (BootstrapSettings.SYSTEM_CALL_FILTER_SETTING.get(context.settings()) && !isSystemCallFilterInstalled()) {
                 final String message =  "system call filters failed to install; " +
                         "check the logs and fix your configuration or disable system call filters at your own risk";
                 return BootstrapCheckResult.failure(message);
@@ -725,10 +725,10 @@ final class BootstrapChecks {
     static class DiscoveryConfiguredCheck implements BootstrapCheck {
         @Override
         public BootstrapCheckResult check(BootstrapContext context) {
-            if (DiscoveryModule.ZEN2_DISCOVERY_TYPE.equals(DiscoveryModule.DISCOVERY_TYPE_SETTING.get(context.getSettings())) == false) {
+            if (DiscoveryModule.ZEN2_DISCOVERY_TYPE.equals(DiscoveryModule.DISCOVERY_TYPE_SETTING.get(context.settings())) == false) {
                 return BootstrapCheckResult.success();
             }
-            if (ClusterBootstrapService.discoveryIsConfigured(context.getSettings())) {
+            if (ClusterBootstrapService.discoveryIsConfigured(context.settings())) {
                 return BootstrapCheckResult.success();
             }
 

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapContext.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapContext.java
@@ -41,15 +41,15 @@ public class BootstrapContext {
         this.metaData = metaData;
     }
 
-    public Environment getEnvironment() {
+    public Environment environment() {
         return environment;
     }
 
-    public Settings getSettings() {
+    public Settings settings() {
         return environment.settings();
     }
 
-    public MetaData getMetaData() {
+    public MetaData metaData() {
         return metaData;
     }
 }

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -677,7 +677,7 @@ public class Node implements Closeable {
             onDiskMetadata = MetaData.EMPTY_META_DATA;
         }
         assert onDiskMetadata != null : "metadata is null but shouldn't"; // this is never null
-        validateNodeBeforeAcceptingRequests(new BootstrapContext(settings, onDiskMetadata), transportService.boundAddress(), pluginsService
+        validateNodeBeforeAcceptingRequests(new BootstrapContext(environment, onDiskMetadata), transportService.boundAddress(), pluginsService
             .filterPlugins(Plugin
             .class)
             .stream()

--- a/server/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
@@ -31,7 +31,7 @@ import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.discovery.zen.SettingsBasedHostsProvider;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.node.NodeValidationException;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -56,9 +56,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class BootstrapChecksTests extends ESTestCase {
-
-    static final BootstrapContext defaultContext = new BootstrapContext(Settings.EMPTY, MetaData.EMPTY_META_DATA);
+public class BootstrapChecksTests extends AbstractBootstrapCheckTestCase {
 
     public void testNonProductionMode() throws NodeValidationException {
         // nothing should happen since we are in non-production mode
@@ -72,18 +70,18 @@ public class BootstrapChecksTests extends ESTestCase {
         BoundTransportAddress boundTransportAddress = mock(BoundTransportAddress.class);
         when(boundTransportAddress.boundAddresses()).thenReturn(transportAddresses.toArray(new TransportAddress[0]));
         when(boundTransportAddress.publishAddress()).thenReturn(publishAddress);
-        BootstrapChecks.check(defaultContext, boundTransportAddress, Collections.emptyList());
+        BootstrapChecks.check(emptyContext, boundTransportAddress, Collections.emptyList());
     }
 
     public void testNoLogMessageInNonProductionMode() throws NodeValidationException {
         final Logger logger = mock(Logger.class);
-        BootstrapChecks.check(defaultContext, false, Collections.emptyList(), logger);
+        BootstrapChecks.check(emptyContext, false, Collections.emptyList(), logger);
         verifyNoMoreInteractions(logger);
     }
 
     public void testLogMessageInProductionMode() throws NodeValidationException {
         final Logger logger = mock(Logger.class);
-        BootstrapChecks.check(defaultContext, true, Collections.emptyList(), logger);
+        BootstrapChecks.check(emptyContext, true, Collections.emptyList(), logger);
         verify(logger).info("bound or publishing to a non-loopback address, enforcing bootstrap checks");
         verifyNoMoreInteractions(logger);
     }
@@ -137,7 +135,7 @@ public class BootstrapChecksTests extends ESTestCase {
 
         final NodeValidationException e =
                 expectThrows(NodeValidationException.class,
-                    () -> BootstrapChecks.check(defaultContext, true, checks));
+                    () -> BootstrapChecks.check(emptyContext, true, checks));
         assertThat(e, hasToString(allOf(containsString("bootstrap checks failed"), containsString("first"), containsString("second"))));
         final Throwable[] suppressed = e.getSuppressed();
         assertThat(suppressed.length, equalTo(2));
@@ -168,7 +166,7 @@ public class BootstrapChecksTests extends ESTestCase {
         final NodeValidationException e =
                 expectThrows(
                         NodeValidationException.class,
-                        () -> BootstrapChecks.check(defaultContext, true, Collections.singletonList(check)));
+                        () -> BootstrapChecks.check(emptyContext, true, Collections.singletonList(check)));
         assertThat(
                 e.getMessage(),
                 containsString("initial heap size [" + initialHeapSize.get() + "] " +
@@ -176,7 +174,7 @@ public class BootstrapChecksTests extends ESTestCase {
 
         initialHeapSize.set(maxHeapSize.get());
 
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(check));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
 
         // nothing should happen if the initial heap size or the max
         // heap size is not available
@@ -185,7 +183,7 @@ public class BootstrapChecksTests extends ESTestCase {
         } else {
             maxHeapSize.set(0);
         }
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(check));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
     }
 
     public void testFileDescriptorLimits() throws NodeValidationException {
@@ -211,17 +209,17 @@ public class BootstrapChecksTests extends ESTestCase {
 
         final NodeValidationException e =
                 expectThrows(NodeValidationException.class,
-                        () -> BootstrapChecks.check(defaultContext, true, Collections.singletonList(check)));
+                        () -> BootstrapChecks.check(emptyContext, true, Collections.singletonList(check)));
         assertThat(e.getMessage(), containsString("max file descriptors"));
 
         maxFileDescriptorCount.set(randomIntBetween(limit + 1, Integer.MAX_VALUE));
 
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(check));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
 
         // nothing should happen if current file descriptor count is
         // not available
         maxFileDescriptorCount.set(-1);
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(check));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
     }
 
     public void testFileDescriptorLimitsThrowsOnInvalidLimit() {
@@ -260,7 +258,7 @@ public class BootstrapChecksTests extends ESTestCase {
                     return testCase.isMemoryLocked;
                 }
             };
-            BootstrapContext bootstrapContext = new BootstrapContext(
+            BootstrapContext bootstrapContext = createTestContext(
                 Settings.builder().put("bootstrap.memory_lock", testCase.mlockallSet).build(), null);
             if (testCase.shouldFail) {
                 final NodeValidationException e = expectThrows(
@@ -291,17 +289,17 @@ public class BootstrapChecksTests extends ESTestCase {
 
         final NodeValidationException e = expectThrows(
                 NodeValidationException.class,
-                () -> BootstrapChecks.check(defaultContext, true, Collections.singletonList(check)));
+                () -> BootstrapChecks.check(emptyContext, true, Collections.singletonList(check)));
         assertThat(e.getMessage(), containsString("max number of threads"));
 
         maxNumberOfThreads.set(randomIntBetween(limit + 1, Integer.MAX_VALUE));
 
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(check));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
 
         // nothing should happen if current max number of threads is
         // not available
         maxNumberOfThreads.set(-1);
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(check));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
     }
 
     public void testMaxSizeVirtualMemory() throws NodeValidationException {
@@ -321,16 +319,16 @@ public class BootstrapChecksTests extends ESTestCase {
 
         final NodeValidationException e = expectThrows(
                 NodeValidationException.class,
-                () -> BootstrapChecks.check(defaultContext, true, Collections.singletonList(check)));
+                () -> BootstrapChecks.check(emptyContext, true, Collections.singletonList(check)));
         assertThat(e.getMessage(), containsString("max size virtual memory"));
 
         maxSizeVirtualMemory.set(rlimInfinity);
 
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(check));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
 
         // nothing should happen if max size virtual memory is not available
         maxSizeVirtualMemory.set(Long.MIN_VALUE);
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(check));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
     }
 
     public void testMaxFileSizeCheck() throws NodeValidationException {
@@ -350,16 +348,16 @@ public class BootstrapChecksTests extends ESTestCase {
 
         final NodeValidationException e = expectThrows(
                 NodeValidationException.class,
-                () -> BootstrapChecks.check(defaultContext, true, Collections.singletonList(check)));
+                () -> BootstrapChecks.check(emptyContext, true, Collections.singletonList(check)));
         assertThat(e.getMessage(), containsString("max file size"));
 
         maxFileSize.set(rlimInfinity);
 
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(check));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
 
         // nothing should happen if max file size is not available
         maxFileSize.set(Long.MIN_VALUE);
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(check));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
     }
 
     public void testClientJvmCheck() throws NodeValidationException {
@@ -373,14 +371,14 @@ public class BootstrapChecksTests extends ESTestCase {
 
         final NodeValidationException e = expectThrows(
                 NodeValidationException.class,
-                () -> BootstrapChecks.check(defaultContext, true, Collections.singletonList(check)));
+                () -> BootstrapChecks.check(emptyContext, true, Collections.singletonList(check)));
         assertThat(
                 e.getMessage(),
                 containsString("JVM is using the client VM [Java HotSpot(TM) 32-Bit Client VM] " +
                         "but should be using a server VM for the best performance"));
 
         vmName.set("Java HotSpot(TM) 32-Bit Server VM");
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(check));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
     }
 
     public void testUseSerialGCCheck() throws NodeValidationException {
@@ -394,20 +392,20 @@ public class BootstrapChecksTests extends ESTestCase {
 
         final NodeValidationException e = expectThrows(
             NodeValidationException.class,
-            () -> BootstrapChecks.check(defaultContext, true, Collections.singletonList(check)));
+            () -> BootstrapChecks.check(emptyContext, true, Collections.singletonList(check)));
         assertThat(
             e.getMessage(),
             containsString("JVM is using the serial collector but should not be for the best performance; " + "" +
                 "either it's the default for the VM [" + JvmInfo.jvmInfo().getVmName() +"] or -XX:+UseSerialGC was explicitly specified"));
 
         useSerialGC.set("false");
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(check));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
     }
 
     public void testSystemCallFilterCheck() throws NodeValidationException {
         final AtomicBoolean isSystemCallFilterInstalled = new AtomicBoolean();
-        BootstrapContext context = randomBoolean() ? new BootstrapContext(Settings.builder().put("bootstrap.system_call_filter", true)
-            .build(), null) : defaultContext;
+        BootstrapContext context = randomBoolean() ? createTestContext(Settings.builder().put("bootstrap.system_call_filter", true)
+            .build(), null) : emptyContext;
 
         final BootstrapChecks.SystemCallFilterCheck systemCallFilterEnabledCheck = new BootstrapChecks.SystemCallFilterCheck() {
             @Override
@@ -426,7 +424,7 @@ public class BootstrapChecksTests extends ESTestCase {
 
         isSystemCallFilterInstalled.set(true);
         BootstrapChecks.check(context, true, Collections.singletonList(systemCallFilterEnabledCheck));
-        BootstrapContext context_1 = new BootstrapContext(Settings.builder().put("bootstrap.system_call_filter", false).build(), null);
+        BootstrapContext context_1 = createTestContext(Settings.builder().put("bootstrap.system_call_filter", false).build(), null);
         final BootstrapChecks.SystemCallFilterCheck systemCallFilterNotEnabledCheck = new BootstrapChecks.SystemCallFilterCheck() {
             @Override
             boolean isSystemCallFilterInstalled() {
@@ -538,13 +536,13 @@ public class BootstrapChecksTests extends ESTestCase {
         } else {
             enableMightFork.run();
         }
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(check));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
 
         // if system call filter is enabled, but we will not fork, nothing should
         // happen
         isSystemCallFilterInstalled.set(true);
         disableMightFork.run();
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(check));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
 
         // if system call filter is enabled, and we might fork, the check should be enforced, regardless of bootstrap checks being enabled
         // or not
@@ -553,7 +551,7 @@ public class BootstrapChecksTests extends ESTestCase {
 
         final NodeValidationException e = expectThrows(
             NodeValidationException.class,
-            () -> BootstrapChecks.check(defaultContext, randomBoolean(), Collections.singletonList(check)));
+            () -> BootstrapChecks.check(emptyContext, randomBoolean(), Collections.singletonList(check)));
         consumer.accept(e);
     }
 
@@ -578,7 +576,7 @@ public class BootstrapChecksTests extends ESTestCase {
         final NodeValidationException e = expectThrows(
                 NodeValidationException.class,
                 () -> {
-                    BootstrapChecks.check(defaultContext, true, checks);
+                    BootstrapChecks.check(emptyContext, true, checks);
                 });
         assertThat(
                 e.getMessage(),
@@ -589,7 +587,7 @@ public class BootstrapChecksTests extends ESTestCase {
 
         // if not on an early-access build, nothing should happen
         javaVersion.set(randomFrom("1.8.0_152", "9"));
-        BootstrapChecks.check(defaultContext, true, checks);
+        BootstrapChecks.check(emptyContext, true, checks);
 
     }
 
@@ -625,7 +623,7 @@ public class BootstrapChecksTests extends ESTestCase {
         final NodeValidationException e =
             expectThrows(
                 NodeValidationException.class,
-                () -> BootstrapChecks.check(defaultContext, true, Collections.singletonList(g1GCCheck)));
+                () -> BootstrapChecks.check(emptyContext, true, Collections.singletonList(g1GCCheck)));
         assertThat(
             e.getMessage(),
             containsString(
@@ -633,12 +631,12 @@ public class BootstrapChecksTests extends ESTestCase {
 
         // if G1GC is disabled, nothing should happen
         isG1GCEnabled.set(false);
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(g1GCCheck));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(g1GCCheck));
 
         // if on or after update 40, nothing should happen independent of whether or not G1GC is enabled
         isG1GCEnabled.set(randomBoolean());
         jvmVersion.set(String.format(Locale.ROOT, "25.%d-b%d", randomIntBetween(40, 112), randomIntBetween(1, 128)));
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(g1GCCheck));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(g1GCCheck));
 
         final BootstrapChecks.G1GCCheck nonOracleCheck = new BootstrapChecks.G1GCCheck() {
 
@@ -650,7 +648,7 @@ public class BootstrapChecksTests extends ESTestCase {
         };
 
         // if not on an Oracle JVM, nothing should happen
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(nonOracleCheck));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(nonOracleCheck));
 
         final BootstrapChecks.G1GCCheck nonJava8Check = new BootstrapChecks.G1GCCheck() {
 
@@ -662,7 +660,7 @@ public class BootstrapChecksTests extends ESTestCase {
         };
 
         // if not Java 8, nothing should happen
-        BootstrapChecks.check(defaultContext, true, Collections.singletonList(nonJava8Check));
+        BootstrapChecks.check(emptyContext, true, Collections.singletonList(nonJava8Check));
     }
 
     public void testAllPermissionCheck() throws NodeValidationException {
@@ -677,12 +675,12 @@ public class BootstrapChecksTests extends ESTestCase {
         final List<BootstrapCheck> checks = Collections.singletonList(allPermissionCheck);
         final NodeValidationException e = expectThrows(
                 NodeValidationException.class,
-                () -> BootstrapChecks.check(defaultContext, true, checks));
+                () -> BootstrapChecks.check(emptyContext, true, checks));
         assertThat(e, hasToString(containsString("granting the all permission effectively disables security")));
 
         // if all permissions are not granted, nothing should happen
         isAllPermissionGranted.set(false);
-        BootstrapChecks.check(defaultContext, true, checks);
+        BootstrapChecks.check(emptyContext, true, checks);
     }
 
     public void testAlwaysEnforcedChecks() {
@@ -700,21 +698,21 @@ public class BootstrapChecksTests extends ESTestCase {
 
         final NodeValidationException alwaysEnforced = expectThrows(
             NodeValidationException.class,
-            () -> BootstrapChecks.check(defaultContext, randomBoolean(), Collections.singletonList(check)));
+            () -> BootstrapChecks.check(emptyContext, randomBoolean(), Collections.singletonList(check)));
         assertThat(alwaysEnforced, hasToString(containsString("error")));
     }
 
     public void testDiscoveryConfiguredCheck() throws NodeValidationException {
         final List<BootstrapCheck> checks = Collections.singletonList(new BootstrapChecks.DiscoveryConfiguredCheck());
 
-        final BootstrapContext zen2Context = new BootstrapContext(Settings.builder()
+        final BootstrapContext zen2Context = createTestContext(Settings.builder()
             .put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), ZEN2_DISCOVERY_TYPE).build(), MetaData.EMPTY_META_DATA);
 
         // not always enforced
         BootstrapChecks.check(zen2Context, false, checks);
 
         // not enforced for non-zen2 discovery
-        BootstrapChecks.check(new BootstrapContext(Settings.builder().put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(),
+        BootstrapChecks.check(createTestContext(Settings.builder().put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(),
             randomFrom(ZEN_DISCOVERY_TYPE, "single-node", randomAlphaOfLength(5))).build(), MetaData.EMPTY_META_DATA), true, checks);
 
         final NodeValidationException e = expectThrows(NodeValidationException.class,
@@ -724,7 +722,7 @@ public class BootstrapChecksTests extends ESTestCase {
 
         CheckedConsumer<Settings.Builder, NodeValidationException> ensureChecksPass = b ->
         {
-            final BootstrapContext context = new BootstrapContext(b
+            final BootstrapContext context = createTestContext(b
                 .put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), ZEN2_DISCOVERY_TYPE).build(), MetaData.EMPTY_META_DATA);
             BootstrapChecks.check(context, true, checks);
         };

--- a/server/src/test/java/org/elasticsearch/bootstrap/MaxMapCountCheckTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/MaxMapCountCheckTests.java
@@ -29,7 +29,7 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 import org.elasticsearch.test.MockLogAppender;
 
 import java.io.BufferedReader;
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class MaxMapCountCheckTests extends ESTestCase {
+public class MaxMapCountCheckTests extends AbstractBootstrapCheckTestCase {
 
     // initialize as if the max map count is under the limit, tests can override by setting maxMapCount before executing the check
     private final AtomicLong maxMapCount = new AtomicLong(randomIntBetween(1, Math.toIntExact(BootstrapChecks.MaxMapCountCheck.LIMIT) - 1));
@@ -69,7 +69,7 @@ public class MaxMapCountCheckTests extends ESTestCase {
     }
 
     public void testMaxMapCountCheckBelowLimit() {
-        assertFailure(check.check(BootstrapChecksTests.defaultContext));
+        assertFailure(check.check(emptyContext));
     }
 
     public void testMaxMapCountCheckBelowLimitAndMemoryMapAllowed() {
@@ -84,14 +84,14 @@ public class MaxMapCountCheckTests extends ESTestCase {
         settingsThatAllowMemoryMap.add(Settings.builder().put("node.store.allow_mmapfs", true).build());
 
         for (final Settings settingThatAllowsMemoryMap : settingsThatAllowMemoryMap) {
-            assertFailure(check.check(new BootstrapContext(settingThatAllowsMemoryMap, MetaData.EMPTY_META_DATA)));
+            assertFailure(check.check(createTestContext(settingThatAllowsMemoryMap, MetaData.EMPTY_META_DATA)));
         }
     }
 
     public void testMaxMapCountCheckNotEnforcedIfMemoryMapNotAllowed() {
         // nothing should happen if current vm.max_map_count is under the limit but mmapfs is not allowed
         final Settings settings = Settings.builder().put("node.store.allow_mmapfs", false).build();
-        final BootstrapContext context = new BootstrapContext(settings, MetaData.EMPTY_META_DATA);
+        final BootstrapContext context = createTestContext(settings, MetaData.EMPTY_META_DATA);
         final BootstrapCheck.BootstrapCheckResult result = check.check(context);
         assertTrue(result.isSuccess());
     }
@@ -99,14 +99,14 @@ public class MaxMapCountCheckTests extends ESTestCase {
     public void testMaxMapCountCheckAboveLimit() {
         // nothing should happen if current vm.max_map_count exceeds the limit
         maxMapCount.set(randomIntBetween(Math.toIntExact(BootstrapChecks.MaxMapCountCheck.LIMIT) + 1, Integer.MAX_VALUE));
-        final BootstrapCheck.BootstrapCheckResult result = check.check(BootstrapChecksTests.defaultContext);
+        final BootstrapCheck.BootstrapCheckResult result = check.check(emptyContext);
         assertTrue(result.isSuccess());
     }
 
     public void testMaxMapCountCheckMaxMapCountNotAvailable() {
         // nothing should happen if current vm.max_map_count is not available
         maxMapCount.set(-1);
-        final BootstrapCheck.BootstrapCheckResult result = check.check(BootstrapChecksTests.defaultContext);
+        final BootstrapCheck.BootstrapCheckResult result = check.check(emptyContext);
         assertTrue(result.isSuccess());
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBootstrapCheckTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBootstrapCheckTestCase.java
@@ -16,40 +16,29 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.bootstrap;
 
+package org.elasticsearch.test;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.bootstrap.BootstrapContext;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 
-/**
- * Context that is passed to every bootstrap check to make decisions on.
- */
-public class BootstrapContext {
-    /**
-     * The node's environment
-     */
-    private final Environment environment;
+import java.nio.file.Path;
 
-    /**
-     * The node's local state metadata loaded on startup
-     */
-    private final MetaData metaData;
+public abstract class AbstractBootstrapCheckTestCase extends ESTestCase {
+    protected final BootstrapContext emptyContext;
 
-    public BootstrapContext(Environment environment, MetaData metaData) {
-        this.environment = environment;
-        this.metaData = metaData;
+    public AbstractBootstrapCheckTestCase() {
+        emptyContext = createTestContext(Settings.EMPTY, MetaData.EMPTY_META_DATA);
     }
 
-    public Environment getEnvironment() {
-        return environment;
-    }
-
-    public Settings getSettings() {
-        return environment.settings();
-    }
-
-    public MetaData getMetaData() {
-        return metaData;
+    protected BootstrapContext createTestContext(Settings settings, MetaData metaData) {
+        Path homePath = createTempDir();
+        Environment environment = new Environment(settings(Version.CURRENT)
+            .put(settings)
+            .put(Environment.PATH_HOME_SETTING.getKey(), homePath.toString()).build(), null);
+        return new BootstrapContext(environment, metaData);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/TLSLicenseBootstrapCheck.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/TLSLicenseBootstrapCheck.java
@@ -17,8 +17,8 @@ import org.elasticsearch.xpack.core.XPackSettings;
 public final class TLSLicenseBootstrapCheck implements BootstrapCheck {
     @Override
     public BootstrapCheckResult check(BootstrapContext context) {
-        if (XPackSettings.TRANSPORT_SSL_ENABLED.get(context.getSettings()) == false) {
-            License license = LicenseService.getLicense(context.getMetaData());
+        if (XPackSettings.TRANSPORT_SSL_ENABLED.get(context.settings()) == false) {
+            License license = LicenseService.getLicense(context.metaData());
             if (license != null && license.isProductionLicense()) {
                 return BootstrapCheckResult.failure("Transport SSL must be enabled for setups with production licenses. Please set " +
                         "[xpack.security.transport.ssl.enabled] to [true] or disable security by setting [xpack.security.enabled] " +

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/TLSLicenseBootstrapCheck.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/TLSLicenseBootstrapCheck.java
@@ -17,8 +17,8 @@ import org.elasticsearch.xpack.core.XPackSettings;
 public final class TLSLicenseBootstrapCheck implements BootstrapCheck {
     @Override
     public BootstrapCheckResult check(BootstrapContext context) {
-        if (XPackSettings.TRANSPORT_SSL_ENABLED.get(context.settings) == false) {
-            License license = LicenseService.getLicense(context.metaData);
+        if (XPackSettings.TRANSPORT_SSL_ENABLED.get(context.getSettings()) == false) {
+            License license = LicenseService.getLicense(context.getMetaData());
             if (license != null && license.isProductionLicense()) {
                 return BootstrapCheckResult.failure("Transport SSL must be enabled for setups with production licenses. Please set " +
                         "[xpack.security.transport.ssl.enabled] to [true] or disable security by setting [xpack.security.enabled] " +

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/TLSLicenseBootstrapCheckTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/TLSLicenseBootstrapCheckTests.java
@@ -5,20 +5,19 @@
  */
 package org.elasticsearch.xpack.core.ssl;
 
-import org.elasticsearch.bootstrap.BootstrapContext;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.TestUtils;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 
 import java.util.EnumSet;
 
-public class TLSLicenseBootstrapCheckTests extends ESTestCase {
+public class TLSLicenseBootstrapCheckTests extends AbstractBootstrapCheckTestCase {
     public void testBootstrapCheck() throws Exception {
-        assertTrue(new TLSLicenseBootstrapCheck().check(new BootstrapContext(Settings.EMPTY, MetaData.EMPTY_META_DATA)).isSuccess());
-        assertTrue(new TLSLicenseBootstrapCheck().check(new BootstrapContext(Settings.builder().put("xpack.security.transport.ssl.enabled"
+        assertTrue(new TLSLicenseBootstrapCheck().check(emptyContext).isSuccess());
+        assertTrue(new TLSLicenseBootstrapCheck().check(createTestContext(Settings.builder().put("xpack.security.transport.ssl.enabled"
                     , randomBoolean()).build(), MetaData.EMPTY_META_DATA)).isSuccess());
         int numIters = randomIntBetween(1,10);
         for (int i = 0; i < numIters; i++) {
@@ -29,15 +28,15 @@ public class TLSLicenseBootstrapCheckTests extends ESTestCase {
             TestUtils.putLicense(builder, license);
             MetaData build = builder.build();
             if (productionModes.contains(license.operationMode()) == false) {
-                assertTrue(new TLSLicenseBootstrapCheck().check(new BootstrapContext(
+                assertTrue(new TLSLicenseBootstrapCheck().check(createTestContext(
                         Settings.builder().put("xpack.security.transport.ssl.enabled", true).build(), build)).isSuccess());
             } else {
-                assertTrue(new TLSLicenseBootstrapCheck().check(new BootstrapContext(
+                assertTrue(new TLSLicenseBootstrapCheck().check(createTestContext(
                         Settings.builder().put("xpack.security.transport.ssl.enabled", false).build(), build)).isFailure());
                 assertEquals("Transport SSL must be enabled for setups with production licenses. Please set " +
                                 "[xpack.security.transport.ssl.enabled] to [true] or disable security by setting " +
                                 "[xpack.security.enabled] to [false]",
-                        new TLSLicenseBootstrapCheck().check(new BootstrapContext(
+                        new TLSLicenseBootstrapCheck().check(createTestContext(
                                 Settings.builder().put("xpack.security.transport.ssl.enabled", false).build(), build)).getMessage());
             }
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/FIPS140JKSKeystoreBootstrapCheck.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/FIPS140JKSKeystoreBootstrapCheck.java
@@ -22,8 +22,8 @@ public class FIPS140JKSKeystoreBootstrapCheck implements BootstrapCheck {
     @Override
     public BootstrapCheckResult check(BootstrapContext context) {
 
-        if (XPackSettings.FIPS_MODE_ENABLED.get(context.getSettings())) {
-            final Settings settings = context.getSettings();
+        if (XPackSettings.FIPS_MODE_ENABLED.get(context.settings())) {
+            final Settings settings = context.settings();
             Settings keystoreTypeSettings = settings.filter(k -> k.endsWith("keystore.type"))
                 .filter(k -> settings.get(k).equalsIgnoreCase("jks"));
             if (keystoreTypeSettings.isEmpty() == false) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/FIPS140JKSKeystoreBootstrapCheck.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/FIPS140JKSKeystoreBootstrapCheck.java
@@ -22,8 +22,8 @@ public class FIPS140JKSKeystoreBootstrapCheck implements BootstrapCheck {
     @Override
     public BootstrapCheckResult check(BootstrapContext context) {
 
-        if (XPackSettings.FIPS_MODE_ENABLED.get(context.settings)) {
-            final Settings settings = context.settings;
+        if (XPackSettings.FIPS_MODE_ENABLED.get(context.getSettings())) {
+            final Settings settings = context.getSettings();
             Settings keystoreTypeSettings = settings.filter(k -> k.endsWith("keystore.type"))
                 .filter(k -> settings.get(k).equalsIgnoreCase("jks"));
             if (keystoreTypeSettings.isEmpty() == false) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/FIPS140LicenseBootstrapCheck.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/FIPS140LicenseBootstrapCheck.java
@@ -24,8 +24,8 @@ final class FIPS140LicenseBootstrapCheck implements BootstrapCheck {
 
     @Override
     public BootstrapCheckResult check(BootstrapContext context) {
-        if (XPackSettings.FIPS_MODE_ENABLED.get(context.settings)) {
-            License license = LicenseService.getLicense(context.metaData);
+        if (XPackSettings.FIPS_MODE_ENABLED.get(context.getSettings())) {
+            License license = LicenseService.getLicense(context.getMetaData());
             if (license != null && ALLOWED_LICENSE_OPERATION_MODES.contains(license.operationMode()) == false) {
                 return BootstrapCheckResult.failure("FIPS mode is only allowed with a Platinum or Trial license");
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/FIPS140LicenseBootstrapCheck.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/FIPS140LicenseBootstrapCheck.java
@@ -24,8 +24,8 @@ final class FIPS140LicenseBootstrapCheck implements BootstrapCheck {
 
     @Override
     public BootstrapCheckResult check(BootstrapContext context) {
-        if (XPackSettings.FIPS_MODE_ENABLED.get(context.getSettings())) {
-            License license = LicenseService.getLicense(context.getMetaData());
+        if (XPackSettings.FIPS_MODE_ENABLED.get(context.settings())) {
+            License license = LicenseService.getLicense(context.metaData());
             if (license != null && ALLOWED_LICENSE_OPERATION_MODES.contains(license.operationMode()) == false) {
                 return BootstrapCheckResult.failure("FIPS mode is only allowed with a Platinum or Trial license");
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/FIPS140PasswordHashingAlgorithmBootstrapCheck.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/FIPS140PasswordHashingAlgorithmBootstrapCheck.java
@@ -21,8 +21,8 @@ public class FIPS140PasswordHashingAlgorithmBootstrapCheck implements BootstrapC
      */
     @Override
     public BootstrapCheckResult check(final BootstrapContext context) {
-        if (XPackSettings.FIPS_MODE_ENABLED.get(context.getSettings())) {
-            final String selectedAlgorithm = XPackSettings.PASSWORD_HASHING_ALGORITHM.get(context.getSettings());
+        if (XPackSettings.FIPS_MODE_ENABLED.get(context.settings())) {
+            final String selectedAlgorithm = XPackSettings.PASSWORD_HASHING_ALGORITHM.get(context.settings());
             if (selectedAlgorithm.toLowerCase(Locale.ROOT).startsWith("pbkdf2") == false) {
                 return BootstrapCheckResult.failure("Only PBKDF2 is allowed for password hashing in a FIPS-140 JVM. Please set the " +
                         "appropriate value for [ " + XPackSettings.PASSWORD_HASHING_ALGORITHM.getKey() + " ] setting.");

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/FIPS140PasswordHashingAlgorithmBootstrapCheck.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/FIPS140PasswordHashingAlgorithmBootstrapCheck.java
@@ -21,8 +21,8 @@ public class FIPS140PasswordHashingAlgorithmBootstrapCheck implements BootstrapC
      */
     @Override
     public BootstrapCheckResult check(final BootstrapContext context) {
-        if (XPackSettings.FIPS_MODE_ENABLED.get(context.settings)) {
-            final String selectedAlgorithm = XPackSettings.PASSWORD_HASHING_ALGORITHM.get(context.settings);
+        if (XPackSettings.FIPS_MODE_ENABLED.get(context.getSettings())) {
+            final String selectedAlgorithm = XPackSettings.PASSWORD_HASHING_ALGORITHM.get(context.getSettings());
             if (selectedAlgorithm.toLowerCase(Locale.ROOT).startsWith("pbkdf2") == false) {
                 return BootstrapCheckResult.failure("Only PBKDF2 is allowed for password hashing in a FIPS-140 JVM. Please set the " +
                         "appropriate value for [ " + XPackSettings.PASSWORD_HASHING_ALGORITHM.getKey() + " ] setting.");

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/PkiRealmBootstrapCheck.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/PkiRealmBootstrapCheck.java
@@ -36,7 +36,7 @@ class PkiRealmBootstrapCheck implements BootstrapCheck {
      */
     @Override
     public BootstrapCheckResult check(BootstrapContext context) {
-        final Settings settings = context.getSettings();
+        final Settings settings = context.settings();
         final Map<RealmConfig.RealmIdentifier, Settings> realms = RealmSettings.getRealmSettings(settings);
         final boolean pkiRealmEnabled = realms.entrySet().stream()
                 .filter(e -> PkiRealmSettings.TYPE.equals(e.getKey().getType()))

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/PkiRealmBootstrapCheck.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/PkiRealmBootstrapCheck.java
@@ -36,7 +36,7 @@ class PkiRealmBootstrapCheck implements BootstrapCheck {
      */
     @Override
     public BootstrapCheckResult check(BootstrapContext context) {
-        final Settings settings = context.settings;
+        final Settings settings = context.getSettings();
         final Map<RealmConfig.RealmIdentifier, Settings> realms = RealmSettings.getRealmSettings(settings);
         final boolean pkiRealmEnabled = realms.entrySet().stream()
                 .filter(e -> PkiRealmSettings.TYPE.equals(e.getKey().getType()))

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/TokenSSLBootstrapCheck.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/TokenSSLBootstrapCheck.java
@@ -18,8 +18,8 @@ final class TokenSSLBootstrapCheck implements BootstrapCheck {
 
     @Override
     public BootstrapCheckResult check(BootstrapContext context) {
-        final Boolean httpsEnabled = XPackSettings.HTTP_SSL_ENABLED.get(context.settings);
-        final Boolean tokenServiceEnabled = XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.get(context.settings);
+        final Boolean httpsEnabled = XPackSettings.HTTP_SSL_ENABLED.get(context.getSettings());
+        final Boolean tokenServiceEnabled = XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.get(context.getSettings());
         if (httpsEnabled == false && tokenServiceEnabled) {
             final String message = String.format(
                     Locale.ROOT,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/TokenSSLBootstrapCheck.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/TokenSSLBootstrapCheck.java
@@ -18,8 +18,8 @@ final class TokenSSLBootstrapCheck implements BootstrapCheck {
 
     @Override
     public BootstrapCheckResult check(BootstrapContext context) {
-        final Boolean httpsEnabled = XPackSettings.HTTP_SSL_ENABLED.get(context.getSettings());
-        final Boolean tokenServiceEnabled = XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.get(context.getSettings());
+        final Boolean httpsEnabled = XPackSettings.HTTP_SSL_ENABLED.get(context.settings());
+        final Boolean tokenServiceEnabled = XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.get(context.settings());
         if (httpsEnabled == false && tokenServiceEnabled) {
             final String message = String.format(
                     Locale.ROOT,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/FIPS140JKSKeystoreBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/FIPS140JKSKeystoreBootstrapCheckTests.java
@@ -5,16 +5,15 @@
  */
 package org.elasticsearch.xpack.security;
 
-import org.elasticsearch.bootstrap.BootstrapContext;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 
-public class FIPS140JKSKeystoreBootstrapCheckTests extends ESTestCase {
+public class FIPS140JKSKeystoreBootstrapCheckTests extends AbstractBootstrapCheckTestCase {
 
     public void testNoKeystoreIsAllowed() {
         final Settings.Builder settings = Settings.builder()
             .put("xpack.security.fips_mode.enabled", "true");
-        assertFalse(new FIPS140JKSKeystoreBootstrapCheck().check(new BootstrapContext(settings.build(), null)).isFailure());
+        assertFalse(new FIPS140JKSKeystoreBootstrapCheck().check(createTestContext(settings.build(), null)).isFailure());
     }
 
     public void testSSLKeystoreTypeIsNotAllowed() {
@@ -22,7 +21,7 @@ public class FIPS140JKSKeystoreBootstrapCheckTests extends ESTestCase {
             .put("xpack.security.fips_mode.enabled", "true")
             .put("xpack.ssl.keystore.path", "/this/is/the/path")
             .put("xpack.ssl.keystore.type", "JKS");
-        assertTrue(new FIPS140JKSKeystoreBootstrapCheck().check(new BootstrapContext(settings.build(), null)).isFailure());
+        assertTrue(new FIPS140JKSKeystoreBootstrapCheck().check(createTestContext(settings.build(), null)).isFailure());
     }
 
     public void testSSLImplicitKeystoreTypeIsNotAllowed() {
@@ -30,7 +29,7 @@ public class FIPS140JKSKeystoreBootstrapCheckTests extends ESTestCase {
             .put("xpack.security.fips_mode.enabled", "true")
             .put("xpack.ssl.keystore.path", "/this/is/the/path")
             .put("xpack.ssl.keystore.type", "JKS");
-        assertTrue(new FIPS140JKSKeystoreBootstrapCheck().check(new BootstrapContext(settings.build(), null)).isFailure());
+        assertTrue(new FIPS140JKSKeystoreBootstrapCheck().check(createTestContext(settings.build(), null)).isFailure());
     }
 
     public void testTransportSSLKeystoreTypeIsNotAllowed() {
@@ -38,7 +37,7 @@ public class FIPS140JKSKeystoreBootstrapCheckTests extends ESTestCase {
             .put("xpack.security.fips_mode.enabled", "true")
             .put("xpack.security.transport.ssl.keystore.path", "/this/is/the/path")
             .put("xpack.security.transport.ssl.keystore.type", "JKS");
-        assertTrue(new FIPS140JKSKeystoreBootstrapCheck().check(new BootstrapContext(settings.build(), null)).isFailure());
+        assertTrue(new FIPS140JKSKeystoreBootstrapCheck().check(createTestContext(settings.build(), null)).isFailure());
     }
 
     public void testHttpSSLKeystoreTypeIsNotAllowed() {
@@ -46,7 +45,7 @@ public class FIPS140JKSKeystoreBootstrapCheckTests extends ESTestCase {
             .put("xpack.security.fips_mode.enabled", "true")
             .put("xpack.security.http.ssl.keystore.path", "/this/is/the/path")
             .put("xpack.security.http.ssl.keystore.type", "JKS");
-        assertTrue(new FIPS140JKSKeystoreBootstrapCheck().check(new BootstrapContext(settings.build(), null)).isFailure());
+        assertTrue(new FIPS140JKSKeystoreBootstrapCheck().check(createTestContext(settings.build(), null)).isFailure());
     }
 
     public void testRealmKeystoreTypeIsNotAllowed() {
@@ -54,13 +53,13 @@ public class FIPS140JKSKeystoreBootstrapCheckTests extends ESTestCase {
             .put("xpack.security.fips_mode.enabled", "true")
             .put("xpack.security.authc.realms.ldap.ssl.keystore.path", "/this/is/the/path")
             .put("xpack.security.authc.realms.ldap.ssl.keystore.type", "JKS");
-        assertTrue(new FIPS140JKSKeystoreBootstrapCheck().check(new BootstrapContext(settings.build(), null)).isFailure());
+        assertTrue(new FIPS140JKSKeystoreBootstrapCheck().check(createTestContext(settings.build(), null)).isFailure());
     }
 
     public void testImplicitRealmKeystoreTypeIsNotAllowed() {
         final Settings.Builder settings = Settings.builder()
             .put("xpack.security.fips_mode.enabled", "true")
             .put("xpack.security.authc.realms.ldap.ssl.keystore.path", "/this/is/the/path");
-        assertTrue(new FIPS140JKSKeystoreBootstrapCheck().check(new BootstrapContext(settings.build(), null)).isFailure());
+        assertTrue(new FIPS140JKSKeystoreBootstrapCheck().check(createTestContext(settings.build(), null)).isFailure());
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/FIPS140LicenseBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/FIPS140LicenseBootstrapCheckTests.java
@@ -6,21 +6,20 @@
 
 package org.elasticsearch.xpack.security;
 
-import org.elasticsearch.bootstrap.BootstrapContext;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.TestUtils;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 
-public class FIPS140LicenseBootstrapCheckTests extends ESTestCase {
+public class FIPS140LicenseBootstrapCheckTests extends AbstractBootstrapCheckTestCase {
 
     public void testBootstrapCheck() throws Exception {
         assertTrue(new FIPS140LicenseBootstrapCheck()
-            .check(new BootstrapContext(Settings.EMPTY, MetaData.EMPTY_META_DATA)).isSuccess());
+            .check(emptyContext).isSuccess());
         assertTrue(new FIPS140LicenseBootstrapCheck()
-            .check(new BootstrapContext(Settings.builder().put("xpack.security.fips_mode.enabled", randomBoolean()).build(), MetaData
+            .check(createTestContext(Settings.builder().put("xpack.security.fips_mode.enabled", randomBoolean()).build(), MetaData
                 .EMPTY_META_DATA)).isSuccess());
 
         MetaData.Builder builder = MetaData.builder();
@@ -29,17 +28,17 @@ public class FIPS140LicenseBootstrapCheckTests extends ESTestCase {
         MetaData metaData = builder.build();
 
         if (FIPS140LicenseBootstrapCheck.ALLOWED_LICENSE_OPERATION_MODES.contains(license.operationMode())) {
-            assertTrue(new FIPS140LicenseBootstrapCheck().check(new BootstrapContext(
+            assertTrue(new FIPS140LicenseBootstrapCheck().check(createTestContext(
                 Settings.builder().put("xpack.security.fips_mode.enabled", true).build(), metaData)).isSuccess());
-            assertTrue(new FIPS140LicenseBootstrapCheck().check(new BootstrapContext(
+            assertTrue(new FIPS140LicenseBootstrapCheck().check(createTestContext(
                 Settings.builder().put("xpack.security.fips_mode.enabled", false).build(), metaData)).isSuccess());
         } else {
-            assertTrue(new FIPS140LicenseBootstrapCheck().check(new BootstrapContext(
+            assertTrue(new FIPS140LicenseBootstrapCheck().check(createTestContext(
                 Settings.builder().put("xpack.security.fips_mode.enabled", false).build(), metaData)).isSuccess());
-            assertTrue(new FIPS140LicenseBootstrapCheck().check(new BootstrapContext(
+            assertTrue(new FIPS140LicenseBootstrapCheck().check(createTestContext(
                 Settings.builder().put("xpack.security.fips_mode.enabled", true).build(), metaData)).isFailure());
             assertEquals("FIPS mode is only allowed with a Platinum or Trial license",
-                new FIPS140LicenseBootstrapCheck().check(new BootstrapContext(
+                new FIPS140LicenseBootstrapCheck().check(createTestContext(
                     Settings.builder().put("xpack.security.fips_mode.enabled", true).build(), metaData)).getMessage());
         }
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/FIPS140PasswordHashingAlgorithmBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/FIPS140PasswordHashingAlgorithmBootstrapCheckTests.java
@@ -7,16 +7,15 @@
 package org.elasticsearch.xpack.security;
 
 import org.elasticsearch.bootstrap.BootstrapCheck;
-import org.elasticsearch.bootstrap.BootstrapContext;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 import org.elasticsearch.xpack.core.XPackSettings;
 
 import java.util.Arrays;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class FIPS140PasswordHashingAlgorithmBootstrapCheckTests extends ESTestCase {
+public class FIPS140PasswordHashingAlgorithmBootstrapCheckTests extends AbstractBootstrapCheckTestCase {
 
     public void testPBKDF2AlgorithmIsAllowed() {
         {
@@ -25,7 +24,7 @@ public class FIPS140PasswordHashingAlgorithmBootstrapCheckTests extends ESTestCa
                     .put(XPackSettings.PASSWORD_HASHING_ALGORITHM.getKey(), "PBKDF2_10000")
                     .build();
             final BootstrapCheck.BootstrapCheckResult result =
-                    new FIPS140PasswordHashingAlgorithmBootstrapCheck().check(new BootstrapContext(settings, null));
+                    new FIPS140PasswordHashingAlgorithmBootstrapCheck().check(createTestContext(settings, null));
             assertFalse(result.isFailure());
         }
 
@@ -35,7 +34,7 @@ public class FIPS140PasswordHashingAlgorithmBootstrapCheckTests extends ESTestCa
                     .put(XPackSettings.PASSWORD_HASHING_ALGORITHM.getKey(), "PBKDF2")
                     .build();
             final BootstrapCheck.BootstrapCheckResult result =
-                    new FIPS140PasswordHashingAlgorithmBootstrapCheck().check(new BootstrapContext(settings, null));
+                    new FIPS140PasswordHashingAlgorithmBootstrapCheck().check(createTestContext(settings, null));
             assertFalse(result.isFailure());
         }
     }
@@ -55,7 +54,7 @@ public class FIPS140PasswordHashingAlgorithmBootstrapCheckTests extends ESTestCa
         }
         final Settings settings = builder.build();
         final BootstrapCheck.BootstrapCheckResult result =
-                new FIPS140PasswordHashingAlgorithmBootstrapCheck().check(new BootstrapContext(settings, null));
+                new FIPS140PasswordHashingAlgorithmBootstrapCheck().check(createTestContext(settings, null));
         assertThat(result.isFailure(), equalTo(fipsModeEnabled));
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/FIPS140SecureSettingsBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/FIPS140SecureSettingsBootstrapCheckTests.java
@@ -9,12 +9,11 @@ import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.SimpleFSDirectory;
-import org.elasticsearch.bootstrap.BootstrapContext;
 import org.elasticsearch.common.settings.KeyStoreWrapper;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
@@ -25,7 +24,7 @@ import java.security.AccessControlException;
 import java.security.KeyStore;
 import java.util.Base64;
 
-public class FIPS140SecureSettingsBootstrapCheckTests extends ESTestCase {
+public class FIPS140SecureSettingsBootstrapCheckTests extends AbstractBootstrapCheckTestCase {
 
     public void testLegacySecureSettingsIsNotAllowed() throws Exception {
         assumeFalse("Can't run in a FIPS JVM, PBE is not available", inFipsJvm());
@@ -34,7 +33,7 @@ public class FIPS140SecureSettingsBootstrapCheckTests extends ESTestCase {
             .put("xpack.security.fips_mode.enabled", "true");
         Environment env = TestEnvironment.newEnvironment(builder.build());
         generateV2Keystore(env);
-        assertTrue(new FIPS140SecureSettingsBootstrapCheck(builder.build(), env).check(new BootstrapContext(builder.build(),
+        assertTrue(new FIPS140SecureSettingsBootstrapCheck(builder.build(), env).check(createTestContext(builder.build(),
             null)).isFailure());
     }
 
@@ -53,7 +52,7 @@ public class FIPS140SecureSettingsBootstrapCheckTests extends ESTestCase {
                 throw e;
             }
         }
-        assertFalse(new FIPS140SecureSettingsBootstrapCheck(builder.build(), env).check(new BootstrapContext(builder.build(),
+        assertFalse(new FIPS140SecureSettingsBootstrapCheck(builder.build(), env).check(createTestContext(builder.build(),
             null)).isFailure());
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/PkiRealmBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/PkiRealmBootstrapCheckTests.java
@@ -6,16 +6,15 @@
 package org.elasticsearch.xpack.security;
 
 import org.elasticsearch.bootstrap.BootstrapCheck;
-import org.elasticsearch.bootstrap.BootstrapContext;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.hamcrest.Matchers;
 
-public class PkiRealmBootstrapCheckTests extends ESTestCase {
+public class PkiRealmBootstrapCheckTests extends AbstractBootstrapCheckTestCase {
 
     public void testPkiRealmBootstrapDefault() throws Exception {
         final Settings settings = Settings.EMPTY;
@@ -82,7 +81,7 @@ public class PkiRealmBootstrapCheckTests extends ESTestCase {
     }
 
     private BootstrapCheck.BootstrapCheckResult runCheck(Settings settings, Environment env) throws Exception {
-        return new PkiRealmBootstrapCheck(new SSLService(settings, env)).check(new BootstrapContext(settings, null));
+        return new PkiRealmBootstrapCheck(new SSLService(settings, env)).check(createTestContext(settings, null));
     }
 
     public void testBootstrapCheckWithDisabledRealm() throws Exception {
@@ -114,6 +113,6 @@ public class PkiRealmBootstrapCheckTests extends ESTestCase {
         Environment env = TestEnvironment.newEnvironment(settings);
         final PkiRealmBootstrapCheck check = new PkiRealmBootstrapCheck(new SSLService(settings, env));
         secureSettings.close();
-        assertThat(check.check(new BootstrapContext(settings, null)).isFailure(), Matchers.equalTo(expectFail));
+        assertThat(check.check(createTestContext(settings, null)).isFailure(), Matchers.equalTo(expectFail));
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/TokenSSLBootsrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/TokenSSLBootsrapCheckTests.java
@@ -5,28 +5,27 @@
  */
 package org.elasticsearch.xpack.security;
 
-import org.elasticsearch.bootstrap.BootstrapContext;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 import org.elasticsearch.xpack.core.XPackSettings;
 
-public class TokenSSLBootsrapCheckTests extends ESTestCase {
+public class TokenSSLBootsrapCheckTests extends AbstractBootstrapCheckTestCase {
 
     public void testTokenSSLBootstrapCheck() {
         Settings settings = Settings.EMPTY;
 
-        assertFalse(new TokenSSLBootstrapCheck().check(new BootstrapContext(settings, null)).isFailure());
+        assertFalse(new TokenSSLBootstrapCheck().check(createTestContext(settings, null)).isFailure());
 
         settings = Settings.builder().put(XPackSettings.HTTP_SSL_ENABLED.getKey(), true).build();
-        assertFalse(new TokenSSLBootstrapCheck().check(new BootstrapContext(settings, null)).isFailure());
+        assertFalse(new TokenSSLBootstrapCheck().check(createTestContext(settings, null)).isFailure());
 
         // XPackSettings.HTTP_SSL_ENABLED default false
         settings = Settings.builder().put(XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.getKey(), true).build();
-        assertTrue(new TokenSSLBootstrapCheck().check(new BootstrapContext(settings, null)).isFailure());
+        assertTrue(new TokenSSLBootstrapCheck().check(createTestContext(settings, null)).isFailure());
 
         settings = Settings.builder()
                 .put(XPackSettings.HTTP_SSL_ENABLED.getKey(), false)
                 .put(XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.getKey(), true).build();
-        assertTrue(new TokenSSLBootstrapCheck().check(new BootstrapContext(settings, null)).isFailure());
+        assertTrue(new TokenSSLBootstrapCheck().check(createTestContext(settings, null)).isFailure());
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/RoleMappingFileBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/RoleMappingFileBootstrapCheckTests.java
@@ -6,11 +6,10 @@
 package org.elasticsearch.xpack.security.authc.support;
 
 import org.elasticsearch.bootstrap.BootstrapCheck;
-import org.elasticsearch.bootstrap.BootstrapContext;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.TestEnvironment;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.RealmSettings;
 import org.elasticsearch.xpack.core.security.authc.support.DnRoleMapperSettings;
@@ -26,7 +25,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class RoleMappingFileBootstrapCheckTests extends ESTestCase {
+public class RoleMappingFileBootstrapCheckTests extends AbstractBootstrapCheckTestCase {
 
     private static final RealmConfig.RealmIdentifier REALM_ID = new RealmConfig.RealmIdentifier("ldap", "ldap-realm-name");
     private static final String ROLE_MAPPING_FILE_SETTING = RealmSettings.getFullSettingKey(
@@ -52,7 +51,7 @@ public class RoleMappingFileBootstrapCheckTests extends ESTestCase {
         final BootstrapCheck check = RoleMappingFileBootstrapCheck.create(config);
         assertThat(check, notNullValue());
         assertThat(check.alwaysEnforce(), equalTo(true));
-        assertFalse(check.check(new BootstrapContext(settings, null)).isFailure());
+        assertFalse(check.check(createTestContext(settings, null)).isFailure());
     }
 
     private static RealmConfig getRealmConfig(Settings settings) {
@@ -70,7 +69,7 @@ public class RoleMappingFileBootstrapCheckTests extends ESTestCase {
         final BootstrapCheck check = RoleMappingFileBootstrapCheck.create(config);
         assertThat(check, notNullValue());
         assertThat(check.alwaysEnforce(), equalTo(true));
-        final BootstrapCheck.BootstrapCheckResult result = check.check(new BootstrapContext(settings, null));
+        final BootstrapCheck.BootstrapCheckResult result = check.check(createTestContext(settings, null));
         assertTrue(result.isFailure());
         assertThat(result.getMessage(), containsString(REALM_ID.getName()));
         assertThat(result.getMessage(), containsString(fileName));
@@ -90,7 +89,7 @@ public class RoleMappingFileBootstrapCheckTests extends ESTestCase {
         final BootstrapCheck check = RoleMappingFileBootstrapCheck.create(config);
         assertThat(check, notNullValue());
         assertThat(check.alwaysEnforce(), equalTo(true));
-        final BootstrapCheck.BootstrapCheckResult result = check.check(new BootstrapContext(settings, null));
+        final BootstrapCheck.BootstrapCheckResult result = check.check(createTestContext(settings, null));
         assertTrue(result.isFailure());
         assertThat(result.getMessage(), containsString(REALM_ID.getName()));
         assertThat(result.getMessage(), containsString(file.toString()));
@@ -110,7 +109,7 @@ public class RoleMappingFileBootstrapCheckTests extends ESTestCase {
         final BootstrapCheck check = RoleMappingFileBootstrapCheck.create(config);
         assertThat(check, notNullValue());
         assertThat(check.alwaysEnforce(), equalTo(true));
-        final BootstrapCheck.BootstrapCheckResult result = check.check(new BootstrapContext(settings, null));
+        final BootstrapCheck.BootstrapCheckResult result = check.check(createTestContext(settings, null));
         assertTrue(result.isFailure());
         assertThat(result.getMessage(), containsString(REALM_ID.getName()));
         assertThat(result.getMessage(), containsString(file.toString()));

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/EncryptSensitiveDataBootstrapCheck.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/EncryptSensitiveDataBootstrapCheck.java
@@ -17,9 +17,9 @@ final class EncryptSensitiveDataBootstrapCheck implements BootstrapCheck {
 
     @Override
     public BootstrapCheckResult check(BootstrapContext context) {
-        if (Watcher.ENCRYPT_SENSITIVE_DATA_SETTING.get(context.getSettings())
-                && WatcherField.ENCRYPTION_KEY_SETTING.exists(context.getSettings()) == false) {
-            final Path systemKeyPath = XPackPlugin.resolveConfigFile(context.getEnvironment(), "system_key").toAbsolutePath();
+        if (Watcher.ENCRYPT_SENSITIVE_DATA_SETTING.get(context.settings())
+                && WatcherField.ENCRYPTION_KEY_SETTING.exists(context.settings()) == false) {
+            final Path systemKeyPath = XPackPlugin.resolveConfigFile(context.environment(), "system_key").toAbsolutePath();
             final String message;
             if (Files.exists(systemKeyPath)) {
                 message = "Encryption of sensitive data requires the key to be placed in the secure setting store. Run " +

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/EncryptSensitiveDataBootstrapCheck.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/EncryptSensitiveDataBootstrapCheck.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.watcher;
 
 import org.elasticsearch.bootstrap.BootstrapCheck;
 import org.elasticsearch.bootstrap.BootstrapContext;
-import org.elasticsearch.env.Environment;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.watcher.WatcherField;
 
@@ -16,17 +15,11 @@ import java.nio.file.Path;
 
 final class EncryptSensitiveDataBootstrapCheck implements BootstrapCheck {
 
-    private final Environment environment;
-
-    EncryptSensitiveDataBootstrapCheck(Environment environment) {
-        this.environment = environment;
-    }
-
     @Override
     public BootstrapCheckResult check(BootstrapContext context) {
-        if (Watcher.ENCRYPT_SENSITIVE_DATA_SETTING.get(context.settings)
-                && WatcherField.ENCRYPTION_KEY_SETTING.exists(context.settings) == false) {
-            final Path systemKeyPath = XPackPlugin.resolveConfigFile(environment, "system_key").toAbsolutePath();
+        if (Watcher.ENCRYPT_SENSITIVE_DATA_SETTING.get(context.getSettings())
+                && WatcherField.ENCRYPTION_KEY_SETTING.exists(context.getSettings()) == false) {
+            final Path systemKeyPath = XPackPlugin.resolveConfigFile(context.getEnvironment(), "system_key").toAbsolutePath();
             final String message;
             if (Files.exists(systemKeyPath)) {
                 message = "Encryption of sensitive data requires the key to be placed in the secure setting store. Run " +

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -233,14 +233,12 @@ public class Watcher extends Plugin implements ActionPlugin, ScriptPlugin, Reloa
     protected final Settings settings;
     protected final boolean transportClient;
     protected final boolean enabled;
-    protected final Environment env;
     protected List<NotificationService> reloadableServices = new ArrayList<>();
 
     public Watcher(final Settings settings) {
         this.settings = settings;
         this.transportClient = XPackPlugin.transportClientMode(settings);
         this.enabled = XPackSettings.WATCHER_ENABLED.get(settings);
-        env = transportClient ? null : new Environment(settings, null);
 
         if (enabled && transportClient == false) {
             validAutoCreateIndex(settings, logger);
@@ -661,7 +659,7 @@ public class Watcher extends Plugin implements ActionPlugin, ScriptPlugin, Reloa
 
     @Override
     public List<BootstrapCheck> getBootstrapChecks() {
-        return Collections.singletonList(new EncryptSensitiveDataBootstrapCheck(env));
+        return Collections.singletonList(new EncryptSensitiveDataBootstrapCheck());
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/EncryptSensitiveDataBootstrapCheckTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/EncryptSensitiveDataBootstrapCheckTests.java
@@ -5,46 +5,33 @@
  */
 package org.elasticsearch.xpack.watcher;
 
-import org.elasticsearch.bootstrap.BootstrapContext;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.env.Environment;
-import org.elasticsearch.env.TestEnvironment;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 import org.elasticsearch.xpack.core.watcher.WatcherField;
 import org.elasticsearch.xpack.core.watcher.crypto.CryptoServiceTests;
 
-public class EncryptSensitiveDataBootstrapCheckTests extends ESTestCase {
+public class EncryptSensitiveDataBootstrapCheckTests extends AbstractBootstrapCheckTestCase {
+    private static final EncryptSensitiveDataBootstrapCheck CHECK = new EncryptSensitiveDataBootstrapCheck();
 
     public void testDefaultIsFalse() {
-        Settings settings = Settings.builder().put("path.home", createTempDir()).build();
-        Environment env = TestEnvironment.newEnvironment(settings);
-        EncryptSensitiveDataBootstrapCheck check = new EncryptSensitiveDataBootstrapCheck(env);
-        assertFalse(check.check(new BootstrapContext(settings, null)).isFailure());
-        assertTrue(check.alwaysEnforce());
+        assertFalse(CHECK.check(emptyContext).isFailure());
+        assertTrue(CHECK.alwaysEnforce());
     }
 
     public void testNoKeyInKeystore() {
-        Settings settings = Settings.builder()
-                .put("path.home", createTempDir())
-                .put(Watcher.ENCRYPT_SENSITIVE_DATA_SETTING.getKey(), true)
-                .build();
-        Environment env = TestEnvironment.newEnvironment(settings);
-        EncryptSensitiveDataBootstrapCheck check = new EncryptSensitiveDataBootstrapCheck(env);
-        assertTrue(check.check(new BootstrapContext(settings, null)).isFailure());
+        Settings settings = Settings.builder().put(Watcher.ENCRYPT_SENSITIVE_DATA_SETTING.getKey(), true).build();
+        assertTrue(CHECK.check(createTestContext(settings, null)).isFailure());
     }
 
     public void testKeyInKeystore() {
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setFile(WatcherField.ENCRYPTION_KEY_SETTING.getKey(), CryptoServiceTests.generateKey());
         Settings settings = Settings.builder()
-                .put("path.home", createTempDir())
                 .put(Watcher.ENCRYPT_SENSITIVE_DATA_SETTING.getKey(), true)
                 .setSecureSettings(secureSettings)
                 .build();
-        Environment env = TestEnvironment.newEnvironment(settings);
-        EncryptSensitiveDataBootstrapCheck check = new EncryptSensitiveDataBootstrapCheck(env);
-        assertFalse(check.check(new BootstrapContext(settings, null)).isFailure());
+        assertFalse(CHECK.check(createTestContext(settings, null)).isFailure());
     }
 
 }


### PR DESCRIPTION
There are certain BootstrapCheck checks that may need access environment-specific
values. Watcher's EncryptSensitiveDataBootstrapCheck passes in the node's environment
via a constructor to bypass the shortcoming in BootstrapContext. This commit
pulls in the node's environment into BootstrapContext.

Another case is found in #36519, where it is useful to check the state of the
data-path. Since PathUtils.get and Paths.get are forbidden APIs, we rely on
the environment to retrieve references to things like node data paths.

This means that the BootstrapContext will have the same Settings used in the
Environment, which currently differs from the Node's settings.

Test Changes:

- introduced AbstractBootstrapCheckTestCase to help with setting up the test Environment