### PR TITLE
Update joda compat methods to use compat class

### DIFF
--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
@@ -130,8 +130,11 @@ class org.elasticsearch.script.JodaCompatibleZonedDateTime {
   boolean equals(Object)
   int hashCode()
   boolean isAfter(ZonedDateTime)
+  boolean isAfter(JodaCompatibleZonedDateTime)
   boolean isBefore(ZonedDateTime)
+  boolean isBefore(JodaCompatibleZonedDateTime)
   boolean isEqual(ZonedDateTime)
+  boolean isEqual(JodaCompatibleZonedDateTime)
   String toString()
 
   #### Joda time methods

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
@@ -129,11 +129,8 @@ class org.elasticsearch.script.JodaCompatibleZonedDateTime {
   #### Joda methods that exist in java time
   boolean equals(Object)
   int hashCode()
-  boolean isAfter(ZonedDateTime)
   boolean isAfter(JodaCompatibleZonedDateTime)
-  boolean isBefore(ZonedDateTime)
   boolean isBefore(JodaCompatibleZonedDateTime)
-  boolean isEqual(ZonedDateTime)
   boolean isEqual(JodaCompatibleZonedDateTime)
   String toString()
 

--- a/server/src/main/java/org/elasticsearch/script/JodaCompatibleZonedDateTime.java
+++ b/server/src/main/java/org/elasticsearch/script/JodaCompatibleZonedDateTime.java
@@ -99,12 +99,25 @@ public class JodaCompatibleZonedDateTime {
         return dt.isAfter(o);
     }
 
+    public boolean isAfter(JodaCompatibleZonedDateTime o) {
+        return dt.isAfter(o.getZonedDateTime());
+    }
+
     public boolean isBefore(ZonedDateTime o) {
         return dt.isBefore(o);
     }
 
+
+    public boolean isBefore(JodaCompatibleZonedDateTime o) {
+        return dt.isBefore(o.getZonedDateTime());
+    }
+
     public boolean isEqual(ZonedDateTime o) {
         return dt.isEqual(o);
+    }
+
+    public boolean isEqual(JodaCompatibleZonedDateTime o) {
+        return dt.isEqual(o.getZonedDateTime());
     }
 
     public int getDayOfMonth() {

--- a/server/src/main/java/org/elasticsearch/script/JodaCompatibleZonedDateTime.java
+++ b/server/src/main/java/org/elasticsearch/script/JodaCompatibleZonedDateTime.java
@@ -95,25 +95,12 @@ public class JodaCompatibleZonedDateTime {
         return DATE_FORMATTER.format(dt);
     }
 
-    public boolean isAfter(ZonedDateTime o) {
-        return dt.isAfter(o);
-    }
-
     public boolean isAfter(JodaCompatibleZonedDateTime o) {
         return dt.isAfter(o.getZonedDateTime());
     }
 
-    public boolean isBefore(ZonedDateTime o) {
-        return dt.isBefore(o);
-    }
-
-
     public boolean isBefore(JodaCompatibleZonedDateTime o) {
         return dt.isBefore(o.getZonedDateTime());
-    }
-
-    public boolean isEqual(ZonedDateTime o) {
-        return dt.isEqual(o);
     }
 
     public boolean isEqual(JodaCompatibleZonedDateTime o) {

--- a/server/src/test/java/org/elasticsearch/script/JodaCompatibleZonedDateTimeTests.java
+++ b/server/src/test/java/org/elasticsearch/script/JodaCompatibleZonedDateTimeTests.java
@@ -261,14 +261,14 @@ public class JodaCompatibleZonedDateTimeTests extends ESTestCase {
     }
 
     public void testIsAfter() {
-        long millis = randomLongBetween(0, Integer.MAX_VALUE /2);
+        long millis = randomLongBetween(0, Integer.MAX_VALUE / 2);
         JodaCompatibleZonedDateTime beforeTime = new JodaCompatibleZonedDateTime(Instant.ofEpochMilli(millis), ZoneOffset.ofHours(-7));
         millis = randomLongBetween(millis + 1, Integer.MAX_VALUE);
         JodaCompatibleZonedDateTime afterTime = new JodaCompatibleZonedDateTime(Instant.ofEpochMilli(millis), ZoneOffset.ofHours(-7));
         assertTrue(afterTime.isAfter(beforeTime));
     }
     public void testIsBefore() {
-        long millis = randomLongBetween(0, Integer.MAX_VALUE /2);
+        long millis = randomLongBetween(0, Integer.MAX_VALUE / 2);
         JodaCompatibleZonedDateTime beforeTime = new JodaCompatibleZonedDateTime(Instant.ofEpochMilli(millis), ZoneOffset.ofHours(-7));
         millis = randomLongBetween(millis + 1, Integer.MAX_VALUE);
         JodaCompatibleZonedDateTime afterTime = new JodaCompatibleZonedDateTime(Instant.ofEpochMilli(millis), ZoneOffset.ofHours(-7));

--- a/server/src/test/java/org/elasticsearch/script/JodaCompatibleZonedDateTimeTests.java
+++ b/server/src/test/java/org/elasticsearch/script/JodaCompatibleZonedDateTimeTests.java
@@ -255,4 +255,23 @@ public class JodaCompatibleZonedDateTimeTests extends ESTestCase {
         JodaCompatibleZonedDateTime dt = new JodaCompatibleZonedDateTime(Instant.EPOCH, ZoneOffset.ofTotalSeconds(0));
         assertMethodDeprecation(() -> dt.toString("yyyy-MM-dd hh:mm"), "toString(String)", "a DateTimeFormatter");
     }
+
+    public void testIsEqual() {
+        assertTrue(javaTime.isEqual(javaTime));
+    }
+
+    public void testIsAfter() {
+        long millis = randomLongBetween(0, Integer.MAX_VALUE /2);
+        JodaCompatibleZonedDateTime beforeTime = new JodaCompatibleZonedDateTime(Instant.ofEpochMilli(millis), ZoneOffset.ofHours(-7));
+        millis = randomLongBetween(millis + 1, Integer.MAX_VALUE);
+        JodaCompatibleZonedDateTime afterTime = new JodaCompatibleZonedDateTime(Instant.ofEpochMilli(millis), ZoneOffset.ofHours(-7));
+        assertTrue(afterTime.isAfter(beforeTime));
+    }
+    public void testIsBefore() {
+        long millis = randomLongBetween(0, Integer.MAX_VALUE /2);
+        JodaCompatibleZonedDateTime beforeTime = new JodaCompatibleZonedDateTime(Instant.ofEpochMilli(millis), ZoneOffset.ofHours(-7));
+        millis = randomLongBetween(millis + 1, Integer.MAX_VALUE);
+        JodaCompatibleZonedDateTime afterTime = new JodaCompatibleZonedDateTime(Instant.ofEpochMilli(millis), ZoneOffset.ofHours(-7));
+        assertTrue(beforeTime.isBefore(afterTime));
+    }
 }


### PR DESCRIPTION
The existing joda compat methods isEquals isAfter and isBefore all took
in a ZonedDateTime, but since all of the scripting is now using the new
JodaCompatZonedDateTime, these are changed to take that in instead.