### PR TITLE
[API] spelling: subtract

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -612,7 +612,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                         .collect(toList()));
 
 
-                AttributeSet missing = resolvedRefs.substract(o.child().outputSet());
+                AttributeSet missing = resolvedRefs.subtract(o.child().outputSet());
 
                 if (!missing.isEmpty()) {
                     // Add missing attributes but project them away afterwards
@@ -648,7 +648,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                         .filter(Expression::resolved)
                         .collect(toList()));
 
-                AttributeSet missing = resolvedRefs.substract(f.child().outputSet());
+                AttributeSet missing = resolvedRefs.subtract(f.child().outputSet());
 
                 if (!missing.isEmpty()) {
                     // Again, add missing attributes and project them away
@@ -695,7 +695,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
 
             if (plan instanceof Project) {
                 Project p = (Project) plan;
-                AttributeSet diff = missing.substract(p.child().outputSet());
+                AttributeSet diff = missing.subtract(p.child().outputSet());
                 return new Project(p.location(), propagateMissing(p.child(), diff, failed), combine(p.projections(), missing));
             }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/AttributeMap.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/AttributeMap.java
@@ -175,7 +175,7 @@ public class AttributeMap<E> {
         delegate.putAll(other.delegate);
     }
 
-    public AttributeMap<E> substract(AttributeMap<E> other) {
+    public AttributeMap<E> subtract(AttributeMap<E> other) {
         AttributeMap<E> diff = new AttributeMap<>();
         for (Entry<AttributeWrapper, E> entry : this.delegate.entrySet()) {
             if (!other.delegate.containsKey(entry.getKey())) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/AttributeSet.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/AttributeSet.java
@@ -57,8 +57,8 @@ public class AttributeSet implements Set<Attribute> {
         delegate.addAll(other.delegate);
     }
 
-    public AttributeSet substract(AttributeSet other) {
-        return new AttributeSet(delegate.substract(other.delegate));
+    public AttributeSet subtract(AttributeSet other) {
+        return new AttributeSet(delegate.subtract(other.delegate));
     }
 
     public AttributeSet intersect(AttributeSet other) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/BinaryArithmeticProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/BinaryArithmeticProcessor.java
@@ -76,7 +76,7 @@ public class BinaryArithmeticProcessor extends FunctionalBinaryProcessor<Object,
                 return Arithmetics.sub((ZonedDateTime) l, ((IntervalDayTime) r).interval());
             }
             if (r instanceof ZonedDateTime && l instanceof Interval<?>) {
-                throw new SqlIllegalArgumentException("Cannot substract a date from an interval; do you mean the reverse?");
+                throw new SqlIllegalArgumentException("Cannot subtract a date from an interval; do you mean the reverse?");
             }
 
             throw new SqlIllegalArgumentException("Cannot compute [-] between [{}] [{}]", l.getClass().getSimpleName(),

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/AttributeMapTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/AttributeMapTests.java
@@ -79,19 +79,19 @@ public class AttributeMapTests extends ESTestCase {
         assertThat(m.containsValue("on"), is(false));
     }
 
-    public void testSubstract() {
+    public void testSubtract() {
         AttributeMap<String> m = threeMap();
         AttributeMap<String> mo = new AttributeMap<>(m.keySet().iterator().next(), "one");
         AttributeMap<String> empty = new AttributeMap<>();
 
-        assertThat(m.substract(empty), is(m));
-        assertThat(m.substract(m), is(empty));
-        assertThat(mo.substract(m), is(empty));
+        assertThat(m.subtract(empty), is(m));
+        assertThat(m.subtract(m), is(empty));
+        assertThat(mo.subtract(m), is(empty));
 
-        AttributeMap<String> substract = m.substract(mo);
+        AttributeMap<String> subtract = m.subtract(mo);
 
-        assertThat(substract.size(), is(2));
-        assertThat(substract.attributeNames(), contains("two", "three"));
+        assertThat(subtract.size(), is(2));
+        assertThat(subtract.attributeNames(), contains("two", "three"));
     }
 
     public void testIntersect() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/BinaryArithmeticTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/BinaryArithmeticTests.java
@@ -139,7 +139,7 @@ public class BinaryArithmeticTests extends ESTestCase {
         TemporalAmount t = Period.ofYears(100).plusMonths(50);
         Literal r = interval(t, INTERVAL_HOUR);
         SqlIllegalArgumentException ex = expectThrows(SqlIllegalArgumentException.class, () -> sub(r, l));
-        assertEquals("Cannot substract a date from an interval; do you mean the reverse?", ex.getMessage());
+        assertEquals("Cannot subtract a date from an interval; do you mean the reverse?", ex.getMessage());
     }
 
     public void testSubNumberFromIntervalIllegal() {


### PR DESCRIPTION
`substract`/`subtract` appears to be an API which should get a distinct review. (Note: similar spelling changes that aren't technically part of the API are included as well.)
split from #37035