### PR TITLE
[API] spelling: likelihood

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/Laplace.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/Laplace.java
@@ -119,7 +119,7 @@ public final class Laplace extends SmoothingModel {
 
     @Override
     public WordScorerFactory buildWordScorerFactory() {
-        return (IndexReader reader, Terms terms, String field, double realWordLikelyhood, BytesRef separator)
-                -> new LaplaceScorer(reader, terms,  field, realWordLikelyhood, separator, alpha);
+        return (IndexReader reader, Terms terms, String field, double realWordLikelihood, BytesRef separator)
+                -> new LaplaceScorer(reader, terms,  field, realWordLikelihood, separator, alpha);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/LaplaceScorer.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/LaplaceScorer.java
@@ -29,8 +29,8 @@ final class LaplaceScorer extends WordScorer {
     private double alpha;
 
     LaplaceScorer(IndexReader reader, Terms terms, String field,
-            double realWordLikelyhood, BytesRef separator, double alpha) throws IOException {
-        super(reader, terms, field, realWordLikelyhood, separator);
+            double realWordLikelihood, BytesRef separator, double alpha) throws IOException {
+        super(reader, terms, field, realWordLikelihood, separator);
         this.alpha = alpha;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/LinearInterpolatingScorer.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/LinearInterpolatingScorer.java
@@ -32,9 +32,9 @@ public final class LinearInterpolatingScorer extends WordScorer {
     private final double bigramLambda;
     private final double trigramLambda;
 
-    public LinearInterpolatingScorer(IndexReader reader, Terms terms, String field, double realWordLikelyhood, BytesRef separator,
+    public LinearInterpolatingScorer(IndexReader reader, Terms terms, String field, double realWordLikelihood, BytesRef separator,
             double trigramLambda, double bigramLambda, double unigramLambda) throws IOException {
-        super(reader, terms, field, realWordLikelyhood, separator);
+        super(reader, terms, field, realWordLikelihood, separator);
         double sum = unigramLambda + bigramLambda + trigramLambda;
         this.unigramLambda = unigramLambda / sum;
         this.bigramLambda = bigramLambda / sum;

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/LinearInterpolation.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/LinearInterpolation.java
@@ -168,8 +168,8 @@ public final class LinearInterpolation extends SmoothingModel {
 
     @Override
     public WordScorerFactory buildWordScorerFactory() {
-        return (IndexReader reader, Terms terms, String field, double realWordLikelyhood, BytesRef separator) ->
-                    new LinearInterpolatingScorer(reader, terms, field, realWordLikelyhood, separator, trigramLambda, bigramLambda,
+        return (IndexReader reader, Terms terms, String field, double realWordLikelihood, BytesRef separator) ->
+                    new LinearInterpolatingScorer(reader, terms, field, realWordLikelihood, separator, trigramLambda, bigramLambda,
                         unigramLambda);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/NoisyChannelSpellChecker.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/NoisyChannelSpellChecker.java
@@ -38,14 +38,14 @@ import java.util.List;
 
 //TODO public for tests
 public final class NoisyChannelSpellChecker {
-    public static final double REAL_WORD_LIKELYHOOD = 0.95d;
+    public static final double REAL_WORD_LIKELIHOOD = 0.95d;
     public static final int DEFAULT_TOKEN_LIMIT = 10;
     private final double realWordLikelihood;
     private final boolean requireUnigram;
     private final int tokenLimit;
 
     public NoisyChannelSpellChecker() {
-        this(REAL_WORD_LIKELYHOOD);
+        this(REAL_WORD_LIKELIHOOD);
     }
 
     public NoisyChannelSpellChecker(double nonErrorLikelihood) {

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
@@ -69,7 +69,7 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
     @Override
     public Suggestion<? extends Entry<? extends Option>> innerExecute(String name, PhraseSuggestionContext suggestion,
             IndexSearcher searcher, CharsRefBuilder spare) throws IOException {
-        double realWordErrorLikelihood = suggestion.realworldErrorLikelyhood();
+        double realWordErrorLikelihood = suggestion.realworldErrorLikelihood();
         final PhraseSuggestion response = new PhraseSuggestion(name, suggestion.getSize());
         final IndexReader indexReader = searcher.getIndexReader();
         List<PhraseSuggestionContext.DirectCandidateGenerator>  generators = suggestion.generators();

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
@@ -40,8 +40,8 @@ class PhraseSuggestionContext extends SuggestionContext {
     static final float DEFAULT_RWE_ERRORLIKELIHOOD = 0.95f;
     static final float DEFAULT_MAX_ERRORS = 0.5f;
     static final String DEFAULT_SEPARATOR = " ";
-    static final WordScorer.WordScorerFactory DEFAULT_SCORER = (IndexReader reader, Terms terms, String field, double realWordLikelyhood,
-            BytesRef separator) -> new StupidBackoffScorer(reader, terms, field, realWordLikelyhood, separator, 0.4f);
+    static final WordScorer.WordScorerFactory DEFAULT_SCORER = (IndexReader reader, Terms terms, String field, double realWordLikelihood,
+            BytesRef separator) -> new StupidBackoffScorer(reader, terms, field, realWordLikelihood, separator, 0.4f);
 
     private float maxErrors = DEFAULT_MAX_ERRORS;
     private BytesRef separator = new BytesRef(DEFAULT_SEPARATOR);
@@ -78,7 +78,7 @@ class PhraseSuggestionContext extends SuggestionContext {
         this.separator = separator;
     }
 
-    public Float realworldErrorLikelyhood() {
+    public Float realworldErrorLikelihood() {
         return realworldErrorLikelihood;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/StupidBackoff.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/StupidBackoff.java
@@ -122,7 +122,7 @@ public final class StupidBackoff extends SmoothingModel {
 
     @Override
     public WordScorerFactory buildWordScorerFactory() {
-        return (IndexReader reader, Terms terms, String field, double realWordLikelyhood, BytesRef separator)
-                -> new StupidBackoffScorer(reader, terms, field, realWordLikelyhood, separator, discount);
+        return (IndexReader reader, Terms terms, String field, double realWordLikelihood, BytesRef separator)
+                -> new StupidBackoffScorer(reader, terms, field, realWordLikelihood, separator, discount);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/StupidBackoffScorer.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/StupidBackoffScorer.java
@@ -29,8 +29,8 @@ class StupidBackoffScorer extends WordScorer {
     private final double discount;
 
     StupidBackoffScorer(IndexReader reader, Terms terms,String field,
-                            double realWordLikelyhood, BytesRef separator, double discount) throws IOException {
-        super(reader, terms, field, realWordLikelyhood, separator);
+                            double realWordLikelihood, BytesRef separator, double discount) throws IOException {
+        super(reader, terms, field, realWordLikelihood, separator);
         this.discount = discount;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/WordScorer.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/WordScorer.java
@@ -37,18 +37,18 @@ public abstract class WordScorer {
     protected final String field;
     protected final Terms terms;
     protected final long vocabluarySize;
-    protected final double realWordLikelyhood;
+    protected final double realWordLikelihood;
     protected final BytesRefBuilder spare = new BytesRefBuilder();
     protected final BytesRef separator;
     protected final long numTerms;
     private final TermsEnum termsEnum;
     private final boolean useTotalTermFreq;
 
-    public WordScorer(IndexReader reader, String field, double realWordLikelyHood, BytesRef separator) throws IOException {
-        this(reader, MultiTerms.getTerms(reader, field), field, realWordLikelyHood, separator);
+    public WordScorer(IndexReader reader, String field, double realWordLikelihood, BytesRef separator) throws IOException {
+        this(reader, MultiTerms.getTerms(reader, field), field, realWordLikelihood, separator);
     }
 
-    public WordScorer(IndexReader reader, Terms terms, String field, double realWordLikelyHood, BytesRef separator) throws IOException {
+    public WordScorer(IndexReader reader, Terms terms, String field, double realWordLikelihood, BytesRef separator) throws IOException {
         this.field = field;
         if (terms == null) {
             throw new IllegalArgumentException("Field: [" + field + "] does not exist");
@@ -65,7 +65,7 @@ public abstract class WordScorer {
         this.termsEnum = new FreqTermsEnum(reader, field, !useTotalTermFreq, useTotalTermFreq, null,
             BigArrays.NON_RECYCLING_INSTANCE); // non recycling for now
         this.reader = reader;
-        this.realWordLikelyhood = realWordLikelyHood;
+        this.realWordLikelihood = realWordLikelihood;
         this.separator = separator;
     }
 
@@ -78,7 +78,7 @@ public abstract class WordScorer {
 
    protected double channelScore(Candidate candidate, Candidate original) throws IOException {
        if (candidate.stringDistance == 1.0d) {
-           return realWordLikelyhood;
+           return realWordLikelihood;
        }
        return candidate.stringDistance;
    }
@@ -117,6 +117,6 @@ public abstract class WordScorer {
 
    public interface WordScorerFactory {
        WordScorer newScorer(IndexReader reader, Terms terms,
-                            String field, double realWordLikelyhood, BytesRef separator) throws IOException;
+                            String field, double realWordLikelihood, BytesRef separator) throws IOException;
    }
 }

--- a/server/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
@@ -195,7 +195,7 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
         assertOptionalEquals(builder.confidence(), phraseSuggesterCtx.confidence(), PhraseSuggestionContext.DEFAULT_CONFIDENCE);
         assertOptionalEquals(builder.collatePrune(), phraseSuggesterCtx.collatePrune(), PhraseSuggestionContext.DEFAULT_COLLATE_PRUNE);
         assertEquals(builder.separator(), phraseSuggesterCtx.separator().utf8ToString());
-        assertOptionalEquals(builder.realWordErrorLikelihood(), phraseSuggesterCtx.realworldErrorLikelyhood(),
+        assertOptionalEquals(builder.realWordErrorLikelihood(), phraseSuggesterCtx.realworldErrorLikelihood(),
                 PhraseSuggestionContext.DEFAULT_RWE_ERRORLIKELIHOOD);
         assertOptionalEquals(builder.maxErrors(), phraseSuggesterCtx.maxErrors(), PhraseSuggestionContext.DEFAULT_MAX_ERRORS);
         assertOptionalEquals(builder.forceUnigrams(), phraseSuggesterCtx.getRequireUnigram(),


### PR DESCRIPTION
`realworldErrorLikelyhood`/`realworldErrorLikelihood ` appears to be an API which should get a distinct review. (Note: similar spelling changes that aren't technically part of the API are included as well.)
split from #37035