### PR TITLE
Support 'include_type_name' in RestGetIndicesAction

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -89,6 +89,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
@@ -209,7 +210,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
             mappingBuilder.startObject().startObject("properties").startObject("field");
             mappingBuilder.field("type", "text");
             mappingBuilder.endObject().endObject().endObject();
-            createIndexRequest.mapping("type_name", mappingBuilder);
+            createIndexRequest.mapping(MapperService.SINGLE_MAPPING_NAME, mappingBuilder);
 
             CreateIndexResponse createIndexResponse =
                     execute(createIndexRequest, highLevelClient().indices()::create, highLevelClient().indices()::createAsync);
@@ -226,7 +227,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
             Map<String, Object> term = (Map) filter.get("term");
             assertEquals(2016, term.get("year"));
 
-            assertEquals("text", XContentMapValues.extractValue(indexName + ".mappings.type_name.properties.field.type", getIndexResponse));
+            assertEquals("text", XContentMapValues.extractValue(indexName + ".mappings.properties.field.type", getIndexResponse));
         }
     }
 
@@ -340,7 +341,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
             .put(SETTING_NUMBER_OF_SHARDS, 1)
             .put(SETTING_NUMBER_OF_REPLICAS, 0)
             .build();
-        String mappings = "\"type-1\":{\"properties\":{\"field-1\":{\"type\":\"integer\"}}}";
+        String mappings = "\"_doc\":{\"properties\":{\"field-1\":{\"type\":\"integer\"}}}";
         createIndex(indexName, basicSettings, mappings);
 
         GetIndexRequest getIndexRequest = new GetIndexRequest()
@@ -353,8 +354,8 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertEquals("1", getIndexResponse.getSetting(indexName, SETTING_NUMBER_OF_SHARDS));
         assertEquals("0", getIndexResponse.getSetting(indexName, SETTING_NUMBER_OF_REPLICAS));
         assertNotNull(getIndexResponse.getMappings().get(indexName));
-        assertNotNull(getIndexResponse.getMappings().get(indexName).get("type-1"));
-        Object o = getIndexResponse.getMappings().get(indexName).get("type-1").getSourceAsMap().get("properties");
+        assertNotNull(getIndexResponse.getMappings().get(indexName).get("_doc"));
+        Object o = getIndexResponse.getMappings().get(indexName).get("_doc").getSourceAsMap().get("properties");
         assertThat(o, instanceOf(Map.class));
         //noinspection unchecked
         assertThat(((Map<String, Object>) o).get("field-1"), instanceOf(Map.class));
@@ -370,7 +371,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
             .put(SETTING_NUMBER_OF_SHARDS, 1)
             .put(SETTING_NUMBER_OF_REPLICAS, 0)
             .build();
-        String mappings = "\"type-1\":{\"properties\":{\"field-1\":{\"type\":\"integer\"}}}";
+        String mappings = "\"_doc\":{\"properties\":{\"field-1\":{\"type\":\"integer\"}}}";
         createIndex(indexName, basicSettings, mappings);
 
         GetIndexRequest getIndexRequest = new GetIndexRequest()
@@ -384,8 +385,8 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertEquals("1", getIndexResponse.getSetting(indexName, SETTING_NUMBER_OF_SHARDS));
         assertEquals("0", getIndexResponse.getSetting(indexName, SETTING_NUMBER_OF_REPLICAS));
         assertNotNull(getIndexResponse.getMappings().get(indexName));
-        assertNotNull(getIndexResponse.getMappings().get(indexName).get("type-1"));
-        Object o = getIndexResponse.getMappings().get(indexName).get("type-1").getSourceAsMap().get("properties");
+        assertNotNull(getIndexResponse.getMappings().get(indexName).get("_doc"));
+        Object o = getIndexResponse.getMappings().get(indexName).get("_doc").getSourceAsMap().get("properties");
         assertThat(o, instanceOf(Map.class));
         assertThat(((Map<String, Object>) o).get("field-1"), instanceOf(Map.class));
         Map<String, Object> fieldMapping = (Map<String, Object>) ((Map<String, Object>) o).get("field-1");
@@ -408,7 +409,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         createIndex(indexName, Settings.EMPTY);
 
         PutMappingRequest putMappingRequest = new PutMappingRequest(indexName);
-        putMappingRequest.type("type_name");
+        putMappingRequest.type("_doc");
         XContentBuilder mappingBuilder = JsonXContent.contentBuilder();
         mappingBuilder.startObject().startObject("properties").startObject("field");
         mappingBuilder.field("type", "text");
@@ -420,7 +421,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertTrue(putMappingResponse.isAcknowledged());
 
         Map<String, Object> getIndexResponse = getAsMap(indexName);
-        assertEquals("text", XContentMapValues.extractValue(indexName + ".mappings.type_name.properties.field.type", getIndexResponse));
+        assertEquals("text", XContentMapValues.extractValue(indexName + ".mappings.properties.field.type", getIndexResponse));
     }
 
     public void testGetMapping() throws IOException {
@@ -440,7 +441,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertTrue(putMappingResponse.isAcknowledged());
 
         Map<String, Object> getIndexResponse = getAsMap(indexName);
-        assertEquals("text", XContentMapValues.extractValue(indexName + ".mappings._doc.properties.field.type", getIndexResponse));
+        assertEquals("text", XContentMapValues.extractValue(indexName + ".mappings.properties.field.type", getIndexResponse));
 
         GetMappingsRequest request = new GetMappingsRequest()
             .indices(indexName)

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -70,15 +70,15 @@ import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.ESRestHighLevelClientTestCase;
-import org.elasticsearch.client.indices.FreezeIndexRequest;
 import org.elasticsearch.client.GetAliasesResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.SyncedFlushResponse;
+import org.elasticsearch.client.core.ShardsAcknowledgedResponse;
+import org.elasticsearch.client.indices.FreezeIndexRequest;
 import org.elasticsearch.client.indices.GetIndexTemplatesRequest;
 import org.elasticsearch.client.indices.IndexTemplatesExistRequest;
 import org.elasticsearch.client.indices.UnfreezeIndexRequest;
-import org.elasticsearch.client.core.ShardsAcknowledgedResponse;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
@@ -1249,7 +1249,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             Settings settings = Settings.builder().put("number_of_shards", 3).build();
             String mappings = "{\"properties\":{\"field-1\":{\"type\":\"integer\"}}}";
             CreateIndexResponse createIndexResponse = client.indices().create(
-                new CreateIndexRequest("index", settings).mapping("doc", mappings, XContentType.JSON),
+                new CreateIndexRequest("index", settings).mapping("_doc", mappings, XContentType.JSON),
                 RequestOptions.DEFAULT);
             assertTrue(createIndexResponse.isAcknowledged());
         }
@@ -1272,7 +1272,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
 
         // tag::get-index-response
         ImmutableOpenMap<String, MappingMetaData> indexMappings = getIndexResponse.getMappings().get("index"); // <1>
-        Map<String, Object> indexTypeMappings = indexMappings.get("doc").getSourceAsMap(); // <2>
+        Map<String, Object> indexTypeMappings = indexMappings.get("_doc").getSourceAsMap(); // <2>
         List<AliasMetaData> indexAliases = getIndexResponse.getAliases().get("index"); // <3>
         String numberOfShardsString = getIndexResponse.getSetting("index", "index.number_of_shards"); // <4>
         Settings indexSettings = getIndexResponse.getSettings().get("index"); // <5>

--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -15,3 +15,63 @@ alias or wildcard expression is required.
 
 The get index API can also be applied to more than one index, or on
 all indices by using `_all` or `*` as index.
+
+[float]
+=== Skipping types
+
+Types are scheduled to be fully removed in Elasticsearch 8.0 and will not appear
+in requests or responses anymore. You can opt in for this future behaviour by
+setting `include_type_name=false` in the request, which will return mappings
+directly under `mappings` without keying by the type name.
+
+Here is an example:
+
+[source,js]
+--------------------------------------------------
+PUT test?include_type_name=false
+{
+  "mappings": {
+    "properties": {
+      "foo": {
+        "type": "keyword"
+      }
+    }
+  }
+}
+
+GET test?include_type_name=false
+--------------------------------------------------
+// CONSOLE
+
+which returns
+
+[source,js]
+--------------------------------------------------
+{
+    "test": {
+        "aliases": {},
+        "mappings": {
+            "properties": {
+                "foo": {
+                    "type": "keyword"
+                }
+            }
+        },
+        "settings": {
+            "index": {
+                "creation_date": "1547028674905",
+                "number_of_shards": "1",
+                "number_of_replicas": "1",
+                "uuid": "u1YpkPqLSqGIn3kNAvY8cA",
+                "version": {
+                    "created": ...
+                },
+                "provided_name": "test"
+            }
+        }
+    }
+}
+--------------------------------------------------
+// TESTRESPONSE[s/1547028674905/$body.test.settings.index.creation_date/]
+// TESTRESPONSE[s/u1YpkPqLSqGIn3kNAvY8cA/$body.test.settings.index.uuid/]
+// TESTRESPONSE[s/"created": \.\.\./"created": $body.test.settings.index.version.created/]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
@@ -13,6 +13,10 @@
         }
       },
       "params":{
+        "include_type_name": {
+          "type" : "boolean",
+          "description" : "Whether to add the type name to the response (default: false)"
+        },
         "local":{
           "type":"boolean",
           "description":"Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
@@ -53,6 +53,35 @@ setup:
   - is_true: test_index.mappings
 
 ---
+"Test include_type_name":
+  - skip:
+      version: " - 6.99.99"
+      reason: the include_type_name parameter is not backported to pre 7.0 versions yet
+
+  - do:
+      indices.get:
+        include_type_name: true
+        index: test_index
+
+  - is_true: test_index.mappings
+  - is_true: test_index.mappings.type_1
+
+  - do:
+      indices.get:
+        include_type_name: false
+        index: test_index
+
+  - is_true: test_index.mappings
+  - is_false: test_index.mappings.type_1
+
+  - do:
+      indices.get:
+        index: test_index
+
+  - is_true: test_index.mappings
+  - is_false: test_index.mappings.type_1
+
+---
 "Get index infos should work for wildcards":
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
@@ -92,7 +92,7 @@ setup:
   - is_true: test_index.aliases
   - is_true: test_index.settings
   - is_true: test_index_2.settings
-  - is_false: test_index_2.mappings
+  - is_true: test_index_2.mappings
   - is_true: test_index_2.aliases
 
 ---

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
@@ -92,7 +92,7 @@ setup:
   - is_true: test_index.aliases
   - is_true: test_index.settings
   - is_true: test_index_2.settings
-  - is_true: test_index_2.mappings
+  - is_false: test_index_2.mappings
   - is_true: test_index_2.aliases
 
 ---

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -310,7 +310,6 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
 
     private static ImmutableOpenMap<String, MappingMetaData> parseMappings(XContentParser parser) throws IOException {
         ImmutableOpenMap.Builder<String, MappingMetaData> indexMappings = ImmutableOpenMap.builder();
-        // We start at START_OBJECT since parseIndexEntry ensures that
         Map<String, Object> map = parser.map();
         if (map.isEmpty() == false) {
             indexMappings.put(MapperService.SINGLE_MAPPING_NAME, new MappingMetaData(MapperService.SINGLE_MAPPING_NAME, map));
@@ -334,7 +333,7 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
         return indexMappings.build();
     }
 
-    private static IndexEntry parseIndexEntry(XContentParser parser, boolean legacyWithTypes) throws IOException {
+    private static IndexEntry parseIndexEntry(XContentParser parser, boolean includeTypeName) throws IOException {
         List<AliasMetaData> indexAliases = null;
         ImmutableOpenMap<String, MappingMetaData> indexMappings = null;
         Settings indexSettings = null;
@@ -349,7 +348,7 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
                         indexAliases = parseAliases(parser);
                         break;
                     case "mappings":
-                        if (legacyWithTypes) {
+                        if (includeTypeName) {
                             indexMappings = parseMappingsWithTypes(parser);
                         } else {
                             indexMappings = parseMappings(parser);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -265,15 +265,18 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
                         }
                         builder.endObject();
                     } else {
-                        if (indexMappings != null && indexMappings.size() > 0) {
-                            builder.field("mappings");
-                            for (final ObjectObjectCursor<String, MappingMetaData> typeEntry : indexMappings) {
-                                builder.map(typeEntry.value.sourceAsMap());
+                        MappingMetaData mappings = null;
+                        for (final ObjectObjectCursor<String, MappingMetaData> typeEntry : indexMappings) {
+                            if (typeEntry.key.equals(MapperService.DEFAULT_MAPPING) == false) {
+                                assert mappings == null;
+                                mappings = typeEntry.value;
                             }
-                        } else {
-                            // we always want to output a mappings object, even if empty
-                            builder.startObject("mappings");
-                            builder.endObject();
+                            if (mappings == null) {
+                                // no mappings yet
+                                builder.startObject("mappings").endObject();
+                            } else {
+                                builder.field("mappings", mappings.sourceAsMap());
+                            }
                         }
                     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -265,17 +265,22 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
                         }
                         builder.endObject();
                     } else {
-                        MappingMetaData mappings = null;
-                        for (final ObjectObjectCursor<String, MappingMetaData> typeEntry : indexMappings) {
-                            if (typeEntry.key.equals(MapperService.DEFAULT_MAPPING) == false) {
-                                assert mappings == null;
-                                mappings = typeEntry.value;
-                            }
-                            if (mappings == null) {
-                                // no mappings yet
-                                builder.startObject("mappings").endObject();
-                            } else {
-                                builder.field("mappings", mappings.sourceAsMap());
+                        if (indexMappings.size() == 0) {
+                            // special case where there are no index mappings at all, we still want to output an empty object
+                            builder.startObject("mappings").endObject();
+                        } else {
+                            MappingMetaData mappings = null;
+                            for (final ObjectObjectCursor<String, MappingMetaData> typeEntry : indexMappings) {
+                                if (typeEntry.key.equals(MapperService.DEFAULT_MAPPING) == false) {
+                                    assert mappings == null;
+                                    mappings = typeEntry.value;
+                                }
+                                if (mappings == null) {
+                                    // no mappings yet
+                                    builder.startObject("mappings").endObject();
+                                } else {
+                                    builder.field("mappings", mappings.sourceAsMap());
+                                }
                             }
                         }
                     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
 
 /**
  * A response for a get index action.
@@ -253,7 +254,7 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
                     builder.endObject();
 
                     ImmutableOpenMap<String, MappingMetaData> indexMappings = mappings.get(index);
-                    boolean includeTypeName = params.paramAsBoolean("include_type_name", false);
+                    boolean includeTypeName = params.paramAsBoolean(INCLUDE_TYPE_NAME_PARAMETER, false);
                     if (includeTypeName) {
                         builder.startObject("mappings");
                         if (indexMappings != null) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -265,23 +265,18 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
                         }
                         builder.endObject();
                     } else {
-                        if (indexMappings.size() == 0) {
-                            // special case where there are no index mappings at all, we still want to output an empty object
+                        MappingMetaData mappings = null;
+                        for (final ObjectObjectCursor<String, MappingMetaData> typeEntry : indexMappings) {
+                            if (typeEntry.key.equals(MapperService.DEFAULT_MAPPING) == false) {
+                                assert mappings == null;
+                                mappings = typeEntry.value;
+                            }
+                        }
+                        if (mappings == null) {
+                            // no mappings yet
                             builder.startObject("mappings").endObject();
                         } else {
-                            MappingMetaData mappings = null;
-                            for (final ObjectObjectCursor<String, MappingMetaData> typeEntry : indexMappings) {
-                                if (typeEntry.key.equals(MapperService.DEFAULT_MAPPING) == false) {
-                                    assert mappings == null;
-                                    mappings = typeEntry.value;
-                                }
-                                if (mappings == null) {
-                                    // no mappings yet
-                                    builder.startObject("mappings").endObject();
-                                } else {
-                                    builder.field("mappings", mappings.sourceAsMap());
-                                }
-                            }
+                            builder.field("mappings", mappings.sourceAsMap());
                         }
                     }
 

--- a/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -62,7 +62,7 @@ public abstract class BaseRestHandler extends AbstractComponent implements RestH
      * Parameter that controls whether certain REST apis should include type names in their requests or responses.
      * Note: Support for this parameter will be removed after the transition perido to typeless APIs.
      */
-    protected static final String INCLUDE_TYPE_NAME_PARAMETER = "include_type_name";
+    public static final String INCLUDE_TYPE_NAME_PARAMETER = "include_type_name";
 
     protected BaseRestHandler(Settings settings) {
         // TODO drop settings from ctor

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
@@ -33,7 +33,10 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.HEAD;
@@ -46,6 +49,9 @@ public class RestGetIndicesAction extends BaseRestHandler {
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestGetIndicesAction.class));
     static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Using `include_type_name` in get indices requests is deprecated. "
             + "The parameter will be removed in the next major version.";
+
+    private static final Set<String> allowedResponseParameters = Collections.unmodifiableSet(Stream
+            .concat(Collections.singleton("include_type_name").stream(), Settings.FORMAT_PARAMS.stream()).collect(Collectors.toSet()));
 
     public RestGetIndicesAction(
             final Settings settings,
@@ -77,9 +83,12 @@ public class RestGetIndicesAction extends BaseRestHandler {
         return channel -> client.admin().indices().getIndex(getIndexRequest, new RestToXContentListener<>(channel));
     }
 
+    /**
+     * Parameters used for controlling the response and thus might not be consumed during
+     * preparation of the request execution in {@link BaseRestHandler#prepareRequest(RestRequest, NodeClient)}.
+     */
     @Override
     protected Set<String> responseParams() {
-        return Settings.FORMAT_PARAMS;
+        return allowedResponseParameters;
     }
-
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
@@ -50,8 +50,9 @@ public class RestGetIndicesAction extends BaseRestHandler {
     static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Using `include_type_name` in get indices requests is deprecated. "
             + "The parameter will be removed in the next major version.";
 
-    private static final Set<String> allowedResponseParameters = Collections.unmodifiableSet(Stream
-            .concat(Collections.singleton(INCLUDE_TYPE_NAME_PARAMETER).stream(), Settings.FORMAT_PARAMS.stream()).collect(Collectors.toSet()));
+    private static final Set<String> allowedResponseParameters = Collections
+            .unmodifiableSet(Stream.concat(Collections.singleton(INCLUDE_TYPE_NAME_PARAMETER).stream(), Settings.FORMAT_PARAMS.stream())
+                    .collect(Collectors.toSet()));
 
     public RestGetIndicesAction(
             final Settings settings,

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
@@ -51,7 +51,7 @@ public class RestGetIndicesAction extends BaseRestHandler {
             + "The parameter will be removed in the next major version.";
 
     private static final Set<String> allowedResponseParameters = Collections.unmodifiableSet(Stream
-            .concat(Collections.singleton("include_type_name").stream(), Settings.FORMAT_PARAMS.stream()).collect(Collectors.toSet()));
+            .concat(Collections.singleton(INCLUDE_TYPE_NAME_PARAMETER).stream(), Settings.FORMAT_PARAMS.stream()).collect(Collectors.toSet()));
 
     public RestGetIndicesAction(
             final Settings settings,

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
@@ -70,7 +70,7 @@ public class RestGetIndicesAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         // starting with 7.0 we don't include types by default in the response
-        if (request.hasParam("include_type_name")) {
+        if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER)) {
             deprecationLogger.deprecatedAndMaybeLog("get_indices_with_types", TYPES_DEPRECATION_MESSAGE);
         }
         final GetIndexRequest getIndexRequest = new GetIndexRequest();

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
@@ -20,8 +20,9 @@
 package org.elasticsearch.rest.action.admin.indices;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-import org.apache.logging.log4j.Logger;
+
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.support.IndicesOptions;

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
@@ -49,9 +49,11 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.action.admin.indices.get.GetIndexResponse.fromXContent;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.index.IndexSettings.INDEX_REFRESH_INTERVAL_SETTING;
+import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
 
 public class GetIndexResponseTests extends AbstractStreamableXContentTestCase<GetIndexResponse> {
 
@@ -209,11 +211,11 @@ public class GetIndexResponseTests extends AbstractStreamableXContentTestCase<Ge
         GetIndexResponse testInstance = this.createTestInstance(true);
         try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
             // this renders the response in the "old" format with types
-            testInstance.toXContent(builder, new ToXContent.MapParams(Collections.singletonMap("include_type_name", "true")));
+            testInstance.toXContent(builder, new ToXContent.MapParams(Collections.singletonMap(INCLUDE_TYPE_NAME_PARAMETER, "true")));
             BytesReference bytes = BytesReference.bytes(builder);
             XContentParser parser = createParser(JsonXContent.jsonXContent, bytes);
             // this parses the output expecting the "old" format with types
-            GetIndexResponse parsedInstance = GetIndexResponse.fromXContent(parser, true);
+            GetIndexResponse parsedInstance = fromXContent(parser, true);
             assertNotSame(parsedInstance, testInstance);
             assertEquals(testInstance, parsedInstance);
             assertEquals(testInstance.hashCode(), parsedInstance.hashCode());

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
@@ -72,10 +72,6 @@ public class GetIndexResponseTests extends AbstractStreamableXContentTestCase<Ge
 
     @Override
     protected GetIndexResponse createTestInstance() {
-        return createTestInstance(false);
-    }
-
-    private GetIndexResponse createTestInstance(boolean randomTypeName) {
         String[] indices = generateRandomStringArray(5, 5, false, false);
         ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetaData>> mappings = ImmutableOpenMap.builder();
         ImmutableOpenMap.Builder<String, List<AliasMetaData>> aliases = ImmutableOpenMap.builder();
@@ -86,7 +82,7 @@ public class GetIndexResponseTests extends AbstractStreamableXContentTestCase<Ge
         for (String index: indices) {
             // rarely have no types
             int typeCount = rarely() ? 0 : 1;
-            mappings.put(index, GetMappingsResponseTests.createMappingsForIndex(typeCount, randomTypeName));
+            mappings.put(index, GetMappingsResponseTests.createMappingsForIndex(typeCount, false));
 
             List<AliasMetaData> aliasMetaDataList = new ArrayList<>();
             int aliasesNum = randomIntBetween(0, 3);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
@@ -31,11 +31,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.RandomCreateIndexGenerator;
 import org.elasticsearch.test.AbstractStreamableXContentTestCase;
 import org.junit.Assert;
@@ -49,11 +45,9 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
 
-import static org.elasticsearch.action.admin.indices.get.GetIndexResponse.fromXContent;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.index.IndexSettings.INDEX_REFRESH_INTERVAL_SETTING;
-import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
 
 public class GetIndexResponseTests extends AbstractStreamableXContentTestCase<GetIndexResponse> {
 
@@ -202,24 +196,4 @@ public class GetIndexResponseTests extends AbstractStreamableXContentTestCase<Ge
 
         Assert.assertEquals(TEST_6_3_0_RESPONSE_BYTES, base64OfResponse);
     }
-
-    /**
-     * test that the old response format with types can still be parsed with the special parser method
-     * when output is rendered with types
-     */
-    public void testFromXContentWithTypes() throws IOException {
-        GetIndexResponse testInstance = this.createTestInstance(true);
-        try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
-            // this renders the response in the "old" format with types
-            testInstance.toXContent(builder, new ToXContent.MapParams(Collections.singletonMap(INCLUDE_TYPE_NAME_PARAMETER, "true")));
-            BytesReference bytes = BytesReference.bytes(builder);
-            XContentParser parser = createParser(JsonXContent.jsonXContent, bytes);
-            // this parses the output expecting the "old" format with types
-            GetIndexResponse parsedInstance = fromXContent(parser, true);
-            assertNotSame(parsedInstance, testInstance);
-            assertEquals(testInstance, parsedInstance);
-            assertEquals(testInstance.hashCode(), parsedInstance.hashCode());
-        }
-    }
-
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.RandomCreateIndexGenerator;
 import org.elasticsearch.test.AbstractStreamableXContentTestCase;
 import org.junit.Assert;
@@ -72,6 +73,10 @@ public class GetIndexResponseTests extends AbstractStreamableXContentTestCase<Ge
 
     @Override
     protected GetIndexResponse createTestInstance() {
+        return createTestInstance(randomBoolean());
+    }
+
+    private GetIndexResponse createTestInstance(boolean randomTypeName) {
         String[] indices = generateRandomStringArray(5, 5, false, false);
         ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetaData>> mappings = ImmutableOpenMap.builder();
         ImmutableOpenMap.Builder<String, List<AliasMetaData>> aliases = ImmutableOpenMap.builder();
@@ -82,7 +87,7 @@ public class GetIndexResponseTests extends AbstractStreamableXContentTestCase<Ge
         for (String index: indices) {
             // rarely have no types
             int typeCount = rarely() ? 0 : 1;
-            mappings.put(index, GetMappingsResponseTests.createMappingsForIndex(typeCount, false));
+            mappings.put(index, GetMappingsResponseTests.createMappingsForIndex(typeCount, randomTypeName));
 
             List<AliasMetaData> aliasMetaDataList = new ArrayList<>();
             int aliasesNum = randomIntBetween(0, 3);
@@ -103,6 +108,12 @@ public class GetIndexResponseTests extends AbstractStreamableXContentTestCase<Ge
         return new GetIndexResponse(
             indices, mappings.build(), aliases.build(), settings.build(), defaultSettings.build()
         );
+    }
+
+    @Override
+    protected GetIndexResponse createXContextTestInstance(XContentType xContentType) {
+        // don't use random type names for XContent roundtrip tests because we cannot parse them back anymore
+        return createTestInstance(false);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesActionTests.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
 import static org.mockito.Mockito.mock;
 
 public class RestGetIndicesActionTests extends ESTestCase {
@@ -39,7 +40,7 @@ public class RestGetIndicesActionTests extends ESTestCase {
      */
     public void testIncludeTypeNamesWarning() throws IOException {
         Map<String, String> params = new HashMap<>();
-        params.put("include_type_name", randomFrom("true", "false"));
+        params.put(INCLUDE_TYPE_NAME_PARAMETER, randomFrom("true", "false"));
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(RestRequest.Method.GET)
             .withPath("/some_index")

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesActionTests.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.indices;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+
+public class RestGetIndicesActionTests extends ESTestCase {
+
+    /**
+     * Test that setting the "include_type_name" parameter raises a warning
+     */
+    public void testIncludeTypeNamesWarning() throws IOException {
+        Map<String, String> params = new HashMap<>();
+        params.put("include_type_name", randomFrom("true", "false"));
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.GET)
+            .withPath("/some_index")
+            .withParams(params)
+            .build();
+
+        RestGetIndicesAction handler = new RestGetIndicesAction(Settings.EMPTY, mock(RestController.class));
+        handler.prepareRequest(request, mock(NodeClient.class));
+        assertWarnings(RestGetIndicesAction.TYPES_DEPRECATION_MESSAGE);
+
+        // the same request without the parameter should pass without warning
+        request = new FakeRestRequest.Builder(xContentRegistry())
+                .withMethod(RestRequest.Method.GET)
+                .withPath("/some_index")
+                .build();
+        handler.prepareRequest(request, mock(NodeClient.class));
+    }
+}


### PR DESCRIPTION
This change adds support for the 'include_type_name' parameter for the
indices.get API. This parameter, which defaults to `false` starting in 7.0,
changes the response to not include the indices type names any longer.

If the parameter is set in the request, we additionally emit a deprecation
warning since using the parameter should be only temporarily necessary while
adapting to the new response format and we will remove it with the next major
version.