### PR TITLE
Option to use endpoints starting with _license

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetBasicStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetBasicStatus.java
@@ -19,6 +19,7 @@ public class RestGetBasicStatus extends XPackRestHandler {
     RestGetBasicStatus(Settings settings, RestController controller) {
         super(settings);
         controller.registerHandler(GET, URI_BASE + "/license/basic_status", this);
+        controller.registerHandler(GET, "/_license/basic_status", this);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartBasicLicense.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartBasicLicense.java
@@ -21,6 +21,7 @@ public class RestPostStartBasicLicense extends XPackRestHandler {
     RestPostStartBasicLicense(Settings settings, RestController controller) {
         super(settings);
         controller.registerHandler(POST, URI_BASE + "/license/start_basic", this);
+        controller.registerHandler(POST, "/_license/start_basic", this);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartTrialLicense.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartTrialLicense.java
@@ -25,6 +25,7 @@ public class RestPostStartTrialLicense extends XPackRestHandler {
     RestPostStartTrialLicense(Settings settings, RestController controller) {
         super(settings);
         controller.registerHandler(POST, URI_BASE + "/license/start_trial", this);
+        controller.registerHandler(POST, "/_license/start_trial", this);
     }
 
     @Override


### PR DESCRIPTION
This commit adds support for the /_license endpoints in 6.x for
the license related endpoints that were not covered in #35974

Resolves #37139