### PR TITLE
Add guidance on using CCR with Logstash

### DIFF
--- a/docs/reference/ccr/requirements.asciidoc
+++ b/docs/reference/ccr/requirements.asciidoc
@@ -72,7 +72,7 @@ manage index templates, you need to configure soft deletes on a custom Logstash
 index template. To configure soft deletes on the underlying index template,
 incorporate the following change to a custom Logstash template.
 
-["source","json"]
+["source","js"]
 ----------------------------------------------------------------------
 {
   "settings" : {

--- a/docs/reference/ccr/requirements.asciidoc
+++ b/docs/reference/ccr/requirements.asciidoc
@@ -49,8 +49,8 @@ For more information about index settings, see {ref}/index-modules.html[Index mo
 If you want to replicate indices created by APM Server or Beats, and are
 allowing APM Server or Beats to manage index templates, you need to configure
 soft deletes on the underlying index templates. To configure soft deletes on the
-underlying index templates, add the following changes to the relevant APM Server
-or Beats configuration file.
+underlying index templates, incorporate the following changes to the relevant
+APM Server or Beats configuration file.
 
 ["source","yaml"]
 ----------------------------------------------------------------------
@@ -62,3 +62,36 @@ setup.template.settings:
 For additional information on controlling the index templates managed by APM
 Server or Beats, see the relevant documentation on loading the Elasticsearch
 index template.
+
+[float]
+[[ccr-overview-logstash]]
+==== Setting soft deletes on indices created by Logstash
+
+If you want to replicate indices created by Logstash, and are using Logstash to
+manage index templates, you need to configure soft deletes on a custom Logstash
+index template. To configure soft deletes on the underlying index template,
+incorporate the following change to a custom Logstash template.
+
+["source","json"]
+----------------------------------------------------------------------
+{
+  "settings" : {
+    "index.soft_deletes.retention.operations" : 1024
+  }
+}
+----------------------------------------------------------------------
+
+Additionally, you will need to configure the Elasticsearch output plugin to use
+this custom template.
+
+["source"]
+----------------------------------------------------------------------
+output {
+  elasticsearch {
+    template => "/path/to/custom/logstash/template.json"
+  }
+}
+----------------------------------------------------------------------
+
+For additional information on controlling the index templates managed by
+Logstash, see the relevant documentation on the Elasticsearch output plugin.

--- a/docs/reference/ccr/requirements.asciidoc
+++ b/docs/reference/ccr/requirements.asciidoc
@@ -80,6 +80,7 @@ incorporate the following change to a custom Logstash template.
   }
 }
 ----------------------------------------------------------------------
+// NOTCONSOLE
 
 Additionally, you will need to configure the Elasticsearch output plugin to use
 this custom template.

--- a/docs/reference/ccr/requirements.asciidoc
+++ b/docs/reference/ccr/requirements.asciidoc
@@ -84,7 +84,7 @@ incorporate the following change to a custom Logstash template.
 Additionally, you will need to configure the Elasticsearch output plugin to use
 this custom template.
 
-["source"]
+["source","ruby"]
 ----------------------------------------------------------------------
 output {
   elasticsearch {


### PR DESCRIPTION
This commit adds a note to the documentation regarding how to configure Logstash indices in the context of being available as leader indices for cross-cluster replication.
