### PR TITLE
Update RequestConverters.java

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -1099,9 +1099,9 @@ final class RequestConverters {
                 //encode each part (e.g. index, type and id) separately before merging them into the path
                 //we prepend "/" to the path part to make this path absolute, otherwise there can be issues with
                 //paths that start with `-` or contain `:`
-                URI uri = new URI(null, null, null, -1, "/" + pathPart, null, null);
+                URI uri = new URI(null, null, null, -1, pathPart, null, null);
                 //manually encode any slash that each part may contain
-                return uri.getRawPath().substring(1).replaceAll("/", "%2F");
+                return "/" + uri.getRawPath().replaceAll("/", "%2F");
             } catch (URISyntaxException e) {
                 throw new IllegalArgumentException("Path part [" + pathPart + "] couldn't be encoded", e);
             }


### PR DESCRIPTION
fix exception when  _id is like this /a/b/c

code:
    UpdateRequest updateRequest = new UpdateRequest("dev_product","product", "/sku/test.com/48923AQ3");
    // ignore
    restHighLevelClient.update(updateRequest, RequestOptions.DEFAULT);
exception:
[dev_product/6rBlaK6USlaQ5frl4HGmWg][[dev_product][0]] ElasticsearchStatusException[Elasticsearch exception [type=document_missing_exception, reason=[product][test.com/48923AQ3]: document missing]

URI [/dev_product/product/test.com%2F48923AQ3/_update?timeout=1m], status line [HTTP/1.1 404 Not Found]



the exception is convert this id /sku/test.com/48923AQ3  to  test.com%2F48923AQ3

