### PR TITLE
[DOCS] More info on disabling swap

### DIFF
--- a/docs/reference/setup/sysconfig/swap.asciidoc
+++ b/docs/reference/setup/sysconfig/swap.asciidoc
@@ -28,9 +28,9 @@ On Linux systems, you can disable swap temporarily by running:
 sudo swapoff -a
 --------------
 
-This will cause an amount of IO workload as the contents of swap is copied 
-back into memory, after which swap will be disabled. This doesn't require
-a restart of Elasticsearch.
+This will cause an I/O spike as the contents of swap is copied back into memory,
+after which swap will be disabled. This doesn't require a restart of 
+Elasticsearch.
 
 To disable it permanently, you will need to edit the `/etc/fstab` file and
 comment out any lines that contain the word `swap`.

--- a/docs/reference/setup/sysconfig/swap.asciidoc
+++ b/docs/reference/setup/sysconfig/swap.asciidoc
@@ -28,9 +28,7 @@ On Linux systems, you can disable swap temporarily by running:
 sudo swapoff -a
 --------------
 
-This will cause an I/O spike as the contents of swap is copied back into memory,
-after which swap will be disabled. This doesn't require a restart of 
-Elasticsearch.
+This doesn't require a restart of Elasticsearch.
 
 To disable it permanently, you will need to edit the `/etc/fstab` file and
 comment out any lines that contain the word `swap`.

--- a/docs/reference/setup/sysconfig/swap.asciidoc
+++ b/docs/reference/setup/sysconfig/swap.asciidoc
@@ -28,6 +28,10 @@ On Linux systems, you can disable swap temporarily by running:
 sudo swapoff -a
 --------------
 
+This will cause an amount of IO workload as the contents of swap is copied 
+back into memory, after which swap will be disabled. This doesn't require
+a restart of Elasticsearch.
+
 To disable it permanently, you will need to edit the `/etc/fstab` file and
 comment out any lines that contain the word `swap`.
 


### PR DESCRIPTION
Let users know that disabling swap might create some IO and that an Elasticsearch restart isn't required to complete this process.