### PR TITLE
[FEATURE][ML] Add checksum checks on dataframe result joining

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/DataFrameDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/DataFrameDataExtractor.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.ml.datafeed.extractor.fields.ExtractedField;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -239,8 +240,8 @@ public class DataFrameDataExtractor {
             return values == null;
         }
 
-        public String getIdHash() {
-            return String.valueOf(hit.getId().hashCode());
+        public int getChecksum() {
+            return Arrays.hashCode(values);
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/DataFrameDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/DataFrameDataExtractor.java
@@ -238,5 +238,9 @@ public class DataFrameDataExtractor {
         public boolean shouldSkip() {
             return values == null;
         }
+
+        public String getIdHash() {
+            return String.valueOf(hit.getId().hashCode());
+        }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/DataFrameDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/DataFrameDataExtractorFactory.java
@@ -109,7 +109,10 @@ public class DataFrameDataExtractorFactory {
         Set<String> fields = fieldCapabilitiesResponse.get().keySet();
         fields.removeAll(IGNORE_FIELDS);
         removeFieldsWithIncompatibleTypes(fields, fieldCapabilitiesResponse);
-        ExtractedFields extractedFields = ExtractedFields.build(new ArrayList<>(fields), Collections.emptySet(), fieldCapabilitiesResponse)
+        List<String> sortedFields = new ArrayList<>(fields);
+        // We sort the fields to ensure the checksum for each document is deterministic
+        Collections.sort(sortedFields);
+        ExtractedFields extractedFields = ExtractedFields.build(sortedFields, Collections.emptySet(), fieldCapabilitiesResponse)
                 .filterFields(ExtractedField.ExtractionMethod.DOC_VALUE);
         if (extractedFields.getAllFields().isEmpty()) {
             throw ExceptionsHelper.badRequestException("No compatible fields could be detected");

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsProcessManager.java
@@ -78,7 +78,7 @@ public class AnalyticsProcessManager {
     }
 
     private void writeDataRows(DataFrameDataExtractor dataExtractor, AnalyticsProcess process) throws IOException {
-        // The extra fields are for the id hash and the control field (should be an empty string)
+        // The extra fields are for the doc hash and the control field (should be an empty string)
         String[] record = new String[dataExtractor.getFieldNames().size() + 2];
         // The value of the control field should be an empty string for data frame rows
         record[record.length - 1] = "";
@@ -90,7 +90,7 @@ public class AnalyticsProcessManager {
                     if (row.shouldSkip() == false) {
                         String[] rowValues = row.getValues();
                         System.arraycopy(rowValues, 0, record, 0, rowValues.length);
-                        record[record.length - 2] = row.getIdHash();
+                        record[record.length - 2] = String.valueOf(row.getChecksum());
                         process.writeRecord(record);
                     }
                 }
@@ -102,7 +102,7 @@ public class AnalyticsProcessManager {
         List<String> fieldNames = dataExtractor.getFieldNames();
 
         // We add 2 extra fields, both named dot:
-        //   - the document id hash
+        //   - the document hash
         //   - the control message
         String[] headerRecord = new String[fieldNames.size() + 2];
         for (int i = 0; i < fieldNames.size(); i++) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsProcessManager.java
@@ -78,8 +78,8 @@ public class AnalyticsProcessManager {
     }
 
     private void writeDataRows(DataFrameDataExtractor dataExtractor, AnalyticsProcess process) throws IOException {
-        // The extra field is the control field (should be an empty string)
-        String[] record = new String[dataExtractor.getFieldNames().size() + 1];
+        // The extra fields are for the id hash and the control field (should be an empty string)
+        String[] record = new String[dataExtractor.getFieldNames().size() + 2];
         // The value of the control field should be an empty string for data frame rows
         record[record.length - 1] = "";
 
@@ -90,6 +90,7 @@ public class AnalyticsProcessManager {
                     if (row.shouldSkip() == false) {
                         String[] rowValues = row.getValues();
                         System.arraycopy(rowValues, 0, record, 0, rowValues.length);
+                        record[record.length - 2] = row.getIdHash();
                         process.writeRecord(record);
                     }
                 }
@@ -99,11 +100,16 @@ public class AnalyticsProcessManager {
 
     private void writeHeaderRecord(DataFrameDataExtractor dataExtractor, AnalyticsProcess process) throws IOException {
         List<String> fieldNames = dataExtractor.getFieldNames();
-        String[] headerRecord = new String[fieldNames.size() + 1];
+
+        // We add 2 extra fields, both named dot:
+        //   - the document id hash
+        //   - the control message
+        String[] headerRecord = new String[fieldNames.size() + 2];
         for (int i = 0; i < fieldNames.size(); i++) {
             headerRecord[i] = fieldNames.get(i);
         }
-        // The field name of the control field is dot
+
+        headerRecord[headerRecord.length - 2] = ".";
         headerRecord[headerRecord.length - 1] = ".";
         process.writeRecord(headerRecord);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsResult.java
@@ -17,27 +17,27 @@ import java.util.Objects;
 public class AnalyticsResult implements ToXContentObject {
 
     public static final ParseField TYPE = new ParseField("analytics_result");
-    public static final ParseField ID_HASH = new ParseField("id_hash");
+    public static final ParseField CHECKSUM = new ParseField("checksum");
     public static final ParseField RESULTS = new ParseField("results");
 
     static final ConstructingObjectParser<AnalyticsResult, Void> PARSER = new ConstructingObjectParser<>(TYPE.getPreferredName(),
-            a -> new AnalyticsResult((String) a[0], (Map<String, Object>) a[1]));
+            a -> new AnalyticsResult((Integer) a[0], (Map<String, Object>) a[1]));
 
     static {
-        PARSER.declareString(ConstructingObjectParser.constructorArg(), ID_HASH);
+        PARSER.declareInt(ConstructingObjectParser.constructorArg(), CHECKSUM);
         PARSER.declareObject(ConstructingObjectParser.constructorArg(), (p, context) -> p.map(), RESULTS);
     }
 
-    private final String idHash;
+    private final int checksum;
     private final Map<String, Object> results;
 
-    public AnalyticsResult(String idHash, Map<String, Object> results) {
-        this.idHash = Objects.requireNonNull(idHash);
+    public AnalyticsResult(int checksum, Map<String, Object> results) {
+        this.checksum = Objects.requireNonNull(checksum);
         this.results = Objects.requireNonNull(results);
     }
 
-    public String getIdHash() {
-        return idHash;
+    public int getChecksum() {
+        return checksum;
     }
 
     public Map<String, Object> getResults() {
@@ -47,7 +47,7 @@ public class AnalyticsResult implements ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(ID_HASH.getPreferredName(), idHash);
+        builder.field(CHECKSUM.getPreferredName(), checksum);
         builder.field(RESULTS.getPreferredName(), results);
         builder.endObject();
         return builder;
@@ -63,11 +63,11 @@ public class AnalyticsResult implements ToXContentObject {
         }
 
         AnalyticsResult that = (AnalyticsResult) other;
-        return Objects.equals(idHash, that.idHash) && Objects.equals(results, that.results);
+        return checksum == that.checksum && Objects.equals(results, that.results);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(idHash, results);
+        return Objects.hash(checksum, results);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsResultProcessor.java
@@ -96,7 +96,7 @@ public class AnalyticsResultProcessor {
                 continue;
             }
             AnalyticsResult result = currentResults.get(i);
-            checkIdHashesMatch(row, result);
+            checkChecksumsMatch(row, result);
 
             SearchHit hit = row.getHit();
             Map<String, Object> source = new LinkedHashMap(hit.getSourceAsMap());
@@ -115,13 +115,13 @@ public class AnalyticsResultProcessor {
         }
     }
 
-    private void checkIdHashesMatch(DataFrameDataExtractor.Row row, AnalyticsResult result) {
-        if (row.getIdHash().equals(result.getIdHash()) == false) {
-            StringBuilder msg = new StringBuilder();
-            msg.append("Detected id hash mismatch for document with id [" + row.getHit().getId() + "]; ");
-            msg.append("expected hash was [" + row.getIdHash() + "] but result had [" + result.getIdHash() + "]; ");
-            msg.append("this implies that the data frame index copy has been modified externally while analysis was running");
-            throw new IllegalStateException(msg.toString());
+    private void checkChecksumsMatch(DataFrameDataExtractor.Row row, AnalyticsResult result) {
+        if (row.getChecksum() != result.getChecksum()) {
+            String msg = "Detected checksum mismatch for document with id [" + row.getHit().getId() + "]; ";
+            msg += "expected [" + row.getChecksum() + "] but result had [" + result.getChecksum() + "]; ";
+            msg += "this implies the data frame index was modified while the analysis was running. ";
+            msg += "We rely on this index being immutable during a running analysis and so the results will be unreliable.";
+            throw new IllegalStateException(msg);
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsResultProcessor.java
@@ -96,6 +96,8 @@ public class AnalyticsResultProcessor {
                 continue;
             }
             AnalyticsResult result = currentResults.get(i);
+            checkIdHashesMatch(row, result);
+
             SearchHit hit = row.getHit();
             Map<String, Object> source = new LinkedHashMap(hit.getSourceAsMap());
             source.putAll(result.getResults());
@@ -110,6 +112,16 @@ public class AnalyticsResultProcessor {
                 LOGGER.error("Failures while writing data frame");
                 // TODO Better error handling
             }
+        }
+    }
+
+    private void checkIdHashesMatch(DataFrameDataExtractor.Row row, AnalyticsResult result) {
+        if (row.getIdHash().equals(result.getIdHash()) == false) {
+            StringBuilder msg = new StringBuilder();
+            msg.append("Detected id hash mismatch for document with id [" + row.getHit().getId() + "]; ");
+            msg.append("expected hash was [" + row.getIdHash() + "] but result had [" + result.getIdHash() + "]; ");
+            msg.append("this implies that the data frame index copy has been modified externally while analysis was running");
+            throw new IllegalStateException(msg.toString());
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsResultProcessor.java
@@ -119,7 +119,7 @@ public class AnalyticsResultProcessor {
         if (row.getChecksum() != result.getChecksum()) {
             String msg = "Detected checksum mismatch for document with id [" + row.getHit().getId() + "]; ";
             msg += "expected [" + row.getChecksum() + "] but result had [" + result.getChecksum() + "]; ";
-            msg += "this implies the data frame index was modified while the analysis was running. ";
+            msg += "this implies the data frame index [" + row.getHit().getIndex() + "] was modified while the analysis was running. ";
             msg += "We rely on this index being immutable during a running analysis and so the results will be unreliable.";
             throw new IllegalStateException(msg);
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/process/NativeAnalyticsProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/analytics/process/NativeAnalyticsProcessFactory.java
@@ -45,8 +45,8 @@ public class NativeAnalyticsProcessFactory implements AnalyticsProcessFactory {
         ProcessPipes processPipes = new ProcessPipes(env, NAMED_PIPE_HELPER, AnalyticsBuilder.ANALYTICS, jobId,
                 true, false, true, true, false, false);
 
-        // The extra 1 is the control field
-        int numberOfFields = analyticsProcessConfig.cols() + 1;
+        // The extra 2 are for the checksum and the control field
+        int numberOfFields = analyticsProcessConfig.cols() + 2;
 
         createNativeProcess(jobId, analyticsProcessConfig, filesToDelete, processPipes);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsResultProcessorTests.java
@@ -63,13 +63,13 @@ public class AnalyticsResultProcessorTests extends ESTestCase {
 
         String dataDoc = "{\"f_1\": \"foo\", \"f_2\": 42.0}";
         String[] dataValues = {"42.0"};
-        DataFrameDataExtractor.Row row = newRow(newHit("1", dataDoc), dataValues);
+        DataFrameDataExtractor.Row row = newRow(newHit(dataDoc), dataValues, 1);
         givenSingleDataFrameBatch(Arrays.asList(row));
 
         Map<String, Object> resultFields = new HashMap<>();
         resultFields.put("a", "1");
         resultFields.put("b", "2");
-        AnalyticsResult result = new AnalyticsResult(String.valueOf("1".hashCode()), resultFields);
+        AnalyticsResult result = new AnalyticsResult(1, resultFields);
         givenProcessResults(Arrays.asList(result));
 
         AnalyticsResultProcessor resultProcessor = createResultProcessor();
@@ -95,13 +95,13 @@ public class AnalyticsResultProcessorTests extends ESTestCase {
 
         String dataDoc = "{\"f_1\": \"foo\", \"f_2\": 42.0}";
         String[] dataValues = {"42.0"};
-        DataFrameDataExtractor.Row row = newRow(newHit("1", dataDoc), dataValues);
+        DataFrameDataExtractor.Row row = newRow(newHit(dataDoc), dataValues, 1);
         givenSingleDataFrameBatch(Arrays.asList(row));
 
         Map<String, Object> resultFields = new HashMap<>();
         resultFields.put("a", "1");
         resultFields.put("b", "2");
-        AnalyticsResult result = new AnalyticsResult(String.valueOf("2".hashCode()), resultFields);
+        AnalyticsResult result = new AnalyticsResult(2, resultFields);
         givenProcessResults(Arrays.asList(result));
 
         AnalyticsResultProcessor resultProcessor = createResultProcessor();
@@ -121,17 +121,17 @@ public class AnalyticsResultProcessorTests extends ESTestCase {
         when(dataExtractor.next()).thenReturn(Optional.of(batch)).thenReturn(Optional.empty());
     }
 
-    private static SearchHit newHit(String id, String json) {
-        SearchHit hit = new SearchHit(42, id, new Text("doc"), Collections.emptyMap());
+    private static SearchHit newHit(String json) {
+        SearchHit hit = new SearchHit(randomInt(), randomAlphaOfLength(10), new Text("doc"), Collections.emptyMap());
         hit.sourceRef(new BytesArray(json));
         return hit;
     }
 
-    private static DataFrameDataExtractor.Row newRow(SearchHit hit, String[] values) {
+    private static DataFrameDataExtractor.Row newRow(SearchHit hit, String[] values, int checksum) {
         DataFrameDataExtractor.Row row = mock(DataFrameDataExtractor.Row.class);
         when(row.getHit()).thenReturn(hit);
         when(row.getValues()).thenReturn(values);
-        when(row.getIdHash()).thenReturn(String.valueOf(hit.getId().hashCode()));
+        when(row.getChecksum()).thenReturn(checksum);
         return row;
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsResultTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/analytics/process/AnalyticsResultTests.java
@@ -16,7 +16,7 @@ public class AnalyticsResultTests extends AbstractXContentTestCase<AnalyticsResu
 
     @Override
     protected AnalyticsResult createTestInstance() {
-        String idHash = randomAlphaOfLength(20);
+        int checksum = randomInt();
         Map<String, Object> results = new HashMap<>();
         int resultsSize = randomIntBetween(1, 10);
         for (int i = 0; i < resultsSize; i++) {
@@ -24,7 +24,7 @@ public class AnalyticsResultTests extends AbstractXContentTestCase<AnalyticsResu
             Object resultValue = randomBoolean() ? randomAlphaOfLength(20) : randomDouble();
             results.put(resultField, resultValue);
         }
-        return new AnalyticsResult(idHash, results);
+        return new AnalyticsResult(checksum, results);
     }
 
     @Override


### PR DESCRIPTION
In order to sanity check that analytics results are joined
correctly with their corresponding dataframe rows, we write
a 32-bit hash of the document ids to the c++ process which
includes it in the results. Upon joining we check the id
hashes match.
