### PR TITLE
[doc] highlight sysv alongwith init since they are one thing

### DIFF
--- a/docs/reference/setup/install/deb-init.asciidoc
+++ b/docs/reference/setup/install/deb-init.asciidoc
@@ -1,4 +1,4 @@
-==== Running Elasticsearch with SysV `init`
+==== Running Elasticsearch with `SysV init`
 
 Use the `update-rc.d` command to configure Elasticsearch to start automatically
 when the system boots up:

--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -173,7 +173,7 @@ include::xpack-indices.asciidoc[]
 
 endif::include-xpack[]
 
-==== SysV `init` vs `systemd`
+==== `SysV init` vs `systemd`
 
 include::init-systemd.asciidoc[]
 

--- a/docs/reference/setup/install/init-systemd.asciidoc
+++ b/docs/reference/setup/install/init-systemd.asciidoc
@@ -1,5 +1,5 @@
 Elasticsearch is not started automatically after installation. How to start
-and stop Elasticsearch depends on whether your system uses SysV `init` or
+and stop Elasticsearch depends on whether your system uses `SysV init` or
 `systemd` (used by newer distributions).  You can tell which is being used by
 running this command:
 

--- a/docs/reference/setup/install/rpm-init.asciidoc
+++ b/docs/reference/setup/install/rpm-init.asciidoc
@@ -1,4 +1,4 @@
-==== Running Elasticsearch with SysV `init`
+==== Running Elasticsearch with `SysV init`
 
 Use the `chkconfig` command to configure Elasticsearch to start automatically
 when the system boots up:

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -160,7 +160,7 @@ include::xpack-indices.asciidoc[]
 
 endif::include-xpack[]
 
-==== SysV `init` vs `systemd`
+==== `SysV init` vs `systemd`
 
 include::init-systemd.asciidoc[]
 

--- a/docs/reference/upgrade/shut-down-node.asciidoc
+++ b/docs/reference/upgrade/shut-down-node.asciidoc
@@ -5,7 +5,7 @@
 sudo systemctl stop elasticsearch.service
 --------------------------------------------------
 
-* If you are running Elasticsearch with SysV `init`:
+* If you are running Elasticsearch with `SysV init`:
 +
 [source,sh]
 --------------------------------------------------


### PR DESCRIPTION
When following installation instructions for Linux from https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html when coming to the part on 'SysV init vs system' it seems like SysV is mentioned for both init and system.

So when I came over to this section, I searched online for `SysV systemd` since the command showed my system to be based on systemd which is just systemd actually. Hence, I feel highlighting SysV alongwith init should improve clarity of the doc since that will suggest that SysV init and systemd are the two separate entities.