### PR TITLE
[Docs] Fix badly escaped keywords in migrate_7_0/search.asciidoc

### DIFF
--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -204,4 +204,4 @@ will be removed in the next major version (8.0).
 If `track_total_hits` is set to `false` in the search request the search response
 will set `hits.total` to null and the object will not be displayed in the rest
 layer. You can add `rest_total_hits_as_int=true` in the search request parameters
-to get the old format back (`"total": 1`).
+to get the old format back (`"total": -1`).

--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -174,9 +174,10 @@ major version.
 ==== `hits.total` is now an object in the search response
 
 The total hits that match the search request is now returned as an object
-with a `value` and a `relation`. `value indicates the number of hits that
-match and `relation indicates whether the value is accurate (`eq`) or a lower bound
+with a `value` and a `relation`. `value` indicates the number of hits that
+match and `relation` indicates whether the value is accurate (`eq`) or a lower bound
 (`gte`):
+
 ```
 {
     "hits": {
@@ -200,7 +201,7 @@ will be removed in the next major version (8.0).
 [float]
 ==== `hits.total` is omitted in the response if `track_total_hits` is disabled (false)
 
-If `track_total_hits` is set to `false in the search request the search response
+If `track_total_hits` is set to `false` in the search request the search response
 will set `hits.total` to null and the object will not be displayed in the rest
 layer. You can add `rest_total_hits_as_int=true` in the search request parameters
-to get the old format back (`"total": -1`).
+to get the old format back (`"total": 1`).


### PR DESCRIPTION
The code sample and detailed explanation are not rendered correctly here https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html#_literal_hits_total_literal_is_now_an_object_in_the_search_response :

![image](https://user-images.githubusercontent.com/225704/50382831-53b2a600-06a8-11e9-8798-86c500159004.png)

This PR adds the missing char, and also change the last example from "total: -1" to "total: 1" because it makes no sense to have "-1" results.