### PR TITLE
Deprecation check for discovery configuration

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -42,6 +42,7 @@ public class DeprecationChecks {
             NodeDeprecationChecks::indexThreadPoolCheck,
             NodeDeprecationChecks::tribeNodeCheck,
             NodeDeprecationChecks::httpPipeliningCheck,
+            NodeDeprecationChecks::discoveryConfigurationCheck,
             NodeDeprecationChecks::azureRepositoryChanges,
             NodeDeprecationChecks::gcsRepositoryChanges,
             NodeDeprecationChecks::fileDiscoveryPluginRemoved

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -15,6 +15,10 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_HOSTS_PROVIDER_SETTING;
+import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_TYPE_SETTING;
+import static org.elasticsearch.discovery.zen.SettingsBasedHostsProvider.DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING;
+
 /**
  * Node-specific deprecation checks
  */
@@ -81,16 +85,14 @@ public class NodeDeprecationChecks {
     }
 
     static DeprecationIssue discoveryConfigurationCheck(List<NodeInfo> nodeInfos, List<NodeStats> nodeStats) {
-        if (nodeInfos.size() == 1
-            && nodeInfos.stream().anyMatch(nodeInfo -> "single-node".equals(nodeInfo.getSettings().get("discovery.type")))) {
-            // We are in single-node discovery mode, and therefore not in production mode, so this check doesn't need to apply.
-            return null;
-        }
 
-        // This only checks for `ping.unicast.hosts` and `hosts_provider` because `cluster.initial_master_nodes` does not exist in 6.x
         List<String> nodesFound = nodeInfos.stream()
-            .filter(nodeInfo -> nodeInfo.getSettings().hasValue("discovery.zen.ping.unicast.hosts") == false)
-            .filter(nodeInfo -> nodeInfo.getSettings().hasValue("discovery.zen.hosts_provider") == false)
+            // These checks only apply in Zen2, which is the new default in 7.0 and can't be used in 6.x, so only apply the checks if this
+            // node does not have a discovery type explicitly set
+            .filter(nodeInfo -> nodeInfo.getSettings().hasValue(DISCOVERY_TYPE_SETTING.getKey()) == false)
+            // This only checks for `ping.unicast.hosts` and `hosts_provider` because `cluster.initial_master_nodes` does not exist in 6.x
+            .filter(nodeInfo -> nodeInfo.getSettings().hasValue(DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING.getKey()) == false)
+            .filter(nodeInfo -> nodeInfo.getSettings().hasValue(DISCOVERY_HOSTS_PROVIDER_SETTING.getKey()) == false)
             .map(nodeInfo -> nodeInfo.getNode().getName())
             .collect(Collectors.toList());
         if (nodesFound.size() > 0) {

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -25,6 +25,10 @@ import java.util.Collections;
 import java.util.List;
 
 import static java.util.Collections.singletonList;
+import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING;
+import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_HOSTS_PROVIDER_SETTING;
+import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_TYPE_SETTING;
+import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
 import static org.elasticsearch.xpack.deprecation.DeprecationChecks.NODE_SETTINGS_CHECKS;
 
 public class NodeDeprecationChecksTests extends ESTestCase {
@@ -45,9 +49,9 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
     private void assertSettingsAndIssue(String key, String value, DeprecationIssue expected) {
         Settings settings = Settings.builder()
-            .put("cluster.name", "elasticsearch")
-            .put("node.name", "node_check")
-            .put("discovery.type", "single-node") // Needed due to NodeDeprecationChecks#discoveryConfigurationCheck
+            .put(CLUSTER_NAME_SETTING.getKey(), "elasticsearch")
+            .put(NODE_NAME_SETTING.getKey(), "node_check")
+            .put(DISCOVERY_TYPE_SETTING.getKey(), "single-node") // Needed due to NodeDeprecationChecks#discoveryConfigurationCheck
             .put(key, value)
             .build();
         List<NodeInfo> nodeInfos = Collections.singletonList(new NodeInfo(Version.CURRENT, Build.CURRENT,
@@ -103,13 +107,13 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             null, null, null, null, new FsInfo(0L, null, paths), null, null, null,
             null, null, null, null));
         Settings baseSettings = Settings.builder()
-            .put("cluster.name", "elasticsearch")
-            .put("node.name", "node_check")
+            .put(CLUSTER_NAME_SETTING.getKey(), "elasticsearch")
+            .put(NODE_NAME_SETTING.getKey(), "node_check")
             .build();
 
         {
             Settings hostsProviderSettings = Settings.builder().put(baseSettings)
-                .put("discovery.zen.hosts_provider", "file")
+                .put(DISCOVERY_HOSTS_PROVIDER_SETTING.getKey(), "file")
                 .build();
             List<NodeInfo> nodeInfos = Collections.singletonList(new NodeInfo(Version.CURRENT, Build.CURRENT,
                 discoveryNode, hostsProviderSettings, osInfo, null, null,


### PR DESCRIPTION
Adds a check for missing discovery configuration, which is now
required.

Relates to https://github.com/elastic/elasticsearch/issues/36024 and https://github.com/elastic/elasticsearch/pull/36215