### PR TITLE
SNAPSHOTS: Adjust BwC Versions in Restore Logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,8 +163,8 @@ task verifyVersions {
  * the enabled state of every bwc task. It should be set back to true
  * after the backport of the backcompat code is complete.
  */
-final boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/36659" /* place a PR link here when committing bwc changes */
+final boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/server/src/main/java/org/elasticsearch/cluster/RestoreInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/RestoreInProgress.java
@@ -46,7 +46,7 @@ import java.util.UUID;
 public class RestoreInProgress extends AbstractNamedDiffable<Custom> implements Custom, Iterable<RestoreInProgress.Entry> {
 
     /**
-     * Fallback UUID used for restore operations that were started before v7.0 and don't have a uuid in the cluster state.
+     * Fallback UUID used for restore operations that were started before v6.6 and don't have a uuid in the cluster state.
      */
     public static final String BWC_UUID = new UUID(0, 0).toString();
 
@@ -436,7 +436,7 @@ public class RestoreInProgress extends AbstractNamedDiffable<Custom> implements 
         final ImmutableOpenMap.Builder<String, Entry> entriesBuilder = ImmutableOpenMap.builder(count);
         for (int i = 0; i < count; i++) {
             final String uuid;
-            if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
+            if (in.getVersion().onOrAfter(Version.V_6_6_0)) {
                 uuid = in.readString();
             } else {
                 uuid = BWC_UUID;
@@ -468,7 +468,7 @@ public class RestoreInProgress extends AbstractNamedDiffable<Custom> implements 
         out.writeVInt(entries.size());
         for (ObjectCursor<Entry> v : entries.values()) {
             Entry entry = v.value;
-            if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
+            if (out.getVersion().onOrAfter(Version.V_6_6_0)) {
                 out.writeString(entry.uuid);
             }
             entry.snapshot().writeTo(out);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RecoverySource.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RecoverySource.java
@@ -222,7 +222,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
         }
 
         SnapshotRecoverySource(StreamInput in) throws IOException {
-            if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
+            if (in.getVersion().onOrAfter(Version.V_6_6_0)) {
                 restoreUUID = in.readString();
             } else {
                 restoreUUID = RestoreInProgress.BWC_UUID;
@@ -250,7 +250,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
 
         @Override
         protected void writeAdditionalFields(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
+            if (out.getVersion().onOrAfter(Version.V_6_6_0)) {
                 out.writeString(restoreUUID);
             }
             snapshot.writeTo(out);


### PR DESCRIPTION
* Re-enables bwc tests with adjusted version conditions now that #36397 enables concurrent snapshots in 6.6+
