### PR TITLE
Remove two unused methods in Iterables

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/iterable/Iterables.java
+++ b/server/src/main/java/org/elasticsearch/common/util/iterable/Iterables.java
@@ -21,7 +21,6 @@ package org.elasticsearch.common.util.iterable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -29,8 +28,6 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class Iterables {
-    public Iterables() {
-    }
 
     public static <T> Iterable<T> concat(Iterable<T>... inputs) {
         Objects.requireNonNull(inputs);
@@ -78,45 +75,6 @@ public class Iterables {
                     .stream(inputs.spliterator(), false)
                     .flatMap(s -> StreamSupport.stream(s.spliterator(), false)).iterator();
         }
-    }
-
-    public static boolean allElementsAreEqual(Iterable<?> left, Iterable<?> right) {
-        Objects.requireNonNull(left);
-        Objects.requireNonNull(right);
-        if (left instanceof Collection && right instanceof Collection) {
-            Collection collection1 = (Collection) left;
-            Collection collection2 = (Collection) right;
-            if (collection1.size() != collection2.size()) {
-                return false;
-            }
-        }
-
-        Iterator<?> leftIt = left.iterator();
-        Iterator<?> rightIt = right.iterator();
-
-        while (true) {
-            if (leftIt.hasNext()) {
-                if (!rightIt.hasNext()) {
-                    return false;
-                }
-
-                Object o1 = leftIt.next();
-                Object o2 = rightIt.next();
-                if (Objects.equals(o1, o2)) {
-                    continue;
-                }
-
-                return false;
-            }
-
-            return !rightIt.hasNext();
-        }
-    }
-
-    public static <T> T getFirst(Iterable<T> collection, T defaultValue) {
-        Objects.requireNonNull(collection);
-        Iterator<T> iterator = collection.iterator();
-        return iterator.hasNext() ? iterator.next() : defaultValue;
     }
 
     public static <T> T get(Iterable<T> iterable, int position) {


### PR DESCRIPTION
These helper methods are unused in the rest of the codebase.