### PR TITLE
[API] spelling: interruptible

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -311,7 +311,7 @@ public class TestClustersPlugin implements Plugin<Project> {
             shutdownExecutorService();
         });
         // When the Daemon is not used, or runs into issues, rely on a shutdown hook
-        // When the daemon is used, but does not work correctly and eventually dies off (e.x. due to non interruptable
+        // When the daemon is used, but does not work correctly and eventually dies off (e.x. due to non interruptible
         // thread in the build) process will be stopped eventually when the daemon dies.
         Runtime.getRuntime().addShutdownHook(new Thread(TestClustersPlugin::shutDownAllClusters));
     }

--- a/server/src/main/java/org/elasticsearch/common/util/CancellableThreads.java
+++ b/server/src/main/java/org/elasticsearch/common/util/CancellableThreads.java
@@ -29,7 +29,7 @@ import java.util.Set;
 
 /**
  * A utility class for multi threaded operation that needs to be cancellable via interrupts. Every cancellable operation should be
- * executed via {@link #execute(Interruptable)}, which will capture the executing thread and make sure it is interrupted in the case
+ * executed via {@link #execute(Interruptible)}, which will capture the executing thread and make sure it is interrupted in the case
  * of cancellation.
  *
  * Cancellation policy: This class does not support external interruption via <code>Thread#interrupt()</code>. Always use #cancel() instead.
@@ -77,33 +77,33 @@ public class CancellableThreads {
     }
 
     /**
-     * run the Interruptable, capturing the executing thread. Concurrent calls to {@link #cancel(String)} will interrupt this thread
+     * run the Interruptible, capturing the executing thread. Concurrent calls to {@link #cancel(String)} will interrupt this thread
      * causing the call to prematurely return.
      *
-     * @param interruptable code to run
+     * @param interruptible code to run
      */
-    public void execute(Interruptable interruptable) {
+    public void execute(Interruptible interruptible) {
         try {
-            executeIO(interruptable);
+            executeIO(interruptible);
         } catch (IOException e) {
-            assert false : "the passed interruptable can not result in an IOException";
+            assert false : "the passed interruptible can not result in an IOException";
             throw new RuntimeException("unexpected IO exception", e);
         }
     }
     /**
-     * run the Interruptable, capturing the executing thread. Concurrent calls to {@link #cancel(String)} will interrupt this thread
+     * run the Interruptible, capturing the executing thread. Concurrent calls to {@link #cancel(String)} will interrupt this thread
      * causing the call to prematurely return.
      *
-     * @param interruptable code to run
+     * @param interruptible code to run
      */
-    public void executeIO(IOInterruptable interruptable) throws IOException {
+    public void executeIO(IOInterruptible interruptible) throws IOException {
         boolean wasInterrupted = add();
         boolean cancelledByExternalInterrupt = false;
         RuntimeException runtimeException = null;
         IOException ioException = null;
 
         try {
-            interruptable.run();
+            interruptible.run();
         } catch (InterruptedException | ThreadInterruptedException e) {
             // ignore, this interrupt has been triggered by us in #cancel()...
             assert cancelled : "Interruption via Thread#interrupt() is unsupported. Use CancellableThreads#cancel() instead";
@@ -167,11 +167,11 @@ public class CancellableThreads {
     }
 
 
-    public interface Interruptable extends IOInterruptable {
+    public interface Interruptible extends IOInterruptible {
         void run() throws InterruptedException;
     }
 
-    public interface IOInterruptable {
+    public interface IOInterruptible {
         void run() throws IOException, InterruptedException;
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -237,7 +237,7 @@ public class RecoverySourceHandler {
         return targetHistoryUUID != null && targetHistoryUUID.equals(shard.getHistoryUUID());
     }
 
-    static void runUnderPrimaryPermit(CancellableThreads.Interruptable runnable, String reason,
+    static void runUnderPrimaryPermit(CancellableThreads.Interruptible runnable, String reason,
                                       IndexShard primary, CancellableThreads cancellableThreads, Logger logger) {
         cancellableThreads.execute(() -> {
             CompletableFuture<Releasable> permit = new CompletableFuture<>();
@@ -563,7 +563,7 @@ public class RecoverySourceHandler {
             logger.trace("no translog operations to send");
         }
 
-        final CancellableThreads.IOInterruptable sendBatch = () -> {
+        final CancellableThreads.IOInterruptible sendBatch = () -> {
             final long targetCheckpoint = recoveryTarget.indexTranslogOperations(
                 operations, expectedTotalOps, maxSeenAutoIdTimestamp, maxSeqNoOfUpdatesOrDeletes);
             targetLocalCheckpoint.set(targetCheckpoint);

--- a/server/src/test/java/org/elasticsearch/common/util/CancellableThreadsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/CancellableThreadsTests.java
@@ -18,8 +18,8 @@
  */
 package org.elasticsearch.common.util;
 
-import org.elasticsearch.common.util.CancellableThreads.IOInterruptable;
-import org.elasticsearch.common.util.CancellableThreads.Interruptable;
+import org.elasticsearch.common.util.CancellableThreads.IOInterruptible;
+import org.elasticsearch.common.util.CancellableThreads.Interruptible;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
 
@@ -62,7 +62,7 @@ public class CancellableThreadsTests extends ESTestCase {
         }
     }
 
-    static class TestRunnable implements Interruptable {
+    static class TestRunnable implements Interruptible {
         final TestPlan plan;
         final CountDownLatch readyForCancel;
 
@@ -95,7 +95,7 @@ public class CancellableThreadsTests extends ESTestCase {
         }
     }
 
-    static class TestIORunnable implements IOInterruptable {
+    static class TestIORunnable implements IOInterruptible {
         final TestPlan plan;
         final CountDownLatch readyForCancel;
 


### PR DESCRIPTION
`Interruptable`,`IOInterruptable`/`IOInterruptable`,`IOInterruptible` appears to be an API which should get a distinct review. (Note: similar spelling changes that aren't technically part of the API are included as well.)
split from #37035