### PR TITLE
Add the method PutMappingRequest#isTypeless to detect whether a mapping is typed.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -290,6 +290,21 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
         }
     }
 
+    /**
+     * Gives a best-effort attempt at determining whether a mapping definition is typeless.
+     *
+     * The mappings are considered typeless if any recognized component of the mapping definition,
+     * such as 'properties', '_routing', or '_source', appears at the root level.
+     */
+    public static boolean isTypeless(Map<String, Object> mappings) {
+        for (String key : mappings.keySet()) {
+            if (key.equals("properties") || RESERVED_FIELDS.contains(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -418,6 +418,9 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         if (type.charAt(0) == '.') {
             throw new IllegalArgumentException("mapping type name [" + type + "] must not start with a '.'");
         }
+        if (type.equals("properties")) {
+            throw new InvalidTypeNameException("mapping type cannot be named [properties]");
+        }
     }
 
     private synchronized Map<String, DocumentMapper> internalMerge(@Nullable DocumentMapper defaultMapper,

--- a/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -87,6 +87,9 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
         e = expectThrows(InvalidTypeNameException.class, () -> MapperService.validateTypeName("_document"));
         assertEquals("mapping type name [_document] can't start with '_' unless it is called [_doc]", e.getMessage());
 
+        e = expectThrows(InvalidTypeNameException.class, () -> MapperService.validateTypeName("_routing"));
+        assertEquals("mapping type name [_routing] can't start with '_' unless it is called [_doc]", e.getMessage());
+
         MapperService.validateTypeName("_doc"); // no exception
     }
 


### PR DESCRIPTION
Opening a PR in hopes of starting a discussion around automatically detecting typeless mappings.

With this approach, we can avoid adding the `include_type_name` parameter to the create index, put mapping, and put index template APIs, and simply accept both formats. There are a few advantages: 
- Users can just switch to these typeless APIs, without worrying about first preparing for the change in 6.7 by setting `include_type_name = false`. This cuts down on the amount of work + complexity around the upgrade.
- Under the current plan, we will have to backport the (quite extensive) changes to create index, put mapping, and put index templates to 6.x. Then in 7.0, we'll also need to update all REST yml tests to set `include_type_name` when creating an index, to make sure we can run backwards-compatibility tests (this includes ~900 tests, and applies to all new tests). Not adding the `include_type_name` parameter lets us avoid this complexity.

We can only give a best-effort attempt at determining whether a mapping definition is typeless. The heuristic for being typeless is if any recognized mapping component, such as `properties`, `_routing`, or `_source`, appears at the root level. This heuristic works quite well because of the following:
- All mapping components except `properties` start with an underscore, and type names cannot start with an underscore (except for the `_doc` type).
- Because the way `DocumentMapperParser#extractMapping` attempts to unwrap mappings, defining a type named `properties` is not possible and will result in an error. For robustness, this PR adds validation to ensure that a type cannot be named `properties`.

The worst-case scenario is if a typeless mapping definition is provided that's slightly off, like `"properteis": { ... }`. In this case, we will interpret the mapping as being typed, and likely fail to parse the definition. I think that with careful wording of error messages, we can mitigate confusion. From my perspective, the rare slightly confusing situation is balanced out by improved user experience by not introducing `include_type_name` to these APIs.