### PR TITLE
Fix suite scope random initialization

### DIFF
--- a/test/framework/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterIT.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/SuiteScopeClusterIT.java
@@ -41,7 +41,6 @@ public class SuiteScopeClusterIT extends ESIntegTestCase {
     @Test
     @SuppressForbidden(reason = "repeat is a feature here")
     @Repeat(iterations = 10, useConstantSeed = true)
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/36202")
     public void testReproducible() throws IOException {
         if (ITER++ == 0) {
             CLUSTER_SEED = cluster().seed();


### PR DESCRIPTION
The initialization of a suite scope cluster had some side-effects on
subsequent runs which causes issues when tests must be reproduced.
This moves the suite scope initialization to a private random context.

Closes #36202