### PR TITLE
[TEST] Awaits tasks termination in the RestHighLevelClient tests

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/TasksIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/TasksIT.java
@@ -72,7 +72,7 @@ public class TasksIT extends ESRestHighLevelClientTestCase {
         assertTrue("List tasks were not found", listTasksFound);
     }
     
-    public void testGetValidTask() throws IOException {
+    public void testGetValidTask() throws Exception {
 
         // Run a Reindex to create a task
 
@@ -112,7 +112,10 @@ public class TasksIT extends ESRestHighLevelClientTestCase {
         TaskInfo info = taskResponse.getTaskInfo();
         assertTrue(info.isCancellable());
         assertEquals("reindex from [source1] to [dest][_doc]", info.getDescription());
-        assertEquals("indices:data/write/reindex", info.getAction());                
+        assertEquals("indices:data/write/reindex", info.getAction());
+        if (taskResponse.isCompleted() == false) {
+            assertBusy(ReindexIT.checkCompletionStatus(client(), taskId.toString()));
+        }
     }    
     
     public void testGetInvalidTask() throws IOException {


### PR DESCRIPTION
This change ensures that TasksIT#testGetValidTask and ReindexIT#testReindexTask
don't leave a non-completed task on the cluster when they finish.

Closes #35644
