### PR TITLE
Add copy constructor to SearchRequest

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollParallelizationHelper.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollParallelizationHelper.java
@@ -154,19 +154,9 @@ class BulkByScrollParallelizationHelper {
                 }
                 slicedSource = request.source().copyWithNewSlice(sliceBuilder);
             }
-            slices[slice] = new SearchRequest()
-                    .source(slicedSource)
-                    .searchType(request.searchType())
-                    .indices(request.indices())
-                    .types(request.types())
-                    .routing(request.routing())
-                    .preference(request.preference())
-                    .requestCache(request.requestCache())
-                    .scroll(request.scroll())
-                    .indicesOptions(request.indicesOptions());
-            if (request.allowPartialSearchResults() != null) {
-                slices[slice].allowPartialSearchResults(request.allowPartialSearchResults());
-            }
+            SearchRequest searchRequest = new SearchRequest(request);
+            searchRequest.source(slicedSource);
+            slices[slice] = searchRequest;
         }
         return slices;
     }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -77,7 +77,6 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
 
     private Boolean allowPartialSearchResults;
 
-
     private Scroll scroll;
 
     private int batchedReduceSize = DEFAULT_BATCHED_REDUCE_SIZE;
@@ -93,6 +92,25 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
     private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
 
     public SearchRequest() {
+    }
+
+    /**
+     * Constructs a new search request from the provided search request
+     */
+    public SearchRequest(SearchRequest searchRequest) {
+        this.allowPartialSearchResults = searchRequest.allowPartialSearchResults;
+        this.batchedReduceSize = searchRequest.batchedReduceSize;
+        this.indices = searchRequest.indices;
+        this.indicesOptions = searchRequest.indicesOptions;
+        this.maxConcurrentShardRequests = searchRequest.maxConcurrentShardRequests;
+        this.preference = searchRequest.preference;
+        this.preFilterShardSize = searchRequest.preFilterShardSize;
+        this.requestCache = searchRequest.requestCache;
+        this.routing = searchRequest.routing;
+        this.scroll = searchRequest.scroll;
+        this.searchType = searchRequest.searchType;
+        this.source = searchRequest.source;
+        this.types = searchRequest.types;
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/search/SearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchRequestTests.java
@@ -23,9 +23,6 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -42,15 +39,10 @@ public class SearchRequestTests extends AbstractSearchTestCase {
 
     public void testSerialization() throws Exception {
         SearchRequest searchRequest = createSearchRequest();
-        try (BytesStreamOutput output = new BytesStreamOutput()) {
-            searchRequest.writeTo(output);
-            try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), namedWriteableRegistry)) {
-                SearchRequest deserializedRequest = new SearchRequest(in);
-                assertEquals(deserializedRequest, searchRequest);
-                assertEquals(deserializedRequest.hashCode(), searchRequest.hashCode());
-                assertNotSame(deserializedRequest, searchRequest);
-            }
-        }
+        SearchRequest deserializedRequest = copyWriteable(searchRequest, namedWriteableRegistry, SearchRequest::new);
+        assertEquals(deserializedRequest, searchRequest);
+        assertEquals(deserializedRequest.hashCode(), searchRequest.hashCode());
+        assertNotSame(deserializedRequest, searchRequest);
     }
 
     public void testIllegalArguments() {
@@ -142,7 +134,7 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         checkEqualsAndHashCode(createSearchRequest(), SearchRequestTests::copyRequest, this::mutate);
     }
 
-    private SearchRequest mutate(SearchRequest searchRequest) throws IOException {
+    private SearchRequest mutate(SearchRequest searchRequest) {
         SearchRequest mutation = copyRequest(searchRequest);
         List<Runnable> mutators = new ArrayList<>();
         mutators.add(() -> mutation.indices(ArrayUtils.concat(searchRequest.indices(), new String[] { randomAlphaOfLength(10) })));
@@ -161,20 +153,7 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         return mutation;
     }
 
-    private static SearchRequest copyRequest(SearchRequest searchRequest) throws IOException {
-        SearchRequest result = new SearchRequest();
-        result.indices(searchRequest.indices());
-        result.indicesOptions(searchRequest.indicesOptions());
-        result.types(searchRequest.types());
-        result.searchType(searchRequest.searchType());
-        result.preference(searchRequest.preference());
-        result.routing(searchRequest.routing());
-        result.requestCache(searchRequest.requestCache());
-        result.allowPartialSearchResults(searchRequest.allowPartialSearchResults());
-        result.scroll(searchRequest.scroll());
-        if (searchRequest.source() != null) {
-            result.source(searchRequest.source());
-        }
-        return result;
+    private static SearchRequest copyRequest(SearchRequest searchRequest) {
+        return new SearchRequest(searchRequest);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/SearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchRequestTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.rescore.QueryRescorerBuilder;
+import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -130,6 +131,14 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         }
     }
 
+    public void testCopyConstructor() throws IOException {
+        SearchRequest searchRequest = createSearchRequest();
+        SearchRequest deserializedRequest = copyWriteable(searchRequest, namedWriteableRegistry, SearchRequest::new);
+        assertEquals(deserializedRequest, searchRequest);
+        assertEquals(deserializedRequest.hashCode(), searchRequest.hashCode());
+        assertNotSame(deserializedRequest, searchRequest);
+    }
+
     public void testEqualsAndHashcode() throws IOException {
         checkEqualsAndHashCode(createSearchRequest(), SearchRequestTests::copyRequest, this::mutate);
     }
@@ -143,7 +152,7 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         mutators.add(() -> mutation.types(ArrayUtils.concat(searchRequest.types(), new String[] { randomAlphaOfLength(10) })));
         mutators.add(() -> mutation.preference(randomValueOtherThan(searchRequest.preference(), () -> randomAlphaOfLengthBetween(3, 10))));
         mutators.add(() -> mutation.routing(randomValueOtherThan(searchRequest.routing(), () -> randomAlphaOfLengthBetween(3, 10))));
-        mutators.add(() -> mutation.requestCache((randomValueOtherThan(searchRequest.requestCache(), () -> randomBoolean()))));
+        mutators.add(() -> mutation.requestCache((randomValueOtherThan(searchRequest.requestCache(), ESTestCase::randomBoolean))));
         mutators.add(() -> mutation
                 .scroll(randomValueOtherThan(searchRequest.scroll(), () -> new Scroll(new TimeValue(randomNonNegativeLong() % 100000)))));
         mutators.add(() -> mutation.searchType(randomValueOtherThan(searchRequest.searchType(),


### PR DESCRIPTION
For cross cluster search alternate execution mode (see #32125) we will need to take a search request that spans across multiple clusters (based on index prefixes e.g. cluster1:index, cluster2:index etc.) and split it into multiple search requests to be sent to each cluster. A copy constructor added to `SearchRequest` would make that easy and well maintainable over time.

Something along the same lines already happens in `BulkByScrollParallelizationHelper`, but the corresponding code went outdated as some new fields were added to `SearchRequest` which were not added to the bulk by scroll code. A copy constructor should make the need of adjusting it more visible when adding new fields.