### PR TITLE
Add ability to suggest shard_size on coord node rewrite

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.ParsedQuery;
+import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.indices.IndexClosedException;
@@ -108,8 +109,8 @@ public class TransportValidateQueryAction extends TransportBroadcastAction<
         if (request.query() == null) {
             rewriteListener.onResponse(request.query());
         } else {
-            Rewriteable.rewriteAndFetch(request.query(), searchService.getRewriteContext(timeProvider),
-                rewriteListener);
+            QueryRewriteContext rewriteContext = searchService.getRewriteContext(timeProvider, false);
+            Rewriteable.rewriteAndFetch(request.query(), rewriteContext, rewriteListener);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchService;
@@ -214,8 +215,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         if (searchRequest.source() == null) {
             rewriteListener.onResponse(searchRequest.source());
         } else {
-            Rewriteable.rewriteAndFetch(searchRequest.source(), searchService.getRewriteContext(timeProvider::getAbsoluteStartMillis),
-                rewriteListener);
+            QueryRewriteContext rewriteContext = searchService.getRewriteContext(timeProvider::getAbsoluteStartMillis, false);
+            Rewriteable.rewriteAndFetch(searchRequest.source(), rewriteContext, rewriteListener);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
@@ -36,18 +36,18 @@ import java.util.function.LongSupplier;
 public class QueryRewriteContext {
     private final NamedXContentRegistry xContentRegistry;
     private final NamedWriteableRegistry writeableRegistry;
+    private final boolean multipleClusters;
     protected final Client client;
     protected final LongSupplier nowInMillis;
     private final List<BiConsumer<Client, ActionListener<?>>> asyncActions = new ArrayList<>();
 
-    public QueryRewriteContext(
-            NamedXContentRegistry xContentRegistry, NamedWriteableRegistry writeableRegistry,Client client,
-            LongSupplier nowInMillis) {
-
+    public QueryRewriteContext(NamedXContentRegistry xContentRegistry, NamedWriteableRegistry writeableRegistry,
+                               Client client, LongSupplier nowInMillis, boolean multipleClusters) {
         this.xContentRegistry = xContentRegistry;
         this.writeableRegistry = writeableRegistry;
         this.client = client;
         this.nowInMillis = nowInMillis;
+        this.multipleClusters = multipleClusters;
     }
 
     /**
@@ -66,6 +66,14 @@ public class QueryRewriteContext {
 
     public NamedWriteableRegistry getWriteableRegistry() {
         return writeableRegistry;
+    }
+
+    /**
+     * Returns whether the request being rewritten is part of a cross-cluster search request where each cluster performs
+     * its own local reduction, and the targeted clusters are more than one.
+     */
+    public boolean isMultipleClusters() {
+        return multipleClusters;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -110,7 +110,7 @@ public class QueryShardContext extends QueryRewriteContext {
                              SimilarityService similarityService, ScriptService scriptService, NamedXContentRegistry xContentRegistry,
                              NamedWriteableRegistry namedWriteableRegistry, Client client, IndexReader reader, LongSupplier nowInMillis,
                              String clusterAlias) {
-        super(xContentRegistry, namedWriteableRegistry,client, nowInMillis);
+        super(xContentRegistry, namedWriteableRegistry,client, nowInMillis, false);
         this.shardId = shardId;
         this.similarityService = similarityService;
         this.mapperService = mapperService;

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -1357,8 +1357,8 @@ public class IndicesService extends AbstractLifecycleComponent
     /**
      * Returns a new {@link QueryRewriteContext} with the given {@code now} provider
      */
-    public QueryRewriteContext getRewriteContext(LongSupplier nowInMillis) {
-        return new QueryRewriteContext(xContentRegistry, namedWriteableRegistry, client, nowInMillis);
+    public QueryRewriteContext getRewriteContext(LongSupplier nowInMillis, boolean multipleClusters) {
+        return new QueryRewriteContext(xContentRegistry, namedWriteableRegistry, client, nowInMillis, multipleClusters);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1097,14 +1097,14 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         // we also do rewrite on the coordinating node (TransportSearchService) but we also need to do it here for BWC as well as
         // AliasFilters that might need to be rewritten. These are edge-cases but we are every efficient doing the rewrite here so it's not
         // adding a lot of overhead
-        Rewriteable.rewriteAndFetch(request.getRewriteable(), indicesService.getRewriteContext(request::nowInMillis), actionListener);
+        Rewriteable.rewriteAndFetch(request.getRewriteable(), getRewriteContext(request::nowInMillis, false), actionListener);
     }
 
     /**
      * Returns a new {@link QueryRewriteContext} with the given {@code now} provider
      */
-    public QueryRewriteContext getRewriteContext(LongSupplier nowInMillis) {
-        return indicesService.getRewriteContext(nowInMillis);
+    public QueryRewriteContext getRewriteContext(LongSupplier nowInMillis, boolean multipleClusters) {
+        return indicesService.getRewriteContext(nowInMillis, multipleClusters);
     }
 
     public IndicesService getIndicesService() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -125,7 +125,7 @@ public abstract class AggregationBuilder
      * identity reference must be returned otherwise the builder will be
      * rewritten infinitely.
      */
-    protected AggregationBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
+    protected AggregationBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregationBuilder.java
@@ -84,8 +84,8 @@ public class FilterAggregationBuilder extends AbstractAggregationBuilder<FilterA
     }
 
     @Override
-    protected AggregationBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
-        QueryBuilder result = Rewriteable.rewrite(filter, queryShardContext);
+    protected AggregationBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
+        QueryBuilder result = Rewriteable.rewrite(filter, queryRewriteContext);
         if (result != filter) {
             return new FilterAggregationBuilder(getName(), result);
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregationBuilder.java
@@ -198,11 +198,11 @@ public class FiltersAggregationBuilder extends AbstractAggregationBuilder<Filter
     }
 
     @Override
-    protected AggregationBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
+    protected AggregationBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
         List<KeyedFilter> rewrittenFilters = new ArrayList<>(filters.size());
         boolean changed = false;
         for (KeyedFilter kf : filters) {
-            QueryBuilder result = Rewriteable.rewrite(kf.filter(), queryShardContext);
+            QueryBuilder result = Rewriteable.rewrite(kf.filter(), queryRewriteContext);
             rewrittenFilters.add(new KeyedFilter(kf.key(), result));
             if (result != kf.filter()) {
                 changed = true;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregator.java
@@ -54,7 +54,7 @@ import java.util.Set;
 
 public abstract class TermsAggregator extends DeferableBucketAggregator {
 
-    public static class BucketCountThresholds implements Writeable, ToXContentFragment {
+    public static final class BucketCountThresholds implements Writeable, ToXContentFragment {
         private long minDocCount;
         private long shardMinDocCount;
         private int requiredSize;
@@ -90,7 +90,7 @@ public abstract class TermsAggregator extends DeferableBucketAggregator {
                     bucketCountThresholds.shardSize);
         }
 
-        public void ensureValidity() {
+        void ensureValidity() {
 
             // shard_size cannot be smaller than size as we need to at least fetch <size> entries from every shards in order to return
             // <size>

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
@@ -74,7 +74,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testIsFieldWithinQueryEmptyReader() throws IOException {
-        QueryRewriteContext context = new QueryRewriteContext(xContentRegistry(), writableRegistry(), null, () -> nowInMillis);
+        QueryRewriteContext context = new QueryRewriteContext(xContentRegistry(), writableRegistry(), null, () -> nowInMillis, false);
         IndexReader reader = new MultiReader();
         DateFieldType ft = new DateFieldType();
         ft.setName("my_date");
@@ -84,7 +84,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
 
     private void doTestIsFieldWithinQuery(DateFieldType ft, DirectoryReader reader,
             DateTimeZone zone, DateMathParser alternateFormat) throws IOException {
-        QueryRewriteContext context = new QueryRewriteContext(xContentRegistry(), writableRegistry(), null, () -> nowInMillis);
+        QueryRewriteContext context = new QueryRewriteContext(xContentRegistry(), writableRegistry(), null, () -> nowInMillis, false);
         assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(reader, "2015-10-09", "2016-01-02",
                 randomBoolean(), randomBoolean(), null, null, context));
         assertEquals(Relation.INTERSECTS, ft.isFieldWithinQuery(reader, "2016-01-02", "2016-06-20",
@@ -131,7 +131,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         DateFieldType ft2 = new DateFieldType();
         ft2.setName("my_date2");
 
-        QueryRewriteContext context = new QueryRewriteContext(xContentRegistry(), writableRegistry(), null, () -> nowInMillis);
+        QueryRewriteContext context = new QueryRewriteContext(xContentRegistry(), writableRegistry(), null, () -> nowInMillis, false);
         assertEquals(Relation.DISJOINT, ft2.isFieldWithinQuery(reader, "2015-10-09", "2016-01-02", false, false, null, null, context));
         IOUtils.close(reader, w, dir);
     }

--- a/server/src/test/java/org/elasticsearch/index/query/RewriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RewriteableTests.java
@@ -32,7 +32,7 @@ import java.util.function.Supplier;
 public class RewriteableTests extends ESTestCase {
 
     public void testRewrite() throws IOException {
-        QueryRewriteContext context = new QueryRewriteContext(null, null, null, null);
+        QueryRewriteContext context = new QueryRewriteContext(null, null, null, null, false);
         TestRewriteable rewrite = Rewriteable.rewrite(new TestRewriteable(randomIntBetween(0, Rewriteable.MAX_REWRITE_ROUNDS)), context,
             randomBoolean());
         assertEquals(rewrite.numRewrites, 0);
@@ -47,7 +47,7 @@ public class RewriteableTests extends ESTestCase {
     }
 
     public void testRewriteAndFetch() throws ExecutionException, InterruptedException {
-        QueryRewriteContext context = new QueryRewriteContext(null, null, null, null);
+        QueryRewriteContext context = new QueryRewriteContext(null, null, null, null, false);
         PlainActionFuture<TestRewriteable> future = new PlainActionFuture<>();
         Rewriteable.rewriteAndFetch(new TestRewriteable(randomIntBetween(0, Rewriteable.MAX_REWRITE_ROUNDS), true), context, future);
         TestRewriteable rewrite = future.get();
@@ -65,7 +65,7 @@ public class RewriteableTests extends ESTestCase {
     }
 
     public void testRewriteList() throws IOException {
-        QueryRewriteContext context = new QueryRewriteContext(null, null, null, null);
+        QueryRewriteContext context = new QueryRewriteContext(null, null, null, null, false);
         List<TestRewriteable> rewriteableList = new ArrayList<>();
         int numInstances = randomIntBetween(1, 10);
         rewriteableList.add(new TestRewriteable(randomIntBetween(1, Rewriteable.MAX_REWRITE_ROUNDS)));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
@@ -210,7 +210,7 @@ public class AggregatorFactoriesTests extends ESTestCase {
         AggregatorFactories.Builder builder = new AggregatorFactories.Builder().addAggregator(filterAggBuilder)
                 .addPipelineAggregator(pipelineAgg);
         AggregatorFactories.Builder rewritten = builder
-                .rewrite(new QueryRewriteContext(xContentRegistry, null, null, () -> 0L));
+                .rewrite(new QueryRewriteContext(xContentRegistry, null, null, () -> 0L, false));
         assertNotSame(builder, rewritten);
         Collection<AggregationBuilder> aggregatorFactories = rewritten.getAggregatorFactories();
         assertEquals(1, aggregatorFactories.size());
@@ -224,7 +224,7 @@ public class AggregatorFactoriesTests extends ESTestCase {
 
         // Check that a further rewrite returns the same aggregation factories builder
         AggregatorFactories.Builder secondRewritten = rewritten
-                .rewrite(new QueryRewriteContext(xContentRegistry, null, null, () -> 0L));
+                .rewrite(new QueryRewriteContext(xContentRegistry, null, null, () -> 0L, false));
         assertSame(rewritten, secondRewritten);
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/FiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/FiltersTests.java
@@ -131,12 +131,12 @@ public class FiltersTests extends BaseAggregationTestCase<FiltersAggregationBuil
         // test non-keyed filter that doesn't rewrite
         AggregationBuilder original = new FiltersAggregationBuilder("my-agg", new MatchAllQueryBuilder());
         original.setMetaData(Collections.singletonMap(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20)));
-        AggregationBuilder rewritten = original.rewrite(new QueryRewriteContext(xContentRegistry(), null, null, () -> 0L));
+        AggregationBuilder rewritten = original.rewrite(new QueryRewriteContext(xContentRegistry(), null, null, () -> 0L, false));
         assertSame(original, rewritten);
 
         // test non-keyed filter that does rewrite
         original = new FiltersAggregationBuilder("my-agg", new BoolQueryBuilder());
-        rewritten = original.rewrite(new QueryRewriteContext(xContentRegistry(), null, null, () -> 0L));
+        rewritten = original.rewrite(new QueryRewriteContext(xContentRegistry(), null, null, () -> 0L, false));
         assertNotSame(original, rewritten);
         assertThat(rewritten, instanceOf(FiltersAggregationBuilder.class));
         assertEquals("my-agg", ((FiltersAggregationBuilder) rewritten).getName());
@@ -147,12 +147,12 @@ public class FiltersTests extends BaseAggregationTestCase<FiltersAggregationBuil
 
         // test keyed filter that doesn't rewrite
         original = new FiltersAggregationBuilder("my-agg", new KeyedFilter("my-filter",  new MatchAllQueryBuilder()));
-        rewritten = original.rewrite(new QueryRewriteContext(xContentRegistry(), null, null, () -> 0L));
+        rewritten = original.rewrite(new QueryRewriteContext(xContentRegistry(), null, null, () -> 0L, false));
         assertSame(original, rewritten);
 
         // test non-keyed filter that does rewrite
         original = new FiltersAggregationBuilder("my-agg", new KeyedFilter("my-filter",  new BoolQueryBuilder()));
-        rewritten = original.rewrite(new QueryRewriteContext(xContentRegistry(), null, null, () -> 0L));
+        rewritten = original.rewrite(new QueryRewriteContext(xContentRegistry(), null, null, () -> 0L, false));
         assertNotSame(original, rewritten);
         assertThat(rewritten, instanceOf(FiltersAggregationBuilder.class));
         assertEquals("my-agg", ((FiltersAggregationBuilder) rewritten).getName());
@@ -166,7 +166,7 @@ public class FiltersTests extends BaseAggregationTestCase<FiltersAggregationBuil
             .subAggregation(
                 new FiltersAggregationBuilder("my-agg", new KeyedFilter("my-filter",  new BoolQueryBuilder()))
             );
-        rewritten = original.rewrite(new QueryRewriteContext(xContentRegistry(), null, null, () -> 0L));
+        rewritten = original.rewrite(new QueryRewriteContext(xContentRegistry(), null, null, () -> 0L, false));
         assertNotSame(original, rewritten);
         assertNotEquals(original, rewritten);
         assertThat(rewritten, instanceOf(TermsAggregationBuilder.class));
@@ -176,7 +176,7 @@ public class FiltersTests extends BaseAggregationTestCase<FiltersAggregationBuil
         assertNotSame(original.getSubAggregations().iterator().next(), subAgg);
         assertEquals("my-agg", subAgg.getName());
         assertSame(rewritten,
-            rewritten.rewrite(new QueryRewriteContext(xContentRegistry(), null, null, () -> 0L)));
+            rewritten.rewrite(new QueryRewriteContext(xContentRegistry(), null, null, () -> 0L, false)));
     }
 
     public void testRewritePreservesOtherBucket() throws IOException {
@@ -184,8 +184,7 @@ public class FiltersTests extends BaseAggregationTestCase<FiltersAggregationBuil
         originalFilters.otherBucket(randomBoolean());
         originalFilters.otherBucketKey(randomAlphaOfLength(10));
 
-        AggregationBuilder rewritten = originalFilters.rewrite(new QueryRewriteContext(xContentRegistry(),
-            null, null, () -> 0L));
+        AggregationBuilder rewritten = originalFilters.rewrite(new QueryRewriteContext(xContentRegistry(), null, null, () -> 0L, false));
         assertThat(rewritten, instanceOf(FiltersAggregationBuilder.class));
 
         FiltersAggregationBuilder rewrittenFilters = (FiltersAggregationBuilder) rewritten;

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -463,6 +463,6 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
 
     private SearchSourceBuilder rewrite(SearchSourceBuilder searchSourceBuilder) throws IOException {
         return Rewriteable.rewrite(searchSourceBuilder, new QueryRewriteContext(xContentRegistry(), writableRegistry(),
-                null, Long.valueOf(1)::longValue));
+                null, Long.valueOf(1)::longValue, false));
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexSearcherWrapper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexSearcherWrapper.java
@@ -5,8 +5,8 @@
  */
 package org.elasticsearch.xpack.core.security.authz.accesscontrol;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BooleanQuery;
@@ -365,7 +365,7 @@ public class SecurityIndexSearcherWrapper extends IndexSearcherWrapper {
     static void failIfQueryUsesClient(QueryBuilder queryBuilder, QueryRewriteContext original)
             throws IOException {
         QueryRewriteContext copy = new QueryRewriteContext(
-                original.getXContentRegistry(), original.getWriteableRegistry(), null, original::nowInMillis);
+                original.getXContentRegistry(), original.getWriteableRegistry(), null, original::nowInMillis, false);
         Rewriteable.rewrite(queryBuilder, copy);
         if (copy.hasAsyncActions()) {
             throw new IllegalStateException("role queries are not allowed to execute additional requests");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/index/engine/RewriteCachingDirectoryReaderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/index/engine/RewriteCachingDirectoryReaderTests.java
@@ -90,7 +90,7 @@ public class RewriteCachingDirectoryReaderTests extends ESTestCase {
                     DateFieldMapper.Builder b = new DateFieldMapper.Builder("test");
                     DateFieldMapper.DateFieldType dateFieldType = b.fieldType();
                     dateFieldType.setName("test");
-                    QueryRewriteContext context = new QueryRewriteContext(xContentRegistry(), writableRegistry(), null, () -> 0);
+                    QueryRewriteContext context = new QueryRewriteContext(xContentRegistry(), writableRegistry(), null, () -> 0, false);
                     MappedFieldType.Relation relation = dateFieldType.isFieldWithinQuery(cachingDirectoryReader, 0, 10,
                         true, true, DateTimeZone.UTC, null, context);
                     assertEquals(relation, MappedFieldType.Relation.WITHIN);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexSearcherWrapperUnitTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexSearcherWrapperUnitTests.java
@@ -34,7 +34,6 @@ import org.apache.lucene.store.RAMDirectory;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.FixedBitSet;
-import org.elasticsearch.core.internal.io.IOUtils;
 import org.apache.lucene.util.SparseFixedBitSet;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
@@ -43,6 +42,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
@@ -664,8 +664,7 @@ public class SecurityIndexSearcherWrapperUnitTests extends ESTestCase {
         Client client = mock(Client.class);
         when(client.settings()).thenReturn(Settings.EMPTY);
         final long nowInMillis = randomNonNegativeLong();
-        QueryRewriteContext context = new QueryRewriteContext(xContentRegistry(), writableRegistry(), client,
-                () -> nowInMillis);
+        QueryRewriteContext context = new QueryRewriteContext(xContentRegistry(), writableRegistry(), client, () -> nowInMillis, false);
         QueryBuilder queryBuilder1 = new TermsQueryBuilder("field", "val1", "val2");
         SecurityIndexSearcherWrapper.failIfQueryUsesClient(queryBuilder1, context);
 


### PR DESCRIPTION
With #36997 and #37000 we added the ability to provide a cluster alias with a SearchRequest and to perform non-final reduction when a cluster alias is set to the incoming search request.

With CCS soon supporting local reduction on each remote cluster, we also need to prevent shard_size of terms aggs to be adjusted on the data nodes. We may end up querying a single shard per cluster, but later we will have to reduce results coming from multiple cluster hence we still have to collect more buckets than needed to guarantee some level of precision.

This is done by adding the ability to override the shard_size on the coordinating node as part of the rewrite phase. This will be done only
when searching against multiple clusters, meaning when using CCS with alternate execution mode. Setting the shard_size explicitly on the coord node means that it will not be overridden later on the data nodes. The shard_size will still be set on the data nodes like before in all other cases (local search, or CCS with ordinary execution mode).

 Relates to #32125