### PR TITLE
[Backport] Add hybridfs store type

### DIFF
--- a/docs/reference/index-modules/store.asciidoc
+++ b/docs/reference/index-modules/store.asciidoc
@@ -67,12 +67,22 @@ process equal to the size of the file being mapped. Before using this
 class, be sure you have allowed plenty of
 <<vm-max-map-count,virtual address space>>.
 
+[[hybridfs]]`hybridfs`::
+
+The `hybridfs` type is a hybrid of `niofs` and `mmapfs`, which chooses the best
+file system type for each type of file based on the read access pattern.
+Currently only the Lucene term dictionary, norms and doc values files are
+memory mapped. All other files are opened using Lucene `NIOFSDirectory`.
+Similarly to `mmapfs` be sure you have allowed plenty of
+<<vm-max-map-count,virtual address space>>.
+
 [[allow-mmapfs]]
-You can restrict the use of the `mmapfs` store type via the setting
-`node.store.allow_mmapfs`. This is a boolean setting indicating whether or not
-`mmapfs` is allowed. The default is to allow `mmapfs`. This setting is useful,
-for example, if you are in an environment where you can not control the ability
-to create a lot of memory maps so you need disable the ability to use `mmapfs`.
+You can restrict the use of the `mmapfs` and the related `hybridfs` store type
+via the setting `node.store.allow_mmapfs`. This is a boolean setting indicating
+whether or not memory-mapping is allowed. The default is to allow it. This
+setting is useful, for example, if you are in an environment where you can not
+control the ability to create a lot of memory maps so you need disable the
+ability to use memory-mapping.
 
 === Pre-loading data into the file system cache
 

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -302,6 +302,7 @@ public final class IndexModule {
 
 
     public enum Type {
+        HYBRIDFS("hybridfs"),
         NIOFS("niofs"),
         MMAPFS("mmapfs"),
         SIMPLEFS("simplefs"),
@@ -330,7 +331,7 @@ public final class IndexModule {
         public static Type fromSettingsKey(final String key) {
             final Type type = TYPES.get(key);
             if (type == null) {
-                throw new IllegalArgumentException("no matching type for [" + key + "]");
+                throw new IllegalArgumentException("no matching store type for [" + key + "]");
             }
             return type;
         }

--- a/server/src/test/java/org/elasticsearch/index/store/IndexStoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/IndexStoreTests.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.index.store;
 
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FileSwitchDirectory;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.store.NoLockFactory;
@@ -64,6 +65,9 @@ public class IndexStoreTests extends ESTestCase {
             new ShardPath(false, tempDir, tempDir, new ShardId(index, 0)));
         try (Directory directory = service.newFSDirectory(tempDir, NoLockFactory.INSTANCE)) {
             switch (type) {
+                case HYBRIDFS:
+                    assertHybridDirectory(directory);
+                    break;
                 case NIOFS:
                     assertTrue(type + " " + directory.toString(), directory instanceof NIOFSDirectory);
                     break;
@@ -88,4 +92,9 @@ public class IndexStoreTests extends ESTestCase {
         }
     }
 
+    private void assertHybridDirectory(Directory directory) {
+        assertTrue(directory.toString(), directory instanceof FileSwitchDirectory);
+        Directory primaryDirectory = ((FileSwitchDirectory) directory).getPrimaryDir();
+        assertTrue("primary directory " +  primaryDirectory.toString(), primaryDirectory instanceof MMapDirectory);
+    }
 }


### PR DESCRIPTION
With this commit we introduce a new store type `hybridfs` that is a
hybrid between `mmapfs` and `niofs`. This store type chooses different
strategies to read Lucene files based on the read access pattern (random
or linear) in order to optimize performance.

This store type has been available in earlier versions of Elasticsearch
as `default_fs`. We have chosen a different name now in order to convey
the intent of the store type instead of tying it to the fact whether it
is the default choice.

Relates #36668