### PR TITLE
SQL: use the same format when comparing the error messages containing date fields

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcTestUtils.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcTestUtils.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.qa.jdbc;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.xpack.sql.action.CliFormatter;
 import org.elasticsearch.xpack.sql.proto.ColumnInfo;
+import org.elasticsearch.xpack.sql.proto.StringUtils;
 
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -134,7 +135,7 @@ public abstract class JdbcTestUtils {
         logger.info("\n" + formatter.formatWithHeader(cols, data));
     }
     
-    public static ZonedDateTime of(long millis) {
-        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), UTC);
+    public static String of(long millis) {
+        return StringUtils.toString(ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), UTC));
     }
 }


### PR DESCRIPTION
This is a fix for a rare-ish test bug #36932 reproduceable when the milliseconds of the date used in tests is `000`. This specific test showed that the format we used in the tests wasn't the correct one, or better said the one that ES SQL is using to send a [date formatted value over the wire](https://github.com/elastic/elasticsearch/pull/36800/files#diff-9c40df2a2c88784815d6ee4af403433bR175). And this test bug was introduced with PR #36800.

The normal `toString()` method of a `ZonedDateTime` will display a date in the "shortest" ISO-8601 format which, in the case of a `000` milliseconds scenario, means that the milliseconds are not printed at all. Thus the rare-ish test failures. This PR makes sure the same approach is used for formatting a `ZonedDateTime` when is pretty printed.