### PR TITLE
Revert transport.port change for tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -371,7 +371,7 @@ class ClusterFormationTasks {
         }
         esConfig['node.max_local_storage_nodes'] = node.config.numNodes
         esConfig['http.port'] = node.config.httpPort
-        esConfig['transport.port'] =  node.config.transportPort
+        esConfig['transport.tcp.port'] =  node.config.transportPort
         // Default the watermarks to absurdly low to prevent the tests from failing on nodes without enough disk space
         esConfig['cluster.routing.allocation.disk.watermark.low'] = '1b'
         esConfig['cluster.routing.allocation.disk.watermark.high'] = '1b'

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -333,7 +333,7 @@ public class ElasticsearchNode {
         config.put("node.attr.testattr", "test");
         config.put("node.portsfile", "true");
         config.put("http.port", "0");
-        config.put("transport.port", "0");
+        config.put("transport.tcp.port", "0");
         // Default the watermarks to absurdly low to prevent the tests from failing on nodes without enough disk space
         config.put("cluster.routing.allocation.disk.watermark.low", "1b");
         config.put("cluster.routing.allocation.disk.watermark.high", "1b");

--- a/client/sniffer/src/test/resources/create_test_nodes_info.bash
+++ b/client/sniffer/src/test/resources/create_test_nodes_info.bash
@@ -60,7 +60,7 @@ node${attr}.dummy:  everyone_has_me
 node${attr}.number: ${node:1}
 node${attr}.array:  [${node:0:1}, ${node:1}]
 http.port:          ${http_port}
-transport.port:     ${transport_port}
+transport.tcp.port: ${transport_port}
 discovery.zen.minimum_master_nodes: 3
 discovery.zen.ping.unicast.hosts: ['localhost:9300','localhost:9301','localhost:9302']
 __ES_YML

--- a/server/src/test/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
@@ -65,7 +65,7 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
                 .builder()
                 .put(super.nodeSettings(nodeOrdinal))
                 .put("discovery.type", "single-node")
-                .put("transport.port", "0")
+                .put("transport.tcp.port", "0")
                 .build();
     }
 

--- a/test/fixtures/old-elasticsearch/src/main/java/oldes/OldElasticsearch.java
+++ b/test/fixtures/old-elasticsearch/src/main/java/oldes/OldElasticsearch.java
@@ -82,7 +82,7 @@ public class OldElasticsearch {
         Path bin = esDir.resolve("bin").resolve("elasticsearch" + (Constants.WINDOWS ? ".bat" : ""));
         Path config = esDir.resolve("config").resolve("elasticsearch.yml");
 
-        Files.write(config, Arrays.asList("http.port: 0", "transport.port: 0", "network.host: 127.0.0.1"), StandardCharsets.UTF_8);
+        Files.write(config, Arrays.asList("http.port: 0", "transport.tcp.port: 0", "network.host: 127.0.0.1"), StandardCharsets.UTF_8);
 
         List<String> command = new ArrayList<>();
         command.add(bin.toString());

--- a/x-pack/qa/vagrant/src/test/resources/packaging/tests/certgen.bash
+++ b/x-pack/qa/vagrant/src/test/resources/packaging/tests/certgen.bash
@@ -256,7 +256,7 @@ xpack.ssl.certificate: $ESCONFIG/certs/node-master/node-master.crt
 xpack.ssl.certificate_authorities: ["$ESCONFIG/certs/ca/ca.crt"]
 
 xpack.security.transport.ssl.enabled: true
-transport.port: 9300
+transport.tcp.port: 9300
 
 xpack.security.http.ssl.enabled: true
 http.port: 9200
@@ -339,7 +339,7 @@ xpack.ssl.certificate: $ESCONFIG/certs/node-data/node-data.crt
 xpack.ssl.certificate_authorities: ["$ESCONFIG/certs/ca/ca.crt"]
 
 xpack.security.transport.ssl.enabled: true
-transport.port: 9301
+transport.tcp.port: 9301
 
 xpack.security.http.ssl.enabled: true
 http.port: 9201


### PR DESCRIPTION
Commit #36786 updated docs and strings to reference transport.port instead of
transport.tcp.port. However, this breaks backwards compatibility tests
as the tests rely on string configurations and transport.port does not
exist prior to 6.6. This commit reverts the places were we reference
transport.tcp.port for tests. This work will need to be reintroduced in
a backwards compatible way.