### PR TITLE
Use SearchRequest copy constructor in ExpandSearchPhase

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
@@ -91,7 +91,8 @@ final class ExpandSearchPhase extends SearchPhase {
                     SearchSourceBuilder sourceBuilder = buildExpandSearchSourceBuilder(innerHitBuilder, innerCollapseBuilder)
                         .query(groupQuery)
                         .postFilter(searchRequest.source().postFilter());
-                    SearchRequest groupRequest = buildExpandSearchRequest(searchRequest, sourceBuilder);
+                    SearchRequest groupRequest = new SearchRequest(searchRequest);
+                    groupRequest.source(sourceBuilder);
                     multiRequest.add(groupRequest);
                 }
             }
@@ -118,22 +119,6 @@ final class ExpandSearchPhase extends SearchPhase {
         } else {
             context.executeNextPhase(this, nextPhaseFactory.apply(searchResponse));
         }
-    }
-
-    private SearchRequest buildExpandSearchRequest(SearchRequest orig, SearchSourceBuilder sourceBuilder) {
-        SearchRequest groupRequest = new SearchRequest(orig.indices())
-            .types(orig.types())
-            .source(sourceBuilder)
-            .indicesOptions(orig.indicesOptions())
-            .requestCache(orig.requestCache())
-            .preference(orig.preference())
-            .routing(orig.routing())
-            .searchType(orig.searchType());
-        if (orig.allowPartialSearchResults() != null){
-            groupRequest.allowPartialSearchResults(orig.allowPartialSearchResults());
-        }
-        groupRequest.setMaxConcurrentShardRequests(orig.getMaxConcurrentShardRequests());
-        return groupRequest;
     }
 
     private SearchSourceBuilder buildExpandSearchSourceBuilder(InnerHitBuilder options, CollapseBuilder innerCollapseBuilder) {


### PR DESCRIPTION
Using the copy constructor introduced with #36641 guarantees that whenever new fields are added to `SearchRequest` they are properly propagated to its copies. Copies created in `ExpandSearchPhase` were missing a couple of recently added fields.