### PR TITLE
Warn when using `use_dis_max` in `multi_match`

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -67,7 +67,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
     private static final ParseField LENIENT_FIELD = new ParseField("lenient");
     private static final ParseField CUTOFF_FREQUENCY_FIELD = new ParseField("cutoff_frequency");
     private static final ParseField TIE_BREAKER_FIELD = new ParseField("tie_breaker");
-    private static final ParseField USE_DIS_MAX_FIELD = new ParseField("use_dis_max");
+    private static final ParseField USE_DIS_MAX_FIELD = new ParseField("use_dis_max").withAllDeprecated("use tie_breaker instead");
     private static final ParseField FUZZY_REWRITE_FIELD = new ParseField("fuzzy_rewrite");
     private static final ParseField MINIMUM_SHOULD_MATCH_FIELD = new ParseField("minimum_should_match");
     private static final ParseField OPERATOR_FIELD = new ParseField("operator");

--- a/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -125,9 +125,6 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
             query.fuzzyRewrite(getRandomRewriteMethod());
         }
         if (randomBoolean()) {
-            query.useDisMax(randomBoolean());
-        }
-        if (randomBoolean()) {
             query.tieBreaker(randomFloat());
         }
         if (randomBoolean()) {
@@ -474,6 +471,19 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
                 0f), BooleanClause.Occur.SHOULD)
             .build();
         assertEquals(expected, query);
+    }
+
+    public void testDisMaxDeprecation() throws Exception {
+        String json =
+                "{\n" +
+                "  \"multi_match\" : {\n" +
+                "    \"query\" : \"foo:bar\",\n" +
+                "    \"use_dis_max\" : true\n" +
+                "  }\n" +
+                "}";
+
+        parseQuery(json);
+        assertWarnings("Deprecated field [use_dis_max] used, replaced by [use tie_breaker instead]");
     }
 
     private static IndexMetaData newIndexMeta(String name, Settings oldIndexSettings, Settings indexSettings) {


### PR DESCRIPTION
The rest parameter is already deprecated at least since 6.0, this PR only adds
an additional warning when the parameter gets used via the query DSL.

Relates to #36488