### PR TITLE
Publish cluster states in chunks

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ElectionSchedulerFactory.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ElectionSchedulerFactory.java
@@ -52,6 +52,7 @@ public class ElectionSchedulerFactory {
     private static final String ELECTION_BACK_OFF_TIME_SETTING_KEY = "cluster.election.back_off_time";
     private static final String ELECTION_MAX_TIMEOUT_SETTING_KEY = "cluster.election.max_timeout";
     private static final String ELECTION_DURATION_SETTING_KEY = "cluster.election.duration";
+    private static final String ELECTION_GRACE_PERIOD_SETTING_KEY = "cluster.election.grace_period";
 
     /*
      * The first election is scheduled to occur a random number of milliseconds after the scheduler is started, where the random number of
@@ -78,6 +79,12 @@ public class ElectionSchedulerFactory {
 
     public static final Setting<TimeValue> ELECTION_DURATION_SETTING = Setting.timeSetting(ELECTION_DURATION_SETTING_KEY,
         TimeValue.timeValueMillis(500), TimeValue.timeValueMillis(1), TimeValue.timeValueSeconds(300), Property.NodeScope);
+
+    /**
+     * Setting that determines how long to wait after receiving a chunk of a cluster state before scheduling another election.
+     */
+    public static final Setting<TimeValue> ELECTION_GRACE_PERIOD_SETTING = Setting.timeSetting(ELECTION_GRACE_PERIOD_SETTING_KEY,
+        TimeValue.timeValueMillis(1000), TimeValue.timeValueMillis(1), TimeValue.timeValueSeconds(300), Property.NodeScope);
 
     private final TimeValue initialTimeout;
     private final TimeValue backoffTime;

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -41,6 +41,7 @@ import org.elasticsearch.cluster.coordination.FollowersChecker;
 import org.elasticsearch.cluster.coordination.JoinHelper;
 import org.elasticsearch.cluster.coordination.LagDetector;
 import org.elasticsearch.cluster.coordination.LeaderChecker;
+import org.elasticsearch.cluster.coordination.PublicationTransportHandler;
 import org.elasticsearch.cluster.coordination.Reconfigurator;
 import org.elasticsearch.cluster.metadata.IndexGraveyard;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -474,6 +475,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     ElectionSchedulerFactory.ELECTION_BACK_OFF_TIME_SETTING,
                     ElectionSchedulerFactory.ELECTION_MAX_TIMEOUT_SETTING,
                     ElectionSchedulerFactory.ELECTION_DURATION_SETTING,
+                    ElectionSchedulerFactory.ELECTION_GRACE_PERIOD_SETTING,
+                    PublicationTransportHandler.PUBLISH_CHUNK_SIZE_SETTING,
                     Coordinator.PUBLISH_TIMEOUT_SETTING,
                     JoinHelper.JOIN_TIMEOUT_SETTING,
                     FollowersChecker.FOLLOWER_CHECK_TIMEOUT_SETTING,

--- a/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
@@ -113,7 +113,7 @@ public class PublishClusterStateAction {
         this.namedWriteableRegistry = namedWriteableRegistry;
         this.incomingClusterStateListener = incomingClusterStateListener;
         this.discoverySettings = discoverySettings;
-        transportService.registerRequestHandler(SEND_ACTION_NAME, BytesTransportRequest::new, ThreadPool.Names.SAME, false, false,
+        transportService.registerRequestHandler(SEND_ACTION_NAME, ThreadPool.Names.SAME, false, false, BytesTransportRequest::new,
             new SendClusterStateRequestHandler());
         transportService.registerRequestHandler(COMMIT_ACTION_NAME, CommitClusterStateRequest::new, ThreadPool.Names.SAME, false, false,
             new CommitClusterStateRequestHandler());

--- a/server/src/main/java/org/elasticsearch/transport/BytesTransportRequest.java
+++ b/server/src/main/java/org/elasticsearch/transport/BytesTransportRequest.java
@@ -32,16 +32,19 @@ import java.io.IOException;
  */
 public class BytesTransportRequest extends TransportRequest {
 
-    BytesReference bytes;
-    Version version;
-
-    public BytesTransportRequest() {
-
-    }
+    final BytesReference bytes;
+    final Version version;
 
     public BytesTransportRequest(BytesReference bytes, Version version) {
         this.bytes = bytes;
         this.version = version;
+    }
+
+    public BytesTransportRequest(StreamInput in) throws IOException {
+        super(in);
+        readBeforeBytes(in);
+        bytes = in.readBytesReference();
+        version = in.getVersion();
     }
 
     public Version version() {
@@ -53,24 +56,30 @@ public class BytesTransportRequest extends TransportRequest {
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        bytes = in.readBytesReference();
-        version = in.getVersion();
+    public final void readFrom(StreamInput in) throws IOException {
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
+    }
+
+    protected void readBeforeBytes(StreamInput in) throws IOException {
+    }
+
+    protected void writeBeforeBytes(StreamOutput out) throws IOException {
     }
 
     /**
      * Writes the data in a "thin" manner, without the actual bytes, assumes
      * the actual bytes will be appended right after this content.
      */
-    public void writeThin(StreamOutput out) throws IOException {
+    public final void writeThin(StreamOutput out) throws IOException {
         super.writeTo(out);
+        writeBeforeBytes(out);
         out.writeVInt(bytes.length());
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
+    public final void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+        writeBeforeBytes(out);
         out.writeBytesReference(bytes);
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/bootstrap/TransportGetDiscoveredNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/bootstrap/TransportGetDiscoveredNodesActionTests.java
@@ -33,11 +33,13 @@ import org.elasticsearch.cluster.coordination.InMemoryPersistedState;
 import org.elasticsearch.cluster.coordination.NoOpClusterApplier;
 import org.elasticsearch.cluster.coordination.PeersResponse;
 import org.elasticsearch.cluster.coordination.PublicationTransportHandler;
+import org.elasticsearch.cluster.coordination.PublicationTransportHandler.PublishStateChunkRequest;
 import org.elasticsearch.cluster.coordination.PublishWithJoinResponse;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.MasterService;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -50,7 +52,6 @@ import org.elasticsearch.test.transport.MockTransport;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPool.Names;
-import org.elasticsearch.transport.BytesTransportRequest;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportResponseHandler;
@@ -311,9 +312,9 @@ public class TransportGetDiscoveredNodesActionTests extends ESTestCase {
             .lastCommittedConfiguration(new VotingConfiguration(singleton(otherNode.getId())))
             .build()));
 
-        transportService.sendRequest(localNode, PublicationTransportHandler.PUBLISH_STATE_ACTION_NAME,
-            new BytesTransportRequest(PublicationTransportHandler.serializeFullClusterState(publishedClusterState.build(), Version.CURRENT),
-                Version.CURRENT),
+        transportService.sendRequest(localNode, PublicationTransportHandler.PUBLISH_STATE_LAST_CHUNK_ACTION_NAME,
+            new PublishStateChunkRequest(UUIDs.randomBase64UUID(random()), 0, 1,
+                PublicationTransportHandler.serializeFullClusterState(publishedClusterState.build(), Version.CURRENT), Version.CURRENT),
             new TransportResponseHandler<PublishWithJoinResponse>() {
                 @Override
                 public void handleResponse(PublishWithJoinResponse response) {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1465,6 +1465,7 @@ public class CoordinatorTests extends ESTestCase {
                 };
 
                 final Settings settings = Settings.builder()
+                    .put(PublicationTransportHandler.PUBLISH_CHUNK_SIZE_SETTING.getKey(), randomIntBetween(1, 1000) + "b")
                     .putList(ClusterBootstrapService.INITIAL_MASTER_NODES_SETTING.getKey(),
                         ClusterBootstrapService.INITIAL_MASTER_NODES_SETTING.get(Settings.EMPTY)).build(); // suppress auto-bootstrap
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -52,8 +52,8 @@ public class PublicationTransportHandlerTests extends ESTestCase {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             x -> localNode,
             clusterSettings, Collections.emptySet());
-        final PublicationTransportHandler handler = new PublicationTransportHandler(transportService,
-            writableRegistry(), pu -> null, (pu, l) -> {});
+        final PublicationTransportHandler handler = new PublicationTransportHandler(Settings.EMPTY, transportService,
+            writableRegistry(), pu -> null, (pu, l) -> {}, random(), () -> {});
         transportService.start();
         transportService.acceptIncomingRequests();
 

--- a/server/src/test/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
@@ -157,10 +157,13 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
         TransportService localTransportService =
                 internalCluster().getInstance(TransportService.class, discoveryNodes.getLocalNode().getName());
         if (randomBoolean()) {
-            masterTransportService.addFailToSendNoConnectRule(localTransportService, PublishClusterStateAction.SEND_ACTION_NAME,
-                PublicationTransportHandler.PUBLISH_STATE_ACTION_NAME);
+            masterTransportService.addFailToSendNoConnectRule(localTransportService,
+                PublishClusterStateAction.SEND_ACTION_NAME,
+                PublicationTransportHandler.PUBLISH_STATE_CHUNK_ACTION_NAME,
+                PublicationTransportHandler.PUBLISH_STATE_LAST_CHUNK_ACTION_NAME);
         } else {
-            masterTransportService.addFailToSendNoConnectRule(localTransportService, PublishClusterStateAction.COMMIT_ACTION_NAME,
+            masterTransportService.addFailToSendNoConnectRule(localTransportService,
+                PublishClusterStateAction.COMMIT_ACTION_NAME,
                 PublicationTransportHandler.COMMIT_STATE_ACTION_NAME);
         }
 


### PR DESCRIPTION
In order to ensure that master elections occur reasonably reliably we require
that only one node is trying to perform an election at once. However, the full
election process requires a publication of a cluster state, which may be
arbitrarily large, and the larger it is the longer an election takes and
therefore the more likely it is that an election clash occurs.

This change breaks the cluster state publication process up into chunks of
bounded size, and suppresses further elections for a short period on receipt of
each chunk.