### PR TITLE
[API] spelling: repositories

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetRepositoriesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetRepositoriesAction.java
@@ -51,7 +51,7 @@ public class RestGetRepositoriesAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "get_respositories_action";
+        return "get_repositories_action";
     }
 
     @Override


### PR DESCRIPTION
I can't tell if `get_respositories_action`/`get_repositories_action` is an API which should get a distinct review.

It's possible this is purely a debug string...

split from #37035