### PR TITLE
Provide an upgrade path from pre 6.2 to oss

### DIFF
--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -24,6 +24,8 @@ import java.nio.file.Path
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
+import org.redline_rpm.header.Flags
+
 /*****************************************************************************
  *                         Deb and rpm configuration                         *
  *****************************************************************************
@@ -56,7 +58,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.netflix.nebula:gradle-ospackage-plugin:4.7.1'
+    classpath 'com.netflix.nebula:gradle-ospackage-plugin:5.2.0'
   }
 }
 
@@ -235,7 +237,21 @@ Closure commonPackageConfig(String type, boolean oss) {
     copyEmptyDir('/usr/share/elasticsearch/plugins', 'root', 'root', 0755)
 
     // the oss package conflicts with the default distribution and vice versa
-    conflicts('elasticsearch' + (oss ? '' : '-oss'))
+    if (oss) {
+      // elasticsearch 6.2 has a single package called 'elaticsearch' that has  an OSS licence.
+      // starting with 6.3 this was renamed to `elasticsearch-oss` and a new package that has the same name as the OSS
+      // used to have (`elasticsearch`) was introduced.
+      // The configuration bellow prevents both elasticsearch and elasticsearch-oss to be installed after 6.3 and
+      // provides an upgrade path from before 6.3 elasticsearch to elasticsearch-oss
+      conflicts 'elasticsearch', '6.3', Flags.GREATER | Flags.EQUAL
+    } else {
+      conflicts "elasticsearch-oss"
+    }
+    if (type == "rpm") {
+      obsoletes 'elasticsearch', '6.3', Flags.LESS
+    } else {
+      replaces 'elasticsearch', '6.3', Flags.LESS
+    }
   }
 }
 
@@ -305,16 +321,8 @@ task buildOssDeb(type: Deb) {
   configure(commonDebConfig(true))
 }
 
-Closure commonRpmConfig(boolean oss) {
+Closure commonRpmConfig() {
   return {
-    configure(commonPackageConfig('rpm', oss))
-
-    if (oss) {
-      license 'ASL 2.0'
-    } else {
-      license 'Elastic License'
-    }
-
     packageGroup 'Application/Internet'
     requires '/bin/bash'
 
@@ -334,11 +342,15 @@ Closure commonRpmConfig(boolean oss) {
 }
 
 task buildRpm(type: Rpm) {
-  configure(commonRpmConfig(false))
+  configure(commonPackageConfig('rpm', false))
+  configure(commonRpmConfig())
+  license 'Elastic License'
 }
 
 task buildOssRpm(type: Rpm) {
-  configure(commonRpmConfig(true))
+  configure(commonPackageConfig('rpm', true))
+  configure(commonRpmConfig())
+  license 'ASL 2.0'
 }
 
 Closure dpkgExists = { it -> new File('/bin/dpkg-deb').exists() || new File('/usr/bin/dpkg-deb').exists() || new File('/usr/local/bin/dpkg-deb').exists() }

--- a/distribution/packages/src/common/scripts/postinst
+++ b/distribution/packages/src/common/scripts/postinst
@@ -101,4 +101,17 @@ if [ "$PACKAGE" = "deb" -a ! -f /etc/elasticsearch/elasticsearch.keystore ]; the
     md5sum /etc/elasticsearch/elasticsearch.keystore > /etc/elasticsearch/.elasticsearch.keystore.initial_md5sum
 fi
 
+# Special case for upgrading from pre 6.3 RPM to oss. RPM doesn't flag that as an upgrade
+if [ "$PACKAGE" = "rpm" ] ; then
+   # Save user, gropup and dirs to prevent "postrm" of old package from being disruptive.
+   mkdir /var/lib/rpm-state/elasticsearch/
+   id -u elasticsearch > /var/lib/rpm-state/elasticsearch/elasticsearch.user
+   id -g elasticsearch > /var/lib/rpm-state/elasticsearch/elasticsearch.group
+
+   mv /var/log/elasticsearch /var/log/elasticsearch.rpmsave
+   mv /usr/share/elasticsearch/plugins /usr/share/elasticsearch/plugins.rpmsave
+   mv /var/run/elasticsearch /var/run/elasticsearch.rpmsave
+   mv /var/lib/elasticsearch /var/lib/elasticsearch.rpmsave
+fi
+
 ${scripts.footer}

--- a/distribution/packages/src/common/scripts/posttrans
+++ b/distribution/packages/src/common/scripts/posttrans
@@ -1,8 +1,35 @@
+if [ -f /var/lib/rpm-state/elasticsearch/elasticsearch.user ] ; then
+    # move everything back to place from after postinst
+    groupadd -g `cat /var/lib/rpm-state/elasticsearch/elasticsearch.group` elasticsearch
+    useradd -M -u `cat /var/lib/rpm-state/elasticsearch/elasticsearch.user` elasticsearch -g elasticsearch
+
+    mv /var/log/elasticsearch.rpmsave /var/log/elasticsearch
+    mv /usr/share/elasticsearch/plugins.rpmsave /usr/share/elasticsearch/plugins
+    mv /var/run/elasticsearch.rpmsave /var/run/elasticsearch
+    mv /var/lib/elasticsearch.rpmsave /var/lib/elasticsearch
+fi
+
 if [ ! -f /etc/elasticsearch/elasticsearch.keystore ]; then
     /usr/share/elasticsearch/bin/elasticsearch-keystore create
     chown root:elasticsearch /etc/elasticsearch/elasticsearch.keystore
     chmod 660 /etc/elasticsearch/elasticsearch.keystore
     md5sum /etc/elasticsearch/elasticsearch.keystore > /etc/elasticsearch/.elasticsearch.keystore.initial_md5sum
+fi
+
+if [ -f /var/lib/rpm-state/elasticsearch/elasticsearch.user ] ; then
+    rm -Rf /var/lib/rpm-state/elasticsearch
+    # pre-rm disables the service, undo
+        if command -v systemctl >/dev/null; then
+            systemctl daemon-reload
+            systemctl enable elasticsearch.service || true
+            systemctl start elasticsearch.service || true
+        elif [ -x /etc/init.d/elasticsearch ]; then
+            chkconfig --add elasticsearch
+            /etc/init.d/elasticsearch start || true
+        elif [ -x /etc/rc.d/init.d/elasticsearch ] ; then
+            chkconfig --add elasticsearch
+            /etc/rc.d/init.d/elasticsearch start || true
+    fi
 fi
 
 ${scripts.footer}

--- a/qa/vagrant/src/test/resources/packaging/tests/81_upgrade_oss.bats
+++ b/qa/vagrant/src/test/resources/packaging/tests/81_upgrade_oss.bats
@@ -47,24 +47,28 @@ setup() {
     if [ "$(cat upgrade_from_version)" == "$(cat version)" ]; then
         sameVersion="true"
     fi
-    export PACKAGE_NAME="elasticsearch"
 }
 
-@test "[UPGRADE] install old version" {
-    clean_before_test
+@test "[UPGRADE OSS] install old version" {
     PACKAGE_NAME="elasticsearch-oss" clean_before_test
+    PACKAGE_NAME="elasticsearch" clean_before_test
+    if ! is_upgrade_from_pre_6.3 ; then
+        export PACKAGE_NAME="elasticsearch-oss"
+    else
+        export PACKAGE_NAME="elasticsearch"
+    fi
     install_package -v $(cat upgrade_from_version)
 }
 
-@test "[UPGRADE] start old version" {
+@test "[UPGRADE OSS] start old version" {
     start_elasticsearch_service
 }
 
-@test "[UPGRADE] check elasticsearch version is old version" {
+@test "[UPGRADE OSS] check elasticsearch version is old version" {
     check_elasticsearch_version "$(cat upgrade_from_version)"
 }
 
-@test "[UPGRADE] index some documents into a few indexes" {
+@test "[UPGRADE OSS] index some documents into a few indexes" {
     curl -s -H "Content-Type: application/json" -XPOST localhost:9200/library/book/1?pretty -d '{
       "title": "Elasticsearch - The Definitive Guide"
     }'
@@ -76,17 +80,18 @@ setup() {
     }'
 }
 
-@test "[UPGRADE] verify that the documents are there" {
+@test "[UPGRADE OSS] verify that the documents are there" {
     curl -s localhost:9200/library/book/1?pretty | grep Elasticsearch
     curl -s localhost:9200/library/book/2?pretty | grep World
     curl -s localhost:9200/library2/book/1?pretty | grep Darkness
 }
 
-@test "[UPGRADE] stop old version" {
+@test "[UPGRADE OSS] stop old version" {
     stop_elasticsearch_service
 }
 
-@test "[UPGRADE] install version under test" {
+@test "[UPGRADE OSS] install version under test" {
+    export PACKAGE_NAME="elasticsearch-oss"
     if [ "$sameVersion" == "true" ]; then
         install_package -f
     else
@@ -94,21 +99,21 @@ setup() {
     fi
 }
 
-@test "[UPGRADE] start version under test" {
+@test "[UPGRADE OSS] start version under test" {
     start_elasticsearch_service yellow library
     wait_for_elasticsearch_status yellow library2
 }
 
-@test "[UPGRADE] check elasticsearch version is version under test" {
+@test "[UPGRADE OSS] check elasticsearch version is version under test" {
     check_elasticsearch_version "$(cat version)"
 }
 
-@test "[UPGRADE] verify that the documents are there after restart" {
+@test "[UPGRADE OSS] verify that the documents are there after restart" {
     curl -s localhost:9200/library/book/1?pretty | grep Elasticsearch
     curl -s localhost:9200/library/book/2?pretty | grep World
     curl -s localhost:9200/library2/book/1?pretty | grep Darkness
 }
 
-@test "[UPGRADE] stop version under test" {
+@test "[UPGRADE OSS] stop version under test" {
     stop_elasticsearch_service
 }

--- a/qa/vagrant/src/test/resources/packaging/utils/packages.bash
+++ b/qa/vagrant/src/test/resources/packaging/utils/packages.bash
@@ -76,6 +76,7 @@ install_package() {
     if is_rpm; then
         rpm $rpmCommand $PACKAGE_NAME-$version.rpm
     elif is_dpkg; then
+        echo run dpkg $dpkgCommand -i $PACKAGE_NAME-$version.deb
         run dpkg $dpkgCommand -i $PACKAGE_NAME-$version.deb
         [[ "$status" -eq 0 ]] || {
             echo "dpkg failed:"

--- a/qa/vagrant/src/test/resources/packaging/utils/utils.bash
+++ b/qa/vagrant/src/test/resources/packaging/utils/utils.bash
@@ -213,7 +213,7 @@ assert_module_or_plugin_directory() {
     local directory=$1
     shift
 
-    #owner group and permissions vary depending on how es was installed
+    #owner group and permissions vary depending on how es was instaled
     #just make sure that everything is the same as $CONFIG_DIR, which was properly set up during install
     config_user=$(find "$ESHOME" -maxdepth 0 -printf "%u")
     config_owner=$(find "$ESHOME" -maxdepth 0 -printf "%g")
@@ -603,4 +603,13 @@ unmove_java() {
     which_java=`command -v java.bak`
     assert_file_exist $which_java
     mv $which_java `dirname $which_java`/java
+}
+
+
+is_upgrade_from_pre_6.3() {
+    if [[ -f upgrade_is_oss ]]; then
+        return 0
+    else
+       return 1
+    fi
 }


### PR DESCRIPTION
It's not currently possible to upgrade from pre 6.3 `elasticsearch` package to `elaticsearch-oss` as the two are marked to unconditionally conflict. 
This PR adds this missing upgrade path by leveraging the possibility to express version conditioned relationships in both deb and rpm:

- `elasticsearch` and `elasticsearch-oss` only conflicts in versions including and after `6.3` 
- `elasticsearch-oss` and `elasticsearch` both are marked to replace `elaticsearch <6.3`

These two relations make the upgrade from `elasticsearch < 6.3` to both the oss and default distribution without allowing switching from one to the other ` >= 6.3`.

**Unfortunately it doesn't quite work.**

When going from `elasticsearch < 6.3` to `elasticsearch-oss` the scripts are ran by rpm in this order: `%pre (new) %post (new) %preun (old) %postun (old) %posttrans (new)`. 
On other upgrades `%prerun` and `%postun` detect that's an upgrade and don't  do anything, but rpm doesn't flag this as an upgrade and the directories, users and groups are blown away and the services stopped. The only way to fix this is to restore what can be restored in `%posttrans`, or  save some state between the scripts to detect that it's really an upgrade, but that would require fixing in a patch and we would support upgrades only from that patch. 

I think that given this additional information we should reconsider if we want to pursue this further. The PR can't be merged as it is, it just for exemplification purposes and discussion. 


```
centos-7:~$ sudo rpm -i https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.0.rpm
centos-7:~$ rpm -i  /elasticsearch/distribution/packages/oss-rpm/build/distributions/elasticsearch-oss-7.0.0-SNAPSHOT.rpm
error: Failed dependencies:
	elasticsearch < 6.3 is obsoleted by elasticsearch-oss-0:7.0.0_SNAPSHOT-1.noarch
centos-7:~$ rpm -i  /elasticsearch/distribution/packages/oss-rpm/build/distributions/elasticsearch-oss-7.0.0-SNAPSHOT.rpm
error: Failed dependencies:
	elasticsearch < 6.3 is obsoleted by elasticsearch-oss-0:7.0.0_SNAPSHOT-1.noarch
centos-7:~$ sudo rpm -U  /elasticsearch/distribution/packages/oss-rpm/build/distributions/elasticsearch-oss-7.0.0-SNAPSHOT.rpm
 sudo systemctl daemon-reload
 sudo systemctl enable elasticsearch.service
 sudo systemctl start elasticsearch.service
centos-7:~$ sudo rpm -i  /elasticsearch/distribution/packages/rpm/build/distributions/elasticsearch-7.0.0-SNAPSHOT.rpm
error: Failed dependencies:
	elasticsearch-oss conflicts with elasticsearch-0:7.0.0_SNAPSHOT-1.noarch
	elasticsearch >= 6.3 conflicts with (installed) elasticsearch-oss-0:7.0.0_SNAPSHOT-1.noarch
centos-7:~$ sudo rpm -U  /elasticsearch/distribution/packages/rpm/build/distributions/elasticsearch-7.0.0-SNAPSHOT.rpm
error: Failed dependencies:
	elasticsearch-oss conflicts with elasticsearch-0:7.0.0_SNAPSHOT-1.noarch
	elasticsearch >= 6.3 conflicts with (installed) elasticsearch-oss-0:7.0.0_SNAPSHOT-1.noarch
```

```
ubuntu-1804:~$ wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.0.deb
ubuntu-1804:~$ sudo dpkg -i elasticsearch-5.6.0.deb
Selecting previously unselected package elasticsearch.
(Reading database ... 141015 files and directories currently installed.)
Preparing to unpack elasticsearch-5.6.0.deb ...
Creating elasticsearch group... OK
Creating elasticsearch user... OK
Unpacking elasticsearch (5.6.0) ...
Replaced by files in installed package elasticsearch-oss (7.0.0~SNAPSHOT) ...
Setting up elasticsearch (5.6.0) ...
Processing triggers for ureadahead (0.100.0-20) ...
Processing triggers for systemd (237-3ubuntu10.3) ...

ubuntu-1804:~$ sudo  dpkg -i /elasticsearch/distribution/packages/oss-deb/build/distributions/elasticsearch-oss-7.0.0-SNAPSHOT.deb
(Reading database ... 141082 files and directories currently installed.)
Preparing to unpack .../elasticsearch-oss-7.0.0-SNAPSHOT.deb ...
/usr/bin/java
Removing old lib folder
Unpacking elasticsearch-oss (7.0.0~SNAPSHOT) over (7.0.0~SNAPSHOT) ...
Setting up elasticsearch-oss (7.0.0~SNAPSHOT) ...
Created elasticsearch keystore in /etc/elasticsearch
Processing triggers for ureadahead (0.100.0-20) ...
Processing triggers for systemd (237-3ubuntu10.3) ...
```

As far as testing is concerned, before this change we tested upgrade with `bats` for versions starting with `6.3` only for `elasticsearch-oss` and skip them otherwise. 
With this change we cover the full range for both distribution types, including going from pre `6.3` to any of the current distributions.






Relates to #36142
