### PR TITLE
Narrow down the scope of test ignore - awaiting fix

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -492,4 +492,15 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
             .build();
         return IndexMetaData.builder(name).settings(build).build();
     }
+
+
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/36598")
+    @Override
+    public void testMustRewrite() throws IOException {
+    }
+
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/36598")
+    @Override
+    public void testToQuery() throws IOException {
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -413,7 +413,6 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
      * Test creates the {@link Query} from the {@link QueryBuilder} under test and delegates the
      * assertions being made on the result to the implementing subclass.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/36598")
     public void testToQuery() throws IOException {
         for (int runs = 0; runs < NUMBER_OF_TESTQUERIES; runs++) {
             QueryShardContext context = createShardContext();
@@ -798,7 +797,6 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
      * This test ensures that queries that need to be rewritten have dedicated tests.
      * These queries must override this method accordingly.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/36598")
     public void testMustRewrite() throws IOException {
         QueryShardContext context = createShardContext();
         context.setAllowUnmappedFields(true);


### PR DESCRIPTION
only muting two failing test cases in a subclass where they fail.
issue referencing the problem: #36598
