### PR TITLE
[ML] ML BWC tests cannot run against pre-ML versions

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlMigrationFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlMigrationFullClusterRestartIT.java
@@ -73,6 +73,12 @@ public class MlMigrationFullClusterRestartIT extends AbstractFullClusterRestartT
     }
 
     public void testMigration() throws Exception {
+        // v5.5.0 is the first version where ml jobs can be
+        // retained after upgrade
+        if (getOldClusterVersion().before(Version.V_5_5_0)) {
+            return;
+        }
+
         if (isRunningAgainstOldCluster()) {
             createTestIndex();
             oldClusterTests();


### PR DESCRIPTION
This was spotted in the CI failure https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+6.x+bwc-tests/241/console

```
org.elasticsearch.client.ResponseException: method [PUT], host [http://[::1]:45213], URI [_xpack/ml/anomaly_detectors/migration-old-cluster-open-job], status line [HTTP/1.1 400 Bad Request]
No handler found for uri [_xpack/ml/anomaly_detectors/migration-old-cluster-open-job] and method [PUT]
```

The error is clear from the reproduce line 
```REPRODUCE WITH: ./gradlew :x-pack:qa:full-cluster-restart:with-system-key:v5.0.0#oldClusterTestRunner  ...``` 

ML did not exist in v5.0.0.

This change prevents the full cluster restart tests running against versions prior to v5.5.0. ML was first introduced in v5.4.0 but we do not support opening v5.4.0 jobs