### PR TITLE
Move InternalTestClusterTests to zen2

### DIFF
--- a/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -61,8 +61,8 @@ import static org.elasticsearch.cluster.coordination.ClusterBootstrapService.INI
 import static org.elasticsearch.cluster.node.DiscoveryNode.Role.DATA;
 import static org.elasticsearch.cluster.node.DiscoveryNode.Role.INGEST;
 import static org.elasticsearch.cluster.node.DiscoveryNode.Role.MASTER;
+import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_HOSTS_PROVIDER_SETTING;
 import static org.elasticsearch.discovery.zen.ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING;
-import static org.elasticsearch.test.discovery.TestZenDiscovery.USE_ZEN2;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFileExists;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFileNotExists;
 import static org.hamcrest.Matchers.equalTo;
@@ -272,7 +272,7 @@ public class InternalTestClusterTests extends ESTestCase {
                         NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(),
                         2 + (masterNodes ? InternalTestCluster.DEFAULT_HIGH_NUM_MASTER_NODES : 0) + maxNumDataNodes + numClientNodes)
                     .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
-                    .put(USE_ZEN2.getKey(), false) // full cluster restarts not yet supported
+                    .putList(DISCOVERY_HOSTS_PROVIDER_SETTING.getKey(), "file")
                     .build();
             }
 
@@ -384,7 +384,7 @@ public class InternalTestClusterTests extends ESTestCase {
                         // speedup join timeout as setting initial state timeout to 0 makes split
                         // elections more likely
                         .put(ZenDiscovery.JOIN_TIMEOUT_SETTING.getKey(), "3s")
-                        .put(USE_ZEN2.getKey(), false) // full cluster restarts not yet supported
+                        .putList(DISCOVERY_HOSTS_PROVIDER_SETTING.getKey(), "file")
                         .build();
             }
 
@@ -408,10 +408,12 @@ public class InternalTestClusterTests extends ESTestCase {
             roles.add(role);
         }
 
+        final long masterCount = roles.stream().filter(role -> role == MASTER).count();
         final Settings minMasterNodes = Settings.builder()
-            .put(DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.getKey(),
-                roles.stream().filter(role -> role == MASTER).count() / 2 + 1
-            ).build();
+            .put(DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.getKey(), masterCount / 2 + 1)
+            .put(INITIAL_MASTER_NODE_COUNT_SETTING.getKey(), masterCount)
+            .build();
+
         try {
             Map<DiscoveryNode.Role, Set<String>> pathsPerRole = new HashMap<>();
             for (int i = 0; i < numNodes; i++) {
@@ -467,7 +469,7 @@ public class InternalTestClusterTests extends ESTestCase {
                 return Settings.builder()
                     .put(NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(), 2)
                     .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
-                    .put(USE_ZEN2.getKey(), false) // full cluster restarts not yet supported
+                    .putList(DISCOVERY_HOSTS_PROVIDER_SETTING.getKey(), "file")
                     .build();
             }
 

--- a/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -273,6 +273,7 @@ public class InternalTestClusterTests extends ESTestCase {
                         2 + (masterNodes ? InternalTestCluster.DEFAULT_HIGH_NUM_MASTER_NODES : 0) + maxNumDataNodes + numClientNodes)
                     .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
                     .putList(DISCOVERY_HOSTS_PROVIDER_SETTING.getKey(), "file")
+                    .putList(SettingsBasedHostsProvider.DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING.getKey())
                     .build();
             }
 
@@ -385,6 +386,7 @@ public class InternalTestClusterTests extends ESTestCase {
                         // elections more likely
                         .put(ZenDiscovery.JOIN_TIMEOUT_SETTING.getKey(), "3s")
                         .putList(DISCOVERY_HOSTS_PROVIDER_SETTING.getKey(), "file")
+                        .putList(SettingsBasedHostsProvider.DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING.getKey())
                         .build();
             }
 
@@ -470,6 +472,7 @@ public class InternalTestClusterTests extends ESTestCase {
                     .put(NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(), 2)
                     .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
                     .putList(DISCOVERY_HOSTS_PROVIDER_SETTING.getKey(), "file")
+                    .putList(SettingsBasedHostsProvider.DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING.getKey())
                     .build();
             }
 


### PR DESCRIPTION
Today `InternalTestClusterTests` is still using zen1.
This commit fixes it.
Two types of changes were required:
1. Explicitly pass file discovery host provider setting. It's done in `ESIntegTestCase` as a part of the Zen2 feature and should be done here as well.
2. For the test, that uses `autoManageMinMasterNodes = false` perform cluster bootstrap. Currently, I'm using `INITIAL_MASTER_NODE_COUNT_SETTING` setting that will be replaced with `INITIAL_MASTER_NODES_SETTING` once https://github.com/elastic/elasticsearch/pull/36897 is merged.