### PR TITLE
6.5 Release Notes on Structured Audit

### DIFF
--- a/docs/reference/release-notes/6.5.asciidoc
+++ b/docs/reference/release-notes/6.5.asciidoc
@@ -240,7 +240,7 @@ Audit::
 * Structured audit logging {pull}31931[#31931] and {pull}33894[#33894] (backport) (issue: {issue}31046[#31046])
 This introduces a new format for the logfile audit type which is output alongside the
 previous one. Conforming to the out-of-the-box `log4j2.properties` configuration,
-the new and deprecated audit formats should be output to the `<cluster_name>_access.log`
+the new and deprecated audit formats are output to the `<cluster_name>_access.log`
 and `<cluster_name>_audit.log` files, respectively.
 See {stack-ov}/audit-log-output.html[logfile audit output] for more details.
 

--- a/docs/reference/release-notes/6.5.asciidoc
+++ b/docs/reference/release-notes/6.5.asciidoc
@@ -237,8 +237,12 @@ Analysis::
 * Add conditional token filter to elasticsearch {pull}31958[#31958]
 
 Audit::
-* Backport Structured Audit Logging {pull}33894[#33894] (issue: {issue}31046[#31046])
-* Structured audit logging {pull}31931[#31931] (issue: {issue}31046[#31046])
+* Structured audit logging {pull}31931[#31931] and {pull}33894[#33894] (backport) (issue: {issue}31046[#31046])
+This introduces a new format for the logfile audit type which is output alongside the
+previous one. Conforming to the out-of-the-box `log4j2.properties` configuration,
+the new and deprecated audit formats should be output to the `<cluster_name>_access.log`
+and `<cluster_name>_audit.log` files, respectively.
+See {stack-ov}/audit-log-output.html[logfile audit output] for more details.
 
 Authentication::
 * Allow User/Password realms to disable authc {pull}34033[#34033] (issue: {issue}33292[#33292])

--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -15,7 +15,9 @@ a `<clustername>_audit.log` file in the logs directory. This file is new to
 version 6.5 and prints audit entries as JSON documents. 
 
 For backwards compatibility purposes, a `<clustername>_access.log` with the old style of 
-formatting is also generated. See also <<breaking_65_settings_changes>>. 
+formatting is also generated. See also <<breaking_65_settings_changes>>. Due to this,
+the logging throughput effectively doubles. It is recommended to enable only the
+new audit format in production (adjust `log4j2.properties`).
 
 [float]
 === Discover the structure of text files

--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -16,7 +16,7 @@ version 6.5 and prints audit entries as JSON documents.
 
 For backwards compatibility purposes, a `<clustername>_access.log` with the old style of 
 formatting is also generated. See also <<breaking_65_settings_changes>>. Due to this,
-the logging throughput effectively doubles. It is recommended to enable only the
+the logging throughput effectively doubles. It is recommended that you enable only the
 new audit format in production (adjust `log4j2.properties`).
 
 [float]

--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -17,7 +17,7 @@ version 6.5 and prints audit entries as JSON documents.
 For backwards compatibility purposes, a `<clustername>_access.log` with the old style of 
 formatting is also generated. See also <<breaking_65_settings_changes>>. Due to this,
 the logging throughput effectively doubles. It is recommended that you enable only the
-new audit format in production (adjust `log4j2.properties`).
+new audit format in production (by adjusting the settings in the `log4j2.properties` file).
 
 [float]
 === Discover the structure of text files


### PR DESCRIPTION
Highlight in the release notes that the new audit format is generated alongside the deprecated one and that logging the throughput doubles.