### PR TITLE
[DOCs] Adds ml-cpp PRs to alpha release notes

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -14,8 +14,9 @@ release-state can be: released | prerelease | unreleased
 :release-state:   prerelease
 
 :issue:           https://github.com/elastic/elasticsearch/issues/
+:ml-issue:        https://github.com/elastic/ml-cpp/issues/
 :pull:            https://github.com/elastic/elasticsearch/pull/
-
+:ml-pull:         https://github.com/elastic/ml-cpp/pull/
 :docker-repo:     docker.elastic.co/elasticsearch/elasticsearch
 :docker-image:    {docker-repo}:{version}
 :plugin_url:      https://artifacts.elastic.co/downloads/elasticsearch-plugins

--- a/docs/reference/release-notes/7.0.0-alpha1.asciidoc
+++ b/docs/reference/release-notes/7.0.0-alpha1.asciidoc
@@ -30,3 +30,10 @@ Suggesters::
   explicitly indicate the type of suggestion that they produce. Existing plugins will
   require changes to their plugin registration. See the `custom-suggester` example
   plugin {pull}30284[#30284]
+  
+[float]
+[[enhancement-7.0.0-alpha1]]
+=== Enhancements
+
+Machine learning::
+* Adds categorical filter type to detector rules. {ml-pull}27[#27]

--- a/docs/reference/release-notes/7.0.0-alpha2.asciidoc
+++ b/docs/reference/release-notes/7.0.0-alpha2.asciidoc
@@ -4,14 +4,6 @@
 coming[7.0.0-alpha2]
 
 [float]
-[[enhancement-7.0.0-alpha2]]
-=== Enhancements
-
-Machine learning::
-* Adds include categorical filter type to detector rules. {ml-pull}27[#27]
-
-
-[float]
 [[bug-7.0.0-alpha2]]
 === Bug fixes
 

--- a/docs/reference/release-notes/7.0.0-alpha2.asciidoc
+++ b/docs/reference/release-notes/7.0.0-alpha2.asciidoc
@@ -2,3 +2,17 @@
 == {es} version 7.0.0-alpha2
 
 coming[7.0.0-alpha2]
+
+[float]
+[[enhancement-7.0.0-alpha2]]
+=== Enhancements
+
+Machine learning::
+* Adds include categorical filter type to detector rules. {ml-pull}27[#27]
+
+
+[float]
+[[bug-7.0.0-alpha2]]
+=== Bug fixes
+
+* Fixes CPoissonMeanConjugate sampling error. {ml-pull}335[#335]


### PR DESCRIPTION
Related to https://github.com/elastic/ml-cpp/pull/347

This PR adds the ml-cpp PRs to the release notes in the Elasticsearch Reference.