### PR TITLE
[Tests] Change cluster scope in CorruptedFileIT and FlushIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/test/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -107,7 +107,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST)
 public class CorruptedFileIT extends ESIntegTestCase {
 
     @Override

--- a/server/src/test/java/org/elasticsearch/indices/flush/FlushIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/flush/FlushIT.java
@@ -64,6 +64,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST)
 public class FlushIT extends ESIntegTestCase {
 
     public void testWaitIfOngoing() throws InterruptedException {


### PR DESCRIPTION
These tests failed on CI multiple times in the past weeks because they use a test cluster with a  `SUITE` scope that recreates nodes between tests. With such a scope, nodes can be recreated in between test executions and can inherit a node id from a previous test execution, while they are assigned a random data path. With the successive node recreations it is possible that a newly recreated node shares the same node id (but different data path) as a non recreated node.

This commit changes the cluster scope of the CorruptedFileIT and FlushIT tests which often fail.

The failure is reproducable with : 
```
./gradlew :server:integTest -Dtests.seed=EF3A50C225CF377 -Dtests.class=org.elasticsearch.index.store.CorruptedFileIT -Dtests.security.manager=true -Dtests.locale=th-TH-u-nu-thai-x-lvariant-TH -Dtests.timezone=America/Rio_Branco -Dcompiler.java=11 -Druntime.java=8 
```

It does not fix the underlying issue of data paths begin randomly assigned by InternalTestCluster.
