### PR TITLE
[DOCS] Adds monitoring requirement for ingest node

### DIFF
--- a/docs/reference/monitoring/collecting-monitoring-data.asciidoc
+++ b/docs/reference/monitoring/collecting-monitoring-data.asciidoc
@@ -101,10 +101,12 @@ the `xpack.monitoring.collection.interval` setting 10 seconds. See
 +
 --
 By default, the data is stored on the same cluster by using a 
-<<local-exporter,`local` exporter>>. 
-
-Alternatively, you can use an <<http-exporter,`http` exporter>> to send data to 
+<<local-exporter,`local` exporter>>. Alternatively, you can use an <<http-exporter,`http` exporter>> to send data to 
 a separate _monitoring cluster_. 
+
+IMPORTANT: The {es} {monitor-features} use ingest pipelines, therefore the
+cluster that stores the monitoring data must have at least one 
+<<ingest,ingest node>>. 
 
 For more information about typical monitoring architectures, 
 see {stack-ov}/how-monitoring-works.html[How Monitoring Works].

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -164,6 +164,10 @@ output.elasticsearch:
 <1> In this example, the data is stored on a monitoring cluster with nodes 
 `es-mon-1` and `es-mon-2`. 
 
+IMPORTANT: The {es} {monitor-features} use ingest pipelines, therefore the
+cluster that stores the monitoring data must have at least one 
+<<ingest,ingest node>>. 
+
 For more information about these configuration options, see 
 {metricbeat-ref}/elasticsearch-output.html[Configure the {es} output].
 --


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/36508

This PR updates https://www.elastic.co/guide/en/elasticsearch/reference/master/collecting-monitoring-data.html and https://www.elastic.co/guide/en/elasticsearch/reference/master/configuring-metricbeat.html such that they call out the need for an ingest node.