### PR TITLE
Deprecate use of the _type field in aggregations.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -75,8 +75,8 @@ import static java.util.Collections.unmodifiableMap;
 public class QueryShardContext extends QueryRewriteContext {
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
         LogManager.getLogger(QueryShardContext.class));
-    static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Using the _type field " +
-        "in queries is deprecated, prefer to filter on a field instead.";
+    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Using the _type field " +
+        "in queries and aggregations is deprecated, prefer to use a field instead.";
 
     private final ScriptService scriptService;
     private final IndexSettings indexSettings;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfigTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfigTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine.Searcher;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.mapper.TypeFieldMapper;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
@@ -259,6 +260,16 @@ public class ValuesSourceConfigTests extends ESSingleNodeTestCase {
         }
     }
 
+    public void testTypeFieldDeprecation() {
+        IndexService indexService = createIndex("index", Settings.EMPTY, "type");
+        try (Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
+            QueryShardContext context = indexService.newQueryShardContext(0, searcher.reader(), () -> 42L, null);
+
+            ValuesSourceConfig<ValuesSource.Bytes> config = ValuesSourceConfig.resolve(
+                context, null, TypeFieldMapper.NAME, null, null, null, null);
+            assertWarnings(QueryShardContext.TYPES_DEPRECATION_MESSAGE);
+        }
+    }
 
     public void testFieldAlias() throws Exception {
         IndexService indexService = createIndex("index", Settings.EMPTY, "type",


### PR DESCRIPTION
We already started issuing a deprecation warning in #36802, so this PR just adds a test and tweaks the message to cover aggregations.