### PR TITLE
[Tests] Fix edge case in SimpleQueryStringBuilderTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -68,7 +68,8 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
 
     @Override
     protected SimpleQueryStringBuilder doCreateTestQueryBuilder() {
-        SimpleQueryStringBuilder result = new SimpleQueryStringBuilder(randomAlphaOfLengthBetween(1, 10));
+        String queryText = randomAlphaOfLengthBetween(1, 10);
+        SimpleQueryStringBuilder result = new SimpleQueryStringBuilder(queryText);
         if (randomBoolean()) {
             result.analyzeWildcard(randomBoolean());
         }
@@ -105,9 +106,9 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
                 fields.put(STRING_FIELD_NAME_2, 2.0f / randomIntBetween(1, 20));
             }
         }
-        // special handling if query is "now" and no field specified. This hits the "mapped_date" field which leads to the query not being
-        // cacheable and trigger later test failures (see https://github.com/elastic/elasticsearch/issues/35183)
-        if (fieldCount == 0 && result.value().equalsIgnoreCase("now")) {
+        // special handling if query start with "now" and no field specified. This hits the "mapped_date" field which leads to the query not
+        // being cacheable and trigger later test failures (see https://github.com/elastic/elasticsearch/issues/35183)
+        if (fieldCount == 0 && queryText.length() >= 3 && queryText.substring(0,3).equalsIgnoreCase("now")) {
             fields.put(STRING_FIELD_NAME_2, 2.0f / randomIntBetween(1, 20));
         }
 


### PR DESCRIPTION
A previous fix of a similar problem in #35201 wasn't general enough, we also
need to catch cases where the randomly generated query string starts with some
version of "now" and hits a date field.

Closes #36595