### PR TITLE
Remove deprecated PutIndexTemplateRequestBuilder#setTemplate

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestBuilder.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -40,16 +39,6 @@ public class PutIndexTemplateRequestBuilder
 
     public PutIndexTemplateRequestBuilder(ElasticsearchClient client, PutIndexTemplateAction action, String name) {
         super(client, action, new PutIndexTemplateRequest(name));
-    }
-
-    /**
-     * Sets the match expression that will be used to match on indices created.
-     *
-     * @deprecated Replaced by {@link #setPatterns(List)}
-     */
-    @Deprecated
-    public PutIndexTemplateRequestBuilder setTemplate(String indexPattern) {
-        return setPatterns(Collections.singletonList(indexPattern));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.gateway;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
+
 import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
@@ -374,7 +375,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
 
         logger.info("--> add some metadata and additional template");
         client().admin().indices().preparePutTemplate("template_1")
-            .setTemplate("te*")
+            .setPatterns(Collections.singletonList("te*"))
             .setOrder(0)
             .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
                 .startObject("field1").field("type", "text").field("store", true).endObject()

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/PermissionPrecedenceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/PermissionPrecedenceTests.java
@@ -91,7 +91,7 @@ public class PermissionPrecedenceTests extends SecurityIntegTestCase {
             .filterWithHeader(Collections.singletonMap(UsernamePasswordToken.BASIC_AUTH_HEADER,
                     basicAuthHeaderValue(transportClientUsername(), transportClientPassword())))
             .admin().indices().preparePutTemplate("template1")
-            .setTemplate("test_*")
+            .setPatterns(Collections.singletonList("test_*"))
             .get();
         assertAcked(putResponse);
 
@@ -105,7 +105,7 @@ public class PermissionPrecedenceTests extends SecurityIntegTestCase {
         Map<String, String> auth = Collections.singletonMap(UsernamePasswordToken.BASIC_AUTH_HEADER, basicAuthHeaderValue("user",
                 transportClientPassword()));
         assertThrowsAuthorizationException(client.filterWithHeader(auth).admin().indices().preparePutTemplate("template1")
-                .setTemplate("test_*")::get, PutIndexTemplateAction.NAME, "user");
+                .setPatterns(Collections.singletonList("test_*"))::get, PutIndexTemplateAction.NAME, "user");
 
         Map<String, String> headers = Collections.singletonMap(UsernamePasswordToken.BASIC_AUTH_HEADER, basicAuthHeaderValue("user",
                 new SecureString("test123")));


### PR DESCRIPTION
The method has been removed since 6.0, there is a direct replacement and it is
only used in tests still.