### PR TITLE
Date handling: Unify exception handling between joda/javatime

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/JavaDateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/JavaDateFormatter.java
@@ -72,13 +72,13 @@ class JavaDateFormatter implements DateFormatter {
 
     @Override
     public TemporalAccessor parse(String input) {
-        DateTimeParseException failure = null;
+        IllegalArgumentException failure = null;
         for (int i = 0; i < parsers.length; i++) {
             try {
                 return parsers[i].parse(input);
             } catch (DateTimeParseException e) {
                 if (failure == null) {
-                    failure = e;
+                    failure = new IllegalArgumentException(e);
                 } else {
                     failure.addSuppressed(e);
                 }

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -28,7 +28,6 @@ import org.joda.time.DateTimeZone;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.util.Locale;
 
@@ -519,7 +518,8 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
 
     private void assertJavaTimeParseException(String input, String format, String expectedMessage) {
         DateFormatter javaTimeFormatter = DateFormatters.forPattern(format);
-        DateTimeParseException dateTimeParseException = expectThrows(DateTimeParseException.class, () -> javaTimeFormatter.parse(input));
-        assertThat(dateTimeParseException.getMessage(), startsWith(expectedMessage));
+        IllegalArgumentException dateTimeParseException =
+            expectThrows(IllegalArgumentException.class, () -> javaTimeFormatter.parse(input));
+        assertThat(dateTimeParseException.getCause().getMessage(), startsWith(expectedMessage));
     }
 }


### PR DESCRIPTION
Due to the change in exception handling in #36447 the backport now used
different exceptions on parser failures between java and joda time
formatting. This uses now IllegalArgumentExceptions for formatting
errors all over the place.

Closes #36598

Reviewers Note: There are different ways to solve this, this might not be the best one, so fully open for discussion.