### PR TITLE
[ML] Revert mute MlMigrationFullClusterRestartIT

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlMigrationFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlMigrationFullClusterRestartIT.java
@@ -72,7 +72,6 @@ public class MlMigrationFullClusterRestartIT extends AbstractFullClusterRestartT
         client().performRequest(createTestIndex);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/36816")
     public void testMigration() throws Exception {
         if (isRunningAgainstOldCluster()) {
             createTestIndex();


### PR DESCRIPTION
Re-enable the muted MlMigrationFullClusterRestartIT test

The test was muted due to #36816 but the bug only occurred on the 6.x and master branches and was fixed in #37077 and #37118
