### PR TITLE
Add support for providing absolute start time to SearchRequest

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -257,14 +257,14 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
     }
 
     /**
-     * Returns the current time in milliseconds from the time epoch, to be used for the execution of this search request. A non-null
-     * value (expected to be greater or equal than 0) indicates that this search request is being executed as part of a locally reduced
-     * cross-cluster search request. The provided current time is used to ensure that the same value, determined by the CCS coordinating
-     * node, is used on all clusters involved in the execution of the search request.
+     * Returns the current time in milliseconds from the time epoch, to be used for the execution of this search request. Used to
+     * ensure that the same value, determined by the coordinating node, is used on all nodes involved in the execution of the search
+     * request. When created through {@link #SearchRequest(String, long)}, this method returns the provided current time, otherwise
+     * it will return {@link System#currentTimeMillis()}.
+     *
      */
-    @Nullable
-    Long getAbsoluteStartMillis() {
-        return absoluteStartMillis == DEFAULT_ABSOLUTE_START_MILLIS ? null : absoluteStartMillis;
+    long getOrCreateAbsoluteStartMillis() {
+        return absoluteStartMillis == DEFAULT_ABSOLUTE_START_MILLIS ? System.currentTimeMillis() : absoluteStartMillis;
     }
 
     /**
@@ -607,7 +607,7 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
                 ", preFilterShardSize=" + preFilterShardSize +
                 ", allowPartialSearchResults=" + allowPartialSearchResults +
                 ", localClusterAlias=" + localClusterAlias +
-                ", absoluteStartMillis=" + absoluteStartMillis +
+                ", getOrCreateAbsoluteStartMillis=" + absoluteStartMillis +
                 ", source=" + source + '}';
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -62,7 +62,10 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
     public static final int DEFAULT_PRE_FILTER_SHARD_SIZE = 128;
     public static final int DEFAULT_BATCHED_REDUCE_SIZE = 512;
 
+    private static final long DEFAULT_ABSOLUTE_START_MILLIS = -1;
+
     private final String localClusterAlias;
+    private final long absoluteStartMillis;
 
     private SearchType searchType = SearchType.DEFAULT;
 
@@ -95,6 +98,7 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
 
     public SearchRequest() {
         this.localClusterAlias = null;
+        this.absoluteStartMillis = DEFAULT_ABSOLUTE_START_MILLIS;
     }
 
     /**
@@ -115,6 +119,7 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
         this.source = searchRequest.source;
         this.types = searchRequest.types;
         this.localClusterAlias = searchRequest.localClusterAlias;
+        this.absoluteStartMillis = searchRequest.absoluteStartMillis;
     }
 
     /**
@@ -138,12 +143,17 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
     }
 
     /**
-     * Creates a new search request by providing the alias of the cluster where it will be executed. Used when a {@link SearchRequest}
-     * is created and executed as part of a cross-cluster search request performing local reduction on each cluster.
-     * The coordinating CCS node provides the alias to prefix index names with in the returned search results.
+     * Creates a new search request by providing the alias of the cluster where it will be executed, as well as the current time in
+     * milliseconds from the epoch time. Used when a {@link SearchRequest} is created and executed as part of a cross-cluster search
+     * request performing local reduction on each cluster. The coordinating CCS node provides the alias to prefix index names with in
+     * the returned search results, and the current time to be used on the remote clusters to ensure that the same value is used.
      */
-    SearchRequest(String localClusterAlias) {
+    SearchRequest(String localClusterAlias, long absoluteStartMillis) {
         this.localClusterAlias = Objects.requireNonNull(localClusterAlias, "cluster alias must not be null");
+        if (absoluteStartMillis < 0) {
+            throw new IllegalArgumentException("absoluteStartMillis must not be negative but was [" + absoluteStartMillis + "]");
+        }
+        this.absoluteStartMillis = absoluteStartMillis;
     }
 
     /**
@@ -155,10 +165,7 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
     public SearchRequest(StreamInput in) throws IOException {
         super(in);
         searchType = SearchType.fromId(in.readByte());
-        indices = new String[in.readVInt()];
-        for (int i = 0; i < indices.length; i++) {
-            indices[i] = in.readString();
-        }
+        indices = in.readStringArray();
         routing = in.readOptionalString();
         preference = in.readOptionalString();
         scroll = in.readOptionalWriteable(Scroll::new);
@@ -175,8 +182,14 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
         //TODO update version after backport
         if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
             localClusterAlias = in.readOptionalString();
+            if (localClusterAlias != null) {
+                absoluteStartMillis = in.readVLong();
+            } else {
+                absoluteStartMillis = DEFAULT_ABSOLUTE_START_MILLIS;
+            }
         } else {
             localClusterAlias = null;
+            absoluteStartMillis = DEFAULT_ABSOLUTE_START_MILLIS;
         }
     }
 
@@ -184,10 +197,7 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeByte(searchType.id());
-        out.writeVInt(indices.length);
-        for (String index : indices) {
-            out.writeString(index);
-        }
+        out.writeStringArray(indices);
         out.writeOptionalString(routing);
         out.writeOptionalString(preference);
         out.writeOptionalWriteable(scroll);
@@ -204,6 +214,9 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
         //TODO update version after backport
         if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
             out.writeOptionalString(localClusterAlias);
+            if (localClusterAlias != null) {
+                out.writeVLong(absoluteStartMillis);
+            }
         }
     }
 
@@ -241,6 +254,17 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
     @Nullable
     String getLocalClusterAlias() {
         return localClusterAlias;
+    }
+
+    /**
+     * Returns the current time in milliseconds from the time epoch, to be used for the execution of this search request. A non-null
+     * value (expected to be greater or equal than 0) indicates that this search request is being executed as part of a locally reduced
+     * cross-cluster search request. The provided current time is used to ensure that the same value, determined by the CCS coordinating
+     * node, is used on all clusters involved in the execution of the search request.
+     */
+    @Nullable
+    Long getAbsoluteStartMillis() {
+        return absoluteStartMillis == DEFAULT_ABSOLUTE_START_MILLIS ? null : absoluteStartMillis;
     }
 
     /**
@@ -435,7 +459,6 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
         return this.allowPartialSearchResults;
     }
 
-
     /**
      * Sets the number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection
      * mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.
@@ -499,13 +522,6 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
     }
 
     /**
-     * Returns <code>true</code> iff the maxConcurrentShardRequest is set.
-     */
-    boolean isMaxConcurrentShardRequestsSet() {
-        return maxConcurrentShardRequests != 0;
-    }
-
-    /**
      * @return true if the request only has suggest
      */
     public boolean isSuggestOnly() {
@@ -538,7 +554,7 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
+    public void readFrom(StreamInput in) {
         throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
@@ -564,14 +580,15 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
                 Objects.equals(preFilterShardSize, that.preFilterShardSize) &&
                 Objects.equals(indicesOptions, that.indicesOptions) &&
                 Objects.equals(allowPartialSearchResults, that.allowPartialSearchResults) &&
-                Objects.equals(localClusterAlias, that.localClusterAlias);
+                Objects.equals(localClusterAlias, that.localClusterAlias) &&
+                absoluteStartMillis == that.absoluteStartMillis;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(searchType, Arrays.hashCode(indices), routing, preference, source, requestCache,
                 scroll, Arrays.hashCode(types), indicesOptions, batchedReduceSize, maxConcurrentShardRequests, preFilterShardSize,
-                allowPartialSearchResults, localClusterAlias);
+                allowPartialSearchResults, localClusterAlias, absoluteStartMillis);
     }
 
     @Override
@@ -590,6 +607,7 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
                 ", preFilterShardSize=" + preFilterShardSize +
                 ", allowPartialSearchResults=" + allowPartialSearchResults +
                 ", localClusterAlias=" + localClusterAlias +
+                ", absoluteStartMillis=" + absoluteStartMillis +
                 ", source=" + source + '}';
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -180,7 +180,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
 
     @Override
     protected void doExecute(Task task, SearchRequest searchRequest, ActionListener<SearchResponse> listener) {
-        final long absoluteStartMillis = System.currentTimeMillis();
+        final long absoluteStartMillis = searchRequest.getAbsoluteStartMillis() != null ?
+            searchRequest.getAbsoluteStartMillis() : System.currentTimeMillis();
         final long relativeStartNanos = System.nanoTime();
         final SearchTimeProvider timeProvider =
                 new SearchTimeProvider(absoluteStartMillis, relativeStartNanos, System::nanoTime);

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -180,11 +180,9 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
 
     @Override
     protected void doExecute(Task task, SearchRequest searchRequest, ActionListener<SearchResponse> listener) {
-        final long absoluteStartMillis = searchRequest.getAbsoluteStartMillis() != null ?
-            searchRequest.getAbsoluteStartMillis() : System.currentTimeMillis();
         final long relativeStartNanos = System.nanoTime();
         final SearchTimeProvider timeProvider =
-                new SearchTimeProvider(absoluteStartMillis, relativeStartNanos, System::nanoTime);
+            new SearchTimeProvider(searchRequest.getOrCreateAbsoluteStartMillis(), relativeStartNanos, System::nanoTime);
         ActionListener<SearchSourceBuilder> rewriteListener = ActionListener.wrap(source -> {
             if (source != searchRequest.source()) {
                 // only set it if it changed - we don't allow null values to be set but it might be already null be we want to catch

--- a/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
@@ -48,10 +48,17 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         if (randomBoolean()) {
             return super.createSearchRequest();
         }
-        //clusterAlias does not have public getter/setter hence we randomize it only in this test specifically.
-        SearchRequest searchRequest = new SearchRequest(randomAlphaOfLengthBetween(5, 10));
+        //clusterAlias and absoluteStartMillis do not have public getters/setters hence we randomize them only in this test specifically.
+        SearchRequest searchRequest = new SearchRequest(randomAlphaOfLengthBetween(5, 10), randomNonNegativeLong());
         RandomSearchRequestGenerator.randomSearchRequest(searchRequest, this::createSearchSourceBuilder);
         return searchRequest;
+    }
+
+    public void testClusterAliasValidation() {
+        expectThrows(NullPointerException.class, () -> new SearchRequest(null, 0));
+        expectThrows(IllegalArgumentException.class, () -> new SearchRequest("", -1));
+        SearchRequest searchRequest = new SearchRequest("", 0);
+        assertNull(searchRequest.validate());
     }
 
     public void testSerialization() throws Exception {
@@ -69,8 +76,10 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         //TODO update version after backport
         if (version.before(Version.V_7_0_0)) {
             assertNull(deserializedRequest.getLocalClusterAlias());
+            assertNull(deserializedRequest.getAbsoluteStartMillis());
         } else {
             assertEquals(searchRequest.getLocalClusterAlias(), deserializedRequest.getLocalClusterAlias());
+            assertEquals(searchRequest.getAbsoluteStartMillis(), deserializedRequest.getAbsoluteStartMillis());
         }
     }
 
@@ -78,9 +87,11 @@ public class SearchRequestTests extends AbstractSearchTestCase {
     public void testReadFromPre7_0_0() throws IOException {
         String msg = "AAEBBWluZGV4AAAAAQACAAAA/////w8AAAAAAAAA/////w8AAAAAAAACAAAAAAABAAMCBAUBAAKABACAAQIAAA==";
         try (StreamInput in = StreamInput.wrap(Base64.getDecoder().decode(msg))) {
+            in.setVersion(VersionUtils.randomVersionBetween(random(), Version.V_6_4_0, VersionUtils.getPreviousVersion(Version.V_7_0_0)));
             SearchRequest searchRequest = new SearchRequest(in);
             assertArrayEquals(new String[]{"index"}, searchRequest.indices());
             assertNull(searchRequest.getLocalClusterAlias());
+            assertNull(searchRequest.getAbsoluteStartMillis());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
@@ -40,6 +40,9 @@ import java.util.Base64;
 import java.util.List;
 
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class SearchRequestTests extends AbstractSearchTestCase {
 
@@ -76,10 +79,10 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         //TODO update version after backport
         if (version.before(Version.V_7_0_0)) {
             assertNull(deserializedRequest.getLocalClusterAlias());
-            assertNull(deserializedRequest.getAbsoluteStartMillis());
+            assertAbsoluteStartMillisIsCurrentTime(deserializedRequest);
         } else {
             assertEquals(searchRequest.getLocalClusterAlias(), deserializedRequest.getLocalClusterAlias());
-            assertEquals(searchRequest.getAbsoluteStartMillis(), deserializedRequest.getAbsoluteStartMillis());
+            assertEquals(searchRequest.getOrCreateAbsoluteStartMillis(), deserializedRequest.getOrCreateAbsoluteStartMillis());
         }
     }
 
@@ -91,8 +94,15 @@ public class SearchRequestTests extends AbstractSearchTestCase {
             SearchRequest searchRequest = new SearchRequest(in);
             assertArrayEquals(new String[]{"index"}, searchRequest.indices());
             assertNull(searchRequest.getLocalClusterAlias());
-            assertNull(searchRequest.getAbsoluteStartMillis());
+            assertAbsoluteStartMillisIsCurrentTime(searchRequest);
         }
+    }
+
+    private static void assertAbsoluteStartMillisIsCurrentTime(SearchRequest searchRequest) {
+        long before = System.currentTimeMillis();
+        long absoluteStartMillis = searchRequest.getOrCreateAbsoluteStartMillis();
+        long after = System.currentTimeMillis();
+        assertThat(absoluteStartMillis, allOf(greaterThanOrEqualTo(before), lessThanOrEqualTo(after)));
     }
 
     public void testIllegalArguments() {


### PR DESCRIPTION
We have recently added support for providing a local cluster alias to a
SearchRequest through a package protected constructor. When executing
cross-cluster search requests with local reduction on each cluster, the
CCS coordinating node will have to provide such cluster alias to each
remote cluster, as well as the absolute start time of the search action
in milliseconds from the time epoch, to be used when evaluating date
math expressions both while executing queries / scripts as well as when
resolving index names.

This commit adds support for providing the start time together with the
cluster alias. It is a final member in the search request, which will
only be set when using cross-cluster search with local reduction (also
known as alternate execution mode). When not provided, the coordinating
node will determine the current time and pass it through (by calling
`System.currentTimeMillis`).

Relates to #32125