### PR TITLE
Remove hardcoded ports in security vagrant tests #30782

### DIFF
--- a/x-pack/test/idp-fixture/Vagrantfile
+++ b/x-pack/test/idp-fixture/Vagrantfile
@@ -10,15 +10,20 @@ Vagrant.configure("2") do |config|
     config.cache.scope = :box
   end
 
-  config.vm.network "forwarded_port", guest: 389, host: 60389, protocol: "tcp"
-  config.vm.network "forwarded_port", guest: 636, host: 60636, protocol: "tcp"
-  config.vm.network "forwarded_port", guest: 8080, host: 60080, protocol: "tcp"
-  config.vm.network "forwarded_port", guest: 8443, host: 60443, protocol: "tcp"
+  TCP_PORTS_LIST = { "389" => 60389, "636" => 60636, "8080" => 60080, "8443" => "60443"}
+
+  TCP_PORTS_LIST.each do |guest, host|
+    config.vm.network "forwarded_port", guest: "#{guest}", host: "{host}", protocol: "tcp",
+    config.vm.usable_port_range = 389..8443,
+    auto_correct: true
 
   config.vm.provision "ansible_local" do |ansible|
     ansible.verbose = "v"
     ansible.playbook = "src/main/resources/provision/playbook.yml"
     ansible.install_mode = "pip"
+    ansible.extra_vars = {
+      ports_list: TCP_PORTS_LIST
+    }
   end
 
 end

--- a/x-pack/test/idp-fixture/Vagrantfile
+++ b/x-pack/test/idp-fixture/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
     config.cache.scope = :box
   end
 
-  TCP_PORTS_LIST = { "389" => 60389, "636" => 60636, "8080" => 60080, "8443" => "60443"}
+  TCP_PORTS_LIST = { "389" => 60389, "636" => 60636, "8080" => 60080, "8443" => 60443}
 
   TCP_PORTS_LIST.each do |guest, host|
     config.vm.network "forwarded_port", guest: "#{guest}", host: "{host}", protocol: "tcp",

--- a/x-pack/test/idp-fixture/src/main/resources/provision/playbook.yml
+++ b/x-pack/test/idp-fixture/src/main/resources/provision/playbook.yml
@@ -3,6 +3,10 @@
   vars_files:
       - vars/default.yml
 
+  vars:
+      - ports: ports_list
+      - shib_dns_name: "{{ ansible_fqdn }}:{{ ports|map(attribute='8443') }}"
+      
   roles:
       - { role: java-8-openjdk, become: yes }
       - { role: certs, become: yes }

--- a/x-pack/test/idp-fixture/src/main/resources/provision/vars/default.yml
+++ b/x-pack/test/idp-fixture/src/main/resources/provision/vars/default.yml
@@ -20,7 +20,6 @@ tomcat_key_alias: tomcat
 shib_idp_version: 3.3.1
 shib_installdir: /opt
 shib_home: "{{ shib_installdir }}/shibboleth-idp"
-shib_dns_name: "{{ ansible_fqdn }}:60443"
 idp_sealer_password: secret
 idp_keystore_password: secret1
 ...


### PR DESCRIPTION
Checked recent changes to smb fixture and noticed its tests are no longer using hardcoded port values. As for the idp fixture, I could find no tests that used the port values defined in the vagrantfile in these folders: https://github.com/elastic/elasticsearch/tree/master/x-pack/qa/saml-idp-tests, https://github.com/elastic/elasticsearch/tree/master/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml.