### PR TITLE
[DOCS] Rolling upgrade with old internal indices

### DIFF
--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -18,6 +18,12 @@ you can do a rolling upgrade you must encrypt the internode-communication with
 SSL/TLS, which requires a full cluster restart. For more information about this
 requirement and the associated bootstrap check, see <<bootstrap-checks-tls>>.
 
+WARNING: The format used for the internal indices used by Kibana and {xpack}
+has changed in 6.x. These internal indices have to be
+{stack-ref}/upgrading-elastic-stack.html#upgrade-internal-indices[upgraded]
+before the rolling upgrade procedure can start, otherwise upgraded nodes will
+refuse to join the cluster.
+
 To perform a rolling upgrade:
 
 . *Disable shard allocation*.

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -19,9 +19,9 @@ SSL/TLS, which requires a full cluster restart. For more information about this
 requirement and the associated bootstrap check, see <<bootstrap-checks-tls>>.
 
 WARNING: The format used for the internal indices used by Kibana and {xpack}
-has changed in 6.x. These internal indices have to be
-{stack-ref}/upgrading-elastic-stack.html#upgrade-internal-indices[upgraded]
-before the rolling upgrade procedure can start, otherwise upgraded nodes will
+has changed in 6.x. When upgrading from 5.6 to 6.x, these internal indices have
+to be {stack-ref}/upgrading-elastic-stack.html#upgrade-internal-indices[upgraded]
+before the rolling upgrade procedure can start. Otherwise the upgraded node will
 refuse to join the cluster.
 
 To perform a rolling upgrade:


### PR DESCRIPTION
[Upgrading the Elastic Stack](https://www.elastic.co/guide/en/elastic-stack/6.5/upgrading-elastic-stack.html#upgrading-elastic-stack) perfectly documents the process to upgrade ES from 5 to 6 when internal indices are present. However, the rolling upgrade docs do not mention anything about internal indices.

 This adds a *warning* in the rolling upgrade procedure, highlighting that internal indices should be upgraded before the rolling upgrade procedure can be started.


Closes https://github.com/elastic/elasticsearch/issues/36984