### PR TITLE
Modify SHA-1 matcher in Docker version output

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -292,7 +292,7 @@ class BuildPlugin implements Plugin<Project> {
                                 it.standardOutput = dockerVersionOutput
                             })
                     final String dockerVersion = dockerVersionOutput.toString().trim()
-                    final Matcher matcher = dockerVersion =~ /Docker version (\d+\.\d+)\.\d+(?:-ce)?, build [0-9a-f]{7}/
+                    final Matcher matcher = dockerVersion =~ /Docker version (\d+\.\d+)\.\d+(?:-ce)?, build [0-9a-f]{7,40}/
                     assert matcher.matches() : dockerVersion
                     final dockerMajorMinorVersion = matcher.group(1)
                     final String[] majorMinor = dockerMajorMinorVersion.split("\\.")


### PR DESCRIPTION
The Docker version (docker --version) contains the SHA-1 of the commit used for the build. This commit can be represented as short hash, but not necessarily limited to seven characters. This commit modifies the regular expression used to match the SHA-1 so that we do not fail on builds that use a longer hash.

Closes #36414