### PR TITLE
[ML] Resolve 7.0.0 TODOs in ML code

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/OpenJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/OpenJobAction.java
@@ -39,7 +39,6 @@ public class OpenJobAction extends Action<AcknowledgedResponse> {
     public static final OpenJobAction INSTANCE = new OpenJobAction();
     public static final String NAME = "cluster:admin/xpack/ml/job/open";
 
-
     private OpenJobAction() {
         super(NAME);
     }
@@ -132,15 +131,12 @@ public class OpenJobAction extends Action<AcknowledgedResponse> {
 
     public static class JobParams implements XPackPlugin.XPackPersistentTaskParams {
 
-        /** TODO Remove in 7.0.0 */
-        public static final ParseField IGNORE_DOWNTIME = new ParseField("ignore_downtime");
         public static final ParseField TIMEOUT = new ParseField("timeout");
         public static final ParseField JOB = new ParseField("job");
 
         public static ObjectParser<JobParams, Void> PARSER = new ObjectParser<>(MlTasks.JOB_TASK_NAME, true, JobParams::new);
         static {
             PARSER.declareString(JobParams::setJobId, Job.ID);
-            PARSER.declareBoolean((p, v) -> {}, IGNORE_DOWNTIME);
             PARSER.declareString((params, val) ->
                     params.setTimeout(TimeValue.parseTimeValue(val, TIMEOUT.getPreferredName())), TIMEOUT);
             PARSER.declareObject(JobParams::setJob, (p, c) -> Job.LENIENT_PARSER.apply(p, c).build(), JOB);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -130,7 +130,6 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
     public static final ParseField AGGREGATIONS = new ParseField("aggregations");
     public static final ParseField AGGS = new ParseField("aggs");
     public static final ParseField SCRIPT_FIELDS = new ParseField("script_fields");
-    public static final ParseField SOURCE = new ParseField("_source");
     public static final ParseField CHUNKING_CONFIG = new ParseField("chunking_config");
     public static final ParseField HEADERS = new ParseField("headers");
     public static final ParseField DELAYED_DATA_CHECK_CONFIG = new ParseField("delayed_data_check_config");
@@ -185,9 +184,6 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             return parsedScriptFields;
         }, SCRIPT_FIELDS);
         parser.declareInt(Builder::setScrollSize, SCROLL_SIZE);
-        // TODO this is to read former _source field. Remove in v7.0.0
-        parser.declareBoolean((builder, value) -> {
-        }, SOURCE);
         parser.declareObject(Builder::setChunkingConfig, ignoreUnknownFields ? ChunkingConfig.LENIENT_PARSER : ChunkingConfig.STRICT_PARSER,
             CHUNKING_CONFIG);
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
@@ -136,30 +136,7 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
         detectors = Collections.unmodifiableList(in.readList(Detector::new));
         influencers = Collections.unmodifiableList(in.readList(StreamInput::readString));
 
-        // BWC for result_finalization_window and overlapping_buckets
-        // TODO Remove in 7.0.0
-        if (in.getVersion().before(Version.V_6_6_0)) {
-            in.readOptionalBoolean();
-            in.readOptionalLong();
-        }
         multivariateByFields = in.readOptionalBoolean();
-
-        // BWC for removed multiple_bucket_spans
-        // TODO Remove in 7.0.0
-        if (in.getVersion().before(Version.V_6_5_0)) {
-            if (in.readBoolean()) {
-                final int arraySize = in.readVInt();
-                for (int i = 0; i < arraySize; i++) {
-                    in.readTimeValue();
-                }
-            }
-        }
-
-        // BWC for removed per-partition normalization
-        // TODO Remove in 7.0.0
-        if (in.getVersion().before(Version.V_6_5_0)) {
-            in.readBoolean();
-        }
     }
 
     @Override
@@ -180,25 +157,7 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
         out.writeList(detectors);
         out.writeStringList(influencers);
 
-        // BWC for result_finalization_window and overlapping_buckets
-        // TODO Remove in 7.0.0
-        if (out.getVersion().before(Version.V_6_6_0)) {
-            out.writeOptionalBoolean(null);
-            out.writeOptionalLong(null);
-        }
         out.writeOptionalBoolean(multivariateByFields);
-
-        // BWC for removed multiple_bucket_spans
-        // TODO Remove in 7.0.0
-        if (out.getVersion().before(Version.V_6_5_0)) {
-            out.writeBoolean(false);
-        }
-
-        // BWC for removed per-partition normalization
-        // TODO Remove in 7.0.0
-        if (out.getVersion().before(Version.V_6_5_0)) {
-            out.writeBoolean(false);
-        }
     }
 
     /**

--- a/x-pack/plugin/ml/qa/basic-multi-node/src/test/java/org/elasticsearch/xpack/ml/integration/MlBasicMultiNodeIT.java
+++ b/x-pack/plugin/ml/qa/basic-multi-node/src/test/java/org/elasticsearch/xpack/ml/integration/MlBasicMultiNodeIT.java
@@ -266,7 +266,6 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
         xContentBuilder.field("job_id", jobId);
         xContentBuilder.array("indexes", "airline-data");
         xContentBuilder.array("types", "_doc");
-        xContentBuilder.field("_source", true);
         xContentBuilder.endObject();
         Request request = new Request("PUT", MachineLearning.BASE_PATH + "datafeeds/" + datafeedId);
         request.setJsonEntity(Strings.toString(xContentBuilder));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -293,7 +293,6 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
 
     public static boolean isMlNode(DiscoveryNode node) {
         Map<String, String> nodeAttributes = node.getAttributes();
-        boolean enabled;
         try {
             return Integer.parseInt(nodeAttributes.get(MAX_OPEN_JOBS_NODE_ATTR)) > 0;
         } catch (NumberFormatException e) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -259,7 +260,8 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
 
     public static final Setting<Boolean> ML_ENABLED =
             Setting.boolSetting("node.ml", XPackSettings.MACHINE_LEARNING_ENABLED, Property.NodeScope);
-    public static final String ML_ENABLED_NODE_ATTR = "ml.enabled";
+    // This is not used in v7 and higher, but users are still prevented from setting it directly to avoid confusion
+    private static final String PRE_V7_ML_ENABLED_NODE_ATTR = "ml.enabled";
     public static final String MAX_OPEN_JOBS_NODE_ATTR = "ml.max_open_jobs";
     public static final String MACHINE_MEMORY_NODE_ATTR = "ml.machine_memory";
     public static final Setting<Integer> CONCURRENT_JOB_ALLOCATIONS =
@@ -289,6 +291,15 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
 
     protected XPackLicenseState getLicenseState() { return XPackPlugin.getSharedLicenseState(); }
 
+    public static boolean isMlNode(DiscoveryNode node) {
+        Map<String, String> nodeAttributes = node.getAttributes();
+        boolean enabled;
+        try {
+            return Integer.parseInt(nodeAttributes.get(MAX_OPEN_JOBS_NODE_ATTR)) > 0;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
 
     public List<Setting<?>> getSettings() {
         return Collections.unmodifiableList(
@@ -299,16 +310,14 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                         MAX_LAZY_ML_NODES,
                         MAX_MACHINE_MEMORY_PERCENT,
                         AutodetectBuilder.DONT_PERSIST_MODEL_STATE_SETTING,
-                        AutodetectBuilder.MAX_ANOMALY_RECORDS_SETTING,
                         AutodetectBuilder.MAX_ANOMALY_RECORDS_SETTING_DYNAMIC,
-                        AutodetectProcessManager.MAX_RUNNING_JOBS_PER_NODE,
                         AutodetectProcessManager.MAX_OPEN_JOBS_PER_NODE,
                         AutodetectProcessManager.MIN_DISK_SPACE_OFF_HEAP,
                         MlConfigMigrationEligibilityCheck.ENABLE_CONFIG_MIGRATION));
     }
 
     public Settings additionalSettings() {
-        String mlEnabledNodeAttrName = "node.attr." + ML_ENABLED_NODE_ATTR;
+        String mlEnabledNodeAttrName = "node.attr." + PRE_V7_ML_ENABLED_NODE_ATTR;
         String maxOpenJobsPerNodeNodeAttrName = "node.attr." + MAX_OPEN_JOBS_NODE_ATTR;
         String machineMemoryAttrName = "node.attr." + MACHINE_MEMORY_NODE_ATTR;
 
@@ -320,8 +329,6 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
         Settings.Builder additionalSettings = Settings.builder();
         Boolean allocationEnabled = ML_ENABLED.get(settings);
         if (allocationEnabled != null && allocationEnabled) {
-            // TODO: the simple true/false flag will not be required once all supported versions have the number - consider removing in 7.0
-            addMlNodeAttribute(additionalSettings, mlEnabledNodeAttrName, "true");
             addMlNodeAttribute(additionalSettings, maxOpenJobsPerNodeNodeAttrName,
                     String.valueOf(AutodetectProcessManager.MAX_OPEN_JOBS_PER_NODE.get(settings)));
             addMlNodeAttribute(additionalSettings, machineMemoryAttrName,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -333,6 +333,8 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                     String.valueOf(AutodetectProcessManager.MAX_OPEN_JOBS_PER_NODE.get(settings)));
             addMlNodeAttribute(additionalSettings, machineMemoryAttrName,
                     Long.toString(machineMemoryFromStats(OsProbe.getInstance().osStats())));
+            // This is not used in v7 and higher, but users are still prevented from setting it directly to avoid confusion
+            disallowMlNodeAttributes(mlEnabledNodeAttrName);
         } else {
             disallowMlNodeAttributes(mlEnabledNodeAttrName, maxOpenJobsPerNodeNodeAttrName, machineMemoryAttrName);
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSet.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSet.java
@@ -143,8 +143,7 @@ public class MachineLearningFeatureSet implements XPackFeatureSet {
 
         int mlNodeCount = 0;
         for (DiscoveryNode node : clusterState.getNodes()) {
-            String enabled = node.getAttributes().get(MachineLearning.ML_ENABLED_NODE_ATTR);
-            if (Boolean.parseBoolean(enabled)) {
+            if (MachineLearning.isMlNode(node)) {
                 ++mlNodeCount;
             }
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
@@ -399,9 +399,7 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
         // The quantiles type and doc ID changed in v5.5 so delete both the old and new format
         DeleteByQueryRequest request = new DeleteByQueryRequest(AnomalyDetectorsIndex.jobStateIndexName());
         // Just use ID here, not type, as trying to delete different types spams the logs with an exception stack trace
-        IdsQueryBuilder query = new IdsQueryBuilder().addIds(Quantiles.documentId(jobId),
-                // TODO: remove in 7.0
-                Quantiles.v54DocumentId(jobId));
+        IdsQueryBuilder query = new IdsQueryBuilder().addIds(Quantiles.documentId(jobId));
         request.setQuery(query);
         request.setIndicesOptions(MlIndicesUtils.addIgnoreUnavailable(IndicesOptions.lenientExpandOpen()));
         request.setAbortOnVersionConflict(false);
@@ -436,9 +434,7 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
         // The categorizer state type and doc ID changed in v5.5 so delete both the old and new format
         DeleteByQueryRequest request = new DeleteByQueryRequest(AnomalyDetectorsIndex.jobStateIndexName());
         // Just use ID here, not type, as trying to delete different types spams the logs with an exception stack trace
-        IdsQueryBuilder query = new IdsQueryBuilder().addIds(CategorizerState.documentId(jobId, docNum),
-                // TODO: remove in 7.0
-                CategorizerState.v54DocumentId(jobId, docNum));
+        IdsQueryBuilder query = new IdsQueryBuilder().addIds(CategorizerState.documentId(jobId, docNum));
         request.setQuery(query);
         request.setIndicesOptions(MlIndicesUtils.addIgnoreUnavailable(IndicesOptions.lenientExpandOpen()));
         request.setAbortOnVersionConflict(false);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPersistJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPersistJobAction.java
@@ -5,21 +5,13 @@
  */
 package org.elasticsearch.xpack.ml.action;
 
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
-import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.PersistJobAction;
-import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager;
 
 public class TransportPersistJobAction extends TransportJobTaskAction<PersistJobAction.Request, PersistJobAction.Response> {
@@ -43,34 +35,5 @@ public class TransportPersistJobAction extends TransportJobTaskAction<PersistJob
                 listener.onFailure(e);
             }
         });
-    }
-
-    @Override
-    protected void doExecute(Task task, PersistJobAction.Request request, ActionListener<PersistJobAction.Response> listener) {
-        // TODO Remove this overridden method in 7.0.0
-        DiscoveryNodes nodes = clusterService.state().nodes();
-        PersistentTasksCustomMetaData tasks = clusterService.state().getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
-        PersistentTasksCustomMetaData.PersistentTask<?> jobTask = MlTasks.getJobTask(request.getJobId(), tasks);
-        if (jobTask == null || jobTask.getExecutorNode() == null) {
-            logger.debug("[{}] Cannot persist the job because the job is not open", request.getJobId());
-            listener.onResponse(new PersistJobAction.Response(false));
-            return;
-        }
-
-        DiscoveryNode executorNode = nodes.get(jobTask.getExecutorNode());
-        if (executorNode == null) {
-            listener.onFailure(ExceptionsHelper.conflictStatusException("Cannot persist job [{}] as" +
-                    "executor node [{}] cannot be found", request.getJobId(), jobTask.getExecutorNode()));
-            return;
-        }
-
-        Version nodeVersion = executorNode.getVersion();
-        if (nodeVersion.before(Version.V_6_3_0)) {
-            listener.onFailure(
-                    new ElasticsearchException("Cannot persist job [" + request.getJobId() + "] on node with version " + nodeVersion));
-            return;
-        }
-
-        super.doExecute(task, request, listener);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectBuilder.java
@@ -82,16 +82,9 @@ public class AutodetectBuilder {
     /**
      * The maximum number of anomaly records that will be written each bucket
      */
-    @Deprecated
-    public static final Setting<Integer> MAX_ANOMALY_RECORDS_SETTING = Setting.intSetting("max.anomaly.records", DEFAULT_MAX_NUM_RECORDS,
-            Setting.Property.NodeScope, Setting.Property.Deprecated);
-    // Though this setting is dynamic, it is only set when a new job is opened. So, already runnin jobs will not get the updated value.
-    public static final Setting<Integer> MAX_ANOMALY_RECORDS_SETTING_DYNAMIC = Setting.intSetting(
-        "xpack.ml.max_anomaly_records",
-        MAX_ANOMALY_RECORDS_SETTING,
-        1,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic);
+    // Though this setting is dynamic, it is only set when a new job is opened. So, already running jobs will not get the updated value.
+    public static final Setting<Integer> MAX_ANOMALY_RECORDS_SETTING_DYNAMIC = Setting.intSetting("xpack.ml.max_anomaly_records",
+            DEFAULT_MAX_NUM_RECORDS, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     /**
      * Config setting storing the flag that disables model persistence

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -95,15 +95,11 @@ public class AutodetectProcessManager {
     // available resources on that node: https://github.com/elastic/x-pack-elasticsearch/issues/546
     // However, it is useful to also be able to apply a hard limit.
 
-    // WARNING: These settings cannot be made DYNAMIC, because they are tied to several threadpools
+    // WARNING: This setting cannot be made DYNAMIC, because it is tied to several threadpools
     // and a threadpool's size can't be changed at runtime.
     // See MachineLearning#getExecutorBuilders(...)
-    // TODO: Remove the deprecated setting in 7.0 and move the default value to the replacement setting
-    @Deprecated
-    public static final Setting<Integer> MAX_RUNNING_JOBS_PER_NODE =
-            Setting.intSetting("max_running_jobs", 20, 1, 512, Property.NodeScope, Property.Deprecated);
     public static final Setting<Integer> MAX_OPEN_JOBS_PER_NODE =
-            Setting.intSetting("xpack.ml.max_open_jobs", MAX_RUNNING_JOBS_PER_NODE, 1, Property.NodeScope);
+            Setting.intSetting("xpack.ml.max_open_jobs", 20, 1, 512, Property.NodeScope);
 
     // Undocumented setting for integration test purposes
     public static final Setting<ByteSizeValue> MIN_DISK_SPACE_OFF_HEAP =

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
@@ -342,7 +342,7 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
         for (int i = 0; i < nodeCount; i++) {
             Map<String, String> attrs = new HashMap<>();
-            attrs.put(MachineLearning.ML_ENABLED_NODE_ATTR, Boolean.toString(true));
+            attrs.put(MachineLearning.MAX_OPEN_JOBS_NODE_ATTR, Integer.toString(20));
             Set<DiscoveryNode.Role> roles = new HashSet<>();
             roles.add(DiscoveryNode.Role.DATA);
             roles.add(DiscoveryNode.Role.MASTER);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
@@ -209,7 +209,6 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
             PersistentTask<?> task = tasks.getTask(MlTasks.jobTaskId(jobId));
 
             DiscoveryNode node = clusterState.nodes().resolveNode(task.getExecutorNode());
-            assertThat(node.getAttributes(), hasEntry(MachineLearning.ML_ENABLED_NODE_ATTR, "true"));
             assertThat(node.getAttributes(), hasEntry(MachineLearning.MAX_OPEN_JOBS_NODE_ATTR, "20"));
             JobTaskState jobTaskState = (JobTaskState) task.getState();
             assertNotNull(jobTaskState);
@@ -425,7 +424,6 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
             assertNotNull(task.getExecutorNode());
             assertFalse(needsReassignment(task.getAssignment(), clusterState.nodes()));
             DiscoveryNode node = clusterState.nodes().resolveNode(task.getExecutorNode());
-            assertThat(node.getAttributes(), hasEntry(MachineLearning.ML_ENABLED_NODE_ATTR, "true"));
             assertThat(node.getAttributes(), hasEntry(MachineLearning.MAX_OPEN_JOBS_NODE_ATTR, "20"));
 
             JobTaskState jobTaskState = (JobTaskState) task.getState();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
@@ -153,25 +153,6 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         assertEquals(7, maxOpenJobs);
     }
 
-    public void testMaxOpenJobsSetting_givenOldSettingOnly() {
-        Settings.Builder settings = Settings.builder();
-        settings.put(AutodetectProcessManager.MAX_RUNNING_JOBS_PER_NODE.getKey(), 9);
-        int maxOpenJobs = AutodetectProcessManager.MAX_OPEN_JOBS_PER_NODE.get(settings.build());
-        assertEquals(9, maxOpenJobs);
-        assertWarnings("[max_running_jobs] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version.");
-    }
-
-    public void testMaxOpenJobsSetting_givenOldAndNewSettings() {
-        Settings.Builder settings = Settings.builder();
-        settings.put(AutodetectProcessManager.MAX_OPEN_JOBS_PER_NODE.getKey(), 7);
-        settings.put(AutodetectProcessManager.MAX_RUNNING_JOBS_PER_NODE.getKey(), 9);
-        int maxOpenJobs = AutodetectProcessManager.MAX_OPEN_JOBS_PER_NODE.get(settings.build());
-        assertEquals(7, maxOpenJobs);
-        assertWarnings("[max_running_jobs] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version.");
-    }
-
     public void testOpenJob() {
         Client client = mock(Client.class);
         AutodetectCommunicator communicator = mock(AutodetectCommunicator.class);

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
@@ -160,7 +160,7 @@ setup:
   - match: { datafeeds.0.state: "started"}
   - is_true: datafeeds.0.node.name
   - is_true: datafeeds.0.node.transport_address
-  - match: { datafeeds.0.node.attributes.ml\.enabled: "true"}
+  - match: { datafeeds.0.node.attributes.ml\.max_open_jobs: "20"}
 
 ---
 "Test implicit get all datafeed stats given started datafeeds":

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_stats.yml
@@ -97,7 +97,7 @@ setup:
   - match: { jobs.0.state: opened }
   - is_true: jobs.0.node.name
   - is_true: jobs.0.node.transport_address
-  - match: { jobs.0.node.attributes.ml\.enabled: "true"}
+  - match: { jobs.0.node.attributes.ml\.max_open_jobs: "20"}
   - is_true: jobs.0.open_time
 
 ---


### PR DESCRIPTION
This change cleans up a number of ugly BWC
workarounds in the ML code.

7.0 cannot run in a mixed version cluster with
versions prior to 6.7, so code that deals with
these old versions is no longer required.

Closes #29963