### PR TITLE
Add placeholder ingest-geoip plugin page

### DIFF
--- a/docs/plugins/ingest-geoip.asciidoc
+++ b/docs/plugins/ingest-geoip.asciidoc
@@ -1,11 +1,11 @@
-[[ingest-geoip-plugin]]
+[[ingest-geoip]]
 === Ingest `geoip` Processor Plugin
 
 The `geoip` processor is no longer distributed as a plugin, but is now a module
-distributed by default with Elasticsearch. See <<ingest-geoip>> for more
-details.
+distributed by default with Elasticsearch. See
+{ref}/ingest-geoip.html[Ingest `geoip` processor] for more details.
 
 [[using-ingest-geoip]]
 ==== Using the `geoip` Processor in a Pipeline
 
-See <<ingest-geoip>>.
+See {ref}/using-ingest-geoip.html[using `ingest-geoip`].

--- a/docs/plugins/ingest-geoip.asciidoc
+++ b/docs/plugins/ingest-geoip.asciidoc
@@ -1,0 +1,6 @@
+[[ingest-geoip-plugin]]
+=== Ingest `geoip` Processor Plugin
+
+The `geoip` processor is no longer distributed as a plugin, but is not a module
+distributed by default with Elasticsearch. See <<ingest-geoip>> for more
+details.

--- a/docs/plugins/ingest-geoip.asciidoc
+++ b/docs/plugins/ingest-geoip.asciidoc
@@ -4,3 +4,8 @@
 The `geoip` processor is no longer distributed as a plugin, but is now a module
 distributed by default with Elasticsearch. See <<ingest-geoip>> for more
 details.
+
+[[using-ingest-geoip]]
+==== Using the `geoip` Processor in a Pipeline
+
+See <<ingest-geoip>>

--- a/docs/plugins/ingest-geoip.asciidoc
+++ b/docs/plugins/ingest-geoip.asciidoc
@@ -8,4 +8,4 @@ details.
 [[using-ingest-geoip]]
 ==== Using the `geoip` Processor in a Pipeline
 
-See <<ingest-geoip>>
+See <<ingest-geoip>>.

--- a/docs/plugins/ingest-geoip.asciidoc
+++ b/docs/plugins/ingest-geoip.asciidoc
@@ -1,6 +1,6 @@
 [[ingest-geoip-plugin]]
 === Ingest `geoip` Processor Plugin
 
-The `geoip` processor is no longer distributed as a plugin, but is not a module
+The `geoip` processor is no longer distributed as a plugin, but is now a module
 distributed by default with Elasticsearch. See <<ingest-geoip>> for more
 details.

--- a/docs/plugins/ingest.asciidoc
+++ b/docs/plugins/ingest.asciidoc
@@ -13,6 +13,15 @@ The core ingest plugins are:
 The ingest attachment plugin lets Elasticsearch extract file attachments in common formats (such as PPT, XLS, and PDF) by
 using the Apache text extraction library http://lucene.apache.org/tika/[Tika].
 
+<<ingest-geoip>>::
+
+The `geoip` processor adds information about the geographical location of IP
+addresses, based on data from the Maxmind databases. This processor adds this
+information by default under the `geoip` field. The `geoip` processor is no
+longer distributed as a plugin, but is now a module distributed by default with
+Elasticsearch. See {ref}/ingest-geoip.html[Ingest `geoip` processor] for more
+details.
+
 <<ingest-user-agent>>::
 
 A processor that extracts details from the User-Agent header value.

--- a/docs/plugins/ingest.asciidoc
+++ b/docs/plugins/ingest.asciidoc
@@ -26,4 +26,6 @@ The following plugin has been contributed by our community:
 
 include::ingest-attachment.asciidoc[]
 
+include::ingest-geoip.asciidoc[]
+
 include::ingest-user-agent.asciidoc[]

--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -16,7 +16,7 @@ uncompressed. The `ingest-geoip` config directory is located at `$ES_HOME/config
 ==== Using the `geoip` Processor in a Pipeline
 
 [[ingest-geoip-options]]
-.`geoip` options
+.geoip options
 [options="header"]
 |======
 | Name                   | Required  | Default                                                                            | Description

--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -1,16 +1,16 @@
 [[ingest-geoip]]
-=== Ingest Geoip Processor
+=== Ingest `geoip` Processor
 
-The GeoIP processor adds information about the geographical location of IP addresses, based on data from the Maxmind databases.
+The `geoip` processor adds information about the geographical location of IP addresses, based on data from the Maxmind databases.
 This processor adds this information by default under the `geoip` field. The `geoip` processor can resolve both IPv4 and
 IPv6 addresses.
 
-The ingest-geoip module ships by default with the GeoLite2 City, GeoLite2 Country and GeoLite2 ASN geoip2 databases from Maxmind made available
+The `ingest-geoip` module ships by default with the GeoLite2 City, GeoLite2 Country and GeoLite2 ASN geoip2 databases from Maxmind made available
 under the CCA-ShareAlike 4.0 license. For more details see, http://dev.maxmind.com/geoip/geoip2/geolite2/
 
-The GeoIP processor can run with other geoip2 databases from Maxmind. The files must be copied into the geoip config directory,
+The GeoIP processor can run with other GeoIP2 databases from Maxmind. The files must be copied into the `ingest-geoip` config directory,
 and the `database_file` option should be used to specify the filename of the custom database. Custom database files must be stored
-uncompressed. The geoip config directory is located at `$ES_HOME/config/ingest-geoip` and holds the shipped databases too.
+uncompressed. The `ingest-geoip` config directory is located at `$ES_HOME/config/ingest-geoip`.
 
 [[using-ingest-geoip]]
 ==== Using the Geoip Processor in a Pipeline
@@ -301,10 +301,10 @@ GET /my_ip_locations/_search
 [[ingest-geoip-settings]]
 ===== Node Settings
 
-The geoip processor supports the following setting:
+The `geoip` processor supports the following setting:
 
 `ingest.geoip.cache_size`::
 
     The maximum number of results that should be cached. Defaults to `1000`.
 
-Note that these settings are node settings and apply to all geoip processors, i.e. there is one cache for all defined geoip processors.
+Note that these settings are node settings and apply to all `geoip` processors, i.e. there is one cache for all defined `geoip` processors.

--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -16,7 +16,7 @@ uncompressed. The `ingest-geoip` config directory is located at `$ES_HOME/config
 ==== Using the `geoip` Processor in a Pipeline
 
 [[ingest-geoip-options]]
-.geoip options
+.`geoip` options
 [options="header"]
 |======
 | Name                   | Required  | Default                                                                            | Description

--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -13,10 +13,10 @@ and the `database_file` option should be used to specify the filename of the cus
 uncompressed. The `ingest-geoip` config directory is located at `$ES_HOME/config/ingest-geoip`.
 
 [[using-ingest-geoip]]
-==== Using the Geoip Processor in a Pipeline
+==== Using the `geoip` Processor in a Pipeline
 
 [[ingest-geoip-options]]
-.Geoip options
+.`geoip` options
 [options="header"]
 |======
 | Name                   | Required  | Default                                                                            | Description

--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -8,7 +8,7 @@ IPv6 addresses.
 The `ingest-geoip` module ships by default with the GeoLite2 City, GeoLite2 Country and GeoLite2 ASN geoip2 databases from Maxmind made available
 under the CCA-ShareAlike 4.0 license. For more details see, http://dev.maxmind.com/geoip/geoip2/geolite2/
 
-The GeoIP processor can run with other GeoIP2 databases from Maxmind. The files must be copied into the `ingest-geoip` config directory,
+The `geoip` processor can run with other GeoIP2 databases from Maxmind. The files must be copied into the `ingest-geoip` config directory,
 and the `database_file` option should be used to specify the filename of the custom database. Custom database files must be stored
 uncompressed. The `ingest-geoip` config directory is located at `$ES_HOME/config/ingest-geoip`.
 


### PR DESCRIPTION
This commit adds a placeholder ingest-geoip plugin page as there are other components in the Elastic Stack that still refer to these pages. These docs would be broken without this placeholder page forcing teams responsible for those docs to scramble to fix the build over the weekend before a holiday period. Instead, we add a placeholder page so the docs build continues to function, and those teams can fix their docs without the constraint of a broken build. We also cleanup a few minor docs issues that were missed during the initial changes to convert ingest-geoip to a module.

Relates #36898 
Relates #36949