### PR TITLE
[Geo] Integrate Lucene's LatLonShape (BKD Backed GeoShapes) as default `geo_shape` indexing approach

### DIFF
--- a/buildSrc/src/main/resources/forbidden/es-server-signatures.txt
+++ b/buildSrc/src/main/resources/forbidden/es-server-signatures.txt
@@ -147,3 +147,13 @@ org.apache.logging.log4j.Logger#error(java.lang.Object)
 org.apache.logging.log4j.Logger#error(java.lang.Object, java.lang.Throwable)
 org.apache.logging.log4j.Logger#fatal(java.lang.Object)
 org.apache.logging.log4j.Logger#fatal(java.lang.Object, java.lang.Throwable)
+
+# Remove once Lucene 7.7 is integrated
+@defaultMessage Use org.apache.lucene.document.XLatLonShape classes instead
+org.apache.lucene.document.LatLonShape
+org.apache.lucene.document.LatLonShapeBoundingBoxQuery
+org.apache.lucene.document.LatLonShapeLineQuery
+org.apache.lucene.document.LatLonShapePolygonQuery
+org.apache.lucene.document.LatLonShapeQuery
+
+org.apache.lucene.geo.Tessellator @ use @org.apache.lucene.geo.XTessellator instead

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -21,48 +21,59 @@ type.
 |=======================================================================
 |Option |Description| Default
 
-|`tree` |Name of the PrefixTree implementation to be used: `geohash` for
-GeohashPrefixTree and `quadtree` for QuadPrefixTree.
-| `geohash`
+|`tree |deprecated[6.6, PrefixTrees no longer used] Name of the PrefixTree
+implementation to be used: `geohash` for GeohashPrefixTree and `quadtree`
+for QuadPrefixTree. Note: This parameter is only relevant for `term` and
+`recursive` strategies.
+| `quadtree`
 
-|`precision` |This parameter may be used instead of `tree_levels` to set
-an appropriate value for the `tree_levels` parameter. The value
-specifies the desired precision and Elasticsearch will calculate the
-best tree_levels value to honor this precision. The value should be a
-number followed by an optional distance unit. Valid distance units
-include: `in`, `inch`, `yd`, `yard`, `mi`, `miles`, `km`, `kilometers`,
-`m`,`meters`, `cm`,`centimeters`, `mm`, `millimeters`.
-| `meters`
-
-|`tree_levels` |Maximum number of layers to be used by the PrefixTree.
-This can be used to control the precision of shape representations and
-therefore how many terms are indexed. Defaults to the default value of
-the chosen PrefixTree implementation. Since this parameter requires a
-certain level of understanding of the underlying implementation, users
-may use the `precision` parameter instead. However, Elasticsearch only
-uses the tree_levels parameter internally and this is what is returned
-via the mapping API even if you use the precision parameter.
+|`precision` |deprecated[6.6, PrefixTrees no longer used] This parameter may
+be used instead of `tree_levels` to set an appropriate value for the
+`tree_levels` parameter. The value specifies the desired precision and
+Elasticsearch will calculate the best tree_levels value to honor this
+precision. The value should be a number followed by an optional distance
+unit. Valid distance units include: `in`, `inch`, `yd`, `yard`, `mi`,
+`miles`, `km`, `kilometers`, `m`,`meters`, `cm`,`centimeters`, `mm`,
+`millimeters`. Note: This parameter is only relevant for `term` and
+`recursive` strategies.
 | `50m`
 
-|`strategy` |The strategy parameter defines the approach for how to
-represent shapes at indexing and search time. It also influences the
-capabilities available so it is recommended to let Elasticsearch set
-this parameter automatically. There are two strategies available:
-`recursive` and `term`. Term strategy supports point types only (the
-`points_only` parameter will be automatically set to true) while
-Recursive strategy supports all shape types. (IMPORTANT: see
-<<prefix-trees, Prefix trees>> for more detailed information)
+|`tree_levels` |deprecated[6.6, PrefixTrees no longer used] Maximum number
+of layers to be used by the PrefixTree. This can be used to control the
+precision of shape representations andtherefore how many terms are
+indexed. Defaults to the default value of the chosen PrefixTree
+implementation. Since this parameter requires a certain level of
+understanding of the underlying implementation, users may use the
+`precision` parameter instead. However, Elasticsearch only uses the
+tree_levels parameter internally and this is what is returned via the
+mapping API even if you use the precision parameter. Note: This parameter
+is only relevant for `term` and `recursive` strategies.
+| various
+
+|`strategy` |deprecated[6.6, PrefixTrees no longer used] The strategy
+parameter defines the approach for how to represent shapes at indexing
+and search time. It also influences the capabilities available so it
+is recommended to let Elasticsearch set this parameter automatically.
+There are two strategies available: `recursive`, and `term`.
+Recursive and Term strategies are deprecated and will be removed in a
+future version. While they are still available, the Term strategy
+supports point types only (the `points_only` parameter will be
+automatically set to true) while Recursive strategy supports all
+shape types. (IMPORTANT: see <<prefix-trees, Prefix trees>> for more
+detailed information about these strategies)
 | `recursive`
 
-|`distance_error_pct` |Used as a hint to the PrefixTree about how
-precise it should be. Defaults to 0.025 (2.5%) with 0.5 as the maximum
-supported value. PERFORMANCE NOTE: This value will default to 0 if a `precision` or
-`tree_level` definition is explicitly defined. This guarantees spatial precision
-at the level defined in the mapping. This can lead to significant memory usage
-for high resolution shapes with low error (e.g., large shapes at 1m with < 0.001 error).
-To improve indexing performance (at the cost of query accuracy) explicitly define
-`tree_level` or `precision` along with a reasonable `distance_error_pct`, noting
-that large shapes will have greater false positives.
+|`distance_error_pct` |deprecated[6.6, PrefixTrees no longer used] Used as a
+hint to the PrefixTree about how precise it should be. Defaults to 0.025 (2.5%)
+with 0.5 as the maximum supported value. PERFORMANCE NOTE: This value will
+default to 0 if a `precision` or `tree_level` definition is explicitly defined.
+This guarantees spatial precision at the level defined in the mapping. This can
+lead to significant memory usage for high resolution shapes with low error
+(e.g., large shapes at 1m with < 0.001 error). To improve indexing performance
+(at the cost of query accuracy) explicitly define `tree_level` or `precision`
+along with a reasonable `distance_error_pct`, noting that large shapes will have
+greater false positives. Note: This parameter is only relevant for `term` and
+`recursive` strategies.
 | `0.025`
 
 |`orientation` |Optionally define how to interpret vertex order for
@@ -77,13 +88,13 @@ sets vertex order for the coordinate list of a geo_shape field but can be
 overridden in each individual GeoJSON or WKT document.
 | `ccw`
 
-|`points_only` |Setting this option to `true` (defaults to `false`) configures
-the `geo_shape` field type for point shapes only (NOTE: Multi-Points are not
-yet supported). This optimizes index and search performance for the `geohash` and
-`quadtree` when it is known that only points will be indexed. At present geo_shape
-queries can not be executed on `geo_point` field types. This option bridges the gap
-by improving point performance on a `geo_shape` field so that `geo_shape` queries are
-optimal on a point only field.
+|`points_only` |deprecated[6.6, PrefixTrees no longer used] Setting this option to
+`true` (defaults to `false`) configures the `geo_shape` field type for point
+shapes only (NOTE: Multi-Points are not yet supported). This optimizes index and
+search performance for the `geohash` and `quadtree` when it is known that only points
+will be indexed. At present geo_shape queries can not be executed on `geo_point`
+field types. This option bridges the gap by improving point performance on a
+`geo_shape` field so that `geo_shape` queries are optimal on a point only field.
 | `false`
 
 |`ignore_malformed` |If true, malformed GeoJSON or WKT shapes are ignored. If
@@ -100,16 +111,35 @@ and reject the whole document.
 
 |=======================================================================
 
+
+[[geoshape-indexing-approach]]
+[float]
+==== Indexing approach
+GeoShape types are indexed by decomposing the shape into a triangular mesh and
+indexing each triangle as a 7 dimension point in a BKD tree. This provides
+near perfect spatial resolution (down to 1e-7 decimal degree precision) since all
+spatial relations are computed using an encoded vector representation of the
+original shape instead of a raster-grid representation as used by the
+<<prefix-trees>> indexing approach. Performance of the tessellator primarily
+depends on the number of vertices that define the polygon/multi-polyogn. While
+this is the default indexing technique prefix trees can still be used by setting
+the `tree` or `strategy` parameters according to the appropriate
+<<geo-shape-mapping-options>>. Note that these parameters are now deprecated
+and will be removed in a future version.
+
 [[prefix-trees]]
 [float]
 ==== Prefix trees
 
-To efficiently represent shapes in the index, Shapes are converted into
-a series of hashes representing grid squares (commonly referred to as "rasters")
-using implementations of a PrefixTree. The tree notion comes from the fact that
-the PrefixTree uses multiple grid layers, each with an increasing level of
-precision to represent the Earth. This can be thought of as increasing the level
-of detail of a map or image at higher zoom levels.
+deprecated[6.6, PrefixTrees no longer used] To efficiently represent shapes in
+an inverted index, Shapes are converted into a series of hashes representing
+grid squares (commonly referred to as "rasters") using implementations of a
+PrefixTree. The tree notion comes from the fact that the PrefixTree uses multiple
+grid layers, each with an increasing level of precision to represent the Earth.
+This can be thought of as increasing the level of detail of a map or image at higher
+zoom levels. Since this approach causes precision issues with indexed shape, it has
+been deprecated in favor of a vector indexing approach that indexes the shapes as a
+triangular mesh (see <<geoshape-indexing-approach>>).
 
 Multiple PrefixTree implementations are provided:
 
@@ -131,9 +161,10 @@ amount of levels for the quad trees in Elasticsearch is 50.
 [[spatial-strategy]]
 [float]
 ===== Spatial strategies
-The PrefixTree implementations rely on a SpatialStrategy for decomposing
-the provided Shape(s) into approximated grid squares. Each strategy answers
-the following:
+deprecated[6.6, PrefixTrees no longer used]  The indexing implementation
+selected relies on a  SpatialStrategy for choosing how to decompose the shapes
+(either as grid  squares or a tessellated triangular mesh). Each strategy
+answers the following:
 
 * What type of Shapes can be indexed?
 * What types of Query Operations and Shapes can be used?
@@ -146,7 +177,7 @@ are provided:
 |=======================================================================
 |Strategy |Supported Shapes |Supported Queries |Multiple Shapes
 
-|`recursive` |<<input-structure, All>> |`INTERSECTS`, `DISJOINT`, `WITHIN`, `CONTAINS` |Yes
+|`recursive`  |<<input-structure, All>> |`INTERSECTS`, `DISJOINT`, `WITHIN`, `CONTAINS` |Yes
 |`term` |<<point, Points>> |`INTERSECTS` |Yes
 
 |=======================================================================
@@ -154,13 +185,13 @@ are provided:
 [float]
 ===== Accuracy
 
-Geo_shape does not provide 100% accuracy and depending on how it is configured
-it may return some false positives for `INTERSECTS`, `WITHIN` and `CONTAINS`
-queries, and some false negatives for `DISJOINT` queries. To mitigate this, it
-is important to select an appropriate value for the tree_levels parameter and
-to adjust expectations accordingly. For example, a point may be near the border
-of a particular grid cell and may thus not match a query that only matches the
-cell right next to it -- even though the shape is very close to the point.
+`Recursive` and `Term` strategies do not provide 100% accuracy and depending on
+how they are configured it may return some false positives for `INTERSECTS`,
+`WITHIN` and `CONTAINS` queries, and some false negatives for `DISJOINT` queries.
+To mitigate this, it is important to select an appropriate value for the tree_levels
+parameter and to adjust expectations accordingly. For example, a point may be near
+the border of a particular grid cell and may thus not match a query that only matches
+the cell right next to it -- even though the shape is very close to the point.
 
 [float]
 ===== Example
@@ -173,9 +204,7 @@ PUT /example
         "doc": {
             "properties": {
                 "location": {
-                    "type": "geo_shape",
-                    "tree": "quadtree",
-                    "precision": "100m"
+                    "type": "geo_shape"
                 }
             }
         }
@@ -185,22 +214,23 @@ PUT /example
 // CONSOLE
 // TESTSETUP
 
-This mapping maps the location field to the geo_shape type using the
-quad_tree implementation and a precision of 100m. Elasticsearch translates
-this into a tree_levels setting of 20.
+This mapping definition maps the location field to the geo_shape
+type using the default vector implementation. It provides
+approximately 1e-7 decimal degree precision.
 
 [float]
-===== Performance considerations
+===== Performance considerations with Prefix Trees
 
-Elasticsearch uses the paths in the prefix tree as terms in the index
-and in queries. The higher the level is (and thus the precision), the
-more terms are generated. Of course, calculating the terms, keeping them in
+deprecated[6.6, PrefixTrees no longer used] With prefix trees,
+Elasticsearch uses the paths in the tree as terms in the inverted index
+and in queries. The higher the level (and thus the precision), the more
+terms are generated. Of course, calculating the terms, keeping them in
 memory, and storing them on disk all have a price. Especially with higher
-tree levels, indices can become extremely large even with a modest
-amount of data. Additionally, the size of the features also matters.
-Big, complex polygons can take up a lot of space at higher tree levels.
-Which setting is right depends on the use case. Generally one trades off
-accuracy against index size and query performance.
+tree levels, indices can become extremely large even with a modest amount
+of data. Additionally, the size of the features also matters. Big, complex
+polygons can take up a lot of space at higher tree levels. Which setting
+is right depends on the use case. Generally one trades off accuracy against
+index size and query performance.
 
 The defaults in Elasticsearch for both implementations are a compromise
 between index size and a reasonable level of precision of 50m at the
@@ -598,7 +628,10 @@ POST /example/doc
 ===== Circle
 
 Elasticsearch supports a `circle` type, which consists of a center
-point with a radius:
+point with a radius. Note that this circle representation can only
+be indexed when using the `recursive` Prefix Tree strategy. For
+the default <<geoshape-indexing-approach>> circles should be approximated using
+a `POLYGON`.
 
 [source,js]
 --------------------------------------------------
@@ -612,6 +645,7 @@ POST /example/doc
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[skip:not supported in default]
 
 Note: The inner `radius` field is required. If not specified, then
 the units of the `radius` will default to `METERS`.

--- a/docs/reference/query-dsl/geo-shape-query.asciidoc
+++ b/docs/reference/query-dsl/geo-shape-query.asciidoc
@@ -7,7 +7,7 @@ Requires the <<geo-shape,`geo_shape` Mapping>>.
 
 The `geo_shape` query uses the same grid square representation as the
 `geo_shape` mapping to find documents that have a shape that intersects
-with the query shape. It will also use the same PrefixTree configuration
+with the query shape. It will also use the same Prefix Tree configuration
 as defined for the field mapping.
 
 The query supports two ways of defining the query shape, either by
@@ -157,7 +157,8 @@ has nothing in common with the query geometry.
 * `WITHIN` - Return all documents whose `geo_shape` field
 is within the query geometry.
 * `CONTAINS` - Return all documents whose `geo_shape` field
-contains the query geometry.
+contains the query geometry. Note: this is only supported using the
+`recursive` Prefix Tree Strategy deprecated[6.6]
 
 [float]
 ==== Ignore Unmapped

--- a/server/src/main/java/org/apache/lucene/document/XLatLonShape.java
+++ b/server/src/main/java/org/apache/lucene/document/XLatLonShape.java
@@ -52,7 +52,6 @@ import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
  * @see PointValues
  * @see LatLonDocValuesField
  *
- * @lucene.experimental
  */
 public class XLatLonShape {
   public static final int BYTES = LatLonPoint.BYTES;

--- a/server/src/main/java/org/apache/lucene/document/XLatLonShape.java
+++ b/server/src/main/java/org/apache/lucene/document/XLatLonShape.java
@@ -1,0 +1,373 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.document;
+
+import org.apache.lucene.geo.GeoUtils;
+import org.apache.lucene.geo.Line;
+import org.apache.lucene.geo.Polygon;
+import org.apache.lucene.geo.XTessellator;
+import org.apache.lucene.geo.XTessellator.Triangle;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.lucene.geo.GeoEncodingUtils.encodeLatitude;
+import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
+
+/**
+ * An indexed shape utility class.
+ * <p>
+ * {@link Polygon}'s are decomposed into a triangular mesh using the {@link XTessellator} utility class
+ * Each {@link Triangle} is encoded and indexed as a multi-value field.
+ * <p>
+ * Finding all shapes that intersect a range (e.g., bounding box) at search time is efficient.
+ * <p>
+ * This class defines static factory methods for common operations:
+ * <ul>
+ *   <li>{@link #createIndexableFields(String, Polygon)} for matching polygons that intersect a bounding box.
+ *   <li>{@link #newBoxQuery newBoxQuery()} for matching polygons that intersect a bounding box.
+ * </ul>
+
+ * <b>WARNING</b>: Like {@link LatLonPoint}, vertex values are indexed with some loss of precision from the
+ * original {@code double} values (4.190951585769653E-8 for the latitude component
+ * and 8.381903171539307E-8 for longitude).
+ * @see PointValues
+ * @see LatLonDocValuesField
+ *
+ * @lucene.experimental
+ */
+public class XLatLonShape {
+  public static final int BYTES = LatLonPoint.BYTES;
+
+  protected static final FieldType TYPE = new FieldType();
+  static {
+    TYPE.setDimensions(7, 4, BYTES);
+    TYPE.freeze();
+  }
+
+  // no instance:
+  private XLatLonShape() {
+  }
+
+  /** create indexable fields for polygon geometry */
+  public static Field[] createIndexableFields(String fieldName, Polygon polygon) {
+    // the lionshare of the indexing is done by the tessellator
+    List<Triangle> tessellation = XTessellator.tessellate(polygon);
+    List<LatLonTriangle> fields = new ArrayList<>();
+    for (Triangle t : tessellation) {
+      fields.add(new LatLonTriangle(fieldName, t));
+    }
+    return fields.toArray(new Field[fields.size()]);
+  }
+
+  /** create indexable fields for line geometry */
+  public static Field[] createIndexableFields(String fieldName, Line line) {
+    int numPoints = line.numPoints();
+    Field[] fields = new Field[numPoints - 1];
+    // create "flat" triangles
+    for (int i = 0, j = 1; j < numPoints; ++i, ++j) {
+      fields[i] = new LatLonTriangle(fieldName, line.getLat(i), line.getLon(i), line.getLat(j), line.getLon(j),
+          line.getLat(i), line.getLon(i));
+    }
+    return fields;
+  }
+
+  /** create indexable fields for point geometry */
+  public static Field[] createIndexableFields(String fieldName, double lat, double lon) {
+    return new Field[] {new LatLonTriangle(fieldName, lat, lon, lat, lon, lat, lon)};
+  }
+
+  /** create a query to find all polygons that intersect a defined bounding box
+   **/
+  public static Query newBoxQuery(String field, QueryRelation queryRelation,
+                                  double minLatitude, double maxLatitude, double minLongitude, double maxLongitude) {
+    return new XLatLonShapeBoundingBoxQuery(field, queryRelation, minLatitude, maxLatitude, minLongitude, maxLongitude);
+  }
+
+  /** create a query to find all polygons that intersect a provided linestring (or array of linestrings)
+   *  note: does not support dateline crossing
+   **/
+  public static Query newLineQuery(String field, QueryRelation queryRelation, Line... lines) {
+    return new XLatLonShapeLineQuery(field, queryRelation, lines);
+  }
+
+  /** create a query to find all polygons that intersect a provided polygon (or array of polygons)
+   *  note: does not support dateline crossing
+   **/
+  public static Query newPolygonQuery(String field, QueryRelation queryRelation, Polygon... polygons) {
+    return new XLatLonShapePolygonQuery(field, queryRelation, polygons);
+  }
+
+  /** polygons are decomposed into tessellated triangles using {@link XTessellator}
+   * these triangles are encoded and inserted as separate indexed POINT fields
+   */
+  private static class LatLonTriangle extends Field {
+
+    LatLonTriangle(String name, double aLat, double aLon, double bLat, double bLon, double cLat, double cLon) {
+      super(name, TYPE);
+      setTriangleValue(encodeLongitude(aLon), encodeLatitude(aLat), encodeLongitude(bLon), encodeLatitude(bLat),
+          encodeLongitude(cLon), encodeLatitude(cLat));
+    }
+
+    LatLonTriangle(String name, Triangle t) {
+      super(name, TYPE);
+      setTriangleValue(t.getEncodedX(0), t.getEncodedY(0), t.getEncodedX(1), t.getEncodedY(1),
+          t.getEncodedX(2), t.getEncodedY(2));
+    }
+
+
+    public void setTriangleValue(int aX, int aY, int bX, int bY, int cX, int cY) {
+      final byte[] bytes;
+
+      if (fieldsData == null) {
+        bytes = new byte[7 * BYTES];
+        fieldsData = new BytesRef(bytes);
+      } else {
+        bytes = ((BytesRef) fieldsData).bytes;
+      }
+      encodeTriangle(bytes, aY, aX, bY, bX, cY, cX);
+    }
+  }
+
+  /** Query Relation Types **/
+  public enum QueryRelation {
+    INTERSECTS, WITHIN, DISJOINT
+  }
+
+  private static final int MINY_MINX_MAXY_MAXX_Y_X = 0;
+  private static final int MINY_MINX_Y_X_MAXY_MAXX = 1;
+  private static final int MAXY_MINX_Y_X_MINY_MAXX = 2;
+  private static final int MAXY_MINX_MINY_MAXX_Y_X = 3;
+  private static final int Y_MINX_MINY_X_MAXY_MAXX = 4;
+  private static final int Y_MINX_MINY_MAXX_MAXY_X = 5;
+  private static final int MAXY_MINX_MINY_X_Y_MAXX = 6;
+  private static final int MINY_MINX_Y_MAXX_MAXY_X = 7;
+
+  /**
+   * A triangle is encoded using 6 points and an extra point with encoded information in three bits of how to reconstruct it.
+   * Triangles are encoded with CCW orientation and might be rotated to limit the number of possible reconstructions to 2^3.
+   * Reconstruction always happens from west to east.
+   */
+  public static void encodeTriangle(byte[] bytes, int aLat, int aLon, int bLat, int bLon, int cLat, int cLon) {
+    assert bytes.length == 7 * BYTES;
+    int aX;
+    int bX;
+    int cX;
+    int aY;
+    int bY;
+    int cY;
+    //change orientation if CW
+    if (GeoUtils.orient(aLon, aLat, bLon, bLat, cLon, cLat) == -1) {
+      aX = cLon;
+      bX = bLon;
+      cX = aLon;
+      aY = cLat;
+      bY = bLat;
+      cY = aLat;
+    } else {
+      aX = aLon;
+      bX = bLon;
+      cX = cLon;
+      aY = aLat;
+      bY = bLat;
+      cY = cLat;
+    }
+    //rotate edges and place minX at the beginning
+    if (bX < aX || cX < aX) {
+      if (bX < cX) {
+        int tempX = aX;
+        int tempY = aY;
+        aX = bX;
+        aY = bY;
+        bX = cX;
+        bY = cY;
+        cX = tempX;
+        cY = tempY;
+      } else if (cX < aX) {
+        int tempX = aX;
+        int tempY = aY;
+        aX = cX;
+        aY = cY;
+        cX = bX;
+        cY = bY;
+        bX = tempX;
+        bY = tempY;
+      }
+    } else if (aX == bX && aX == cX) {
+      //degenerated case, all points with same longitude
+      //we need to prevent that aX is in the middle (not part of the MBS)
+      if (bY < aY || cY < aY) {
+        if (bY < cY) {
+          int tempX = aX;
+          int tempY = aY;
+          aX = bX;
+          aY = bY;
+          bX = cX;
+          bY = cY;
+          cX = tempX;
+          cY = tempY;
+        } else if (cY < aY) {
+          int tempX = aX;
+          int tempY = aY;
+          aX = cX;
+          aY = cY;
+          cX = bX;
+          cY = bY;
+          bX = tempX;
+          bY = tempY;
+        }
+      }
+    }
+
+    int minX = aX;
+    int minY = StrictMath.min(aY, StrictMath.min(bY, cY));
+    int maxX = StrictMath.max(aX, StrictMath.max(bX, cX));
+    int maxY = StrictMath.max(aY, StrictMath.max(bY, cY));
+
+    int bits, x, y;
+    if (minY == aY) {
+      if (maxY == bY && maxX == bX) {
+        y = cY;
+        x = cX;
+        bits = MINY_MINX_MAXY_MAXX_Y_X;
+      } else if (maxY == cY && maxX == cX) {
+        y = bY;
+        x = bX;
+        bits = MINY_MINX_Y_X_MAXY_MAXX;
+      } else {
+        y = bY;
+        x = cX;
+        bits = MINY_MINX_Y_MAXX_MAXY_X;
+      }
+    } else if (maxY == aY) {
+      if (minY == bY && maxX == bX) {
+        y = cY;
+        x = cX;
+        bits = MAXY_MINX_MINY_MAXX_Y_X;
+      } else if (minY == cY && maxX == cX) {
+        y = bY;
+        x = bX;
+        bits = MAXY_MINX_Y_X_MINY_MAXX;
+      } else {
+        y = cY;
+        x = bX;
+        bits = MAXY_MINX_MINY_X_Y_MAXX;
+      }
+    }  else if (maxX == bX && minY == bY) {
+      y = aY;
+      x = cX;
+      bits = Y_MINX_MINY_MAXX_MAXY_X;
+    } else if (maxX == cX && maxY == cY) {
+      y = aY;
+      x = bX;
+      bits = Y_MINX_MINY_X_MAXY_MAXX;
+    } else {
+      throw new IllegalArgumentException("Could not encode the provided triangle");
+    }
+    NumericUtils.intToSortableBytes(minY, bytes, 0);
+    NumericUtils.intToSortableBytes(minX, bytes, BYTES);
+    NumericUtils.intToSortableBytes(maxY, bytes, 2 * BYTES);
+    NumericUtils.intToSortableBytes(maxX, bytes, 3 * BYTES);
+    NumericUtils.intToSortableBytes(y, bytes, 4 * BYTES);
+    NumericUtils.intToSortableBytes(x, bytes, 5 * BYTES);
+    NumericUtils.intToSortableBytes(bits, bytes, 6 * BYTES);
+  }
+
+  /**
+   * Decode a triangle encoded by {@link XLatLonShape#encodeTriangle(byte[], int, int, int, int, int, int)}.
+   */
+  public static void decodeTriangle(byte[] t, int[] triangle) {
+    assert triangle.length == 6;
+    int bits = NumericUtils.sortableBytesToInt(t, 6 * XLatLonShape.BYTES);
+    //extract the first three bits
+    int tCode = (((1 << 3) - 1) & (bits >> 0));
+    switch (tCode) {
+      case MINY_MINX_MAXY_MAXX_Y_X:
+        triangle[0] = NumericUtils.sortableBytesToInt(t, 0 * XLatLonShape.BYTES);
+        triangle[1] = NumericUtils.sortableBytesToInt(t, 1 * XLatLonShape.BYTES);
+        triangle[2] = NumericUtils.sortableBytesToInt(t, 2 * XLatLonShape.BYTES);
+        triangle[3] = NumericUtils.sortableBytesToInt(t, 3 * XLatLonShape.BYTES);
+        triangle[4] = NumericUtils.sortableBytesToInt(t, 4 * XLatLonShape.BYTES);
+        triangle[5] = NumericUtils.sortableBytesToInt(t, 5 * XLatLonShape.BYTES);
+        break;
+      case MINY_MINX_Y_X_MAXY_MAXX:
+        triangle[0] = NumericUtils.sortableBytesToInt(t, 0 * XLatLonShape.BYTES);
+        triangle[1] = NumericUtils.sortableBytesToInt(t, 1 * XLatLonShape.BYTES);
+        triangle[2] = NumericUtils.sortableBytesToInt(t, 4 * XLatLonShape.BYTES);
+        triangle[3] = NumericUtils.sortableBytesToInt(t, 5 * XLatLonShape.BYTES);
+        triangle[4] = NumericUtils.sortableBytesToInt(t, 2 * XLatLonShape.BYTES);
+        triangle[5] = NumericUtils.sortableBytesToInt(t, 3 * XLatLonShape.BYTES);
+        break;
+      case MAXY_MINX_Y_X_MINY_MAXX:
+        triangle[0] = NumericUtils.sortableBytesToInt(t, 2 * XLatLonShape.BYTES);
+        triangle[1] = NumericUtils.sortableBytesToInt(t, 1 * XLatLonShape.BYTES);
+        triangle[2] = NumericUtils.sortableBytesToInt(t, 4 * XLatLonShape.BYTES);
+        triangle[3] = NumericUtils.sortableBytesToInt(t, 5 * XLatLonShape.BYTES);
+        triangle[4] = NumericUtils.sortableBytesToInt(t, 0 * XLatLonShape.BYTES);
+        triangle[5] = NumericUtils.sortableBytesToInt(t, 3 * XLatLonShape.BYTES);
+        break;
+      case MAXY_MINX_MINY_MAXX_Y_X:
+        triangle[0] = NumericUtils.sortableBytesToInt(t, 2 * XLatLonShape.BYTES);
+        triangle[1] = NumericUtils.sortableBytesToInt(t, 1 * XLatLonShape.BYTES);
+        triangle[2] = NumericUtils.sortableBytesToInt(t, 0 * XLatLonShape.BYTES);
+        triangle[3] = NumericUtils.sortableBytesToInt(t, 3 * XLatLonShape.BYTES);
+        triangle[4] = NumericUtils.sortableBytesToInt(t, 4 * XLatLonShape.BYTES);
+        triangle[5] = NumericUtils.sortableBytesToInt(t, 5 * XLatLonShape.BYTES);
+        break;
+      case Y_MINX_MINY_X_MAXY_MAXX:
+        triangle[0] = NumericUtils.sortableBytesToInt(t, 4 * XLatLonShape.BYTES);
+        triangle[1] = NumericUtils.sortableBytesToInt(t, 1 * XLatLonShape.BYTES);
+        triangle[2] = NumericUtils.sortableBytesToInt(t, 0 * XLatLonShape.BYTES);
+        triangle[3] = NumericUtils.sortableBytesToInt(t, 5 * XLatLonShape.BYTES);
+        triangle[4] = NumericUtils.sortableBytesToInt(t, 2 * XLatLonShape.BYTES);
+        triangle[5] = NumericUtils.sortableBytesToInt(t, 3 * XLatLonShape.BYTES);
+        break;
+      case Y_MINX_MINY_MAXX_MAXY_X:
+        triangle[0] = NumericUtils.sortableBytesToInt(t, 4 * XLatLonShape.BYTES);
+        triangle[1] = NumericUtils.sortableBytesToInt(t, 1 * XLatLonShape.BYTES);
+        triangle[2] = NumericUtils.sortableBytesToInt(t, 0 * XLatLonShape.BYTES);
+        triangle[3] = NumericUtils.sortableBytesToInt(t, 3 * XLatLonShape.BYTES);
+        triangle[4] = NumericUtils.sortableBytesToInt(t, 2 * XLatLonShape.BYTES);
+        triangle[5] = NumericUtils.sortableBytesToInt(t, 5 * XLatLonShape.BYTES);
+        break;
+      case MAXY_MINX_MINY_X_Y_MAXX:
+        triangle[0] = NumericUtils.sortableBytesToInt(t, 2 * XLatLonShape.BYTES);
+        triangle[1] = NumericUtils.sortableBytesToInt(t, 1 * XLatLonShape.BYTES);
+        triangle[2] = NumericUtils.sortableBytesToInt(t, 0 * XLatLonShape.BYTES);
+        triangle[3] = NumericUtils.sortableBytesToInt(t, 5 * XLatLonShape.BYTES);
+        triangle[4] = NumericUtils.sortableBytesToInt(t, 4 * XLatLonShape.BYTES);
+        triangle[5] = NumericUtils.sortableBytesToInt(t, 3 * XLatLonShape.BYTES);
+        break;
+      case MINY_MINX_Y_MAXX_MAXY_X:
+        triangle[0] = NumericUtils.sortableBytesToInt(t, 0 * XLatLonShape.BYTES);
+        triangle[1] = NumericUtils.sortableBytesToInt(t, 1 * XLatLonShape.BYTES);
+        triangle[2] = NumericUtils.sortableBytesToInt(t, 4 * XLatLonShape.BYTES);
+        triangle[3] = NumericUtils.sortableBytesToInt(t, 3 * XLatLonShape.BYTES);
+        triangle[4] = NumericUtils.sortableBytesToInt(t, 2 * XLatLonShape.BYTES);
+        triangle[5] = NumericUtils.sortableBytesToInt(t, 5 * XLatLonShape.BYTES);
+        break;
+      default:
+        throw new IllegalArgumentException("Could not decode the provided triangle");
+    }
+    //Points of the decoded triangle must be co-planar or CCW oriented
+    assert GeoUtils.orient(triangle[1], triangle[0], triangle[3], triangle[2], triangle[5], triangle[4]) >= 0;
+  }
+}

--- a/server/src/main/java/org/apache/lucene/document/XLatLonShapeBoundingBoxQuery.java
+++ b/server/src/main/java/org/apache/lucene/document/XLatLonShapeBoundingBoxQuery.java
@@ -26,7 +26,6 @@ import org.apache.lucene.index.PointValues.Relation;
  * <p>The field must be indexed using
  * {@link XLatLonShape#createIndexableFields} added per document.
  *
- *  @lucene.experimental
  **/
 final class XLatLonShapeBoundingBoxQuery extends XLatLonShapeQuery {
   final XRectangle2D rectangle2D;

--- a/server/src/main/java/org/apache/lucene/document/XLatLonShapeBoundingBoxQuery.java
+++ b/server/src/main/java/org/apache/lucene/document/XLatLonShapeBoundingBoxQuery.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.document;
+
+import org.apache.lucene.geo.Rectangle;
+import org.apache.lucene.geo.XRectangle2D;
+import org.apache.lucene.index.PointValues.Relation;
+
+/**
+ * Finds all previously indexed shapes that intersect the specified bounding box.
+ *
+ * <p>The field must be indexed using
+ * {@link XLatLonShape#createIndexableFields} added per document.
+ *
+ *  @lucene.experimental
+ **/
+final class XLatLonShapeBoundingBoxQuery extends XLatLonShapeQuery {
+  final XRectangle2D rectangle2D;
+
+  XLatLonShapeBoundingBoxQuery(String field, XLatLonShape.QueryRelation queryRelation,
+                               double minLat, double maxLat, double minLon, double maxLon) {
+    super(field, queryRelation);
+    Rectangle rectangle = new Rectangle(minLat, maxLat, minLon, maxLon);
+    this.rectangle2D = XRectangle2D.create(rectangle);
+  }
+
+  @Override
+  protected Relation relateRangeBBoxToQuery(int minXOffset, int minYOffset, byte[] minTriangle,
+                                            int maxXOffset, int maxYOffset, byte[] maxTriangle) {
+    return rectangle2D.relateRangeBBox(minXOffset, minYOffset, minTriangle, maxXOffset, maxYOffset, maxTriangle);
+  }
+
+  /** returns true if the query matches the encoded triangle */
+  @Override
+  protected boolean queryMatches(byte[] t, int[] scratchTriangle) {
+    // decode indexed triangle
+    XLatLonShape.decodeTriangle(t, scratchTriangle);
+
+    int aY = scratchTriangle[0];
+    int aX = scratchTriangle[1];
+    int bY = scratchTriangle[2];
+    int bX = scratchTriangle[3];
+    int cY = scratchTriangle[4];
+    int cX = scratchTriangle[5];
+
+    if (queryRelation == XLatLonShape.QueryRelation.WITHIN) {
+      return rectangle2D.containsTriangle(aX, aY, bX, bY, cX, cY);
+    }
+    return rectangle2D.intersectsTriangle(aX, aY, bX, bY, cX, cY);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return sameClassAs(o) && equalsTo(getClass().cast(o));
+  }
+
+  @Override
+  protected boolean equalsTo(Object o) {
+    return super.equalsTo(o) && rectangle2D.equals(((XLatLonShapeBoundingBoxQuery)o).rectangle2D);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = super.hashCode();
+    hash = 31 * hash + rectangle2D.hashCode();
+    return hash;
+  }
+
+  @Override
+  public String toString(String field) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName());
+    sb.append(':');
+    if (this.field.equals(field) == false) {
+      sb.append(" field=");
+      sb.append(this.field);
+      sb.append(':');
+    }
+    sb.append(rectangle2D.toString());
+    return sb.toString();
+  }
+}

--- a/server/src/main/java/org/apache/lucene/document/XLatLonShapeLineQuery.java
+++ b/server/src/main/java/org/apache/lucene/document/XLatLonShapeLineQuery.java
@@ -41,7 +41,6 @@ import java.util.Arrays;
  * <p>The field must be indexed using
  * {@link XLatLonShape#createIndexableFields} added per document.
  *
- *  @lucene.experimental
  **/
 final class XLatLonShapeLineQuery extends XLatLonShapeQuery {
   final Line[] lines;

--- a/server/src/main/java/org/apache/lucene/document/XLatLonShapeLineQuery.java
+++ b/server/src/main/java/org/apache/lucene/document/XLatLonShapeLineQuery.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.document;
+
+import org.apache.lucene.document.XLatLonShape.QueryRelation;
+import org.apache.lucene.geo.GeoEncodingUtils;
+import org.apache.lucene.geo.Line;
+import org.apache.lucene.geo.Line2D;
+import org.apache.lucene.index.PointValues.Relation;
+import org.apache.lucene.util.NumericUtils;
+
+import java.util.Arrays;
+
+/**
+ * Finds all previously indexed shapes that intersect the specified arbitrary {@code Line}.
+ * <p>
+ * Note:
+ * <ul>
+ *    <li>{@code QueryRelation.WITHIN} queries are not yet supported</li>
+ *    <li>Dateline crossing is not yet supported</li>
+ * </ul>
+ * <p>
+ * todo:
+ * <ul>
+ *   <li>Add distance support for buffered queries</li>
+ * </ul>
+ * <p>The field must be indexed using
+ * {@link XLatLonShape#createIndexableFields} added per document.
+ *
+ *  @lucene.experimental
+ **/
+final class XLatLonShapeLineQuery extends XLatLonShapeQuery {
+  final Line[] lines;
+  private final Line2D line2D;
+
+  XLatLonShapeLineQuery(String field, QueryRelation queryRelation, Line... lines) {
+    super(field, queryRelation);
+    /** line queries do not support within relations, only intersects and disjoint */
+    if (queryRelation == QueryRelation.WITHIN) {
+      throw new IllegalArgumentException("LatLonShapeLineQuery does not support " + QueryRelation.WITHIN + " queries");
+    }
+
+    if (lines == null) {
+      throw new IllegalArgumentException("lines must not be null");
+    }
+    if (lines.length == 0) {
+      throw new IllegalArgumentException("lines must not be empty");
+    }
+    for (int i = 0; i < lines.length; ++i) {
+      if (lines[i] == null) {
+        throw new IllegalArgumentException("line[" + i + "] must not be null");
+      } else if (lines[i].minLon > lines[i].maxLon) {
+        throw new IllegalArgumentException("LatLonShapeLineQuery does not currently support querying across dateline.");
+      }
+    }
+    this.lines = lines.clone();
+    this.line2D = Line2D.create(lines);
+  }
+
+  @Override
+  protected Relation relateRangeBBoxToQuery(int minXOffset, int minYOffset, byte[] minTriangle,
+                                            int maxXOffset, int maxYOffset, byte[] maxTriangle) {
+    double minLat = GeoEncodingUtils.decodeLatitude(NumericUtils.sortableBytesToInt(minTriangle, minYOffset));
+    double minLon = GeoEncodingUtils.decodeLongitude(NumericUtils.sortableBytesToInt(minTriangle, minXOffset));
+    double maxLat = GeoEncodingUtils.decodeLatitude(NumericUtils.sortableBytesToInt(maxTriangle, maxYOffset));
+    double maxLon = GeoEncodingUtils.decodeLongitude(NumericUtils.sortableBytesToInt(maxTriangle, maxXOffset));
+
+    // check internal node against query
+    return line2D.relate(minLat, maxLat, minLon, maxLon);
+  }
+
+  @Override
+  protected boolean queryMatches(byte[] t, int[] scratchTriangle) {
+    XLatLonShape.decodeTriangle(t, scratchTriangle);
+
+    double alat = GeoEncodingUtils.decodeLatitude(scratchTriangle[0]);
+    double alon = GeoEncodingUtils.decodeLongitude(scratchTriangle[1]);
+    double blat = GeoEncodingUtils.decodeLatitude(scratchTriangle[2]);
+    double blon = GeoEncodingUtils.decodeLongitude(scratchTriangle[3]);
+    double clat = GeoEncodingUtils.decodeLatitude(scratchTriangle[4]);
+    double clon = GeoEncodingUtils.decodeLongitude(scratchTriangle[5]);
+
+    if (queryRelation == XLatLonShape.QueryRelation.WITHIN) {
+      return line2D.relateTriangle(alon, alat, blon, blat, clon, clat) == Relation.CELL_INSIDE_QUERY;
+    }
+    // INTERSECTS
+    return line2D.relateTriangle(alon, alat, blon, blat, clon, clat) != Relation.CELL_OUTSIDE_QUERY;
+  }
+
+  @Override
+  public String toString(String field) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName());
+    sb.append(':');
+    if (this.field.equals(field) == false) {
+      sb.append(" field=");
+      sb.append(this.field);
+      sb.append(':');
+    }
+    sb.append("Line(" + lines[0].toGeoJSON() + ")");
+    return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return super.equals(o);
+  }
+
+  @Override
+  protected boolean equalsTo(Object o) {
+    return super.equalsTo(o) && Arrays.equals(lines, ((XLatLonShapeLineQuery)o).lines);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = super.hashCode();
+    hash = 31 * hash + Arrays.hashCode(lines);
+    return hash;
+  }
+}

--- a/server/src/main/java/org/apache/lucene/document/XLatLonShapePolygonQuery.java
+++ b/server/src/main/java/org/apache/lucene/document/XLatLonShapePolygonQuery.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.document;
+
+import org.apache.lucene.document.XLatLonShape.QueryRelation;
+import org.apache.lucene.geo.GeoEncodingUtils;
+import org.apache.lucene.geo.Polygon;
+import org.apache.lucene.geo.Polygon2D;
+import org.apache.lucene.index.PointValues.Relation;
+import org.apache.lucene.util.NumericUtils;
+
+import java.util.Arrays;
+
+/**
+ * Finds all previously indexed shapes that intersect the specified arbitrary.
+ *
+ * <p>The field must be indexed using
+ * {@link XLatLonShape#createIndexableFields} added per document.
+ *
+ *  @lucene.experimental
+ **/
+final class XLatLonShapePolygonQuery extends XLatLonShapeQuery {
+  final Polygon[] polygons;
+  private final Polygon2D poly2D;
+
+  /**
+   * Creates a query that matches all indexed shapes to the provided polygons
+   */
+  XLatLonShapePolygonQuery(String field, QueryRelation queryRelation, Polygon... polygons) {
+    super(field, queryRelation);
+    if (polygons == null) {
+      throw new IllegalArgumentException("polygons must not be null");
+    }
+    if (polygons.length == 0) {
+      throw new IllegalArgumentException("polygons must not be empty");
+    }
+    for (int i = 0; i < polygons.length; i++) {
+      if (polygons[i] == null) {
+        throw new IllegalArgumentException("polygon[" + i + "] must not be null");
+      } else if (polygons[i].minLon > polygons[i].maxLon) {
+        throw new IllegalArgumentException("LatLonShapePolygonQuery does not currently support querying across dateline.");
+      }
+    }
+    this.polygons = polygons.clone();
+    this.poly2D = Polygon2D.create(polygons);
+  }
+
+  @Override
+  protected Relation relateRangeBBoxToQuery(int minXOffset, int minYOffset, byte[] minTriangle,
+                                            int maxXOffset, int maxYOffset, byte[] maxTriangle) {
+
+    double minLat = GeoEncodingUtils.decodeLatitude(NumericUtils.sortableBytesToInt(minTriangle, minYOffset));
+    double minLon = GeoEncodingUtils.decodeLongitude(NumericUtils.sortableBytesToInt(minTriangle, minXOffset));
+    double maxLat = GeoEncodingUtils.decodeLatitude(NumericUtils.sortableBytesToInt(maxTriangle, maxYOffset));
+    double maxLon = GeoEncodingUtils.decodeLongitude(NumericUtils.sortableBytesToInt(maxTriangle, maxXOffset));
+
+    // check internal node against query
+    return poly2D.relate(minLat, maxLat, minLon, maxLon);
+  }
+
+  @Override
+  protected boolean queryMatches(byte[] t, int[] scratchTriangle) {
+    XLatLonShape.decodeTriangle(t, scratchTriangle);
+
+    double alat = GeoEncodingUtils.decodeLatitude(scratchTriangle[0]);
+    double alon = GeoEncodingUtils.decodeLongitude(scratchTriangle[1]);
+    double blat = GeoEncodingUtils.decodeLatitude(scratchTriangle[2]);
+    double blon = GeoEncodingUtils.decodeLongitude(scratchTriangle[3]);
+    double clat = GeoEncodingUtils.decodeLatitude(scratchTriangle[4]);
+    double clon = GeoEncodingUtils.decodeLongitude(scratchTriangle[5]);
+
+    if (queryRelation == QueryRelation.WITHIN) {
+      return poly2D.relateTriangle(alon, alat, blon, blat, clon, clat) == Relation.CELL_INSIDE_QUERY;
+    }
+    // INTERSECTS
+    return poly2D.relateTriangle(alon, alat, blon, blat, clon, clat) != Relation.CELL_OUTSIDE_QUERY;
+  }
+
+  @Override
+  public String toString(String field) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName());
+    sb.append(':');
+    if (this.field.equals(field) == false) {
+      sb.append(" field=");
+      sb.append(this.field);
+      sb.append(':');
+    }
+    sb.append("Polygon(" + polygons[0].toGeoJSON() + ")");
+    return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return super.equals(o);
+  }
+
+  @Override
+  protected boolean equalsTo(Object o) {
+    return super.equalsTo(o) && Arrays.equals(polygons, ((XLatLonShapePolygonQuery)o).polygons);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = super.hashCode();
+    hash = 31 * hash + Arrays.hashCode(polygons);
+    return hash;
+  }
+}

--- a/server/src/main/java/org/apache/lucene/document/XLatLonShapePolygonQuery.java
+++ b/server/src/main/java/org/apache/lucene/document/XLatLonShapePolygonQuery.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
  * <p>The field must be indexed using
  * {@link XLatLonShape#createIndexableFields} added per document.
  *
- *  @lucene.experimental
  **/
 final class XLatLonShapePolygonQuery extends XLatLonShapeQuery {
   final Polygon[] polygons;

--- a/server/src/main/java/org/apache/lucene/document/XLatLonShapeQuery.java
+++ b/server/src/main/java/org/apache/lucene/document/XLatLonShapeQuery.java
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.document;
+
+import org.apache.lucene.document.XLatLonShape.QueryRelation;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.index.PointValues.IntersectVisitor;
+import org.apache.lucene.index.PointValues.Relation;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BitSetIterator;
+import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.FixedBitSet;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Base LatLonShape Query class providing common query logic for
+ * {@link XLatLonShapeBoundingBoxQuery} and {@link XLatLonShapePolygonQuery}
+ *
+ * Note: this class implements the majority of the INTERSECTS, WITHIN, DISJOINT relation logic
+ *
+ * @lucene.experimental
+ **/
+abstract class XLatLonShapeQuery extends Query {
+  /** field name */
+  final String field;
+  /** query relation
+   * disjoint: {@code CELL_OUTSIDE_QUERY}
+   * intersects: {@code CELL_CROSSES_QUERY},
+   * within: {@code CELL_WITHIN_QUERY} */
+  final XLatLonShape.QueryRelation queryRelation;
+
+  protected XLatLonShapeQuery(String field, final QueryRelation queryType) {
+    if (field == null) {
+      throw new IllegalArgumentException("field must not be null");
+    }
+    this.field = field;
+    this.queryRelation = queryType;
+  }
+
+  /**
+   *   relates an internal node (bounding box of a range of triangles) to the target query
+   *   Note: logic is specific to query type
+   *   see {@link XLatLonShapeBoundingBoxQuery#relateRangeToQuery} and {@link XLatLonShapePolygonQuery#relateRangeToQuery}
+   */
+  protected abstract Relation relateRangeBBoxToQuery(int minXOffset, int minYOffset, byte[] minTriangle,
+                                                     int maxXOffset, int maxYOffset, byte[] maxTriangle);
+
+  /** returns true if the provided triangle matches the query */
+  protected abstract boolean queryMatches(byte[] triangle, int[] scratchTriangle);
+
+  /** relates a range of triangles (internal node) to the query */
+  protected Relation relateRangeToQuery(byte[] minTriangle, byte[] maxTriangle) {
+    // compute bounding box of internal node
+    Relation r = relateRangeBBoxToQuery(XLatLonShape.BYTES, 0, minTriangle, 3 * XLatLonShape.BYTES,
+        2 * XLatLonShape.BYTES, maxTriangle);
+    if (queryRelation == QueryRelation.DISJOINT) {
+      return transposeRelation(r);
+    }
+    return r;
+  }
+
+  @Override
+  public final Weight createWeight(IndexSearcher searcher, boolean needsScores, float boost) throws IOException {
+
+    return new ConstantScoreWeight(this, boost) {
+
+      /** create a visitor that adds documents that match the query using a sparse bitset. (Used by INTERSECT) */
+      protected IntersectVisitor getSparseIntersectVisitor(DocIdSetBuilder result) {
+        return new IntersectVisitor() {
+          final int[] scratchTriangle = new int[6];
+          DocIdSetBuilder.BulkAdder adder;
+
+          @Override
+          public void grow(int count) {
+            adder = result.grow(count);
+          }
+
+          @Override
+          public void visit(int docID) throws IOException {
+            adder.add(docID);
+          }
+
+          @Override
+          public void visit(int docID, byte[] t) throws IOException {
+            if (queryMatches(t, scratchTriangle)) {
+              adder.add(docID);
+            }
+          }
+
+          @Override
+          public Relation compare(byte[] minTriangle, byte[] maxTriangle) {
+            return relateRangeToQuery(minTriangle, maxTriangle);
+          }
+        };
+      }
+
+      /** create a visitor that adds documents that match the query using a dense bitset. (Used by WITHIN, DISJOINT) */
+      protected IntersectVisitor getDenseIntersectVisitor(FixedBitSet intersect, FixedBitSet disjoint) {
+        return new IntersectVisitor() {
+          final int[] scratchTriangle = new int[6];
+          @Override
+          public void visit(int docID) throws IOException {
+            if (queryRelation == QueryRelation.DISJOINT) {
+              // if DISJOINT query set the doc in the disjoint bitset
+              disjoint.set(docID);
+            } else {
+              // for INTERSECT, and WITHIN queries we set the intersect bitset
+              intersect.set(docID);
+            }
+          }
+
+          @Override
+          public void visit(int docID, byte[] t) throws IOException {
+            if (queryMatches(t, scratchTriangle)) {
+              intersect.set(docID);
+            } else {
+              disjoint.set(docID);
+            }
+          }
+
+          @Override
+          public Relation compare(byte[] minTriangle, byte[] maxTriangle) {
+            return relateRangeToQuery(minTriangle, maxTriangle);
+          }
+        };
+      }
+
+      /** get a scorer supplier for INTERSECT queries */
+      protected ScorerSupplier getIntersectScorerSupplier(LeafReader reader, PointValues values, Weight weight) throws IOException {
+        DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+        IntersectVisitor visitor = getSparseIntersectVisitor(result);
+        return new RelationScorerSupplier(values, visitor) {
+          @Override
+          public Scorer get(long leadCost) throws IOException {
+            return getIntersectsScorer(XLatLonShapeQuery.this, reader, weight, result, score());
+          }
+        };
+      }
+
+      /** get a scorer supplier for all other queries (DISJOINT, WITHIN) */
+      protected ScorerSupplier getScorerSupplier(LeafReader reader, PointValues values, Weight weight) throws IOException {
+        if (queryRelation == QueryRelation.INTERSECTS) {
+          return getIntersectScorerSupplier(reader, values, weight);
+        }
+
+        FixedBitSet intersect = new FixedBitSet(reader.maxDoc());
+        FixedBitSet disjoint = new FixedBitSet(reader.maxDoc());
+        IntersectVisitor visitor = getDenseIntersectVisitor(intersect, disjoint);
+        return new RelationScorerSupplier(values, visitor) {
+          @Override
+          public Scorer get(long leadCost) throws IOException {
+            return getScorer(XLatLonShapeQuery.this, weight, intersect, disjoint, score());
+          }
+        };
+      }
+
+      @Override
+      public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+        LeafReader reader = context.reader();
+        PointValues values = reader.getPointValues(field);
+        if (values == null) {
+          // No docs in this segment had any points fields
+          return null;
+        }
+        FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(field);
+        if (fieldInfo == null) {
+          // No docs in this segment indexed this field at all
+          return null;
+        }
+
+        boolean allDocsMatch = true;
+        if (values.getDocCount() != reader.maxDoc() ||
+            relateRangeToQuery(values.getMinPackedValue(), values.getMaxPackedValue()) != Relation.CELL_INSIDE_QUERY) {
+          allDocsMatch = false;
+        }
+
+        final Weight weight = this;
+        if (allDocsMatch) {
+          return new ScorerSupplier() {
+            @Override
+            public Scorer get(long leadCost) throws IOException {
+              return new ConstantScoreScorer(weight, score(), DocIdSetIterator.all(reader.maxDoc()));
+            }
+
+            @Override
+            public long cost() {
+              return reader.maxDoc();
+            }
+          };
+        } else {
+          return getScorerSupplier(reader, values, weight);
+        }
+      }
+
+      @Override
+      public Scorer scorer(LeafReaderContext context) throws IOException {
+        ScorerSupplier scorerSupplier = scorerSupplier(context);
+        if (scorerSupplier == null) {
+          return null;
+        }
+        return scorerSupplier.get(Long.MAX_VALUE);
+      }
+
+      @Override
+      public boolean isCacheable(LeafReaderContext ctx) {
+        return true;
+      }
+    };
+  }
+
+  /** returns the field name */
+  public String getField() {
+    return field;
+  }
+
+  /** returns the query relation */
+  public QueryRelation getQueryRelation() {
+    return queryRelation;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = classHash();
+    hash = 31 * hash + field.hashCode();
+    hash = 31 * hash + queryRelation.hashCode();
+    return hash;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return sameClassAs(o) && equalsTo(o);
+  }
+
+  protected boolean equalsTo(Object o) {
+    return Objects.equals(field, ((XLatLonShapeQuery)o).field) && this.queryRelation == ((XLatLonShapeQuery)o).queryRelation;
+  }
+
+  /** transpose the relation; INSIDE becomes OUTSIDE, OUTSIDE becomes INSIDE, CROSSES remains unchanged */
+  private static Relation transposeRelation(Relation r) {
+    if (r == Relation.CELL_INSIDE_QUERY) {
+      return Relation.CELL_OUTSIDE_QUERY;
+    } else if (r == Relation.CELL_OUTSIDE_QUERY) {
+      return Relation.CELL_INSIDE_QUERY;
+    }
+    return Relation.CELL_CROSSES_QUERY;
+  }
+
+  /** utility class for implementing constant score logic specific to INTERSECT, WITHIN, and DISJOINT */
+  private abstract static class RelationScorerSupplier extends ScorerSupplier {
+    PointValues values;
+    IntersectVisitor visitor;
+    long cost = -1;
+
+    RelationScorerSupplier(PointValues values, IntersectVisitor visitor) {
+      this.values = values;
+      this.visitor = visitor;
+    }
+
+    /** create a visitor that clears documents that do NOT match the polygon query; used with INTERSECTS */
+    private IntersectVisitor getInverseIntersectVisitor(XLatLonShapeQuery query, FixedBitSet result, int[] cost) {
+      return new IntersectVisitor() {
+        int[] scratchTriangle = new int[6];
+        @Override
+        public void visit(int docID) {
+          result.clear(docID);
+          cost[0]--;
+        }
+
+        @Override
+        public void visit(int docID, byte[] packedTriangle) {
+          if (query.queryMatches(packedTriangle, scratchTriangle) == false) {
+            result.clear(docID);
+            cost[0]--;
+          }
+        }
+
+        @Override
+        public Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+          return transposeRelation(query.relateRangeToQuery(minPackedValue, maxPackedValue));
+        }
+      };
+    }
+
+    /** returns a Scorer for INTERSECT queries that uses a sparse bitset */
+    protected Scorer getIntersectsScorer(XLatLonShapeQuery query, LeafReader reader, Weight weight,
+                                         DocIdSetBuilder docIdSetBuilder, final float boost) throws IOException {
+      if (values.getDocCount() == reader.maxDoc()
+          && values.getDocCount() == values.size()
+          && cost() > reader.maxDoc() / 2) {
+        // If all docs have exactly one value and the cost is greater
+        // than half the leaf size then maybe we can make things faster
+        // by computing the set of documents that do NOT match the query
+        final FixedBitSet result = new FixedBitSet(reader.maxDoc());
+        result.set(0, reader.maxDoc());
+        int[] cost = new int[]{reader.maxDoc()};
+        values.intersect(getInverseIntersectVisitor(query, result, cost));
+        final DocIdSetIterator iterator = new BitSetIterator(result, cost[0]);
+        return new ConstantScoreScorer(weight, boost, iterator);
+      }
+
+      values.intersect(visitor);
+      DocIdSetIterator iterator = docIdSetBuilder.build().iterator();
+      return new ConstantScoreScorer(weight, boost, iterator);
+    }
+
+    /** returns a Scorer for all other (non INTERSECT) queries */
+    protected Scorer getScorer(XLatLonShapeQuery query, Weight weight,
+                               FixedBitSet intersect, FixedBitSet disjoint, final float boost) throws IOException {
+      values.intersect(visitor);
+      DocIdSetIterator iterator;
+      if (query.queryRelation == QueryRelation.DISJOINT) {
+        disjoint.andNot(intersect);
+        iterator = new BitSetIterator(disjoint, cost());
+      } else if (query.queryRelation == QueryRelation.WITHIN) {
+        intersect.andNot(disjoint);
+        iterator = new BitSetIterator(intersect, cost());
+      } else {
+        iterator = new BitSetIterator(intersect, cost());
+      }
+      return new ConstantScoreScorer(weight, boost, iterator);
+    }
+
+    @Override
+    public long cost() {
+      if (cost == -1) {
+        // Computing the cost may be expensive, so only do it if necessary
+        cost = values.estimatePointCount(visitor);
+        assert cost >= 0;
+      }
+      return cost;
+    }
+  }
+}

--- a/server/src/main/java/org/apache/lucene/document/XLatLonShapeQuery.java
+++ b/server/src/main/java/org/apache/lucene/document/XLatLonShapeQuery.java
@@ -44,7 +44,6 @@ import java.util.Objects;
  *
  * Note: this class implements the majority of the INTERSECTS, WITHIN, DISJOINT relation logic
  *
- * @lucene.experimental
  **/
 abstract class XLatLonShapeQuery extends Query {
   /** field name */

--- a/server/src/main/java/org/apache/lucene/geo/XRectangle2D.java
+++ b/server/src/main/java/org/apache/lucene/geo/XRectangle2D.java
@@ -1,0 +1,317 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.geo;
+
+import org.apache.lucene.document.XLatLonShape;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.util.FutureArrays;
+import org.apache.lucene.util.NumericUtils;
+
+import java.util.Arrays;
+
+import static org.apache.lucene.document.XLatLonShape.BYTES;
+import static org.apache.lucene.geo.GeoEncodingUtils.MAX_LON_ENCODED;
+import static org.apache.lucene.geo.GeoEncodingUtils.MIN_LON_ENCODED;
+import static org.apache.lucene.geo.GeoEncodingUtils.decodeLatitude;
+import static org.apache.lucene.geo.GeoEncodingUtils.decodeLongitude;
+import static org.apache.lucene.geo.GeoEncodingUtils.encodeLatitude;
+import static org.apache.lucene.geo.GeoEncodingUtils.encodeLatitudeCeil;
+import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
+import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitudeCeil;
+import static org.apache.lucene.geo.GeoUtils.orient;
+
+/**
+ * 2D rectangle implementation containing spatial logic.
+ *
+ * @lucene.internal
+ */
+public class XRectangle2D {
+  final byte[] bbox;
+  final byte[] west;
+  final int minX;
+  final int maxX;
+  final int minY;
+  final int maxY;
+
+  private XRectangle2D(double minLat, double maxLat, double minLon, double maxLon) {
+    this.bbox = new byte[4 * BYTES];
+    int minXenc = encodeLongitudeCeil(minLon);
+    int maxXenc = encodeLongitude(maxLon);
+    int minYenc = encodeLatitudeCeil(minLat);
+    int maxYenc = encodeLatitude(maxLat);
+    if (minYenc > maxYenc) {
+      minYenc = maxYenc;
+    }
+    this.minY = minYenc;
+    this.maxY = maxYenc;
+
+    if (minLon > maxLon == true) {
+      // crossing dateline is split into east/west boxes
+      this.west = new byte[4 * BYTES];
+      this.minX = minXenc;
+      this.maxX = maxXenc;
+      encode(MIN_LON_ENCODED, this.maxX, this.minY, this.maxY, this.west);
+      encode(this.minX, MAX_LON_ENCODED, this.minY, this.maxY, this.bbox);
+    } else {
+      // encodeLongitudeCeil may cause minX to be > maxX iff
+      // the delta between the longitude < the encoding resolution
+      if (minXenc > maxXenc) {
+        minXenc = maxXenc;
+      }
+      this.west = null;
+      this.minX = minXenc;
+      this.maxX = maxXenc;
+      encode(this.minX, this.maxX, this.minY, this.maxY, bbox);
+    }
+  }
+
+  /** Builds a XRectangle2D from rectangle */
+  public static XRectangle2D create(Rectangle rectangle) {
+    return new XRectangle2D(rectangle.minLat, rectangle.maxLat, rectangle.minLon, rectangle.maxLon);
+  }
+
+  public boolean crossesDateline() {
+    return minX > maxX;
+  }
+
+  /** Checks if the rectangle contains the provided point **/
+  public boolean queryContainsPoint(int x, int y) {
+    if (this.crossesDateline() == true) {
+      return bboxContainsPoint(x, y, MIN_LON_ENCODED, this.maxX, this.minY, this.maxY)
+          || bboxContainsPoint(x, y, this.minX, MAX_LON_ENCODED, this.minY, this.maxY);
+    }
+    return bboxContainsPoint(x, y, this.minX, this.maxX, this.minY, this.maxY);
+  }
+
+  /** compare this to a provided rangle bounding box **/
+  public PointValues.Relation relateRangeBBox(int minXOffset, int minYOffset, byte[] minTriangle,
+                                              int maxXOffset, int maxYOffset, byte[] maxTriangle) {
+    PointValues.Relation eastRelation = compareBBoxToRangeBBox(this.bbox, minXOffset, minYOffset, minTriangle,
+        maxXOffset, maxYOffset, maxTriangle);
+    if (this.crossesDateline() && eastRelation == PointValues.Relation.CELL_OUTSIDE_QUERY) {
+      return compareBBoxToRangeBBox(this.west, minXOffset, minYOffset, minTriangle, maxXOffset, maxYOffset, maxTriangle);
+    }
+    return eastRelation;
+  }
+
+  /** Checks if the rectangle intersects the provided triangle **/
+  public boolean intersectsTriangle(int aX, int aY, int bX, int bY, int cX, int cY) {
+    // 1. query contains any triangle points
+    if (queryContainsPoint(aX, aY) || queryContainsPoint(bX, bY) || queryContainsPoint(cX, cY)) {
+      return true;
+    }
+
+    // compute bounding box of triangle
+    int tMinX = StrictMath.min(StrictMath.min(aX, bX), cX);
+    int tMaxX = StrictMath.max(StrictMath.max(aX, bX), cX);
+    int tMinY = StrictMath.min(StrictMath.min(aY, bY), cY);
+    int tMaxY = StrictMath.max(StrictMath.max(aY, bY), cY);
+
+    // 2. check bounding boxes are disjoint
+    if (this.crossesDateline() == true) {
+      if (boxesAreDisjoint(tMinX, tMaxX, tMinY, tMaxY, MIN_LON_ENCODED, this.maxX, this.minY, this.maxY)
+          && boxesAreDisjoint(tMinX, tMaxX, tMinY, tMaxY, this.minX, MAX_LON_ENCODED, this.minY, this.maxY)) {
+        return false;
+      }
+    } else if (tMaxX < minX || tMinX > maxX || tMinY > maxY || tMaxY < minY) {
+      return false;
+    }
+
+    // 3. check triangle contains any query points
+    if (XTessellator.pointInTriangle(minX, minY, aX, aY, bX, bY, cX, cY)) {
+      return true;
+    } else if (XTessellator.pointInTriangle(maxX, minY, aX, aY, bX, bY, cX, cY)) {
+      return true;
+    } else if (XTessellator.pointInTriangle(maxX, maxY, aX, aY, bX, bY, cX, cY)) {
+      return true;
+    } else if (XTessellator.pointInTriangle(minX, maxY, aX, aY, bX, bY, cX, cY)) {
+      return true;
+    }
+
+    // 4. last ditch effort: check crossings
+    if (queryIntersects(aX, aY, bX, bY, cX, cY)) {
+      return true;
+    }
+    return false;
+  }
+
+  /** Checks if the rectangle contains the provided triangle **/
+  public boolean containsTriangle(int ax, int ay, int bx, int by, int cx, int cy) {
+    if (this.crossesDateline() == true) {
+      return bboxContainsTriangle(ax, ay, bx, by, cx, cy, MIN_LON_ENCODED, this.maxX, this.minY, this.maxY)
+          || bboxContainsTriangle(ax, ay, bx, by, cx, cy, this.minX, MAX_LON_ENCODED, this.minY, this.maxY);
+    }
+    return bboxContainsTriangle(ax, ay, bx, by, cx, cy, minX, maxX, minY, maxY);
+  }
+
+  /** static utility method to compare a bbox with a range of triangles (just the bbox of the triangle collection) */
+  private static PointValues.Relation compareBBoxToRangeBBox(final byte[] bbox,
+                                                             int minXOffset, int minYOffset, byte[] minTriangle,
+                                                             int maxXOffset, int maxYOffset, byte[] maxTriangle) {
+    // check bounding box (DISJOINT)
+    if (FutureArrays.compareUnsigned(minTriangle, minXOffset, minXOffset + BYTES, bbox, 3 * BYTES, 4 * BYTES) > 0 ||
+        FutureArrays.compareUnsigned(maxTriangle, maxXOffset, maxXOffset + BYTES, bbox, BYTES, 2 * BYTES) < 0 ||
+        FutureArrays.compareUnsigned(minTriangle, minYOffset, minYOffset + BYTES, bbox, 2 * BYTES, 3 * BYTES) > 0 ||
+        FutureArrays.compareUnsigned(maxTriangle, maxYOffset, maxYOffset + BYTES, bbox, 0, BYTES) < 0) {
+      return PointValues.Relation.CELL_OUTSIDE_QUERY;
+    }
+
+    if (FutureArrays.compareUnsigned(minTriangle, minXOffset, minXOffset + BYTES, bbox, BYTES, 2 * BYTES) >= 0 &&
+        FutureArrays.compareUnsigned(maxTriangle, maxXOffset, maxXOffset + BYTES, bbox, 3 * BYTES, 4 * BYTES) <= 0 &&
+        FutureArrays.compareUnsigned(minTriangle, minYOffset, minYOffset + BYTES, bbox, 0, BYTES) >= 0 &&
+        FutureArrays.compareUnsigned(maxTriangle, maxYOffset, maxYOffset + BYTES, bbox, 2 * BYTES, 3 * BYTES) <= 0) {
+      return PointValues.Relation.CELL_INSIDE_QUERY;
+    }
+    return PointValues.Relation.CELL_CROSSES_QUERY;
+  }
+
+  /**
+   * encodes a bounding box into the provided byte array
+   */
+  private static void encode(final int minX, final int maxX, final int minY, final int maxY, byte[] b) {
+    if (b == null) {
+      b = new byte[4 * XLatLonShape.BYTES];
+    }
+    NumericUtils.intToSortableBytes(minY, b, 0);
+    NumericUtils.intToSortableBytes(minX, b, BYTES);
+    NumericUtils.intToSortableBytes(maxY, b, 2 * BYTES);
+    NumericUtils.intToSortableBytes(maxX, b, 3 * BYTES);
+  }
+
+  /** returns true if the query intersects the provided triangle (in encoded space) */
+  private boolean queryIntersects(int ax, int ay, int bx, int by, int cx, int cy) {
+    // check each edge of the triangle against the query
+    if (edgeIntersectsQuery(ax, ay, bx, by) ||
+        edgeIntersectsQuery(bx, by, cx, cy) ||
+        edgeIntersectsQuery(cx, cy, ax, ay)) {
+      return true;
+    }
+    return false;
+  }
+
+  /** returns true if the edge (defined by (ax, ay) (bx, by)) intersects the query */
+  private boolean edgeIntersectsQuery(int ax, int ay, int bx, int by) {
+    if (this.crossesDateline() == true) {
+      return edgeIntersectsBox(ax, ay, bx, by, MIN_LON_ENCODED, this.maxX, this.minY, this.maxY)
+          || edgeIntersectsBox(ax, ay, bx, by, this.minX, MAX_LON_ENCODED, this.minY, this.maxY);
+    }
+    return edgeIntersectsBox(ax, ay, bx, by, this.minX, this.maxX, this.minY, this.maxY);
+  }
+
+  /** static utility method to check if a bounding box contains a point */
+  private static boolean bboxContainsPoint(int x, int y, int minX, int maxX, int minY, int maxY) {
+    return (x < minX || x > maxX || y < minY || y > maxY) == false;
+  }
+
+  /** static utility method to check if a bounding box contains a triangle */
+  private static boolean bboxContainsTriangle(int ax, int ay, int bx, int by, int cx, int cy,
+                                             int minX, int maxX, int minY, int maxY) {
+    return bboxContainsPoint(ax, ay, minX, maxX, minY, maxY)
+        && bboxContainsPoint(bx, by, minX, maxX, minY, maxY)
+        && bboxContainsPoint(cx, cy, minX, maxX, minY, maxY);
+  }
+
+  /** returns true if the edge (defined by (ax, ay) (bx, by)) intersects the query */
+  private static boolean edgeIntersectsBox(int ax, int ay, int bx, int by,
+                                           int minX, int maxX, int minY, int maxY) {
+    // shortcut: if edge is a point (occurs w/ Line shapes); simply check bbox w/ point
+    if (ax == bx && ay == by) {
+      return Rectangle.containsPoint(ay, ax, minY, maxY, minX, maxX);
+    }
+
+    // shortcut: check if either of the end points fall inside the box
+    if (bboxContainsPoint(ax, ay, minX, maxX, minY, maxY)
+        || bboxContainsPoint(bx, by, minX, maxX, minY, maxY)) {
+      return true;
+    }
+
+    // shortcut: check bboxes of edges are disjoint
+    if (boxesAreDisjoint(Math.min(ax, bx), Math.max(ax, bx), Math.min(ay, by), Math.max(ay, by),
+        minX, maxX, minY, maxY)) {
+      return false;
+    }
+
+    // shortcut: edge is a point
+    if (ax == bx && ay == by) {
+      return false;
+    }
+
+    // top
+    if (orient(ax, ay, bx, by, minX, maxY) * orient(ax, ay, bx, by, maxX, maxY) <= 0 &&
+        orient(minX, maxY, maxX, maxY, ax, ay) * orient(minX, maxY, maxX, maxY, bx, by) <= 0) {
+      return true;
+    }
+
+    // right
+    if (orient(ax, ay, bx, by, maxX, maxY) * orient(ax, ay, bx, by, maxX, minY) <= 0 &&
+        orient(maxX, maxY, maxX, minY, ax, ay) * orient(maxX, maxY, maxX, minY, bx, by) <= 0) {
+      return true;
+    }
+
+    // bottom
+    if (orient(ax, ay, bx, by, maxX, minY) * orient(ax, ay, bx, by, minX, minY) <= 0 &&
+        orient(maxX, minY, minX, minY, ax, ay) * orient(maxX, minY, minX, minY, bx, by) <= 0) {
+      return true;
+    }
+
+    // left
+    if (orient(ax, ay, bx, by, minX, minY) * orient(ax, ay, bx, by, minX, maxY) <= 0 &&
+        orient(minX, minY, minX, maxY, ax, ay) * orient(minX, minY, minX, maxY, bx, by) <= 0) {
+      return true;
+    }
+    return false;
+  }
+
+  /** utility method to check if two boxes are disjoint */
+  private static boolean boxesAreDisjoint(final int aMinX, final int aMaxX, final int aMinY, final int aMaxY,
+                                         final int bMinX, final int bMaxX, final int bMinY, final int bMaxY) {
+    return (aMaxX < bMinX || aMinX > bMaxX || aMaxY < bMinY || aMinY > bMaxY);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return Arrays.equals(bbox, ((XRectangle2D)o).bbox)
+        && Arrays.equals(west, ((XRectangle2D)o).west);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = super.hashCode();
+    hash = 31 * hash + Arrays.hashCode(bbox);
+    hash = 31 * hash + Arrays.hashCode(west);
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder();
+    sb.append("Rectangle(lat=");
+    sb.append(decodeLatitude(minY));
+    sb.append(" TO ");
+    sb.append(decodeLatitude(maxY));
+    sb.append(" lon=");
+    sb.append(decodeLongitude(minX));
+    sb.append(" TO ");
+    sb.append(decodeLongitude(maxX));
+    if (maxX < minX) {
+      sb.append(" [crosses dateline!]");
+    }
+    sb.append(")");
+    return sb.toString();
+  }
+}

--- a/server/src/main/java/org/apache/lucene/geo/XRectangle2D.java
+++ b/server/src/main/java/org/apache/lucene/geo/XRectangle2D.java
@@ -38,7 +38,6 @@ import static org.apache.lucene.geo.GeoUtils.orient;
 /**
  * 2D rectangle implementation containing spatial logic.
  *
- * @lucene.internal
  */
 public class XRectangle2D {
   final byte[] bbox;

--- a/server/src/main/java/org/apache/lucene/geo/XTessellator.java
+++ b/server/src/main/java/org/apache/lucene/geo/XTessellator.java
@@ -1,0 +1,889 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.geo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.lucene.geo.GeoUtils.WindingOrder;
+import org.apache.lucene.util.BitUtil;
+
+import static org.apache.lucene.geo.GeoEncodingUtils.encodeLatitude;
+import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
+import static org.apache.lucene.geo.GeoUtils.orient;
+
+/**
+ * Computes a triangular mesh tessellation for a given polygon.
+ * <p>
+ * This is inspired by mapbox's earcut algorithm (https://github.com/mapbox/earcut)
+ * which is a modification to FIST (https://www.cosy.sbg.ac.at/~held/projects/triang/triang.html)
+ * written by Martin Held, and ear clipping (https://www.geometrictools.com/Documentation/TriangulationByEarClipping.pdf)
+ * written by David Eberly.
+ * <p>
+ * Notes:
+ *   <ul>
+ *     <li>Requires valid polygons:
+ *       <ul>
+ *         <li>No self intersections
+ *         <li>Holes may only touch at one vertex
+ *         <li>Polygon must have an area (e.g., no "line" boxes)
+ *      <li>sensitive to overflow (e.g, subatomic values such as E-200 can cause unexpected behavior)
+ *      </ul>
+ *  </ul>
+ * <p>
+ * The code is a modified version of the javascript implementation provided by MapBox
+ * under the following license:
+ * <p>
+ * ISC License
+ * <p>
+ * Copyright (c) 2016, Mapbox
+ * <p>
+ * Permission to use, copy, modify, and/or distribute this software for any purpose
+ * with or without fee is hereby granted, provided that the above copyright notice
+ * and this permission notice appear in all copies.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH'
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+ * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+ * THIS SOFTWARE.
+ *
+ * @lucene.experimental
+ */
+public final class XTessellator {
+  // this is a dumb heuristic to control whether we cut over to sorted morton values
+  private static final int VERTEX_THRESHOLD = 80;
+
+  /** state of the tessellated split - avoids recursion */
+  private enum State {
+    INIT, CURE, SPLIT
+  }
+
+  // No Instance:
+  private XTessellator() {}
+
+  /** Produces an array of vertices representing the triangulated result set of the Points array */
+  public static List<Triangle> tessellate(final Polygon polygon) {
+    // Attempt to establish a doubly-linked list of the provided shell points (should be CCW, but this will correct);
+    // then filter instances of intersections.
+    Node outerNode = createDoublyLinkedList(polygon, 0, WindingOrder.CW);
+    // If an outer node hasn't been detected, the shape is malformed. (must comply with OGC SFA specification)
+    if(outerNode == null) {
+      throw new IllegalArgumentException("Malformed shape detected in XTessellator!");
+    }
+
+    // Determine if the specified list of points contains holes
+    if (polygon.numHoles() > 0) {
+      // Eliminate the hole triangulation.
+      outerNode = eliminateHoles(polygon, outerNode);
+    }
+
+    // If the shape crosses VERTEX_THRESHOLD, use z-order curve hashing:
+    final boolean mortonOptimized;
+    {
+      int threshold = VERTEX_THRESHOLD - polygon.numPoints();
+      for (int i = 0; threshold >= 0 && i < polygon.numHoles(); ++i) {
+        threshold -= polygon.getHole(i).numPoints();
+      }
+
+      // Link polygon nodes in Z-Order
+      mortonOptimized = threshold < 0;
+      if (mortonOptimized == true) {
+        sortByMorton(outerNode);
+      }
+    }
+    // Calculate the tessellation using the doubly LinkedList.
+    List<Triangle> result = earcutLinkedList(outerNode, new ArrayList<>(), State.INIT, mortonOptimized);
+    if (result.size() == 0) {
+      throw new IllegalArgumentException("Unable to Tessellate shape [" + polygon + "]. Possible malformed shape detected.");
+    }
+
+    return result;
+  }
+
+  /** Creates a circular doubly linked list using polygon points. The order is governed by the specified winding order */
+  private static Node createDoublyLinkedList(final Polygon polygon, int startIndex, final WindingOrder windingOrder) {
+    Node lastNode = null;
+    // Link points into the circular doubly-linked list in the specified winding order
+    if (windingOrder == polygon.getWindingOrder()) {
+      for (int i = 0; i < polygon.numPoints(); ++i) {
+        lastNode = insertNode(polygon, startIndex++, i, lastNode);
+      }
+    } else {
+      for (int i = polygon.numPoints() - 1; i >= 0; --i) {
+        lastNode = insertNode(polygon, startIndex++, i, lastNode);
+      }
+    }
+    // if first and last node are the same then remove the end node and set lastNode to the start
+    if (lastNode != null && isVertexEquals(lastNode, lastNode.next)) {
+      removeNode(lastNode);
+      lastNode = lastNode.next;
+    }
+
+    // Return the last node in the Doubly-Linked List
+    return filterPoints(lastNode, null);
+  }
+
+  /** Links every hole into the outer loop, producing a single-ring polygon without holes. **/
+  private static Node eliminateHoles(final Polygon polygon, Node outerNode) {
+    // Define a list to hole a reference to each filtered hole list.
+    final List<Node> holeList = new ArrayList<>();
+    // Iterate through each array of hole vertices.
+    Polygon[] holes = polygon.getHoles();
+    int nodeIndex = polygon.numPoints();
+    for(int i = 0; i < polygon.numHoles(); ++i) {
+      // create the doubly-linked hole list
+      Node list = createDoublyLinkedList(holes[i], nodeIndex, WindingOrder.CCW);
+      if (list == list.next) {
+        list.isSteiner = true;
+      }
+      // Determine if the resulting hole polygon was successful.
+      if(list != null) {
+        // Add the leftmost vertex of the hole.
+        holeList.add(fetchLeftmost(list));
+      }
+      nodeIndex += holes[i].numPoints();
+    }
+
+    // Sort the hole vertices by x coordinate
+    holeList.sort((Node pNodeA, Node pNodeB) ->
+        pNodeA.getX() < pNodeB.getX() ? -1 : pNodeA.getX() == pNodeB.getX() ? 0 : 1);
+
+    // Process holes from left to right.
+    for(int i = 0; i < holeList.size(); ++i) {
+      // Eliminate hole triangles from the result set
+      final Node holeNode = holeList.get(i);
+      eliminateHole(holeNode, outerNode);
+      // Filter the new polygon.
+      outerNode = filterPoints(outerNode, outerNode.next);
+    }
+    // Return a pointer to the list.
+    return outerNode;
+  }
+
+  /** Finds a bridge between vertices that connects a hole with an outer ring, and links it */
+  private static void eliminateHole(final Node holeNode, Node outerNode) {
+    // Attempt to find a logical bridge between the HoleNode and OuterNode.
+    outerNode = fetchHoleBridge(holeNode, outerNode);
+    // Determine whether a hole bridge could be fetched.
+    if(outerNode != null) {
+      // Split the resulting polygon.
+      Node node = splitPolygon(outerNode, holeNode);
+      // Filter the split nodes.
+      filterPoints(node, node.next);
+    }
+  }
+
+  /**
+   * David Eberly's algorithm for finding a bridge between a hole and outer polygon
+   *
+   * see: http://www.geometrictools.com/Documentation/TriangulationByEarClipping.pdf
+   **/
+  private static Node fetchHoleBridge(final Node holeNode, final Node outerNode) {
+    Node p = outerNode;
+    double qx = Double.NEGATIVE_INFINITY;
+    final double hx = holeNode.getX();
+    final double hy = holeNode.getY();
+    Node connection = null;
+    // 1. find a segment intersected by a ray from the hole's leftmost point to the left;
+    // segment's endpoint with lesser x will be potential connection point
+    {
+      do {
+        if (hy <= p.getY() && hy >= p.next.getY() && p.next.getY() != p.getY()) {
+          final double x = p.getX() + (hy - p.getY()) * (p.next.getX() - p.getX()) / (p.next.getY() - p.getY());
+          if (x <= hx && x > qx) {
+            qx = x;
+            if (x == hx) {
+              if (hy == p.getY()) return p;
+              if (hy == p.next.getY()) return p.next;
+            }
+            connection = p.getX() < p.next.getX() ? p : p.next;
+          }
+        }
+        p = p.next;
+      } while (p != outerNode);
+    }
+
+    if (connection == null) {
+      return null;
+    } else if (hx == qx) {
+      return connection.previous;
+    }
+
+    // 2. look for points inside the triangle of hole point, segment intersection, and endpoint
+    // its a valid connection iff there are no points found;
+    // otherwise choose the point of the minimum angle with the ray as the connection point
+    Node stop = connection;
+    final double mx = connection.getX();
+    final double my = connection.getY();
+    double tanMin = Double.POSITIVE_INFINITY;
+    double tan;
+    p = connection.next;
+    {
+      while (p != stop) {
+        if (hx >= p.getX() && p.getX() >= mx && hx != p.getX()
+            && pointInEar(p.getX(), p.getY(), hy < my ? hx : qx, hy, mx, my, hy < my ? qx : hx, hy)) {
+          tan = Math.abs(hy - p.getY()) / (hx - p.getX()); // tangential
+          if ((tan < tanMin || (tan == tanMin && p.getX() > connection.getX())) && isLocallyInside(p, holeNode)) {
+            connection = p;
+            tanMin = tan;
+          }
+        }
+        p = p.next;
+      }
+    }
+
+    return connection;
+  }
+
+  /** Finds the left-most hole of a polygon ring. **/
+  private static Node fetchLeftmost(final Node start) {
+    Node node = start;
+    Node leftMost = start;
+    do {
+      // Determine if the current node possesses a lesser X position.
+      if (node.getX() < leftMost.getX()) {
+        // Maintain a reference to this Node.
+        leftMost = node;
+      }
+      // Progress the search to the next node in the doubly-linked list.
+      node = node.next;
+    } while (node != start);
+
+    // Return the node with the smallest X value.
+    return leftMost;
+  }
+
+  /** Main ear slicing loop which triangulates the vertices of a polygon, provided as a doubly-linked list. **/
+  private static List<Triangle> earcutLinkedList(Node currEar, final List<Triangle> tessellation,
+                                                       State state, final boolean mortonOptimized) {
+    earcut : do {
+      if (currEar == null || currEar.previous == currEar.next) {
+        return tessellation;
+      }
+
+      Node stop = currEar;
+      Node prevNode;
+      Node nextNode;
+
+      // Iteratively slice ears
+      do {
+        prevNode = currEar.previous;
+        nextNode = currEar.next;
+        // Determine whether the current triangle must be cut off.
+        final boolean isReflex = area(prevNode.getX(), prevNode.getY(), currEar.getX(), currEar.getY(),
+            nextNode.getX(), nextNode.getY()) >= 0;
+        if (isReflex == false && isEar(currEar, mortonOptimized) == true) {
+          // Return the triangulated data
+          tessellation.add(new Triangle(prevNode, currEar, nextNode));
+          // Remove the ear node.
+          removeNode(currEar);
+
+          // Skipping to the next node leaves fewer slither triangles.
+          currEar = nextNode.next;
+          stop = nextNode.next;
+          continue;
+        }
+        currEar = nextNode;
+
+        // If the whole polygon has been iterated over and no more ears can be found.
+        if (currEar == stop) {
+          switch (state) {
+            case INIT:
+              // try filtering points and slicing again
+              currEar = filterPoints(currEar, null);
+              state = State.CURE;
+              continue earcut;
+            case CURE:
+              // if this didn't work, try curing all small self-intersections locally
+              currEar = cureLocalIntersections(currEar, tessellation);
+              state = State.SPLIT;
+              continue earcut;
+            case SPLIT:
+              // as a last resort, try splitting the remaining polygon into two
+              if (splitEarcut(currEar, tessellation, mortonOptimized) == false) {
+                //we could not process all points. Tessellation failed
+                tessellation.clear();
+              }
+              break;
+          }
+          break;
+        }
+      } while (currEar.previous != currEar.next);
+      break;
+    } while (true);
+    // Return the calculated tessellation
+    return tessellation;
+  }
+
+  /** Determines whether a polygon node forms a valid ear with adjacent nodes. **/
+  private static boolean isEar(final Node ear, final boolean mortonOptimized) {
+    if (mortonOptimized == true) {
+      return mortonIsEar(ear);
+    }
+
+    // make sure there aren't other points inside the potential ear
+    Node node = ear.next.next;
+    while (node != ear.previous) {
+      if (pointInEar(node.getX(), node.getY(), ear.previous.getX(), ear.previous.getY(), ear.getX(), ear.getY(),
+          ear.next.getX(), ear.next.getY())
+          && area(node.previous.getX(), node.previous.getY(), node.getX(), node.getY(),
+          node.next.getX(), node.next.getY()) >= 0) {
+        return false;
+      }
+      node = node.next;
+    }
+    return true;
+  }
+
+  /** Uses morton code for speed to determine whether or a polygon node forms a valid ear w/ adjacent nodes */
+  private static boolean mortonIsEar(final Node ear) {
+    // triangle bbox (flip the bits so negative encoded values are < positive encoded values)
+    int minTX = StrictMath.min(StrictMath.min(ear.previous.x, ear.x), ear.next.x) ^ 0x80000000;
+    int minTY = StrictMath.min(StrictMath.min(ear.previous.y, ear.y), ear.next.y) ^ 0x80000000;
+    int maxTX = StrictMath.max(StrictMath.max(ear.previous.x, ear.x), ear.next.x) ^ 0x80000000;
+    int maxTY = StrictMath.max(StrictMath.max(ear.previous.y, ear.y), ear.next.y) ^ 0x80000000;
+
+    // z-order range for the current triangle bbox;
+    long minZ = BitUtil.interleave(minTX, minTY);
+    long maxZ = BitUtil.interleave(maxTX, maxTY);
+
+    // now make sure we don't have other points inside the potential ear;
+
+    // look for points inside the triangle in both directions
+    Node p = ear.previousZ;
+    Node n = ear.nextZ;
+    while (p != null && Long.compareUnsigned(p.morton, minZ) >= 0
+        && n != null && Long.compareUnsigned(n.morton, maxZ) <= 0) {
+      if (p.idx != ear.previous.idx && p.idx != ear.next.idx &&
+          pointInEar(p.getX(), p.getY(), ear.previous.getX(), ear.previous.getY(), ear.getX(), ear.getY(),
+              ear.next.getX(), ear.next.getY()) &&
+          area(p.previous.getX(), p.previous.getY(), p.getX(), p.getY(), p.next.getX(), p.next.getY()) >= 0) return false;
+      p = p.previousZ;
+
+      if (n.idx != ear.previous.idx && n.idx != ear.next.idx &&
+          pointInEar(n.getX(), n.getY(), ear.previous.getX(), ear.previous.getY(), ear.getX(), ear.getY(),
+              ear.next.getX(), ear.next.getY()) &&
+          area(n.previous.getX(), n.previous.getY(), n.getX(), n.getY(), n.next.getX(), n.next.getY()) >= 0) return false;
+      n = n.nextZ;
+    }
+
+    // first look for points inside the triangle in decreasing z-order
+    while (p != null && Long.compareUnsigned(p.morton, minZ) >= 0) {
+      if (p.idx != ear.previous.idx && p.idx != ear.next.idx
+            && pointInEar(p.getX(), p.getY(), ear.previous.getX(), ear.previous.getY(), ear.getX(), ear.getY(),
+          ear.next.getX(), ear.next.getY())
+            && area(p.previous.getX(), p.previous.getY(), p.getX(), p.getY(), p.next.getX(), p.next.getY()) >= 0) {
+          return false;
+        }
+      p = p.previousZ;
+    }
+    // then look for points in increasing z-order
+    while (n != null &&
+        Long.compareUnsigned(n.morton, maxZ) <= 0) {
+        if (n.idx != ear.previous.idx && n.idx != ear.next.idx
+            && pointInEar(n.getX(), n.getY(), ear.previous.getX(), ear.previous.getY(), ear.getX(), ear.getY(),
+            ear.next.getX(), ear.next.getY())
+            && area(n.previous.getX(), n.previous.getY(), n.getX(), n.getY(), n.next.getX(), n.next.getY()) >= 0) {
+          return false;
+        }
+      n = n.nextZ;
+    }
+    return true;
+  }
+
+  /** Iterate through all polygon nodes and remove small local self-intersections **/
+  private static Node cureLocalIntersections(Node startNode, final List<Triangle> tessellation) {
+    Node node = startNode;
+    Node nextNode;
+    do {
+      nextNode = node.next;
+      Node a = node.previous;
+      Node b = nextNode.next;
+
+      // a self-intersection where edge (v[i-1],v[i]) intersects (v[i+1],v[i+2])
+      if (isVertexEquals(a, b) == false
+          && isIntersectingPolygon(a, a.getX(), a.getY(), b.getX(), b.getY()) == false
+          && linesIntersect(a.getX(), a.getY(), node.getX(), node.getY(), nextNode.getX(), nextNode.getY(), b.getX(), b.getY())
+          && isLocallyInside(a, b) && isLocallyInside(b, a)) {
+        // Return the triangulated vertices to the tessellation
+        tessellation.add(new Triangle(a, node, b));
+
+        // remove two nodes involved
+        removeNode(node);
+        removeNode(node.next);
+        node = startNode = b;
+      }
+      node = node.next;
+    } while (node != startNode);
+
+    return node;
+  }
+
+  /** Attempt to split a polygon and independently triangulate each side. Return true if the polygon was splitted **/
+  private static boolean splitEarcut(final Node start, final List<Triangle> tessellation, final boolean mortonIndexed) {
+    // Search for a valid diagonal that divides the polygon into two.
+    Node searchNode = start;
+    Node nextNode;
+    do {
+      nextNode = searchNode.next;
+      Node diagonal = nextNode.next;
+      while (diagonal != searchNode.previous) {
+        if(isValidDiagonal(searchNode, diagonal)) {
+          // Split the polygon into two at the point of the diagonal
+          Node splitNode = splitPolygon(searchNode, diagonal);
+          // Filter the resulting polygon.
+          searchNode = filterPoints(searchNode, searchNode.next);
+          splitNode  = filterPoints(splitNode, splitNode.next);
+          // Attempt to earcut both of the resulting polygons
+          if (mortonIndexed) {
+            sortByMortonWithReset(searchNode);
+            sortByMortonWithReset(splitNode);
+          }
+          earcutLinkedList(searchNode, tessellation, State.INIT, mortonIndexed);
+          earcutLinkedList(splitNode,  tessellation, State.INIT, mortonIndexed);
+          // Finish the iterative search
+          return true;
+        }
+        diagonal = diagonal.next;
+      }
+      searchNode = searchNode.next;
+    } while (searchNode != start);
+    return false;
+  }
+
+  /** Links two polygon vertices using a bridge. **/
+  private static Node splitPolygon(final Node a, final Node b) {
+    final Node a2 = new Node(a);
+    final Node b2 = new Node(b);
+    final Node an = a.next;
+    final Node bp = b.previous;
+
+    a.next = b;
+    a.nextZ = b;
+    b.previous = a;
+    b.previousZ = a;
+    a2.next = an;
+    a2.nextZ = an;
+    an.previous = a2;
+    an.previousZ = a2;
+    b2.next = a2;
+    b2.nextZ = a2;
+    a2.previous = b2;
+    a2.previousZ = b2;
+    bp.next = b2;
+    bp.nextZ = b2;
+
+    return b2;
+  }
+
+  /** Determines whether a diagonal between two polygon nodes lies within a polygon interior.
+   * (This determines the validity of the ray.) **/
+  private static boolean isValidDiagonal(final Node a, final Node b) {
+    return a.next.idx != b.idx && a.previous.idx != b.idx
+        && isIntersectingPolygon(a, a.getX(), a.getY(), b.getX(), b.getY()) == false
+        && isLocallyInside(a, b) && isLocallyInside(b, a)
+        && middleInsert(a, a.getX(), a.getY(), b.getX(), b.getY());
+  }
+
+  private static boolean isLocallyInside(final Node a, final Node b) {
+    // if a is cw
+    if (area(a.previous.getX(), a.previous.getY(), a.getX(), a.getY(), a.next.getX(), a.next.getY()) < 0) {
+      return area(a.getX(), a.getY(), b.getX(), b.getY(), a.next.getX(), a.next.getY()) >= 0
+          && area(a.getX(), a.getY(), a.previous.getX(), a.previous.getY(), b.getX(), b.getY()) >= 0;
+    }
+    // ccw
+    return area(a.getX(), a.getY(), b.getX(), b.getY(), a.previous.getX(), a.previous.getY()) < 0
+        || area(a.getX(), a.getY(), a.next.getX(), a.next.getY(), b.getX(), b.getY()) < 0;
+  }
+
+  /** Determine whether the middle point of a polygon diagonal is contained within the polygon */
+  private static boolean middleInsert(final Node start, final double x0, final double y0,
+                                            final double x1, final double y1) {
+    Node node = start;
+    Node nextNode;
+    boolean lIsInside = false;
+    final double lDx = (x0 + x1) / 2.0f;
+    final double lDy = (y0 + y1) / 2.0f;
+    do {
+      nextNode = node.next;
+      if (node.getY() > lDy != nextNode.getY() > lDy &&
+          lDx < (nextNode.getX() - node.getX()) * (lDy - node.getY()) / (nextNode.getY() - node.getY()) + node.getX()) {
+        lIsInside = !lIsInside;
+      }
+      node = node.next;
+    } while (node != start);
+    return lIsInside;
+  }
+
+  /** Determines if the diagonal of a polygon is intersecting with any polygon elements. **/
+  private static boolean isIntersectingPolygon(final Node start, final double x0, final double y0,
+                                                     final double x1, final double y1) {
+    Node node = start;
+    Node nextNode;
+    do {
+      nextNode = node.next;
+      if(isVertexEquals(node, x0, y0) == false && isVertexEquals(node, x1, y1) == false) {
+        if (linesIntersect(node.getX(), node.getY(), nextNode.getX(), nextNode.getY(), x0, y0, x1, y1)) {
+          return true;
+        }
+      }
+      node = nextNode;
+    } while (node != start);
+
+    return false;
+  }
+
+  /** Determines whether two line segments intersect. **/
+  public static boolean linesIntersect(final double aX0, final double aY0, final double aX1, final double aY1,
+                                             final double bX0, final double bY0, final double bX1, final double bY1) {
+    return (area(aX0, aY0, aX1, aY1, bX0, bY0) > 0) != (area(aX0, aY0, aX1, aY1, bX1, bY1) > 0)
+        && (area(bX0, bY0, bX1, bY1, aX0, aY0) > 0) != (area(bX0, bY0, bX1, bY1, aX1, aY1) > 0);
+  }
+
+  /** Interlinks polygon nodes in Z-Order. It reset the values on the z values**/
+  private static void sortByMortonWithReset(Node start) {
+    Node next = start;
+    do {
+      next.previousZ = next.previous;
+      next.nextZ = next.next;
+      next = next.next;
+    } while (next != start);
+    sortByMorton(start);
+  }
+
+  /** Interlinks polygon nodes in Z-Order. **/
+  private static void sortByMorton(Node start) {
+    start.previousZ.nextZ = null;
+    start.previousZ = null;
+    // Sort the generated ring using Z ordering.
+    tathamSort(start);
+  }
+
+  /**
+   * Simon Tatham's doubly-linked list O(n log n) mergesort
+   * see: http://www.chiark.greenend.org.uk/~sgtatham/algorithms/listsort.html
+   **/
+  private static void tathamSort(Node list) {
+    Node p, q, e, tail;
+    int i, numMerges, pSize, qSize;
+    int inSize = 1;
+
+    if (list == null) {
+      return;
+    }
+
+    do {
+      p = list;
+      list = null;
+      tail = null;
+      // count number of merges in this pass
+      numMerges = 0;
+
+      while(p != null) {
+        ++numMerges;
+        // step 'insize' places along from p
+        q = p;
+        for (i = 0, pSize = 0; i < inSize && q != null; ++i, ++pSize, q = q.nextZ);
+        // if q hasn't fallen off end, we have two lists to merge
+        qSize = inSize;
+
+        // now we have two lists; merge
+        while (pSize > 0 || (qSize > 0 && q != null)) {
+          if (pSize != 0 && (qSize == 0 || q == null || Long.compareUnsigned(p.morton, q.morton) <= 0)) {
+            e = p;
+            p = p.nextZ;
+            --pSize;
+          } else {
+            e = q;
+            q = q.nextZ;
+            --qSize;
+          }
+
+          if (tail != null) {
+            tail.nextZ = e;
+          } else {
+            list = e;
+          }
+          // maintain reverse pointers
+          e.previousZ = tail;
+          tail = e;
+        }
+        // now p has stepped 'insize' places along, and q has too
+        p = q;
+      }
+
+      tail.nextZ = null;
+      inSize *= 2;
+    } while (numMerges > 1);
+  }
+
+  /** Eliminate colinear/duplicate points from the doubly linked list */
+  private static Node filterPoints(final Node start, Node end) {
+    if (start == null) {
+      return start;
+    }
+
+    if(end == null) {
+      end = start;
+    }
+
+    Node node = start;
+    Node nextNode;
+    Node prevNode;
+    boolean continueIteration;
+
+    do {
+      continueIteration = false;
+      nextNode = node.next;
+      prevNode = node.previous;
+      if (node.isSteiner == false && isVertexEquals(node, nextNode)
+          || area(prevNode.getX(), prevNode.getY(), node.getX(), node.getY(), nextNode.getX(), nextNode.getY()) == 0) {
+        // Remove the node
+        removeNode(node);
+        node = end = prevNode;
+
+        if (node == nextNode) {
+          break;
+        }
+        continueIteration = true;
+      } else {
+        node = nextNode;
+      }
+    } while (continueIteration || node != end);
+    return end;
+  }
+
+  /** Creates a node and optionally links it with a previous node in a circular doubly-linked list */
+  private static Node insertNode(final Polygon polygon, int index, int vertexIndex, final Node lastNode) {
+    final Node node = new Node(polygon, index, vertexIndex);
+    if(lastNode == null) {
+      node.previous = node;
+      node.previousZ = node;
+      node.next = node;
+      node.nextZ = node;
+    } else {
+      node.next = lastNode.next;
+      node.nextZ = lastNode.next;
+      node.previous = lastNode;
+      node.previousZ = lastNode;
+      lastNode.next.previous = node;
+      lastNode.nextZ.previousZ = node;
+      lastNode.next = node;
+      lastNode.nextZ = node;
+    }
+    return node;
+  }
+
+  /** Removes a node from the doubly linked list */
+  private static void removeNode(Node node) {
+    node.next.previous = node.previous;
+    node.previous.next = node.next;
+
+    if (node.previousZ != null) {
+      node.previousZ.nextZ = node.nextZ;
+    }
+    if (node.nextZ != null) {
+      node.nextZ.previousZ = node.previousZ;
+    }
+  }
+
+  /** Determines if two point vertices are equal. **/
+  private static boolean isVertexEquals(final Node a, final Node b) {
+    return isVertexEquals(a, b.getX(), b.getY());
+  }
+
+  /** Determines if two point vertices are equal. **/
+  private static boolean isVertexEquals(final Node a, final double x, final  double y) {
+    return a.getX() == x && a.getY() == y;
+  }
+
+  /** Compute signed area of triangle */
+  private static double area(final double aX, final double aY, final double bX, final double bY,
+                             final double cX, final double cY) {
+    return (bY - aY) * (cX - bX) - (bX - aX) * (cY - bY);
+  }
+
+  /** Compute whether point is in a candidate ear */
+  private static boolean pointInEar(final double x, final double y, final double ax, final double ay,
+                                    final double bx, final double by, final double cx, final double cy) {
+    return (cx - x) * (ay - y) - (ax - x) * (cy - y) >= 0 &&
+           (ax - x) * (by - y) - (bx - x) * (ay - y) >= 0 &&
+           (bx - x) * (cy - y) - (cx - x) * (by - y) >= 0;
+  }
+
+  /** compute whether the given x, y point is in a triangle; uses the winding order method */
+  public static boolean pointInTriangle (double x, double y, double ax, double ay, double bx, double by, double cx, double cy) {
+    int a = orient(x, y, ax, ay, bx, by);
+    int b = orient(x, y, bx, by, cx, cy);
+    if (a == 0 || b == 0 || a < 0 == b < 0) {
+      int c = orient(x, y, cx, cy, ax, ay);
+      return c == 0 || (c < 0 == (b < 0 || a < 0));
+    }
+    return false;
+  }
+
+  /** Brute force compute if a point is in the polygon by traversing entire triangulation
+   * todo: speed this up using either binary tree or prefix coding (filtering by bounding box of triangle)
+   **/
+  public static boolean pointInPolygon(final List<Triangle> tessellation, double lat, double lon) {
+    // each triangle
+    for (int i = 0; i < tessellation.size(); ++i) {
+      if (tessellation.get(i).containsPoint(lat, lon)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Circular Doubly-linked list used for polygon coordinates */
+  protected static class Node {
+    // node index in the linked list
+    private final int idx;
+    // vertex index in the polygon
+    private final int vrtxIdx;
+    // reference to the polygon for lat/lon values
+    private final Polygon polygon;
+    // encoded x value
+    private final int x;
+    // encoded y value
+    private final int y;
+    // morton code for sorting
+    private final long morton;
+
+    // previous node
+    private Node previous;
+    // next node
+    private Node next;
+    // previous z node
+    private Node previousZ;
+    // next z node
+    private Node nextZ;
+    // triangle center
+    private boolean isSteiner = false;
+
+    protected Node(final Polygon polygon, final int index, final int vertexIndex) {
+      this.idx = index;
+      this.vrtxIdx = vertexIndex;
+      this.polygon = polygon;
+      this.y = encodeLatitude(polygon.getPolyLat(vrtxIdx));
+      this.x = encodeLongitude(polygon.getPolyLon(vrtxIdx));
+      this.morton = BitUtil.interleave(x ^ 0x80000000, y ^ 0x80000000);
+      this.previous = null;
+      this.next = null;
+      this.previousZ = null;
+      this.nextZ = null;
+    }
+
+    /** simple deep copy constructor */
+    protected Node(Node other) {
+      this.idx = other.idx;
+      this.vrtxIdx = other.vrtxIdx;
+      this.polygon = other.polygon;
+      this.morton = other.morton;
+      this.x = other.x;
+      this.y = other.y;
+      this.previous = other.previous;
+      this.next = other.next;
+      this.previousZ = other.previousZ;
+      this.nextZ = other.nextZ;
+      this.isSteiner = other.isSteiner;
+    }
+
+    /** get the x value */
+    public final double getX() {
+      return polygon.getPolyLon(vrtxIdx);
+    }
+
+    /** get the y value */
+    public final double getY() {
+      return polygon.getPolyLat(vrtxIdx);
+    }
+
+    /** get the longitude value */
+    public final double getLon() {
+      return polygon.getPolyLon(vrtxIdx);
+    }
+
+    /** get the latitude value */
+    public final double getLat() {
+      return polygon.getPolyLat(vrtxIdx);
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder builder = new StringBuilder();
+      if (this.previous == null)
+        builder.append("||-");
+      else
+        builder.append(this.previous.idx + " <- ");
+      builder.append(this.idx);
+      if (this.next == null)
+        builder.append(" -||");
+      else
+        builder.append(" -> " + this.next.idx);
+      return builder.toString();
+    }
+  }
+
+  /** Triangle in the tessellated mesh */
+  public static final class Triangle {
+    Node[] vertex;
+
+    protected Triangle(Node a, Node b, Node c) {
+      this.vertex = new Node[] {a, b, c};
+    }
+
+    /** get quantized x value for the given vertex */
+    public int getEncodedX(int vertex) {
+      return this.vertex[vertex].x;
+    }
+
+    /** get quantized y value for the given vertex */
+    public int getEncodedY(int vertex) {
+      return this.vertex[vertex].y;
+    }
+
+    /** get latitude value for the given vertex */
+    public double getLat(int vertex) {
+      return this.vertex[vertex].getLat();
+    }
+
+    /** get longitude value for the given vertex */
+    public double getLon(int vertex) {
+      return this.vertex[vertex].getLon();
+    }
+
+    /** utility method to compute whether the point is in the triangle */
+    protected boolean containsPoint(double lat, double lon) {
+      return pointInTriangle(lon, lat,
+          vertex[0].getLon(), vertex[0].getLat(),
+          vertex[1].getLon(), vertex[1].getLat(),
+          vertex[2].getLon(), vertex[2].getLat());
+    }
+
+    /** pretty print the triangle vertices */
+    public String toString() {
+      String result = vertex[0].x + ", " + vertex[0].y + " " +
+                      vertex[1].x + ", " + vertex[1].y + " " +
+                      vertex[2].x + ", " + vertex[2].y;
+      return result;
+    }
+  }
+}

--- a/server/src/main/java/org/apache/lucene/geo/XTessellator.java
+++ b/server/src/main/java/org/apache/lucene/geo/XTessellator.java
@@ -64,7 +64,6 @@ import static org.apache.lucene.geo.GeoUtils.orient;
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
  * THIS SOFTWARE.
  *
- * @lucene.experimental
  */
 public final class XTessellator {
   // this is a dumb heuristic to control whether we cut over to sorted morton values

--- a/server/src/main/java/org/elasticsearch/common/geo/ShapeRelation.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/ShapeRelation.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.geo;
 
+import org.apache.lucene.document.XLatLonShape.QueryRelation;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -60,6 +61,17 @@ public enum ShapeRelation implements Writeable {
             }
         }
         return null;
+    }
+
+    /** Maps ShapeRelation to Lucene's LatLonShapeRelation */
+    public QueryRelation getLuceneRelation() {
+        switch (this) {
+            case INTERSECTS: return QueryRelation.INTERSECTS;
+            case DISJOINT: return QueryRelation.DISJOINT;
+            case WITHIN: return QueryRelation.WITHIN;
+            default:
+                throw new IllegalArgumentException("ShapeRelation [" + this + "] not supported");
+        }
     }
 
     public String getRelationName() {

--- a/server/src/main/java/org/elasticsearch/common/geo/builders/GeometryCollectionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/builders/GeometryCollectionBuilder.java
@@ -198,9 +198,6 @@ public class GeometryCollectionBuilder extends ShapeBuilder {
             }
         }
 
-        if (shapes.size() == 1) {
-            return shapes.get(0);
-        }
         return shapes.toArray(new Object[shapes.size()]);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/geo/parsers/GeoJsonParser.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/parsers/GeoJsonParser.java
@@ -26,10 +26,11 @@ import org.elasticsearch.common.geo.GeoShapeType;
 import org.elasticsearch.common.geo.builders.CircleBuilder;
 import org.elasticsearch.common.geo.builders.GeometryCollectionBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.geo.builders.ShapeBuilder.Orientation;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentSubParser;
-import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.BaseGeoShapeFieldMapper;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -41,17 +42,22 @@ import java.util.List;
  * complies with geojson specification: https://tools.ietf.org/html/rfc7946
  */
 abstract class GeoJsonParser {
-    protected static ShapeBuilder parse(XContentParser parser, GeoShapeFieldMapper shapeMapper)
+    protected static ShapeBuilder parse(XContentParser parser, BaseGeoShapeFieldMapper shapeMapper)
         throws IOException {
         GeoShapeType shapeType = null;
         DistanceUnit.Distance radius = null;
         CoordinateNode coordinateNode = null;
         GeometryCollectionBuilder geometryCollections = null;
 
-        ShapeBuilder.Orientation requestedOrientation =
-            (shapeMapper == null) ? ShapeBuilder.Orientation.RIGHT : shapeMapper.fieldType().orientation();
-        Explicit<Boolean> coerce = (shapeMapper == null) ? GeoShapeFieldMapper.Defaults.COERCE : shapeMapper.coerce();
-        Explicit<Boolean> ignoreZValue = (shapeMapper == null) ? GeoShapeFieldMapper.Defaults.IGNORE_Z_VALUE : shapeMapper.ignoreZValue();
+        Orientation orientation = (shapeMapper == null)
+            ? BaseGeoShapeFieldMapper.Defaults.ORIENTATION.value()
+            : shapeMapper.orientation();
+        Explicit<Boolean> coerce = (shapeMapper == null)
+            ? BaseGeoShapeFieldMapper.Defaults.COERCE
+            : shapeMapper.coerce();
+        Explicit<Boolean> ignoreZValue = (shapeMapper == null)
+            ? BaseGeoShapeFieldMapper.Defaults.IGNORE_Z_VALUE
+            : shapeMapper.ignoreZValue();
 
         String malformedException = null;
 
@@ -102,7 +108,7 @@ abstract class GeoJsonParser {
                             malformedException = "cannot have [" + ShapeParser.FIELD_ORIENTATION + "] with type set to [" + shapeType + "]";
                         }
                         subParser.nextToken();
-                        requestedOrientation = ShapeBuilder.Orientation.fromString(subParser.text());
+                        orientation = ShapeBuilder.Orientation.fromString(subParser.text());
                     } else {
                         subParser.nextToken();
                         subParser.skipChildren();
@@ -132,7 +138,7 @@ abstract class GeoJsonParser {
             return geometryCollections;
         }
 
-        return shapeType.getBuilder(coordinateNode, radius, requestedOrientation, coerce.value());
+        return shapeType.getBuilder(coordinateNode, radius, orientation, coerce.value());
     }
 
     /**
@@ -206,7 +212,7 @@ abstract class GeoJsonParser {
      * @return Geometry[] geometries of the GeometryCollection
      * @throws IOException Thrown if an error occurs while reading from the XContentParser
      */
-    static GeometryCollectionBuilder parseGeometries(XContentParser parser, GeoShapeFieldMapper mapper) throws
+    static GeometryCollectionBuilder parseGeometries(XContentParser parser, BaseGeoShapeFieldMapper mapper) throws
         IOException {
         if (parser.currentToken() != XContentParser.Token.START_ARRAY) {
             throw new ElasticsearchParseException("geometries must be an array of geojson objects");

--- a/server/src/main/java/org/elasticsearch/common/geo/parsers/GeoWKTParser.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/parsers/GeoWKTParser.java
@@ -37,7 +37,7 @@ import org.elasticsearch.common.geo.builders.PolygonBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.BaseGeoShapeFieldMapper;
 
 import java.io.IOException;
 import java.io.StreamTokenizer;
@@ -64,7 +64,7 @@ public class GeoWKTParser {
     // no instance
     private GeoWKTParser() {}
 
-    public static ShapeBuilder parse(XContentParser parser, final GeoShapeFieldMapper shapeMapper)
+    public static ShapeBuilder parse(XContentParser parser, final BaseGeoShapeFieldMapper shapeMapper)
             throws IOException, ElasticsearchParseException {
         return parseExpectedType(parser, null, shapeMapper);
     }
@@ -76,13 +76,13 @@ public class GeoWKTParser {
 
     /** throws an exception if the parsed geometry type does not match the expected shape type */
     public static ShapeBuilder parseExpectedType(XContentParser parser, final GeoShapeType shapeType,
-                                                 final GeoShapeFieldMapper shapeMapper)
+                                                 final BaseGeoShapeFieldMapper shapeMapper)
             throws IOException, ElasticsearchParseException {
         StringReader reader = new StringReader(parser.text());
         try {
-            Explicit<Boolean> ignoreZValue = (shapeMapper == null) ? GeoShapeFieldMapper.Defaults.IGNORE_Z_VALUE :
+            Explicit<Boolean> ignoreZValue = (shapeMapper == null) ? BaseGeoShapeFieldMapper.Defaults.IGNORE_Z_VALUE :
                 shapeMapper.ignoreZValue();
-            Explicit<Boolean> coerce = (shapeMapper == null) ? GeoShapeFieldMapper.Defaults.COERCE : shapeMapper.coerce();
+            Explicit<Boolean> coerce = (shapeMapper == null) ? BaseGeoShapeFieldMapper.Defaults.COERCE : shapeMapper.coerce();
             // setup the tokenizer; configured to read words w/o numbers
             StreamTokenizer tokenizer = new StreamTokenizer(reader);
             tokenizer.resetSyntax();
@@ -261,7 +261,8 @@ public class GeoWKTParser {
         if (nextEmptyOrOpen(stream).equals(EMPTY)) {
             return null;
         }
-        PolygonBuilder builder = new PolygonBuilder(parseLinearRing(stream, ignoreZValue, coerce), ShapeBuilder.Orientation.RIGHT);
+        PolygonBuilder builder = new PolygonBuilder(parseLinearRing(stream, ignoreZValue, coerce),
+            BaseGeoShapeFieldMapper.Defaults.ORIENTATION.value());
         while (nextCloserOrComma(stream).equals(COMMA)) {
             builder.hole(parseLinearRing(stream, ignoreZValue, coerce));
         }

--- a/server/src/main/java/org/elasticsearch/common/geo/parsers/ShapeParser.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/parsers/ShapeParser.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.BaseGeoShapeFieldMapper;
 
 import java.io.IOException;
 
@@ -46,7 +46,7 @@ public interface ShapeParser {
      *          if the parsers current token has been <code>null</code>
      * @throws IOException if the input could not be read
      */
-    static ShapeBuilder parse(XContentParser parser, GeoShapeFieldMapper shapeMapper) throws IOException {
+    static ShapeBuilder parse(XContentParser parser, BaseGeoShapeFieldMapper shapeMapper) throws IOException {
         if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
             return null;
         } if (parser.currentToken() == XContentParser.Token.START_OBJECT) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BaseGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BaseGeoShapeFieldMapper.java
@@ -1,0 +1,348 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.geo.builders.ShapeBuilder.Orientation;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.index.mapper.LegacyGeoShapeFieldMapper.DeprecatedParameters;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.QueryShardException;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.index.mapper.GeoPointFieldMapper.Names.IGNORE_MALFORMED;
+
+/**
+ * Base class for {@link GeoShapeFieldMapper} and {@link LegacyGeoShapeFieldMapper}
+ */
+public abstract class BaseGeoShapeFieldMapper extends FieldMapper {
+    public static final String CONTENT_TYPE = "geo_shape";
+
+    public static class Names {
+        public static final ParseField ORIENTATION = new ParseField("orientation");
+        public static final ParseField COERCE = new ParseField("coerce");
+    }
+
+    public static class Defaults {
+        public static final Explicit<Orientation> ORIENTATION = new Explicit<>(Orientation.RIGHT, false);
+        public static final Explicit<Boolean> COERCE = new Explicit<>(false, false);
+        public static final Explicit<Boolean> IGNORE_MALFORMED = new Explicit<>(false, false);
+        public static final Explicit<Boolean> IGNORE_Z_VALUE = new Explicit<>(true, false);
+    }
+
+    public abstract static class Builder<T extends Builder, Y extends BaseGeoShapeFieldMapper>
+            extends FieldMapper.Builder<T, Y> {
+        protected Boolean coerce;
+        protected Boolean ignoreMalformed;
+        protected Boolean ignoreZValue;
+        protected Orientation orientation;
+
+        /** default builder - used for external mapper*/
+        public Builder(String name, MappedFieldType fieldType, MappedFieldType defaultFieldType) {
+            super(name, fieldType, defaultFieldType);
+        }
+
+        public Builder(String name, MappedFieldType fieldType, MappedFieldType defaultFieldType,
+                       boolean coerce, boolean ignoreMalformed, Orientation orientation, boolean ignoreZ) {
+            super(name, fieldType, defaultFieldType);
+            this.coerce = coerce;
+            this.ignoreMalformed = ignoreMalformed;
+            this.orientation = orientation;
+            this.ignoreZValue = ignoreZ;
+        }
+
+        public Builder coerce(boolean coerce) {
+            this.coerce = coerce;
+            return this;
+        }
+
+        protected Explicit<Boolean> coerce(BuilderContext context) {
+            if (coerce != null) {
+                return new Explicit<>(coerce, true);
+            }
+            if (context.indexSettings() != null) {
+                return new Explicit<>(COERCE_SETTING.get(context.indexSettings()), false);
+            }
+            return Defaults.COERCE;
+        }
+
+        public Builder orientation(Orientation orientation) {
+            this.orientation = orientation;
+            return this;
+        }
+
+        protected Explicit<Orientation> orientation() {
+            if (orientation != null) {
+                return new Explicit<>(orientation, true);
+            }
+            return Defaults.ORIENTATION;
+        }
+
+        @Override
+        protected boolean defaultDocValues(Version indexCreated) {
+            return false;
+        }
+
+        public Builder ignoreMalformed(boolean ignoreMalformed) {
+            this.ignoreMalformed = ignoreMalformed;
+            return this;
+        }
+
+        protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {
+            if (ignoreMalformed != null) {
+                return new Explicit<>(ignoreMalformed, true);
+            }
+            if (context.indexSettings() != null) {
+                return new Explicit<>(IGNORE_MALFORMED_SETTING.get(context.indexSettings()), false);
+            }
+            return Defaults.IGNORE_MALFORMED;
+        }
+
+        protected Explicit<Boolean> ignoreZValue() {
+            if (ignoreZValue != null) {
+                return new Explicit<>(ignoreZValue, true);
+            }
+            return Defaults.IGNORE_Z_VALUE;
+        }
+
+        public Builder ignoreZValue(final boolean ignoreZValue) {
+            this.ignoreZValue = ignoreZValue;
+            return this;
+        }
+
+        @Override
+        protected void setupFieldType(BuilderContext context) {
+            super.setupFieldType(context);
+
+            // field mapper handles this at build time
+            // but prefix tree strategies require a name, so throw a similar exception
+            if (name().isEmpty()) {
+                throw new IllegalArgumentException("name cannot be empty string");
+            }
+
+            BaseGeoShapeFieldType ft = (BaseGeoShapeFieldType)fieldType();
+            ft.setOrientation(orientation().value());
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+
+        @Override
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            Boolean coerce = null;
+            Boolean ignoreZ = null;
+            Boolean ignoreMalformed = null;
+            Orientation orientation = null;
+            DeprecatedParameters deprecatedParameters = new DeprecatedParameters();
+            boolean parsedDeprecatedParams = false;
+            for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
+                Map.Entry<String, Object> entry = iterator.next();
+                String fieldName = entry.getKey();
+                Object fieldNode = entry.getValue();
+                if (DeprecatedParameters.parse(name, fieldName, fieldNode, deprecatedParameters)) {
+                    parsedDeprecatedParams = true;
+                    iterator.remove();
+                } else if (Names.ORIENTATION.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
+                    orientation = ShapeBuilder.Orientation.fromString(fieldNode.toString());
+                    iterator.remove();
+                } else if (IGNORE_MALFORMED.equals(fieldName)) {
+                    ignoreMalformed = XContentMapValues.nodeBooleanValue(fieldNode, name + ".ignore_malformed");
+                    iterator.remove();
+                } else if (Names.COERCE.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
+                    coerce = XContentMapValues.nodeBooleanValue(fieldNode, name + "." + Names.COERCE.getPreferredName());
+                    iterator.remove();
+                } else if (GeoPointFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName().equals(fieldName)) {
+                    ignoreZ = XContentMapValues.nodeBooleanValue(fieldNode,
+                        name + "." + GeoPointFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName());
+                    iterator.remove();
+                }
+            }
+            final Builder builder;
+            if (parsedDeprecatedParams || parserContext.indexVersionCreated().before(Version.V_6_6_0)) {
+                // Legacy index-based shape
+                builder = new LegacyGeoShapeFieldMapper.Builder(name, deprecatedParameters);
+            } else {
+                // BKD-based shape
+                builder = new GeoShapeFieldMapper.Builder(name);
+            }
+
+            if (coerce != null) {
+                builder.coerce(coerce);
+            }
+
+            if (ignoreZ != null) {
+                builder.ignoreZValue(ignoreZ);
+            }
+
+            if (ignoreMalformed != null) {
+                builder.ignoreMalformed(ignoreMalformed);
+            }
+
+            if (orientation != null) {
+                builder.orientation(orientation);
+            }
+
+            return builder;
+        }
+    }
+
+    public abstract static class BaseGeoShapeFieldType extends MappedFieldType {
+        protected Orientation orientation = Defaults.ORIENTATION.value();
+
+        protected BaseGeoShapeFieldType() {
+            setIndexOptions(IndexOptions.DOCS);
+            setTokenized(false);
+            setStored(false);
+            setStoreTermVectors(false);
+            setOmitNorms(true);
+        }
+
+        protected BaseGeoShapeFieldType(BaseGeoShapeFieldType ref) {
+            super(ref);
+            this.orientation = ref.orientation;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!super.equals(o)) return false;
+            BaseGeoShapeFieldType that = (BaseGeoShapeFieldType) o;
+            return orientation == that.orientation;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), orientation);
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        public void checkCompatibility(MappedFieldType fieldType, List<String> conflicts, boolean strict) {
+            super.checkCompatibility(fieldType, conflicts, strict);
+        }
+
+        public Orientation orientation() { return this.orientation; }
+
+        public void setOrientation(Orientation orientation) {
+            checkIfFrozen();
+            this.orientation = orientation;
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
+        }
+
+        @Override
+        public Query termQuery(Object value, QueryShardContext context) {
+            throw new QueryShardException(context, "Geo fields do not support exact searching, use dedicated geo queries instead");
+        }
+    }
+
+    protected Explicit<Boolean> coerce;
+    protected Explicit<Boolean> ignoreMalformed;
+    protected Explicit<Boolean> ignoreZValue;
+
+    protected BaseGeoShapeFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
+                                     Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
+                                     Explicit<Boolean> ignoreZValue, Settings indexSettings,
+                                     MultiFields multiFields, CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        this.coerce = coerce;
+        this.ignoreMalformed = ignoreMalformed;
+        this.ignoreZValue = ignoreZValue;
+    }
+
+    @Override
+    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+        super.doMerge(mergeWith, updateAllTypes);
+        BaseGeoShapeFieldMapper gsfm = (BaseGeoShapeFieldMapper)mergeWith;
+        if (gsfm.coerce.explicit()) {
+            this.coerce = gsfm.coerce;
+        }
+        if (gsfm.ignoreMalformed.explicit()) {
+            this.ignoreMalformed = gsfm.ignoreMalformed;
+        }
+        if (gsfm.ignoreZValue.explicit()) {
+            this.ignoreZValue = gsfm.ignoreZValue;
+        }
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException {
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        builder.field("type", contentType());
+        BaseGeoShapeFieldType ft = (BaseGeoShapeFieldType)fieldType();
+        if (includeDefaults || ft.orientation() != Defaults.ORIENTATION.value()) {
+            builder.field(Names.ORIENTATION.getPreferredName(), ft.orientation());
+        }
+        if (includeDefaults || coerce.explicit()) {
+            builder.field(Names.COERCE.getPreferredName(), coerce.value());
+        }
+        if (includeDefaults || ignoreMalformed.explicit()) {
+            builder.field(IGNORE_MALFORMED, ignoreMalformed.value());
+        }
+        if (includeDefaults || ignoreZValue.explicit()) {
+            builder.field(GeoPointFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName(), ignoreZValue.value());
+        }
+    }
+
+    public Explicit<Boolean> coerce() {
+        return coerce;
+    }
+
+    public Explicit<Boolean> ignoreMalformed() {
+        return ignoreMalformed;
+    }
+
+    public Explicit<Boolean> ignoreZValue() {
+        return ignoreZValue;
+    }
+
+    public Orientation orientation() {
+        return ((BaseGeoShapeFieldType)fieldType).orientation();
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -18,47 +18,24 @@
  */
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.XLatLonShape;
+import org.apache.lucene.geo.Line;
+import org.apache.lucene.geo.Polygon;
+import org.apache.lucene.geo.Rectangle;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.index.Term;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.spatial.prefix.PrefixTreeStrategy;
-import org.apache.lucene.spatial.prefix.RecursivePrefixTreeStrategy;
-import org.apache.lucene.spatial.prefix.TermQueryPrefixTreeStrategy;
-import org.apache.lucene.spatial.prefix.tree.GeohashPrefixTree;
-import org.apache.lucene.spatial.prefix.tree.PackedQuadPrefixTree;
-import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
-import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Explicit;
-import org.elasticsearch.common.geo.GeoUtils;
-import org.elasticsearch.common.geo.SpatialStrategy;
-import org.elasticsearch.common.geo.XShapeCollection;
+import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
-import org.elasticsearch.common.geo.builders.ShapeBuilder.Orientation;
 import org.elasticsearch.common.geo.parsers.ShapeParser;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.DistanceUnit;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.index.query.QueryShardException;
-import org.locationtech.spatial4j.shape.Point;
-import org.locationtech.spatial4j.shape.Shape;
-import org.locationtech.spatial4j.shape.jts.JtsGeometry;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
-import static org.elasticsearch.index.mapper.GeoPointFieldMapper.Names.IGNORE_MALFORMED;
 
 /**
- * FieldMapper for indexing {@link org.locationtech.spatial4j.shape.Shape}s.
+ * FieldMapper for indexing {@link XLatLonShape}s.
  * <p>
  * Currently Shapes can only be indexed and can only be queried using
  * {@link org.elasticsearch.index.query.GeoShapeQueryBuilder}, consequently
@@ -72,567 +49,123 @@ import static org.elasticsearch.index.mapper.GeoPointFieldMapper.Names.IGNORE_MA
  * [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ]
  * ]
  * }
+ * <p>
+ * or:
+ * <p>
+ * "field" : "POLYGON ((100.0 0.0, 101.0 0.0, 101.0 1.0, 100.0 1.0, 100.0 0.0))
  */
-public class GeoShapeFieldMapper extends FieldMapper {
+public class GeoShapeFieldMapper extends BaseGeoShapeFieldMapper {
 
-    public static final String CONTENT_TYPE = "geo_shape";
-
-    public static class Names {
-        public static final String TREE = "tree";
-        public static final String TREE_GEOHASH = "geohash";
-        public static final String TREE_QUADTREE = "quadtree";
-        public static final String TREE_LEVELS = "tree_levels";
-        public static final String TREE_PRESISION = "precision";
-        public static final String DISTANCE_ERROR_PCT = "distance_error_pct";
-        public static final String ORIENTATION = "orientation";
-        public static final String STRATEGY = "strategy";
-        public static final String STRATEGY_POINTS_ONLY = "points_only";
-        public static final String COERCE = "coerce";
-    }
-
-    public static class Defaults {
-        public static final String TREE = Names.TREE_GEOHASH;
-        public static final String STRATEGY = SpatialStrategy.RECURSIVE.getStrategyName();
-        public static final boolean POINTS_ONLY = false;
-        public static final int GEOHASH_LEVELS = GeoUtils.geoHashLevelsForPrecision("50m");
-        public static final int QUADTREE_LEVELS = GeoUtils.quadTreeLevelsForPrecision("50m");
-        public static final Orientation ORIENTATION = Orientation.RIGHT;
-        public static final double LEGACY_DISTANCE_ERROR_PCT = 0.025d;
-        public static final Explicit<Boolean> COERCE = new Explicit<>(false, false);
-        public static final Explicit<Boolean> IGNORE_MALFORMED = new Explicit<>(false, false);
-        public static final Explicit<Boolean> IGNORE_Z_VALUE = new Explicit<>(true, false);
-
-        public static final MappedFieldType FIELD_TYPE = new GeoShapeFieldType();
-
-        static {
-            // setting name here is a hack so freeze can be called...instead all these options should be
-            // moved to the default ctor for GeoShapeFieldType, and defaultFieldType() should be removed from mappers...
-            FIELD_TYPE.setName("DoesNotExist");
-            FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
-            FIELD_TYPE.setTokenized(false);
-            FIELD_TYPE.setStored(false);
-            FIELD_TYPE.setStoreTermVectors(false);
-            FIELD_TYPE.setOmitNorms(true);
-            FIELD_TYPE.freeze();
-        }
-    }
-
-    public static class Builder extends FieldMapper.Builder<Builder, GeoShapeFieldMapper> {
-
-        private Boolean coerce;
-        private Boolean ignoreMalformed;
-        private Boolean ignoreZValue;
-
+    public static class Builder extends BaseGeoShapeFieldMapper.Builder<BaseGeoShapeFieldMapper.Builder, GeoShapeFieldMapper> {
         public Builder(String name) {
-            super(name, Defaults.FIELD_TYPE, Defaults.FIELD_TYPE);
-        }
-
-        @Override
-        public GeoShapeFieldType fieldType() {
-            return (GeoShapeFieldType)fieldType;
-        }
-
-        public Builder coerce(boolean coerce) {
-            this.coerce = coerce;
-            return this;
-        }
-
-        @Override
-        protected boolean defaultDocValues(Version indexCreated) {
-            return false;
-        }
-
-        protected Explicit<Boolean> coerce(BuilderContext context) {
-            if (coerce != null) {
-                return new Explicit<>(coerce, true);
-            }
-            if (context.indexSettings() != null) {
-                return new Explicit<>(COERCE_SETTING.get(context.indexSettings()), false);
-            }
-            return Defaults.COERCE;
-        }
-
-        public Builder ignoreMalformed(boolean ignoreMalformed) {
-            this.ignoreMalformed = ignoreMalformed;
-            return this;
-        }
-
-        protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {
-            if (ignoreMalformed != null) {
-                return new Explicit<>(ignoreMalformed, true);
-            }
-            if (context.indexSettings() != null) {
-                return new Explicit<>(IGNORE_MALFORMED_SETTING.get(context.indexSettings()), false);
-            }
-            return Defaults.IGNORE_MALFORMED;
-        }
-
-        protected Explicit<Boolean> ignoreZValue(BuilderContext context) {
-            if (ignoreZValue != null) {
-                return new Explicit<>(ignoreZValue, true);
-            }
-            return Defaults.IGNORE_Z_VALUE;
-        }
-
-        public Builder ignoreZValue(final boolean ignoreZValue) {
-            this.ignoreZValue = ignoreZValue;
-            return this;
+            super (name, new GeoShapeFieldType(), new GeoShapeFieldType());
         }
 
         @Override
         public GeoShapeFieldMapper build(BuilderContext context) {
-            GeoShapeFieldType geoShapeFieldType = (GeoShapeFieldType)fieldType;
-
-            if (geoShapeFieldType.treeLevels() == 0 && geoShapeFieldType.precisionInMeters() < 0) {
-                geoShapeFieldType.setDefaultDistanceErrorPct(Defaults.LEGACY_DISTANCE_ERROR_PCT);
-            }
             setupFieldType(context);
-
-            return new GeoShapeFieldMapper(name, fieldType, ignoreMalformed(context), coerce(context), ignoreZValue(context),
-                    context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            return new GeoShapeFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context), coerce(context),
+                ignoreZValue(), context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
         }
     }
 
-    public static class TypeParser implements Mapper.TypeParser {
-
-        @Override
-        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            Builder builder = new Builder(name);
-            Boolean pointsOnly = null;
-            for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
-                Map.Entry<String, Object> entry = iterator.next();
-                String fieldName = entry.getKey();
-                Object fieldNode = entry.getValue();
-                if (Names.TREE.equals(fieldName)) {
-                    builder.fieldType().setTree(fieldNode.toString());
-                    iterator.remove();
-                } else if (Names.TREE_LEVELS.equals(fieldName)) {
-                    builder.fieldType().setTreeLevels(Integer.parseInt(fieldNode.toString()));
-                    iterator.remove();
-                } else if (Names.TREE_PRESISION.equals(fieldName)) {
-                    builder.fieldType().setPrecisionInMeters(DistanceUnit.parse(fieldNode.toString(),
-                        DistanceUnit.DEFAULT, DistanceUnit.DEFAULT));
-                    iterator.remove();
-                } else if (Names.DISTANCE_ERROR_PCT.equals(fieldName)) {
-                    builder.fieldType().setDistanceErrorPct(Double.parseDouble(fieldNode.toString()));
-                    iterator.remove();
-                } else if (Names.ORIENTATION.equals(fieldName)) {
-                    builder.fieldType().setOrientation(ShapeBuilder.Orientation.fromString(fieldNode.toString()));
-                    iterator.remove();
-                } else if (Names.STRATEGY.equals(fieldName)) {
-                    builder.fieldType().setStrategyName(fieldNode.toString());
-                    iterator.remove();
-                } else if (IGNORE_MALFORMED.equals(fieldName)) {
-                    builder.ignoreMalformed(TypeParsers.nodeBooleanValue(fieldName, "ignore_malformed",
-                        fieldNode, parserContext));
-                    iterator.remove();
-                } else if (Names.COERCE.equals(fieldName)) {
-                    builder.coerce(TypeParsers.nodeBooleanValue(fieldName, Names.COERCE, fieldNode, parserContext));
-                    iterator.remove();
-                } else if (GeoPointFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName().equals(fieldName)) {
-                    builder.ignoreZValue(TypeParsers.nodeBooleanValue(fieldName,
-                        GeoPointFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName(),
-                        fieldNode, parserContext));
-                    iterator.remove();
-                } else if (Names.STRATEGY_POINTS_ONLY.equals(fieldName)) {
-                    pointsOnly = TypeParsers.nodeBooleanValue(fieldName, Names.STRATEGY_POINTS_ONLY, fieldNode, parserContext);
-                    iterator.remove();
-                }
-            }
-            if (pointsOnly != null) {
-                if (builder.fieldType().strategyName.equals(SpatialStrategy.TERM.getStrategyName()) && pointsOnly == false) {
-                    throw new IllegalArgumentException("points_only cannot be set to false for term strategy");
-                } else {
-                    builder.fieldType().setPointsOnly(pointsOnly);
-                }
-            }
-            return builder;
+    public static final class GeoShapeFieldType extends BaseGeoShapeFieldType {
+        public GeoShapeFieldType() {
+            super();
         }
-    }
-
-    public static final class GeoShapeFieldType extends MappedFieldType {
-
-        private String tree = Defaults.TREE;
-        private String strategyName = Defaults.STRATEGY;
-        private boolean pointsOnly = Defaults.POINTS_ONLY;
-        private int treeLevels = 0;
-        private double precisionInMeters = -1;
-        private Double distanceErrorPct;
-        private double defaultDistanceErrorPct = 0.0;
-        private Orientation orientation = Defaults.ORIENTATION;
-
-        // these are built when the field type is frozen
-        private PrefixTreeStrategy defaultStrategy;
-        private RecursivePrefixTreeStrategy recursiveStrategy;
-        private TermQueryPrefixTreeStrategy termStrategy;
-
-        public GeoShapeFieldType() {}
 
         protected GeoShapeFieldType(GeoShapeFieldType ref) {
             super(ref);
-            this.tree = ref.tree;
-            this.strategyName = ref.strategyName;
-            this.pointsOnly = ref.pointsOnly;
-            this.treeLevels = ref.treeLevels;
-            this.precisionInMeters = ref.precisionInMeters;
-            this.distanceErrorPct = ref.distanceErrorPct;
-            this.defaultDistanceErrorPct = ref.defaultDistanceErrorPct;
-            this.orientation = ref.orientation;
         }
 
         @Override
         public GeoShapeFieldType clone() {
             return new GeoShapeFieldType(this);
         }
-
-        @Override
-        public boolean equals(Object o) {
-            if (!super.equals(o)) return false;
-            GeoShapeFieldType that = (GeoShapeFieldType) o;
-            return treeLevels == that.treeLevels &&
-                precisionInMeters == that.precisionInMeters &&
-                defaultDistanceErrorPct == that.defaultDistanceErrorPct &&
-                Objects.equals(tree, that.tree) &&
-                Objects.equals(strategyName, that.strategyName) &&
-                pointsOnly == that.pointsOnly &&
-                Objects.equals(distanceErrorPct, that.distanceErrorPct) &&
-                orientation == that.orientation;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(super.hashCode(), tree, strategyName, pointsOnly, treeLevels, precisionInMeters, distanceErrorPct,
-                defaultDistanceErrorPct, orientation);
-        }
-
-        @Override
-        public String typeName() {
-            return CONTENT_TYPE;
-        }
-
-        @Override
-        public void freeze() {
-            super.freeze();
-            // This is a bit hackish: we need to setup the spatial tree and strategies once the field name is set, which
-            // must be by the time freeze is called.
-            SpatialPrefixTree prefixTree;
-            if ("geohash".equals(tree)) {
-                prefixTree = new GeohashPrefixTree(ShapeBuilder.SPATIAL_CONTEXT,
-                    getLevels(treeLevels, precisionInMeters, Defaults.GEOHASH_LEVELS, true));
-            } else if ("legacyquadtree".equals(tree)) {
-                prefixTree = new QuadPrefixTree(ShapeBuilder.SPATIAL_CONTEXT,
-                    getLevels(treeLevels, precisionInMeters, Defaults.QUADTREE_LEVELS, false));
-            } else if ("quadtree".equals(tree)) {
-                prefixTree = new PackedQuadPrefixTree(ShapeBuilder.SPATIAL_CONTEXT,
-                    getLevels(treeLevels, precisionInMeters, Defaults.QUADTREE_LEVELS, false));
-            } else {
-                throw new IllegalArgumentException("Unknown prefix tree type [" + tree + "]");
-            }
-
-            recursiveStrategy = new RecursivePrefixTreeStrategy(prefixTree, name());
-            recursiveStrategy.setDistErrPct(distanceErrorPct());
-            recursiveStrategy.setPruneLeafyBranches(false);
-            termStrategy = new TermQueryPrefixTreeStrategy(prefixTree, name());
-            termStrategy.setDistErrPct(distanceErrorPct());
-            defaultStrategy = resolveStrategy(strategyName);
-            defaultStrategy.setPointsOnly(pointsOnly);
-        }
-
-        @Override
-        public void checkCompatibility(MappedFieldType fieldType, List<String> conflicts, boolean strict) {
-            super.checkCompatibility(fieldType, conflicts, strict);
-            GeoShapeFieldType other = (GeoShapeFieldType)fieldType;
-            // prevent user from changing strategies
-            if (strategyName().equals(other.strategyName()) == false) {
-                conflicts.add("mapper [" + name() + "] has different [strategy]");
-            }
-
-            // prevent user from changing trees (changes encoding)
-            if (tree().equals(other.tree()) == false) {
-                conflicts.add("mapper [" + name() + "] has different [tree]");
-            }
-
-            if ((pointsOnly() != other.pointsOnly())) {
-                conflicts.add("mapper [" + name() + "] has different points_only");
-            }
-
-            // TODO we should allow this, but at the moment levels is used to build bookkeeping variables
-            // in lucene's SpatialPrefixTree implementations, need a patch to correct that first
-            if (treeLevels() != other.treeLevels()) {
-                conflicts.add("mapper [" + name() + "] has different [tree_levels]");
-            }
-            if (precisionInMeters() != other.precisionInMeters()) {
-                conflicts.add("mapper [" + name() + "] has different [precision]");
-            }
-
-            if (strict) {
-                if (orientation() != other.orientation()) {
-                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update"
-                        + " [orientation] across all types.");
-                }
-                if (distanceErrorPct() != other.distanceErrorPct()) {
-                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update"
-                        + " [distance_error_pct] across all types.");
-                }
-            }
-        }
-
-        private static int getLevels(int treeLevels, double precisionInMeters, int defaultLevels, boolean geoHash) {
-            if (treeLevels > 0 || precisionInMeters >= 0) {
-                return Math.max(treeLevels, precisionInMeters >= 0 ? (geoHash ? GeoUtils.geoHashLevelsForPrecision(precisionInMeters)
-                    : GeoUtils.quadTreeLevelsForPrecision(precisionInMeters)) : 0);
-            }
-            return defaultLevels;
-        }
-
-        public String tree() {
-            return tree;
-        }
-
-        public void setTree(String tree) {
-            checkIfFrozen();
-            this.tree = tree;
-        }
-
-        public String strategyName() {
-            return strategyName;
-        }
-
-        public void setStrategyName(String strategyName) {
-            checkIfFrozen();
-            this.strategyName = strategyName;
-            if (this.strategyName.equals(SpatialStrategy.TERM.getStrategyName())) {
-                this.pointsOnly = true;
-            }
-        }
-
-        public boolean pointsOnly() {
-            return pointsOnly;
-        }
-
-        public void setPointsOnly(boolean pointsOnly) {
-            checkIfFrozen();
-            this.pointsOnly = pointsOnly;
-        }
-        public int treeLevels() {
-            return treeLevels;
-        }
-
-        public void setTreeLevels(int treeLevels) {
-            checkIfFrozen();
-            this.treeLevels = treeLevels;
-        }
-
-        public double precisionInMeters() {
-            return precisionInMeters;
-        }
-
-        public void setPrecisionInMeters(double precisionInMeters) {
-            checkIfFrozen();
-            this.precisionInMeters = precisionInMeters;
-        }
-
-        public double distanceErrorPct() {
-            return distanceErrorPct == null ? defaultDistanceErrorPct : distanceErrorPct;
-        }
-
-        public void setDistanceErrorPct(double distanceErrorPct) {
-            checkIfFrozen();
-            this.distanceErrorPct = distanceErrorPct;
-        }
-
-        public void setDefaultDistanceErrorPct(double defaultDistanceErrorPct) {
-            checkIfFrozen();
-            this.defaultDistanceErrorPct = defaultDistanceErrorPct;
-        }
-
-        public Orientation orientation() { return this.orientation; }
-
-        public void setOrientation(Orientation orientation) {
-            checkIfFrozen();
-            this.orientation = orientation;
-        }
-
-        public PrefixTreeStrategy defaultStrategy() {
-            return this.defaultStrategy;
-        }
-
-        public PrefixTreeStrategy resolveStrategy(SpatialStrategy strategy) {
-            return resolveStrategy(strategy.getStrategyName());
-        }
-
-        public PrefixTreeStrategy resolveStrategy(String strategyName) {
-            if (SpatialStrategy.RECURSIVE.getStrategyName().equals(strategyName)) {
-                return recursiveStrategy;
-            }
-            if (SpatialStrategy.TERM.getStrategyName().equals(strategyName)) {
-                return termStrategy;
-            }
-            throw new IllegalArgumentException("Unknown prefix tree strategy [" + strategyName + "]");
-        }
-
-        @Override
-        public Query existsQuery(QueryShardContext context) {
-            return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
-        }
-
-        @Override
-        public Query termQuery(Object value, QueryShardContext context) {
-            throw new QueryShardException(context, "Geo fields do not support exact searching, use dedicated geo queries instead");
-        }
     }
 
-    protected Explicit<Boolean> coerce;
-    protected Explicit<Boolean> ignoreMalformed;
-    protected Explicit<Boolean> ignoreZValue;
-
-    public GeoShapeFieldMapper(String simpleName, MappedFieldType fieldType, Explicit<Boolean> ignoreMalformed,
-                               Explicit<Boolean> coerce, Explicit<Boolean> ignoreZValue, Settings indexSettings,
+    public GeoShapeFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
+                               Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
+                               Explicit<Boolean> ignoreZValue, Settings indexSettings,
                                MultiFields multiFields, CopyTo copyTo) {
-        super(simpleName, fieldType, Defaults.FIELD_TYPE, indexSettings, multiFields, copyTo);
-        this.coerce = coerce;
-        this.ignoreMalformed = ignoreMalformed;
-        this.ignoreZValue = ignoreZValue;
+        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, ignoreZValue, indexSettings,
+            multiFields, copyTo);
     }
 
     @Override
     public GeoShapeFieldType fieldType() {
         return (GeoShapeFieldType) super.fieldType();
     }
+
+    /** parsing logic for {@link XLatLonShape} indexing */
     @Override
     public void parse(ParseContext context) throws IOException {
         try {
-            Shape shape = context.parseExternalValue(Shape.class);
+            Object shape = context.parseExternalValue(Object.class);
             if (shape == null) {
                 ShapeBuilder shapeBuilder = ShapeParser.parse(context.parser(), this);
                 if (shapeBuilder == null) {
                     return;
                 }
-                shape = shapeBuilder.buildS4J();
-            }
-            if (fieldType().pointsOnly() == true) {
-                // index configured for pointsOnly
-                if (shape instanceof XShapeCollection && XShapeCollection.class.cast(shape).pointsOnly()) {
-                    // MULTIPOINT data: index each point separately
-                    List<Shape> shapes = ((XShapeCollection) shape).getShapes();
-                    for (Shape s : shapes) {
-                        indexShape(context, s);
-                    }
-                    return;
-                } else if (shape instanceof Point == false) {
-                    throw new MapperParsingException("[{" + fieldType().name() + "}] is configured for points only but a "
-                        + ((shape instanceof JtsGeometry) ? ((JtsGeometry)shape).getGeom().getGeometryType() : shape.getClass())
-                        + " was found");
-                }
+                shape = shapeBuilder.buildLucene();
             }
             indexShape(context, shape);
         } catch (Exception e) {
             if (ignoreMalformed.value() == false) {
                 throw new MapperParsingException("failed to parse field [{}] of type [{}]", e, fieldType().name(),
-                        fieldType().typeName());
+                    fieldType().typeName());
             }
-            context.addIgnoredField(fieldType.name());
+            context.addIgnoredField(fieldType().name());
         }
     }
 
-    private void indexShape(ParseContext context, Shape shape) {
-        List<IndexableField> fields = new ArrayList<>(Arrays.asList(fieldType().defaultStrategy().createIndexableFields(shape)));
-        createFieldNamesField(context, fields);
-        for (IndexableField field : fields) {
-            context.doc().add(field);
-        }
-    }
-
-    @Override
-    protected void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException {
-    }
-
-    @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
-
-        GeoShapeFieldMapper gsfm = (GeoShapeFieldMapper)mergeWith;
-        if (gsfm.coerce.explicit()) {
-            this.coerce = gsfm.coerce;
-        }
-        if (gsfm.ignoreMalformed.explicit()) {
-            this.ignoreMalformed = gsfm.ignoreMalformed;
-        }
-        if (gsfm.ignoreZValue.explicit()) {
-            this.ignoreZValue = gsfm.ignoreZValue;
-        }
-    }
-
-    @Override
-    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
-        builder.field("type", contentType());
-
-        if (includeDefaults || fieldType().tree().equals(Defaults.TREE) == false) {
-            builder.field(Names.TREE, fieldType().tree());
-        }
-
-        if (fieldType().treeLevels() != 0) {
-            builder.field(Names.TREE_LEVELS, fieldType().treeLevels());
-        } else if(includeDefaults && fieldType().precisionInMeters() == -1) { // defaults only make sense if precision is not specified
-            if ("geohash".equals(fieldType().tree())) {
-                builder.field(Names.TREE_LEVELS, Defaults.GEOHASH_LEVELS);
-            } else if ("legacyquadtree".equals(fieldType().tree())) {
-                builder.field(Names.TREE_LEVELS, Defaults.QUADTREE_LEVELS);
-            } else if ("quadtree".equals(fieldType().tree())) {
-                builder.field(Names.TREE_LEVELS, Defaults.QUADTREE_LEVELS);
-            } else {
-                throw new IllegalArgumentException("Unknown prefix tree type [" + fieldType().tree() + "]");
+    private void indexShape(ParseContext context, Object luceneShape) {
+        if (luceneShape instanceof GeoPoint) {
+            GeoPoint pt = (GeoPoint) luceneShape;
+            indexFields(context, XLatLonShape.createIndexableFields(name(), pt.lat(), pt.lon()));
+        } else if (luceneShape instanceof double[]) {
+            double[] pt = (double[]) luceneShape;
+            indexFields(context, XLatLonShape.createIndexableFields(name(), pt[1], pt[0]));
+        } else if (luceneShape instanceof Line) {
+            indexFields(context, XLatLonShape.createIndexableFields(name(), (Line)luceneShape));
+        } else if (luceneShape instanceof Polygon) {
+            indexFields(context, XLatLonShape.createIndexableFields(name(), (Polygon) luceneShape));
+        } else if (luceneShape instanceof double[][]) {
+            double[][] pts = (double[][])luceneShape;
+            for (int i = 0; i < pts.length; ++i) {
+                indexFields(context, XLatLonShape.createIndexableFields(name(), pts[i][1], pts[i][0]));
             }
-        }
-        if (fieldType().precisionInMeters() != -1) {
-            builder.field(Names.TREE_PRESISION, DistanceUnit.METERS.toString(fieldType().precisionInMeters()));
-        } else if (includeDefaults && fieldType().treeLevels() == 0) { // defaults only make sense if tree levels are not specified
-            builder.field(Names.TREE_PRESISION, DistanceUnit.METERS.toString(50));
-        }
-        if (includeDefaults || fieldType().strategyName().equals(Defaults.STRATEGY) == false) {
-            builder.field(Names.STRATEGY, fieldType().strategyName());
-        }
-        if (includeDefaults || fieldType().distanceErrorPct() != fieldType().defaultDistanceErrorPct) {
-            builder.field(Names.DISTANCE_ERROR_PCT, fieldType().distanceErrorPct());
-        }
-        if (includeDefaults || fieldType().orientation() != Defaults.ORIENTATION) {
-            builder.field(Names.ORIENTATION, fieldType().orientation());
-        }
-        if (fieldType().strategyName().equals(SpatialStrategy.TERM.getStrategyName())) {
-            // For TERMs strategy the defaults for points only change to true
-            if (includeDefaults || fieldType().pointsOnly() != true) {
-                builder.field(Names.STRATEGY_POINTS_ONLY, fieldType().pointsOnly());
+        } else if (luceneShape instanceof Line[]) {
+            Line[] lines = (Line[]) luceneShape;
+            for (int i = 0; i < lines.length; ++i) {
+                indexFields(context, XLatLonShape.createIndexableFields(name(), lines[i]));
+            }
+        } else if (luceneShape instanceof Polygon[]) {
+            Polygon[] polys = (Polygon[]) luceneShape;
+            for (int i = 0; i < polys.length; ++i) {
+                indexFields(context, XLatLonShape.createIndexableFields(name(), polys[i]));
+            }
+        } else if (luceneShape instanceof Rectangle) {
+            // index rectangle as a polygon
+            Rectangle r = (Rectangle) luceneShape;
+            Polygon p = new Polygon(new double[]{r.minLat, r.minLat, r.maxLat, r.maxLat, r.minLat},
+                new double[]{r.minLon, r.maxLon, r.maxLon, r.minLon, r.minLon});
+            indexFields(context, XLatLonShape.createIndexableFields(name(), p));
+        } else if (luceneShape instanceof Object[]) {
+            // recurse to index geometry collection
+            for (Object o : (Object[])luceneShape) {
+                indexShape(context, o);
             }
         } else {
-            if (includeDefaults || fieldType().pointsOnly() != GeoShapeFieldMapper.Defaults.POINTS_ONLY) {
-                builder.field(Names.STRATEGY_POINTS_ONLY, fieldType().pointsOnly());
-            }
-        }
-        if (includeDefaults || coerce.explicit()) {
-            builder.field(Names.COERCE, coerce.value());
-        }
-        if (includeDefaults || ignoreMalformed.explicit()) {
-            builder.field(IGNORE_MALFORMED, ignoreMalformed.value());
-        }
-        if (includeDefaults || ignoreZValue.explicit()) {
-            builder.field(GeoPointFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName(), ignoreZValue.value());
+            throw new IllegalArgumentException("invalid shape type found [" + luceneShape.getClass() + "] while indexing shape");
         }
     }
 
-    public Explicit<Boolean> coerce() {
-        return coerce;
-    }
-
-    public Explicit<Boolean> ignoreMalformed() {
-        return ignoreMalformed;
-    }
-
-    public Explicit<Boolean> ignoreZValue() {
-        return ignoreZValue;
-    }
-
-    @Override
-    protected String contentType() {
-        return CONTENT_TYPE;
+    private void indexFields(ParseContext context, Field[] fields) {
+        ArrayList<IndexableField> flist = new ArrayList<>(Arrays.asList(fields));
+        createFieldNamesField(context, flist);
+        for (IndexableField f : flist) {
+            context.doc().add(f);
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -1,0 +1,576 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.mapper;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.spatial.prefix.PrefixTreeStrategy;
+import org.apache.lucene.spatial.prefix.RecursivePrefixTreeStrategy;
+import org.apache.lucene.spatial.prefix.TermQueryPrefixTreeStrategy;
+import org.apache.lucene.spatial.prefix.tree.GeohashPrefixTree;
+import org.apache.lucene.spatial.prefix.tree.PackedQuadPrefixTree;
+import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
+import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.common.geo.ShapesAvailability;
+import org.elasticsearch.common.geo.SpatialStrategy;
+import org.elasticsearch.common.geo.XShapeCollection;
+import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.geo.builders.ShapeBuilder.Orientation;
+import org.elasticsearch.common.geo.parsers.ShapeParser;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Shape;
+import org.locationtech.spatial4j.shape.jts.JtsGeometry;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * FieldMapper for indexing {@link org.locationtech.spatial4j.shape.Shape}s.
+ * <p>
+ * Currently Shapes can only be indexed and can only be queried using
+ * {@link org.elasticsearch.index.query.GeoShapeQueryBuilder}, consequently
+ * a lot of behavior in this Mapper is disabled.
+ * <p>
+ * Format supported:
+ * <p>
+ * "field" : {
+ * "type" : "polygon",
+ * "coordinates" : [
+ * [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ]
+ * ]
+ * }
+ * <p>
+ * or:
+ * <p>
+ * "field" : "POLYGON ((100.0 0.0, 101.0 0.0, 101.0 1.0, 100.0 1.0, 100.0 0.0))
+ *
+ * @deprecated use {@link GeoShapeFieldMapper}
+ */
+@Deprecated
+public class LegacyGeoShapeFieldMapper extends BaseGeoShapeFieldMapper {
+
+    public static final String CONTENT_TYPE = "geo_shape";
+
+    @Deprecated
+    public static class DeprecatedParameters {
+        public static class Names {
+            public static final ParseField STRATEGY = new ParseField("strategy");
+            public static final ParseField TREE = new ParseField("tree");
+            public static final ParseField TREE_LEVELS = new ParseField("tree_levels");
+            public static final ParseField PRECISION = new ParseField("precision");
+            public static final ParseField DISTANCE_ERROR_PCT = new ParseField("distance_error_pct");
+            public static final ParseField POINTS_ONLY = new ParseField("points_only");
+        }
+
+        public static class PrefixTrees {
+            public static final String LEGACY_QUADTREE = "legacyquadtree";
+            public static final String QUADTREE = "quadtree";
+            public static final String GEOHASH = "geohash";
+        }
+
+        public static class Defaults {
+            public static final SpatialStrategy STRATEGY = SpatialStrategy.RECURSIVE;
+            public static final String TREE = "quadtree";
+            public static final String PRECISION = "50m";
+            public static final int QUADTREE_LEVELS = GeoUtils.quadTreeLevelsForPrecision(PRECISION);
+            public static final int GEOHASH_TREE_LEVELS = GeoUtils.geoHashLevelsForPrecision(PRECISION);
+            public static final boolean POINTS_ONLY = false;
+            public static final double DISTANCE_ERROR_PCT = 0.025d;
+        }
+
+        public SpatialStrategy strategy = null;
+        public String tree = null;
+        public Integer treeLevels = null;
+        public String precision = null;
+        public Boolean pointsOnly = null;
+        public Double distanceErrorPct = null;
+
+        public void setSpatialStrategy(SpatialStrategy strategy) {
+            this.strategy = strategy;
+        }
+
+        public void setTree(String prefixTree) {
+            this.tree = prefixTree;
+        }
+
+        public void setTreeLevels(int treeLevels) {
+            this.treeLevels = treeLevels;
+        }
+
+        public void setPrecision(String precision) {
+            this.precision = precision;
+        }
+
+        public void setPointsOnly(boolean pointsOnly) {
+            if (this.strategy == SpatialStrategy.TERM && pointsOnly == false) {
+                throw new ElasticsearchParseException("points_only cannot be set to false for term strategy");
+            }
+            this.pointsOnly = pointsOnly;
+        }
+
+        public void setDistanceErrorPct(double distanceErrorPct) {
+            this.distanceErrorPct = distanceErrorPct;
+        }
+
+        public static boolean parse(String name, String fieldName, Object fieldNode, DeprecatedParameters deprecatedParameters) {
+            if (Names.STRATEGY.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
+                checkPrefixTreeSupport(fieldName);
+                deprecatedParameters.setSpatialStrategy(SpatialStrategy.fromString(fieldNode.toString()));
+            } else if (Names.TREE.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
+                checkPrefixTreeSupport(fieldName);
+                deprecatedParameters.setTree(fieldNode.toString());
+            } else if (Names.TREE_LEVELS.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
+                checkPrefixTreeSupport(fieldName);
+                deprecatedParameters.setTreeLevels(Integer.parseInt(fieldNode.toString()));
+            } else if (Names.PRECISION.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
+                checkPrefixTreeSupport(fieldName);
+                deprecatedParameters.setPrecision(fieldNode.toString());
+            } else if (Names.DISTANCE_ERROR_PCT.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
+                checkPrefixTreeSupport(fieldName);
+                deprecatedParameters.setDistanceErrorPct(Double.parseDouble(fieldNode.toString()));
+            } else if (Names.POINTS_ONLY.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
+                checkPrefixTreeSupport(fieldName);
+                deprecatedParameters.setPointsOnly(
+                    XContentMapValues.nodeBooleanValue(fieldNode, name + "." + DeprecatedParameters.Names.POINTS_ONLY));
+            } else {
+                return false;
+            }
+            return true;
+        }
+
+        private static void checkPrefixTreeSupport(String fieldName) {
+            if (ShapesAvailability.JTS_AVAILABLE == false || ShapesAvailability.SPATIAL4J_AVAILABLE == false) {
+                throw new ElasticsearchParseException("Field parameter [{}] is not supported for [{}] field type",
+                    fieldName, CONTENT_TYPE);
+            }
+            DEPRECATION_LOGGER.deprecated("Field parameter [{}] is deprecated and will be removed in a future version.",
+                fieldName);
+        }
+    }
+
+    private static final Logger logger = LogManager.getLogger(LegacyGeoShapeFieldMapper.class);
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(logger);
+
+    public static class Builder extends BaseGeoShapeFieldMapper.Builder<BaseGeoShapeFieldMapper.Builder, LegacyGeoShapeFieldMapper> {
+
+        DeprecatedParameters deprecatedParameters;
+
+        public Builder(String name) {
+            this(name, new DeprecatedParameters());
+        }
+
+        public Builder(String name, DeprecatedParameters deprecatedParameters) {
+            super(name, new GeoShapeFieldType(), new GeoShapeFieldType());
+            this.deprecatedParameters = deprecatedParameters;
+        }
+
+        @Override
+        public GeoShapeFieldType fieldType() {
+            return (GeoShapeFieldType)fieldType;
+        }
+
+        private void setupFieldTypeDeprecatedParameters() {
+            GeoShapeFieldType ft = fieldType();
+            if (deprecatedParameters.strategy != null) {
+                ft.setStrategy(deprecatedParameters.strategy);
+            }
+            if (deprecatedParameters.tree != null) {
+                ft.setTree(deprecatedParameters.tree);
+            }
+            if (deprecatedParameters.treeLevels != null) {
+                ft.setTreeLevels(deprecatedParameters.treeLevels);
+            }
+            if (deprecatedParameters.precision != null) {
+                // precision is only set iff: a. treeLevel is not explicitly set, b. its explicitly set
+                ft.setPrecisionInMeters(DistanceUnit.parse(deprecatedParameters.precision,
+                    DistanceUnit.DEFAULT, DistanceUnit.DEFAULT));
+            }
+            if (deprecatedParameters.distanceErrorPct != null) {
+                ft.setDistanceErrorPct(deprecatedParameters.distanceErrorPct);
+            }
+            if (deprecatedParameters.pointsOnly != null) {
+                ft.setPointsOnly(deprecatedParameters.pointsOnly);
+            }
+
+            GeoShapeFieldType geoShapeFieldType = (GeoShapeFieldType)fieldType;
+
+            if (geoShapeFieldType.treeLevels() == 0 && geoShapeFieldType.precisionInMeters() < 0) {
+                geoShapeFieldType.setDefaultDistanceErrorPct(DeprecatedParameters.Defaults.DISTANCE_ERROR_PCT);
+            }
+        }
+
+        private void setupPrefixTrees() {
+            GeoShapeFieldType ft = fieldType();
+            SpatialPrefixTree prefixTree;
+            if (ft.tree().equals(DeprecatedParameters.PrefixTrees.GEOHASH)) {
+                prefixTree = new GeohashPrefixTree(ShapeBuilder.SPATIAL_CONTEXT,
+                    getLevels(ft.treeLevels(), ft.precisionInMeters(), DeprecatedParameters.Defaults.GEOHASH_TREE_LEVELS, true));
+            } else if (ft.tree().equals(DeprecatedParameters.PrefixTrees.LEGACY_QUADTREE)) {
+                prefixTree = new QuadPrefixTree(ShapeBuilder.SPATIAL_CONTEXT,
+                    getLevels(ft.treeLevels(), ft.precisionInMeters(), DeprecatedParameters.Defaults.QUADTREE_LEVELS, false));
+            } else if (ft.tree().equals(DeprecatedParameters.PrefixTrees.QUADTREE)) {
+                prefixTree = new PackedQuadPrefixTree(ShapeBuilder.SPATIAL_CONTEXT,
+                    getLevels(ft.treeLevels(), ft.precisionInMeters(), DeprecatedParameters.Defaults.QUADTREE_LEVELS, false));
+            } else {
+                throw new IllegalArgumentException("Unknown prefix tree type [" + ft.tree() + "]");
+            }
+
+            // setup prefix trees regardless of strategy (this is used for the QueryBuilder)
+            // recursive:
+            RecursivePrefixTreeStrategy rpts = new RecursivePrefixTreeStrategy(prefixTree, ft.name());
+            rpts.setDistErrPct(ft.distanceErrorPct());
+            rpts.setPruneLeafyBranches(false);
+            ft.recursiveStrategy = rpts;
+
+            // term:
+            TermQueryPrefixTreeStrategy termStrategy = new TermQueryPrefixTreeStrategy(prefixTree, ft.name());
+            termStrategy.setDistErrPct(ft.distanceErrorPct());
+            ft.termStrategy = termStrategy;
+
+            // set default (based on strategy):
+            ft.defaultPrefixTreeStrategy = ft.resolvePrefixTreeStrategy(ft.strategy());
+            ft.defaultPrefixTreeStrategy.setPointsOnly(ft.pointsOnly());
+        }
+
+        @Override
+        protected void setupFieldType(BuilderContext context) {
+            super.setupFieldType(context);
+
+            // field mapper handles this at build time
+            // but prefix tree strategies require a name, so throw a similar exception
+            if (fieldType().name().isEmpty()) {
+                throw new IllegalArgumentException("name cannot be empty string");
+            }
+
+            // setup the deprecated parameters and the prefix tree configuration
+            setupFieldTypeDeprecatedParameters();
+            setupPrefixTrees();
+        }
+
+        private static int getLevels(int treeLevels, double precisionInMeters, int defaultLevels, boolean geoHash) {
+            if (treeLevels > 0 || precisionInMeters >= 0) {
+                return Math.max(treeLevels, precisionInMeters >= 0 ? (geoHash ? GeoUtils.geoHashLevelsForPrecision(precisionInMeters)
+                    : GeoUtils.quadTreeLevelsForPrecision(precisionInMeters)) : 0);
+            }
+            return defaultLevels;
+        }
+
+        @Override
+        public LegacyGeoShapeFieldMapper build(BuilderContext context) {
+            setupFieldType(context);
+
+            return new LegacyGeoShapeFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context),
+                coerce(context), orientation(), ignoreZValue(), context.indexSettings(),
+                multiFieldsBuilder.build(this, context), copyTo);
+        }
+    }
+
+    public static final class GeoShapeFieldType extends BaseGeoShapeFieldType {
+
+        private String tree = DeprecatedParameters.Defaults.TREE;
+        private SpatialStrategy strategy = DeprecatedParameters.Defaults.STRATEGY;
+        private boolean pointsOnly = DeprecatedParameters.Defaults.POINTS_ONLY;
+        private int treeLevels = 0;
+        private double precisionInMeters = -1;
+        private Double distanceErrorPct;
+        private double defaultDistanceErrorPct = 0.0;
+
+        // these are built when the field type is frozen
+        private PrefixTreeStrategy defaultPrefixTreeStrategy;
+        private RecursivePrefixTreeStrategy recursiveStrategy;
+        private TermQueryPrefixTreeStrategy termStrategy;
+
+        public GeoShapeFieldType() {
+            setIndexOptions(IndexOptions.DOCS);
+            setTokenized(false);
+            setStored(false);
+            setStoreTermVectors(false);
+            setOmitNorms(true);
+        }
+
+        protected GeoShapeFieldType(GeoShapeFieldType ref) {
+            super(ref);
+            this.tree = ref.tree;
+            this.strategy = ref.strategy;
+            this.pointsOnly = ref.pointsOnly;
+            this.treeLevels = ref.treeLevels;
+            this.precisionInMeters = ref.precisionInMeters;
+            this.distanceErrorPct = ref.distanceErrorPct;
+            this.defaultDistanceErrorPct = ref.defaultDistanceErrorPct;
+        }
+
+        @Override
+        public GeoShapeFieldType clone() {
+            return new GeoShapeFieldType(this);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!super.equals(o)) return false;
+            GeoShapeFieldType that = (GeoShapeFieldType) o;
+            return treeLevels == that.treeLevels &&
+                precisionInMeters == that.precisionInMeters &&
+                defaultDistanceErrorPct == that.defaultDistanceErrorPct &&
+                Objects.equals(tree, that.tree) &&
+                Objects.equals(strategy, that.strategy) &&
+                pointsOnly == that.pointsOnly &&
+                Objects.equals(distanceErrorPct, that.distanceErrorPct);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), tree, strategy, pointsOnly, treeLevels, precisionInMeters, distanceErrorPct,
+                    defaultDistanceErrorPct);
+        }
+
+        @Override
+        public void checkCompatibility(MappedFieldType fieldType, List<String> conflicts, boolean strict) {
+            super.checkCompatibility(fieldType, conflicts, strict);
+            GeoShapeFieldType other = (GeoShapeFieldType)fieldType;
+            // prevent user from changing strategies
+            if (strategy() != other.strategy()) {
+                conflicts.add("mapper [" + name() + "] has different [strategy]");
+            }
+
+            // prevent user from changing trees (changes encoding)
+            if (tree().equals(other.tree()) == false) {
+                conflicts.add("mapper [" + name() + "] has different [tree]");
+            }
+
+            if ((pointsOnly() != other.pointsOnly())) {
+                conflicts.add("mapper [" + name() + "] has different points_only");
+            }
+
+            // TODO we should allow this, but at the moment levels is used to build bookkeeping variables
+            // in lucene's SpatialPrefixTree implementations, need a patch to correct that first
+            if (treeLevels() != other.treeLevels()) {
+                conflicts.add("mapper [" + name() + "] has different [tree_levels]");
+            }
+            if (precisionInMeters() != other.precisionInMeters()) {
+                conflicts.add("mapper [" + name() + "] has different [precision]");
+            }
+            if (distanceErrorPct() != other.distanceErrorPct()) {
+                conflicts.add("mapper [" + name() + "] has different [distance_error_pct]");
+            }
+        }
+
+        public String tree() {
+            return tree;
+        }
+
+        public void setTree(String tree) {
+            checkIfFrozen();
+            this.tree = tree;
+        }
+
+        public SpatialStrategy strategy() {
+            return strategy;
+        }
+
+        public void setStrategy(SpatialStrategy strategy) {
+            checkIfFrozen();
+            this.strategy = strategy;
+            if (this.strategy.equals(SpatialStrategy.TERM)) {
+                this.pointsOnly = true;
+            }
+        }
+
+        public boolean pointsOnly() {
+            return pointsOnly;
+        }
+
+        public void setPointsOnly(boolean pointsOnly) {
+            checkIfFrozen();
+            this.pointsOnly = pointsOnly;
+        }
+        public int treeLevels() {
+            return treeLevels;
+        }
+
+        public void setTreeLevels(int treeLevels) {
+            checkIfFrozen();
+            this.treeLevels = treeLevels;
+        }
+
+        public double precisionInMeters() {
+            return precisionInMeters;
+        }
+
+        public void setPrecisionInMeters(double precisionInMeters) {
+            checkIfFrozen();
+            this.precisionInMeters = precisionInMeters;
+        }
+
+        public double distanceErrorPct() {
+            return distanceErrorPct == null ? defaultDistanceErrorPct : distanceErrorPct;
+        }
+
+        public void setDistanceErrorPct(double distanceErrorPct) {
+            checkIfFrozen();
+            this.distanceErrorPct = distanceErrorPct;
+        }
+
+        public void setDefaultDistanceErrorPct(double defaultDistanceErrorPct) {
+            checkIfFrozen();
+            this.defaultDistanceErrorPct = defaultDistanceErrorPct;
+        }
+
+        public PrefixTreeStrategy defaultPrefixTreeStrategy() {
+            return this.defaultPrefixTreeStrategy;
+        }
+
+        public PrefixTreeStrategy resolvePrefixTreeStrategy(SpatialStrategy strategy) {
+            return resolvePrefixTreeStrategy(strategy.getStrategyName());
+        }
+
+        public PrefixTreeStrategy resolvePrefixTreeStrategy(String strategyName) {
+            if (SpatialStrategy.RECURSIVE.getStrategyName().equals(strategyName)) {
+                return recursiveStrategy;
+            }
+            if (SpatialStrategy.TERM.getStrategyName().equals(strategyName)) {
+                return termStrategy;
+            }
+            throw new IllegalArgumentException("Unknown prefix tree strategy [" + strategyName + "]");
+        }
+    }
+
+    public LegacyGeoShapeFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
+                               Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce, Explicit<Orientation> orientation,
+                               Explicit<Boolean> ignoreZValue, Settings indexSettings,
+                               MultiFields multiFields, CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, ignoreZValue, indexSettings,
+            multiFields, copyTo);
+    }
+
+    @Override
+    public GeoShapeFieldType fieldType() {
+        return (GeoShapeFieldType) super.fieldType();
+    }
+
+    @Override
+    public void parse(ParseContext context) throws IOException {
+        try {
+            Shape shape = context.parseExternalValue(Shape.class);
+            if (shape == null) {
+                ShapeBuilder shapeBuilder = ShapeParser.parse(context.parser(), this);
+                if (shapeBuilder == null) {
+                    return;
+                }
+                shape = shapeBuilder.buildS4J();
+            }
+            if (fieldType().pointsOnly() == true) {
+                // index configured for pointsOnly
+                if (shape instanceof XShapeCollection && XShapeCollection.class.cast(shape).pointsOnly()) {
+                    // MULTIPOINT data: index each point separately
+                    List<Shape> shapes = ((XShapeCollection) shape).getShapes();
+                    for (Shape s : shapes) {
+                        indexShape(context, s);
+                    }
+                    return;
+                } else if (shape instanceof Point == false) {
+                    throw new MapperParsingException("[{" + fieldType().name() + "}] is configured for points only but a "
+                        + ((shape instanceof JtsGeometry) ? ((JtsGeometry)shape).getGeom().getGeometryType() : shape.getClass())
+                        + " was found");
+                }
+            }
+            indexShape(context, shape);
+        } catch (Exception e) {
+            if (ignoreMalformed.value() == false) {
+                throw new MapperParsingException("failed to parse field [{}] of type [{}]", e, fieldType().name(),
+                    fieldType().typeName());
+            }
+            context.addIgnoredField(fieldType.name());
+        }
+    }
+
+    private void indexShape(ParseContext context, Shape shape) {
+        List<IndexableField> fields = new ArrayList<>(Arrays.asList(fieldType().defaultPrefixTreeStrategy().createIndexableFields(shape)));
+        createFieldNamesField(context, fields);
+        for (IndexableField field : fields) {
+            context.doc().add(field);
+        }
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        super.doXContentBody(builder, includeDefaults, params);
+
+        if (includeDefaults || fieldType().tree().equals(DeprecatedParameters.Defaults.TREE) == false) {
+            builder.field(DeprecatedParameters.Names.TREE.getPreferredName(), fieldType().tree());
+        }
+
+        if (fieldType().treeLevels() != 0) {
+            builder.field(DeprecatedParameters.Names.TREE_LEVELS.getPreferredName(), fieldType().treeLevels());
+        } else if(includeDefaults && fieldType().precisionInMeters() == -1) { // defaults only make sense if precision is not specified
+            if (DeprecatedParameters.PrefixTrees.GEOHASH.equals(fieldType().tree())) {
+                builder.field(DeprecatedParameters.Names.TREE_LEVELS.getPreferredName(),
+                    DeprecatedParameters.Defaults.GEOHASH_TREE_LEVELS);
+            } else if (DeprecatedParameters.PrefixTrees.LEGACY_QUADTREE.equals(fieldType().tree())) {
+                builder.field(DeprecatedParameters.Names.TREE_LEVELS.getPreferredName(),
+                    DeprecatedParameters.Defaults.QUADTREE_LEVELS);
+            } else if (DeprecatedParameters.PrefixTrees.QUADTREE.equals(fieldType().tree())) {
+                builder.field(DeprecatedParameters.Names.TREE_LEVELS.getPreferredName(),
+                    DeprecatedParameters.Defaults.QUADTREE_LEVELS);
+            } else {
+                throw new IllegalArgumentException("Unknown prefix tree type [" + fieldType().tree() + "]");
+            }
+        }
+        if (fieldType().precisionInMeters() != -1) {
+            builder.field(DeprecatedParameters.Names.PRECISION.getPreferredName(),
+                DistanceUnit.METERS.toString(fieldType().precisionInMeters()));
+        } else if (includeDefaults && fieldType().treeLevels() == 0) { // defaults only make sense if tree levels are not specified
+            builder.field(DeprecatedParameters.Names.PRECISION.getPreferredName(),
+                DistanceUnit.METERS.toString(50));
+        }
+
+        if (indexCreatedVersion.onOrAfter(Version.V_6_6_0)) {
+            builder.field(DeprecatedParameters.Names.STRATEGY.getPreferredName(), fieldType().strategy().getStrategyName());
+        }
+
+        if (includeDefaults || fieldType().distanceErrorPct() != fieldType().defaultDistanceErrorPct) {
+            builder.field(DeprecatedParameters.Names.DISTANCE_ERROR_PCT.getPreferredName(), fieldType().distanceErrorPct());
+        }
+        if (fieldType().strategy() == SpatialStrategy.TERM) {
+            // For TERMs strategy the defaults for points only change to true
+            if (includeDefaults || fieldType().pointsOnly() != true) {
+                builder.field(DeprecatedParameters.Names.POINTS_ONLY.getPreferredName(), fieldType().pointsOnly());
+            }
+        } else {
+            if (includeDefaults || fieldType().pointsOnly() != DeprecatedParameters.Defaults.POINTS_ONLY) {
+                builder.field(DeprecatedParameters.Names.POINTS_ONLY.getPreferredName(), fieldType().pointsOnly());
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -19,6 +19,10 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.document.XLatLonShape;
+import org.apache.lucene.geo.Line;
+import org.apache.lucene.geo.Polygon;
+import org.apache.lucene.geo.Rectangle;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
@@ -36,8 +40,9 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.GeoShapeType;
 import org.elasticsearch.common.geo.ShapeRelation;
-import org.elasticsearch.common.geo.ShapesAvailability;
 import org.elasticsearch.common.geo.SpatialStrategy;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.geo.parsers.ShapeParser;
@@ -48,7 +53,8 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.BaseGeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.LegacyGeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
@@ -329,9 +335,9 @@ public class GeoShapeQueryBuilder extends AbstractQueryBuilder<GeoShapeQueryBuil
         if (relation == null) {
             throw new IllegalArgumentException("No Shape Relation defined");
         }
-        if (strategy != null && strategy == SpatialStrategy.TERM && relation != ShapeRelation.INTERSECTS) {
+        if (SpatialStrategy.TERM.equals(strategy) && relation != ShapeRelation.INTERSECTS) {
             throw new IllegalArgumentException("current strategy [" + strategy.getStrategyName() + "] only supports relation ["
-                    + ShapeRelation.INTERSECTS.getRelationName() + "] found relation [" + relation.getRelationName() + "]");
+                + ShapeRelation.INTERSECTS.getRelationName() + "] found relation [" + relation.getRelationName() + "]");
         }
         this.relation = relation;
         return this;
@@ -376,32 +382,96 @@ public class GeoShapeQueryBuilder extends AbstractQueryBuilder<GeoShapeQueryBuil
             } else {
                 throw new QueryShardException(context, "failed to find geo_shape field [" + fieldName + "]");
             }
-        } else if (fieldType.typeName().equals(GeoShapeFieldMapper.CONTENT_TYPE) == false) {
+        } else if (fieldType.typeName().equals(BaseGeoShapeFieldMapper.CONTENT_TYPE) == false) {
             throw new QueryShardException(context,
                     "Field [" + fieldName + "] is not of type [geo_shape] but of type [" + fieldType.typeName() + "]");
         }
 
-        final GeoShapeFieldMapper.GeoShapeFieldType shapeFieldType = (GeoShapeFieldMapper.GeoShapeFieldType) fieldType;
-
-        PrefixTreeStrategy strategy = shapeFieldType.defaultStrategy();
-        if (this.strategy != null) {
-            strategy = shapeFieldType.resolveStrategy(this.strategy);
-        }
+        final BaseGeoShapeFieldMapper.BaseGeoShapeFieldType ft = (BaseGeoShapeFieldMapper.BaseGeoShapeFieldType) fieldType;
         Query query;
-        if (strategy instanceof RecursivePrefixTreeStrategy && relation == ShapeRelation.DISJOINT) {
-            // this strategy doesn't support disjoint anymore: but it did
-            // before, including creating lucene fieldcache (!)
-            // in this case, execute disjoint as exists && !intersects
-            BooleanQuery.Builder bool = new BooleanQuery.Builder();
-            Query exists = ExistsQueryBuilder.newFilter(context, fieldName);
-            Query intersects = strategy.makeQuery(getArgs(shapeToQuery, ShapeRelation.INTERSECTS));
-            bool.add(exists, BooleanClause.Occur.MUST);
-            bool.add(intersects, BooleanClause.Occur.MUST_NOT);
-            query = new ConstantScoreQuery(bool.build());
+        if (strategy != null || ft instanceof LegacyGeoShapeFieldMapper.GeoShapeFieldType) {
+            LegacyGeoShapeFieldMapper.GeoShapeFieldType shapeFieldType = (LegacyGeoShapeFieldMapper.GeoShapeFieldType) ft;
+            SpatialStrategy spatialStrategy = shapeFieldType.strategy();
+            if (this.strategy != null) {
+                spatialStrategy = this.strategy;
+            }
+            PrefixTreeStrategy prefixTreeStrategy = shapeFieldType.resolvePrefixTreeStrategy(spatialStrategy);
+            if (prefixTreeStrategy instanceof RecursivePrefixTreeStrategy && relation == ShapeRelation.DISJOINT) {
+                // this strategy doesn't support disjoint anymore: but it did
+                // before, including creating lucene fieldcache (!)
+                // in this case, execute disjoint as exists && !intersects
+                BooleanQuery.Builder bool = new BooleanQuery.Builder();
+                Query exists = ExistsQueryBuilder.newFilter(context, fieldName);
+                Query intersects = prefixTreeStrategy.makeQuery(getArgs(shapeToQuery, ShapeRelation.INTERSECTS));
+                bool.add(exists, BooleanClause.Occur.MUST);
+                bool.add(intersects, BooleanClause.Occur.MUST_NOT);
+                query = new ConstantScoreQuery(bool.build());
+            } else {
+                query = new ConstantScoreQuery(prefixTreeStrategy.makeQuery(getArgs(shapeToQuery, relation)));
+            }
         } else {
-            query = new ConstantScoreQuery(strategy.makeQuery(getArgs(shapeToQuery, relation)));
+            query = new ConstantScoreQuery(getVectorQuery(context, shapeToQuery));
         }
         return query;
+    }
+
+    private Query getVectorQuery(QueryShardContext context, ShapeBuilder queryShapeBuilder) {
+        // CONTAINS queries are not yet supported by VECTOR strategy
+        if (relation == ShapeRelation.CONTAINS) {
+            throw new QueryShardException(context,
+                ShapeRelation.CONTAINS + " query relation not supported for Field [" + fieldName + "]");
+        }
+
+        // wrap geoQuery as a ConstantScoreQuery
+        return getVectorQueryFromShape(context, queryShapeBuilder.buildLucene());
+    }
+
+    private Query getVectorQueryFromShape(QueryShardContext context, Object queryShape) {
+        Query geoQuery;
+        if (queryShape instanceof Line[]) {
+            geoQuery = XLatLonShape.newLineQuery(fieldName(), relation.getLuceneRelation(), (Line[]) queryShape);
+        } else if (queryShape instanceof Polygon[]) {
+            geoQuery = XLatLonShape.newPolygonQuery(fieldName(), relation.getLuceneRelation(), (Polygon[]) queryShape);
+        } else if (queryShape instanceof Line) {
+            geoQuery = XLatLonShape.newLineQuery(fieldName(), relation.getLuceneRelation(), (Line) queryShape);
+        } else if (queryShape instanceof Polygon) {
+            geoQuery = XLatLonShape.newPolygonQuery(fieldName(), relation.getLuceneRelation(), (Polygon) queryShape);
+        } else if (queryShape instanceof Rectangle) {
+            Rectangle r = (Rectangle) queryShape;
+            geoQuery = XLatLonShape.newBoxQuery(fieldName(), relation.getLuceneRelation(),
+                r.minLat, r.maxLat, r.minLon, r.maxLon);
+        } else if (queryShape instanceof double[][]) {
+            // note: we decompose point queries into a bounding box query with min values == max values
+            // to do this for multipoint we would have to create a BooleanQuery for each point
+            // this is *way* too costly. So we do not allow multipoint queries
+            throw new QueryShardException(context, "Field [" + fieldName + "] does not support " + GeoShapeType.MULTIPOINT + " queries");
+        } else if (queryShape instanceof double[] || queryShape instanceof GeoPoint) {
+            // for now just create a single bounding box query with min values == max values
+            double[] pt;
+            if (queryShape instanceof GeoPoint) {
+                pt = new double[] {((GeoPoint)queryShape).lon(), ((GeoPoint)queryShape).lat()};
+            } else {
+                pt = (double[])queryShape;
+                if (pt.length != 2) {
+                    throw new QueryShardException(context, "Expected double array of length 2. "
+                        + "But found length " + pt.length + " for field [" + fieldName + "]");
+                }
+            }
+            return XLatLonShape.newBoxQuery(fieldName, relation.getLuceneRelation(), pt[1], pt[1], pt[0], pt[0]);
+        } else if (queryShape instanceof Object[]) {
+            geoQuery = createGeometryCollectionQuery(context, (Object[]) queryShape);
+        } else {
+            throw new QueryShardException(context, "Field [" + fieldName + "] found and unknown shape");
+        }
+        return geoQuery;
+    }
+
+    private Query createGeometryCollectionQuery(QueryShardContext context, Object... shapes) {
+        BooleanQuery.Builder bqb = new BooleanQuery.Builder();
+        for (Object shape : shapes) {
+            bqb.add(getVectorQueryFromShape(context, shape), BooleanClause.Occur.SHOULD);
+        }
+        return bqb.build();
     }
 
     /**
@@ -414,9 +484,6 @@ public class GeoShapeQueryBuilder extends AbstractQueryBuilder<GeoShapeQueryBuil
      *            Shape itself is located
      */
     private void fetch(Client client, GetRequest getRequest, String path, ActionListener<ShapeBuilder> listener) {
-        if (ShapesAvailability.JTS_AVAILABLE == false) {
-            throw new IllegalStateException("JTS not available");
-        }
         getRequest.preference("_local");
         client.get(getRequest, new ActionListener<GetResponse>(){
 

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -25,7 +25,6 @@ import org.elasticsearch.action.admin.indices.rollover.MaxDocsCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
 import org.elasticsearch.action.resync.TransportResyncReplicationAction;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.geo.ShapesAvailability;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry.Entry;
@@ -33,6 +32,7 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.mapper.AllFieldMapper;
+import org.elasticsearch.index.mapper.BaseGeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.BinaryFieldMapper;
 import org.elasticsearch.index.mapper.BooleanFieldMapper;
 import org.elasticsearch.index.mapper.CompletionFieldMapper;
@@ -40,7 +40,6 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.FieldAliasMapper;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
-import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.IgnoredFieldMapper;
 import org.elasticsearch.index.mapper.IndexFieldMapper;
@@ -135,10 +134,7 @@ public class IndicesModule extends AbstractModule {
         mappers.put(CompletionFieldMapper.CONTENT_TYPE, new CompletionFieldMapper.TypeParser());
         mappers.put(FieldAliasMapper.CONTENT_TYPE, new FieldAliasMapper.TypeParser());
         mappers.put(GeoPointFieldMapper.CONTENT_TYPE, new GeoPointFieldMapper.TypeParser());
-
-        if (ShapesAvailability.JTS_AVAILABLE && ShapesAvailability.SPATIAL4J_AVAILABLE) {
-            mappers.put(GeoShapeFieldMapper.CONTENT_TYPE, new GeoShapeFieldMapper.TypeParser());
-        }
+        mappers.put(BaseGeoShapeFieldMapper.CONTENT_TYPE, new BaseGeoShapeFieldMapper.TypeParser());
 
         for (MapperPlugin mapperPlugin : mapperPlugins) {
             for (Map.Entry<String, Mapper.TypeParser> entry : mapperPlugin.getMappers().entrySet()) {

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoJsonShapeParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoJsonShapeParserTests.java
@@ -32,7 +32,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.ContentPath;
-import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.LegacyGeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.hamcrest.ElasticsearchGeoAssertions;
@@ -294,8 +294,8 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
         LinearRing shell = GEOMETRY_FACTORY.createLinearRing(shellCoordinates.toArray(new Coordinate[shellCoordinates.size()]));
         Polygon expected = GEOMETRY_FACTORY.createPolygon(shell, null);
         Mapper.BuilderContext mockBuilderContext = new Mapper.BuilderContext(indexSettings, new ContentPath());
-        final GeoShapeFieldMapper mapperBuilder = new GeoShapeFieldMapper.Builder("test").ignoreZValue(true).build(mockBuilderContext);
-
+        final LegacyGeoShapeFieldMapper mapperBuilder =
+            (LegacyGeoShapeFieldMapper) (new LegacyGeoShapeFieldMapper.Builder("test").ignoreZValue(true).build(mockBuilderContext));
         try (XContentParser parser = createParser(polygonGeoJson)) {
             parser.nextToken();
             ElasticsearchGeoAssertions.assertEquals(jtsGeom(expected), ShapeParser.parse(parser, mapperBuilder).buildS4J());
@@ -879,7 +879,6 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                         .startArray().value(101.0).value(1.0).endArray()
                     .endArray()
                 .endObject();
-
         ShapeCollection<?> expected = shapeCollection(
             SPATIAL_CONTEXT.makePoint(100, 0),
             SPATIAL_CONTEXT.makePoint(101, 1.0));
@@ -950,7 +949,6 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
         shellCoordinates.add(new Coordinate(103, 2));
         shellCoordinates.add(new Coordinate(102, 2));
         shellCoordinates.add(new Coordinate(102, 3));
-
 
         shell = GEOMETRY_FACTORY.createLinearRing(shellCoordinates.toArray(new Coordinate[shellCoordinates.size()]));
         Polygon withoutHoles = GEOMETRY_FACTORY.createPolygon(shell, null);
@@ -1131,7 +1129,6 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                     .startObject("nested").startArray("coordinates").value(200.0).value(0.0).endArray().endObject()
                     .startObject("lala").field("type", "NotAPoint").endObject()
                 .endObject();
-
             Point expected = GEOMETRY_FACTORY.createPoint(new Coordinate(100.0, 0.0));
             assertGeometryEquals(new JtsPoint(expected, SPATIAL_CONTEXT), pointGeoJson, true);
 

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoWKTShapeParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoWKTShapeParserTests.java
@@ -49,6 +49,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.LegacyGeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.test.geo.RandomShapeGenerator;
 import org.locationtech.spatial4j.exception.InvalidShapeException;
@@ -146,7 +147,6 @@ public class GeoWKTShapeParserTests extends BaseGeoParsingTestCase {
     @Override
     public void testParseLineString() throws IOException {
         List<Coordinate> coordinates = randomLineStringCoords();
-
         LineString expected = GEOMETRY_FACTORY.createLineString(coordinates.toArray(new Coordinate[coordinates.size()]));
         assertExpected(jtsGeom(expected), new LineStringBuilder(coordinates), true);
 
@@ -279,13 +279,14 @@ public class GeoWKTShapeParserTests extends BaseGeoParsingTestCase {
         parser.nextToken();
 
         Settings indexSettings = Settings.builder()
-            .put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_6_3_0)
+            .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID()).build();
 
         Mapper.BuilderContext mockBuilderContext = new Mapper.BuilderContext(indexSettings, new ContentPath());
-        final GeoShapeFieldMapper mapperBuilder = new GeoShapeFieldMapper.Builder("test").ignoreZValue(false).build(mockBuilderContext);
+        final GeoShapeFieldMapper mapperBuilder =
+            (GeoShapeFieldMapper) (new GeoShapeFieldMapper.Builder("test").ignoreZValue(false).build(mockBuilderContext));
 
         // test store z disabled
         ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class,
@@ -323,7 +324,8 @@ public class GeoWKTShapeParserTests extends BaseGeoParsingTestCase {
             .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID()).build();
 
         Mapper.BuilderContext mockBuilderContext = new Mapper.BuilderContext(indexSettings, new ContentPath());
-        final GeoShapeFieldMapper mapperBuilder = new GeoShapeFieldMapper.Builder("test").ignoreZValue(true).build(mockBuilderContext);
+        final LegacyGeoShapeFieldMapper mapperBuilder =
+            (LegacyGeoShapeFieldMapper)(new LegacyGeoShapeFieldMapper.Builder("test").ignoreZValue(true).build(mockBuilderContext));
 
         // test store z disabled
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
@@ -352,7 +354,8 @@ public class GeoWKTShapeParserTests extends BaseGeoParsingTestCase {
             .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID()).build();
 
         Mapper.BuilderContext mockBuilderContext = new Mapper.BuilderContext(indexSettings, new ContentPath());
-        final GeoShapeFieldMapper mapperBuilder = new GeoShapeFieldMapper.Builder("test").ignoreZValue(true).build(mockBuilderContext);
+        final LegacyGeoShapeFieldMapper mapperBuilder =
+            (LegacyGeoShapeFieldMapper)(new LegacyGeoShapeFieldMapper.Builder("test").ignoreZValue(true).build(mockBuilderContext));
 
         ShapeBuilder shapeBuilder = ShapeParser.parse(parser, mapperBuilder);
         assertEquals(shapeBuilder.numDimensions(), 3);
@@ -372,12 +375,14 @@ public class GeoWKTShapeParserTests extends BaseGeoParsingTestCase {
             .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID()).build();
 
         Mapper.BuilderContext mockBuilderContext = new Mapper.BuilderContext(indexSettings, new ContentPath());
-        final GeoShapeFieldMapper defaultMapperBuilder = new GeoShapeFieldMapper.Builder("test").coerce(false).build(mockBuilderContext);
+        final LegacyGeoShapeFieldMapper defaultMapperBuilder =
+            (LegacyGeoShapeFieldMapper)(new LegacyGeoShapeFieldMapper.Builder("test").coerce(false).build(mockBuilderContext));
         ElasticsearchParseException exception = expectThrows(ElasticsearchParseException.class,
             () -> ShapeParser.parse(parser, defaultMapperBuilder));
         assertEquals("invalid LinearRing found (coordinates are not closed)", exception.getMessage());
 
-        final GeoShapeFieldMapper coercingMapperBuilder = new GeoShapeFieldMapper.Builder("test").coerce(true).build(mockBuilderContext);
+        final LegacyGeoShapeFieldMapper coercingMapperBuilder =
+            (LegacyGeoShapeFieldMapper)(new LegacyGeoShapeFieldMapper.Builder("test").coerce(true).build(mockBuilderContext));
         ShapeBuilder<?, ?> shapeBuilder = ShapeParser.parse(parser, coercingMapperBuilder);
         assertNotNull(shapeBuilder);
         assertEquals("polygon ((100.0 5.0, 100.0 10.0, 90.0 10.0, 90.0 5.0, 100.0 5.0))", shapeBuilder.toWKT());

--- a/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
@@ -24,13 +24,13 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.geo.builders.PointBuilder;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.builders.PointBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.locationtech.spatial4j.shape.Point;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -63,6 +63,7 @@ public class ExternalMapper extends FieldMapper {
         private BooleanFieldMapper.Builder boolBuilder = new BooleanFieldMapper.Builder(Names.FIELD_BOOL);
         private GeoPointFieldMapper.Builder latLonPointBuilder = new GeoPointFieldMapper.Builder(Names.FIELD_POINT);
         private GeoShapeFieldMapper.Builder shapeBuilder = new GeoShapeFieldMapper.Builder(Names.FIELD_SHAPE);
+        private LegacyGeoShapeFieldMapper.Builder legacyShapeBuilder = new LegacyGeoShapeFieldMapper.Builder(Names.FIELD_SHAPE);
         private Mapper.Builder stringBuilder;
         private String generatedValue;
         private String mapperName;
@@ -86,7 +87,9 @@ public class ExternalMapper extends FieldMapper {
             BinaryFieldMapper binMapper = binBuilder.build(context);
             BooleanFieldMapper boolMapper = boolBuilder.build(context);
             GeoPointFieldMapper pointMapper = latLonPointBuilder.build(context);
-            GeoShapeFieldMapper shapeMapper = shapeBuilder.build(context);
+            BaseGeoShapeFieldMapper shapeMapper = (context.indexCreatedVersion().before(Version.V_6_6_0))
+                ? legacyShapeBuilder.build(context)
+                : shapeBuilder.build(context);
             FieldMapper stringMapper = (FieldMapper)stringBuilder.build(context);
             context.path().remove();
 
@@ -150,13 +153,13 @@ public class ExternalMapper extends FieldMapper {
     private BinaryFieldMapper binMapper;
     private BooleanFieldMapper boolMapper;
     private GeoPointFieldMapper pointMapper;
-    private GeoShapeFieldMapper shapeMapper;
+    private BaseGeoShapeFieldMapper shapeMapper;
     private FieldMapper stringMapper;
 
     public ExternalMapper(String simpleName, MappedFieldType fieldType,
                           String generatedValue, String mapperName,
                           BinaryFieldMapper binMapper, BooleanFieldMapper boolMapper, GeoPointFieldMapper pointMapper,
-                          GeoShapeFieldMapper shapeMapper, FieldMapper stringMapper, Settings indexSettings,
+                          BaseGeoShapeFieldMapper shapeMapper, FieldMapper stringMapper, Settings indexSettings,
                           MultiFields multiFields, CopyTo copyTo) {
         super(simpleName, fieldType, new ExternalFieldType(), indexSettings, multiFields, copyTo);
         this.generatedValue = generatedValue;
@@ -182,8 +185,12 @@ public class ExternalMapper extends FieldMapper {
         pointMapper.parse(context.createExternalValueContext(point));
 
         // Let's add a Dummy Shape
-        Point shape = new PointBuilder(-100, 45).buildS4J();
-        shapeMapper.parse(context.createExternalValueContext(shape));
+        PointBuilder pb = new PointBuilder(-100, 45);
+        if (shapeMapper instanceof GeoShapeFieldMapper) {
+            shapeMapper.parse(context.createExternalValueContext(pb.buildLucene()));
+        } else {
+            shapeMapper.parse(context.createExternalValueContext(pb.buildS4J()));
+        }
 
         context = context.createExternalValueContext(generatedValue);
 
@@ -210,7 +217,7 @@ public class ExternalMapper extends FieldMapper {
         BinaryFieldMapper binMapperUpdate = (BinaryFieldMapper) binMapper.updateFieldType(fullNameToFieldType);
         BooleanFieldMapper boolMapperUpdate = (BooleanFieldMapper) boolMapper.updateFieldType(fullNameToFieldType);
         GeoPointFieldMapper pointMapperUpdate = (GeoPointFieldMapper) pointMapper.updateFieldType(fullNameToFieldType);
-        GeoShapeFieldMapper shapeMapperUpdate = (GeoShapeFieldMapper) shapeMapper.updateFieldType(fullNameToFieldType);
+        BaseGeoShapeFieldMapper shapeMapperUpdate = (BaseGeoShapeFieldMapper) shapeMapper.updateFieldType(fullNameToFieldType);
         TextFieldMapper stringMapperUpdate = (TextFieldMapper) stringMapper.updateFieldType(fullNameToFieldType);
         if (update == this
                 && multiFieldsUpdate == multiFields

--- a/server/src/test/java/org/elasticsearch/index/mapper/ExternalValuesMapperIntegrationIT.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ExternalValuesMapperIntegrationIT.java
@@ -21,12 +21,13 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.geo.ShapeRelation;
-import org.elasticsearch.common.geo.builders.PointBuilder;
+import org.elasticsearch.common.geo.builders.EnvelopeBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.locationtech.jts.geom.Coordinate;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -118,7 +119,8 @@ public class ExternalValuesMapperIntegrationIT extends ESIntegTestCase {
         assertThat(response.getHits().getTotalHits(), equalTo((long) 1));
 
         response = client().prepareSearch("test-idx")
-            .setPostFilter(QueryBuilders.geoShapeQuery("field.shape", new PointBuilder(-100, 45)).relation(ShapeRelation.WITHIN))
+                .setPostFilter(QueryBuilders.geoShapeQuery("field.shape",
+                    new EnvelopeBuilder(new Coordinate(-101, 46), new Coordinate(-99, 44))).relation(ShapeRelation.WITHIN))
                         .execute().actionGet();
 
         assertThat(response.getHits().getTotalHits(), equalTo((long) 1));

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldMapperTests.java
@@ -18,14 +18,9 @@
  */
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.spatial.prefix.PrefixTreeStrategy;
-import org.apache.lucene.spatial.prefix.RecursivePrefixTreeStrategy;
-import org.apache.lucene.spatial.prefix.tree.GeohashPrefixTree;
-import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -42,7 +37,6 @@ import static org.elasticsearch.index.mapper.GeoPointFieldMapper.Names.IGNORE_Z_
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
 
 public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
 
@@ -53,10 +47,10 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
 
     public void testDefaultConfiguration() throws IOException {
         String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                    .field("type", "geo_shape")
-                .endObject().endObject()
-                .endObject().endObject());
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape")
+            .endObject().endObject()
+            .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
             .parse("type1", new CompressedXContent(mapping));
@@ -64,12 +58,8 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
-        PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultStrategy();
-
-        assertThat(strategy.getDistErrPct(), equalTo(0.025d));
-        assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
-        assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoShapeFieldMapper.Defaults.GEOHASH_LEVELS));
-        assertThat(geoShapeFieldMapper.fieldType().orientation(), equalTo(GeoShapeFieldMapper.Defaults.ORIENTATION));
+        assertThat(geoShapeFieldMapper.fieldType().orientation(),
+            equalTo(GeoShapeFieldMapper.Defaults.ORIENTATION.value()));
     }
 
     /**
@@ -77,11 +67,11 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
      */
     public void testOrientationParsing() throws IOException {
         String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                .field("type", "geo_shape")
-                .field("orientation", "left")
-                .endObject().endObject()
-                .endObject().endObject());
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape")
+            .field("orientation", "left")
+            .endObject().endObject()
+            .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
             .parse("type1", new CompressedXContent(mapping));
@@ -95,11 +85,11 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
 
         // explicit right orientation test
         mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                .field("type", "geo_shape")
-                .field("orientation", "right")
-                .endObject().endObject()
-                .endObject().endObject());
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape")
+            .field("orientation", "right")
+            .endObject().endObject()
+            .endObject().endObject());
 
         defaultMapper = createIndex("test2").mapperService().documentMapperParser()
             .parse("type1", new CompressedXContent(mapping));
@@ -117,11 +107,11 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
      */
     public void testCoerceParsing() throws IOException {
         String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                .field("type", "geo_shape")
-                .field("coerce", "true")
-                .endObject().endObject()
-                .endObject().endObject());
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape")
+            .field("coerce", "true")
+            .endObject().endObject()
+            .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
             .parse("type1", new CompressedXContent(mapping));
@@ -133,11 +123,11 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
 
         // explicit false coerce test
         mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                .field("type", "geo_shape")
-                .field("coerce", "false")
-                .endObject().endObject()
-                .endObject().endObject());
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape")
+            .field("coerce", "false")
+            .endObject().endObject()
+            .endObject().endObject());
 
         defaultMapper = createIndex("test2").mapperService().documentMapperParser()
             .parse("type1", new CompressedXContent(mapping));
@@ -146,6 +136,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
 
         coerce = ((GeoShapeFieldMapper)fieldMapper).coerce().value();
         assertThat(coerce, equalTo(false));
+        assertFieldWarnings("tree");
     }
 
 
@@ -222,305 +213,45 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(ignoreMalformed.value(), equalTo(false));
     }
 
-    public void testGeohashConfiguration() throws IOException {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                    .field("type", "geo_shape")
-                    .field("tree", "geohash")
-                    .field("tree_levels", "4")
-                    .field("distance_error_pct", "0.1")
-                .endObject().endObject()
-                .endObject().endObject());
 
-        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
-            .parse("type1", new CompressedXContent(mapping));
-        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
-        assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
-
-        GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
-        PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultStrategy();
-
-        assertThat(strategy.getDistErrPct(), equalTo(0.1));
-        assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
-        assertThat(strategy.getGrid().getMaxLevels(), equalTo(4));
-    }
-
-    public void testQuadtreeConfiguration() throws IOException {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                    .field("type", "geo_shape")
-                    .field("tree", "quadtree")
-                    .field("tree_levels", "6")
-                    .field("distance_error_pct", "0.5")
-                    .field("points_only", true)
-                .endObject().endObject()
-                .endObject().endObject());
-
-        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
-            .parse("type1", new CompressedXContent(mapping));
-        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
-        assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
-
-        GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
-        PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultStrategy();
-
-        assertThat(strategy.getDistErrPct(), equalTo(0.5));
-        assertThat(strategy.getGrid(), instanceOf(QuadPrefixTree.class));
-        assertThat(strategy.getGrid().getMaxLevels(), equalTo(6));
-        assertThat(strategy.isPointsOnly(), equalTo(true));
-    }
-
-    public void testLevelPrecisionConfiguration() throws IOException {
-        DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
-
-        {
-            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                    .startObject("properties").startObject("location")
-                        .field("type", "geo_shape")
-                        .field("tree", "quadtree")
-                        .field("tree_levels", "6")
-                        .field("precision", "70m")
-                        .field("distance_error_pct", "0.5")
-                    .endObject().endObject()
-                    .endObject().endObject());
-
-
-            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
-            assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
-
-            GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
-            PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultStrategy();
-
-            assertThat(strategy.getDistErrPct(), equalTo(0.5));
-            assertThat(strategy.getGrid(), instanceOf(QuadPrefixTree.class));
-            // 70m is more precise so it wins
-            assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoUtils.quadTreeLevelsForPrecision(70d)));
-        }
-
-        {
-            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                    .startObject("properties").startObject("location")
-                    .field("type", "geo_shape")
-                    .field("tree", "quadtree")
-                    .field("tree_levels", "26")
-                    .field("precision", "70m")
-                    .endObject().endObject()
-                    .endObject().endObject());
-
-
-            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
-            assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
-
-            GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
-            PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultStrategy();
-
-            // distance_error_pct was not specified so we expect the mapper to take the highest precision between "precision" and
-            // "tree_levels" setting distErrPct to 0 to guarantee desired precision
-            assertThat(strategy.getDistErrPct(), equalTo(0.0));
-            assertThat(strategy.getGrid(), instanceOf(QuadPrefixTree.class));
-            // 70m is less precise so it loses
-            assertThat(strategy.getGrid().getMaxLevels(), equalTo(26));
-        }
-
-        {
-            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                    .startObject("properties").startObject("location")
-                        .field("type", "geo_shape")
-                        .field("tree", "geohash")
-                        .field("tree_levels", "6")
-                        .field("precision", "70m")
-                        .field("distance_error_pct", "0.5")
-                    .endObject().endObject()
-                    .endObject().endObject());
-
-            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
-            assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
-
-            GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
-            PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultStrategy();
-
-            assertThat(strategy.getDistErrPct(), equalTo(0.5));
-            assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
-            // 70m is more precise so it wins
-            assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoUtils.geoHashLevelsForPrecision(70d)));
-        }
-
-        {
-            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                    .startObject("properties").startObject("location")
-                        .field("type", "geo_shape")
-                        .field("tree", "geohash")
-                        .field("tree_levels",  GeoUtils.geoHashLevelsForPrecision(70d)+1)
-                        .field("precision", "70m")
-                        .field("distance_error_pct", "0.5")
-                    .endObject().endObject()
-                    .endObject().endObject());
-
-            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
-            assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
-
-            GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
-            PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultStrategy();
-
-            assertThat(strategy.getDistErrPct(), equalTo(0.5));
-            assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
-            assertThat(strategy.getGrid().getMaxLevels(),  equalTo(GeoUtils.geoHashLevelsForPrecision(70d)+1));
-        }
-
-        {
-            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                    .startObject("properties").startObject("location")
-                        .field("type", "geo_shape")
-                        .field("tree", "quadtree")
-                        .field("tree_levels", GeoUtils.quadTreeLevelsForPrecision(70d)+1)
-                        .field("precision", "70m")
-                        .field("distance_error_pct", "0.5")
-                    .endObject().endObject()
-                    .endObject().endObject());
-
-            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
-            assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
-
-            GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
-            PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultStrategy();
-
-            assertThat(strategy.getDistErrPct(), equalTo(0.5));
-            assertThat(strategy.getGrid(), instanceOf(QuadPrefixTree.class));
-            assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoUtils.quadTreeLevelsForPrecision(70d)+1));
-        }
-    }
-
-    public void testPointsOnlyOption() throws IOException {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                .field("type", "geo_shape")
-                .field("tree", "geohash")
-                .field("points_only", true)
-                .endObject().endObject()
-                .endObject().endObject());
-
-        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
-            .parse("type1", new CompressedXContent(mapping));
-        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
-        assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
-
-        GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
-        PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultStrategy();
-
-        assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
-        assertThat(strategy.isPointsOnly(), equalTo(true));
-    }
-
-    public void testLevelDefaults() throws IOException {
-        DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
-        {
-            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                    .startObject("properties").startObject("location")
-                        .field("type", "geo_shape")
-                        .field("tree", "quadtree")
-                        .field("distance_error_pct", "0.5")
-                    .endObject().endObject()
-                    .endObject().endObject());
-
-
-            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
-            assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
-
-            GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
-            PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultStrategy();
-
-            assertThat(strategy.getDistErrPct(), equalTo(0.5));
-            assertThat(strategy.getGrid(), instanceOf(QuadPrefixTree.class));
-            /* 50m is default */
-            assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoUtils.quadTreeLevelsForPrecision(50d)));
-        }
-
-        {
-            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                    .startObject("properties").startObject("location")
-                        .field("type", "geo_shape")
-                        .field("tree", "geohash")
-                        .field("distance_error_pct", "0.5")
-                    .endObject().endObject()
-                    .endObject().endObject());
-
-            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
-            assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
-
-            GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
-            PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultStrategy();
-
-            assertThat(strategy.getDistErrPct(), equalTo(0.5));
-            assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
-            /* 50m is default */
-            assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoUtils.geoHashLevelsForPrecision(50d)));
+    private void assertFieldWarnings(String... fieldNames) {
+        String[] warnings = new String[fieldNames.length];
+        for (int i = 0; i < fieldNames.length; ++i) {
+            warnings[i] = "Field parameter [" + fieldNames[i] + "] "
+                + "is deprecated and will be removed in a future version.";
         }
     }
 
     public void testGeoShapeMapperMerge() throws Exception {
         String stage1Mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type").startObject("properties")
-                .startObject("shape").field("type", "geo_shape").field("tree", "geohash")
-                .field("strategy", "recursive")
-                .field("precision", "1m").field("tree_levels", 8).field("distance_error_pct", 0.01)
-                .field("orientation", "ccw")
-                .endObject().endObject().endObject().endObject());
+            .startObject("shape").field("type", "geo_shape")
+            .field("orientation", "ccw")
+            .endObject().endObject().endObject().endObject());
         MapperService mapperService = createIndex("test").mapperService();
         DocumentMapper docMapper = mapperService.merge("type", new CompressedXContent(stage1Mapping),
             MapperService.MergeReason.MAPPING_UPDATE, false);
         String stage2Mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("properties").startObject("shape").field("type", "geo_shape")
-                .field("tree", "quadtree")
-                .field("strategy", "term").field("precision", "1km")
-                .field("tree_levels", 26).field("distance_error_pct", 26)
-                .field("orientation", "cw").endObject().endObject().endObject().endObject());
-        try {
-            mapperService.merge("type", new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
-            fail();
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("mapper [shape] has different [strategy]"));
-            assertThat(e.getMessage(), containsString("mapper [shape] has different [tree]"));
-            assertThat(e.getMessage(), containsString("mapper [shape] has different [tree_levels]"));
-            assertThat(e.getMessage(), containsString("mapper [shape] has different [precision]"));
-        }
+            .startObject("properties").startObject("shape").field("type", "geo_shape")
+            .field("orientation", "cw").endObject().endObject().endObject().endObject());
+        mapperService.merge("type", new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
 
         // verify nothing changed
         Mapper fieldMapper = docMapper.mappers().getMapper("shape");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
-        PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultStrategy();
-
-        assertThat(strategy, instanceOf(RecursivePrefixTreeStrategy.class));
-        assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
-        assertThat(strategy.getDistErrPct(), equalTo(0.01));
-        assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoUtils.geoHashLevelsForPrecision(1d)));
         assertThat(geoShapeFieldMapper.fieldType().orientation(), equalTo(ShapeBuilder.Orientation.CCW));
 
-        // correct mapping
+        // change mapping; orientation
         stage2Mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("properties").startObject("shape").field("type", "geo_shape").field("precision", "1m")
-                .field("tree_levels", 8).field("distance_error_pct", 0.001)
-                .field("orientation", "cw").endObject().endObject().endObject().endObject());
-        docMapper = mapperService.merge("type", new CompressedXContent(stage2Mapping),
-            MapperService.MergeReason.MAPPING_UPDATE, false);
+            .startObject("properties").startObject("shape").field("type", "geo_shape")
+            .field("orientation", "cw").endObject().endObject().endObject().endObject());
+        docMapper = mapperService.merge("type", new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
 
         fieldMapper = docMapper.mappers().getMapper("shape");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
-        strategy = geoShapeFieldMapper.fieldType().defaultStrategy();
-
-        assertThat(strategy, instanceOf(RecursivePrefixTreeStrategy.class));
-        assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
-        assertThat(strategy.getDistErrPct(), equalTo(0.001));
-        assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoUtils.geoHashLevelsForPrecision(1d)));
         assertThat(geoShapeFieldMapper.fieldType().orientation(), equalTo(ShapeBuilder.Orientation.CW));
     }
 
@@ -545,112 +276,12 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
             String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
                 .startObject("properties").startObject("location")
                 .field("type", "geo_shape")
-                .field("tree", "quadtree")
                 .endObject().endObject()
                 .endObject().endObject());
             DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
             String serialized = toXContentString((GeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
-            assertTrue(serialized, serialized.contains("\"precision\":\"50.0m\""));
-            assertTrue(serialized, serialized.contains("\"tree_levels\":21"));
+            assertTrue(serialized, serialized.contains("\"orientation\":\"" + BaseGeoShapeFieldMapper.Defaults.ORIENTATION.value() + "\""));
         }
-        {
-            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                .field("type", "geo_shape")
-                .field("tree", "geohash")
-                .endObject().endObject()
-                .endObject().endObject());
-            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            String serialized = toXContentString((GeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
-            assertTrue(serialized, serialized.contains("\"precision\":\"50.0m\""));
-            assertTrue(serialized, serialized.contains("\"tree_levels\":9"));
-        }
-        {
-            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                .field("type", "geo_shape")
-                .field("tree", "quadtree")
-                .field("tree_levels", "6")
-                .endObject().endObject()
-                .endObject().endObject());
-            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            String serialized = toXContentString((GeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
-            assertFalse(serialized, serialized.contains("\"precision\":"));
-            assertTrue(serialized, serialized.contains("\"tree_levels\":6"));
-        }
-        {
-            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                .field("type", "geo_shape")
-                .field("tree", "quadtree")
-                .field("precision", "6")
-                .endObject().endObject()
-                .endObject().endObject());
-            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            String serialized = toXContentString((GeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
-            assertTrue(serialized, serialized.contains("\"precision\":\"6.0m\""));
-            assertFalse(serialized, serialized.contains("\"tree_levels\":"));
-        }
-        {
-            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                .field("type", "geo_shape")
-                .field("tree", "quadtree")
-                .field("precision", "6m")
-                .field("tree_levels", "5")
-                .endObject().endObject()
-                .endObject().endObject());
-            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            String serialized = toXContentString((GeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
-            assertTrue(serialized, serialized.contains("\"precision\":\"6.0m\""));
-            assertTrue(serialized, serialized.contains("\"tree_levels\":5"));
-        }
-    }
-
-    public void testPointsOnlyDefaultsWithTermStrategy() throws IOException {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-            .startObject("properties").startObject("location")
-            .field("type", "geo_shape")
-            .field("tree", "quadtree")
-            .field("precision", "10m")
-            .field("strategy", "term")
-            .endObject().endObject()
-            .endObject().endObject());
-
-        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
-            .parse("type1", new CompressedXContent(mapping));
-        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
-        assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
-
-        GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
-        PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultStrategy();
-
-        assertThat(strategy.getDistErrPct(), equalTo(0.0));
-        assertThat(strategy.getGrid(), instanceOf(QuadPrefixTree.class));
-        assertThat(strategy.getGrid().getMaxLevels(), equalTo(23));
-        assertThat(strategy.isPointsOnly(), equalTo(true));
-        // term strategy changes the default for points_only, check that we handle it correctly
-        assertThat(toXContentString(geoShapeFieldMapper, false), not(containsString("points_only")));
-    }
-
-
-    public void testPointsOnlyFalseWithTermStrategy() throws Exception {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-            .startObject("properties").startObject("location")
-            .field("type", "geo_shape")
-            .field("tree", "quadtree")
-            .field("precision", "10m")
-            .field("strategy", "term")
-            .field("points_only", false)
-            .endObject().endObject()
-            .endObject().endObject());
-
-        DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
-
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-            () -> parser.parse("type1", new CompressedXContent(mapping))
-        );
-        assertThat(e.getMessage(), containsString("points_only cannot be set to false for term strategy"));
     }
 
     public String toXContentString(GeoShapeFieldMapper mapper, boolean includeDefaults) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
@@ -1,0 +1,716 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.spatial.prefix.PrefixTreeStrategy;
+import org.apache.lucene.spatial.prefix.RecursivePrefixTreeStrategy;
+import org.apache.lucene.spatial.prefix.tree.GeohashPrefixTree;
+import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.elasticsearch.index.mapper.GeoPointFieldMapper.Names.IGNORE_Z_VALUE;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+
+public class LegacyGeoShapeFieldMapperTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(InternalSettingsPlugin.class);
+    }
+
+    public void testDefaultConfiguration() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                    .field("type", "geo_shape")
+                    .field("strategy", "recursive")
+                .endObject().endObject()
+                .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+        assertEquals(mapping, defaultMapper.mappingSource().toString());
+
+        LegacyGeoShapeFieldMapper geoShapeFieldMapper = (LegacyGeoShapeFieldMapper) fieldMapper;
+        assertThat(geoShapeFieldMapper.fieldType().tree(),
+            equalTo(LegacyGeoShapeFieldMapper.DeprecatedParameters.Defaults.TREE));
+        assertThat(geoShapeFieldMapper.fieldType().treeLevels(), equalTo(0));
+        assertThat(geoShapeFieldMapper.fieldType().pointsOnly(),
+            equalTo(LegacyGeoShapeFieldMapper.DeprecatedParameters.Defaults.POINTS_ONLY));
+        assertThat(geoShapeFieldMapper.fieldType().distanceErrorPct(),
+            equalTo(LegacyGeoShapeFieldMapper.DeprecatedParameters.Defaults.DISTANCE_ERROR_PCT));
+        assertThat(geoShapeFieldMapper.fieldType().orientation(),
+            equalTo(LegacyGeoShapeFieldMapper.Defaults.ORIENTATION.value()));
+        assertFieldWarnings("strategy");
+    }
+
+    /**
+     * Test that orientation parameter correctly parses
+     */
+    public void testOrientationParsing() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("tree", "quadtree")
+                .field("orientation", "left")
+                .endObject().endObject()
+                .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+        ShapeBuilder.Orientation orientation = ((LegacyGeoShapeFieldMapper)fieldMapper).fieldType().orientation();
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.CLOCKWISE));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.LEFT));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.CW));
+
+        // explicit right orientation test
+        mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("tree", "quadtree")
+                .field("orientation", "right")
+                .endObject().endObject()
+                .endObject().endObject());
+
+        defaultMapper = createIndex("test2").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+        orientation = ((LegacyGeoShapeFieldMapper)fieldMapper).fieldType().orientation();
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.COUNTER_CLOCKWISE));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.RIGHT));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.CCW));
+        assertFieldWarnings("tree");
+    }
+
+    /**
+     * Test that coerce parameter correctly parses
+     */
+    public void testCoerceParsing() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("tree", "quadtree")
+                .field("coerce", "true")
+                .endObject().endObject()
+                .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+        boolean coerce = ((LegacyGeoShapeFieldMapper)fieldMapper).coerce().value();
+        assertThat(coerce, equalTo(true));
+
+        // explicit false coerce test
+        mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("tree", "quadtree")
+                .field("coerce", "false")
+                .endObject().endObject()
+                .endObject().endObject());
+
+        defaultMapper = createIndex("test2").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+        coerce = ((LegacyGeoShapeFieldMapper)fieldMapper).coerce().value();
+        assertThat(coerce, equalTo(false));
+        assertFieldWarnings("tree");
+    }
+
+
+    /**
+     * Test that accept_z_value parameter correctly parses
+     */
+    public void testIgnoreZValue() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape")
+            .field("strategy", "recursive")
+            .field(IGNORE_Z_VALUE.getPreferredName(), "true")
+            .endObject().endObject()
+            .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+        boolean ignoreZValue = ((LegacyGeoShapeFieldMapper)fieldMapper).ignoreZValue().value();
+        assertThat(ignoreZValue, equalTo(true));
+
+        // explicit false accept_z_value test
+        mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape")
+            .field("tree", "quadtree")
+            .field(IGNORE_Z_VALUE.getPreferredName(), "false")
+            .endObject().endObject()
+            .endObject().endObject());
+
+        defaultMapper = createIndex("test2").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+        ignoreZValue = ((LegacyGeoShapeFieldMapper)fieldMapper).ignoreZValue().value();
+        assertThat(ignoreZValue, equalTo(false));
+        assertFieldWarnings("strategy", "tree");
+    }
+
+    /**
+     * Test that ignore_malformed parameter correctly parses
+     */
+    public void testIgnoreMalformedParsing() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape")
+            .field("tree", "quadtree")
+            .field("ignore_malformed", "true")
+            .endObject().endObject()
+            .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+        Explicit<Boolean> ignoreMalformed = ((LegacyGeoShapeFieldMapper)fieldMapper).ignoreMalformed();
+        assertThat(ignoreMalformed.value(), equalTo(true));
+
+        // explicit false ignore_malformed test
+        mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape")
+            .field("tree", "quadtree")
+            .field("ignore_malformed", "false")
+            .endObject().endObject()
+            .endObject().endObject());
+
+        defaultMapper = createIndex("test2").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+        ignoreMalformed = ((LegacyGeoShapeFieldMapper)fieldMapper).ignoreMalformed();
+        assertThat(ignoreMalformed.explicit(), equalTo(true));
+        assertThat(ignoreMalformed.value(), equalTo(false));
+        assertFieldWarnings("tree");
+    }
+
+    public void testGeohashConfiguration() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                    .field("type", "geo_shape")
+                    .field("tree", "geohash")
+                    .field("tree_levels", "4")
+                    .field("distance_error_pct", "0.1")
+                .endObject().endObject()
+                .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+        LegacyGeoShapeFieldMapper geoShapeFieldMapper = (LegacyGeoShapeFieldMapper) fieldMapper;
+        PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultPrefixTreeStrategy();
+
+        assertThat(strategy.getDistErrPct(), equalTo(0.1));
+        assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
+        assertThat(strategy.getGrid().getMaxLevels(), equalTo(4));
+        assertFieldWarnings("tree", "tree_levels", "distance_error_pct");
+    }
+
+    public void testQuadtreeConfiguration() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                    .field("type", "geo_shape")
+                    .field("tree", "quadtree")
+                    .field("tree_levels", "6")
+                    .field("distance_error_pct", "0.5")
+                    .field("points_only", true)
+                .endObject().endObject()
+                .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+        LegacyGeoShapeFieldMapper geoShapeFieldMapper = (LegacyGeoShapeFieldMapper) fieldMapper;
+        PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultPrefixTreeStrategy();
+
+        assertThat(strategy.getDistErrPct(), equalTo(0.5));
+        assertThat(strategy.getGrid(), instanceOf(QuadPrefixTree.class));
+        assertThat(strategy.getGrid().getMaxLevels(), equalTo(6));
+        assertThat(strategy.isPointsOnly(), equalTo(true));
+        assertFieldWarnings("tree", "tree_levels", "distance_error_pct", "points_only");
+    }
+
+    private void assertFieldWarnings(String... fieldNames) {
+        String[] warnings = new String[fieldNames.length];
+        for (int i = 0; i < fieldNames.length; ++i) {
+            warnings[i] = "Field parameter [" + fieldNames[i] + "] "
+                + "is deprecated and will be removed in a future version.";
+        }
+        assertWarnings(warnings);
+    }
+
+    public void testLevelPrecisionConfiguration() throws IOException {
+        DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
+
+        {
+            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                    .startObject("properties").startObject("location")
+                        .field("type", "geo_shape")
+                        .field("tree", "quadtree")
+                        .field("tree_levels", "6")
+                        .field("precision", "70m")
+                        .field("distance_error_pct", "0.5")
+                    .endObject().endObject()
+                    .endObject().endObject());
+
+
+            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
+            Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+            assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+            LegacyGeoShapeFieldMapper geoShapeFieldMapper = (LegacyGeoShapeFieldMapper) fieldMapper;
+            PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultPrefixTreeStrategy();
+
+            assertThat(strategy.getDistErrPct(), equalTo(0.5));
+            assertThat(strategy.getGrid(), instanceOf(QuadPrefixTree.class));
+            // 70m is more precise so it wins
+            assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoUtils.quadTreeLevelsForPrecision(70d)));
+        }
+
+        {
+            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                    .startObject("properties").startObject("location")
+                    .field("type", "geo_shape")
+                    .field("tree", "quadtree")
+                    .field("tree_levels", "26")
+                    .field("precision", "70m")
+                    .endObject().endObject()
+                    .endObject().endObject());
+
+
+            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
+            Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+            assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+            LegacyGeoShapeFieldMapper geoShapeFieldMapper = (LegacyGeoShapeFieldMapper) fieldMapper;
+            PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultPrefixTreeStrategy();
+
+            // distance_error_pct was not specified so we expect the mapper to take the highest precision between "precision" and
+            // "tree_levels" setting distErrPct to 0 to guarantee desired precision
+            assertThat(strategy.getDistErrPct(), equalTo(0.0));
+            assertThat(strategy.getGrid(), instanceOf(QuadPrefixTree.class));
+            // 70m is less precise so it loses
+            assertThat(strategy.getGrid().getMaxLevels(), equalTo(26));
+        }
+
+        {
+            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                    .startObject("properties").startObject("location")
+                        .field("type", "geo_shape")
+                        .field("tree", "geohash")
+                        .field("tree_levels", "6")
+                        .field("precision", "70m")
+                        .field("distance_error_pct", "0.5")
+                    .endObject().endObject()
+                    .endObject().endObject());
+
+            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
+            Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+            assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+            LegacyGeoShapeFieldMapper geoShapeFieldMapper = (LegacyGeoShapeFieldMapper) fieldMapper;
+            PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultPrefixTreeStrategy();
+
+            assertThat(strategy.getDistErrPct(), equalTo(0.5));
+            assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
+            // 70m is more precise so it wins
+            assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoUtils.geoHashLevelsForPrecision(70d)));
+        }
+
+        {
+            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                    .startObject("properties").startObject("location")
+                        .field("type", "geo_shape")
+                        .field("tree", "geohash")
+                        .field("tree_levels",  GeoUtils.geoHashLevelsForPrecision(70d)+1)
+                        .field("precision", "70m")
+                        .field("distance_error_pct", "0.5")
+                    .endObject().endObject()
+                    .endObject().endObject());
+
+            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
+            Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+            assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+            LegacyGeoShapeFieldMapper geoShapeFieldMapper = (LegacyGeoShapeFieldMapper) fieldMapper;
+            PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultPrefixTreeStrategy();
+
+            assertThat(strategy.getDistErrPct(), equalTo(0.5));
+            assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
+            assertThat(strategy.getGrid().getMaxLevels(),  equalTo(GeoUtils.geoHashLevelsForPrecision(70d)+1));
+        }
+
+        {
+            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                    .startObject("properties").startObject("location")
+                        .field("type", "geo_shape")
+                        .field("tree", "quadtree")
+                        .field("tree_levels", GeoUtils.quadTreeLevelsForPrecision(70d)+1)
+                        .field("precision", "70m")
+                        .field("distance_error_pct", "0.5")
+                    .endObject().endObject()
+                    .endObject().endObject());
+
+            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
+            Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+            assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+            LegacyGeoShapeFieldMapper geoShapeFieldMapper = (LegacyGeoShapeFieldMapper) fieldMapper;
+            PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultPrefixTreeStrategy();
+
+            assertThat(strategy.getDistErrPct(), equalTo(0.5));
+            assertThat(strategy.getGrid(), instanceOf(QuadPrefixTree.class));
+            assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoUtils.quadTreeLevelsForPrecision(70d)+1));
+        }
+        assertFieldWarnings("tree", "tree_levels", "precision", "distance_error_pct");
+    }
+
+    public void testPointsOnlyOption() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("tree", "geohash")
+                .field("points_only", true)
+                .endObject().endObject()
+                .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+        LegacyGeoShapeFieldMapper geoShapeFieldMapper = (LegacyGeoShapeFieldMapper) fieldMapper;
+        PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultPrefixTreeStrategy();
+
+        assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
+        assertThat(strategy.isPointsOnly(), equalTo(true));
+        assertFieldWarnings("tree", "points_only");
+    }
+
+    public void testLevelDefaults() throws IOException {
+        DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
+        {
+            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                    .startObject("properties").startObject("location")
+                        .field("type", "geo_shape")
+                        .field("tree", "quadtree")
+                        .field("distance_error_pct", "0.5")
+                    .endObject().endObject()
+                    .endObject().endObject());
+
+
+            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
+            Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+            assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+            LegacyGeoShapeFieldMapper geoShapeFieldMapper = (LegacyGeoShapeFieldMapper) fieldMapper;
+            PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultPrefixTreeStrategy();
+
+            assertThat(strategy.getDistErrPct(), equalTo(0.5));
+            assertThat(strategy.getGrid(), instanceOf(QuadPrefixTree.class));
+            /* 50m is default */
+            assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoUtils.quadTreeLevelsForPrecision(50d)));
+        }
+
+        {
+            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                    .startObject("properties").startObject("location")
+                        .field("type", "geo_shape")
+                        .field("tree", "geohash")
+                        .field("distance_error_pct", "0.5")
+                    .endObject().endObject()
+                    .endObject().endObject());
+
+            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
+            Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+            assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+            LegacyGeoShapeFieldMapper geoShapeFieldMapper = (LegacyGeoShapeFieldMapper) fieldMapper;
+            PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultPrefixTreeStrategy();
+
+            assertThat(strategy.getDistErrPct(), equalTo(0.5));
+            assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
+            /* 50m is default */
+            assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoUtils.geoHashLevelsForPrecision(50d)));
+        }
+        assertFieldWarnings("tree", "distance_error_pct");
+    }
+
+    public void testGeoShapeMapperMerge() throws Exception {
+        String stage1Mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type").startObject("properties")
+                .startObject("shape").field("type", "geo_shape").field("tree", "geohash")
+                .field("strategy", "recursive")
+                .field("precision", "1m").field("tree_levels", 8).field("distance_error_pct", 0.01)
+                .field("orientation", "ccw")
+                .endObject().endObject().endObject().endObject());
+        MapperService mapperService = createIndex("test").mapperService();
+        DocumentMapper docMapper = mapperService.merge("type", new CompressedXContent(stage1Mapping),
+            MapperService.MergeReason.MAPPING_UPDATE, false);
+        String stage2Mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("shape").field("type", "geo_shape")
+                .field("tree", "quadtree")
+                .field("strategy", "term").field("precision", "1km")
+                .field("tree_levels", 26).field("distance_error_pct", 26)
+                .field("orientation", "cw").endObject().endObject().endObject().endObject());
+        try {
+            mapperService.merge("type", new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("mapper [shape] has different [strategy]"));
+            assertThat(e.getMessage(), containsString("mapper [shape] has different [tree]"));
+            assertThat(e.getMessage(), containsString("mapper [shape] has different [tree_levels]"));
+            assertThat(e.getMessage(), containsString("mapper [shape] has different [precision]"));
+            assertThat(e.getMessage(), containsString("mapper [shape] has different [distance_error_pct]"));
+        }
+
+        // verify nothing changed
+        Mapper fieldMapper = docMapper.mappers().getMapper("shape");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+        LegacyGeoShapeFieldMapper geoShapeFieldMapper = (LegacyGeoShapeFieldMapper) fieldMapper;
+        PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultPrefixTreeStrategy();
+
+        assertThat(strategy, instanceOf(RecursivePrefixTreeStrategy.class));
+        assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
+        assertThat(strategy.getDistErrPct(), equalTo(0.01));
+        assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoUtils.geoHashLevelsForPrecision(1d)));
+        assertThat(geoShapeFieldMapper.fieldType().orientation(), equalTo(ShapeBuilder.Orientation.CCW));
+
+        // correct mapping
+        stage2Mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("shape").field("type", "geo_shape")
+                .field("tree", "geohash")
+                .field("strategy", "recursive")
+                .field("precision", "1m")
+                .field("tree_levels", 8).field("distance_error_pct", 0.01)
+                .field("orientation", "cw").endObject().endObject().endObject().endObject());
+        docMapper = mapperService.merge("type", new CompressedXContent(stage2Mapping),
+            MapperService.MergeReason.MAPPING_UPDATE, false);
+
+        fieldMapper = docMapper.mappers().getMapper("shape");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+        geoShapeFieldMapper = (LegacyGeoShapeFieldMapper) fieldMapper;
+        strategy = geoShapeFieldMapper.fieldType().defaultPrefixTreeStrategy();
+
+        assertThat(strategy, instanceOf(RecursivePrefixTreeStrategy.class));
+        assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
+        assertThat(strategy.getDistErrPct(), equalTo(0.01));
+        assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoUtils.geoHashLevelsForPrecision(1d)));
+        assertThat(geoShapeFieldMapper.fieldType().orientation(), equalTo(ShapeBuilder.Orientation.CW));
+
+        assertFieldWarnings("tree", "strategy", "precision", "tree_levels", "distance_error_pct");
+    }
+
+    public void testEmptyName() throws Exception {
+        // after 5.x
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("")
+            .field("type", "geo_shape")
+            .field("tree", "quadtree")
+            .endObject().endObject()
+            .endObject().endObject());
+        DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> parser.parse("type1", new CompressedXContent(mapping))
+        );
+        assertThat(e.getMessage(), containsString("name cannot be empty string"));
+        assertFieldWarnings("tree");
+    }
+
+    public void testSerializeDefaults() throws Exception {
+        DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
+        {
+            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("tree", "quadtree")
+                .endObject().endObject()
+                .endObject().endObject());
+            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
+            String serialized = toXContentString((LegacyGeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
+            assertTrue(serialized, serialized.contains("\"precision\":\"50.0m\""));
+            assertTrue(serialized, serialized.contains("\"tree_levels\":21"));
+        }
+        {
+            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("tree", "geohash")
+                .endObject().endObject()
+                .endObject().endObject());
+            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
+            String serialized = toXContentString((LegacyGeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
+            assertTrue(serialized, serialized.contains("\"precision\":\"50.0m\""));
+            assertTrue(serialized, serialized.contains("\"tree_levels\":9"));
+        }
+        {
+            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("tree", "quadtree")
+                .field("tree_levels", "6")
+                .endObject().endObject()
+                .endObject().endObject());
+            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
+            String serialized = toXContentString((LegacyGeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
+            assertFalse(serialized, serialized.contains("\"precision\":"));
+            assertTrue(serialized, serialized.contains("\"tree_levels\":6"));
+        }
+        {
+            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("tree", "quadtree")
+                .field("precision", "6")
+                .endObject().endObject()
+                .endObject().endObject());
+            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
+            String serialized = toXContentString((LegacyGeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
+            assertTrue(serialized, serialized.contains("\"precision\":\"6.0m\""));
+            assertFalse(serialized, serialized.contains("\"tree_levels\":"));
+        }
+        {
+            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("tree", "quadtree")
+                .field("precision", "6m")
+                .field("tree_levels", "5")
+                .endObject().endObject()
+                .endObject().endObject());
+            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
+            String serialized = toXContentString((LegacyGeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
+            assertTrue(serialized, serialized.contains("\"precision\":\"6.0m\""));
+            assertTrue(serialized, serialized.contains("\"tree_levels\":5"));
+        }
+        assertFieldWarnings("tree", "tree_levels", "precision");
+    }
+
+    public void testPointsOnlyDefaultsWithTermStrategy() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape")
+            .field("tree", "quadtree")
+            .field("precision", "10m")
+            .field("strategy", "term")
+            .endObject().endObject()
+            .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+        LegacyGeoShapeFieldMapper geoShapeFieldMapper = (LegacyGeoShapeFieldMapper) fieldMapper;
+        PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultPrefixTreeStrategy();
+
+        assertThat(strategy.getDistErrPct(), equalTo(0.0));
+        assertThat(strategy.getGrid(), instanceOf(QuadPrefixTree.class));
+        assertThat(strategy.getGrid().getMaxLevels(), equalTo(23));
+        assertThat(strategy.isPointsOnly(), equalTo(true));
+        // term strategy changes the default for points_only, check that we handle it correctly
+        assertThat(toXContentString(geoShapeFieldMapper, false), not(containsString("points_only")));
+        assertFieldWarnings("tree", "precision", "strategy");
+    }
+
+
+    public void testPointsOnlyFalseWithTermStrategy() throws Exception {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape")
+            .field("tree", "quadtree")
+            .field("precision", "10m")
+            .field("strategy", "term")
+            .field("points_only", false)
+            .endObject().endObject()
+            .endObject().endObject());
+
+        DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
+
+        ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class,
+            () -> parser.parse("type1", new CompressedXContent(mapping))
+        );
+        assertThat(e.getMessage(), containsString("points_only cannot be set to false for term strategy"));
+        assertFieldWarnings("tree", "precision", "strategy", "points_only");
+    }
+
+    public String toXContentString(LegacyGeoShapeFieldMapper mapper, boolean includeDefaults) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        ToXContent.Params params;
+        if (includeDefaults) {
+            params = new ToXContent.MapParams(Collections.singletonMap("include_defaults", "true"));
+        } else {
+            params = ToXContent.EMPTY_PARAMS;
+        }
+        mapper.doXContentBody(builder, includeDefaults, params);
+        return Strings.toString(builder.endObject());
+    }
+
+    public String toXContentString(LegacyGeoShapeFieldMapper mapper) throws IOException {
+        return toXContentString(mapper, true);
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldTypeTests.java
@@ -19,16 +19,15 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.geo.SpatialStrategy;
-import org.elasticsearch.common.geo.builders.ShapeBuilder;
-import org.elasticsearch.index.mapper.GeoShapeFieldMapper.GeoShapeFieldType;
+import org.elasticsearch.index.mapper.LegacyGeoShapeFieldMapper.GeoShapeFieldType;
 import org.junit.Before;
 
 import java.io.IOException;
 
-public class GeoShapeFieldTypeTests extends FieldTypeTestCase {
+public class LegacyGeoShapeFieldTypeTests extends FieldTypeTestCase {
     @Override
     protected MappedFieldType createDefaultFieldType() {
-        return new GeoShapeFieldMapper.GeoShapeFieldType();
+        return new GeoShapeFieldType();
     }
 
     @Before
@@ -36,51 +35,45 @@ public class GeoShapeFieldTypeTests extends FieldTypeTestCase {
         addModifier(new Modifier("tree", false) {
             @Override
             public void modify(MappedFieldType ft) {
-                ((GeoShapeFieldMapper.GeoShapeFieldType)ft).setTree("quadtree");
+                ((GeoShapeFieldType)ft).setTree("geohash");
             }
         });
         addModifier(new Modifier("strategy", false) {
             @Override
             public void modify(MappedFieldType ft) {
-                ((GeoShapeFieldMapper.GeoShapeFieldType)ft).setStrategyName("term");
+                ((GeoShapeFieldType)ft).setStrategy(SpatialStrategy.TERM);
             }
         });
         addModifier(new Modifier("tree_levels", false) {
             @Override
             public void modify(MappedFieldType ft) {
-                ((GeoShapeFieldMapper.GeoShapeFieldType)ft).setTreeLevels(10);
+                ((GeoShapeFieldType)ft).setTreeLevels(10);
             }
         });
         addModifier(new Modifier("precision", false) {
             @Override
             public void modify(MappedFieldType ft) {
-                ((GeoShapeFieldMapper.GeoShapeFieldType)ft).setPrecisionInMeters(20);
+                ((GeoShapeFieldType)ft).setPrecisionInMeters(20);
             }
         });
-        addModifier(new Modifier("distance_error_pct", true) {
+        addModifier(new Modifier("distance_error_pct", false) {
             @Override
             public void modify(MappedFieldType ft) {
-                ((GeoShapeFieldMapper.GeoShapeFieldType)ft).setDefaultDistanceErrorPct(0.5);
-            }
-        });
-        addModifier(new Modifier("orientation", true) {
-            @Override
-            public void modify(MappedFieldType ft) {
-                ((GeoShapeFieldMapper.GeoShapeFieldType)ft).setOrientation(ShapeBuilder.Orientation.LEFT);
+                ((GeoShapeFieldType)ft).setDefaultDistanceErrorPct(0.5);
             }
         });
     }
 
     /**
-     * Test for {@link GeoShapeFieldType#setStrategyName(String)} that checks that {@link GeoShapeFieldType#pointsOnly()}
-     * gets set as a side effect when using SpatialStrategy.TERM
+     * Test for {@link LegacyGeoShapeFieldMapper.GeoShapeFieldType#setStrategy(SpatialStrategy)} that checks
+     * that {@link LegacyGeoShapeFieldMapper.GeoShapeFieldType#pointsOnly()} gets set as a side effect when using SpatialStrategy.TERM
      */
     public void testSetStrategyName() throws IOException {
-        GeoShapeFieldType fieldType = new GeoShapeFieldMapper.GeoShapeFieldType();
+        GeoShapeFieldType fieldType = new GeoShapeFieldType();
         assertFalse(fieldType.pointsOnly());
-        fieldType.setStrategyName(SpatialStrategy.RECURSIVE.getStrategyName());
+        fieldType.setStrategy(SpatialStrategy.RECURSIVE);
         assertFalse(fieldType.pointsOnly());
-        fieldType.setStrategyName(SpatialStrategy.TERM.getStrategyName());
+        fieldType.setStrategy(SpatialStrategy.TERM);
         assertTrue(fieldType.pointsOnly());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.BooleanQuery;
@@ -24,21 +23,24 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.geo.ShapeRelation;
-import org.elasticsearch.common.geo.SpatialStrategy;
 import org.elasticsearch.common.geo.builders.EnvelopeBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.AbstractQueryTestCase;
+import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.geo.RandomShapeGenerator;
 import org.elasticsearch.test.geo.RandomShapeGenerator.ShapeType;
 import org.junit.After;
@@ -54,29 +56,46 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<GeoShapeQueryBuilder> {
 
-    private static String indexedShapeId;
-    private static String indexedShapeType;
-    private static String indexedShapePath;
-    private static String indexedShapeIndex;
-    private static String indexedShapeRouting;
-    private static ShapeBuilder indexedShapeToReturn;
+    protected static String indexedShapeId;
+    protected static String indexedShapeType;
+    protected static String indexedShapePath;
+    protected static String indexedShapeIndex;
+    protected static String indexedShapeRouting;
+    protected static ShapeBuilder<?, ?> indexedShapeToReturn;
+
+    protected String fieldName() {
+        return GEO_SHAPE_FIELD_NAME;
+    }
+
+    @Override
+    protected Settings createTestIndexSettings() {
+        // force the new shape impl
+        Version version = VersionUtils.randomVersionBetween(random(), Version.V_6_6_0, Version.CURRENT);
+        return Settings.builder()
+                .put(super.createTestIndexSettings())
+                .put(IndexMetaData.SETTING_VERSION_CREATED, version)
+                .build();
+    }
 
     @Override
     protected GeoShapeQueryBuilder doCreateTestQueryBuilder() {
         return doCreateTestQueryBuilder(randomBoolean());
     }
-    private GeoShapeQueryBuilder doCreateTestQueryBuilder(boolean indexedShape) {
-        ShapeType shapeType = ShapeType.randomType(random());
-        ShapeBuilder shape = RandomShapeGenerator.createShapeWithin(random(), null, shapeType);
+
+    protected GeoShapeQueryBuilder doCreateTestQueryBuilder(boolean indexedShape) {
+        // LatLonShape does not support MultiPoint queries
+        RandomShapeGenerator.ShapeType shapeType =
+            randomFrom(ShapeType.POINT, ShapeType.LINESTRING, ShapeType.MULTILINESTRING, ShapeType.POLYGON);
+        ShapeBuilder<?, ?> shape = RandomShapeGenerator.createShapeWithin(random(), null, shapeType);
         GeoShapeQueryBuilder builder;
         clearShapeFields();
         if (indexedShape == false) {
-            builder = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, shape);
+            builder = new GeoShapeQueryBuilder(fieldName(), shape);
         } else {
             indexedShapeToReturn = shape;
             indexedShapeId = randomAlphaOfLengthBetween(3, 20);
             indexedShapeType = randomAlphaOfLengthBetween(3, 20);
-            builder = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, indexedShapeId, indexedShapeType);
+            builder = new GeoShapeQueryBuilder(fieldName(), indexedShapeId, indexedShapeType);
             if (randomBoolean()) {
                 indexedShapeIndex = randomAlphaOfLengthBetween(3, 20);
                 builder.indexedShapeIndex(indexedShapeIndex);
@@ -91,15 +110,11 @@ public class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<GeoShapeQue
             }
         }
         if (randomBoolean()) {
-            SpatialStrategy strategy = randomFrom(SpatialStrategy.values());
-            // ShapeType.MULTILINESTRING + SpatialStrategy.TERM can lead to large queries and will slow down tests, so
-            // we try to avoid that combination
-            while (shapeType == ShapeType.MULTILINESTRING && strategy == SpatialStrategy.TERM) {
-                strategy = randomFrom(SpatialStrategy.values());
-            }
-            builder.strategy(strategy);
-            if (strategy != SpatialStrategy.TERM) {
-                builder.relation(randomFrom(ShapeRelation.values()));
+            if (shapeType == ShapeType.LINESTRING || shapeType == ShapeType.MULTILINESTRING) {
+                builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS));
+            } else {
+                // LatLonShape does not support CONTAINS:
+                builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.WITHIN));
             }
         }
 
@@ -172,39 +187,26 @@ public class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<GeoShapeQue
     }
 
     public void testNoShape() throws IOException {
-        expectThrows(IllegalArgumentException.class, () -> new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, null));
+        expectThrows(IllegalArgumentException.class, () -> new GeoShapeQueryBuilder(fieldName(), null));
     }
 
     public void testNoIndexedShape() throws IOException {
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, null, "type"));
+            () -> new GeoShapeQueryBuilder(fieldName(), null, "type"));
         assertEquals("either shapeBytes or indexedShapeId and indexedShapeType are required", e.getMessage());
     }
 
     public void testNoIndexedShapeType() throws IOException {
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, "id", null));
+            () -> new GeoShapeQueryBuilder(fieldName(), "id", null));
         assertEquals("indexedShapeType is required if indexedShapeId is specified", e.getMessage());
     }
 
     public void testNoRelation() throws IOException {
-        ShapeBuilder shape = RandomShapeGenerator.createShapeWithin(random(), null);
-        GeoShapeQueryBuilder builder = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, shape);
+        ShapeBuilder<?, ?> shape = RandomShapeGenerator.createShapeWithin(random(), null);
+        GeoShapeQueryBuilder builder = new GeoShapeQueryBuilder(fieldName(), shape);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> builder.relation(null));
         assertEquals("No Shape Relation defined", e.getMessage());
-    }
-
-    public void testInvalidRelation() throws IOException {
-        ShapeBuilder shape = RandomShapeGenerator.createShapeWithin(random(), null);
-        GeoShapeQueryBuilder builder = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, shape);
-        builder.strategy(SpatialStrategy.TERM);
-        expectThrows(IllegalArgumentException.class, () -> builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.WITHIN)));
-        GeoShapeQueryBuilder builder2 = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, shape);
-        builder2.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.WITHIN));
-        expectThrows(IllegalArgumentException.class, () -> builder2.strategy(SpatialStrategy.TERM));
-        GeoShapeQueryBuilder builder3 = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, shape);
-        builder3.strategy(SpatialStrategy.TERM);
-        expectThrows(IllegalArgumentException.class, () -> builder3.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.WITHIN)));
     }
 
     // see #3878
@@ -216,7 +218,7 @@ public class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<GeoShapeQue
 
     public void testFromJson() throws IOException {
         String json =
-                "{\n" +
+            "{\n" +
                 "  \"geo_shape\" : {\n" +
                 "    \"location\" : {\n" +
                 "      \"shape\" : {\n" +
@@ -241,7 +243,7 @@ public class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<GeoShapeQue
         UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, () -> query.toQuery(createShardContext()));
         assertEquals("query must be rewritten first", e.getMessage());
         QueryBuilder rewrite = rewriteAndFetch(query, createShardContext());
-        GeoShapeQueryBuilder geoShapeQueryBuilder = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, indexedShapeToReturn);
+        GeoShapeQueryBuilder geoShapeQueryBuilder = new GeoShapeQueryBuilder(fieldName(), indexedShapeToReturn);
         geoShapeQueryBuilder.strategy(query.strategy());
         geoShapeQueryBuilder.relation(query.relation());
         assertEquals(geoShapeQueryBuilder, rewrite);
@@ -255,7 +257,7 @@ public class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<GeoShapeQue
 
         builder = rewriteAndFetch(builder, createShardContext());
 
-        GeoShapeQueryBuilder expectedShape = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, indexedShapeToReturn);
+        GeoShapeQueryBuilder expectedShape = new GeoShapeQueryBuilder(fieldName(), indexedShapeToReturn);
         expectedShape.strategy(shape.strategy());
         expectedShape.relation(shape.relation());
         QueryBuilder expected = new BoolQueryBuilder()

--- a/server/src/test/java/org/elasticsearch/index/query/LegacyGeoShapeFieldQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/LegacyGeoShapeFieldQueryTests.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.geo.ShapeRelation;
+import org.elasticsearch.common.geo.SpatialStrategy;
+import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.test.geo.RandomShapeGenerator;
+import org.elasticsearch.test.geo.RandomShapeGenerator.ShapeType;
+
+import java.io.IOException;
+
+public class LegacyGeoShapeFieldQueryTests extends GeoShapeQueryBuilderTests {
+
+    @Override
+    protected String fieldName() {
+        return GEO_SHAPE_FIELD_NAME;
+    }
+
+    @Override
+    protected Settings createTestIndexSettings() {
+        // force the legacy shape impl
+        Version version = VersionUtils.randomVersionBetween(random(), Version.V_6_0_0, Version.V_6_5_0);
+        return Settings.builder()
+                .put(super.createTestIndexSettings())
+                .put(IndexMetaData.SETTING_VERSION_CREATED, version)
+                .build();
+    }
+
+    @Override
+    protected GeoShapeQueryBuilder doCreateTestQueryBuilder(boolean indexedShape) {
+        ShapeType shapeType = ShapeType.randomType(random());
+        ShapeBuilder<?, ?> shape = RandomShapeGenerator.createShapeWithin(random(), null, shapeType);
+        GeoShapeQueryBuilder builder;
+        clearShapeFields();
+        if (indexedShape == false) {
+            builder = new GeoShapeQueryBuilder(fieldName(), shape);
+        } else {
+            indexedShapeToReturn = shape;
+            indexedShapeId = randomAlphaOfLengthBetween(3, 20);
+            indexedShapeType = randomAlphaOfLengthBetween(3, 20);
+            builder = new GeoShapeQueryBuilder(fieldName(), indexedShapeId, indexedShapeType);
+            if (randomBoolean()) {
+                indexedShapeIndex = randomAlphaOfLengthBetween(3, 20);
+                builder.indexedShapeIndex(indexedShapeIndex);
+            }
+            if (randomBoolean()) {
+                indexedShapePath = randomAlphaOfLengthBetween(3, 20);
+                builder.indexedShapePath(indexedShapePath);
+            }
+            if (randomBoolean()) {
+                indexedShapeRouting = randomAlphaOfLengthBetween(3, 20);
+                builder.indexedShapeRouting(indexedShapeRouting);
+            }
+        }
+        if (randomBoolean()) {
+            SpatialStrategy strategy = randomFrom(SpatialStrategy.values());
+            // ShapeType.MULTILINESTRING + SpatialStrategy.TERM can lead to large queries and will slow down tests, so
+            // we try to avoid that combination
+            while (shapeType == ShapeType.MULTILINESTRING && strategy == SpatialStrategy.TERM) {
+                strategy = randomFrom(SpatialStrategy.values());
+            }
+            builder.strategy(strategy);
+            if (strategy != SpatialStrategy.TERM) {
+                builder.relation(randomFrom(ShapeRelation.values()));
+            }
+        }
+
+        if (randomBoolean()) {
+            builder.ignoreUnmapped(randomBoolean());
+        }
+        return builder;
+    }
+
+    public void testInvalidRelation() throws IOException {
+        ShapeBuilder<?, ?> shape = RandomShapeGenerator.createShapeWithin(random(), null);
+        GeoShapeQueryBuilder builder = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, shape);
+        builder.strategy(SpatialStrategy.TERM);
+        expectThrows(IllegalArgumentException.class, () -> builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.WITHIN)));
+        GeoShapeQueryBuilder builder2 = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, shape);
+        builder2.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.WITHIN));
+        expectThrows(IllegalArgumentException.class, () -> builder2.strategy(SpatialStrategy.TERM));
+        GeoShapeQueryBuilder builder3 = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, shape);
+        builder3.strategy(SpatialStrategy.TERM);
+        expectThrows(IllegalArgumentException.class, () -> builder3.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.WITHIN)));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -67,6 +67,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuilder> {
+
     @Override
     protected MatchQueryBuilder doCreateTestQueryBuilder() {
         String fieldName = randomFrom(STRING_FIELD_NAME, STRING_ALIAS_FIELD_NAME, BOOLEAN_FIELD_NAME,

--- a/server/src/test/java/org/elasticsearch/search/geo/GeoFilterIT.java
+++ b/server/src/test/java/org/elasticsearch/search/geo/GeoFilterIT.java
@@ -375,6 +375,7 @@ public class GeoFilterIT extends ESIntegTestCase {
                 .endObject()
                 .startObject("location")
                 .field("type", "geo_shape")
+                .field("ignore_malformed", true)
                 .endObject()
                 .endObject()
                 .endObject()

--- a/server/src/test/java/org/elasticsearch/search/geo/GeoShapeQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/geo/GeoShapeQueryTests.java
@@ -19,16 +19,21 @@
 
 package org.elasticsearch.search.geo;
 
+import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
+import org.apache.lucene.geo.GeoTestUtil;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.ShapeRelation;
+import org.elasticsearch.common.geo.SpatialStrategy;
 import org.elasticsearch.common.geo.builders.CoordinatesBuilder;
 import org.elasticsearch.common.geo.builders.EnvelopeBuilder;
 import org.elasticsearch.common.geo.builders.GeometryCollectionBuilder;
 import org.elasticsearch.common.geo.builders.LineStringBuilder;
+import org.elasticsearch.common.geo.builders.MultiPointBuilder;
+import org.elasticsearch.common.geo.builders.PointBuilder;
 import org.elasticsearch.common.geo.builders.PolygonBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.settings.Settings;
@@ -36,7 +41,9 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.mapper.LegacyGeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.GeoShapeQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -63,13 +70,27 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.nullValue;
 
 public class GeoShapeQueryTests extends ESSingleNodeTestCase {
+    private static final String[] PREFIX_TREES = new String[] {
+        LegacyGeoShapeFieldMapper.DeprecatedParameters.PrefixTrees.GEOHASH,
+        LegacyGeoShapeFieldMapper.DeprecatedParameters.PrefixTrees.QUADTREE
+    };
+
+    private XContentBuilder createMapping() throws Exception {
+        XContentBuilder xcb = XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape");
+        if (randomBoolean()) {
+            xcb = xcb.field("tree", randomFrom(PREFIX_TREES))
+            .field("strategy", randomFrom(SpatialStrategy.RECURSIVE, SpatialStrategy.TERM));
+        }
+        xcb = xcb.endObject().endObject().endObject().endObject();
+
+        return xcb;
+    }
+
     public void testNullShape() throws Exception {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                .field("type", "geo_shape")
-                .endObject().endObject()
-                .endObject().endObject());
-        client().admin().indices().prepareCreate("test").addMapping("type1", mapping, XContentType.JSON).execute().actionGet();
+        String mapping = Strings.toString(createMapping());
+        client().admin().indices().prepareCreate("test").addMapping("type1", mapping, XContentType.JSON).get();
         ensureGreen();
 
         client().prepareIndex("test", "type1", "aNullshape").setSource("{\"location\": null}", XContentType.JSON)
@@ -79,13 +100,8 @@ public class GeoShapeQueryTests extends ESSingleNodeTestCase {
     }
 
     public void testIndexPointsFilterRectangle() throws Exception {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                .field("type", "geo_shape")
-                .field("tree", "quadtree")
-                .endObject().endObject()
-                .endObject().endObject());
-        client().admin().indices().prepareCreate("test").addMapping("type1", mapping, XContentType.JSON).execute().actionGet();
+        String mapping = Strings.toString(createMapping());
+        client().admin().indices().prepareCreate("test").addMapping("type1", mapping, XContentType.JSON).get();
         ensureGreen();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
@@ -126,13 +142,12 @@ public class GeoShapeQueryTests extends ESSingleNodeTestCase {
     }
 
     public void testEdgeCases() throws Exception {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                .field("type", "geo_shape")
-                .field("tree", "quadtree")
-                .endObject().endObject()
-                .endObject().endObject());
-        client().admin().indices().prepareCreate("test").addMapping("type1", mapping, XContentType.JSON).execute().actionGet();
+        XContentBuilder xcb = XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape")
+            .endObject().endObject().endObject().endObject();
+        String mapping = Strings.toString(xcb);
+        client().admin().indices().prepareCreate("test").addMapping("type1", mapping, XContentType.JSON).get();
         ensureGreen();
 
         client().prepareIndex("test", "type1", "blakely").setSource(jsonBuilder().startObject()
@@ -163,13 +178,8 @@ public class GeoShapeQueryTests extends ESSingleNodeTestCase {
     }
 
     public void testIndexedShapeReference() throws Exception {
-        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("properties").startObject("location")
-                .field("type", "geo_shape")
-                .field("tree", "quadtree")
-                .endObject().endObject()
-                .endObject().endObject());
-        client().admin().indices().prepareCreate("test").addMapping("type1", mapping, XContentType.JSON).execute().actionGet();
+        String mapping = Strings.toString(createMapping());
+        client().admin().indices().prepareCreate("test").addMapping("type1", mapping, XContentType.JSON).get();
         createIndex("shapes");
         ensureGreen();
 
@@ -205,14 +215,7 @@ public class GeoShapeQueryTests extends ESSingleNodeTestCase {
     }
 
     public void testIndexedShapeReferenceSourceDisabled() throws Exception {
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject()
-                .startObject("properties")
-                    .startObject("location")
-                        .field("type", "geo_shape")
-                        .field("tree", "quadtree")
-                    .endObject()
-                .endObject()
-            .endObject();
+        XContentBuilder mapping = createMapping();
         client().admin().indices().prepareCreate("test").addMapping("type1", mapping).get();
         createIndex("shapes", Settings.EMPTY, "shape_type", "_source", "enabled=false");
         ensureGreen();
@@ -325,24 +328,107 @@ public class GeoShapeQueryTests extends ESSingleNodeTestCase {
         assertHitCount(result, 1);
     }
 
-    public void testShapeFilterWithRandomGeoCollection() throws Exception {
+    public void testQueryRandomGeoCollection() throws Exception {
         // Create a random geometry collection.
         GeometryCollectionBuilder gcb = RandomShapeGenerator.createGeometryCollection(random());
+        org.apache.lucene.geo.Polygon randomPoly = GeoTestUtil.nextPolygon();
+        CoordinatesBuilder cb = new CoordinatesBuilder();
+        for (int i = 0; i < randomPoly.numPoints(); ++i) {
+            cb.coordinate(randomPoly.getPolyLon(i), randomPoly.getPolyLat(i));
+        }
+        gcb.shape(new PolygonBuilder(cb));
 
         logger.info("Created Random GeometryCollection containing {} shapes", gcb.numShapes());
 
-        client().admin().indices().prepareCreate("test").addMapping("type", "location", "type=geo_shape,tree=quadtree")
-                .execute().actionGet();
+        if (randomBoolean()) {
+            client().admin().indices().prepareCreate("test")
+                .addMapping("type", "location", "type=geo_shape").get();
+        } else {
+            client().admin().indices().prepareCreate("test")
+                .addMapping("type", "location", "type=geo_shape,tree=quadtree").get();
+        }
 
         XContentBuilder docSource = gcb.toXContent(jsonBuilder().startObject().field("location"), null).endObject();
         client().prepareIndex("test", "type", "1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
 
-        ShapeBuilder filterShape = (gcb.getShapeAt(randomIntBetween(0, gcb.numShapes() - 1)));
+        ShapeBuilder filterShape = (gcb.getShapeAt(gcb.numShapes() - 1));
 
-        GeoShapeQueryBuilder filter = QueryBuilders.geoShapeQuery("location", filterShape);
-        filter.relation(ShapeRelation.INTERSECTS);
-        SearchResponse result = client().prepareSearch("test").setTypes("type").setQuery(QueryBuilders.matchAllQuery())
-                .setPostFilter(filter).get();
+        GeoShapeQueryBuilder geoShapeQueryBuilder = QueryBuilders.geoShapeQuery("location", filterShape);
+        geoShapeQueryBuilder.relation(ShapeRelation.INTERSECTS);
+        SearchResponse result = client().prepareSearch("test").setTypes("type").setQuery(geoShapeQueryBuilder).get();
+        assertSearchResponse(result);
+        assertHitCount(result, 1);
+    }
+
+    public void testRandomGeoCollectionQuery() throws Exception {
+        boolean usePrefixTrees = randomBoolean();
+        // Create a random geometry collection to index.
+        GeometryCollectionBuilder gcb;
+        if (usePrefixTrees) {
+            gcb = RandomShapeGenerator.createGeometryCollection(random());
+        } else {
+            // vector strategy does not yet support multipoint queries
+            gcb = new GeometryCollectionBuilder();
+            int numShapes = RandomNumbers.randomIntBetween(random(), 1, 4);
+            for (int i = 0; i < numShapes; ++i) {
+                ShapeBuilder shape;
+                do {
+                    shape = RandomShapeGenerator.createShape(random());
+                } while (shape instanceof MultiPointBuilder);
+                gcb.shape(shape);
+            }
+        }
+        org.apache.lucene.geo.Polygon randomPoly = GeoTestUtil.nextPolygon();
+        CoordinatesBuilder cb = new CoordinatesBuilder();
+        for (int i = 0; i < randomPoly.numPoints(); ++i) {
+            cb.coordinate(randomPoly.getPolyLon(i), randomPoly.getPolyLat(i));
+        }
+        gcb.shape(new PolygonBuilder(cb));
+
+        logger.info("Created Random GeometryCollection containing {} shapes", gcb.numShapes());
+
+        if (usePrefixTrees == false) {
+            client().admin().indices().prepareCreate("test").addMapping("type", "location", "type=geo_shape")
+                .execute().actionGet();
+        } else {
+            client().admin().indices().prepareCreate("test").addMapping("type", "location", "type=geo_shape,tree=quadtree")
+                .execute().actionGet();
+        }
+
+        XContentBuilder docSource = gcb.toXContent(jsonBuilder().startObject().field("location"), null).endObject();
+        client().prepareIndex("test", "type", "1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
+
+        // Create a random geometry collection to query
+        GeometryCollectionBuilder queryCollection = RandomShapeGenerator.createGeometryCollection(random());
+        queryCollection.shape(new PolygonBuilder(cb));
+
+        GeoShapeQueryBuilder geoShapeQueryBuilder = QueryBuilders.geoShapeQuery("location", queryCollection);
+        geoShapeQueryBuilder.relation(ShapeRelation.INTERSECTS);
+        SearchResponse result = client().prepareSearch("test").setTypes("type").setQuery(geoShapeQueryBuilder).get();
+        assertSearchResponse(result);
+        assertTrue(result.getHits().getTotalHits() > 0);
+    }
+
+    /** tests querying a random geometry collection with a point */
+    public void testPointQuery() throws Exception {
+        // Create a random geometry collection to index.
+        GeometryCollectionBuilder gcb = RandomShapeGenerator.createGeometryCollection(random());
+        double[] pt = new double[] {GeoTestUtil.nextLongitude(), GeoTestUtil.nextLatitude()};
+        PointBuilder pb = new PointBuilder(pt[0], pt[1]);
+        gcb.shape(pb);
+        if (randomBoolean()) {
+            client().admin().indices().prepareCreate("test").addMapping("type", "location", "type=geo_shape")
+                .execute().actionGet();
+        } else {
+            client().admin().indices().prepareCreate("test").addMapping("type", "location", "type=geo_shape,tree=quadtree")
+                .execute().actionGet();
+        }
+        XContentBuilder docSource = gcb.toXContent(jsonBuilder().startObject().field("location"), null).endObject();
+        client().prepareIndex("test", "type", "1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
+
+        GeoShapeQueryBuilder geoShapeQueryBuilder = QueryBuilders.geoShapeQuery("location", pb);
+        geoShapeQueryBuilder.relation(ShapeRelation.INTERSECTS);
+        SearchResponse result = client().prepareSearch("test").setTypes("type").setQuery(geoShapeQueryBuilder).get();
         assertSearchResponse(result);
         assertHitCount(result, 1);
     }
@@ -371,6 +457,28 @@ public class GeoShapeQueryTests extends ESSingleNodeTestCase {
         assertSearchResponse(response);
 
         assertThat(response.getHits().getTotalHits(), greaterThan(0L));
+    }
+
+    public void testExistsQuery() throws Exception {
+        // Create a random geometry collection.
+        GeometryCollectionBuilder gcb = RandomShapeGenerator.createGeometryCollection(random());
+        logger.info("Created Random GeometryCollection containing {} shapes", gcb.numShapes());
+
+        if (randomBoolean()) {
+            client().admin().indices().prepareCreate("test").addMapping("type", "location", "type=geo_shape")
+                .execute().actionGet();
+        } else {
+            client().admin().indices().prepareCreate("test").addMapping("type", "location", "type=geo_shape,tree=quadtree")
+                .execute().actionGet();
+        }
+
+        XContentBuilder docSource = gcb.toXContent(jsonBuilder().startObject().field("location"), null).endObject();
+        client().prepareIndex("test", "type", "1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
+
+        ExistsQueryBuilder eqb = QueryBuilders.existsQuery("location");
+        SearchResponse result = client().prepareSearch("test").setTypes("type").setQuery(eqb).get();
+        assertSearchResponse(result);
+        assertHitCount(result, 1);
     }
 
     public void testShapeFilterWithDefinedGeoCollection() throws Exception {

--- a/server/src/test/java/org/elasticsearch/test/geo/RandomShapeGenerator.java
+++ b/server/src/test/java/org/elasticsearch/test/geo/RandomShapeGenerator.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.geo.builders.MultiPointBuilder;
 import org.elasticsearch.common.geo.builders.PointBuilder;
 import org.elasticsearch.common.geo.builders.PolygonBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.search.geo.GeoShapeQueryTests;
 import org.junit.Assert;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.distance.DistanceUtils;
@@ -153,6 +154,7 @@ public class RandomShapeGenerator extends RandomGeoGenerator {
     /**
      * Creates a random shape useful for randomized testing, NOTE: exercise caution when using this to build random GeometryCollections
      * as creating a large random number of random shapes can result in massive resource consumption
+     * see: {@link GeoShapeQueryTests#testQueryRandomGeoCollection()}
      *
      * The following options are included
      * @param nearPoint Create a shape near a provided point

--- a/x-pack/plugin/sql/sql-cli/build.gradle
+++ b/x-pack/plugin/sql/sql-cli/build.gradle
@@ -74,8 +74,9 @@ artifacts  {
     nodeps nodepsJar
 }
 
-
-tasks.withType(CheckForbiddenApis) {
+forbiddenApisMain {
+    //sql does not depend on server, so only jdk signatures should be checked
+    replaceSignatureFiles 'jdk-signatures'
     signaturesFiles += files('src/forbidden/cli-signatures.txt')
 }
 


### PR DESCRIPTION
This commit  exposes lucene's LatLonShape field as the default type in GeoShapeFieldMapper. To use the new indexing approach, simply set "type" : "geo_shape" in the mappings without setting any of the strategy, precision, tree_levels, or distance_error_pct parameters. Note the following when using the new indexing approach:
    
 * geo_shape query does not support querying by MULTIPOINT.
 * LINESTRING and MULTILINESTRING queries do not yet support WITHIN relation.
 * CONTAINS relation is not yet supported.
 * The tree, precision, tree_levels, distance_error_pct, and points_only parameters are deprecated.
