### PR TITLE
[Backport] Remove `indexing_complete` when removing policy

### DIFF
--- a/docs/reference/ilm/using-policies-rollover.asciidoc
+++ b/docs/reference/ilm/using-policies-rollover.asciidoc
@@ -129,18 +129,18 @@ the new index, enabling indexing to continue uninterrupted.
 
 beta[]
 
-After an index has been rolled over by {ilm}, the
-`index.lifecycle.indexing_complete` setting will be set to `true` on the index.
-This indicates to {ilm} that this index has already been rolled over, and does
-not need to be rolled over again. If you <<ilm-remove-policy,remove the policy>>
-from an index and set it to use another policy, this setting indicates that the
-new policy should skip execution of the Rollover action.
-
-You can also set this setting to `true` manually if you want to indicate that
-{ilm} should not roll over a particular index. This is useful if you need to
-make an exception to your normal Lifecycle Policy and switching the alias to a
+The `index.lifecycle.indexing_complete` setting indicates to {ilm} whether this
+index has already been rolled over. If it is set to `true`, that indicates that
+this index has already been rolled over and does not need to be rolled over
+again. Therefore, {ilm} will skip any Rollover Action configured in the
+associated lifecycle policy for this index. This is useful if you need to make
+an exception to your normal Lifecycle Policy and switching the alias to a
 different index by hand, but do not want to remove the index from {ilm}
 completely.
+
+This setting is set to `true` automatically by ILM upon the successful
+completion of a Rollover Action. However, it will be removed if
+<<ilm-remove-policy,the policy is removed>> from the index.
 
 IMPORTANT: If `index.lifecycle.indexing_complete` is set to `true` on an index,
 it will not be rolled over by {ilm}, but {ilm} will verify that this index is no

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/WaitForRolloverReadyStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/WaitForRolloverReadyStep.java
@@ -53,18 +53,30 @@ public class WaitForRolloverReadyStep extends AsyncWaitStep {
             return;
         }
 
-        if (indexMetaData.getAliases().containsKey(rolloverAlias) == false) {
-            listener.onFailure(new IllegalArgumentException(String.format(Locale.ROOT,
-                "%s [%s] does not point to index [%s]", RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, rolloverAlias,
-                indexMetaData.getIndex().getName())));
-            return;
+        // The order of the following checks is important in ways which may not be obvious.
+
+        // First, figure out if 1) The configured alias points to this index, and if so,
+        // whether this index is the write alias for this index
+        boolean aliasPointsToThisIndex = indexMetaData.getAliases().containsKey(rolloverAlias);
+
+        Boolean isWriteIndex = null;
+        if (aliasPointsToThisIndex) {
+            // The writeIndex() call returns a tri-state boolean:
+            // true  -> this index is the write index for this alias
+            // false -> this index is not the write index for this alias
+            // null  -> this alias is a "classic-style" alias and does not have a write index configured, but only points to one index
+            //          and is thus the write index by default
+            isWriteIndex = indexMetaData.getAliases().get(rolloverAlias).writeIndex();
         }
 
         boolean indexingComplete = LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE_SETTING.get(indexMetaData.getSettings());
         if (indexingComplete) {
             logger.trace(indexMetaData.getIndex() + " has lifecycle complete set, skipping " + WaitForRolloverReadyStep.NAME);
-            Boolean isWriteIndex = indexMetaData.getAliases().get(rolloverAlias).writeIndex();
-            if (Boolean.TRUE.equals(isWriteIndex)) {
+            // If this index is still the write index for this alias, skipping rollover and continuing with the policy almost certainly
+            // isn't what we want, as something likely still expects to be writing to this index.
+            // If the alias doesn't point to this index, that's okay as that will be the result if this index is using a
+            // "classic-style" alias and has already rolled over, and we want to continue with the policy.
+            if (aliasPointsToThisIndex && Boolean.TRUE.equals(isWriteIndex)) {
                 listener.onFailure(new IllegalStateException(String.format(Locale.ROOT,
                     "index [%s] has [%s] set to [true], but is still the write index for alias [%s]",
                     indexMetaData.getIndex().getName(), LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE, rolloverAlias)));
@@ -73,6 +85,20 @@ public class WaitForRolloverReadyStep extends AsyncWaitStep {
 
             listener.onResponse(true, new WaitForRolloverReadyStep.EmptyInfo());
             return;
+        }
+
+        // If indexing_complete is *not* set, and the alias does not point to this index, we can't roll over this index, so error out.
+        if (aliasPointsToThisIndex == false) {
+            listener.onFailure(new IllegalArgumentException(String.format(Locale.ROOT,
+                "%s [%s] does not point to index [%s]", RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, rolloverAlias,
+                indexMetaData.getIndex().getName())));
+            return;
+        }
+
+        // Similarly, if isWriteIndex is false (see note above on false vs. null), we can't roll over this index, so error out.
+        if (Boolean.FALSE.equals(isWriteIndex)) {
+            listener.onFailure(new IllegalArgumentException(String.format(Locale.ROOT,
+                "index [%s] is not the write index for alias [%s]", rolloverAlias, indexMetaData.getIndex().getName())));
         }
 
         RolloverRequest rolloverRequest = new RolloverRequest(rolloverAlias, null);

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunner.java
@@ -500,6 +500,7 @@ public class IndexLifecycleRunner {
         boolean notChanged = true;
 
         notChanged &= Strings.isNullOrEmpty(newSettings.remove(LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey()));
+        notChanged &= Strings.isNullOrEmpty(newSettings.remove(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE_SETTING.getKey()));
         notChanged &= Strings.isNullOrEmpty(newSettings.remove(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS_SETTING.getKey()));
         long newSettingsVersion = notChanged ? indexMetadata.getSettingsVersion() : 1 + indexMetadata.getSettingsVersion();
 


### PR DESCRIPTION
Backport to 6.6 of #36620

---

Leaving `index.lifecycle.indexing_complete` in place when removing the
lifecycle policy from an index can cause confusion, as if a new policy
is associated with the policy, rollover will be silently skipped.
Removing that setting when removing the policy from an index makes
associating a new policy with the index more involved, but allows ILM to
fail loudly, rather than silently skipping operations which the user may
assume are being performed.

* Adjust order of checks in WaitForRolloverReadyStep

This allows ILM to error out properly for indices that have a valid
alias, but are not the write index, while still handling
`indexing_complete` on old-style aliases and rollover (that is, those
which only point to a single index at a time with no explicit write
index)