### PR TITLE
Fix rest reindex test for IPv4 addresses

### DIFF
--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -100,7 +100,7 @@ integTestRunner {
 
 integTestCluster {
   systemProperty 'es.scripting.update.ctx_in_params', 'false'
-  setting 'reindex.remote.whitelist', '"[::1]:*"'
+  setting 'reindex.remote.whitelist', ['"[::1]:*"', '"127.0.0.1:*"']
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.security.authc.token.enabled', 'true'


### PR DESCRIPTION
Some of our CI boxes end up giving out an IPv4 address for this
test. This commit allows both v4 and v6 addresses to be used.
