### PR TITLE
Docs: add clarification about geohash use in geohashgrid agg

### DIFF
--- a/docs/reference/aggregations/bucket/geohashgrid-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/geohashgrid-aggregation.asciidoc
@@ -182,7 +182,7 @@ POST /museums/_search?size=0
 --------------------------------------------------
 // TESTRESPONSE[s/\.\.\./"took": $body.took,"_shards": $body._shards,"hits":$body.hits,"timed_out":false,/]
 
-For "zooming in" in the system that don't support geohashes, the bucket keys should be translated into bounding boxes using
+For "zooming in" on the system that don't support geohashes, the bucket keys should be translated into bounding boxes using
 one of available geohash libraries. For example, for javascript the https://github.com/sunng87/node-geohash[node-geohash] library
 can be used:
 

--- a/docs/reference/aggregations/bucket/geohashgrid-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/geohashgrid-aggregation.asciidoc
@@ -121,6 +121,82 @@ POST /museums/_search?size=0
 // CONSOLE
 // TEST[continued]
 
+The geohashes returned by the `geohash_grid` aggregation can be also used for zooming in. To zoom into the
+first geohash `u17` returned in the previous example, it should be specified as both `top_left` and `bottom_right` corner:
+
+[source,js]
+--------------------------------------------------
+POST /museums/_search?size=0
+{
+    "aggregations" : {
+        "zoomed-in" : {
+            "filter" : {
+                "geo_bounding_box" : {
+                    "location" : {
+                        "top_left" : "u17",
+                        "bottom_right" : "u17"
+                    }
+                }
+            },
+            "aggregations":{
+                "zoom1":{
+                    "geohash_grid" : {
+                        "field": "location",
+                        "precision": 8
+                    }
+                }
+            }
+        }
+    }
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+[source,js]
+--------------------------------------------------
+{
+    ...
+    "aggregations" : {
+        "zoomed-in" : {
+            "doc_count" : 3,
+            "zoom1" : {
+                "buckets" : [
+                    {
+                        "key" : "u173zy3j",
+                        "doc_count" : 1
+                    },
+                    {
+                        "key" : "u173zvfz",
+                        "doc_count" : 1
+                    },
+                    {
+                        "key" : "u173zt90",
+                        "doc_count" : 1
+                    }
+                ]
+            }
+        }
+    }
+}
+--------------------------------------------------
+// TESTRESPONSE[s/\.\.\./"took": $body.took,"_shards": $body._shards,"hits":$body.hits,"timed_out":false,/]
+
+For "zooming in" in the system that don't support geohashes, the bucket keys should be translated into bounding boxes using
+one of available geohash libraries. For example, for javascript the https://github.com/sunng87/node-geohash[node-geohash] library
+can be used:
+
+[source,js]
+--------------------------------------------------
+var geohash = require('ngeohash');
+
+// bbox will contain [ 52.03125, 4.21875, 53.4375, 5.625 ]
+//                   [   minlat,  minlon,  maxlat, maxlon]
+var bbox = geohash.decode_bbox('u17');
+--------------------------------------------------
+// NOTCONSOLE
+
+
 ==== Cell dimensions at the equator
 The table below shows the metric dimensions for cells covered by various string lengths of geohash.
 Cell dimensions vary with latitude and so the table is for the worst-case scenario at the equator.


### PR DESCRIPTION
Adds example on translating geohashes returned by geohashgrid agg
as bucket keys into geo bounding box filters in elasticsearch as well
as 3rd party applications.

Closes #36413 
