### PR TITLE
Make ILM examples larger

### DIFF
--- a/docs/reference/ilm/index.asciidoc
+++ b/docs/reference/ilm/index.asciidoc
@@ -41,7 +41,7 @@ replicas can be reduced.
 For example, if you are indexing metrics data from a fleet of ATMs into
 Elasticsearch, you might define a policy that says:
 
-. When the index reaches 5GB, roll over to a new index.
+. When the index reaches 50GB, roll over to a new index.
 . Move the old index into the warm stage, mark it read only, and shrink it down
 to a single shard.
 . After 7 days, move the index into the cold stage and move it to less expensive

--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -393,7 +393,7 @@ PUT _ilm/policy/my_policy
 ===== Example: Rollover when index has too many documents
 
 This example rolls the index over when it contains at least
-1000000 documents.
+100000000 documents.
 
 [source,js]
 --------------------------------------------------
@@ -404,7 +404,7 @@ PUT _ilm/policy/my_policy
       "hot": {
         "actions": {
           "rollover" : {
-            "max_docs": 1000000
+            "max_docs": 100000000
           }
         }
       }
@@ -553,7 +553,7 @@ beta[]
 
 With all of these actions, we can support complex management strategies for our
 indices. This policy will define an index that will start in the hot phase,
-rolling over every 20g or 7 days. After 30 days it enters the warm phase
+rolling over every 50 GB or 7 days. After 30 days it enters the warm phase
 and increases the replicas to 2, force merges and shrinks. After 60 days
 it enters the cold phase and allocates to "cold" nodes, and after 90 days the
 index is deleted.
@@ -568,7 +568,7 @@ PUT _ilm/policy/full_policy
         "actions": {
           "rollover": {
             "max_age": "7d",
-            "max_size": "20G"
+            "max_size": "50G"
           }
         }
       },

--- a/docs/reference/ilm/using-policies-rollover.asciidoc
+++ b/docs/reference/ilm/using-policies-rollover.asciidoc
@@ -34,9 +34,9 @@ The rollover action takes the following parameters:
 |===
 |Name |Description
 |max_size |The maximum estimated size the index is allowed to grow
-to. Defaults tonull. Optional.
+to. Defaults to `null`. Optional.
 |max_docs |The maximum number of document the index should
-contain. Defaults tonull. Optional.
+contain. Defaults to `null`. Optional.
 |max_age |The maximum age of the index. Defaults to `null`. Optional.
 |===
 


### PR DESCRIPTION
There are a handful of examples in the ILM documentation that could result in
rolling over indices more quickly than we might normally recommend,
contributing to over-sharding in cases where the examples are copied without
modification. This change makes some numbers bigger to try and avoid this.