### PR TITLE
Add JDK 12 to CI rotation

### DIFF
--- a/.ci/matrix-build-javas.yml
+++ b/.ci/matrix-build-javas.yml
@@ -7,3 +7,4 @@
 
 ES_BUILD_JAVA:
   - java11
+  - openjdk12

--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -9,5 +9,6 @@ ES_RUNTIME_JAVA:
   - java8
   - java8fips
   - java11
+  - openjdk12
   - zulu8
   - zulu11


### PR DESCRIPTION
Now that JDK 12 has entered rampdown phase one, it is time for us to add JDK 12 to the CI rotation. This commit adds matrix parameters such that we try to build with JDK 12, and we test running on JDK 12.
