### PR TITLE
[ML] Have delayed data detection create annotations

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
@@ -77,6 +77,19 @@ public class Annotation implements ToXContentObject, Writeable {
         this.type = Objects.requireNonNull(type);
     }
 
+    public Annotation(Annotation other) {
+        Objects.requireNonNull(other);
+        this.annotation = other.annotation;
+        this.createTime = new Date(other.createTime.getTime());
+        this.createUsername = other.createUsername;
+        this.timestamp = new Date(other.timestamp.getTime());
+        this.endTimestamp = other.endTimestamp == null ? null : new Date(other.endTimestamp.getTime());
+        this.jobId = other.jobId;
+        this.modifiedTime = other.modifiedTime == null ? null : new Date(other.modifiedTime.getTime());
+        this.modifiedUsername = other.modifiedUsername;
+        this.type = other.type;
+    }
+
     public Annotation(StreamInput in) throws IOException {
         annotation = in.readString();
         createTime = new Date(in.readLong());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationTests.java
@@ -11,6 +11,8 @@ import org.elasticsearch.test.AbstractSerializingTestCase;
 
 import java.util.Date;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class AnnotationTests extends AbstractSerializingTestCase<Annotation> {
 
     @Override
@@ -34,5 +36,12 @@ public class AnnotationTests extends AbstractSerializingTestCase<Annotation> {
     @Override
     protected Writeable.Reader<Annotation> instanceReader() {
         return Annotation::new;
+    }
+
+    public void testCopyConstructor() {
+        for (int i = 0; i < NUMBER_OF_TEST_RUNS; i++) {
+            Annotation testAnnotation = createTestInstance();
+            assertThat(testAnnotation, equalTo(new Annotation(testAnnotation)));
+        }
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
@@ -6,18 +6,28 @@
 package org.elasticsearch.xpack.ml.datafeed;
 
 import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentElasticsearchExtension;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.mock.orig.Mockito;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.action.FlushJobAction;
 import org.elasticsearch.xpack.core.ml.action.PersistJobAction;
 import org.elasticsearch.xpack.core.ml.action.PostDataAction;
+import org.elasticsearch.xpack.core.ml.annotations.Annotation;
+import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
 import org.elasticsearch.xpack.core.ml.datafeed.extractor.DataExtractor;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
@@ -66,8 +76,11 @@ public class DatafeedJobTests extends ESTestCase {
     private DataDescription.Builder dataDescription;
     ActionFuture<PostDataAction.Response> postDataFuture;
     private ActionFuture<FlushJobAction.Response> flushJobFuture;
+    private ActionFuture<IndexResponse> indexFuture;
+    private ActionFuture<UpdateResponse> updateFuture;
     private ArgumentCaptor<FlushJobAction.Request> flushJobRequests;
     private FlushJobAction.Response flushJobResponse;
+    private String annotationDocId;
 
     private long currentTime;
     private XContentType xContentType;
@@ -87,6 +100,9 @@ public class DatafeedJobTests extends ESTestCase {
         dataDescription.setFormat(DataDescription.DataFormat.XCONTENT);
         postDataFuture = mock(ActionFuture.class);
         flushJobFuture = mock(ActionFuture.class);
+        indexFuture = mock(ActionFuture.class);
+        updateFuture = mock(ActionFuture.class);
+        annotationDocId = "AnnotationDocId";
         flushJobResponse = new FlushJobAction.Response(true, new Date());
         delayedDataDetector = mock(DelayedDataDetector.class);
         when(delayedDataDetector.getWindow()).thenReturn(DatafeedJob.MISSING_DATA_CHECK_INTERVAL_MS);
@@ -109,6 +125,12 @@ public class DatafeedJobTests extends ESTestCase {
         flushJobRequests = ArgumentCaptor.forClass(FlushJobAction.Request.class);
         when(flushJobFuture.actionGet()).thenReturn(flushJobResponse);
         when(client.execute(same(FlushJobAction.INSTANCE), flushJobRequests.capture())).thenReturn(flushJobFuture);
+
+        when(indexFuture.actionGet()).thenReturn(new IndexResponse(new ShardId("index", "uuid", 0), "doc", annotationDocId, 0, 0, 0, true));
+        when(client.index(any())).thenReturn(indexFuture);
+
+        when(updateFuture.actionGet()).thenReturn(new UpdateResponse());
+        when(client.update(any())).thenReturn(updateFuture);
     }
 
     public void testLookBackRunWithEndTime() throws Exception {
@@ -244,10 +266,57 @@ public class DatafeedJobTests extends ESTestCase {
         when(dataExtractorFactory.newExtractor(anyLong(), anyLong())).thenReturn(dataExtractor);
         datafeedJob.runRealtime();
 
-        verify(auditor, times(1)).warning(jobId,
-            Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_MISSING_DATA,
-                10,
-                XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(2000)));
+        String msg = Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_MISSING_DATA,
+            10,
+            XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(2000));
+
+        Annotation expectedAnnotation = new Annotation(msg,
+            new Date(currentTime),
+            "ml-delayed-data-checker",
+            bucket.getTimestamp(),
+            bucket.getTimestamp(),
+            jobId,
+            null,
+            null,
+            "annotation");
+
+        IndexRequest request = new IndexRequest(AnnotationIndex.WRITE_ALIAS_NAME);
+        try (XContentBuilder xContentBuilder = expectedAnnotation.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)) {
+            request.source(xContentBuilder);
+        }
+        ArgumentCaptor<IndexRequest> indexRequestArgumentCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        verify(client, times(1)).index(indexRequestArgumentCaptor.capture());
+        assertThat(request.index(), equalTo(indexRequestArgumentCaptor.getValue().index()));
+        assertThat(request.source(), equalTo(indexRequestArgumentCaptor.getValue().source()));
+
+        // Execute a fourth time, this time we return a new delayedDataDetector response to verify annotation gets updated
+        when(delayedDataDetector.detectMissingData(2000))
+            .thenReturn(Collections.singletonList(BucketWithMissingData.fromMissingAndBucket(15, bucket)));
+        currentTime = currentTime + DatafeedJob.MISSING_DATA_CHECK_INTERVAL_MS + 1;
+        inputStream = new ByteArrayInputStream(contentBytes);
+        when(dataExtractor.hasNext()).thenReturn(true).thenReturn(false);
+        when(dataExtractor.next()).thenReturn(Optional.of(inputStream));
+        when(dataExtractorFactory.newExtractor(anyLong(), anyLong())).thenReturn(dataExtractor);
+        datafeedJob.runRealtime();
+
+        msg = Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_MISSING_DATA,
+            15,
+            XContentElasticsearchExtension.DEFAULT_DATE_PRINTER.print(2000));
+        UpdateRequest updateRequest = new UpdateRequest(AnnotationIndex.WRITE_ALIAS_NAME, annotationDocId);
+        Annotation updatedAnnotation = new Annotation(expectedAnnotation);
+        updatedAnnotation.setAnnotation(msg);
+        updatedAnnotation.setModifiedTime(new Date(currentTime));
+        updatedAnnotation.setModifiedUsername("ml-delayed-data-checker");
+        try (XContentBuilder xContentBuilder = updatedAnnotation.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)) {
+            updateRequest.doc(xContentBuilder);
+        }
+
+        ArgumentCaptor<UpdateRequest> updateRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
+
+        verify(client, times(1)).update(updateRequestArgumentCaptor.capture());
+        assertThat(updateRequest.index(), equalTo(updateRequestArgumentCaptor.getValue().index()));
+        assertThat(updateRequest.doc().source().utf8ToString(),
+            equalTo(updateRequestArgumentCaptor.getValue().doc().source().utf8ToString()));
     }
 
     public void testEmptyDataCountGivenlookback() throws Exception {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
 import org.elasticsearch.xpack.core.ml.datafeed.extractor.DataExtractor;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
+import org.elasticsearch.xpack.core.security.user.SystemUser;
 import org.elasticsearch.xpack.ml.datafeed.delayeddatacheck.DelayedDataDetector;
 import org.elasticsearch.xpack.ml.datafeed.delayeddatacheck.DelayedDataDetectorFactory.BucketWithMissingData;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
@@ -272,7 +273,7 @@ public class DatafeedJobTests extends ESTestCase {
 
         Annotation expectedAnnotation = new Annotation(msg,
             new Date(currentTime),
-            "ml-delayed-data-checker",
+            SystemUser.NAME,
             bucket.getTimestamp(),
             bucket.getTimestamp(),
             jobId,
@@ -306,7 +307,7 @@ public class DatafeedJobTests extends ESTestCase {
         Annotation updatedAnnotation = new Annotation(expectedAnnotation);
         updatedAnnotation.setAnnotation(msg);
         updatedAnnotation.setModifiedTime(new Date(currentTime));
-        updatedAnnotation.setModifiedUsername("ml-delayed-data-checker");
+        updatedAnnotation.setModifiedUsername(SystemUser.NAME);
         try (XContentBuilder xContentBuilder = updatedAnnotation.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)) {
             updateRequest.doc(xContentBuilder);
         }


### PR DESCRIPTION
This moves the delayed data detector to create annotations as well as writing to the job audits.

How it looks:

<img width="1476" alt="image" src="https://user-images.githubusercontent.com/4357155/50177674-3789c000-02c8-11e9-8aa4-e66ae69fd7fe.png">

