### PR TITLE
Added IP Address and port prints to the DeprecationLogger

### DIFF
--- a/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
@@ -28,6 +28,7 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.network.CloseableChannel;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.network.NetworkService;
@@ -129,6 +130,11 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
         return new HttpStats(httpChannels.size(), totalChannelsAccepted.get());
     }
 
+    private void initializeDeprecationLogger()
+    {
+        DeprecationLogger.setPort(this.boundAddress.publishAddress().getPort());
+    }
+
     protected void bindServer() {
         // Bind and start to accept incoming connections.
         InetAddress hostAddresses[];
@@ -153,6 +159,9 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
         final int publishPort = resolvePublishPort(settings, boundAddresses, publishInetAddress);
         TransportAddress publishAddress = new TransportAddress(new InetSocketAddress(publishInetAddress, publishPort));
         this.boundAddress = new BoundTransportAddress(boundAddresses.toArray(new TransportAddress[0]), publishAddress);
+
+        initializeDeprecationLogger();
+
         logger.info("{}", boundAddress);
     }
 

--- a/server/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
@@ -21,19 +21,32 @@ package org.elasticsearch.common.logging;
 import com.carrotsearch.randomizedtesting.generators.CodepointSetGenerator;
 
 import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.inject.spi.Dependency;
+import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.env.Environment;
+
+import java.io.*;
+import java.lang.StringBuilder;
+
+import org.elasticsearch.node.MockNode;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.node.NodeValidationException;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.MockHttpTransport;
 import org.elasticsearch.test.hamcrest.RegexMatcher;
 import org.hamcrest.core.IsSame;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.net.*;
+import java.nio.file.Path;
+
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.nio.charset.StandardCharsets;
 
@@ -303,11 +316,34 @@ public class DeprecationLoggerTests extends ESTestCase {
         }
     }
 
+    public void testPrintFlag() {
+
+        DeprecationLogger logger2 = new DeprecationLogger(LogManager.getLogger(getClass()));
+
+        assertEquals(logger2.getPrintIPFlag(), false);
+        logger2.enableIPAddressPrints();
+        assertEquals(logger2.getPrintIPFlag(), true);
+        logger2.disableIPAddressPrints();
+        assertEquals(logger2.getPrintIPFlag(), false);
+
+    }
+
+    public void testPort(){
+
+        DeprecationLogger.setPort(-1);
+        assertEquals(DeprecationLogger.getPort(), -1);
+    }
+
+
+
+
     private String range(int lowerInclusive, int upperInclusive) {
         return IntStream
                 .range(lowerInclusive, upperInclusive + 1)
                 .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
                 .toString();
     }
+
+
 
 }


### PR DESCRIPTION
Added a print of the local IP Address and port on the DeprecationLogger as per requested on https://github.com/elastic/elasticsearch/issues/34127. The IP Addess is grabbed using the NetworkInterface class and the port is grabbed from the AbstractHttpServerTransport class.
![screenshot_5](https://user-images.githubusercontent.com/17949587/49973433-f3479a00-ff2c-11e8-8671-e98dff84f60e.png)

Closes https://github.com/elastic/elasticsearch/issues/34127
