### PR TITLE
[ML] Order GET job stats response by job id

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManage
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -91,6 +92,7 @@ public class TransportGetJobsStatsAction extends TransportTasksAction<TransportO
         for (QueryPage<JobStats> task : tasks) {
             stats.addAll(task.results());
         }
+        Collections.sort(stats, Comparator.comparing(GetJobsStatsAction.Response.JobStats::getJobId));
         return new GetJobsStatsAction.Response(taskOperationFailures, failedNodeExceptions, new QueryPage<>(stats, stats.size(),
                 Job.RESULTS_FIELD));
     }
@@ -148,6 +150,7 @@ public class TransportGetJobsStatsAction extends TransportTasksAction<TransportO
                     if (counter.decrementAndGet() == 0) {
                         List<JobStats> results = response.getResponse().results();
                         results.addAll(jobStats.asList());
+                        Collections.sort(results, Comparator.comparing(GetJobsStatsAction.Response.JobStats::getJobId));
                         listener.onResponse(new GetJobsStatsAction.Response(response.getTaskFailures(), response.getNodeFailures(),
                                 new QueryPage<>(results, results.size(), Job.RESULTS_FIELD)));
                     }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_stats.yml
@@ -151,7 +151,9 @@ setup:
       ml.get_job_stats:
         job_id: _all
   - match: { count: 2 }
+  - match: { jobs.0.job_id : job-stats-test }
   - match: { jobs.0.state: opened }
+  - match: { jobs.1.job_id : jobs-get-stats-datafeed-job }
   - match: { jobs.1.state: opened }
 
 ---
@@ -161,7 +163,9 @@ setup:
       ml.get_job_stats:
         job_id: "*"
   - match: { count: 2 }
+  - match: { jobs.0.job_id : job-stats-test }
   - match: { jobs.0.state: opened }
+  - match: { jobs.1.job_id : jobs-get-stats-datafeed-job }
   - match: { jobs.1.state: opened }
 
 ---
@@ -311,6 +315,7 @@ setup:
   - do:
       ml.get_job_stats: {}
   - match: { count: 2 }
+  - match: { jobs.0.job_id : job-stats-test }
   - match: { jobs.0.data_counts.processed_record_count: 0 }
   - match: { jobs.0.data_counts.processed_field_count: 0 }
   - match: { jobs.0.data_counts.input_field_count: 0 }
@@ -318,6 +323,7 @@ setup:
   - match: { jobs.0.state: closed }
   - is_false: jobs.0.node
   - is_false: jobs.0.open_time
+  - match: { jobs.1.job_id : jobs-get-stats-datafeed-job }
   - match: { jobs.1.data_counts.processed_record_count: 0 }
   - match: { jobs.1.data_counts.processed_field_count: 0 }
   - match: { jobs.1.data_counts.input_field_count: 0 }
@@ -325,5 +331,3 @@ setup:
   - match: { jobs.1.state: closed }
   - is_false: jobs.1.node
   - is_false: jobs.1.open_time
-
-


### PR DESCRIPTION
On reviewing #36683 I noticed the response of GET job stats is not ordered by job id. This commit orders the response. 

Reviewing the code on the 6.x branch this problem was fixed in 6.6 as a side affect of another change. I'm leaving the v6.6.0 label on this even though it won't be back ported so that the release notes are generated for the correct version. 