### PR TITLE
SNAPSHOTS: Disable BwC Tests Until #36659 Landed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,8 +163,8 @@ task verifyVersions {
  * the enabled state of every bwc task. It should be set back to true
  * after the backport of the backcompat code is complete.
  */
-final boolean bwc_tests_enabled = true
-final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+final boolean bwc_tests_enabled = false
+final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/36659" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")


### PR DESCRIPTION
* Turning off BwC tests until #36659 is in `6.x`/`6.6`, then we re-enable them after setting the serialization version checks for `org.elasticsearch.cluster.RestoreInProgress` to check against `6.6`.