### PR TITLE
[ILM][DOCS] Update ILM API authorization docs

### DIFF
--- a/docs/reference/ilm/apis/delete-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/delete-lifecycle.asciidoc
@@ -31,7 +31,8 @@ include::{docdir}/rest-api/timeoutparms.asciidoc[]
 
 ==== Authorization
 
-include::ilm-cluster-mgt-privilege.asciidoc[]
+You must have the `manage_ilm` cluster privilege to use this API.
+For more information, see {stack-ov}/security-privileges.html[Security Privileges].
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/explain.asciidoc
+++ b/docs/reference/ilm/apis/explain.asciidoc
@@ -32,7 +32,9 @@ include::{docdir}/rest-api/timeoutparms.asciidoc[]
 
 ==== Authorization
 
-include::ilm-index-mgt-privilege.asciidoc[]
+You must have the `view_index_metadata` or `manage_ilm` or both privileges on the indices
+being managed to use this API.
+For more information, see {stack-ov}/security-privileges.html[Security Privileges].
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/get-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/get-lifecycle.asciidoc
@@ -31,7 +31,8 @@ include::{docdir}/rest-api/timeoutparms.asciidoc[]
 
 ==== Authorization
 
-include::ilm-cluster-mgt-privilege.asciidoc[]
+You must have the `manage_ilm` or `read_ilm` or both cluster privileges to use this API.
+For more information, see {stack-ov}/security-privileges.html[Security Privileges].
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/get-status.asciidoc
+++ b/docs/reference/ilm/apis/get-status.asciidoc
@@ -27,7 +27,8 @@ include::{docdir}/rest-api/timeoutparms.asciidoc[]
 
 ==== Authorization
 
-include::ilm-cluster-mgt-privilege.asciidoc[]
+You must have the `manage_ilm` or `read_ilm` or both cluster privileges to use this API.
+For more information, see {stack-ov}/security-privileges.html[Security Privileges].
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/ilm-cluster-mgt-privilege.asciidoc
+++ b/docs/reference/ilm/apis/ilm-cluster-mgt-privilege.asciidoc
@@ -1,2 +1,0 @@
-You must have the cluster `manage` privilege to use this API.
-For more information, see {stack-ov}/security-privileges.html[Security Privileges].

--- a/docs/reference/ilm/apis/ilm-index-mgt-privilege.asciidoc
+++ b/docs/reference/ilm/apis/ilm-index-mgt-privilege.asciidoc
@@ -1,2 +1,0 @@
-You must have the `manage` privilege on the indices being managed to use this API.
-For more information, see {stack-ov}/security-privileges.html[Security Privileges].

--- a/docs/reference/ilm/apis/move-to-step.asciidoc
+++ b/docs/reference/ilm/apis/move-to-step.asciidoc
@@ -40,7 +40,8 @@ include::{docdir}/rest-api/timeoutparms.asciidoc[]
 
 ==== Authorization
 
-include::ilm-index-mgt-privilege.asciidoc[]
+You must have the `manage_ilm` privileges on the indices being managed to use this API.
+For more information, see {stack-ov}/security-privileges.html[Security Privileges].
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/put-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/put-lifecycle.asciidoc
@@ -33,7 +33,8 @@ include::{docdir}/rest-api/timeoutparms.asciidoc[]
 
 ==== Authorization
 
-include::ilm-cluster-mgt-privilege.asciidoc[]
+You must have the `manage_ilm` cluster privilege to use this API.
+For more information, see {stack-ov}/security-privileges.html[Security Privileges].
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/put-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/put-lifecycle.asciidoc
@@ -33,7 +33,10 @@ include::{docdir}/rest-api/timeoutparms.asciidoc[]
 
 ==== Authorization
 
-You must have the `manage_ilm` cluster privilege to use this API.
+You must have the `manage_ilm` cluster privilege to use this API. You must
+also have the `manage` index privilege on all indices being managed by `policy`.
+All operations executed by {Ilm} for a policy are executed as the user that
+put the latest version of a policy.
 For more information, see {stack-ov}/security-privileges.html[Security Privileges].
 
 ==== Examples

--- a/docs/reference/ilm/apis/remove-policy-from-index.asciidoc
+++ b/docs/reference/ilm/apis/remove-policy-from-index.asciidoc
@@ -31,7 +31,8 @@ include::{docdir}/rest-api/timeoutparms.asciidoc[]
 
 ==== Authorization
 
-include::ilm-cluster-mgt-privilege.asciidoc[]
+You must have the `manage_ilm` privileges on the indices being managed to use this API.
+For more information, see {stack-ov}/security-privileges.html[Security Privileges].
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/retry-policy.asciidoc
+++ b/docs/reference/ilm/apis/retry-policy.asciidoc
@@ -31,7 +31,8 @@ include::{docdir}/rest-api/timeoutparms.asciidoc[]
 
 ==== Authorization
 
-include::ilm-index-mgt-privilege.asciidoc[]
+You must have the `manage_ilm` privileges on the indices being managed to use this API.
+For more information, see {stack-ov}/security-privileges.html[Security Privileges].
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/start.asciidoc
+++ b/docs/reference/ilm/apis/start.asciidoc
@@ -26,7 +26,8 @@ include::{docdir}/rest-api/timeoutparms.asciidoc[]
 
 ==== Authorization
 
-include::ilm-cluster-mgt-privilege.asciidoc[]
+You must have the `manage_ilm` cluster privilege to use this API.
+For more information, see {stack-ov}/security-privileges.html[Security Privileges].
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/stop.asciidoc
+++ b/docs/reference/ilm/apis/stop.asciidoc
@@ -31,7 +31,8 @@ include::{docdir}/rest-api/timeoutparms.asciidoc[]
 
 ==== Authorization
 
-include::ilm-cluster-mgt-privilege.asciidoc[]
+You must have the `manage_ilm` cluster privilege to use this API.
+For more information, see {stack-ov}/security-privileges.html[Security Privileges].
 
 ==== Examples
 


### PR DESCRIPTION
#36493 adds the `manage_ilm` and `read_ilm` cluster privileges, along 
with the `manage_ilm` index privilege and modifications to the `view_index_metadata` privilege.
Now the ILM API authorization documentation mentions the need for these roles in more
specific ways.