### PR TITLE
Fix artifactId in plugin poms

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -114,7 +114,7 @@ public class PluginBuildPlugin extends BuildPlugin {
                 generatePOMTask.ext.pomFileName = "${project.archivesBaseName}-client-${project.versions.elasticsearch}.pom"
             }
         } else {
-            project.plugins.withType(MavenPublishPlugin).whenPluginAdded {
+            if (project.plugins.hasPlugin(MavenPublishPlugin)) {
                 project.publishing.publications.nebula(MavenPublication).artifactId(
                         project.pluginProperties.extension.name
                 )


### PR DESCRIPTION
Fix the broken artifactId introduced in #32351. 
Looks like `plugins.withType().whenPlugginAdded` doesn't work with `projectsEvaluated`, probably too late for that hook to be interpreted. 
Since we are in a `projectsEvaluated` hook, it's safe to check for the existence of the plugin at that time rather than use a hook. 

Closes #37166.