### PR TITLE
Compatability mode for forbidden APIs for Java 12

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -123,8 +123,14 @@ class PrecommitTasks {
         project.tasks.withType(CheckForbiddenApis) {
             dependsOn(buildResources)
             targetCompatibility = project.runtimeJavaVersion >= JavaVersion.VERSION_1_9 ?
-                    project.runtimeJavaVersion.getMajorVersion() :
-                    project.runtimeJavaVersion
+                    project.runtimeJavaVersion.getMajorVersion() : project.runtimeJavaVersion
+            if (project.runtimeJavaVersion > JavaVersion.VERSION_11) {
+                doLast {
+                    println "Forbidden APIs does not support java version past 11. Will use the signatures from 11 for " +
+                            project.runtimeJavaVersion
+                }
+                targetCompatibility = JavaVersion.VERSION_11.getMajorVersion()
+            }
             bundledSignatures = [
                     "jdk-unsafe", "jdk-deprecated", "jdk-non-portable", "jdk-system-out"
             ]

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -126,8 +126,10 @@ class PrecommitTasks {
                     project.runtimeJavaVersion.getMajorVersion() : project.runtimeJavaVersion
             if (project.runtimeJavaVersion > JavaVersion.VERSION_11) {
                 doLast {
-                    println "Forbidden APIs does not support java version past 11. Will use the signatures from 11 for " +
+                    project.logger.info(
+                            "Forbidden APIs does not support java version past 11. Will use the signatures from 11 for ",
                             project.runtimeJavaVersion
+                    )
                 }
                 targetCompatibility = JavaVersion.VERSION_11.getMajorVersion()
             }


### PR DESCRIPTION
Limit the maximum `targetVersion` we set `forbiddenApis` to. No support for Java 12 yet.
Closes #37007.