### PR TITLE
Deprecation check for index_options on numeric fields

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -57,6 +57,7 @@ public class DeprecationChecks {
             IndexDeprecationChecks::percolatorUnmappedFieldsAsStringCheck,
             IndexDeprecationChecks::indexNameCheck,
 			IndexDeprecationChecks::nodeLeftDelayedTimeCheck,
+            IndexDeprecationChecks::indexOptionsOnNumericFieldsCheck,
             IndexDeprecationChecks::shardOnStartupCheck,
             IndexDeprecationChecks::classicSimilarityMappingCheck,
             IndexDeprecationChecks::classicSimilaritySettingsCheck


### PR DESCRIPTION
~Checks for index_options on numeric fields, which are not supported in
7.0. The indices will still be available, but attempting to make
modifications to the mapping appear to result in errors, which is why
this is a `WARNING` rather than `CRITICAL`.~
See note below.

Relates to https://github.com/elastic/elasticsearch/issues/36024 and https://github.com/elastic/elasticsearch/pull/26668