### PR TITLE
SNAPSHOT+TESTS: Stabilize SnapshotDisruptionIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/discovery/SnapshotDisruptionIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/SnapshotDisruptionIT.java
@@ -75,7 +75,6 @@ public class SnapshotDisruptionIT extends ESIntegTestCase {
             .build();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/36779")
     public void testDisruptionOnSnapshotInitialization() throws Exception {
         final String idxName = "test";
         final List<String> allMasterEligibleNodes = internalCluster().startMasterOnlyNodes(3);
@@ -180,7 +179,11 @@ public class SnapshotDisruptionIT extends ESIntegTestCase {
 
         logger.info("--> verify that snapshot eventually will be created due to retries");
         assertBusy(() -> {
-            assertSnapshotExists("test-repo", "test-snap-2");
+            try {
+                assertSnapshotExists("test-repo", "test-snap-2");
+            } catch (SnapshotMissingException ex) {
+                throw new AssertionError(ex);
+            }
         }, 1, TimeUnit.MINUTES);
     }
 


### PR DESCRIPTION
* Ensure retry by busy assert on SnapshotMissingException
  * This should fix the test since the retry should still happen even when running into the race between retry and deletion as a result of the prior failing snapshot but it could be that the assert is hit right when the delete worked out and the retry hasn't yet happened so we need to make the busy assert  retry here
* Closes #36779
