### PR TITLE
Removing unused methods in Numbers class

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/Numbers.java
+++ b/server/src/main/java/org/elasticsearch/common/Numbers.java
@@ -33,48 +33,6 @@ public final class Numbers {
     private static final BigInteger MIN_LONG_VALUE = BigInteger.valueOf(Long.MIN_VALUE);
 
     private Numbers() {
-
-    }
-
-    /**
-     * Converts a byte array to an short.
-     *
-     * @param arr The byte array to convert to an short
-     * @return The int converted
-     */
-    public static short bytesToShort(byte[] arr) {
-        return (short) (((arr[0] & 0xff) << 8) | (arr[1] & 0xff));
-    }
-
-    public static short bytesToShort(BytesRef bytes) {
-        return (short) (((bytes.bytes[bytes.offset] & 0xff) << 8) | (bytes.bytes[bytes.offset + 1] & 0xff));
-    }
-
-    /**
-     * Converts a byte array to an int.
-     *
-     * @param arr The byte array to convert to an int
-     * @return The int converted
-     */
-    public static int bytesToInt(byte[] arr) {
-        return (arr[0] << 24) | ((arr[1] & 0xff) << 16) | ((arr[2] & 0xff) << 8) | (arr[3] & 0xff);
-    }
-
-    public static int bytesToInt(BytesRef bytes) {
-        return (bytes.bytes[bytes.offset] << 24) | ((bytes.bytes[bytes.offset + 1] & 0xff) << 16) |
-            ((bytes.bytes[bytes.offset + 2] & 0xff) << 8) | (bytes.bytes[bytes.offset + 3] & 0xff);
-    }
-
-    /**
-     * Converts a byte array to a long.
-     *
-     * @param arr The byte array to convert to a long
-     * @return The long converter
-     */
-    public static long bytesToLong(byte[] arr) {
-        int high = (arr[0] << 24) | ((arr[1] & 0xff) << 16) | ((arr[2] & 0xff) << 8) | (arr[3] & 0xff);
-        int low = (arr[4] << 24) | ((arr[5] & 0xff) << 16) | ((arr[6] & 0xff) << 8) | (arr[7] & 0xff);
-        return (((long) high) << 32) | (low & 0x0ffffffffL);
     }
 
     public static long bytesToLong(BytesRef bytes) {
@@ -85,40 +43,6 @@ public final class Numbers {
         return (((long) high) << 32) | (low & 0x0ffffffffL);
     }
 
-    /**
-     * Converts a byte array to float.
-     *
-     * @param arr The byte array to convert to a float
-     * @return The float converted
-     */
-    public static float bytesToFloat(byte[] arr) {
-        return Float.intBitsToFloat(bytesToInt(arr));
-    }
-
-    public static float bytesToFloat(BytesRef bytes) {
-        return Float.intBitsToFloat(bytesToInt(bytes));
-    }
-
-    /**
-     * Converts a byte array to double.
-     *
-     * @param arr The byte array to convert to a double
-     * @return The double converted
-     */
-    public static double bytesToDouble(byte[] arr) {
-        return Double.longBitsToDouble(bytesToLong(arr));
-    }
-
-    public static double bytesToDouble(BytesRef bytes) {
-        return Double.longBitsToDouble(bytesToLong(bytes));
-    }
-
-    /**
-     * Converts an int to a byte array.
-     *
-     * @param val The int to convert to a byte array
-     * @return The byte array converted
-     */
     public static byte[] intToBytes(int val) {
         byte[] arr = new byte[4];
         arr[0] = (byte) (val >>> 24);
@@ -158,16 +82,6 @@ public final class Numbers {
         arr[6] = (byte) (val >>> 8);
         arr[7] = (byte) (val);
         return arr;
-    }
-
-    /**
-     * Converts a float to a byte array.
-     *
-     * @param val The float to convert to a byte array
-     * @return The byte array converted
-     */
-    public static byte[] floatToBytes(float val) {
-        return intToBytes(Float.floatToRawIntBits(val));
     }
 
     /**


### PR DESCRIPTION
Remove several unused helper methods. Most of them are one-liners and should be easier to
be used from the corresponding primitive wrapper classes. The bytes array conversion methods
are unused as well, it should be easy to re-create them if needed.