### PR TITLE
TESTS: Shutdown ThreadPool after TestNodes

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
@@ -81,12 +81,6 @@ public abstract class TaskManagerTestCase extends ESTestCase {
         threadPool = new TestThreadPool(TransportTasksActionTests.class.getSimpleName());
     }
 
-    @After
-    public void tearDownThreadPool() {
-        ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
-        threadPool = null;
-    }
-
     public void setupTestNodes(Settings settings) {
         nodesCount = randomIntBetween(2, 10);
         testNodes = new TestNode[nodesCount];
@@ -100,6 +94,8 @@ public abstract class TaskManagerTestCase extends ESTestCase {
         for (TestNode testNode : testNodes) {
             testNode.close();
         }
+        ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+        threadPool = null;
     }
 
 


### PR DESCRIPTION
* If the threadpool gets shut down before the testnodes we run into an error => fixed by moving to single `After` method
* Relates #36976
