### PR TITLE
[API] spelling: similar

### DIFF
--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/ConnectionConfiguration.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/ConnectionConfiguration.java
@@ -161,7 +161,7 @@ public class ConnectionConfiguration {
         if (knownOptions.contains(propertyName)) {
             return null;
         }
-        return "Unknown parameter [" + propertyName + "] ; did you mean " + StringUtils.findSimiliar(propertyName, knownOptions);
+        return "Unknown parameter [" + propertyName + "] ; did you mean " + StringUtils.findSimilar(propertyName, knownOptions);
     }
 
     protected <T> T parseValue(String key, String value, Function<String, T> parser) {

--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/StringUtils.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/StringUtils.java
@@ -262,7 +262,7 @@ public abstract class StringUtils {
         return -1;
     }
 
-    public static List<String> findSimiliar(CharSequence match, Collection<String> potential) {
+    public static List<String> findSimilar(CharSequence match, Collection<String> potential) {
         List<String> list = new ArrayList<String>(3);
 
         // 1 switches or 1 extra char


### PR DESCRIPTION
`findSimiliar`/`findSimilar` appears to be an API which should get a distinct review. (Note: similar spelling changes that aren't technically part of the API are included as well.)
split from #37035