### PR TITLE
Fix racy use of ConcurrentHashMap

### DIFF
--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -55,17 +55,18 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyList;
 import static org.elasticsearch.cluster.coordination.Coordinator.isZen1Node;
 import static org.elasticsearch.cluster.coordination.DiscoveryUpgradeService.createDiscoveryNodeWithImpossiblyHighId;
-import static java.util.Collections.emptyList;
-import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.newConcurrentMap;
 
 public abstract class PeerFinder {
 
@@ -95,7 +96,7 @@ public abstract class PeerFinder {
     private volatile long currentTerm;
     private boolean active;
     private DiscoveryNodes lastAcceptedNodes;
-    private final Map<TransportAddress, Peer> peersByAddress = newConcurrentMap();
+    private final Map<TransportAddress, Peer> peersByAddress = new LinkedHashMap<>();
     private Optional<DiscoveryNode> leader = Optional.empty();
     private volatile List<TransportAddress> lastResolvedAddresses = emptyList();
 
@@ -150,6 +151,7 @@ public abstract class PeerFinder {
     }
 
     private boolean assertInactiveWithNoKnownPeers() {
+        assert holdsLock() : "PeerFinder mutex not held";
         assert active == false;
         assert peersByAddress.isEmpty() : peersByAddress.keySet();
         return true;
@@ -256,15 +258,20 @@ public abstract class PeerFinder {
     private boolean handleWakeUp() {
         assert holdsLock() : "PeerFinder mutex not held";
 
-        boolean peersRemoved = false;
-
-        for (final Peer peer : peersByAddress.values()) {
-            peersRemoved = peer.handleWakeUp() || peersRemoved; // care: avoid short-circuiting, each peer needs waking up
+        final List<TransportAddress> peersAddressesToRemove = new ArrayList<>();
+        for (final Entry<TransportAddress, Peer> addressAndPeer : peersByAddress.entrySet()) {
+            if (addressAndPeer.getValue().handleWakeUp()) {
+                peersAddressesToRemove.add(addressAndPeer.getKey());
+            }
+        }
+        for (final TransportAddress peersAddressToRemove : peersAddressesToRemove) {
+            final Peer removedPeer = peersByAddress.remove(peersAddressToRemove);
+            assert removedPeer != null;
         }
 
         if (active == false) {
             logger.trace("not active");
-            return peersRemoved;
+            return peersAddressesToRemove.isEmpty() == false;
         }
 
         logger.trace("probing master nodes from cluster state: {}", lastAcceptedNodes);
@@ -308,7 +315,7 @@ public abstract class PeerFinder {
             }
         });
 
-        return peersRemoved;
+        return peersAddressesToRemove.isEmpty() == false;
     }
 
     private void startProbe(TransportAddress transportAddress) {
@@ -344,7 +351,6 @@ public abstract class PeerFinder {
             assert holdsLock() : "PeerFinder mutex not held";
 
             if (active == false) {
-                removePeer();
                 return true;
             }
 
@@ -358,7 +364,6 @@ public abstract class PeerFinder {
                     }
                 } else {
                     logger.trace("{} no longer connected", this);
-                    removePeer();
                     return true;
                 }
             }
@@ -394,16 +399,11 @@ public abstract class PeerFinder {
                 @Override
                 public void onFailure(Exception e) {
                     logger.debug(() -> new ParameterizedMessage("{} connection failed", Peer.this), e);
-                    removePeer();
+                    synchronized (mutex) {
+                        peersByAddress.remove(transportAddress);
+                    }
                 }
             });
-        }
-
-        void removePeer() {
-            final Peer removed = peersByAddress.remove(transportAddress);
-            // assert removed == Peer.this : removed + " != " + Peer.this;
-            // ^ This assertion sometimes trips if we are deactivated and reactivated while a request is in flight.
-            // TODO be more careful about avoiding multiple active Peer objects for each address
         }
 
         private void requestPeers() {


### PR DESCRIPTION
ConcurrentHashMap does not always behave correctly if removing elements and
concurrently checking for its emptyiness. Work around this in PeerFinder by
protecting all usages with a mutex (there was only one usage unprotected by the
mutex anyway) and then we don't even need a ConcurrentHashMap at all.