### PR TITLE
[TEST] Unmute 60_ml_config_migration rolling upgrade

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/60_ml_config_migration.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/60_ml_config_migration.yml
@@ -8,9 +8,6 @@ setup:
 
 ---
 "Test old cluster jobs and datafeeds and delete them":
-  - skip:
-      version: "all"
-      reason: "@AwaitsFix: https://github.com/elastic/elasticsearch/issues/36810"
 
   - do:
       xpack.ml.get_jobs:


### PR DESCRIPTION
This reverts commit d7efadcc47862ae2910f7c82c95c45853d49e446

The test should now work following the change made in #37227

Closes #36810