### PR TITLE
[TEST] Revert "Mute ForecastIT.testSingleSeries"

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ForecastIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ForecastIT.java
@@ -41,7 +41,6 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         cleanUp();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/36258")
     public void testSingleSeries() throws Exception {
         Detector.Builder detector = new Detector.Builder("mean", "value");
 


### PR DESCRIPTION
The problem that caused the test to be muted was fixed in
https://github.com/elastic/ml-cpp/pull/332

Closes #36258