### PR TITLE
[Docs] Delete explanation for completion suggester default analyzer choice

### DIFF
--- a/docs/reference/search/suggesters/completion-suggest.asciidoc
+++ b/docs/reference/search/suggesters/completion-suggest.asciidoc
@@ -47,10 +47,6 @@ Mapping supports the following parameters:
 
 `analyzer`::
     The index analyzer to use, defaults to `simple`.
-    In case you are wondering why we did not opt for the `standard`
-    analyzer: We try to have easy to understand behaviour here, and if you
-    index the field content `At the Drive-in`, you will not get any
-    suggestions for `a`, nor for `d` (the first non stopword).
 
 `search_analyzer`::
     The search analyzer to use, defaults to value of `analyzer`.


### PR DESCRIPTION
The explanation given in the completion suggester documentation why we use the
"simple" analyzer as the default is no longer valid. Since we still use "simple"
as the default, we should just delete the explanation that doesn't fit anymore.

Closes #36715