### PR TITLE
[FEATURE][ML] Add cluster setting to enable/disable config  migration

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -268,7 +268,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
     public static final Setting<Integer> MAX_MACHINE_MEMORY_PERCENT =
             Setting.intSetting("xpack.ml.max_machine_memory_percent", 30, 5, 90, Property.Dynamic, Property.NodeScope);
     public static final Setting<Integer> MAX_LAZY_ML_NODES =
-        Setting.intSetting("xpack.ml.max_lazy_ml_nodes", 0, 0, 3, Property.Dynamic, Property.NodeScope);
+            Setting.intSetting("xpack.ml.max_lazy_ml_nodes", 0, 0, 3, Property.Dynamic, Property.NodeScope);
 
     private static final Logger logger = LogManager.getLogger(XPackPlugin.class);
 
@@ -308,7 +308,8 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                         AutodetectBuilder.MAX_ANOMALY_RECORDS_SETTING_DYNAMIC,
                         AutodetectProcessManager.MAX_RUNNING_JOBS_PER_NODE,
                         AutodetectProcessManager.MAX_OPEN_JOBS_PER_NODE,
-                        AutodetectProcessManager.MIN_DISK_SPACE_OFF_HEAP));
+                        AutodetectProcessManager.MIN_DISK_SPACE_OFF_HEAP,
+                        MlConfigMigrationEligibilityCheck.ENABLE_CONFIG_MIGRATION));
     }
 
     public Settings additionalSettings() {
@@ -444,7 +445,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 jobDataCountsPersister,
                 datafeedManager,
                 auditor,
-                new MlAssignmentNotifier(auditor, threadPool, client, clusterService),
+                new MlAssignmentNotifier(settings, auditor, threadPool, client, clusterService),
                 memoryTracker
         );
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.LocalNodeMasterListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData.Assignment;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData.PersistentTask;
@@ -36,10 +37,10 @@ public class MlAssignmentNotifier implements ClusterStateListener, LocalNodeMast
     private final ThreadPool threadPool;
     private final AtomicBoolean enabled = new AtomicBoolean(false);
 
-    MlAssignmentNotifier(Auditor auditor, ThreadPool threadPool, Client client, ClusterService clusterService) {
+    MlAssignmentNotifier(Settings settings, Auditor auditor, ThreadPool threadPool, Client client, ClusterService clusterService) {
         this.auditor = auditor;
         this.clusterService = clusterService;
-        this.mlConfigMigrator = new MlConfigMigrator(client, clusterService);
+        this.mlConfigMigrator = new MlConfigMigrator(settings, client, clusterService);
         this.threadPool = threadPool;
         clusterService.addLocalNodeMasterListener(this);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrationEligibilityCheck.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrationEligibilityCheck.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
+import org.elasticsearch.xpack.core.ml.MlMetadata;
+import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+
+/**
+ * Checks whether migration can start and whether ML resources (e.g. jobs, datafeeds)
+ * are eligible to be migrated from the cluster state into the config index
+ */
+public class MlConfigMigrationEligibilityCheck {
+
+    private static final Version MIN_NODE_VERSION = Version.V_6_6_0;
+
+    public static final Setting<Boolean> ENABLE_CONFIG_MIGRATION = Setting.boolSetting(
+        "xpack.ml.enable_config_migration", true, Setting.Property.Dynamic, Setting.Property.NodeScope);
+
+    private volatile boolean isConfigMigrationEnabled;
+
+    public MlConfigMigrationEligibilityCheck(Settings settings, ClusterService clusterService) {
+        isConfigMigrationEnabled = ENABLE_CONFIG_MIGRATION.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(ENABLE_CONFIG_MIGRATION, this::setConfigMigrationEnabled);
+    }
+
+    private void setConfigMigrationEnabled(boolean configMigrationEnabled) {
+        this.isConfigMigrationEnabled = configMigrationEnabled;
+    }
+
+    /**
+     * Can migration start? Returns:
+     *     False if config migration is disabled via the setting {@link #ENABLE_CONFIG_MIGRATION}
+     *     False if the min node version of the cluster is before {@link #MIN_NODE_VERSION}
+     *     True otherwise
+     * @param clusterState The cluster state
+     * @return A boolean that dictates if config migration can start
+     */
+    public boolean canStartMigration(ClusterState clusterState) {
+        if (isConfigMigrationEnabled == false) {
+            return false;
+        }
+
+        Version minNodeVersion = clusterState.nodes().getMinNodeVersion();
+        if (minNodeVersion.before(MIN_NODE_VERSION)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Is the job a eligible for migration? Returns:
+     *     False if {@link #canStartMigration(ClusterState)} returns {@code false}
+     *     False if the {@link Job#isDeleting()}
+     *     False if the job has a persistent task
+     *     True otherwise i.e. the job is present, not deleting
+     *     and does not have a persistent task.
+     *
+     * @param jobId         The job Id
+     * @param clusterState  The cluster state
+     * @return A boolean depending on the conditions listed above
+     */
+    public boolean jobIsEligibleForMigration(String jobId, ClusterState clusterState) {
+        if (canStartMigration(clusterState) == false) {
+            return false;
+        }
+
+        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
+        Job job = mlMetadata.getJobs().get(jobId);
+
+        if (job == null || job.isDeleting()) {
+            return false;
+        }
+
+        PersistentTasksCustomMetaData persistentTasks = clusterState.metaData().custom(PersistentTasksCustomMetaData.TYPE);
+        return MlTasks.openJobIds(persistentTasks).contains(jobId) == false;
+    }
+
+    /**
+     * Is the datafeed a eligible for migration? Returns:
+     *     False if {@link #canStartMigration(ClusterState)} returns {@code false}
+     *     False if the datafeed is not in the cluster state
+     *     False if the datafeed has a persistent task
+     *     True otherwise i.e. the datafeed is present and does not have a persistent task.
+     *
+     * @param datafeedId   The datafeed Id
+     * @param clusterState  The cluster state
+     * @return A boolean depending on the conditions listed above
+     */
+    public boolean datafeedIsEligibleForMigration(String datafeedId, ClusterState clusterState) {
+        if (canStartMigration(clusterState) == false) {
+            return false;
+        }
+
+        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
+        if (mlMetadata.getDatafeeds().containsKey(datafeedId) == false) {
+            return false;
+        }
+
+        PersistentTasksCustomMetaData persistentTasks = clusterState.metaData().custom(PersistentTasksCustomMetaData.TYPE);
+        return MlTasks.startedDatafeedIds(persistentTasks).contains(datafeedId) == false;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -41,6 +42,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -80,18 +82,19 @@ public class MlConfigMigrator {
     private static final Logger logger = LogManager.getLogger(MlConfigMigrator.class);
 
     public static final String MIGRATED_FROM_VERSION = "migrated from version";
-    public static final Version MIN_NODE_VERSION = Version.V_6_6_0;
 
     static final int MAX_BULK_WRITE_SIZE = 100;
 
     private final Client client;
     private final ClusterService clusterService;
+    private final MlConfigMigrationEligibilityCheck migrationEligibilityCheck;
 
     private final AtomicBoolean migrationInProgress;
 
-    public MlConfigMigrator(Client client, ClusterService clusterService) {
-        this.client = client;
-        this.clusterService = clusterService;
+    public MlConfigMigrator(Settings settings, Client client, ClusterService clusterService) {
+        this.client = Objects.requireNonNull(client);
+        this.clusterService = Objects.requireNonNull(clusterService);
+        this.migrationEligibilityCheck = new MlConfigMigrationEligibilityCheck(settings, clusterService);
         this.migrationInProgress = new AtomicBoolean(false);
     }
 
@@ -114,9 +117,8 @@ public class MlConfigMigrator {
      */
     public void migrateConfigsWithoutTasks(ClusterState clusterState, ActionListener<Boolean> listener) {
 
-        Version minNodeVersion = clusterState.nodes().getMinNodeVersion();
-        if (minNodeVersion.before(MIN_NODE_VERSION)) {
-            listener.onResponse(Boolean.FALSE);
+        if (migrationEligibilityCheck.canStartMigration(clusterState) == false) {
+            listener.onResponse(false);
             return;
         }
 
@@ -454,61 +456,5 @@ public class MlConfigMigrator {
                 .map(DatafeedConfig::getId)
                 .filter(id -> failedDocumentIds.contains(DatafeedConfig.documentId(id)) == false)
                 .collect(Collectors.toList());
-    }
-
-    /**
-     * Is the job a eligible for migration? Returns:
-     *     False if the min node version of the cluster is before {@link #MIN_NODE_VERSION}
-     *     False if the job is not in the cluster state
-     *     False if the {@link Job#isDeleting()}
-     *     False if the job has a persistent task
-     *     True otherwise i.e. the job is present, not deleting
-     *     and does not have a persistent task.
-     *
-     * @param jobId         The job Id
-     * @param clusterState  clusterstate
-     * @return A boolean depending on the conditions listed above
-     */
-    public static boolean jobIsEligibleForMigration(String jobId, ClusterState clusterState) {
-        Version minNodeVersion = clusterState.nodes().getMinNodeVersion();
-        if (minNodeVersion.before(MIN_NODE_VERSION)) {
-            return false;
-        }
-
-        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
-        Job job = mlMetadata.getJobs().get(jobId);
-
-        if (job == null || job.isDeleting()) {
-            return false;
-        }
-
-        PersistentTasksCustomMetaData persistentTasks = clusterState.metaData().custom(PersistentTasksCustomMetaData.TYPE);
-        return MlTasks.openJobIds(persistentTasks).contains(jobId) == false;
-    }
-
-    /**
-     * Is the datafeed a eligible for migration? Returns:
-     *     False if the min node version of the cluster is before {@link #MIN_NODE_VERSION}
-     *     False if the datafeed is not in the cluster state
-     *     False if the datafeed has a persistent task
-     *     True otherwise i.e. the datafeed is present and does not have a persistent task.
-     *
-     * @param datafeedId   The datafeed Id
-     * @param clusterState clusterstate
-     * @return A boolean depending on the conditions listed above
-     */
-    public static boolean datafeedIsEligibleForMigration(String datafeedId, ClusterState clusterState) {
-        Version minNodeVersion = clusterState.nodes().getMinNodeVersion();
-        if (minNodeVersion.before(MIN_NODE_VERSION)) {
-            return false;
-        }
-
-        MlMetadata mlMetadata = MlMetadata.getMlMetadata(clusterState);
-        if (mlMetadata.getDatafeeds().containsKey(datafeedId) == false) {
-            return false;
-        }
-
-        PersistentTasksCustomMetaData persistentTasks = clusterState.metaData().custom(PersistentTasksCustomMetaData.TYPE);
-        return MlTasks.startedDatafeedIds(persistentTasks).contains(datafeedId) == false;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
@@ -64,7 +64,7 @@ import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.CategorizerS
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.Quantiles;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
-import org.elasticsearch.xpack.ml.MlConfigMigrator;
+import org.elasticsearch.xpack.ml.MlConfigMigrationEligibilityCheck;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.job.JobManager;
 import org.elasticsearch.xpack.ml.job.persistence.JobDataDeleter;
@@ -97,6 +97,7 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
     private final JobManager jobManager;
     private final DatafeedConfigProvider datafeedConfigProvider;
     private final MlMemoryTracker memoryTracker;
+    private final MlConfigMigrationEligibilityCheck migrationEligibilityCheck;
 
     /**
      * A map of task listeners by job_id.
@@ -122,6 +123,7 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
         this.jobManager = jobManager;
         this.datafeedConfigProvider = datafeedConfigProvider;
         this.memoryTracker = memoryTracker;
+        this.migrationEligibilityCheck = new MlConfigMigrationEligibilityCheck(settings, clusterService);
         this.listenersByJobId = new HashMap<>();
     }
 
@@ -149,7 +151,7 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
     protected void masterOperation(Task task, DeleteJobAction.Request request, ClusterState state,
                                    ActionListener<AcknowledgedResponse> listener) {
 
-        if (MlConfigMigrator.jobIsEligibleForMigration(request.getJobId(), state)) {
+        if (migrationEligibilityCheck.jobIsEligibleForMigration(request.getJobId(), state)) {
             listener.onFailure(ExceptionsHelper.configHasNotBeenMigrated("delete job", request.getJobId()));
             return;
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigrationEligibilityCheckTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigrationEligibilityCheckTests.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.MlMetadata;
+import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
+import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.config.JobTests;
+import org.junit.Before;
+
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MlConfigMigrationEligibilityCheckTests extends ESTestCase {
+
+    private ClusterService clusterService;
+
+    @Before
+    public void setUpTests() {
+        clusterService = mock(ClusterService.class);
+    }
+
+    public void testCanStartMigration_givenMigrationIsDisabled() {
+        Settings settings = newSettings(false);
+        givenClusterSettings(settings);
+        ClusterState clusterState = mock(ClusterState.class);
+
+        MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+
+        assertFalse(check.canStartMigration(clusterState));
+    }
+
+    public void testCanStartMigration_givenNodesNotUpToVersion() {
+        // mixed 6.5 and 6.6 nodes
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
+            .nodes(DiscoveryNodes.builder()
+                .add(new DiscoveryNode("node_id1", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.V_6_5_0))
+                .add(new DiscoveryNode("node_id2", new TransportAddress(InetAddress.getLoopbackAddress(), 9301), Version.V_6_6_0)))
+            .build();
+
+        Settings settings = newSettings(true);
+        givenClusterSettings(settings);
+
+        MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+
+        assertFalse(check.canStartMigration(clusterState));
+    }
+
+    public void testCanStartMigration_givenNodesNotUpToVersionAndMigrationIsEnabled() {
+        // mixed 6.5 and 6.6 nodes
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
+            .nodes(DiscoveryNodes.builder()
+                .add(new DiscoveryNode("node_id1", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.V_6_6_0))
+                .add(new DiscoveryNode("node_id2", new TransportAddress(InetAddress.getLoopbackAddress(), 9301), Version.V_6_6_0)))
+            .build();
+
+        Settings settings = newSettings(true);
+        givenClusterSettings(settings);
+
+        MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+
+        assertTrue(check.canStartMigration(clusterState));
+    }
+
+    public void testJobIsEligibleForMigration_givenNodesNotUpToVersion() {
+        // mixed 6.5 and 6.6 nodes
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
+            .nodes(DiscoveryNodes.builder()
+                .add(new DiscoveryNode("node_id1", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.V_6_5_0))
+                .add(new DiscoveryNode("node_id2", new TransportAddress(InetAddress.getLoopbackAddress(), 9301), Version.V_6_6_0)))
+            .build();
+
+        Settings settings = newSettings(true);
+        givenClusterSettings(settings);
+
+        MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+
+        assertFalse(check.jobIsEligibleForMigration("pre-min-version", clusterState));
+    }
+
+    public void testJobIsEligibleForMigration_givenJobNotInClusterState() {
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests")).build();
+
+        Settings settings = newSettings(true);
+        givenClusterSettings(settings);
+
+        MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+
+        assertFalse(check.jobIsEligibleForMigration("not-in-state", clusterState));
+    }
+
+    public void testJobIsEligibleForMigration_givenDeletingJob() {
+        Job deletingJob = JobTests.buildJobBuilder("deleting-job").setDeleting(true).build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(deletingJob, false);
+
+        PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
+        tasksBuilder.addTask(MlTasks.jobTaskId(deletingJob.getId()),
+            MlTasks.JOB_TASK_NAME, new OpenJobAction.JobParams(deletingJob.getId()),
+            new PersistentTasksCustomMetaData.Assignment("node-1", "test assignment"));
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+            .metaData(MetaData.builder()
+                .putCustom(MlMetadata.TYPE, mlMetadata.build())
+                .putCustom(PersistentTasksCustomMetaData.TYPE, tasksBuilder.build())
+            )
+            .build();
+
+        Settings settings = newSettings(true);
+        givenClusterSettings(settings);
+
+        MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+
+        assertFalse(check.jobIsEligibleForMigration(deletingJob.getId(), clusterState));
+    }
+
+    public void testJobIsEligibleForMigration_givenOpenJob() {
+        Job openJob = JobTests.buildJobBuilder("open-job").build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(openJob, false);
+
+        PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
+        tasksBuilder.addTask(MlTasks.jobTaskId(openJob.getId()), MlTasks.JOB_TASK_NAME, new OpenJobAction.JobParams(openJob.getId()),
+            new PersistentTasksCustomMetaData.Assignment("node-1", "test assignment"));
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+            .metaData(MetaData.builder()
+                .putCustom(MlMetadata.TYPE, mlMetadata.build())
+                .putCustom(PersistentTasksCustomMetaData.TYPE, tasksBuilder.build())
+            )
+            .build();
+
+        Settings settings = newSettings(true);
+        givenClusterSettings(settings);
+
+        MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+
+        assertFalse(check.jobIsEligibleForMigration(openJob.getId(), clusterState));
+    }
+
+    public void testJobIsEligibleForMigration_givenOpenJobAndAndMigrationIsDisabled() {
+        Job openJob = JobTests.buildJobBuilder("open-job").build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(openJob, false);
+
+        PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
+        tasksBuilder.addTask(MlTasks.jobTaskId(openJob.getId()), MlTasks.JOB_TASK_NAME, new OpenJobAction.JobParams(openJob.getId()),
+            new PersistentTasksCustomMetaData.Assignment("node-1", "test assignment"));
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+            .metaData(MetaData.builder()
+                .putCustom(MlMetadata.TYPE, mlMetadata.build())
+                .putCustom(PersistentTasksCustomMetaData.TYPE, tasksBuilder.build())
+            )
+            .build();
+
+        Settings settings = newSettings(false);
+        givenClusterSettings(settings);
+
+        MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+
+        assertFalse(check.jobIsEligibleForMigration(openJob.getId(), clusterState));
+    }
+
+    public void testJobIsEligibleForMigration_givenClosedJob() {
+        Job closedJob = JobTests.buildJobBuilder("closed-job").build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(closedJob, false);
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+            .metaData(MetaData.builder()
+                .putCustom(MlMetadata.TYPE, mlMetadata.build())
+            )
+            .build();
+
+        Settings settings = newSettings(true);
+        givenClusterSettings(settings);
+
+        MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+
+        assertTrue(check.jobIsEligibleForMigration(closedJob.getId(), clusterState));
+    }
+
+    public void testDatafeedIsEligibleForMigration_givenNodesNotUpToVersion() {
+        // mixed 6.5 and 6.6 nodes
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
+            .nodes(DiscoveryNodes.builder()
+                .add(new DiscoveryNode("node_id1", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.V_6_5_0))
+                .add(new DiscoveryNode("node_id2", new TransportAddress(InetAddress.getLoopbackAddress(), 9301), Version.V_6_6_0)))
+            .build();
+
+        Settings settings = newSettings(true);
+        givenClusterSettings(settings);
+
+        MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+
+        assertFalse(check.datafeedIsEligibleForMigration("pre-min-version", clusterState));
+    }
+
+    public void testDatafeedIsEligibleForMigration_givenDatafeedNotInClusterState() {
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests")).build();
+        Settings settings = newSettings(true);
+        givenClusterSettings(settings);
+
+        MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+
+        assertFalse(check.datafeedIsEligibleForMigration("not-in-state", clusterState));
+    }
+
+    public void testDatafeedIsEligibleForMigration_givenStartedDatafeed() {
+        Job openJob = JobTests.buildJobBuilder("open-job").build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(openJob, false);
+        mlMetadata.putDatafeed(createCompatibleDatafeed(openJob.getId()), Collections.emptyMap());
+        String datafeedId = "df-" + openJob.getId();
+
+        PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
+        tasksBuilder.addTask(MlTasks.datafeedTaskId(datafeedId), MlTasks.DATAFEED_TASK_NAME,
+            new StartDatafeedAction.DatafeedParams(datafeedId, 0L),
+            new PersistentTasksCustomMetaData.Assignment("node-1", "test assignment"));
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+            .metaData(MetaData.builder()
+                .putCustom(MlMetadata.TYPE, mlMetadata.build())
+                .putCustom(PersistentTasksCustomMetaData.TYPE, tasksBuilder.build())
+            )
+            .build();
+
+        Settings settings = newSettings(true);
+        givenClusterSettings(settings);
+
+        MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+
+        assertFalse(check.datafeedIsEligibleForMigration(datafeedId, clusterState));
+    }
+
+    public void testDatafeedIsEligibleForMigration_givenStartedDatafeedAndMigrationIsDisabled() {
+        Job openJob = JobTests.buildJobBuilder("open-job").build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(openJob, false);
+        mlMetadata.putDatafeed(createCompatibleDatafeed(openJob.getId()), Collections.emptyMap());
+        String datafeedId = "df-" + openJob.getId();
+
+        PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
+        tasksBuilder.addTask(MlTasks.datafeedTaskId(datafeedId), MlTasks.DATAFEED_TASK_NAME,
+            new StartDatafeedAction.DatafeedParams(datafeedId, 0L),
+            new PersistentTasksCustomMetaData.Assignment("node-1", "test assignment"));
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+            .metaData(MetaData.builder()
+                .putCustom(MlMetadata.TYPE, mlMetadata.build())
+                .putCustom(PersistentTasksCustomMetaData.TYPE, tasksBuilder.build())
+            )
+            .build();
+
+        Settings settings = newSettings(false);
+        givenClusterSettings(settings);
+
+        MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+
+        assertFalse(check.datafeedIsEligibleForMigration(datafeedId, clusterState));
+    }
+
+    public void testDatafeedIsEligibleForMigration_givenStoppedDatafeed() {
+        Job job = JobTests.buildJobBuilder("closed-job").build();
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(job, false);
+        mlMetadata.putDatafeed(createCompatibleDatafeed(job.getId()), Collections.emptyMap());
+        String datafeedId = "df-" + job.getId();
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
+            .metaData(MetaData.builder()
+                .putCustom(MlMetadata.TYPE, mlMetadata.build())
+            )
+            .build();
+
+        Settings settings = newSettings(true);
+        givenClusterSettings(settings);
+
+        MlConfigMigrationEligibilityCheck check = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+
+        assertTrue(check.datafeedIsEligibleForMigration(datafeedId, clusterState));
+    }
+
+    private void givenClusterSettings(Settings settings) {
+        ClusterSettings clusterSettings = new ClusterSettings(settings, new HashSet<>(Collections.singletonList(
+                MlConfigMigrationEligibilityCheck.ENABLE_CONFIG_MIGRATION)));
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+    }
+
+    private static Settings newSettings(boolean migrationEnabled) {
+        return Settings.builder()
+                .put(MlConfigMigrationEligibilityCheck.ENABLE_CONFIG_MIGRATION.getKey(), migrationEnabled)
+                .build();
+    }
+
+    private DatafeedConfig createCompatibleDatafeed(String jobId) {
+        // create a datafeed without aggregations or anything
+        // else that may cause validation errors
+        DatafeedConfig.Builder datafeedBuilder = new DatafeedConfig.Builder("df-" + jobId, jobId);
+        datafeedBuilder.setIndices(Collections.singletonList("my_index"));
+        return datafeedBuilder.build();
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigratorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigratorTests.java
@@ -11,9 +11,6 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
@@ -24,7 +21,6 @@ import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobTests;
 
-import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -216,124 +212,6 @@ public class MlConfigMigratorTests extends ESTestCase {
         assertThat(removalResult.mlMetadata.getDatafeeds().keySet(), contains("df-job1"));
         assertThat(removalResult.removedJobIds, contains("job1"));
         assertThat(removalResult.removedDatafeedIds, empty());
-    }
-
-    public void testJobIsEligibleForMigration_givenNodesNotUpToVersion() {
-        // mixed 6.5 and 6.6 nodes
-        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
-                .nodes(DiscoveryNodes.builder()
-                        .add(new DiscoveryNode("node_id1", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.V_6_5_0))
-                        .add(new DiscoveryNode("node_id2", new TransportAddress(InetAddress.getLoopbackAddress(), 9301), Version.V_6_6_0)))
-                .build();
-
-        assertFalse(MlConfigMigrator.jobIsEligibleForMigration("pre-min-version", clusterState));
-    }
-
-    public void testJobIsEligibleForMigration_givenJobNotInClusterState() {
-        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests")).build();
-        assertFalse(MlConfigMigrator.jobIsEligibleForMigration("not-in-state", clusterState));
-    }
-
-    public void testJobIsEligibleForMigration_givenDeletingJob() {
-        Job deletingJob = JobTests.buildJobBuilder("deleting-job").setDeleting(true).build();
-        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(deletingJob, false);
-
-        PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
-        tasksBuilder.addTask(MlTasks.jobTaskId(deletingJob.getId()),
-                MlTasks.JOB_TASK_NAME, new OpenJobAction.JobParams(deletingJob.getId()),
-                new PersistentTasksCustomMetaData.Assignment("node-1", "test assignment"));
-
-        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
-                .metaData(MetaData.builder()
-                        .putCustom(MlMetadata.TYPE, mlMetadata.build())
-                        .putCustom(PersistentTasksCustomMetaData.TYPE, tasksBuilder.build())
-                )
-                .build();
-
-        assertFalse(MlConfigMigrator.jobIsEligibleForMigration(deletingJob.getId(), clusterState));
-    }
-
-    public void testJobIsEligibleForMigration_givenOpenJob() {
-        Job openJob = JobTests.buildJobBuilder("open-job").build();
-        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(openJob, false);
-
-        PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
-        tasksBuilder.addTask(MlTasks.jobTaskId(openJob.getId()), MlTasks.JOB_TASK_NAME, new OpenJobAction.JobParams(openJob.getId()),
-                new PersistentTasksCustomMetaData.Assignment("node-1", "test assignment"));
-
-        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
-                .metaData(MetaData.builder()
-                        .putCustom(MlMetadata.TYPE, mlMetadata.build())
-                        .putCustom(PersistentTasksCustomMetaData.TYPE, tasksBuilder.build())
-                )
-                .build();
-
-        assertFalse(MlConfigMigrator.jobIsEligibleForMigration(openJob.getId(), clusterState));
-    }
-
-    public void testJobIsEligibleForMigration_givenClosedJob() {
-        Job closedJob = JobTests.buildJobBuilder("closed-job").build();
-        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(closedJob, false);
-
-        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
-                .metaData(MetaData.builder()
-                        .putCustom(MlMetadata.TYPE, mlMetadata.build())
-                )
-                .build();
-
-        assertTrue(MlConfigMigrator.jobIsEligibleForMigration(closedJob.getId(), clusterState));
-    }
-
-    public void testDatafeedIsEligibleForMigration_givenNodesNotUpToVersion() {
-        // mixed 6.5 and 6.6 nodes
-        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
-                .nodes(DiscoveryNodes.builder()
-                        .add(new DiscoveryNode("node_id1", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.V_6_5_0))
-                        .add(new DiscoveryNode("node_id2", new TransportAddress(InetAddress.getLoopbackAddress(), 9301), Version.V_6_6_0)))
-                .build();
-
-        assertFalse(MlConfigMigrator.datafeedIsEligibleForMigration("pre-min-version", clusterState));
-    }
-
-    public void testDatafeedIsEligibleForMigration_givenDatafeedNotInClusterState() {
-        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests")).build();
-        assertFalse(MlConfigMigrator.datafeedIsEligibleForMigration("not-in-state", clusterState));
-    }
-
-    public void testDatafeedIsEligibleForMigration_givenStartedDatafeed() {
-        Job openJob = JobTests.buildJobBuilder("open-job").build();
-        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(openJob, false);
-        mlMetadata.putDatafeed(createCompatibleDatafeed(openJob.getId()), Collections.emptyMap());
-        String datafeedId = "df-" + openJob.getId();
-
-        PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
-        tasksBuilder.addTask(MlTasks.datafeedTaskId(datafeedId), MlTasks.DATAFEED_TASK_NAME,
-                new StartDatafeedAction.DatafeedParams(datafeedId, 0L),
-                new PersistentTasksCustomMetaData.Assignment("node-1", "test assignment"));
-
-        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
-                .metaData(MetaData.builder()
-                        .putCustom(MlMetadata.TYPE, mlMetadata.build())
-                        .putCustom(PersistentTasksCustomMetaData.TYPE, tasksBuilder.build())
-                )
-                .build();
-
-        assertFalse(MlConfigMigrator.datafeedIsEligibleForMigration(datafeedId, clusterState));
-    }
-
-    public void testDatafeedIsEligibleForMigration_givenStoppedDatafeed() {
-        Job job = JobTests.buildJobBuilder("closed-job").build();
-        MlMetadata.Builder mlMetadata = new MlMetadata.Builder().putJob(job, false);
-        mlMetadata.putDatafeed(createCompatibleDatafeed(job.getId()), Collections.emptyMap());
-        String datafeedId = "df-" + job.getId();
-
-        ClusterState clusterState = ClusterState.builder(new ClusterName("migratortests"))
-                .metaData(MetaData.builder()
-                        .putCustom(MlMetadata.TYPE, mlMetadata.build())
-                )
-                .build();
-
-        assertTrue(MlConfigMigrator.datafeedIsEligibleForMigration(datafeedId, clusterState));
     }
 
     public void testLimitWrites_GivenBelowLimit() {


### PR DESCRIPTION
This commit adds a cluster settings called `xpack.ml.enable_config_migration`.
The setting is `true` by default. When set to `false`, no config migration will
be attempted and non-migrated resources (e.g. jobs, datafeeds) will be able
to be updated normally.

Relates #32905
