### PR TITLE
Rename ParameterMap to DeprecationMap

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/AbstractSortScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractSortScript.java
@@ -66,7 +66,7 @@ abstract class AbstractSortScript implements ScorerAware {
         this.leafLookup = lookup.getLeafSearchLookup(leafContext);
         Map<String, Object> parameters = new HashMap<>(params);
         parameters.putAll(leafLookup.asMap());
-        this.params = new ParameterMap(parameters, DEPRECATIONS);
+        this.params = new DeprecationMap(parameters, DEPRECATIONS);
     }
 
     protected AbstractSortScript() {

--- a/server/src/main/java/org/elasticsearch/script/AggregationScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AggregationScript.java
@@ -71,7 +71,7 @@ public abstract class AggregationScript implements ScorerAware {
     private Object value;
 
     public AggregationScript(Map<String, Object> params, SearchLookup lookup, LeafReaderContext leafContext) {
-        this.params = new ParameterMap(new HashMap<>(params), DEPRECATIONS);
+        this.params = new DeprecationMap(new HashMap<>(params), DEPRECATIONS);
         this.leafLookup = lookup.getLeafSearchLookup(leafContext);
         this.params.putAll(leafLookup.asMap());
     }

--- a/server/src/main/java/org/elasticsearch/script/DeprecationMap.java
+++ b/server/src/main/java/org/elasticsearch/script/DeprecationMap.java
@@ -31,33 +31,33 @@ public final class DeprecationMap implements Map<String, Object> {
     private static final DeprecationLogger deprecationLogger =
         new DeprecationLogger(LogManager.getLogger(DeprecationMap.class));
 
-    private final Map<String, Object> params;
+    private final Map<String, Object> delegate;
 
     private final Map<String, String> deprecations;
 
-    public DeprecationMap(Map<String, Object> params, Map<String, String> deprecations) {
-        this.params = params;
+    public DeprecationMap(Map<String, Object> delegate, Map<String, String> deprecations) {
+        this.delegate = delegate;
         this.deprecations = deprecations;
     }
 
     @Override
     public int size() {
-        return params.size();
+        return delegate.size();
     }
 
     @Override
     public boolean isEmpty() {
-        return params.isEmpty();
+        return delegate.isEmpty();
     }
 
     @Override
     public boolean containsKey(final Object key) {
-        return params.containsKey(key);
+        return delegate.containsKey(key);
     }
 
     @Override
     public boolean containsValue(final Object value) {
-        return params.containsValue(value);
+        return delegate.containsValue(value);
     }
 
     @Override
@@ -66,41 +66,41 @@ public final class DeprecationMap implements Map<String, Object> {
         if (deprecationMessage != null) {
             deprecationLogger.deprecated(deprecationMessage);
         }
-        return params.get(key);
+        return delegate.get(key);
     }
 
     @Override
     public Object put(final String key, final Object value) {
-        return params.put(key, value);
+        return delegate.put(key, value);
     }
 
     @Override
     public Object remove(final Object key) {
-        return params.remove(key);
+        return delegate.remove(key);
     }
 
     @Override
     public void putAll(final Map<? extends String, ?> m) {
-        params.putAll(m);
+        delegate.putAll(m);
     }
 
     @Override
     public void clear() {
-        params.clear();
+        delegate.clear();
     }
 
     @Override
     public Set<String> keySet() {
-        return params.keySet();
+        return delegate.keySet();
     }
 
     @Override
     public Collection<Object> values() {
-        return params.values();
+        return delegate.values();
     }
 
     @Override
     public Set<Entry<String, Object>> entrySet() {
-        return params.entrySet();
+        return delegate.entrySet();
     }
 }

--- a/server/src/main/java/org/elasticsearch/script/DeprecationMap.java
+++ b/server/src/main/java/org/elasticsearch/script/DeprecationMap.java
@@ -26,16 +26,16 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-public final class ParameterMap implements Map<String, Object> {
+public final class DeprecationMap implements Map<String, Object> {
 
     private static final DeprecationLogger deprecationLogger =
-        new DeprecationLogger(LogManager.getLogger(ParameterMap.class));
+        new DeprecationLogger(LogManager.getLogger(DeprecationMap.class));
 
     private final Map<String, Object> params;
 
     private final Map<String, String> deprecations;
 
-    public ParameterMap(Map<String, Object> params, Map<String, String> deprecations) {
+    public DeprecationMap(Map<String, Object> params, Map<String, String> deprecations) {
         this.params = params;
         this.deprecations = deprecations;
     }

--- a/server/src/main/java/org/elasticsearch/script/FieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/FieldScript.java
@@ -63,7 +63,7 @@ public abstract class FieldScript {
         this.leafLookup = lookup.getLeafSearchLookup(leafContext);
         params = new HashMap<>(params);
         params.putAll(leafLookup.asMap());
-        this.params = new ParameterMap(params, DEPRECATIONS);
+        this.params = new DeprecationMap(params, DEPRECATIONS);
     }
 
     // for expression engine

--- a/server/src/main/java/org/elasticsearch/script/ScoreScript.java
+++ b/server/src/main/java/org/elasticsearch/script/ScoreScript.java
@@ -73,7 +73,7 @@ public abstract class ScoreScript {
             this.leafLookup = lookup.getLeafSearchLookup(leafContext);
             params = new HashMap<>(params);
             params.putAll(leafLookup.asMap());
-            this.params = new ParameterMap(params, DEPRECATIONS);
+            this.params = new DeprecationMap(params, DEPRECATIONS);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/script/ScriptedMetricAggContexts.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptedMetricAggContexts.java
@@ -95,7 +95,7 @@ public class ScriptedMetricAggContexts {
             if (leafLookup != null) {
                 params = new HashMap<>(params); // copy params so we aren't modifying input
                 params.putAll(leafLookup.asMap()); // add lookup vars
-                params = new ParameterMap(params, DEPRECATIONS); // wrap with deprecations
+                params = new DeprecationMap(params, DEPRECATIONS); // wrap with deprecations
             }
             this.params = params;
         }

--- a/server/src/main/java/org/elasticsearch/script/TermsSetQueryScript.java
+++ b/server/src/main/java/org/elasticsearch/script/TermsSetQueryScript.java
@@ -64,7 +64,7 @@ public abstract class TermsSetQueryScript {
         Map<String, Object> parameters = new HashMap<>(params);
         this.leafLookup = lookup.getLeafSearchLookup(leafContext);
         parameters.putAll(leafLookup.asMap());
-        this.params = new ParameterMap(parameters, DEPRECATIONS);
+        this.params = new DeprecationMap(parameters, DEPRECATIONS);
     }
 
     protected TermsSetQueryScript() {


### PR DESCRIPTION
Mechanical change to rename ParameterMap to DeprecationMap as this seems more appropriate for an extended Map to issue deprecation warnings.