### PR TITLE
Remove deprecated FieldNamesFieldMapper.Builder#index

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -73,21 +73,14 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         }
     }
 
-    public static class Builder extends MetadataFieldMapper.Builder<Builder, FieldNamesFieldMapper> {
+    private static class Builder extends MetadataFieldMapper.Builder<Builder, FieldNamesFieldMapper> {
         private boolean enabled = Defaults.ENABLED;
 
-        public Builder(MappedFieldType existing) {
+        private Builder(MappedFieldType existing) {
             super(Defaults.NAME, existing == null ? Defaults.FIELD_TYPE : existing, Defaults.FIELD_TYPE);
         }
 
-        @Override
-        @Deprecated
-        public Builder index(boolean index) {
-            enabled(index);
-            return super.index(index);
-        }
-
-        public Builder enabled(boolean enabled) {
+        private Builder enabled(boolean enabled) {
             this.enabled = enabled;
             return this;
         }


### PR DESCRIPTION
The method calls "enabled" in addition to what the super.index() does, but this
seems to be done explicitly now in the TypeParsers `parse` method. The removed
method has been deprecated since at least 6.0. Also making some of the Builders
methods and ctors private since they are only used internally in this class.