### PR TITLE
Add collapse.max_score_threshold parameter

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -305,6 +305,7 @@ public class Lucene {
             float maxScore = in.readFloat();
 
             String field = in.readString();
+            Float maxScoreThreshold = in.readFloat();
             SortField[] fields = new SortField[in.readVInt()];
             for (int i = 0; i < fields.length; i++) {
                fields[i] = readSortField(in);
@@ -316,7 +317,8 @@ public class Lucene {
                 fieldDocs[i] = readFieldDoc(in);
                 collapseValues[i] = readSortValue(in);
             }
-            return new CollapseTopFieldDocs(field, totalHits, fieldDocs, fields, collapseValues, maxScore);
+            return new CollapseTopFieldDocs(
+                field, maxScoreThreshold, totalHits, fieldDocs, fields, collapseValues, maxScore);
         } else {
             throw new IllegalStateException("Unknown type " + type);
         }
@@ -395,6 +397,7 @@ public class Lucene {
             out.writeFloat(topDocs.getMaxScore());
 
             out.writeString(collapseDocs.field);
+            out.writeFloat(collapseDocs.maxScoreThreshold);
 
             out.writeVInt(collapseDocs.fields.length);
             for (SortField sortField : collapseDocs.fields) {

--- a/server/src/main/java/org/elasticsearch/search/collapse/CollapseContext.java
+++ b/server/src/main/java/org/elasticsearch/search/collapse/CollapseContext.java
@@ -32,13 +32,16 @@ import java.util.List;
  */
 public class CollapseContext {
     private final String fieldName;
+    private final Float maxScoreThreshold;
     private final MappedFieldType fieldType;
     private final List<InnerHitBuilder> innerHits;
 
     public CollapseContext(String fieldName,
+                           Float maxScoreThreshold,
                            MappedFieldType fieldType,
                            List<InnerHitBuilder> innerHits) {
         this.fieldName = fieldName;
+        this.maxScoreThreshold = maxScoreThreshold;
         this.fieldType = fieldType;
         this.innerHits = innerHits;
     }
@@ -48,6 +51,13 @@ public class CollapseContext {
      */
     public String getFieldName() {
         return fieldName;
+    }
+
+    /**
+     * The maximum score allowable for a collapsed group, after which the entire collapsed group will be discard.
+     */
+    public Float getMaxScoreThreshold() {
+        return maxScoreThreshold;
     }
 
     /** The field type used for collapsing **/
@@ -62,9 +72,11 @@ public class CollapseContext {
 
     public CollapsingTopDocsCollector<?> createTopDocs(Sort sort, int topN, boolean trackMaxScore) {
         if (fieldType instanceof KeywordFieldMapper.KeywordFieldType) {
-            return CollapsingTopDocsCollector.createKeyword(fieldType.name(), sort, topN, trackMaxScore);
+            return CollapsingTopDocsCollector.createKeyword(
+                fieldType.name(), maxScoreThreshold, sort, topN, trackMaxScore);
         } else if (fieldType instanceof NumberFieldMapper.NumberFieldType) {
-            return CollapsingTopDocsCollector.createNumeric(fieldType.name(), sort, topN, trackMaxScore);
+            return CollapsingTopDocsCollector.createNumeric(
+                fieldType.name(), maxScoreThreshold, sort, topN, trackMaxScore);
         } else {
             throw new IllegalStateException("unknown type for collapse field " + fieldType.name() +
                 ", only keywords and numbers are accepted");


### PR DESCRIPTION
## Background

In certain cases, filtering may need to be applied to the top-scoring collapsed hit after or during the `CollapsingTopDocsCollector` phase, thus filtering out all other documents in the same collapsed hits group. Because even the `search_post_filter` (`FilteredCollector`) operates on a per-document basis before `CollapsingTopDocsCollector`, the `CollapsingTopDocsCollector` phase must provide functionality to discard groups not matching certain criteria.

In this simple PR, a maximum score threshold is provided. If any document within a collapsed group exceeds this maximum score threshold, the entire collapsed group is discarded.

An alternate strategy would be to provide a filter within the `collapse` directive, with which the entire collapsed group would be discarded if _any_ matching document within the collapsed group was matched by the filter.

This PR is provided for early discussion, thus the lack of unit test coverage.

## Example usage

```
{
  ...
  "collapse" : {
    "field": "accountId",
    "max_score_threshold": 500
  }
}
```

## Remaining work

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
