### PR TITLE
[ML] Prevent updates and upgrade tests

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExceptionsHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExceptionsHelper.java
@@ -58,6 +58,11 @@ public class ExceptionsHelper {
         return new ElasticsearchStatusException(msg, RestStatus.BAD_REQUEST, args);
     }
 
+    public static ElasticsearchStatusException configHasNotBeenMigrated(String verb, String id) {
+        return new ElasticsearchStatusException("cannot {} as the configuration [{}] is temporarily pending migration",
+                RestStatus.SERVICE_UNAVAILABLE, verb, id);
+    }
+
     /**
      * Creates an error message that explains there are shard failures, displays info
      * for the first failure (shard/reason) and kindly asks to see more info in the logs

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestTestHelper.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestTestHelper.java
@@ -20,20 +20,38 @@ import org.elasticsearch.xpack.core.ml.notifications.AuditorField;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 public final class XPackRestTestHelper {
 
+    public static final List<String> ML_PRE_V660_TEMPLATES = Collections.unmodifiableList(
+            Arrays.asList(AuditorField.NOTIFICATIONS_INDEX,
+                    MlMetaIndex.INDEX_NAME,
+                    AnomalyDetectorsIndex.jobStateIndexName(),
+                    AnomalyDetectorsIndex.jobResultsIndexPrefix()));
+
+    public static final List<String> ML_POST_V660_TEMPLATES = Collections.unmodifiableList(
+            Arrays.asList(AuditorField.NOTIFICATIONS_INDEX,
+                    MlMetaIndex.INDEX_NAME,
+                    AnomalyDetectorsIndex.jobStateIndexName(),
+                    AnomalyDetectorsIndex.jobResultsIndexPrefix(),
+                    AnomalyDetectorsIndex.configIndexName()));
+
     private XPackRestTestHelper() {
     }
 
     /**
-     * Waits for the Machine Learning templates to be created
-     * and check the version is up to date
+     * For each template name wait for the template to be created and
+     * for the template version to be equal to the master node version.
+     *
+     * @param client            The rest client
+     * @param templateNames     Names of the templates to wait for
+     * @throws InterruptedException If the wait is interrupted
      */
-    public static void waitForMlTemplates(RestClient client) throws InterruptedException {
+    public static void waitForTemplates(RestClient client, List<String> templateNames) throws InterruptedException {
         AtomicReference<Version> masterNodeVersion = new AtomicReference<>();
         ESTestCase.awaitBusy(() -> {
             String response;
@@ -53,8 +71,6 @@ public final class XPackRestTestHelper {
             return false;
         });
 
-        final List<String> templateNames = Arrays.asList(AuditorField.NOTIFICATIONS_INDEX, MlMetaIndex.INDEX_NAME,
-                AnomalyDetectorsIndex.jobStateIndexName(), AnomalyDetectorsIndex.jobResultsIndexPrefix());
         for (String template : templateNames) {
             ESTestCase.awaitBusy(() -> {
                 Map<?, ?> response;
@@ -74,5 +90,4 @@ public final class XPackRestTestHelper {
             });
         }
     }
-
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.ml;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
@@ -83,28 +82,22 @@ public class MlAssignmentNotifier implements ClusterStateListener, LocalNodeMast
         }
         PersistentTasksCustomMetaData previous = event.previousState().getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
         PersistentTasksCustomMetaData current = event.state().getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
-        if (Objects.equals(previous, current)) {
-            return;
-        }
 
-        Version minNodeVersion = event.state().nodes().getMinNodeVersion();
-        if (minNodeVersion.onOrAfter(Version.V_6_6_0)) {
-            // ok to migrate
-            mlConfigMigrator.migrateConfigsWithoutTasks(event.state(), ActionListener.wrap(
-                    response -> threadPool.executor(executorName()).execute(() -> auditChangesToMlTasks(current, previous, event.state())),
-                    e -> {
-                        logger.error("error migrating ml configurations", e);
-                        threadPool.executor(executorName()).execute(() -> auditChangesToMlTasks(current, previous, event.state()));
-                    }
-            ));
-        } else {
-            threadPool.executor(executorName()).execute(() -> auditChangesToMlTasks(current, previous, event.state()));
-        }
-
+        mlConfigMigrator.migrateConfigsWithoutTasks(event.state(), ActionListener.wrap(
+                response -> threadPool.executor(executorName()).execute(() -> auditChangesToMlTasks(current, previous, event.state())),
+                e -> {
+                    logger.error("error migrating ml configurations", e);
+                    threadPool.executor(executorName()).execute(() -> auditChangesToMlTasks(current, previous, event.state()));
+                }
+        ));
     }
 
     private void auditChangesToMlTasks(PersistentTasksCustomMetaData current, PersistentTasksCustomMetaData previous,
                                        ClusterState state) {
+
+        if (Objects.equals(previous, current)) {
+            return;
+        }
 
         for (PersistentTask<?> currentTask : current.tasks()) {
             Assignment currentAssignment = currentTask.getAssignment();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
@@ -80,6 +80,7 @@ public class MlConfigMigrator {
     private static final Logger logger = LogManager.getLogger(MlConfigMigrator.class);
 
     public static final String MIGRATED_FROM_VERSION = "migrated from version";
+    public static final Version MIN_NODE_VERSION = Version.V_6_6_0;
 
     static final int MAX_BULK_WRITE_SIZE = 100;
 
@@ -113,11 +114,17 @@ public class MlConfigMigrator {
      */
     public void migrateConfigsWithoutTasks(ClusterState clusterState, ActionListener<Boolean> listener) {
 
-        if (migrationInProgress.compareAndSet(false, true) == false) {
+        Version minNodeVersion = clusterState.nodes().getMinNodeVersion();
+        if (minNodeVersion.before(MIN_NODE_VERSION)) {
             listener.onResponse(Boolean.FALSE);
             return;
         }
 
+        if (migrationInProgress.compareAndSet(false, true) == false) {
+            listener.onResponse(Boolean.FALSE);
+            return;
+        }
+        
         Collection<DatafeedConfig> stoppedDatafeeds = stoppedDatafeedConfigs(clusterState);
         Map<String, Job> eligibleJobs = nonDeletingJobs(closedJobConfigs(clusterState)).stream()
                 .map(MlConfigMigrator::updateJobForMigration)
@@ -446,5 +453,61 @@ public class MlConfigMigrator {
                 .map(DatafeedConfig::getId)
                 .filter(id -> failedDocumentIds.contains(DatafeedConfig.documentId(id)) == false)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Is the job a eligible for migration? Returns:
+     *     False if the min node version of the cluster is before {@link #MIN_NODE_VERSION}
+     *     False if the job is not in the cluster state
+     *     False if the {@link Job#isDeleting()}
+     *     False if the job has a persistent task
+     *     True otherwise i.e. the job is present, not deleting
+     *     and does not have a persistent task.
+     *
+     * @param jobId         The job Id
+     * @param clusterState  clusterstate
+     * @return A boolean depending on the conditions listed above
+     */
+    public static boolean jobIsEligibleForMigration(String jobId, ClusterState clusterState) {
+        Version minNodeVersion = clusterState.nodes().getMinNodeVersion();
+        if (minNodeVersion.before(MIN_NODE_VERSION)) {
+            return false;
+        }
+
+        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
+        Job job = mlMetadata.getJobs().get(jobId);
+
+        if (job == null || job.isDeleting()) {
+            return false;
+        }
+
+        PersistentTasksCustomMetaData persistentTasks = clusterState.metaData().custom(PersistentTasksCustomMetaData.TYPE);
+        return MlTasks.openJobIds(persistentTasks).contains(jobId) == false;
+    }
+
+    /**
+     * Is the datafeed a eligible for migration? Returns:
+     *     False if the min node version of the cluster is before {@link #MIN_NODE_VERSION}
+     *     False if the datafeed is not in the cluster state
+     *     False if the datafeed has a persistent task
+     *     True otherwise i.e. the datafeed is present and does not have a persistent task.
+     *
+     * @param datafeedId   The datafeed Id
+     * @param clusterState clusterstate
+     * @return A boolean depending on the conditions listed above
+     */
+    public static boolean datafeedIsEligibleForMigration(String datafeedId, ClusterState clusterState) {
+        Version minNodeVersion = clusterState.nodes().getMinNodeVersion();
+        if (minNodeVersion.before(MIN_NODE_VERSION)) {
+            return false;
+        }
+
+        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
+        if (mlMetadata.getDatafeeds().containsKey(datafeedId) == false) {
+            return false;
+        }
+
+        PersistentTasksCustomMetaData persistentTasks = clusterState.metaData().custom(PersistentTasksCustomMetaData.TYPE);
+        return MlTasks.startedDatafeedIds(persistentTasks).contains(datafeedId) == false;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
@@ -124,7 +124,7 @@ public class MlConfigMigrator {
             listener.onResponse(Boolean.FALSE);
             return;
         }
-        
+
         Collection<DatafeedConfig> stoppedDatafeeds = stoppedDatafeedConfigs(clusterState);
         Map<String, Job> eligibleJobs = nonDeletingJobs(closedJobConfigs(clusterState)).stream()
                 .map(MlConfigMigrator::updateJobForMigration)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
@@ -63,6 +63,7 @@ import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.CategorizerS
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.Quantiles;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.MlConfigMigrator;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobDataDeleter;
@@ -146,6 +147,12 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
     @Override
     protected void masterOperation(Task task, DeleteJobAction.Request request, ClusterState state,
                                    ActionListener<AcknowledgedResponse> listener) {
+
+        if (MlConfigMigrator.jobIsEligibleForMigration(request.getJobId(), state)) {
+            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated("delete job", request.getJobId()));
+            return;
+        }
+
         logger.debug("Deleting job '{}'", request.getJobId());
 
         if (request.isForce() == false) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -67,6 +67,7 @@ import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.MachineLearning;
+import org.elasticsearch.xpack.ml.MlConfigMigrator;
 import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager;
@@ -503,6 +504,11 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
 
     @Override
     protected void masterOperation(OpenJobAction.Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener) {
+        if (MlConfigMigrator.jobIsEligibleForMigration(request.getJobParams().getJobId(), state)) {
+            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated("open job", request.getJobParams().getJobId()));
+            return;
+        }
+
         OpenJobAction.JobParams jobParams = request.getJobParams();
         if (licenseState.isMachineLearningAllowed()) {
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -44,6 +44,7 @@ import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.MachineLearning;
+import org.elasticsearch.xpack.ml.MlConfigMigrator;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedManager;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedNodeSelector;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
@@ -134,6 +135,11 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
         StartDatafeedAction.DatafeedParams params = request.getParams();
         if (licenseState.isMachineLearningAllowed() == false) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
+            return;
+        }
+
+        if (MlConfigMigrator.datafeedIsEligibleForMigration(request.getParams().getDatafeedId(), state)) {
+            listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated("start datafeed", request.getParams().getDatafeedId()));
             return;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -48,6 +48,7 @@ import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeSta
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.MachineLearning;
+import org.elasticsearch.xpack.ml.MlConfigMigrator;
 import org.elasticsearch.xpack.ml.job.categorization.CategorizationAnalyzer;
 import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
@@ -335,6 +336,12 @@ public class JobManager {
                                 actionListener::onFailure
                         ));
         };
+
+        ClusterState clusterState = clusterService.state();
+        if (MlConfigMigrator.jobIsEligibleForMigration(request.getJobId(), clusterState)) {
+            actionListener.onFailure(ExceptionsHelper.configHasNotBeenMigrated("update job", request.getJobId()));
+            return;
+        }
 
         if (request.getJobUpdate().getGroups() != null && request.getJobUpdate().getGroups().isEmpty() == false) {
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigratorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigratorTests.java
@@ -11,6 +11,9 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
@@ -21,6 +24,7 @@ import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobTests;
 
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -214,6 +218,123 @@ public class MlConfigMigratorTests extends ESTestCase {
         assertThat(removalResult.removedDatafeedIds, empty());
     }
 
+    public void testJobIsEligibleForMigration_givenNodesNotUpToVersion() {
+        // mixed 6.5 and 6.6 nodes
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
+                .nodes(DiscoveryNodes.builder()
+                        .add(new DiscoveryNode("node_id1", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.V_6_5_0))
+                        .add(new DiscoveryNode("node_id2", new TransportAddress(InetAddress.getLoopbackAddress(), 9301), Version.V_6_6_0)))
+                .build();
+
+        assertFalse(MlConfigMigrator.jobIsEligibleForMigration("pre-min-version", clusterState));
+    }
+
+    public void testJobIsEligibleForMigration_givenJobNotInClusterState() {
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests")).build();
+        assertFalse(MlConfigMigrator.jobIsEligibleForMigration("not-in-state", clusterState));
+    }
+
+    public void testJobIsEligibleForMigration_givenDeletingJob() {
+        Job deletingJob = JobTests.buildJobBuilder("deleting-job").setDeleting(true).build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(deletingJob, false);
+
+        PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
+        tasksBuilder.addTask(MlTasks.jobTaskId(deletingJob.getId()),
+                MlTasks.JOB_TASK_NAME, new OpenJobAction.JobParams(deletingJob.getId()),
+                new PersistentTasksCustomMetaData.Assignment("node-1", "test assignment"));
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+                .metaData(MetaData.builder()
+                        .putCustom(MlMetadata.TYPE, mlMetadata.build())
+                        .putCustom(PersistentTasksCustomMetaData.TYPE, tasksBuilder.build())
+                )
+                .build();
+
+        assertFalse(MlConfigMigrator.jobIsEligibleForMigration(deletingJob.getId(), clusterState));
+    }
+
+    public void testJobIsEligibleForMigration_givenOpenJob() {
+        Job openJob = JobTests.buildJobBuilder("open-job").build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(openJob, false);
+
+        PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
+        tasksBuilder.addTask(MlTasks.jobTaskId(openJob.getId()), MlTasks.JOB_TASK_NAME, new OpenJobAction.JobParams(openJob.getId()),
+                new PersistentTasksCustomMetaData.Assignment("node-1", "test assignment"));
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+                .metaData(MetaData.builder()
+                        .putCustom(MlMetadata.TYPE, mlMetadata.build())
+                        .putCustom(PersistentTasksCustomMetaData.TYPE, tasksBuilder.build())
+                )
+                .build();
+
+        assertFalse(MlConfigMigrator.jobIsEligibleForMigration(openJob.getId(), clusterState));
+    }
+
+    public void testJobIsEligibleForMigration_givenClosedJob() {
+        Job closedJob = JobTests.buildJobBuilder("closed-job").build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(closedJob, false);
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+                .metaData(MetaData.builder()
+                        .putCustom(MlMetadata.TYPE, mlMetadata.build())
+                )
+                .build();
+
+        assertTrue(MlConfigMigrator.jobIsEligibleForMigration(closedJob.getId(), clusterState));
+    }
+
+    public void testDatafeedIsEligibleForMigration_givenNodesNotUpToVersion() {
+        // mixed 6.5 and 6.6 nodes
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
+                .nodes(DiscoveryNodes.builder()
+                        .add(new DiscoveryNode("node_id1", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.V_6_5_0))
+                        .add(new DiscoveryNode("node_id2", new TransportAddress(InetAddress.getLoopbackAddress(), 9301), Version.V_6_6_0)))
+                .build();
+
+        assertFalse(MlConfigMigrator.datafeedIsEligibleForMigration("pre-min-version", clusterState));
+    }
+
+    public void testDatafeedIsEligibleForMigration_givenDatafeedNotInClusterState() {
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests")).build();
+        assertFalse(MlConfigMigrator.datafeedIsEligibleForMigration("not-in-state", clusterState));
+    }
+
+    public void testDatafeedIsEligibleForMigration_givenStartedDatafeed() {
+        Job openJob = JobTests.buildJobBuilder("open-job").build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(openJob, false);
+        mlMetadata.putDatafeed(createCompatibleDatafeed(openJob.getId()), Collections.emptyMap());
+        String datafeedId = "df-" + openJob.getId();
+
+        PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
+        tasksBuilder.addTask(MlTasks.datafeedTaskId(datafeedId), MlTasks.DATAFEED_TASK_NAME,
+                new StartDatafeedAction.DatafeedParams(datafeedId, 0L),
+                new PersistentTasksCustomMetaData.Assignment("node-1", "test assignment"));
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+                .metaData(MetaData.builder()
+                        .putCustom(MlMetadata.TYPE, mlMetadata.build())
+                        .putCustom(PersistentTasksCustomMetaData.TYPE, tasksBuilder.build())
+                )
+                .build();
+
+        assertFalse(MlConfigMigrator.datafeedIsEligibleForMigration(datafeedId, clusterState));
+    }
+
+    public void testDatafeedIsEligibleForMigration_givenStoppedDatafeed() {
+        Job job = JobTests.buildJobBuilder("closed-job").build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(job, false);
+        mlMetadata.putDatafeed(createCompatibleDatafeed(job.getId()), Collections.emptyMap());
+        String datafeedId = "df-" + job.getId();
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+                .metaData(MetaData.builder()
+                        .putCustom(MlMetadata.TYPE, mlMetadata.build())
+                )
+                .build();
+
+        assertTrue(MlConfigMigrator.datafeedIsEligibleForMigration(datafeedId, clusterState));
+    }
 
     public void testLimitWrites_GivenBelowLimit() {
         MlConfigMigrator.JobsAndDatafeeds jobsAndDatafeeds = MlConfigMigrator.limitWrites(Collections.emptyList(), Collections.emptyMap());

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -23,14 +23,12 @@ import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.upgrades.AbstractFullClusterRestartTestCase;
 import org.elasticsearch.xpack.core.watcher.client.WatchSourceBuilder;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
-import org.elasticsearch.xpack.test.rest.XPackRestTestHelper;
 import org.elasticsearch.xpack.watcher.actions.logging.LoggingAction;
 import org.elasticsearch.xpack.watcher.common.text.TextTemplate;
 import org.elasticsearch.xpack.watcher.condition.InternalAlwaysCondition;
 import org.elasticsearch.xpack.watcher.trigger.schedule.IntervalSchedule;
 import org.elasticsearch.xpack.watcher.trigger.schedule.ScheduleTrigger;
 import org.hamcrest.Matcher;
-import org.junit.Before;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -58,11 +56,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
-
-    @Before
-    public void waitForMlTemplates() throws Exception {
-        XPackRestTestHelper.waitForMlTemplates(client());
-    }
 
     @Override
     protected Settings restClientSettings() {

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlMigrationFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlMigrationFullClusterRestartIT.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.restart;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.upgrades.AbstractFullClusterRestartTestCase;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
+import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
+import org.elasticsearch.xpack.core.ml.job.config.Detector;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.test.rest.XPackRestTestHelper;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+
+public class MlMigrationFullClusterRestartIT extends AbstractFullClusterRestartTestCase {
+
+    private static final String OLD_CLUSTER_CLOSED_JOB_ID = "migration-old-cluster-closed-job";
+    private static final String OLD_CLUSTER_STOPPED_DATAFEED_ID = "migration-old-cluster-stopped-datafeed";
+
+    @Override
+    protected Settings restClientSettings() {
+        String token = "Basic " + Base64.getEncoder().encodeToString("test_user:x-pack-test-password".getBytes(StandardCharsets.UTF_8));
+        return Settings.builder()
+                .put(ThreadContext.PREFIX + ".Authorization", token)
+                .build();
+    }
+
+    @Before
+    public void waitForMlTemplates() throws Exception {
+        List<String> templatesToWaitFor = XPackRestTestHelper.ML_POST_V660_TEMPLATES;
+
+        // If upgrading from a version prior to v6.6.0 the set of templates
+        // to wait for is different
+        if (isRunningAgainstOldCluster() && getOldClusterVersion().before(Version.V_6_6_0) ) {
+                templatesToWaitFor = XPackRestTestHelper.ML_PRE_V660_TEMPLATES;
+        }
+
+        XPackRestTestHelper.waitForTemplates(client(), templatesToWaitFor);
+    }
+
+    private void createTestIndex() throws IOException {
+        Request createTestIndex = new Request("PUT", "/airline-data");
+        createTestIndex.setJsonEntity("{\"mappings\": { \"doc\": {\"properties\": {" +
+                "\"time\": {\"type\": \"date\"}," +
+                "\"airline\": {\"type\": \"keyword\"}," +
+                "\"responsetime\": {\"type\": \"float\"}" +
+                "}}}}");
+        client().performRequest(createTestIndex);
+    }
+
+    public void testMigration() throws Exception {
+        if (isRunningAgainstOldCluster()) {
+            createTestIndex();
+            oldClusterTests();
+        } else {
+            upgradedClusterTests();
+        }
+    }
+
+    private void oldClusterTests() throws IOException {
+        // create jobs and datafeeds
+        Detector.Builder d = new Detector.Builder("metric", "responsetime");
+        d.setByFieldName("airline");
+        AnalysisConfig.Builder analysisConfig = new AnalysisConfig.Builder(Collections.singletonList(d.build()));
+        analysisConfig.setBucketSpan(TimeValue.timeValueMinutes(10));
+
+        Job.Builder closedJob = new Job.Builder(OLD_CLUSTER_CLOSED_JOB_ID);
+        closedJob.setAnalysisConfig(analysisConfig);
+        closedJob.setDataDescription(new DataDescription.Builder());
+
+        Request putClosedJob = new Request("PUT", "/_xpack/ml/anomaly_detectors/" + OLD_CLUSTER_CLOSED_JOB_ID);
+        putClosedJob.setJsonEntity(Strings.toString(closedJob));
+        client().performRequest(putClosedJob);
+
+        DatafeedConfig.Builder stoppedDfBuilder = new DatafeedConfig.Builder(OLD_CLUSTER_STOPPED_DATAFEED_ID, OLD_CLUSTER_CLOSED_JOB_ID);
+        if (getOldClusterVersion().before(Version.V_6_6_0)) {
+            stoppedDfBuilder.setDelayedDataCheckConfig(null);
+        }
+        stoppedDfBuilder.setIndices(Collections.singletonList("airline-data"));
+
+        Request putStoppedDatafeed = new Request("PUT", "/_xpack/ml/datafeeds/" + OLD_CLUSTER_STOPPED_DATAFEED_ID);
+        putStoppedDatafeed.setJsonEntity(Strings.toString(stoppedDfBuilder.build()));
+        client().performRequest(putStoppedDatafeed);
+    }
+
+    private void upgradedClusterTests() throws Exception {
+        // wait for the closed job and datafeed to be migrated
+        waitForMigration(Collections.singletonList(OLD_CLUSTER_CLOSED_JOB_ID),
+                Collections.singletonList(OLD_CLUSTER_STOPPED_DATAFEED_ID),
+                Collections.emptyList(), Collections.emptyList());
+
+        // open the migrated job and datafeed
+        Request openJob = new Request("POST", "_ml/anomaly_detectors/" + OLD_CLUSTER_CLOSED_JOB_ID + "/_open");
+        client().performRequest(openJob);
+        Request startDatafeed = new Request("POST", "_ml/datafeeds/" + OLD_CLUSTER_STOPPED_DATAFEED_ID + "/_start");
+        client().performRequest(startDatafeed);
+
+        waitForJobToBeAssigned(OLD_CLUSTER_CLOSED_JOB_ID);
+        waitForDatafeedToBeAssigned(OLD_CLUSTER_STOPPED_DATAFEED_ID);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void waitForJobToBeAssigned(String jobId) throws Exception {
+        assertBusy(() -> {
+            Request getJobStats = new Request("GET", "_ml/anomaly_detectors/" + jobId + "/_stats");
+            Response response = client().performRequest(getJobStats);
+
+            Map<String, Object> stats = entityAsMap(response);
+            List<Map<String, Object>> jobStats =
+                    (List<Map<String, Object>>) XContentMapValues.extractValue("jobs", stats);
+
+            assertEquals(jobId, XContentMapValues.extractValue("job_id", jobStats.get(0)));
+            assertEquals("opened", XContentMapValues.extractValue("state", jobStats.get(0)));
+            assertThat((String) XContentMapValues.extractValue("assignment_explanation", jobStats.get(0)), isEmptyOrNullString());
+            assertNotNull(XContentMapValues.extractValue("node", jobStats.get(0)));
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void waitForDatafeedToBeAssigned(String datafeedId) throws Exception {
+        assertBusy(() -> {
+            Request getDatafeedStats = new Request("GET", "_ml/datafeeds/" + datafeedId + "/_stats");
+            Response response = client().performRequest(getDatafeedStats);
+            Map<String, Object> stats = entityAsMap(response);
+            List<Map<String, Object>> datafeedStats =
+                    (List<Map<String, Object>>) XContentMapValues.extractValue("datafeeds", stats);
+
+            assertEquals(datafeedId, XContentMapValues.extractValue("datafeed_id", datafeedStats.get(0)));
+            assertEquals("started", XContentMapValues.extractValue("state", datafeedStats.get(0)));
+            assertThat((String) XContentMapValues.extractValue("assignment_explanation", datafeedStats.get(0)), isEmptyOrNullString());
+            assertNotNull(XContentMapValues.extractValue("node", datafeedStats.get(0)));
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void waitForMigration(List<String> expectedMigratedJobs, List<String> expectedMigratedDatafeeds,
+                                  List<String> unMigratedJobs, List<String> unMigratedDatafeeds) throws Exception {
+        assertBusy(() -> {
+            // wait for the eligible configs to be moved from the clusterstate
+            Request getClusterState = new Request("GET", "/_cluster/state/metadata");
+            Response response = client().performRequest(getClusterState);
+            Map<String, Object> responseMap = entityAsMap(response);
+
+            List<Map<String, Object>> jobs =
+                    (List<Map<String, Object>>) XContentMapValues.extractValue("metadata.ml.jobs", responseMap);
+            assertNotNull(jobs);
+
+            for (String jobId : expectedMigratedJobs) {
+                assertJob(jobId, jobs, false);
+            }
+
+            for (String jobId : unMigratedJobs) {
+                assertJob(jobId, jobs, true);
+            }
+
+            List<Map<String, Object>> datafeeds =
+                    (List<Map<String, Object>>) XContentMapValues.extractValue("metadata.ml.datafeeds", responseMap);
+            assertNotNull(datafeeds);
+
+            for (String datafeedId : expectedMigratedDatafeeds) {
+                assertDatafeed(datafeedId, datafeeds, false);
+            }
+
+            for (String datafeedId : unMigratedDatafeeds) {
+                assertDatafeed(datafeedId, datafeeds, true);
+            }
+
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    private void assertDatafeed(String datafeedId, List<Map<String, Object>> datafeeds, boolean expectedToBePresent) {
+        Optional<Object> config = datafeeds.stream().map(map -> map.get("datafeed_id"))
+                .filter(id -> id.equals(datafeedId)).findFirst();
+        if (expectedToBePresent) {
+            assertTrue(config.isPresent());
+        } else {
+            assertFalse(config.isPresent());
+        }
+    }
+
+    private void assertJob(String jobId, List<Map<String, Object>> jobs, boolean expectedToBePresent) {
+        Optional<Object> config = jobs.stream().map(map -> map.get("job_id"))
+                .filter(id -> id.equals(jobId)).findFirst();
+        if (expectedToBePresent) {
+            assertTrue(config.isPresent());
+        } else {
+            assertFalse(config.isPresent());
+        }
+    }
+}

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.upgrades;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -68,6 +69,14 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
     }
 
     protected static final ClusterType CLUSTER_TYPE = ClusterType.parse(System.getProperty("tests.rest.suite"));
+    protected static final Version UPGRADED_FROM_VERSION;
+    static {
+        String versionProperty = System.getProperty("tests.upgrade_from_version");
+        if (versionProperty == null) {
+            throw new IllegalStateException("System property 'tests.upgrade_from_version' not set, cannot start tests");
+        }
+        UPGRADED_FROM_VERSION = Version.fromString(versionProperty);
+    }
 
     @Override
     protected Settings restClientSettings() {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.upgrades;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -69,14 +68,6 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
     }
 
     protected static final ClusterType CLUSTER_TYPE = ClusterType.parse(System.getProperty("tests.rest.suite"));
-    protected static final Version UPGRADED_FROM_VERSION;
-    static {
-        String versionProperty = System.getProperty("tests.upgrade_from_version");
-        if (versionProperty == null) {
-            throw new IllegalStateException("System property 'tests.upgrade_from_version' not set, cannot start tests");
-        }
-        UPGRADED_FROM_VERSION = Version.fromString(versionProperty);
-    }
 
     @Override
     protected Settings restClientSettings() {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/UpgradeClusterClientYamlTestSuiteIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/UpgradeClusterClientYamlTestSuiteIT.java
@@ -7,7 +7,6 @@ package org.elasticsearch.upgrades;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
-
 import org.apache.lucene.util.TimeUnits;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -29,7 +28,7 @@ public class UpgradeClusterClientYamlTestSuiteIT extends ESClientYamlSuiteTestCa
      */
     @Before
     public void waitForTemplates() throws Exception {
-        XPackRestTestHelper.waitForMlTemplates(client());
+        XPackRestTestHelper.waitForTemplates(client(), XPackRestTestHelper.ML_POST_V660_TEMPLATES);
     }
 
     @Override


### PR DESCRIPTION
Jindex master branch PR.

Ports the full cluster restart test from #36593 with the difference that the test only asserts jobs closed during a full cluster restart are migrated. Migration of unallocated jobs is to follow. 

Also ports the changes in #36425 that prevent updates to jobs and datafeeds when they are eligible for migration