### PR TITLE
Java Time: Fix timezone parsing

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -38,6 +38,7 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.IsoFields;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.TemporalQueries;
 import java.time.temporal.WeekFields;
 import java.util.Collections;
 import java.util.List;
@@ -122,20 +123,19 @@ public class DateFormatters {
         .optionalStart()
         .appendZoneOrOffsetId()
         .optionalEnd()
-        .optionalEnd()
-        .toFormatter(Locale.ROOT);
-
-    private static final DateTimeFormatter STRICT_DATE_OPTIONAL_TIME_FORMATTER_WITH_NANOS_2 = new DateTimeFormatterBuilder()
-        .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
-        .optionalStart()
-        .appendLiteral('T')
-        .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
-        .optionalStart()
-        .appendFraction(NANO_OF_SECOND, 3, 9, true)
-        .optionalEnd()
         .optionalStart()
         .appendOffset("+HHmm", "Z")
         .optionalEnd()
+        .optionalEnd()
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter STRICT_DATE_OPTIONAL_TIME_PRINTER = new DateTimeFormatterBuilder()
+        .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
+        .appendLiteral('T')
+        .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
+        .appendFraction(NANO_OF_SECOND, 3, 9, true)
+        .optionalStart()
+        .appendZoneOrOffsetId()
         .optionalEnd()
         .toFormatter(Locale.ROOT);
 
@@ -143,9 +143,7 @@ public class DateFormatters {
      * Returns a generic ISO datetime parser where the date is mandatory and the time is optional with nanosecond resolution.
      */
     private static final DateFormatter STRICT_DATE_OPTIONAL_TIME_NANOS = new JavaDateFormatter("strict_date_optional_time_nanos",
-        STRICT_DATE_OPTIONAL_TIME_FORMATTER_WITH_NANOS_1,
-        STRICT_DATE_OPTIONAL_TIME_FORMATTER_WITH_NANOS_1, STRICT_DATE_OPTIONAL_TIME_FORMATTER_WITH_NANOS_2);
-
+        STRICT_DATE_OPTIONAL_TIME_PRINTER, STRICT_DATE_OPTIONAL_TIME_FORMATTER_WITH_NANOS_1);
     /////////////////////////////////////////
     //
     // BEGIN basic time formatters
@@ -281,6 +279,8 @@ public class DateFormatters {
     private static final DateFormatter BASIC_ORDINAL_DATE_TIME = new JavaDateFormatter("basic_ordinal_date_time",
         new DateTimeFormatterBuilder().appendPattern("yyyyDDD").append(BASIC_T_TIME_PRINTER)
             .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+        new DateTimeFormatterBuilder().appendPattern("yyyyDDD").append(BASIC_T_TIME_PRINTER)
+            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
         new DateTimeFormatterBuilder().appendPattern("yyyyDDD").append(BASIC_T_TIME_FORMATTER)
             .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
 
@@ -346,10 +346,28 @@ public class DateFormatters {
      */
     private static final DateFormatter STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS = new JavaDateFormatter("strict_basic_week_date_no_millis",
         new DateTimeFormatterBuilder()
-            .append(STRICT_BASIC_WEEK_DATE_PRINTER).append(DateTimeFormatter.ofPattern("'T'HHmmssX", Locale.ROOT))
+            .append(STRICT_BASIC_WEEK_DATE_PRINTER)
+            .appendLiteral("T")
+            .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
+            .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
+            .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
+            .appendZoneOrOffsetId()
             .toFormatter(Locale.ROOT),
         new DateTimeFormatterBuilder()
-            .append(STRICT_BASIC_WEEK_DATE_FORMATTER).append(DateTimeFormatter.ofPattern("'T'HHmmssX", Locale.ROOT))
+            .append(STRICT_BASIC_WEEK_DATE_PRINTER)
+            .appendLiteral("T")
+            .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
+            .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
+            .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
+            .appendZoneOrOffsetId()
+            .toFormatter(Locale.ROOT),
+        new DateTimeFormatterBuilder()
+            .append(STRICT_BASIC_WEEK_DATE_PRINTER)
+            .appendLiteral("T")
+            .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
+            .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
+            .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
+            .append(TIME_ZONE_FORMATTER_NO_COLON)
             .toFormatter(Locale.ROOT)
     );
 
@@ -363,9 +381,23 @@ public class DateFormatters {
         .append(DateTimeFormatter.ofPattern("'T'HHmmss.SSSX", Locale.ROOT))
         .toFormatter(Locale.ROOT),
         new DateTimeFormatterBuilder()
-        .append(STRICT_BASIC_WEEK_DATE_FORMATTER)
-        .append(DateTimeFormatter.ofPattern("'T'HHmmss.SSSX", Locale.ROOT))
-        .toFormatter(Locale.ROOT)
+            .append(STRICT_BASIC_WEEK_DATE_FORMATTER)
+            .appendLiteral("T")
+            .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
+            .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
+            .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
+            .appendFraction(MILLI_OF_SECOND, 3, 3, true)
+            .appendZoneOrOffsetId()
+            .toFormatter(Locale.ROOT),
+        new DateTimeFormatterBuilder()
+            .append(STRICT_BASIC_WEEK_DATE_FORMATTER)
+            .appendLiteral("T")
+            .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
+            .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
+            .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
+            .appendFraction(MILLI_OF_SECOND, 3, 3, true)
+            .append(TIME_ZONE_FORMATTER_NO_COLON)
+            .toFormatter(Locale.ROOT)
     );
 
     /*
@@ -447,6 +479,8 @@ public class DateFormatters {
      * using a four digit year and three digit dayOfYear (yyyy-DDD'T'HH:mm:ssZZ).
      */
     private static final DateFormatter STRICT_ORDINAL_DATE_TIME_NO_MILLIS = new JavaDateFormatter("strict_ordinal_date_time_no_millis",
+        new DateTimeFormatterBuilder().append(STRICT_ORDINAL_DATE_TIME_NO_MILLIS_BASE)
+            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
         new DateTimeFormatterBuilder().append(STRICT_ORDINAL_DATE_TIME_NO_MILLIS_BASE)
             .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
         new DateTimeFormatterBuilder().append(STRICT_ORDINAL_DATE_TIME_NO_MILLIS_BASE)
@@ -551,6 +585,8 @@ public class DateFormatters {
      * digit year and three digit dayOfYear (yyyy-DDD'T'HH:mm:ss.SSSZZ).
      */
     private static final DateFormatter STRICT_ORDINAL_DATE_TIME = new JavaDateFormatter("strict_ordinal_date_time",
+        new DateTimeFormatterBuilder().append(STRICT_ORDINAL_DATE_TIME_FORMATTER_BASE)
+            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
         new DateTimeFormatterBuilder().append(STRICT_ORDINAL_DATE_TIME_FORMATTER_BASE)
             .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
         new DateTimeFormatterBuilder().append(STRICT_ORDINAL_DATE_TIME_FORMATTER_BASE)
@@ -1625,6 +1661,11 @@ public class DateFormatters {
 
         if (accessor.isSupported(ChronoField.NANO_OF_SECOND)) {
             result = result.with(ChronoField.NANO_OF_SECOND, accessor.getLong(ChronoField.NANO_OF_SECOND));
+        }
+
+        ZoneOffset zoneOffset = accessor.query(TemporalQueries.offset());
+        if (zoneOffset != null) {
+            result = result.withZoneSameLocal(zoneOffset);
         }
 
         return result;

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -1663,7 +1663,7 @@ public class DateFormatters {
             result = result.with(ChronoField.NANO_OF_SECOND, accessor.getLong(ChronoField.NANO_OF_SECOND));
         }
 
-        ZoneOffset zoneOffset = accessor.query(TemporalQueries.offset());
+        ZoneId zoneOffset = accessor.query(TemporalQueries.zone());
         if (zoneOffset != null) {
             result = result.withZoneSameLocal(zoneOffset);
         }

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -86,18 +86,36 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("20181126T121212.123-0800", "basic_date_time");
 
         assertSameDate("20181126T121212Z", "basic_date_time_no_millis");
+        assertSameDate("20181126T121212+01:00", "basic_date_time_no_millis");
+        assertSameDate("20181126T121212+0100", "basic_date_time_no_millis");
         assertSameDate("2018363", "basic_ordinal_date");
         assertSameDate("2018363T121212.123Z", "basic_ordinal_date_time");
+        assertSameDate("2018363T121212.123+0100", "basic_ordinal_date_time");
+        assertSameDate("2018363T121212.123+01:00", "basic_ordinal_date_time");
         assertSameDate("2018363T121212Z", "basic_ordinal_date_time_no_millis");
+        assertSameDate("2018363T121212+0100", "basic_ordinal_date_time_no_millis");
+        assertSameDate("2018363T121212+01:00", "basic_ordinal_date_time_no_millis");
         assertSameDate("121212.123Z", "basic_time");
+        assertSameDate("121212.123+0100", "basic_time");
+        assertSameDate("121212.123+01:00", "basic_time");
         assertSameDate("121212Z", "basic_time_no_millis");
+        assertSameDate("121212+0100", "basic_time_no_millis");
+        assertSameDate("121212+01:00", "basic_time_no_millis");
         assertSameDate("T121212.123Z", "basic_t_time");
+        assertSameDate("T121212.123+0100", "basic_t_time");
+        assertSameDate("T121212.123+01:00", "basic_t_time");
         assertSameDate("T121212Z", "basic_t_time_no_millis");
+        assertSameDate("T121212+0100", "basic_t_time_no_millis");
+        assertSameDate("T121212+01:00", "basic_t_time_no_millis");
         assertSameDate("2018W313", "basic_week_date");
         assertSameDate("1W313", "basic_week_date");
         assertSameDate("18W313", "basic_week_date");
         assertSameDate("2018W313T121212.123Z", "basic_week_date_time");
+        assertSameDate("2018W313T121212.123+0100", "basic_week_date_time");
+        assertSameDate("2018W313T121212.123+01:00", "basic_week_date_time");
         assertSameDate("2018W313T121212Z", "basic_week_date_time_no_millis");
+        assertSameDate("2018W313T121212+0100", "basic_week_date_time_no_millis");
+        assertSameDate("2018W313T121212+01:00", "basic_week_date_time_no_millis");
 
         assertSameDate("2018-12-31", "date");
         assertSameDate("18-5-6", "date");
@@ -127,6 +145,9 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2018-05-30T20:21", "date_optional_time");
         assertSameDate("2018-05-30T20:21:23", "date_optional_time");
         assertSameDate("2018-05-30T20:21:23.123", "date_optional_time");
+        assertSameDate("2018-05-30T20:21:23.123Z", "date_optional_time");
+        assertSameDate("2018-05-30T20:21:23.123+0100", "date_optional_time");
+        assertSameDate("2018-05-30T20:21:23.123+01:00", "date_optional_time");
         assertSameDate("2018-12-1", "date_optional_time");
         assertSameDate("2018-12-31T10:15:30", "date_optional_time");
         assertSameDate("2018-12-31T10:15:3", "date_optional_time");
@@ -134,13 +155,27 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2018-12-31T1:15:30", "date_optional_time");
 
         assertSameDate("2018-12-31T10:15:30.123Z", "date_time");
+        assertSameDate("2018-12-31T10:15:30.123+0100", "date_time");
+        assertSameDate("2018-12-31T10:15:30.123+01:00", "date_time");
         assertSameDate("2018-12-31T10:15:30.11Z", "date_time");
+        assertSameDate("2018-12-31T10:15:30.11+0100", "date_time");
+        assertSameDate("2018-12-31T10:15:30.11+01:00", "date_time");
         assertSameDate("2018-12-31T10:15:3.123Z", "date_time");
+        assertSameDate("2018-12-31T10:15:3.123+0100", "date_time");
+        assertSameDate("2018-12-31T10:15:3.123+01:00", "date_time");
 
         assertSameDate("2018-12-31T10:15:30Z", "date_time_no_millis");
+        assertSameDate("2018-12-31T10:15:30+0100", "date_time_no_millis");
+        assertSameDate("2018-12-31T10:15:30+01:00", "date_time_no_millis");
         assertSameDate("2018-12-31T10:5:30Z", "date_time_no_millis");
+        assertSameDate("2018-12-31T10:5:30+0100", "date_time_no_millis");
+        assertSameDate("2018-12-31T10:5:30+01:00", "date_time_no_millis");
         assertSameDate("2018-12-31T10:15:3Z", "date_time_no_millis");
+        assertSameDate("2018-12-31T10:15:3+0100", "date_time_no_millis");
+        assertSameDate("2018-12-31T10:15:3+01:00", "date_time_no_millis");
         assertSameDate("2018-12-31T1:15:30Z", "date_time_no_millis");
+        assertSameDate("2018-12-31T1:15:30+0100", "date_time_no_millis");
+        assertSameDate("2018-12-31T1:15:30+01:00", "date_time_no_millis");
 
         assertSameDate("12", "hour");
         assertSameDate("01", "hour");
@@ -165,36 +200,78 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2018-1", "ordinal_date");
 
         assertSameDate("2018-128T10:15:30.123Z", "ordinal_date_time");
+        assertSameDate("2018-128T10:15:30.123+0100", "ordinal_date_time");
+        assertSameDate("2018-128T10:15:30.123+01:00", "ordinal_date_time");
         assertSameDate("2018-1T10:15:30.123Z", "ordinal_date_time");
+        assertSameDate("2018-1T10:15:30.123+0100", "ordinal_date_time");
+        assertSameDate("2018-1T10:15:30.123+01:00", "ordinal_date_time");
 
         assertSameDate("2018-128T10:15:30Z", "ordinal_date_time_no_millis");
+        assertSameDate("2018-128T10:15:30+0100", "ordinal_date_time_no_millis");
+        assertSameDate("2018-128T10:15:30+01:00", "ordinal_date_time_no_millis");
         assertSameDate("2018-1T10:15:30Z", "ordinal_date_time_no_millis");
+        assertSameDate("2018-1T10:15:30+0100", "ordinal_date_time_no_millis");
+        assertSameDate("2018-1T10:15:30+01:00", "ordinal_date_time_no_millis");
 
         assertSameDate("10:15:30.123Z", "time");
+        assertSameDate("10:15:30.123+0100", "time");
+        assertSameDate("10:15:30.123+01:00", "time");
         assertSameDate("1:15:30.123Z", "time");
+        assertSameDate("1:15:30.123+0100", "time");
+        assertSameDate("1:15:30.123+01:00", "time");
         assertSameDate("10:1:30.123Z", "time");
+        assertSameDate("10:1:30.123+0100", "time");
+        assertSameDate("10:1:30.123+01:00", "time");
         assertSameDate("10:15:3.123Z", "time");
+        assertSameDate("10:15:3.123+0100", "time");
+        assertSameDate("10:15:3.123+01:00", "time");
         assertParseException("10:15:3.1", "time");
         assertParseException("10:15:3Z", "time");
 
         assertSameDate("10:15:30Z", "time_no_millis");
+        assertSameDate("10:15:30+0100", "time_no_millis");
+        assertSameDate("10:15:30+01:00", "time_no_millis");
         assertSameDate("01:15:30Z", "time_no_millis");
+        assertSameDate("01:15:30+0100", "time_no_millis");
+        assertSameDate("01:15:30+01:00", "time_no_millis");
         assertSameDate("1:15:30Z", "time_no_millis");
+        assertSameDate("1:15:30+0100", "time_no_millis");
+        assertSameDate("1:15:30+01:00", "time_no_millis");
         assertSameDate("10:5:30Z", "time_no_millis");
+        assertSameDate("10:5:30+0100", "time_no_millis");
+        assertSameDate("10:5:30+01:00", "time_no_millis");
         assertSameDate("10:15:3Z", "time_no_millis");
+        assertSameDate("10:15:3+0100", "time_no_millis");
+        assertSameDate("10:15:3+01:00", "time_no_millis");
         assertParseException("10:15:3", "time_no_millis");
 
         assertSameDate("T10:15:30.123Z", "t_time");
+        assertSameDate("T10:15:30.123+0100", "t_time");
+        assertSameDate("T10:15:30.123+01:00", "t_time");
         assertSameDate("T1:15:30.123Z", "t_time");
+        assertSameDate("T1:15:30.123+0100", "t_time");
+        assertSameDate("T1:15:30.123+01:00", "t_time");
         assertSameDate("T10:1:30.123Z", "t_time");
+        assertSameDate("T10:1:30.123+0100", "t_time");
+        assertSameDate("T10:1:30.123+01:00", "t_time");
         assertSameDate("T10:15:3.123Z", "t_time");
+        assertSameDate("T10:15:3.123+0100", "t_time");
+        assertSameDate("T10:15:3.123+01:00", "t_time");
         assertParseException("T10:15:3.1", "t_time");
         assertParseException("T10:15:3Z", "t_time");
 
         assertSameDate("T10:15:30Z", "t_time_no_millis");
+        assertSameDate("T10:15:30+0100", "t_time_no_millis");
+        assertSameDate("T10:15:30+01:00", "t_time_no_millis");
         assertSameDate("T1:15:30Z", "t_time_no_millis");
+        assertSameDate("T1:15:30+0100", "t_time_no_millis");
+        assertSameDate("T1:15:30+01:00", "t_time_no_millis");
         assertSameDate("T10:1:30Z", "t_time_no_millis");
+        assertSameDate("T10:1:30+0100", "t_time_no_millis");
+        assertSameDate("T10:1:30+01:00", "t_time_no_millis");
         assertSameDate("T10:15:3Z", "t_time_no_millis");
+        assertSameDate("T10:15:3+0100", "t_time_no_millis");
+        assertSameDate("T10:15:3+01:00", "t_time_no_millis");
         assertParseException("T10:15:3", "t_time_no_millis");
 
         assertSameDate("2012-W48-6", "week_date");
@@ -206,10 +283,18 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertJavaTimeParseException("2012-W1-8", "week_date", "Text '2012-W1-8' could not be parsed");
 
         assertSameDate("2012-W48-6T10:15:30.123Z", "week_date_time");
+        assertSameDate("2012-W48-6T10:15:30.123+0100", "week_date_time");
+        assertSameDate("2012-W48-6T10:15:30.123+01:00", "week_date_time");
         assertSameDate("2012-W1-6T10:15:30.123Z", "week_date_time");
+        assertSameDate("2012-W1-6T10:15:30.123+0100", "week_date_time");
+        assertSameDate("2012-W1-6T10:15:30.123+01:00", "week_date_time");
 
         assertSameDate("2012-W48-6T10:15:30Z", "week_date_time_no_millis");
+        assertSameDate("2012-W48-6T10:15:30+0100", "week_date_time_no_millis");
+        assertSameDate("2012-W48-6T10:15:30+01:00", "week_date_time_no_millis");
         assertSameDate("2012-W1-6T10:15:30Z", "week_date_time_no_millis");
+        assertSameDate("2012-W1-6T10:15:30+0100", "week_date_time_no_millis");
+        assertSameDate("2012-W1-6T10:15:30+01:00", "week_date_time_no_millis");
 
         assertSameDate("2012", "year");
         assertSameDate("1", "year");
@@ -238,14 +323,24 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2018W313", "strict_basic_week_date");
         assertParseException("18W313", "strict_basic_week_date");
         assertSameDate("2018W313T121212.123Z", "strict_basic_week_date_time");
+        assertSameDate("2018W313T121212.123+0100", "strict_basic_week_date_time");
+        assertSameDate("2018W313T121212.123+01:00", "strict_basic_week_date_time");
         assertParseException("2018W313T12128.123Z", "strict_basic_week_date_time");
         assertParseException("2018W313T81212.123Z", "strict_basic_week_date_time");
         assertParseException("2018W313T12812.123Z", "strict_basic_week_date_time");
         assertParseException("2018W313T12812.1Z", "strict_basic_week_date_time");
         assertSameDate("2018W313T121212Z", "strict_basic_week_date_time_no_millis");
+        assertSameDate("2018W313T121212+0100", "strict_basic_week_date_time_no_millis");
+        assertSameDate("2018W313T121212+01:00", "strict_basic_week_date_time_no_millis");
         assertParseException("2018W313T12128Z", "strict_basic_week_date_time_no_millis");
+        assertParseException("2018W313T12128+0100", "strict_basic_week_date_time_no_millis");
+        assertParseException("2018W313T12128+01:00", "strict_basic_week_date_time_no_millis");
         assertParseException("2018W313T81212Z", "strict_basic_week_date_time_no_millis");
+        assertParseException("2018W313T81212+0100", "strict_basic_week_date_time_no_millis");
+        assertParseException("2018W313T81212+01:00", "strict_basic_week_date_time_no_millis");
         assertParseException("2018W313T12812Z", "strict_basic_week_date_time_no_millis");
+        assertParseException("2018W313T12812+0100", "strict_basic_week_date_time_no_millis");
+        assertParseException("2018W313T12812+01:00", "strict_basic_week_date_time_no_millis");
         assertSameDate("2018-12-31", "strict_date");
         assertParseException("10000-12-31", "strict_date");
         assertParseException("2018-8-31", "strict_date");
@@ -266,15 +361,24 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertParseException("2018-1-31", "strict_date_optional_time");
         assertParseException("10000-01-31", "strict_date_optional_time");
         assertSameDate("2018-12-31T10:15:30", "strict_date_optional_time");
+        assertSameDate("2018-12-31T10:15:30Z", "strict_date_optional_time");
+        assertSameDate("2018-12-31T10:15:30+0100", "strict_date_optional_time");
+        assertSameDate("2018-12-31T10:15:30+01:00", "strict_date_optional_time");
         assertParseException("2018-12-31T10:15:3", "strict_date_optional_time");
         assertParseException("2018-12-31T10:5:30", "strict_date_optional_time");
         assertParseException("2018-12-31T9:15:30", "strict_date_optional_time");
         assertSameDate("2018-12-31T10:15:30.123Z", "strict_date_time");
+        assertSameDate("2018-12-31T10:15:30.123+0100", "strict_date_time");
+        assertSameDate("2018-12-31T10:15:30.123+01:00", "strict_date_time");
         assertSameDate("2018-12-31T10:15:30.11Z", "strict_date_time");
+        assertSameDate("2018-12-31T10:15:30.11+0100", "strict_date_time");
+        assertSameDate("2018-12-31T10:15:30.11+01:00", "strict_date_time");
         assertParseException("2018-12-31T10:15:3.123Z", "strict_date_time");
         assertParseException("2018-12-31T10:5:30.123Z", "strict_date_time");
         assertParseException("2018-12-31T1:15:30.123Z", "strict_date_time");
         assertSameDate("2018-12-31T10:15:30Z", "strict_date_time_no_millis");
+        assertSameDate("2018-12-31T10:15:30+0100", "strict_date_time_no_millis");
+        assertSameDate("2018-12-31T10:15:30+01:00", "strict_date_time_no_millis");
         assertParseException("2018-12-31T10:5:30Z", "strict_date_time_no_millis");
         assertParseException("2018-12-31T10:15:3Z", "strict_date_time_no_millis");
         assertParseException("2018-12-31T1:15:30Z", "strict_date_time_no_millis");
@@ -297,12 +401,18 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertParseException("2018-1", "strict_ordinal_date");
 
         assertSameDate("2018-128T10:15:30.123Z", "strict_ordinal_date_time");
+        assertSameDate("2018-128T10:15:30.123+0100", "strict_ordinal_date_time");
+        assertSameDate("2018-128T10:15:30.123+01:00", "strict_ordinal_date_time");
         assertParseException("2018-1T10:15:30.123Z", "strict_ordinal_date_time");
 
         assertSameDate("2018-128T10:15:30Z", "strict_ordinal_date_time_no_millis");
+        assertSameDate("2018-128T10:15:30+0100", "strict_ordinal_date_time_no_millis");
+        assertSameDate("2018-128T10:15:30+01:00", "strict_ordinal_date_time_no_millis");
         assertParseException("2018-1T10:15:30Z", "strict_ordinal_date_time_no_millis");
 
         assertSameDate("10:15:30.123Z", "strict_time");
+        assertSameDate("10:15:30.123+0100", "strict_time");
+        assertSameDate("10:15:30.123+01:00", "strict_time");
         assertParseException("1:15:30.123Z", "strict_time");
         assertParseException("10:1:30.123Z", "strict_time");
         assertParseException("10:15:3.123Z", "strict_time");
@@ -310,13 +420,19 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertParseException("10:15:3Z", "strict_time");
 
         assertSameDate("10:15:30Z", "strict_time_no_millis");
+        assertSameDate("10:15:30+0100", "strict_time_no_millis");
+        assertSameDate("10:15:30+01:00", "strict_time_no_millis");
         assertSameDate("01:15:30Z", "strict_time_no_millis");
+        assertSameDate("01:15:30+0100", "strict_time_no_millis");
+        assertSameDate("01:15:30+01:00", "strict_time_no_millis");
         assertParseException("1:15:30Z", "strict_time_no_millis");
         assertParseException("10:5:30Z", "strict_time_no_millis");
         assertParseException("10:15:3Z", "strict_time_no_millis");
         assertParseException("10:15:3", "strict_time_no_millis");
 
         assertSameDate("T10:15:30.123Z", "strict_t_time");
+        assertSameDate("T10:15:30.123+0100", "strict_t_time");
+        assertSameDate("T10:15:30.123+01:00", "strict_t_time");
         assertParseException("T1:15:30.123Z", "strict_t_time");
         assertParseException("T10:1:30.123Z", "strict_t_time");
         assertParseException("T10:15:3.123Z", "strict_t_time");
@@ -324,6 +440,8 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertParseException("T10:15:3Z", "strict_t_time");
 
         assertSameDate("T10:15:30Z", "strict_t_time_no_millis");
+        assertSameDate("T10:15:30+0100", "strict_t_time_no_millis");
+        assertSameDate("T10:15:30+01:00", "strict_t_time_no_millis");
         assertParseException("T1:15:30Z", "strict_t_time_no_millis");
         assertParseException("T10:1:30Z", "strict_t_time_no_millis");
         assertParseException("T10:15:3Z", "strict_t_time_no_millis");
@@ -343,9 +461,13 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertJavaTimeParseException("2012-W01-8", "strict_week_date", "Text '2012-W01-8' could not be parsed");
 
         assertSameDate("2012-W48-6T10:15:30.123Z", "strict_week_date_time");
+        assertSameDate("2012-W48-6T10:15:30.123+0100", "strict_week_date_time");
+        assertSameDate("2012-W48-6T10:15:30.123+01:00", "strict_week_date_time");
         assertParseException("2012-W1-6T10:15:30.123Z", "strict_week_date_time");
 
         assertSameDate("2012-W48-6T10:15:30Z", "strict_week_date_time_no_millis");
+        assertSameDate("2012-W48-6T10:15:30+0100", "strict_week_date_time_no_millis");
+        assertSameDate("2012-W48-6T10:15:30+01:00", "strict_week_date_time_no_millis");
         assertParseException("2012-W1-6T10:15:30Z", "strict_week_date_time_no_millis");
 
         assertSameDate("2012", "strict_year");

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -162,4 +162,16 @@ public class DateFormattersTests extends ESTestCase {
         assertThat(mergedFormatter.formatters.get(0), instanceOf(JavaDateFormatter.class));
         assertThat(mergedFormatter.formatters.get(1), instanceOf(JavaDateFormatter.class));
     }
+
+    public void testParsingStrictNanoDates() {
+        DateFormatter formatter = DateFormatters.forPattern("strict_date_optional_time_nanos");
+        formatter.format(formatter.parse("2016-01-01T00:00:00.000"));
+        formatter.format(formatter.parse("2018-05-15T17:14:56"));
+        formatter.format(formatter.parse("2018-05-15T17:14:56Z"));
+        formatter.format(formatter.parse("2018-05-15T17:14:56+0100"));
+        formatter.format(formatter.parse("2018-05-15T17:14:56+01:00"));
+        formatter.format(formatter.parse("2018-05-15T17:14:56.123456789Z"));
+        formatter.format(formatter.parse("2018-05-15T17:14:56.123456789+0100"));
+        formatter.format(formatter.parse("2018-05-15T17:14:56.123456789+01:00"));
+    }
 }


### PR DESCRIPTION
An independent test uncovered an issue when parsing a timezone
containing a colon like `01:00` - some formats did not properly support
this.

This commit adds test for all formats in the dueling tests and fixes a
few issues with existing date formatters.
