### PR TITLE
Register the TCP_CONNECT_TIMEOUT setting

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -325,6 +325,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     TransportSettings.OLD_TRANSPORT_COMPRESS,
                     TransportSettings.TRANSPORT_COMPRESS,
                     TransportSettings.PING_SCHEDULE,
+                    TransportSettings.TCP_CONNECT_TIMEOUT,
                     TransportSettings.CONNECT_TIMEOUT,
                     TransportSettings.DEFAULT_FEATURES_SETTING,
                     TransportSettings.OLD_TCP_NO_DELAY,

--- a/server/src/main/java/org/elasticsearch/transport/TransportSettings.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportSettings.java
@@ -71,6 +71,7 @@ public final class TransportSettings {
     // the scheduled internal ping interval setting, defaults to disabled (-1)
     public static final Setting<TimeValue> PING_SCHEDULE =
         timeSetting("transport.ping_schedule", TimeValue.timeValueSeconds(-1), Setting.Property.NodeScope);
+    // TODO: Deprecate in 7.0
     public static final Setting<TimeValue> TCP_CONNECT_TIMEOUT =
         timeSetting("transport.tcp.connect_timeout", NetworkService.TCP_CONNECT_TIMEOUT, Setting.Property.NodeScope);
     public static final Setting<TimeValue> CONNECT_TIMEOUT =


### PR DESCRIPTION
This commit registers the TCP_CONNECT_TIMEOUT setting in the
ClusterSettings.