### PR TITLE
Fix typo in unitTest task

### DIFF
--- a/x-pack/plugin/security/cli/build.gradle
+++ b/x-pack/plugin/security/cli/build.gradle
@@ -23,7 +23,7 @@ dependencyLicenses {
 }
 
 if (project.inFipsJvm) {
-    tesunitTestt.enabled = false
+    unitTest.enabled = false
     // Forbiden APIs non-portable checks fail because bouncy castle classes being used from the FIPS JDK since those are
     // not part of the Java specification - all of this is as designed, so we have to relax this check for FIPS.
     tasks.withType(CheckForbiddenApis) {

--- a/x-pack/plugin/security/cli/build.gradle
+++ b/x-pack/plugin/security/cli/build.gradle
@@ -29,7 +29,7 @@ if (project.inFipsJvm) {
     tasks.withType(CheckForbiddenApis) {
         bundledSignatures -= "jdk-non-portable"
     }
-    // FIPS JVM includes manny classes from bouncycastle which count as jar hell for the third party audit,
+    // FIPS JVM includes many classes from bouncycastle which count as jar hell for the third party audit,
     // rather than provide a long list of exclusions, disable the check on FIPS.
     thirdPartyAudit.enabled = false
 }


### PR DESCRIPTION
Fix the typo introduced in #36311 causing CI failures with the
FipsJvm.
