### PR TITLE
Removing some deprecated methods

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -379,17 +379,6 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     /**
      * Adds stored fields to load and return (note, it must be stored) as part of the search request.
      * To disable the stored fields entirely (source and metadata fields) use {@code storedField("_none_")}.
-     * @deprecated Use {@link SearchRequestBuilder#storedFields(String...)} instead.
-     */
-    @Deprecated
-    public SearchRequestBuilder fields(String... fields) {
-        sourceBuilder().storedFields(Arrays.asList(fields));
-        return this;
-    }
-
-    /**
-     * Adds stored fields to load and return (note, it must be stored) as part of the search request.
-     * To disable the stored fields entirely (source and metadata fields) use {@code storedField("_none_")}.
      */
     public SearchRequestBuilder storedFields(String... fields) {
         sourceBuilder().storedFields(Arrays.asList(fields));

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -32,12 +32,12 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder.ScriptField;
+import org.elasticsearch.search.collapse.CollapseBuilder;
 import org.elasticsearch.search.fetch.StoredFieldsContext;
 import org.elasticsearch.search.fetch.subphase.DocValueFieldsContext.FieldAndFormat;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
-import org.elasticsearch.search.collapse.CollapseBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -158,6 +158,7 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
         trackScores = in.readBoolean();
         storedFieldsContext = in.readOptionalWriteable(StoredFieldsContext::new);
         if (in.getVersion().before(Version.V_6_4_0)) {
+            @SuppressWarnings("unchecked")
             List<String> fieldList = (List<String>) in.readGenericValue();
             if (fieldList == null) {
                 docValueFields = null;
@@ -306,28 +307,6 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
         this.trackScores = trackScores;
         return this;
     }
-
-    /**
-     * Gets the stored fields to load and return.
-     *
-     * @deprecated Use {@link InnerHitBuilder#getStoredFieldsContext()} instead.
-     */
-    @Deprecated
-    public List<String> getFieldNames() {
-        return storedFieldsContext == null ? null : storedFieldsContext.fieldNames();
-    }
-
-    /**
-     * Sets the stored fields to load and return.
-     * If none are specified, the source of the document will be returned.
-     *
-     * @deprecated Use {@link InnerHitBuilder#setStoredFieldNames(List)} instead.
-     */
-    @Deprecated
-    public InnerHitBuilder setFieldNames(List<String> fieldNames) {
-        return setStoredFieldNames(fieldNames);
-    }
-
 
     /**
      * Gets the stored fields context.

--- a/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -235,19 +235,6 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
     }
 
     /**
-     * The geohash of the geo point to create the range distance facets from.
-     *
-     * Deprecated - please use points(GeoPoint... points) instead.
-     */
-    @Deprecated
-    public GeoDistanceSortBuilder geohashes(String... geohashes) {
-        for (String geohash : geohashes) {
-            this.points.add(GeoPoint.fromGeohash(geohash));
-        }
-        return this;
-    }
-
-    /**
      * The geo distance type used to compute the distance.
      */
     public GeoDistanceSortBuilder geoDistance(GeoDistance geoDistance) {


### PR DESCRIPTION
Removes some unused methods that have been deprecated since 6.0 in SearchRequestBuilder,
InnerHitBuilder and GeoDistanceSortBuilder and simplifies the later builders test case slightly
after removing the test for the deprecated method.