### PR TITLE
[ML] Uplift model memory limit on job migration

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
@@ -52,10 +52,6 @@ setup:
 
 ---
 "Test model memory limit is updated":
-  - skip:
-      version: "all"
-      reason: "@AwaitsFix: https://github.com/elastic/elasticsearch/issues/36961"
-
 # Jobs created in 6.1.x and 6.2.x underestimated the necessary model memory
 # limit, check the limit has been updated.
 # Opening the job updates the limit


### PR DESCRIPTION
When a 6.1-6.3 job is opened in a later version
we increase the model memory limit by 30% if it's
below 0.5GB. The migration of jobs from cluster
state to the config index changes the job version,
so we need to also do this uplift as part of that
config migration.

Relates #36961