### PR TITLE
Fix broken documentation links in deprecation checks

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -21,7 +21,8 @@ public class ClusterDeprecationChecks {
         if (nodeCount > 0 && currentOpenShards >= maxShardsInCluster) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "Number of open shards exceeds cluster soft limit",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html",
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                    "#_cluster_wide_shard_soft_limit",
                 "There are [" + currentOpenShards + "] open shards in this cluster, but the cluster is limited to [" +
                     shardsPerNode + "] per data node, for [" + maxShardsInCluster + "] maximum.");
         }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -92,7 +92,8 @@ public class IndexDeprecationChecks {
         }
         if (issues.size() > 0) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING, "Use of 'delimited_payload_filter'.",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_analysis_changes.html", issues.toString());
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                    "#_literal_delimited_payload_filter_literal_renaming", issues.toString());
         }
         return null;
     }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -144,7 +144,7 @@ public class IndexDeprecationChecks {
         if (issues.size() > 0) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "Classic similarity has been removed",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/" +
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#_the_literal_classic_literal_similarity_has_been_removed",
                 "Fields which use classic similarity: " + issues.toString());
         }
@@ -160,7 +160,7 @@ public class IndexDeprecationChecks {
         if (classicSimilarities.size() > 0) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "Classic similarity has been removed",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/" +
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#_the_literal_classic_literal_similarity_has_been_removed",
                 "Custom similarities defined using classic similarity: " + classicSimilarities.toString());
         }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -32,7 +32,7 @@ public class NodeDeprecationChecks {
         if (nodesFound.size() > 0) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "HTTP Enabled setting removed",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#remove-http-enabled",
                 "nodes with http.enabled set: " + nodesFound);
         }
@@ -47,7 +47,7 @@ public class NodeDeprecationChecks {
         if (nodesFound.size() > 0) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "Audit log node info settings renamed",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#audit-logfile-local-node-info",
                 "nodes with audit log settings that have been renamed: " + nodesFound);
         }
@@ -62,7 +62,7 @@ public class NodeDeprecationChecks {
         if (nodesFound.size() > 0) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "Index thread pool removed in favor of combined write thread pool",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#_index_thread_pool",
                 "nodes with index thread pool settings: " + nodesFound);
         }
@@ -76,7 +76,7 @@ public class NodeDeprecationChecks {
         if (nodesFound.size() > 0) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "Bulk thread pool renamed to write thread pool",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#write-thread-pool-fallback",
                 "nodes with bulk thread pool settings: " + nodesFound);
         }
@@ -91,7 +91,7 @@ public class NodeDeprecationChecks {
         if (nodesFound.size() > 0) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "Tribe Node removed in favor of Cross Cluster Search",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#_tribe_node_removed",
                 "nodes with tribe node settings: " + nodesFound);
         }
@@ -106,7 +106,7 @@ public class NodeDeprecationChecks {
         if (nodesFound.size() > 0) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "HTTP pipelining setting removed as pipelining is now mandatory",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#remove-http-pipelining-setting",
                 "nodes with http.pipelining set: " + nodesFound);
         }
@@ -127,7 +127,7 @@ public class NodeDeprecationChecks {
         if (nodesFound.size() > 0) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "Discovery configuration is required in production mode",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#_discovery_configuration_is_required_in_production",
                 "nodes which do not have discovery configured: " + nodesFound);
         }
@@ -143,7 +143,7 @@ public class NodeDeprecationChecks {
         if (nodesFound.size() > 0) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "Azure Repository settings changed",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#_azure_repository_plugin",
                 "nodes with repository-azure installed: " + nodesFound);
         }
@@ -159,7 +159,7 @@ public class NodeDeprecationChecks {
         if (nodesFound.size() > 0) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "GCS Repository settings changed",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#_google_cloud_storage_repository_plugin",
                 "nodes with repository-gcs installed: " + nodesFound);
         }
@@ -175,7 +175,7 @@ public class NodeDeprecationChecks {
         if (nodesFound.size() > 0) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "File-based discovery is no longer a plugin and uses a different path",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#_file_based_discovery_plugin",
                 "nodes with discovery-file installed: " + nodesFound);
         }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -67,7 +67,8 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(CLUSTER_SETTINGS_CHECKS, c -> c.apply(state));
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "Number of open shards exceeds cluster soft limit",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                "#_cluster_wide_shard_soft_limit",
             "There are [" + currentOpenShards + "] open shards in this cluster, but the cluster is limited to [" +
                 shardsPerNode + "] per data node, for [" + maxShardsInCluster + "] maximum.");
         assertEquals(singletonList(expected), issues);

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -49,7 +49,8 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             .put("index.analysis.filter.my_delimited_payload_filter.encoding", "identity").build();
         IndexMetaData indexMetaData = IndexMetaData.builder("test").settings(settings).numberOfShards(1).numberOfReplicas(0).build();
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING, "Use of 'delimited_payload_filter'.",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_analysis_changes.html",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                "#_literal_delimited_payload_filter_literal_renaming",
             "[The filter [my_delimited_payload_filter] is of deprecated 'delimited_payload_filter' type. "
                 + "The filter type should be changed to 'delimited_payload'.]");
         List<DeprecationIssue> issues = DeprecationInfoAction.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(indexMetaData));
@@ -131,7 +132,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             .build();
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "Classic similarity has been removed",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/" +
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                 "#_the_literal_classic_literal_similarity_has_been_removed",
             "Fields which use classic similarity: [[type: _doc, field: classic_sim_field]]");
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(index));
@@ -150,7 +151,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "Classic similarity has been removed",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/" +
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                 "#_the_literal_classic_literal_similarity_has_been_removed",
             "Custom similarities defined using classic similarity: [my_classic_similarity]");
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(index));

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -67,7 +67,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
     public void testHttpEnabledCheck() {
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "HTTP Enabled setting removed",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                 "#remove-http-enabled",
             "nodes with http.enabled set: [node_check]");
         assertSettingsAndIssue("http.enabled", Boolean.toString(randomBoolean()), expected);
@@ -76,7 +76,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
     public void testAuditLoggingPrefixSettingsCheck() {
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "Audit log node info settings renamed",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                 "#audit-logfile-local-node-info",
             "nodes with audit log settings that have been renamed: [node_check]");
         assertSettingsAndIssue("xpack.security.audit.logfile.prefix.emit_node_host_address", Boolean.toString(randomBoolean()), expected);
@@ -87,7 +87,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
     public void testIndexThreadPoolCheck() {
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "Index thread pool removed in favor of combined write thread pool",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                 "#_index_thread_pool",
             "nodes with index thread pool settings: [node_check]");
         assertSettingsAndIssue("thread_pool.index.size", Integer.toString(randomIntBetween(1, 20000)), expected);
@@ -97,7 +97,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
     public void testBulkThreadPoolCheck() {
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "Bulk thread pool renamed to write thread pool",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                 "#write-thread-pool-fallback",
             "nodes with bulk thread pool settings: [node_check]");
         assertSettingsAndIssue("thread_pool.bulk.size", Integer.toString(randomIntBetween(1, 20000)), expected);
@@ -108,7 +108,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         String tribeSetting = "tribe." + randomAlphaOfLengthBetween(1, 20) + ".cluster.name";
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "Tribe Node removed in favor of Cross Cluster Search",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                 "#_tribe_node_removed",
             "nodes with tribe node settings: [node_check]");
         assertSettingsAndIssue(tribeSetting, randomAlphaOfLength(5), expected);
@@ -117,7 +117,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
     public void testHttpPipeliningCheck() {
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "HTTP pipelining setting removed as pipelining is now mandatory",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                 "#remove-http-pipelining-setting",
             "nodes with http.pipelining set: [node_check]");
         assertSettingsAndIssue("http.pipelining", Boolean.toString(randomBoolean()), expected);
@@ -165,7 +165,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
             DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "Discovery configuration is required in production mode",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#_discovery_configuration_is_required_in_production",
                 "nodes which do not have discovery configured: [node_check]");
             List<DeprecationIssue> issues = DeprecationChecks.filterChecks(NODE_SETTINGS_CHECKS, c -> c.apply(nodeInfos, nodeStats));
@@ -183,7 +183,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "Azure Repository settings changed",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                 "#_azure_repository_plugin",
             "nodes with repository-azure installed: [node_check]");
         assertSettingsAndIssue("foo", "bar", expected);
@@ -198,7 +198,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "GCS Repository settings changed",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                 "#_google_cloud_storage_repository_plugin",
             "nodes with repository-gcs installed: [node_check]");
         assertSettingsAndIssue("foo", "bar", expected);
@@ -213,7 +213,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "File-based discovery is no longer a plugin and uses a different path",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_cluster_changes.html" +
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                 "#_file_based_discovery_plugin",
             "nodes with discovery-file installed: [node_check]");
         assertSettingsAndIssue("foo", "bar", expected);


### PR DESCRIPTION
There are some broken documentation links in the deprecation checks
due to URL format changes. This commit fixes them.