### PR TITLE
SQL: Make sure now() always uses milliseconds precision

### DIFF
--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/TestUtils.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/TestUtils.java
@@ -11,6 +11,10 @@ import org.elasticsearch.xpack.sql.proto.Protocol;
 import org.elasticsearch.xpack.sql.session.Configuration;
 import org.elasticsearch.xpack.sql.util.DateUtils;
 
+import java.time.Clock;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+
 public class TestUtils {
 
     private TestUtils() {}
@@ -18,4 +22,16 @@ public class TestUtils {
     public static final Configuration TEST_CFG = new Configuration(DateUtils.UTC, Protocol.FETCH_SIZE,
             Protocol.REQUEST_TIMEOUT, Protocol.PAGE_TIMEOUT, null, Mode.PLAIN, null, null);
 
+    /**
+     * Returns the current UTC date-time with milliseconds precision.
+     * In Java 9+ (as opposed to Java 8) the {@code Clock} implementation uses system's best clock implementation (which could mean
+     * that the precision of the clock can be milliseconds, microseconds or nanoseconds), whereas in Java 8
+     * {@code System.currentTimeMillis()} is always used. To account for these differences, this method defines a new {@code Clock}
+     * which will offer a value for {@code ZonedDateTime.now()} set to always have milliseconds precision.
+     * 
+     * @return {@link ZonedDateTime} instance for the current date-time with milliseconds precision in UTC
+     */
+    public static final ZonedDateTime now() {
+        return ZonedDateTime.now(Clock.tick(Clock.system(DateUtils.UTC), Duration.ofMillis(1)));
+    }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/type/DataTypeConversionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/type/DataTypeConversionTests.java
@@ -7,12 +7,10 @@ package org.elasticsearch.xpack.sql.type;
 
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.expression.Literal;
 import org.elasticsearch.xpack.sql.type.DataTypeConversion.Conversion;
-import org.elasticsearch.xpack.sql.util.DateUtils;
 
-import java.time.Clock;
-import java.time.Duration;
 import java.time.ZonedDateTime;
 
 import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeTestUtils.dateTime;
@@ -112,7 +110,7 @@ public class DataTypeConversionTests extends ESTestCase {
         assertEquals(dateTime(18000000L), conversion.convert("1970-01-01T00:00:00-05:00"));
         
         // double check back and forth conversion
-        ZonedDateTime dt = ZonedDateTime.now(Clock.tick(Clock.system(DateUtils.UTC), Duration.ofMillis(1)));
+        ZonedDateTime dt = TestUtils.now();
         Conversion forward = conversionFor(DATE, KEYWORD);
         Conversion back = conversionFor(KEYWORD, DATE);
         assertEquals(dt, back.convert(forward.convert(dt)));

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/type/DataTypeConversionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/type/DataTypeConversionTests.java
@@ -11,6 +11,8 @@ import org.elasticsearch.xpack.sql.expression.Literal;
 import org.elasticsearch.xpack.sql.type.DataTypeConversion.Conversion;
 import org.elasticsearch.xpack.sql.util.DateUtils;
 
+import java.time.Clock;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 
 import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeTestUtils.dateTime;
@@ -79,7 +81,6 @@ public class DataTypeConversionTests extends ESTestCase {
         assertEquals("cannot cast [0xff] to [Long]", e.getMessage());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/35683")
     public void testConversionToDate() {
         DataType to = DATE;
         {
@@ -111,7 +112,7 @@ public class DataTypeConversionTests extends ESTestCase {
         assertEquals(dateTime(18000000L), conversion.convert("1970-01-01T00:00:00-05:00"));
         
         // double check back and forth conversion
-        ZonedDateTime dt = ZonedDateTime.now(DateUtils.UTC);
+        ZonedDateTime dt = ZonedDateTime.now(Clock.tick(Clock.system(DateUtils.UTC), Duration.ofMillis(1)));
         Conversion forward = conversionFor(DATE, KEYWORD);
         Conversion back = conversionFor(KEYWORD, DATE);
         assertEquals(dt, back.convert(forward.convert(dt)));


### PR DESCRIPTION
This is fix for a CI failure reproducible for Java 9+ versions.
What is specific to these versions (as opposed to Java 8) is that the Clock implementation uses [system's best clock implementation](https://bugs.openjdk.java.net/browse/JDK-8068730), whereas in Java 8 `System.currentTimeMillis()` is always used. To account for these differences, this solution defines a new Clock which will offer a value for `now()` set to always have milliseconds precision.

Fixes https://github.com/elastic/elasticsearch/issues/35683.