### PR TITLE
Add migration note for ingest plugins

### DIFF
--- a/docs/reference/migration/index.asciidoc
+++ b/docs/reference/migration/index.asciidoc
@@ -35,3 +35,5 @@ include::migrate_6_4.asciidoc[]
 include::migrate_6_5.asciidoc[]
 
 include::migrate_6_6.asciidoc[]
+
+include::migrate_6_7.asciidoc[]

--- a/docs/reference/migration/migrate_6_7.asciidoc
+++ b/docs/reference/migration/migrate_6_7.asciidoc
@@ -1,0 +1,30 @@
+[[breaking-changes-6.7]]
+== Breaking changes in 6.7
+++++
+<titleabbrev>6.7</titleabbrev>
+++++
+
+This section discusses the changes that you need to be aware of when migrating
+your application to Elasticsearch 6.7.
+
+* <<breaking_67_plugin_changes>>
+
+See also <<release-highlights>> and <<es-release-notes>>.
+
+[float]
+[[breaking_67_plugin_changes]]
+=== Plugin changes
+
+[float]
+==== `ingest-geoip` and `ingest-user-agent` are no longer distributed as plugins
+
+The `ingest-geoip` and `ingest-user-agent` plugins have been converted to
+modules and are now included with all Elasticsearch distributions. Starting with
+Elasticsearch 6.7.0, attempting to install or remove these plugins will result
+in a no-op. In Elasticsearch 7.0.0, attempting to install or remove these plugins
+will result in an error. Additionally, there are two minor breaking changes here:
+- `elasticsearch-plugin list` will no longer output `ingest-geoip` nor
+  `ingest-user-agent`
+- `plugin.mandatory` is no longer compatible with `ingest-geoip` nor
+  `ingest-user-agent`
+


### PR DESCRIPTION
We migrated ingest-geoip and ingest-user-agent from plugins to modules. This commit adds a note to the docs regarding this change.

Relates #36898 
Relates #36956 