### PR TITLE
Remove special handling for ingest plugins

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -222,12 +222,6 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
             throw new UserException(ExitCodes.USAGE, "plugin id is required");
         }
 
-        if ("ingest-geoip".equals(pluginId) || "ingest-user-agent".equals(pluginId)) {
-            throw new UserException(
-                    ExitCodes.OK,
-                    "[" + pluginId + "] is no longer a plugin but instead a module packaged with this distribution of Elasticsearch");
-        }
-
         if ("x-pack".equals(pluginId)) {
             handleInstallXPack(buildFlavor());
         }

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
@@ -111,17 +111,6 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
          */
         if ((!Files.exists(pluginDir) && !Files.exists(pluginConfigDir) && !Files.exists(removing))
                 || (!Files.exists(pluginDir) && Files.exists(pluginConfigDir) && !purge)) {
-
-            /*
-             * This is special case handling for ingest-geoip and ingest-user-agent since they are modules now but could have been installed
-             * from a previous version when they were plugins.
-             */
-            if ("ingest-geoip".equals(pluginName) || "ingest-user-agent".equals(pluginName)) {
-                throw new UserException(
-                        ExitCodes.OK,
-                        "[" + pluginName + "] is no longer a plugin but instead a module packaged with this distribution of Elasticsearch");
-            }
-
             final String message = String.format(
                     Locale.ROOT, "plugin [%s] not found; run 'elasticsearch-plugin list' to get list of installed plugins", pluginName);
             throw new UserException(ExitCodes.CONFIG, message);

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
@@ -757,27 +757,6 @@ public class InstallPluginCommandTests extends ESTestCase {
         }
     }
 
-    public void testInstallIngestGeoIp() throws IOException {
-        runInstallIngestGeoIpOrIngestUserAgentTest("ingest-geoip");
-    }
-
-    public void testInstallIngestUserAgent() throws IOException {
-        runInstallIngestGeoIpOrIngestUserAgentTest("ingest-user-agent");
-    }
-
-    private void runInstallIngestGeoIpOrIngestUserAgentTest(final String pluginId) throws IOException {
-        assert "ingest-geoip".equals(pluginId) || "ingest-user-agent".equals(pluginId) : pluginId;
-        final Environment environment = createEnv(fs, temp).v2();
-        final UserException exception =
-                expectThrows(UserException.class, () -> new InstallPluginCommand().execute(terminal, pluginId, false, environment));
-        assertThat(exception.exitCode, equalTo(ExitCodes.OK));
-        assertThat(
-                exception,
-                hasToString(containsString(
-                        "[" + pluginId + "] is no longer a plugin but instead a module packaged with this distribution of Elasticsearch")));
-
-    }
-
     public void testInstallXPack() throws IOException {
         runInstallXPackTest(Build.Flavor.DEFAULT, UserException.class, "this distribution of Elasticsearch contains X-Pack by default");
         runInstallXPackTest(

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/RemovePluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/RemovePluginCommandTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 
 import java.io.BufferedReader;

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/RemovePluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/RemovePluginCommandTests.java
@@ -252,57 +252,6 @@ public class RemovePluginCommandTests extends ESTestCase {
         assertEquals("plugin name is required", e.getMessage());
     }
 
-    /**
-     * The ingest-geoip plugin receives special handling because we have re-packaged it as a module; this test ensures that we are still
-     * able to uninstall an old installation of ingest-geoip.
-     *
-     * @throws Exception if an exception is thrown creating or removing the plugin
-     */
-    public void testRemoveIngestGeoIp() throws Exception {
-        runTestRemoveIngestGeoIpOrIngestUserAgent("ingest-geoip");
-    }
-
-    /**
-     * The ingest-user-agent plugin receives special handling because we have re-packaged it as a module; this test ensures that we are
-     * still able to uninstall an old installation of ingest-user-agent.
-     *
-     * @throws Exception if an exception is thrown creating or removing the plugin
-     */
-    public void testRemoveIngestUserAgent() throws Exception {
-        runTestRemoveIngestGeoIpOrIngestUserAgent("ingest-user-agent");
-    }
-
-    private void runTestRemoveIngestGeoIpOrIngestUserAgent(final String name) throws Exception {
-        assert "ingest-geoip".equals(name) || "ingest-user-agent".equals(name) : name;
-        createPlugin(
-                name,
-                VersionUtils.randomVersionBetween(
-                        random(),
-                        Version.CURRENT.minimumIndexCompatibilityVersion(),
-                        Version.V_6_6_0));
-        removePlugin(name, home, randomBoolean());
-        assertThat(Files.exists(env.pluginsFile().resolve(name)), equalTo(false));
-        assertRemoveCleaned(env);
-    }
-
-    public void testRemoveIngestGeoIpWhenNotInstalled() {
-        runTestRemoveIngestGeoIpOrIngestUserAgentWhenNotInstalled("ingest-geoip");
-    }
-
-    public void testRemoveIngestUserAgentWhenNotInstalled() {
-        runTestRemoveIngestGeoIpOrIngestUserAgentWhenNotInstalled("ingest-user-agent");
-    }
-
-    private void runTestRemoveIngestGeoIpOrIngestUserAgentWhenNotInstalled(final String name) {
-        assert "ingest-geoip".equals(name) || "ingest-user-agent".equals(name) : name;
-        final UserException e = expectThrows(UserException.class, () -> removePlugin(name, home, randomBoolean()));
-        assertThat(e.exitCode, equalTo(ExitCodes.OK));
-        assertThat(
-                e,
-                hasToString(Matchers.containsString(
-                        "[" + name + "] is no longer a plugin but instead a module packaged with this distribution of Elasticsearch")));
-    }
-
     public void testRemoveWhenRemovingMarker() throws Exception {
         createPlugin("fake");
         Files.createFile(env.pluginsFile().resolve("fake").resolve("plugin.jar"));


### PR DESCRIPTION
We added some special handling for installing and removing the ingest-geoip and ingest-user-agent plugins when we converted them to modules. This special handling was done to minimize breaking users in a minor release. However, do not want to maintain this behavior forever so this commit removes that special handling in the master branch so that starting with 7.0.0 this special handling will be gone.

Relates #36898 
Relates #36956 