### PR TITLE
[Docs] Fix URL path to aliases

### DIFF
--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -56,4 +56,4 @@ configurations in `alias3` and `alias4`.
 
 If you only want to get information about specific aliases, you can specify 
 the aliases in comma-delimited format as a URL parameter, e.g., 
-/_cat/aliases/aliases/alias1,alias2.
+/_cat/aliases/alias1,alias2.


### PR DESCRIPTION
This API URL contains `/aliases/aliases` and that seems to be a duplicate