### PR TITLE
Remove deprecated CardinalityAggregationBuilder#rehash method

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
@@ -122,14 +122,6 @@ public final class CardinalityAggregationBuilder
         return precisionThreshold;
     }
 
-    /**
-     * @deprecated no replacement - values will always be rehashed
-     */
-    @Deprecated
-    public void rehash(boolean rehash) {
-        // Deprecated all values are already rehashed so do nothing
-    }
-
     @Override
     protected CardinalityAggregatorFactory innerBuild(SearchContext context, ValuesSourceConfig<ValuesSource> config,
             AggregatorFactory<?> parent, Builder subFactoriesBuilder) throws IOException {


### PR DESCRIPTION
It has been deprecated since at least 6.0, is a no-op and unused in the rest of
our code.