### PR TITLE
Docs be explicit on how to turn off deprecated auditing

### DIFF
--- a/x-pack/docs/en/security/auditing/output-logfile.asciidoc
+++ b/x-pack/docs/en/security/auditing/output-logfile.asciidoc
@@ -9,9 +9,26 @@ is also generated. They differ in the output format but the contents
 are similar. For systems that are not ingesting the audit file for search or
 analytics it is strongly recommended to only keep the newer format.
 Turning off the deprecated output format can be achieved by disabling the logger
-in the `log4j2.properties` file (hint: there is a config comment
-about it).
-For more information, see {ref}/logging.html#configuring-logging-levels[configuring-logging].
+in the `log4j2.properties` file:
+```
+# change info to off
+# logger.xpack_security_audit_deprecated_logfile.level = info
+logger.xpack_security_audit_deprecated_logfile.level = off
+```
+or dynamically {ref}/logging.html#configuring-logging-levels[configuring the logger]
+via the API:
+```
+PUT /_cluster/settings
+{
+  "persistent": {
+    "logger.org.elasticsearch.xpack.security.audit.logfile.DeprecatedLoggingAuditTrail": "off"
+  }
+}
+```
+
+NOTE: If you overwrite the `log4j2.properties` and do not specify appenders for
+any of the audit trails, then audit events would be forwarded to the root
+appender which by default points to the `elasticsearch.log` file.
 
 
 [float]

--- a/x-pack/docs/en/security/auditing/output-logfile.asciidoc
+++ b/x-pack/docs/en/security/auditing/output-logfile.asciidoc
@@ -7,28 +7,36 @@ the `<clustername>_audit.log` file in the logs directory. To maintain
 compatibility with releases prior to 6.5.0, a `<clustername>_access.log` file
 is also generated. They differ in the output format but the contents
 are similar. For systems that are not ingesting the audit file for search or
-analytics it is strongly recommended to only keep the newer format.
-Turning off the deprecated output format can be achieved by disabling the logger
-in the `log4j2.properties` file:
-```
+analytics it is strongly recommended to keep only the newer format.
+
+To turn off the deprecated output format, you can disable the logger in the
+`log4j2.properties` file: 
+
+[source, properties]
+--------------------------------------------------
 # change info to off
 # logger.xpack_security_audit_deprecated_logfile.level = info
 logger.xpack_security_audit_deprecated_logfile.level = off
-```
-or dynamically {ref}/logging.html#configuring-logging-levels[configuring the logger]
-via the API:
-```
+--------------------------------------------------
+
+Alternatively, use the
+{ref}/cluster-update-settings.html[cluster update settings API] to dynamically
+configure the logger:
+
+[source,js]
+--------------------------------------------------
 PUT /_cluster/settings
 {
   "persistent": {
     "logger.org.elasticsearch.xpack.security.audit.logfile.DeprecatedLoggingAuditTrail": "off"
   }
 }
-```
+--------------------------------------------------
+// CONSOLE
 
 NOTE: If you overwrite the `log4j2.properties` and do not specify appenders for
-any of the audit trails, then audit events would be forwarded to the root
-appender which by default points to the `elasticsearch.log` file.
+any of the audit trails, audit events are forwarded to the root appender, which
+by default points to the `elasticsearch.log` file.
 
 
 [float]


### PR DESCRIPTION
Just be explicit about turning off the deprecated audit log appender because we really want people to turn it off.