### PR TITLE
SQL: Move internals from TimeZone to ZoneId

### DIFF
--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcConfiguration.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcConfiguration.java
@@ -11,6 +11,7 @@ import org.elasticsearch.xpack.sql.client.Version;
 
 import java.net.URI;
 import java.sql.DriverPropertyInfo;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -69,7 +70,7 @@ class JdbcConfiguration extends ConnectionConfiguration {
     private final String debugOut;
 
     // mutable ones
-    private TimeZone timeZone;
+    private ZoneId zoneId;
 
     public static JdbcConfiguration create(String u, Properties props, int loginTimeoutSeconds) throws JdbcSQLException {
         URI uri = parseUrl(u);
@@ -148,7 +149,8 @@ class JdbcConfiguration extends ConnectionConfiguration {
         this.debug = parseValue(DEBUG, props.getProperty(DEBUG, DEBUG_DEFAULT), Boolean::parseBoolean);
         this.debugOut = props.getProperty(DEBUG_OUTPUT, DEBUG_OUTPUT_DEFAULT);
 
-        this.timeZone = parseValue(TIME_ZONE, props.getProperty(TIME_ZONE, TIME_ZONE_DEFAULT), TimeZone::getTimeZone);
+        this.zoneId = parseValue(TIME_ZONE, props.getProperty(TIME_ZONE, TIME_ZONE_DEFAULT),
+                s -> TimeZone.getTimeZone(s).toZoneId().normalized());
     }
 
     @Override
@@ -165,11 +167,11 @@ class JdbcConfiguration extends ConnectionConfiguration {
     }
 
     public TimeZone timeZone() {
-        return timeZone;
+        return zoneId != null ? TimeZone.getTimeZone(zoneId) : null;
     }
 
     public void timeZone(TimeZone timeZone) {
-        this.timeZone = timeZone;
+        this.zoneId = timeZone != null ? timeZone.toZoneId() : null;
     }
 
     public static boolean canAccept(String url) {

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryRequest.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryRequest.java
@@ -18,9 +18,9 @@ import org.elasticsearch.xpack.sql.proto.RequestInfo;
 import org.elasticsearch.xpack.sql.proto.SqlTypedParamValue;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
-import java.util.TimeZone;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -40,9 +40,9 @@ public class SqlQueryRequest extends AbstractSqlQueryRequest {
         super();
     }
 
-    public SqlQueryRequest(String query, List<SqlTypedParamValue> params, QueryBuilder filter, TimeZone timeZone,
+    public SqlQueryRequest(String query, List<SqlTypedParamValue> params, QueryBuilder filter, ZoneId zoneId,
                            int fetchSize, TimeValue requestTimeout, TimeValue pageTimeout, String cursor, RequestInfo requestInfo) {
-        super(query, params, filter, timeZone, fetchSize, requestTimeout, pageTimeout, requestInfo);
+        super(query, params, filter, zoneId, fetchSize, requestTimeout, pageTimeout, requestInfo);
         this.cursor = cursor;
     }
 
@@ -104,7 +104,7 @@ public class SqlQueryRequest extends AbstractSqlQueryRequest {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         // This is needed just to test round-trip compatibility with proto.SqlQueryRequest
-        return new org.elasticsearch.xpack.sql.proto.SqlQueryRequest(query(), params(), timeZone(), fetchSize(), requestTimeout(),
+        return new org.elasticsearch.xpack.sql.proto.SqlQueryRequest(query(), params(), zoneId(), fetchSize(), requestTimeout(),
             pageTimeout(), filter(), cursor(), requestInfo()).toXContent(builder, params);
     }
 

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryRequestBuilder.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryRequestBuilder.java
@@ -14,9 +14,9 @@ import org.elasticsearch.xpack.sql.proto.Protocol;
 import org.elasticsearch.xpack.sql.proto.RequestInfo;
 import org.elasticsearch.xpack.sql.proto.SqlTypedParamValue;
 
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
-import java.util.TimeZone;
 
 /**
  * The builder to build sql request
@@ -29,9 +29,9 @@ public class SqlQueryRequestBuilder extends ActionRequestBuilder<SqlQueryRequest
     }
 
     public SqlQueryRequestBuilder(ElasticsearchClient client, SqlQueryAction action, String query, List<SqlTypedParamValue> params,
-                                  QueryBuilder filter, TimeZone timeZone, int fetchSize, TimeValue requestTimeout,
+            QueryBuilder filter, ZoneId zoneId, int fetchSize, TimeValue requestTimeout,
                                   TimeValue pageTimeout, String nextPageInfo, RequestInfo requestInfo) {
-        super(client, action, new SqlQueryRequest(query, params, filter, timeZone, fetchSize, requestTimeout, pageTimeout, nextPageInfo,
+        super(client, action, new SqlQueryRequest(query, params, filter, zoneId, fetchSize, requestTimeout, pageTimeout, nextPageInfo,
                 requestInfo));
     }
 
@@ -60,8 +60,8 @@ public class SqlQueryRequestBuilder extends ActionRequestBuilder<SqlQueryRequest
         return this;
     }
 
-    public SqlQueryRequestBuilder timeZone(TimeZone timeZone) {
-        request.timeZone(timeZone);
+    public SqlQueryRequestBuilder zoneId(ZoneId zoneId) {
+        request.zoneId(zoneId);
         return this;
     }
 

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlTranslateRequest.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlTranslateRequest.java
@@ -18,8 +18,8 @@ import org.elasticsearch.xpack.sql.proto.SqlQueryRequest;
 import org.elasticsearch.xpack.sql.proto.SqlTypedParamValue;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.List;
-import java.util.TimeZone;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -33,9 +33,9 @@ public class SqlTranslateRequest extends AbstractSqlQueryRequest {
         super();
     }
 
-    public SqlTranslateRequest(String query, List<SqlTypedParamValue> params, QueryBuilder filter, TimeZone timeZone,
+    public SqlTranslateRequest(String query, List<SqlTypedParamValue> params, QueryBuilder filter, ZoneId zoneId,
                                int fetchSize, TimeValue requestTimeout, TimeValue pageTimeout, RequestInfo requestInfo) {
-        super(query, params, filter, timeZone, fetchSize, requestTimeout, pageTimeout, requestInfo);
+        super(query, params, filter, zoneId, fetchSize, requestTimeout, pageTimeout, requestInfo);
     }
 
     public SqlTranslateRequest(StreamInput in) throws IOException {
@@ -64,7 +64,7 @@ public class SqlTranslateRequest extends AbstractSqlQueryRequest {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         // This is needed just to test parsing of SqlTranslateRequest, so we can reuse SqlQuerySerialization
-        return new SqlQueryRequest(query(), params(), timeZone(), fetchSize(), requestTimeout(),
+        return new SqlQueryRequest(query(), params(), zoneId(), fetchSize(), requestTimeout(),
             pageTimeout(), filter(), null, requestInfo()).toXContent(builder, params);
 
     }

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlTranslateRequestBuilder.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlTranslateRequestBuilder.java
@@ -14,9 +14,9 @@ import org.elasticsearch.xpack.sql.proto.Protocol;
 import org.elasticsearch.xpack.sql.proto.RequestInfo;
 import org.elasticsearch.xpack.sql.proto.SqlTypedParamValue;
 
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
-import java.util.TimeZone;
 
 /**
  * Builder for the request for the sql action for translating SQL queries into ES requests
@@ -28,10 +28,10 @@ public class SqlTranslateRequestBuilder extends ActionRequestBuilder<SqlTranslat
     }
 
     public SqlTranslateRequestBuilder(ElasticsearchClient client, SqlTranslateAction action, String query, QueryBuilder filter,
-                                      List<SqlTypedParamValue> params, TimeZone timeZone, int fetchSize, TimeValue requestTimeout,
+            List<SqlTypedParamValue> params, ZoneId zoneId, int fetchSize, TimeValue requestTimeout,
                                       TimeValue pageTimeout, RequestInfo requestInfo) {
         super(client, action,
-                new SqlTranslateRequest(query, params, filter, timeZone, fetchSize, requestTimeout, pageTimeout, requestInfo));
+                new SqlTranslateRequest(query, params, filter, zoneId, fetchSize, requestTimeout, pageTimeout, requestInfo));
     }
 
     public SqlTranslateRequestBuilder query(String query) {
@@ -39,8 +39,8 @@ public class SqlTranslateRequestBuilder extends ActionRequestBuilder<SqlTranslat
         return this;
     }
 
-    public SqlTranslateRequestBuilder timeZone(TimeZone timeZone) {
-        request.timeZone(timeZone);
+    public SqlTranslateRequestBuilder zoneId(ZoneId zoneId) {
+        request.zoneId(zoneId);
         return this;
     }
 }

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlQueryRequestTests.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlQueryRequestTests.java
@@ -35,7 +35,7 @@ public class SqlQueryRequestTests extends AbstractSerializingTestCase<SqlQueryRe
 
     @Before
     public void setup() {
-        requestInfo = new RequestInfo(randomFrom(Mode.values()), 
+        requestInfo = new RequestInfo(randomFrom(Mode.values()),
                 randomFrom(randomFrom(CLIENT_IDS), randomAlphaOfLengthBetween(10, 20)));
     }
 
@@ -54,7 +54,7 @@ public class SqlQueryRequestTests extends AbstractSerializingTestCase<SqlQueryRe
     @Override
     protected SqlQueryRequest createTestInstance() {
         return new SqlQueryRequest(randomAlphaOfLength(10), randomParameters(), SqlTestUtils.randomFilterOrNull(random()),
-                randomTimeZone(), between(1, Integer.MAX_VALUE),
+                randomZone(), between(1, Integer.MAX_VALUE),
                 randomTV(), randomTV(), randomAlphaOfLength(10), requestInfo
         );
     }
@@ -104,7 +104,7 @@ public class SqlQueryRequestTests extends AbstractSerializingTestCase<SqlQueryRe
                 request -> request.requestInfo(randomValueOtherThan(request.requestInfo(), this::randomRequestInfo)),
                 request -> request.query(randomValueOtherThan(request.query(), () -> randomAlphaOfLength(5))),
                 request -> request.params(randomValueOtherThan(request.params(), this::randomParameters)),
-                request -> request.timeZone(randomValueOtherThan(request.timeZone(), ESTestCase::randomTimeZone)),
+                request -> request.zoneId(randomValueOtherThan(request.zoneId(), ESTestCase::randomZone)),
                 request -> request.fetchSize(randomValueOtherThan(request.fetchSize(), () -> between(1, Integer.MAX_VALUE))),
                 request -> request.requestTimeout(randomValueOtherThan(request.requestTimeout(), this::randomTV)),
                 request -> request.filter(randomValueOtherThan(request.filter(),
@@ -112,7 +112,7 @@ public class SqlQueryRequestTests extends AbstractSerializingTestCase<SqlQueryRe
                 request -> request.cursor(randomValueOtherThan(request.cursor(), SqlQueryResponseTests::randomStringCursor))
         );
         SqlQueryRequest newRequest = new SqlQueryRequest(instance.query(), instance.params(), instance.filter(),
-                instance.timeZone(), instance.fetchSize(), instance.requestTimeout(), instance.pageTimeout(), instance.cursor(),
+                instance.zoneId(), instance.fetchSize(), instance.requestTimeout(), instance.pageTimeout(), instance.cursor(),
                 instance.requestInfo());
         mutator.accept(newRequest);
         return newRequest;
@@ -120,7 +120,7 @@ public class SqlQueryRequestTests extends AbstractSerializingTestCase<SqlQueryRe
 
     public void testTimeZoneNullException() {
         final SqlQueryRequest sqlQueryRequest = createTestInstance();
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> sqlQueryRequest.timeZone(null));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> sqlQueryRequest.zoneId(null));
         assertEquals("time zone may not be null.", e.getMessage());
     }
 }

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlRequestParsersTests.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlRequestParsersTests.java
@@ -114,10 +114,10 @@ public class SqlRequestParsersTests extends ESTestCase {
         assertEquals("whatever", request.cursor());
         assertEquals("select", request.query());
         
-        List<SqlTypedParamValue> list = new ArrayList<SqlTypedParamValue>(1);
+        List<SqlTypedParamValue> list = new ArrayList<>(1);
         list.add(new SqlTypedParamValue("whatever", 123));
         assertEquals(list, request.params());
-        assertEquals("UTC", request.timeZone().getID());
+        assertEquals("UTC", request.zoneId().getId());
         assertEquals(TimeValue.parseTimeValue("5s", "request_timeout"), request.requestTimeout());
         assertEquals(TimeValue.parseTimeValue("10s", "page_timeout"), request.pageTimeout());
     }

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlTranslateRequestTests.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlTranslateRequestTests.java
@@ -37,7 +37,7 @@ public class SqlTranslateRequestTests extends AbstractSerializingTestCase<SqlTra
     @Override
     protected SqlTranslateRequest createTestInstance() {
         return new SqlTranslateRequest(randomAlphaOfLength(10),  Collections.emptyList(), randomFilterOrNull(random()),
-                randomTimeZone(), between(1, Integer.MAX_VALUE), randomTV(), randomTV(), new RequestInfo(testMode));
+                randomZone(), between(1, Integer.MAX_VALUE), randomTV(), randomTV(), new RequestInfo(testMode));
     }
 
     @Override
@@ -71,14 +71,14 @@ public class SqlTranslateRequestTests extends AbstractSerializingTestCase<SqlTra
         @SuppressWarnings("unchecked")
         Consumer<SqlTranslateRequest> mutator = randomFrom(
                 request -> request.query(randomValueOtherThan(request.query(), () -> randomAlphaOfLength(5))),
-                request -> request.timeZone(randomValueOtherThan(request.timeZone(), ESTestCase::randomTimeZone)),
+                request -> request.zoneId(randomValueOtherThan(request.zoneId(), ESTestCase::randomZone)),
                 request -> request.fetchSize(randomValueOtherThan(request.fetchSize(), () -> between(1, Integer.MAX_VALUE))),
                 request -> request.requestTimeout(randomValueOtherThan(request.requestTimeout(), this::randomTV)),
                 request -> request.filter(randomValueOtherThan(request.filter(),
                         () -> request.filter() == null ? randomFilter(random()) : randomFilterOrNull(random())))
         );
         SqlTranslateRequest newRequest = new SqlTranslateRequest(instance.query(), instance.params(), instance.filter(),
-                instance.timeZone(), instance.fetchSize(), instance.requestTimeout(), instance.pageTimeout(), instance.requestInfo());
+                instance.zoneId(), instance.fetchSize(), instance.requestTimeout(), instance.pageTimeout(), instance.requestInfo());
         mutator.accept(newRequest);
         return newRequest;
     }

--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/HttpClient.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/HttpClient.java
@@ -32,8 +32,8 @@ import java.io.InputStream;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.sql.SQLException;
+import java.time.ZoneId;
 import java.util.Collections;
-import java.util.TimeZone;
 import java.util.function.Function;
 
 import static org.elasticsearch.xpack.sql.proto.RequestInfo.CLI;
@@ -66,7 +66,7 @@ public class HttpClient {
     public SqlQueryResponse queryInit(String query, int fetchSize) throws SQLException {
         // TODO allow customizing the time zone - this is what session set/reset/get should be about
         // method called only from CLI. "client_id" is set to "cli"
-        SqlQueryRequest sqlRequest = new SqlQueryRequest(query, Collections.emptyList(), null, TimeZone.getTimeZone("UTC"),
+        SqlQueryRequest sqlRequest = new SqlQueryRequest(query, Collections.emptyList(), null, ZoneId.of("Z"),
             fetchSize, TimeValue.timeValueMillis(cfg.queryTimeout()), TimeValue.timeValueMillis(cfg.pageTimeout()),
             new RequestInfo(Mode.PLAIN, CLI));
         return query(sqlRequest);

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/Protocol.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/Protocol.java
@@ -8,13 +8,13 @@ package org.elasticsearch.xpack.sql.proto;
 
 import org.elasticsearch.common.unit.TimeValue;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * Sql protocol defaults and end-points shared between JDBC and REST protocol implementations
  */
 public final class Protocol {
-    public static final TimeZone TIME_ZONE = TimeZone.getTimeZone("UTC");
+    public static final ZoneId TIME_ZONE = ZoneId.of("Z");
 
     /**
      * Global choice for the default fetch size.

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/SqlQueryRequest.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/SqlQueryRequest.java
@@ -12,10 +12,10 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.TimeZone;
 
 /**
  * Sql query request for JDBC/CLI client
@@ -24,7 +24,7 @@ public class SqlQueryRequest extends AbstractSqlRequest {
     @Nullable
     private final String cursor;
     private final String query;
-    private final TimeZone timeZone;
+    private final ZoneId zoneId;
     private final int fetchSize;
     private final TimeValue requestTimeout;
     private final TimeValue pageTimeout;
@@ -33,12 +33,12 @@ public class SqlQueryRequest extends AbstractSqlRequest {
     private final List<SqlTypedParamValue> params;
 
 
-    public SqlQueryRequest(String query, List<SqlTypedParamValue> params, TimeZone timeZone, int fetchSize,
+    public SqlQueryRequest(String query, List<SqlTypedParamValue> params, ZoneId zoneId, int fetchSize,
                            TimeValue requestTimeout, TimeValue pageTimeout, ToXContent filter, String cursor, RequestInfo requestInfo) {
         super(requestInfo);
         this.query = query;
         this.params = params;
-        this.timeZone = timeZone;
+        this.zoneId = zoneId;
         this.fetchSize = fetchSize;
         this.requestTimeout = requestTimeout;
         this.pageTimeout = pageTimeout;
@@ -46,9 +46,9 @@ public class SqlQueryRequest extends AbstractSqlRequest {
         this.cursor = cursor;
     }
 
-    public SqlQueryRequest(String query, List<SqlTypedParamValue> params, ToXContent filter, TimeZone timeZone,
+    public SqlQueryRequest(String query, List<SqlTypedParamValue> params, ToXContent filter, ZoneId zoneId,
                            int fetchSize, TimeValue requestTimeout, TimeValue pageTimeout, RequestInfo requestInfo) {
-        this(query, params, timeZone, fetchSize, requestTimeout, pageTimeout, filter, null, requestInfo);
+        this(query, params, zoneId, fetchSize, requestTimeout, pageTimeout, filter, null, requestInfo);
     }
 
     public SqlQueryRequest(String cursor, TimeValue requestTimeout, TimeValue pageTimeout, RequestInfo requestInfo) {
@@ -81,8 +81,8 @@ public class SqlQueryRequest extends AbstractSqlRequest {
     /**
      * The client's time zone
      */
-    public TimeZone timeZone() {
-        return timeZone;
+    public ZoneId zoneId() {
+        return zoneId;
     }
 
 
@@ -116,14 +116,20 @@ public class SqlQueryRequest extends AbstractSqlRequest {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
         SqlQueryRequest that = (SqlQueryRequest) o;
         return fetchSize == that.fetchSize &&
             Objects.equals(query, that.query) &&
             Objects.equals(params, that.params) &&
-            Objects.equals(timeZone, that.timeZone) &&
+                Objects.equals(zoneId, that.zoneId) &&
             Objects.equals(requestTimeout, that.requestTimeout) &&
             Objects.equals(pageTimeout, that.pageTimeout) &&
             Objects.equals(filter, that.filter) &&
@@ -132,7 +138,7 @@ public class SqlQueryRequest extends AbstractSqlRequest {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), query, timeZone, fetchSize, requestTimeout, pageTimeout, filter, cursor);
+        return Objects.hash(super.hashCode(), query, zoneId, fetchSize, requestTimeout, pageTimeout, filter, cursor);
     }
 
     @Override
@@ -151,8 +157,8 @@ public class SqlQueryRequest extends AbstractSqlRequest {
             }
             builder.endArray();
         }
-        if (timeZone != null) {
-            builder.field("time_zone", timeZone.getID());
+        if (zoneId != null) {
+            builder.field("time_zone", zoneId.getId());
         }
         if (fetchSize != Protocol.FETCH_SIZE) {
             builder.field("fetch_size", fetchSize);

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/SqlQueryRequest.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/SqlQueryRequest.java
@@ -129,7 +129,7 @@ public class SqlQueryRequest extends AbstractSqlRequest {
         return fetchSize == that.fetchSize &&
             Objects.equals(query, that.query) &&
             Objects.equals(params, that.params) &&
-                Objects.equals(zoneId, that.zoneId) &&
+            Objects.equals(zoneId, that.zoneId) &&
             Objects.equals(requestTimeout, that.requestTimeout) &&
             Objects.equals(pageTimeout, that.pageTimeout) &&
             Objects.equals(filter, that.filter) &&
@@ -178,5 +178,4 @@ public class SqlQueryRequest extends AbstractSqlRequest {
         }
         return builder;
     }
-
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -263,7 +263,7 @@ public class Querier {
         private BucketExtractor createExtractor(FieldExtraction ref, BucketExtractor totalCount) {
             if (ref instanceof GroupByRef) {
                 GroupByRef r = (GroupByRef) ref;
-                return new CompositeKeyExtractor(r.key(), r.property(), r.timeZone());
+                return new CompositeKeyExtractor(r.key(), r.property(), r.zoneId());
             }
 
             if (ref instanceof MetricAggRef) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/CompositeKeyExtractor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/CompositeKeyExtractor.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.time.ZoneId;
 import java.util.Map;
 import java.util.Objects;
-import java.util.TimeZone;
 
 public class CompositeKeyExtractor implements BucketExtractor {
 
@@ -27,40 +26,37 @@ public class CompositeKeyExtractor implements BucketExtractor {
 
     private final String key;
     private final Property property;
-    private final TimeZone timeZone;
     private final ZoneId zoneId;
 
     /**
      * Constructs a new <code>CompositeKeyExtractor</code> instance.
      * The time-zone parameter is used to indicate a date key.
      */
-    public CompositeKeyExtractor(String key, Property property, TimeZone timeZone) {
+    public CompositeKeyExtractor(String key, Property property, ZoneId zoneId) {
         this.key = key;
         this.property = property;
-        this.timeZone = timeZone;
-        this.zoneId = timeZone != null ? timeZone.toZoneId() : null;
+        this.zoneId = zoneId;
     }
 
     CompositeKeyExtractor(StreamInput in) throws IOException {
         key = in.readString();
         property = in.readEnum(Property.class);
         if (in.readBoolean()) {
-            timeZone = TimeZone.getTimeZone(in.readString());
+            zoneId = ZoneId.of(in.readString());
         } else {
-            timeZone = null;
+            zoneId = null;
         }
-        this.zoneId = timeZone != null ? timeZone.toZoneId() : null;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(key);
         out.writeEnum(property);
-        if (timeZone == null) {
+        if (zoneId == null) {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeString(timeZone.getID());
+            out.writeString(zoneId.getId());
         }
     }
 
@@ -72,8 +68,8 @@ public class CompositeKeyExtractor implements BucketExtractor {
         return property;
     }
 
-    TimeZone timeZone() {
-        return timeZone;
+    ZoneId zoneId() {
+        return zoneId;
     }
 
     @Override
@@ -95,7 +91,7 @@ public class CompositeKeyExtractor implements BucketExtractor {
 
         Object object = ((Map<?, ?>) m).get(key);
 
-        if (timeZone != null) {
+        if (zoneId != null) {
             if (object == null) {
                 return object;
             } else if (object instanceof Long) {
@@ -110,7 +106,7 @@ public class CompositeKeyExtractor implements BucketExtractor {
 
     @Override
     public int hashCode() {
-        return Objects.hash(key, property, timeZone);
+        return Objects.hash(key, property, zoneId);
     }
 
     @Override
@@ -126,7 +122,7 @@ public class CompositeKeyExtractor implements BucketExtractor {
         CompositeKeyExtractor other = (CompositeKeyExtractor) obj;
         return Objects.equals(key, other.key)
                 && Objects.equals(property, other.property)
-                && Objects.equals(timeZone, other.timeZone);
+                && Objects.equals(zoneId, other.zoneId);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/FunctionRegistry.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/FunctionRegistry.java
@@ -100,6 +100,7 @@ import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.type.DataType;
 import org.elasticsearch.xpack.sql.util.Check;
 
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -108,7 +109,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.TimeZone;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -441,13 +441,13 @@ public class FunctionRegistry {
             if (distinct) {
                 throw new IllegalArgumentException("does not support DISTINCT yet it was specified");
             }
-            return ctorRef.build(location, children.get(0), cfg.timeZone());
+            return ctorRef.build(location, children.get(0), cfg.zoneId());
         };
         return def(function, builder, true, names);
     }
 
     interface DatetimeUnaryFunctionBuilder<T> {
-        T build(Location location, Expression target, TimeZone tz);
+        T build(Location location, Expression target, ZoneId zi);
     }
 
     /**
@@ -463,13 +463,13 @@ public class FunctionRegistry {
             if (distinct) {
                 throw new IllegalArgumentException("does not support DISTINCT yet it was specified");
             }
-            return ctorRef.build(location, children.get(0), children.get(1), cfg.timeZone());
+            return ctorRef.build(location, children.get(0), children.get(1), cfg.zoneId());
         };
         return def(function, builder, false, names);
     }
 
     interface DatetimeBinaryFunctionBuilder<T> {
-        T build(Location location, Expression lhs, Expression rhs, TimeZone tz);
+        T build(Location location, Expression lhs, Expression rhs, ZoneId zi);
     }
 
     /**

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/grouping/Histogram.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/grouping/Histogram.java
@@ -15,26 +15,26 @@ import org.elasticsearch.xpack.sql.tree.NodeInfo;
 import org.elasticsearch.xpack.sql.type.DataType;
 import org.elasticsearch.xpack.sql.type.DataTypes;
 
+import java.time.ZoneId;
 import java.util.Objects;
-import java.util.TimeZone;
 
 public class Histogram extends GroupingFunction {
 
     private final Literal interval;
-    private final TimeZone timeZone;
+    private final ZoneId zoneId;
 
-    public Histogram(Location location, Expression field, Expression interval, TimeZone timeZone) {
+    public Histogram(Location location, Expression field, Expression interval, ZoneId zoneId) {
         super(location, field);
         this.interval = (Literal) interval;
-        this.timeZone = timeZone;
+        this.zoneId = zoneId;
     }
 
     public Literal interval() {
         return interval;
     }
 
-    public TimeZone timeZone() {
-        return timeZone;
+    public ZoneId zoneId() {
+        return zoneId;
     }
 
     @Override
@@ -54,7 +54,7 @@ public class Histogram extends GroupingFunction {
 
     @Override
     protected GroupingFunction replaceChild(Expression newChild) {
-        return new Histogram(location(), newChild, interval, timeZone);
+        return new Histogram(location(), newChild, interval, zoneId);
     }
 
     @Override
@@ -64,12 +64,12 @@ public class Histogram extends GroupingFunction {
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, Histogram::new, field(), interval, timeZone);
+        return NodeInfo.create(this, Histogram::new, field(), interval, zoneId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(field(), interval, timeZone);
+        return Objects.hash(field(), interval, zoneId);
     }
 
     @Override
@@ -77,7 +77,7 @@ public class Histogram extends GroupingFunction {
         if (super.equals(obj)) {
             Histogram other = (Histogram) obj;
             return Objects.equals(interval, other.interval)
-                    && Objects.equals(timeZone, other.timeZone);
+                    && Objects.equals(zoneId, other.zoneId);
         }
         return false;
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BaseDateTimeFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BaseDateTimeFunction.java
@@ -16,40 +16,37 @@ import org.elasticsearch.xpack.sql.tree.NodeInfo;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Objects;
-import java.util.TimeZone;
 
 abstract class BaseDateTimeFunction extends UnaryScalarFunction {
     
-    private final TimeZone timeZone;
     private final ZoneId zoneId;
     private final String name;
 
-    BaseDateTimeFunction(Location location, Expression field, TimeZone timeZone) {
+    BaseDateTimeFunction(Location location, Expression field, ZoneId zoneId) {
         super(location, field);
-        this.timeZone = timeZone;
-        this.zoneId = timeZone != null ? timeZone.toZoneId() : null;
+        this.zoneId = zoneId;
 
         StringBuilder sb = new StringBuilder(super.name());
         // add timezone as last argument
-        sb.insert(sb.length() - 1, " [" + timeZone.getID() + "]");
+        sb.insert(sb.length() - 1, " [" + zoneId.getId() + "]");
 
         this.name = sb.toString();
     }
 
     @Override
     protected final NodeInfo<BaseDateTimeFunction> info() {
-        return NodeInfo.create(this, ctorForInfo(), field(), timeZone());
+        return NodeInfo.create(this, ctorForInfo(), field(), zoneId());
     }
 
-    protected abstract NodeInfo.NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo();
+    protected abstract NodeInfo.NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo();
 
     @Override
     protected TypeResolution resolveType() {
         return Expressions.typeMustBeDate(field(), functionName(), ParamOrdinal.DEFAULT);
     }
 
-    public TimeZone timeZone() {
-        return timeZone;
+    public ZoneId zoneId() {
+        return zoneId;
     }
     
     @Override
@@ -82,11 +79,11 @@ abstract class BaseDateTimeFunction extends UnaryScalarFunction {
         }
         BaseDateTimeFunction other = (BaseDateTimeFunction) obj;
         return Objects.equals(other.field(), field())
-            && Objects.equals(other.timeZone(), timeZone());
+                && Objects.equals(other.zoneId(), zoneId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(field(), timeZone());
+        return Objects.hash(field(), zoneId());
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BaseDateTimeProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BaseDateTimeProcessor.java
@@ -14,30 +14,26 @@ import org.elasticsearch.xpack.sql.expression.gen.processor.Processor;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.TimeZone;
 
 public abstract class BaseDateTimeProcessor implements Processor {
 
-    private final TimeZone timeZone;
     private final ZoneId zoneId;
     
-    BaseDateTimeProcessor(TimeZone timeZone) {
-        this.timeZone = timeZone;
-        this.zoneId = timeZone.toZoneId();
+    BaseDateTimeProcessor(ZoneId zoneId) {
+        this.zoneId = zoneId;
     }
     
     BaseDateTimeProcessor(StreamInput in) throws IOException {
-        timeZone = TimeZone.getTimeZone(in.readString());
-        zoneId = timeZone.toZoneId();
+        zoneId = ZoneId.of(in.readString());
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(timeZone.getID());
+        out.writeString(zoneId.getId());
     }
     
-    TimeZone timeZone() {
-        return timeZone;
+    ZoneId zoneId() {
+        return zoneId;
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFunction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xpack.sql.type.DataType;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
-import java.util.TimeZone;
 
 import static org.elasticsearch.xpack.sql.expression.gen.script.ParamsBuilder.paramsBuilder;
 
@@ -24,8 +23,8 @@ public abstract class DateTimeFunction extends BaseDateTimeFunction {
 
     private final DateTimeExtractor extractor;
 
-    DateTimeFunction(Location location, Expression field, TimeZone timeZone, DateTimeExtractor extractor) {
-        super(location, field, timeZone);
+    DateTimeFunction(Location location, Expression field, ZoneId zoneId, DateTimeExtractor extractor) {
+        super(location, field, zoneId);
         this.extractor = extractor;
     }
 
@@ -50,7 +49,7 @@ public abstract class DateTimeFunction extends BaseDateTimeFunction {
         ScriptTemplate script = super.asScript();
         String template = formatTemplate("{sql}.dateTimeChrono(" + script.template() + ", {}, {})");
         params.script(script.params())
-              .variable(timeZone().getID())
+              .variable(zoneId().getId())
               .variable(extractor.chronoField().name());
         
         return new ScriptTemplate(template, params.build(), dataType());
@@ -59,7 +58,7 @@ public abstract class DateTimeFunction extends BaseDateTimeFunction {
 
     @Override
     protected Processor makeProcessor() {
-        return new DateTimeProcessor(extractor, timeZone());
+        return new DateTimeProcessor(extractor, zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeHistogramFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeHistogramFunction.java
@@ -9,7 +9,7 @@ import org.elasticsearch.xpack.sql.expression.Expression;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 import org.elasticsearch.xpack.sql.tree.Location;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * DateTimeFunctions that can be mapped as histogram. This means the dates order is maintained
@@ -17,8 +17,8 @@ import java.util.TimeZone;
  */
 public abstract class DateTimeHistogramFunction extends DateTimeFunction {
 
-    DateTimeHistogramFunction(Location location, Expression field, TimeZone timeZone, DateTimeExtractor extractor) {
-        super(location, field, timeZone, extractor);
+    DateTimeHistogramFunction(Location location, Expression field, ZoneId zoneId, DateTimeExtractor extractor) {
+        super(location, field, zoneId, extractor);
     }
 
     /**

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeProcessor.java
@@ -9,10 +9,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
 import java.util.Objects;
-import java.util.TimeZone;
 
 public class DateTimeProcessor extends BaseDateTimeProcessor {
     
@@ -46,8 +46,8 @@ public class DateTimeProcessor extends BaseDateTimeProcessor {
     public static final String NAME = "dt";
     private final DateTimeExtractor extractor;
 
-    public DateTimeProcessor(DateTimeExtractor extractor, TimeZone timeZone) {
-        super(timeZone);
+    public DateTimeProcessor(DateTimeExtractor extractor, ZoneId zoneId) {
+        super(zoneId);
         this.extractor = extractor;
     }
 
@@ -78,7 +78,7 @@ public class DateTimeProcessor extends BaseDateTimeProcessor {
 
     @Override
     public int hashCode() {
-        return Objects.hash(extractor, timeZone());
+        return Objects.hash(extractor, zoneId());
     }
 
     @Override
@@ -88,7 +88,7 @@ public class DateTimeProcessor extends BaseDateTimeProcessor {
         }
         DateTimeProcessor other = (DateTimeProcessor) obj;
         return Objects.equals(extractor, other.extractor)
-                && Objects.equals(timeZone(), other.timeZone());
+                && Objects.equals(zoneId(), other.zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayName.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayName.java
@@ -10,24 +10,24 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.NamedDate
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * Extract the day of the week from a datetime in text format (Monday, Tuesday etc.)
  */
 public class DayName extends NamedDateTimeFunction {
     
-    public DayName(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone, NameExtractor.DAY_NAME);
+    public DayName(Location location, Expression field, ZoneId zoneId) {
+        super(location, field, zoneId, NameExtractor.DAY_NAME);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo() {
+    protected NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo() {
         return DayName::new;
     }
 
     @Override
     protected DayName replaceChild(Expression newChild) {
-        return new DayName(location(), newChild, timeZone());
+        return new DayName(location(), newChild, zoneId());
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfMonth.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfMonth.java
@@ -10,24 +10,24 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeP
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * Extract the day of the month from a datetime.
  */
 public class DayOfMonth extends DateTimeFunction {
-    public DayOfMonth(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone, DateTimeExtractor.DAY_OF_MONTH);
+    public DayOfMonth(Location location, Expression field, ZoneId zoneId) {
+        super(location, field, zoneId, DateTimeExtractor.DAY_OF_MONTH);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo() {
+    protected NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo() {
         return DayOfMonth::new;
     }
 
     @Override
     protected DayOfMonth replaceChild(Expression newChild) {
-        return new DayOfMonth(location(), newChild, timeZone());
+        return new DayOfMonth(location(), newChild, zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfWeek.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfWeek.java
@@ -10,24 +10,24 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.NonIsoDat
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * Extract the day of the week from a datetime in non-ISO format. 1 is Sunday, 2 is Monday, etc.
  */
 public class DayOfWeek extends NonIsoDateTimeFunction {
     
-    public DayOfWeek(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone, NonIsoDateTimeExtractor.DAY_OF_WEEK);
+    public DayOfWeek(Location location, Expression field, ZoneId zoneId) {
+        super(location, field, zoneId, NonIsoDateTimeExtractor.DAY_OF_WEEK);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo() {
+    protected NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo() {
         return DayOfWeek::new;
     }
 
     @Override
     protected DayOfWeek replaceChild(Expression newChild) {
-        return new DayOfWeek(location(), newChild, timeZone());
+        return new DayOfWeek(location(), newChild, zoneId());
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfYear.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfYear.java
@@ -11,24 +11,24 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeP
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * Extract the day of the year from a datetime.
  */
 public class DayOfYear extends DateTimeFunction {
-    public DayOfYear(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone, DateTimeExtractor.DAY_OF_YEAR);
+    public DayOfYear(Location location, Expression field, ZoneId zoneId) {
+        super(location, field, zoneId, DateTimeExtractor.DAY_OF_YEAR);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo() {
+    protected NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo() {
         return DayOfYear::new;
     }
 
     @Override
     protected UnaryScalarFunction replaceChild(Expression newChild) {
-        return new DayOfYear(location(), newChild, timeZone());
+        return new DayOfYear(location(), newChild, zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/HourOfDay.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/HourOfDay.java
@@ -10,24 +10,24 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeP
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * Extract the hour of the day from a datetime.
  */
 public class HourOfDay extends DateTimeFunction {
-    public HourOfDay(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone, DateTimeExtractor.HOUR_OF_DAY);
+    public HourOfDay(Location location, Expression field, ZoneId zoneId) {
+        super(location, field, zoneId, DateTimeExtractor.HOUR_OF_DAY);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo() {
+    protected NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo() {
         return HourOfDay::new;
     }
 
     @Override
     protected HourOfDay replaceChild(Expression newChild) {
-        return new HourOfDay(location(), newChild, timeZone());
+        return new HourOfDay(location(), newChild, zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/IsoDayOfWeek.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/IsoDayOfWeek.java
@@ -10,24 +10,24 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeP
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * Extract the day of the week (following the ISO standard) from a datetime. 1 is Monday, 2 is Tuesday, etc.
  */
 public class IsoDayOfWeek extends DateTimeFunction {
-    public IsoDayOfWeek(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone, DateTimeExtractor.ISO_DAY_OF_WEEK);
+    public IsoDayOfWeek(Location location, Expression field, ZoneId zoneId) {
+        super(location, field, zoneId, DateTimeExtractor.ISO_DAY_OF_WEEK);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo() {
+    protected NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo() {
         return IsoDayOfWeek::new;
     }
 
     @Override
     protected IsoDayOfWeek replaceChild(Expression newChild) {
-        return new IsoDayOfWeek(location(), newChild, timeZone());
+        return new IsoDayOfWeek(location(), newChild, zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/IsoWeekOfYear.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/IsoWeekOfYear.java
@@ -10,24 +10,24 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeP
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * Extract the week of the year from a datetime following the ISO standard.
  */
 public class IsoWeekOfYear extends DateTimeFunction {
-    public IsoWeekOfYear(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone, DateTimeExtractor.ISO_WEEK_OF_YEAR);
+    public IsoWeekOfYear(Location location, Expression field, ZoneId zoneId) {
+        super(location, field, zoneId, DateTimeExtractor.ISO_WEEK_OF_YEAR);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo() {
+    protected NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo() {
         return IsoWeekOfYear::new;
     }
 
     @Override
     protected IsoWeekOfYear replaceChild(Expression newChild) {
-        return new IsoWeekOfYear(location(), newChild, timeZone());
+        return new IsoWeekOfYear(location(), newChild, zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MinuteOfDay.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MinuteOfDay.java
@@ -10,25 +10,25 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeP
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * Extract the minute of the day from a datetime.
  */
 public class MinuteOfDay extends DateTimeFunction {
 
-    public MinuteOfDay(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone, DateTimeExtractor.MINUTE_OF_DAY);
+    public MinuteOfDay(Location location, Expression field, ZoneId zoneId) {
+        super(location, field, zoneId, DateTimeExtractor.MINUTE_OF_DAY);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo() {
+    protected NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo() {
         return MinuteOfDay::new;
     }
 
     @Override
     protected MinuteOfDay replaceChild(Expression newChild) {
-        return new MinuteOfDay(location(), newChild, timeZone());
+        return new MinuteOfDay(location(), newChild, zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MinuteOfHour.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MinuteOfHour.java
@@ -10,24 +10,24 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeP
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * Exract the minute of the hour from a datetime.
  */
 public class MinuteOfHour extends DateTimeFunction {
-    public MinuteOfHour(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone, DateTimeExtractor.MINUTE_OF_HOUR);
+    public MinuteOfHour(Location location, Expression field, ZoneId zoneId) {
+        super(location, field, zoneId, DateTimeExtractor.MINUTE_OF_HOUR);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo() {
+    protected NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo() {
         return MinuteOfHour::new;
     }
 
     @Override
     protected MinuteOfHour replaceChild(Expression newChild) {
-        return new MinuteOfHour(location(), newChild, timeZone());
+        return new MinuteOfHour(location(), newChild, zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MonthName.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MonthName.java
@@ -10,24 +10,24 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.NamedDate
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * Extract the month from a datetime in text format (January, February etc.)
  */
 public class MonthName extends NamedDateTimeFunction {
     
-    public MonthName(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone, NameExtractor.MONTH_NAME);
+    public MonthName(Location location, Expression field, ZoneId zoneId) {
+        super(location, field, zoneId, NameExtractor.MONTH_NAME);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo() {
+    protected NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo() {
         return MonthName::new;
     }
 
     @Override
     protected MonthName replaceChild(Expression newChild) {
-        return new MonthName(location(), newChild, timeZone());
+        return new MonthName(location(), newChild, zoneId());
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MonthOfYear.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MonthOfYear.java
@@ -10,24 +10,24 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeP
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * Extract the month of the year from a datetime.
  */
 public class MonthOfYear extends DateTimeFunction {
-    public MonthOfYear(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone, DateTimeExtractor.MONTH_OF_YEAR);
+    public MonthOfYear(Location location, Expression field, ZoneId zoneId) {
+        super(location, field, zoneId, DateTimeExtractor.MONTH_OF_YEAR);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo() {
+    protected NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo() {
         return MonthOfYear::new;
     }
 
     @Override
     protected MonthOfYear replaceChild(Expression newChild) {
-        return new MonthOfYear(location(), newChild, timeZone());
+        return new MonthOfYear(location(), newChild, zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NamedDateTimeFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NamedDateTimeFunction.java
@@ -14,9 +14,9 @@ import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.type.DataType;
 import org.elasticsearch.xpack.sql.util.StringUtils;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Locale;
-import java.util.TimeZone;
 
 import static java.lang.String.format;
 import static org.elasticsearch.xpack.sql.expression.gen.script.ParamsBuilder.paramsBuilder;
@@ -28,8 +28,8 @@ abstract class NamedDateTimeFunction extends BaseDateTimeFunction {
 
     private final NameExtractor nameExtractor;
 
-    NamedDateTimeFunction(Location location, Expression field, TimeZone timeZone, NameExtractor nameExtractor) {
-        super(location, field, timeZone);
+    NamedDateTimeFunction(Location location, Expression field, ZoneId zoneId, NameExtractor nameExtractor) {
+        super(location, field, zoneId);
         this.nameExtractor = nameExtractor;
     }
 
@@ -45,13 +45,13 @@ abstract class NamedDateTimeFunction extends BaseDateTimeFunction {
                         StringUtils.underscoreToLowerCamelCase(nameExtractor.name()))),
                 paramsBuilder()
                   .variable(field.name())
-                  .variable(timeZone().getID()).build(),
+                  .variable(zoneId().getId()).build(),
                 dataType());
     }
 
     @Override
     protected Processor makeProcessor() {
-        return new NamedDateTimeProcessor(nameExtractor, timeZone());
+        return new NamedDateTimeProcessor(nameExtractor, zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NamedDateTimeProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NamedDateTimeProcessor.java
@@ -14,7 +14,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.TimeZone;
 import java.util.function.Function;
 
 public class NamedDateTimeProcessor extends BaseDateTimeProcessor {
@@ -46,8 +45,8 @@ public class NamedDateTimeProcessor extends BaseDateTimeProcessor {
 
     private final NameExtractor extractor;
 
-    public NamedDateTimeProcessor(NameExtractor extractor, TimeZone timeZone) {
-        super(timeZone);
+    public NamedDateTimeProcessor(NameExtractor extractor, ZoneId zoneId) {
+        super(zoneId);
         this.extractor = extractor;
     }
 
@@ -78,7 +77,7 @@ public class NamedDateTimeProcessor extends BaseDateTimeProcessor {
 
     @Override
     public int hashCode() {
-        return Objects.hash(extractor, timeZone());
+        return Objects.hash(extractor, zoneId());
     }
 
     @Override
@@ -88,7 +87,7 @@ public class NamedDateTimeProcessor extends BaseDateTimeProcessor {
         }
         NamedDateTimeProcessor other = (NamedDateTimeProcessor) obj;
         return Objects.equals(extractor, other.extractor)
-                && Objects.equals(timeZone(), other.timeZone());
+                && Objects.equals(zoneId(), other.zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NonIsoDateTimeFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NonIsoDateTimeFunction.java
@@ -14,9 +14,9 @@ import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.type.DataType;
 import org.elasticsearch.xpack.sql.util.StringUtils;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Locale;
-import java.util.TimeZone;
 
 import static java.lang.String.format;
 import static org.elasticsearch.xpack.sql.expression.gen.script.ParamsBuilder.paramsBuilder;
@@ -28,8 +28,8 @@ abstract class NonIsoDateTimeFunction extends BaseDateTimeFunction {
 
     private final NonIsoDateTimeExtractor extractor;
 
-    NonIsoDateTimeFunction(Location location, Expression field, TimeZone timeZone, NonIsoDateTimeExtractor extractor) {
-        super(location, field, timeZone);
+    NonIsoDateTimeFunction(Location location, Expression field, ZoneId zoneId, NonIsoDateTimeExtractor extractor) {
+        super(location, field, zoneId);
         this.extractor = extractor;
     }
 
@@ -45,13 +45,13 @@ abstract class NonIsoDateTimeFunction extends BaseDateTimeFunction {
                         StringUtils.underscoreToLowerCamelCase(extractor.name()))),
                 paramsBuilder()
                   .variable(field.name())
-                  .variable(timeZone().getID()).build(),
+                  .variable(zoneId().getId()).build(),
                 dataType());
     }
 
     @Override
     protected Processor makeProcessor() {
-        return new NonIsoDateTimeProcessor(extractor, timeZone());
+        return new NonIsoDateTimeProcessor(extractor, zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NonIsoDateTimeProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NonIsoDateTimeProcessor.java
@@ -60,8 +60,8 @@ public class NonIsoDateTimeProcessor extends BaseDateTimeProcessor {
 
     private final NonIsoDateTimeExtractor extractor;
 
-    public NonIsoDateTimeProcessor(NonIsoDateTimeExtractor extractor, TimeZone timeZone) {
-        super(timeZone);
+    public NonIsoDateTimeProcessor(NonIsoDateTimeExtractor extractor, ZoneId zoneId) {
+        super(zoneId);
         this.extractor = extractor;
     }
 
@@ -92,7 +92,7 @@ public class NonIsoDateTimeProcessor extends BaseDateTimeProcessor {
 
     @Override
     public int hashCode() {
-        return Objects.hash(extractor, timeZone());
+        return Objects.hash(extractor, zoneId());
     }
 
     @Override
@@ -102,7 +102,7 @@ public class NonIsoDateTimeProcessor extends BaseDateTimeProcessor {
         }
         NonIsoDateTimeProcessor other = (NonIsoDateTimeProcessor) obj;
         return Objects.equals(extractor, other.extractor)
-                && Objects.equals(timeZone(), other.timeZone());
+                && Objects.equals(zoneId(), other.zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/Quarter.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/Quarter.java
@@ -14,16 +14,16 @@ import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 import org.elasticsearch.xpack.sql.type.DataType;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.TimeZone;
 
 import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.QuarterProcessor.quarter;
 import static org.elasticsearch.xpack.sql.expression.gen.script.ParamsBuilder.paramsBuilder;
 
 public class Quarter extends BaseDateTimeFunction {
 
-    public Quarter(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone);
+    public Quarter(Location location, Expression field, ZoneId zoneId) {
+        super(location, field, zoneId);
     }
 
     @Override
@@ -36,24 +36,24 @@ public class Quarter extends BaseDateTimeFunction {
         return new ScriptTemplate(formatTemplate("{sql}.quarter(doc[{}].value, {})"),
                 paramsBuilder()
                   .variable(field.name())
-                  .variable(timeZone().getID())
+                  .variable(zoneId().getId())
                   .build(),
                 dataType());
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo() {
+    protected NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo() {
         return Quarter::new;
     }
 
     @Override
     protected Quarter replaceChild(Expression newChild) {
-        return new Quarter(location(), newChild, timeZone());
+        return new Quarter(location(), newChild, zoneId());
     }
 
     @Override
     protected Processor makeProcessor() {
-        return new QuarterProcessor(timeZone());
+        return new QuarterProcessor(zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/QuarterProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/QuarterProcessor.java
@@ -14,12 +14,11 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.TimeZone;
 
 public class QuarterProcessor extends BaseDateTimeProcessor {
     
-    public QuarterProcessor(TimeZone timeZone) {
-        super(timeZone);
+    public QuarterProcessor(ZoneId zoneId) {
+        super(zoneId);
     }
     
     public QuarterProcessor(StreamInput in) throws IOException {
@@ -49,7 +48,7 @@ public class QuarterProcessor extends BaseDateTimeProcessor {
 
     @Override
     public int hashCode() {
-        return Objects.hash(timeZone());
+        return Objects.hash(zoneId());
     }
 
     @Override
@@ -58,6 +57,6 @@ public class QuarterProcessor extends BaseDateTimeProcessor {
             return false;
         }
         DateTimeProcessor other = (DateTimeProcessor) obj;
-        return Objects.equals(timeZone(), other.timeZone());
+        return Objects.equals(zoneId(), other.zoneId());
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/SecondOfMinute.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/SecondOfMinute.java
@@ -10,24 +10,24 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeP
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * Extract the second of the minute from a datetime.
  */
 public class SecondOfMinute extends DateTimeFunction {
-    public SecondOfMinute(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone, DateTimeExtractor.SECOND_OF_MINUTE);
+    public SecondOfMinute(Location location, Expression field, ZoneId zoneId) {
+        super(location, field, zoneId, DateTimeExtractor.SECOND_OF_MINUTE);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo() {
+    protected NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo() {
         return SecondOfMinute::new;
     }
 
     @Override
     protected SecondOfMinute replaceChild(Expression newChild) {
-        return new SecondOfMinute(location(), newChild, timeZone());
+        return new SecondOfMinute(location(), newChild, zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/WeekOfYear.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/WeekOfYear.java
@@ -10,24 +10,24 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.NonIsoDat
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * Extract the week of the year from a datetime following the non-ISO standard.
  */
 public class WeekOfYear extends NonIsoDateTimeFunction {
     
-    public WeekOfYear(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone, NonIsoDateTimeExtractor.WEEK_OF_YEAR);
+    public WeekOfYear(Location location, Expression field, ZoneId zoneId) {
+        super(location, field, zoneId, NonIsoDateTimeExtractor.WEEK_OF_YEAR);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo() {
+    protected NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo() {
         return WeekOfYear::new;
     }
 
     @Override
     protected WeekOfYear replaceChild(Expression newChild) {
-        return new WeekOfYear(location(), newChild, timeZone());
+        return new WeekOfYear(location(), newChild, zoneId());
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/Year.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/Year.java
@@ -10,7 +10,7 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeP
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -20,18 +20,18 @@ public class Year extends DateTimeHistogramFunction {
 
     private static long YEAR_IN_MILLIS = TimeUnit.DAYS.toMillis(1) * 365L;
 
-    public Year(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone, DateTimeExtractor.YEAR);
+    public Year(Location location, Expression field, ZoneId zoneId) {
+        super(location, field, zoneId, DateTimeExtractor.YEAR);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, BaseDateTimeFunction> ctorForInfo() {
+    protected NodeCtor2<Expression, ZoneId, BaseDateTimeFunction> ctorForInfo() {
         return Year::new;
     }
 
     @Override
     protected Year replaceChild(Expression newChild) {
-        return new Year(location(), newChild, timeZone());
+        return new Year(location(), newChild, zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
@@ -259,7 +259,7 @@ final class QueryTranslator {
                     // dates are handled differently because of date histograms
                     if (exp instanceof DateTimeHistogramFunction) {
                         DateTimeHistogramFunction dthf = (DateTimeHistogramFunction) exp;
-                        key = new GroupByDateHistogram(aggId, nameOf(exp), dthf.interval(), dthf.timeZone());
+                        key = new GroupByDateHistogram(aggId, nameOf(exp), dthf.interval(), dthf.zoneId());
                     }
                     // all other scalar functions become a script
                     else if (exp instanceof ScalarFunction) {
@@ -277,9 +277,9 @@ final class QueryTranslator {
                                 long intervalAsMillis = Intervals.inMillis(h.interval());
                                 // TODO: set timezone
                                 if (field instanceof FieldAttribute || field instanceof DateTimeHistogramFunction) {
-                                    key = new GroupByDateHistogram(aggId, nameOf(field), intervalAsMillis, h.timeZone());
+                                    key = new GroupByDateHistogram(aggId, nameOf(field), intervalAsMillis, h.zoneId());
                                 } else if (field instanceof Function) {
-                                    key = new GroupByDateHistogram(aggId, ((Function) field).asScript(), intervalAsMillis, h.timeZone());
+                                    key = new GroupByDateHistogram(aggId, ((Function) field).asScript(), intervalAsMillis, h.zoneId());
                                 }
                             }
                             // numeric histogram

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlClearCursorAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlClearCursorAction.java
@@ -45,7 +45,7 @@ public class TransportSqlClearCursorAction extends HandledTransportAction<SqlCle
             ActionListener<SqlClearCursorResponse> listener) {
         Cursor cursor = Cursors.decodeFromString(request.getCursor());
         planExecutor.cleanCursor(
-                new Configuration(DateUtils.UTC_TZ, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT, Protocol.PAGE_TIMEOUT, null,
+                new Configuration(DateUtils.UTC, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT, Protocol.PAGE_TIMEOUT, null,
                         request.mode(), "", ""),
                 cursor, ActionListener.wrap(
                 success -> listener.onResponse(new SqlClearCursorResponse(success)), listener::onFailure));

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
@@ -71,7 +71,7 @@ public class TransportSqlQueryAction extends HandledTransportAction<SqlQueryRequ
                                  String username, String clusterName) {
         // The configuration is always created however when dealing with the next page, only the timeouts are relevant
         // the rest having default values (since the query is already created)
-        Configuration cfg = new Configuration(request.timeZone(), request.fetchSize(), request.requestTimeout(), request.pageTimeout(),
+        Configuration cfg = new Configuration(request.zoneId(), request.fetchSize(), request.requestTimeout(), request.pageTimeout(),
                 request.filter(), request.mode(), username, clusterName);
 
         // mode() shouldn't be null

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlTranslateAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlTranslateAction.java
@@ -53,7 +53,7 @@ public class TransportSqlTranslateAction extends HandledTransportAction<SqlTrans
         sqlLicenseChecker.checkIfSqlAllowed(request.mode());
 
         planExecutor.metrics().translate();
-        Configuration cfg = new Configuration(request.timeZone(), request.fetchSize(),
+        Configuration cfg = new Configuration(request.zoneId(), request.fetchSize(),
                 request.requestTimeout(), request.pageTimeout(), request.filter(), request.mode(),
                 username(securityContext), clusterName(clusterService));
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByDateHistogram.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByDateHistogram.java
@@ -5,14 +5,14 @@
  */
 package org.elasticsearch.xpack.sql.querydsl.agg;
 
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeValuesSourceBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.DateHistogramValuesSourceBuilder;
 import org.elasticsearch.xpack.sql.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.sql.querydsl.container.Sort.Direction;
-import org.joda.time.DateTimeZone;
 
+import java.time.ZoneId;
 import java.util.Objects;
-import java.util.TimeZone;
 
 /**
  * GROUP BY key based on histograms on date fields.
@@ -20,21 +20,21 @@ import java.util.TimeZone;
 public class GroupByDateHistogram extends GroupByKey {
 
     private final long interval;
-    private final TimeZone timeZone;
+    private final ZoneId zoneId;
 
-    public GroupByDateHistogram(String id, String fieldName, long interval, TimeZone timeZone) {
-        this(id, fieldName, null, null, interval, timeZone);
+    public GroupByDateHistogram(String id, String fieldName, long interval, ZoneId zoneId) {
+        this(id, fieldName, null, null, interval, zoneId);
     }
 
-    public GroupByDateHistogram(String id, ScriptTemplate script, long interval, TimeZone timeZone) {
-        this(id, null, script, null, interval, timeZone);
+    public GroupByDateHistogram(String id, ScriptTemplate script, long interval, ZoneId zoneId) {
+        this(id, null, script, null, interval, zoneId);
     }
 
     private GroupByDateHistogram(String id, String fieldName, ScriptTemplate script, Direction direction, long interval,
-            TimeZone timeZone) {
+            ZoneId zoneId) {
         super(id, fieldName, script, direction);
         this.interval = interval;
-        this.timeZone = timeZone;
+        this.zoneId = zoneId;
 
     }
 
@@ -42,17 +42,17 @@ public class GroupByDateHistogram extends GroupByKey {
     protected CompositeValuesSourceBuilder<?> createSourceBuilder() {
         return new DateHistogramValuesSourceBuilder(id())
                 .interval(interval)
-                .timeZone(DateTimeZone.forTimeZone(timeZone));
+                .timeZone(DateUtils.zoneIdToDateTimeZone(zoneId));
     }
 
     @Override
     protected GroupByKey copy(String id, String fieldName, ScriptTemplate script, Direction direction) {
-        return new GroupByDateHistogram(id, fieldName, script, direction, interval, timeZone);
+        return new GroupByDateHistogram(id, fieldName, script, direction, interval, zoneId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), interval, timeZone);
+        return Objects.hash(super.hashCode(), interval, zoneId);
     }
 
     @Override
@@ -60,7 +60,7 @@ public class GroupByDateHistogram extends GroupByKey {
         if (super.equals(obj)) {
             GroupByDateHistogram other = (GroupByDateHistogram) obj;
             return Objects.equals(interval, other.interval)
-                    && Objects.equals(timeZone, other.timeZone);
+                    && Objects.equals(zoneId, other.zoneId);
         }
         return false;
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/container/GroupByRef.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/container/GroupByRef.java
@@ -7,7 +7,7 @@ package org.elasticsearch.xpack.sql.querydsl.container;
 
 import org.elasticsearch.xpack.sql.execution.search.AggRef;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 /**
  * Reference to a GROUP BY agg (typically this gets translated to a composite key).
@@ -20,12 +20,12 @@ public class GroupByRef extends AggRef {
     
     private final String key;
     private final Property property;
-    private final TimeZone timeZone;
+    private final ZoneId zoneId;
 
-    public GroupByRef(String key, Property property, TimeZone timeZone) {
+    public GroupByRef(String key, Property property, ZoneId zoneId) {
         this.key = key;
         this.property = property == null ? Property.VALUE : property;
-        this.timeZone = timeZone;
+        this.zoneId = zoneId;
     }
 
     public String key() {
@@ -36,8 +36,8 @@ public class GroupByRef extends AggRef {
         return property;
     }
 
-    public TimeZone timeZone() {
-        return timeZone;
+    public ZoneId zoneId() {
+        return zoneId;
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/Configuration.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/Configuration.java
@@ -10,12 +10,12 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.xpack.sql.proto.Mode;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.TimeZone;
 
 // Typed object holding properties for a given query
 public class Configuration {
-    private final TimeZone timeZone;
+    private final ZoneId zoneId;
     private final int pageSize;
     private final TimeValue requestTimeout;
     private final TimeValue pageTimeout;
@@ -27,9 +27,9 @@ public class Configuration {
     @Nullable
     private QueryBuilder filter;
 
-    public Configuration(TimeZone tz, int pageSize, TimeValue requestTimeout, TimeValue pageTimeout, QueryBuilder filter, Mode mode,
+    public Configuration(ZoneId zi, int pageSize, TimeValue requestTimeout, TimeValue pageTimeout, QueryBuilder filter, Mode mode,
                          String username, String clusterName) {
-        this.timeZone = tz;
+        this.zoneId = zi.normalized();
         this.pageSize = pageSize;
         this.requestTimeout = requestTimeout;
         this.pageTimeout = pageTimeout;
@@ -37,11 +37,11 @@ public class Configuration {
         this.mode = mode == null ? Mode.PLAIN : mode;
         this.username = username;
         this.clusterName = clusterName;
-        this.now = ZonedDateTime.now(timeZone.toZoneId().normalized());
+        this.now = ZonedDateTime.now(zoneId);
     }
 
-    public TimeZone timeZone() {
-        return timeZone;
+    public ZoneId zoneId() {
+        return zoneId;
     }
 
     public int pageSize() {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/DateUtils.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/DateUtils.java
@@ -16,15 +16,13 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.TimeZone;
 
 public class DateUtils {
 
     // TODO: do we have a java.time based parser we can use instead?
     private static final DateTimeFormatter UTC_DATE_FORMATTER = ISODateTimeFormat.dateOptionalTimeParser().withZoneUTC();
 
-    public static TimeZone UTC_TZ = TimeZone.getTimeZone("UTC");
-    public static ZoneId UTC_ZI = ZoneId.of("Z");
+    public static ZoneId UTC = ZoneId.of("Z");
 
     private DateUtils() {}
 
@@ -33,7 +31,7 @@ public class DateUtils {
      * Creates a date from the millis since epoch (thus the time-zone is UTC).
      */
     public static ZonedDateTime of(long millis) {
-        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), UTC_ZI);
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), UTC);
     }
 
     /**

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/TestUtils.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/TestUtils.java
@@ -15,7 +15,7 @@ public class TestUtils {
 
     private TestUtils() {}
 
-    public static final Configuration TEST_CFG = new Configuration(DateUtils.UTC_TZ, Protocol.FETCH_SIZE,
+    public static final Configuration TEST_CFG = new Configuration(DateUtils.UTC, Protocol.FETCH_SIZE,
             Protocol.REQUEST_TIMEOUT, Protocol.PAGE_TIMEOUT, null, Mode.PLAIN, null, null);
 
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -212,7 +212,7 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     }
 
     public void testGroupByOrderByScalarOverNonGrouped() {
-        assertEquals("1:50: Cannot order by non-grouped column [YEAR(date [UTC])], expected [text]",
+        assertEquals("1:50: Cannot order by non-grouped column [YEAR(date [Z])], expected [text]",
                 error("SELECT MAX(int) FROM test GROUP BY text ORDER BY YEAR(date)"));
     }
 
@@ -222,7 +222,7 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     }
 
     public void testGroupByOrderByScalarOverNonGrouped_WithHaving() {
-        assertEquals("1:71: Cannot order by non-grouped column [YEAR(date [UTC])], expected [text]",
+        assertEquals("1:71: Cannot order by non-grouped column [YEAR(date [Z])], expected [text]",
             error("SELECT MAX(int) FROM test GROUP BY text HAVING MAX(int) > 10 ORDER BY YEAR(date)"));
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/CompositeKeyExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/CompositeKeyExtractorTests.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xpack.sql.querydsl.container.GroupByRef.Property;
 import org.elasticsearch.xpack.sql.util.DateUtils;
 
 import java.io.IOException;
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -24,7 +24,7 @@ import static java.util.Collections.singletonMap;
 public class CompositeKeyExtractorTests extends AbstractWireSerializingTestCase<CompositeKeyExtractor> {
 
     public static CompositeKeyExtractor randomCompositeKeyExtractor() {
-        return new CompositeKeyExtractor(randomAlphaOfLength(16), randomFrom(asList(Property.values())), randomSafeTimeZone());
+        return new CompositeKeyExtractor(randomAlphaOfLength(16), randomFrom(asList(Property.values())), randomSafeZone());
     }
 
     @Override
@@ -39,13 +39,13 @@ public class CompositeKeyExtractorTests extends AbstractWireSerializingTestCase<
 
     @Override
     protected CompositeKeyExtractor mutateInstance(CompositeKeyExtractor instance) throws IOException {
-        return new CompositeKeyExtractor(instance.key() + "mutated", instance.property(), instance.timeZone());
+        return new CompositeKeyExtractor(instance.key() + "mutated", instance.property(), instance.zoneId());
     }
 
     public void testExtractBucketCount() {
         Bucket bucket = new TestBucket(emptyMap(), randomLong(), new Aggregations(emptyList()));
         CompositeKeyExtractor extractor = new CompositeKeyExtractor(randomAlphaOfLength(16), Property.COUNT,
-                randomTimeZone());
+                randomZone());
         assertEquals(bucket.getDocCount(), extractor.extract(bucket));
     }
 
@@ -58,15 +58,15 @@ public class CompositeKeyExtractorTests extends AbstractWireSerializingTestCase<
     }
 
     public void testExtractDate() {
-        CompositeKeyExtractor extractor = new CompositeKeyExtractor(randomAlphaOfLength(16), Property.VALUE, randomSafeTimeZone());
+        CompositeKeyExtractor extractor = new CompositeKeyExtractor(randomAlphaOfLength(16), Property.VALUE, randomSafeZone());
 
         long millis = System.currentTimeMillis();
         Bucket bucket = new TestBucket(singletonMap(extractor.key(), millis), randomLong(), new Aggregations(emptyList()));
-        assertEquals(DateUtils.of(millis, extractor.timeZone().toZoneId()), extractor.extract(bucket));
+        assertEquals(DateUtils.of(millis, extractor.zoneId()), extractor.extract(bucket));
     }
 
     public void testExtractIncorrectDateKey() {
-        CompositeKeyExtractor extractor = new CompositeKeyExtractor(randomAlphaOfLength(16), Property.VALUE, randomTimeZone());
+        CompositeKeyExtractor extractor = new CompositeKeyExtractor(randomAlphaOfLength(16), Property.VALUE, randomZone());
 
         Object value = new Object();
         Bucket bucket = new TestBucket(singletonMap(extractor.key(), value), randomLong(), new Aggregations(emptyList()));
@@ -79,7 +79,7 @@ public class CompositeKeyExtractorTests extends AbstractWireSerializingTestCase<
      * back to DateTimeZone which we currently still need to do internally,
      * e.g. in bwc serialization and in the extract() method
      */
-    private static TimeZone randomSafeTimeZone() {
-        return randomValueOtherThanMany(tz -> tz.getID().startsWith("SystemV"), () -> randomTimeZone());
+    private static ZoneId randomSafeZone() {
+        return randomValueOtherThanMany(zi -> zi.getId().startsWith("SystemV"), () -> randomZone());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/FunctionRegistryTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/FunctionRegistryTests.java
@@ -20,9 +20,9 @@ import org.elasticsearch.xpack.sql.tree.LocationTests;
 import org.elasticsearch.xpack.sql.tree.NodeInfo;
 import org.elasticsearch.xpack.sql.type.DataType;
 
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
-import java.util.TimeZone;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.xpack.sql.expression.function.FunctionRegistry.def;
@@ -104,10 +104,10 @@ public class FunctionRegistryTests extends ESTestCase {
     public void testDateTimeFunction() {
         boolean urIsExtract = randomBoolean();
         UnresolvedFunction ur = uf(urIsExtract ? EXTRACT : STANDARD, mock(Expression.class));
-        TimeZone providedTimeZone = randomTimeZone();
+        ZoneId providedTimeZone = randomZone().normalized();
         Configuration providedConfiguration = randomConfiguration(providedTimeZone);
-        FunctionRegistry r = new FunctionRegistry(def(DummyFunction.class, (Location l, Expression e, TimeZone tz) -> {
-                    assertEquals(providedTimeZone, tz);
+        FunctionRegistry r = new FunctionRegistry(def(DummyFunction.class, (Location l, Expression e, ZoneId zi) -> {
+                    assertEquals(providedTimeZone, zi);
                     assertSame(e, ur.children().get(0));
                     return new DummyFunction(l);
         }, "DUMMY_FUNCTION"));
@@ -232,7 +232,7 @@ public class FunctionRegistryTests extends ESTestCase {
     }
     
     private Configuration randomConfiguration() {
-        return new Configuration(randomTimeZone(),
+        return new Configuration(randomZone(),
                 randomIntBetween(0,  1000),
                 new TimeValue(randomNonNegativeLong()),
                 new TimeValue(randomNonNegativeLong()),
@@ -242,8 +242,8 @@ public class FunctionRegistryTests extends ESTestCase {
                 randomAlphaOfLength(10));
     }
     
-    private Configuration randomConfiguration(TimeZone providedTimeZone) {
-        return new Configuration(providedTimeZone,
+    private Configuration randomConfiguration(ZoneId providedZoneId) {
+        return new Configuration(providedZoneId,
                 randomIntBetween(0,  1000),
                 new TimeValue(randomNonNegativeLong()),
                 new TimeValue(randomNonNegativeLong()),

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/DatabaseFunctionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/DatabaseFunctionTests.java
@@ -19,8 +19,7 @@ import org.elasticsearch.xpack.sql.proto.Protocol;
 import org.elasticsearch.xpack.sql.session.Configuration;
 import org.elasticsearch.xpack.sql.stats.Metrics;
 import org.elasticsearch.xpack.sql.type.TypesTests;
-
-import java.util.TimeZone;
+import org.elasticsearch.xpack.sql.util.DateUtils;
 
 public class DatabaseFunctionTests extends ESTestCase {
 
@@ -29,7 +28,7 @@ public class DatabaseFunctionTests extends ESTestCase {
         SqlParser parser = new SqlParser();
         EsIndex test = new EsIndex("test", TypesTests.loadMapping("mapping-basic.json", true));
         Analyzer analyzer = new Analyzer(
-                new Configuration(TimeZone.getTimeZone("UTC"), Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT,
+                new Configuration(DateUtils.UTC, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT,
                                   Protocol.PAGE_TIMEOUT, null, randomFrom(Mode.values()), null, clusterName),
                 new FunctionRegistry(),
                 IndexResolution.valid(test),

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/UserFunctionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/UserFunctionTests.java
@@ -19,8 +19,7 @@ import org.elasticsearch.xpack.sql.proto.Protocol;
 import org.elasticsearch.xpack.sql.session.Configuration;
 import org.elasticsearch.xpack.sql.stats.Metrics;
 import org.elasticsearch.xpack.sql.type.TypesTests;
-
-import java.util.TimeZone;
+import org.elasticsearch.xpack.sql.util.DateUtils;
 
 public class UserFunctionTests extends ESTestCase {
 
@@ -28,7 +27,7 @@ public class UserFunctionTests extends ESTestCase {
         SqlParser parser = new SqlParser();
         EsIndex test = new EsIndex("test", TypesTests.loadMapping("mapping-basic.json", true));
         Analyzer analyzer = new Analyzer(
-                new Configuration(TimeZone.getTimeZone("UTC"), Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT,
+                new Configuration(DateUtils.UTC, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT,
                                   Protocol.PAGE_TIMEOUT, null, randomFrom(Mode.values()), null, randomAlphaOfLengthBetween(1, 15)),
                 new FunctionRegistry(),
                 IndexResolution.valid(test),

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeProcessorTests.java
@@ -10,12 +10,11 @@ import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 
 import java.io.IOException;
-import java.util.TimeZone;
 
 import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeTestUtils.dateTime;
+import static org.elasticsearch.xpack.sql.util.DateUtils.UTC;
 
 public class DateTimeProcessorTests extends AbstractWireSerializingTestCase<DateTimeProcessor> {
-    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
     public static DateTimeProcessor randomDateTimeProcessor() {
         return new DateTimeProcessor(randomFrom(DateTimeExtractor.values()), UTC);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeTestUtils.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeTestUtils.java
@@ -20,7 +20,7 @@ public class DateTimeTestUtils {
 
     public static ZonedDateTime dateTime(int year, int month, int day, int hour, int minute) {
         DateTime dateTime = new DateTime(year, month, day, hour, minute, DateTimeZone.UTC);
-        ZonedDateTime zdt = ZonedDateTime.of(year, month, day, hour, minute, 0, 0, DateUtils.UTC_ZI);
+        ZonedDateTime zdt = ZonedDateTime.of(year, month, day, hour, minute, 0, 0, DateUtils.UTC);
         assertEquals(dateTime.getMillis() / 1000, zdt.toEpochSecond());
         return zdt;
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfYearTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfYearTests.java
@@ -9,24 +9,24 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.expression.Literal;
 import org.elasticsearch.xpack.sql.type.DataType;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeTestUtils.dateTime;
+import static org.elasticsearch.xpack.sql.util.DateUtils.UTC;
 
 public class DayOfYearTests extends ESTestCase {
-    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
     public void testAsColumnProcessor() {
         assertEquals(1, extract(dateTime(0), UTC));
-        assertEquals(1, extract(dateTime(0), TimeZone.getTimeZone("GMT+01:00")));
-        assertEquals(365, extract(dateTime(0), TimeZone.getTimeZone("GMT-01:00")));
+        assertEquals(1, extract(dateTime(0), ZoneId.of("GMT+01:00")));
+        assertEquals(365, extract(dateTime(0), ZoneId.of("GMT-01:00")));
     }
 
-    private Object extract(Object value, TimeZone timeZone) {
-        return build(value, timeZone).asPipe().asProcessor().process(value);
+    private Object extract(Object value, ZoneId zoneId) {
+        return build(value, zoneId).asPipe().asProcessor().process(value);
     }
 
-    private DayOfYear build(Object value, TimeZone timeZone) {
-        return new DayOfYear(null, new Literal(null, value, DataType.DATE), timeZone);
+    private DayOfYear build(Object value, ZoneId zoneId) {
+        return new DayOfYear(null, new Literal(null, value, DataType.DATE), zoneId);
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NamedDateTimeProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NamedDateTimeProcessorTests.java
@@ -13,14 +13,13 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.NamedDate
 import org.junit.Assume;
 
 import java.io.IOException;
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeTestUtils.dateTime;
+import static org.elasticsearch.xpack.sql.util.DateUtils.UTC;
 
 public class NamedDateTimeProcessorTests extends AbstractWireSerializingTestCase<NamedDateTimeProcessor> {
     
-    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
-
     public static NamedDateTimeProcessor randomNamedDateTimeProcessor() {
         return new NamedDateTimeProcessor(randomFrom(NameExtractor.values()), UTC);
     }
@@ -42,7 +41,6 @@ public class NamedDateTimeProcessorTests extends AbstractWireSerializingTestCase
     }
 
     public void testValidDayNamesInUTC() {
-        assumeJava9PlusAndCompatLocaleProviderSetting();
         NamedDateTimeProcessor proc = new NamedDateTimeProcessor(NameExtractor.DAY_NAME, UTC);
         assertEquals("Thursday", proc.process(dateTime(0L)));
         assertEquals("Saturday", proc.process(dateTime(-64164233612338L)));
@@ -56,7 +54,7 @@ public class NamedDateTimeProcessorTests extends AbstractWireSerializingTestCase
 
     public void testValidDayNamesWithNonUTCTimeZone() {
         assumeJava9PlusAndCompatLocaleProviderSetting();
-        NamedDateTimeProcessor proc = new NamedDateTimeProcessor(NameExtractor.DAY_NAME, TimeZone.getTimeZone("GMT-10:00"));
+        NamedDateTimeProcessor proc = new NamedDateTimeProcessor(NameExtractor.DAY_NAME, ZoneId.of("GMT-10:00"));
         assertEquals("Wednesday", proc.process(dateTime(0)));
         assertEquals("Friday", proc.process(dateTime(-64164233612338L)));
         assertEquals("Monday", proc.process(dateTime(64164233612338L)));
@@ -83,7 +81,7 @@ public class NamedDateTimeProcessorTests extends AbstractWireSerializingTestCase
 
     public void testValidMonthNamesWithNonUTCTimeZone() {
         assumeJava9PlusAndCompatLocaleProviderSetting();
-        NamedDateTimeProcessor proc = new NamedDateTimeProcessor(NameExtractor.MONTH_NAME, TimeZone.getTimeZone("GMT-3:00"));
+        NamedDateTimeProcessor proc = new NamedDateTimeProcessor(NameExtractor.MONTH_NAME, ZoneId.of("GMT-03:00"));
         assertEquals("December", proc.process(dateTime(0)));
         assertEquals("August", proc.process(dateTime(-64165813612338L))); // GMT: Tuesday, September 1, -0064 2:53:07.662 AM
         assertEquals("April", proc.process(dateTime(64164233612338L))); // GMT: Monday, April 14, 4003 2:13:32.338 PM

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NonIsoDateTimeProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NonIsoDateTimeProcessorTests.java
@@ -10,13 +10,13 @@ import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.NonIsoDateTimeProcessor.NonIsoDateTimeExtractor;
 
 import java.io.IOException;
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeTestUtils.dateTime;
+import static org.elasticsearch.xpack.sql.util.DateUtils.UTC;
 
 public class NonIsoDateTimeProcessorTests extends AbstractWireSerializingTestCase<NonIsoDateTimeProcessor> {
     
-    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
     public static NonIsoDateTimeProcessor randomNonISODateTimeProcessor() {
         return new NonIsoDateTimeProcessor(randomFrom(NonIsoDateTimeExtractor.values()), UTC);
@@ -52,7 +52,7 @@ public class NonIsoDateTimeProcessorTests extends AbstractWireSerializingTestCas
     }
 
     public void testNonISOWeekOfYearInNonUTCTimeZone() {
-        NonIsoDateTimeProcessor proc = new NonIsoDateTimeProcessor(NonIsoDateTimeExtractor.WEEK_OF_YEAR, TimeZone.getTimeZone("GMT-10:00"));
+        NonIsoDateTimeProcessor proc = new NonIsoDateTimeProcessor(NonIsoDateTimeExtractor.WEEK_OF_YEAR, ZoneId.of("GMT-10:00"));
         assertEquals(2, proc.process(dateTime(568372930000L)));
         assertEquals(5, proc.process(dateTime(981278530000L)));
         assertEquals(7, proc.process(dateTime(224241730000L)));
@@ -78,7 +78,7 @@ public class NonIsoDateTimeProcessorTests extends AbstractWireSerializingTestCas
     }
 
     public void testNonISODayOfWeekInNonUTCTimeZone() {
-        NonIsoDateTimeProcessor proc = new NonIsoDateTimeProcessor(NonIsoDateTimeExtractor.DAY_OF_WEEK, TimeZone.getTimeZone("GMT-10:00"));
+        NonIsoDateTimeProcessor proc = new NonIsoDateTimeProcessor(NonIsoDateTimeExtractor.DAY_OF_WEEK, ZoneId.of("GMT-10:00"));
         assertEquals(2, proc.process(dateTime(568372930000L)));
         assertEquals(7, proc.process(dateTime(981278530000L)));
         assertEquals(2, proc.process(dateTime(224241730000L)));

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/QuarterProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/QuarterProcessorTests.java
@@ -8,13 +8,12 @@ package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeTestUtils.dateTime;
+import static org.elasticsearch.xpack.sql.util.DateUtils.UTC;
 
 public class QuarterProcessorTests extends ESTestCase {
-
-    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
     public void testQuarterWithUTCTimezone() {
         QuarterProcessor proc = new QuarterProcessor(UTC);
@@ -30,12 +29,12 @@ public class QuarterProcessorTests extends ESTestCase {
     }
     
     public void testValidDayNamesWithNonUTCTimeZone() {
-        QuarterProcessor proc = new QuarterProcessor(TimeZone.getTimeZone("GMT-10:00"));
+        QuarterProcessor proc = new QuarterProcessor(ZoneId.of("GMT-10:00"));
         assertEquals(4, proc.process(dateTime(0L)));
         assertEquals(4, proc.process(dateTime(-5400, 1, 1, 5, 0)));
         assertEquals(1, proc.process(dateTime(30, 4, 1, 9, 59)));
         
-        proc = new QuarterProcessor(TimeZone.getTimeZone("GMT+10:00"));
+        proc = new QuarterProcessor(ZoneId.of("GMT+10:00"));
         assertEquals(4, proc.process(dateTime(10902, 9, 30, 14, 1)));
         assertEquals(3, proc.process(dateTime(10902, 9, 30, 13, 59)));
         

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/BinaryArithmeticTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/BinaryArithmeticTests.java
@@ -78,7 +78,7 @@ public class BinaryArithmeticTests extends ESTestCase {
     }
 
     public void testAddYearMonthIntervalToDate() {
-        ZonedDateTime now = ZonedDateTime.now(DateUtils.UTC_ZI);
+        ZonedDateTime now = ZonedDateTime.now(DateUtils.UTC);
         Literal l = L(now);
         TemporalAmount t = Period.ofYears(100).plusMonths(50);
         Literal r = interval(t, INTERVAL_HOUR);
@@ -87,7 +87,7 @@ public class BinaryArithmeticTests extends ESTestCase {
     }
 
     public void testAddDayTimeIntervalToDate() {
-        ZonedDateTime now = ZonedDateTime.now(DateUtils.UTC_ZI);
+        ZonedDateTime now = ZonedDateTime.now(DateUtils.UTC);
         Literal l = L(now);
         TemporalAmount t = Duration.ofHours(2);
         Literal r = interval(Duration.ofHours(2), INTERVAL_HOUR);
@@ -96,7 +96,7 @@ public class BinaryArithmeticTests extends ESTestCase {
     }
 
     public void testAddDayTimeIntervalToDateReverse() {
-        ZonedDateTime now = ZonedDateTime.now(DateUtils.UTC_ZI);
+        ZonedDateTime now = ZonedDateTime.now(DateUtils.UTC);
         Literal l = L(now);
         TemporalAmount t = Duration.ofHours(2);
         Literal r = interval(Duration.ofHours(2), INTERVAL_HOUR);
@@ -125,7 +125,7 @@ public class BinaryArithmeticTests extends ESTestCase {
     }
 
     public void testSubYearMonthIntervalToDate() {
-        ZonedDateTime now = ZonedDateTime.now(DateUtils.UTC_ZI);
+        ZonedDateTime now = ZonedDateTime.now(DateUtils.UTC);
         Literal l = L(now);
         TemporalAmount t = Period.ofYears(100).plusMonths(50);
         Literal r = interval(t, INTERVAL_HOUR);
@@ -134,7 +134,7 @@ public class BinaryArithmeticTests extends ESTestCase {
     }
 
     public void testSubYearMonthIntervalToDateIllegal() {
-        ZonedDateTime now = ZonedDateTime.now(DateUtils.UTC_ZI);
+        ZonedDateTime now = ZonedDateTime.now(DateUtils.UTC);
         Literal l = L(now);
         TemporalAmount t = Period.ofYears(100).plusMonths(50);
         Literal r = interval(t, INTERVAL_HOUR);
@@ -149,7 +149,7 @@ public class BinaryArithmeticTests extends ESTestCase {
     }
 
     public void testSubDayTimeIntervalToDate() {
-        ZonedDateTime now = ZonedDateTime.now(DateUtils.UTC_ZI);
+        ZonedDateTime now = ZonedDateTime.now(DateUtils.UTC);
         Literal l = L(now);
         TemporalAmount t = Duration.ofHours(2);
         Literal r = interval(Duration.ofHours(2), INTERVAL_HOUR);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
@@ -23,8 +23,8 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.Cast;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DayName;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DayOfMonth;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DayOfYear;
-import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.MonthOfYear;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.IsoWeekOfYear;
+import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.MonthOfYear;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.Year;
 import org.elasticsearch.xpack.sql.expression.function.scalar.math.ACos;
 import org.elasticsearch.xpack.sql.expression.function.scalar.math.ASin;
@@ -91,7 +91,6 @@ import org.elasticsearch.xpack.sql.util.CollectionUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.TimeZone;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -99,6 +98,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.xpack.sql.expression.Literal.NULL;
 import static org.elasticsearch.xpack.sql.tree.Location.EMPTY;
+import static org.elasticsearch.xpack.sql.util.DateUtils.UTC;
 import static org.hamcrest.Matchers.contains;
 
 public class OptimizerTests extends ESTestCase {
@@ -327,7 +327,6 @@ public class OptimizerTests extends ESTestCase {
     }
 
     public void testConstantFoldingDatetime() {
-        final TimeZone UTC = TimeZone.getTimeZone("UTC");
         Expression cast = new Cast(EMPTY, Literal.of(EMPTY, "2018-01-19T10:23:27Z"), DataType.DATE);
         assertEquals(2018, foldFunction(new Year(EMPTY, cast, UTC)));
         assertEquals(1, foldFunction(new MonthOfYear(EMPTY, cast, UTC)));
@@ -407,7 +406,7 @@ public class OptimizerTests extends ESTestCase {
     public void testGenericNullableExpression() {
         FoldNull rule = new FoldNull();
         // date-time
-        assertNullLiteral(rule.rule(new DayName(EMPTY, Literal.NULL, randomTimeZone())));
+        assertNullLiteral(rule.rule(new DayName(EMPTY, Literal.NULL, randomZone())));
         // math function
         assertNullLiteral(rule.rule(new Cos(EMPTY, Literal.NULL)));
         // string function

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/type/DataTypeConversionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/type/DataTypeConversionTests.java
@@ -111,7 +111,7 @@ public class DataTypeConversionTests extends ESTestCase {
         assertEquals(dateTime(18000000L), conversion.convert("1970-01-01T00:00:00-05:00"));
         
         // double check back and forth conversion
-        ZonedDateTime dt = ZonedDateTime.now(DateUtils.UTC_ZI);
+        ZonedDateTime dt = ZonedDateTime.now(DateUtils.UTC);
         Conversion forward = conversionFor(DATE, KEYWORD);
         Conversion back = conversionFor(KEYWORD, DATE);
         assertEquals(dt, back.convert(forward.convert(dt)));


### PR DESCRIPTION
As the internals have moved to java.time, the usage of TimeZone itself
 should be minimized as it creates issues when being converted to ZoneId
Protocol wise the two are mostly identical so consumer should not see
 any difference.
Note that terminology wise, inside the docs, the public API and inside
 the protocol timeZone will continue to be used as it's more widely
 understood as oppose to zoneId which is an implementation detail
 specific to the JVM

Fix #36535