### PR TITLE
Types removal - forward-compatible code for bulk API change coming in 7.0

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -20,6 +20,7 @@ package org.elasticsearch.upgrades;
 
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.common.Booleans;
+import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 
@@ -125,6 +126,7 @@ public class IndexingIT extends AbstractRollingTestCase {
         }
         Request bulk = new Request("POST", "/_bulk");
         bulk.addParameter("refresh", "true");
+        bulk.setOptions(expectVersionSpecificWarnings(consumer -> consumer.compatible(BulkRequest.TYPES_DEPRECATION_MESSAGE)));
         bulk.setJsonEntity(b.toString());
         client().performRequest(bulk);
     }

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -70,7 +70,8 @@ import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_T
 public class BulkRequest extends ActionRequest implements CompositeIndicesRequest, WriteRequest<BulkRequest> {
     private static final DeprecationLogger DEPRECATION_LOGGER =
         new DeprecationLogger(LogManager.getLogger(BulkRequest.class));
-
+    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal]" +
+            " Specifying types in bulk requests is deprecated.";
     private static final int REQUEST_OVERHEAD = 50;
 
     private static final ParseField INDEX = new ParseField("_index");


### PR DESCRIPTION
This rolling upgrade test now tolerates (but does not require) type removal warnings.
Mainly adding here to 6.x to make the master builds for my bulk types removal PR (36549) pass.