### PR TITLE
Fix expired token message in Exception header

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -148,7 +148,7 @@ public final class TokenService {
     private static final int VERSION_BYTES = 4;
     private static final String ENCRYPTION_CIPHER = "AES/GCM/NoPadding";
     private static final String EXPIRED_TOKEN_WWW_AUTH_VALUE = "Bearer realm=\"" + XPackField.SECURITY +
-            "\", error=\"invalid_token\", error_description=\"The access token expired\"";
+            "\", error=\"token expired\", error_description=\"The access token expired\"";
     private static final String MALFORMED_TOKEN_WWW_AUTH_VALUE = "Bearer realm=\"" + XPackField.SECURITY +
             "\", error=\"invalid_token\", error_description=\"The access token is malformed\"";
     private static final String TYPE = "doc";

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
@@ -227,7 +227,7 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
         ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(request));
         assertEquals(401, e.getResponse().getStatusLine().getStatusCode());
         Response response = e.getResponse();
-        assertEquals("Bearer realm=\"security\", error=\"invalid_token\", error_description=\"The access token expired\"",
+        assertEquals("Bearer realm=\"security\", error=\"token expired\", error_description=\"The access token expired\"",
                 response.getHeader("WWW-Authenticate"));
     }
 


### PR DESCRIPTION
We're adding a WWW-Authenticate header to indicate the token is
expired. This commit fixes the error message we return as part of
this.

Resolves https://github.com/elastic/kibana/issues/27919