### PR TITLE
[ML] Migration test should use different assertions depending on the old cluster version 

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlMigrationFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlMigrationFullClusterRestartIT.java
@@ -72,7 +72,6 @@ public class MlMigrationFullClusterRestartIT extends AbstractFullClusterRestartT
         client().performRequest(createTestIndex);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/36816")
     public void testMigration() throws Exception {
         if (isRunningAgainstOldCluster()) {
             createTestIndex();
@@ -200,6 +199,12 @@ public class MlMigrationFullClusterRestartIT extends AbstractFullClusterRestartT
     @SuppressWarnings("unchecked")
     private void waitForMigration(List<String> expectedMigratedJobs, List<String> expectedMigratedDatafeeds,
                                   List<String> unMigratedJobs, List<String> unMigratedDatafeeds) throws Exception {
+
+        // After v6.6.0 jobs are created in the index so no migration will take place
+        if (getOldClusterVersion().onOrAfter(Version.V_6_6_0)) {
+            return;
+        }
+
         assertBusy(() -> {
             // wait for the eligible configs to be moved from the clusterstate
             Request getClusterState = new Request("GET", "/_cluster/state/metadata");


### PR DESCRIPTION
MlMigrationFullClusterRestartIT is a full cluster restart test. If the old cluster is v6.6.0 or later then the configurations are already in index documents and don't need to be migrated. This change removes the wait for migration check for those clusters.

The test started failing after the v6.6 branch was cut 

Closes #36816