### PR TITLE
Geo: Do not normalize the longitude with value -180 for Lucene shapes

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/builders/PolygonBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/builders/PolygonBuilder.java
@@ -342,6 +342,8 @@ public class PolygonBuilder extends ShapeBuilder<JtsGeometry, PolygonBuilder> {
             holes = new org.apache.lucene.geo.Polygon[polygon.length - 1];
             for (int i = 0; i < holes.length; ++i) {
                 Coordinate[] coords = polygon[i+1];
+                //We do not have holes on the dateline as they get eliminated
+                //when breaking the polygon around it.
                 double[] x = new double[coords.length];
                 double[] y = new double[coords.length];
                 for (int c = 0; c < coords.length; ++c) {
@@ -357,6 +359,8 @@ public class PolygonBuilder extends ShapeBuilder<JtsGeometry, PolygonBuilder> {
         double[] x = new double[shell.length];
         double[] y = new double[shell.length];
         for (int i = 0; i < shell.length; ++i) {
+            //Lucene Tessellator treats different +180 and -180 and we should keep the sign.
+            //normalizeLon method excludes -180.
             x[i] = Math.abs(shell[i].x) > 180 ? normalizeLon(shell[i].x) : shell[i].x;
             y[i] = normalizeLat(shell[i].y);
         }

--- a/server/src/main/java/org/elasticsearch/common/geo/builders/PolygonBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/builders/PolygonBuilder.java
@@ -357,7 +357,7 @@ public class PolygonBuilder extends ShapeBuilder<JtsGeometry, PolygonBuilder> {
         double[] x = new double[shell.length];
         double[] y = new double[shell.length];
         for (int i = 0; i < shell.length; ++i) {
-            x[i] = normalizeLon(shell[i].x);
+            x[i] = Math.abs(shell[i].x) > 180 ? normalizeLon(shell[i].x) : shell[i].x;
             y[i] = normalizeLat(shell[i].y);
         }
 

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoJsonShapeParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoJsonShapeParserTests.java
@@ -1126,7 +1126,7 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
             ),
             new org.apache.lucene.geo.Polygon(
                 new double[] {12.142857142857142d, -12.142857142857142d, -10d, 10d, 12.142857142857142d},
-                new double[] {180d, 180d, -177d, -177d, 180d}
+                new double[] {-180d, -180d, -177d, -177d, -180d}
             )
         };
         assertGeometryEquals(luceneExpected, geometryCollectionGeoJson, false);


### PR DESCRIPTION
Lucene based shapes should not normalize the longitude value -180 to 180.

Closes #37297 