### PR TITLE
[ML][TEST] Clean up max_model_memory_limit cluster setting

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/ml_info.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/ml_info.yml
@@ -1,3 +1,11 @@
+teardown:
+
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            xpack.ml.max_model_memory_limit: null
+
 ---
 "Test ml info":
   - do:


### PR DESCRIPTION
Removes the `xpack.ml.max_model_memory_limit` cluster setting
at the teardown of the `ml_info.yml` tests to ensure the setting
does not trip other tests.
