### PR TITLE
[cleanup] remove deprecated references to dataWithClusterFiles

### DIFF
--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilSecurityTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilSecurityTests.java
@@ -126,9 +126,6 @@ public class EvilSecurityTests extends ESTestCase {
         for (Path dataPath : environment.dataFiles()) {
             assertExactPermissions(new FilePermission(dataPath.toString(), "read,readlink,write,delete"), permissions);
         }
-        for (Path dataPath : environment.dataWithClusterFiles()) {
-            assertExactPermissions(new FilePermission(dataPath.toString(), "read,readlink,write,delete"), permissions);
-        }
         assertExactPermissions(new FilePermission(environment.sharedDataFile().toString(), "read,readlink,write,delete"), permissions);
         // logs: r/w
         assertExactPermissions(new FilePermission(environment.logsFile().toString(), "read,readlink,write,delete"), permissions);

--- a/server/src/main/java/org/elasticsearch/env/Environment.java
+++ b/server/src/main/java/org/elasticsearch/env/Environment.java
@@ -64,8 +64,6 @@ public class Environment {
 
     private final Path[] dataFiles;
 
-    private final Path[] dataWithClusterFiles;
-
     private final Path[] repoFiles;
 
     private final Path configFile;
@@ -118,18 +116,15 @@ public class Environment {
         if (DiscoveryNode.nodeRequiresLocalStorage(settings)) {
             if (dataPaths.isEmpty() == false) {
                 dataFiles = new Path[dataPaths.size()];
-                dataWithClusterFiles = new Path[dataPaths.size()];
                 for (int i = 0; i < dataPaths.size(); i++) {
                     dataFiles[i] = PathUtils.get(dataPaths.get(i));
-                    dataWithClusterFiles[i] = dataFiles[i].resolve(clusterName.value());
                 }
             } else {
                 dataFiles = new Path[]{homeFile.resolve("data")};
-                dataWithClusterFiles = new Path[]{homeFile.resolve("data").resolve(clusterName.value())};
             }
         } else {
             if (dataPaths.isEmpty()) {
-                dataFiles = dataWithClusterFiles = EMPTY_PATH_ARRAY;
+                dataFiles = EMPTY_PATH_ARRAY;
             } else {
                 final String paths = String.join(",", dataPaths);
                 throw new IllegalStateException("node does not require local storage yet path.data is set to [" + paths + "]");
@@ -195,17 +190,6 @@ public class Environment {
      */
     public Path sharedDataFile() {
         return sharedDataFile;
-    }
-
-    /**
-     * The data location with the cluster name as a sub directory.
-     *
-     * @deprecated Used to upgrade old data paths to new ones that do not include the cluster name, should not be used to write files to and
-     * will be removed in ES 6.0
-     */
-    @Deprecated
-    public Path[] dataWithClusterFiles() {
-        return dataWithClusterFiles;
     }
 
     /**
@@ -329,7 +313,7 @@ public class Environment {
      * object which may contain different setting)
      */
     public static void assertEquivalent(Environment actual, Environment expected) {
-        assertEquals(actual.dataWithClusterFiles(), expected.dataWithClusterFiles(), "dataWithClusterFiles");
+        assertEquals(actual.dataFiles(), expected.dataFiles(), "dataFiles");
         assertEquals(actual.repoFiles(), expected.repoFiles(), "repoFiles");
         assertEquals(actual.configFile(), expected.configFile(), "configFile");
         assertEquals(actual.pluginsFile(), expected.pluginsFile(), "pluginsFile");

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -192,7 +192,7 @@ public final class NodeEnvironment  implements Closeable {
                         final Environment environment,
                         final CheckedFunction<Path, Boolean, IOException> pathFunction) throws IOException {
             this.nodeId = nodeId;
-            nodePaths = new NodePath[environment.dataWithClusterFiles().length];
+            nodePaths = new NodePath[environment.dataFiles().length];
             locks = new Lock[nodePaths.length];
             try {
                 final Path[] dataPaths = environment.dataFiles();
@@ -285,7 +285,7 @@ public final class NodeEnvironment  implements Closeable {
                     Locale.ROOT,
                     "failed to obtain node locks, tried [%s] with lock id%s;" +
                         " maybe these locations are not writable or multiple nodes were started without increasing [%s] (was [%d])?",
-                    Arrays.toString(environment.dataWithClusterFiles()),
+                    Arrays.toString(environment.dataFiles()),
                     maxLocalStorageNodes == 1 ? " [0]" : "s [0--" + (maxLocalStorageNodes - 1) + "]",
                     MAX_LOCAL_STORAGE_NODES_SETTING.getKey(),
                     maxLocalStorageNodes);


### PR DESCRIPTION
data files under the cluster name subdirectory has been deprecated and was
meant to be removed in 6.0. This commit removes some leftover references to
these paths.