### PR TITLE
Link ILM management and policy information in ILM API documentation

### DIFF
--- a/docs/reference/ilm/apis/ilm-api.asciidoc
+++ b/docs/reference/ilm/apis/ilm-api.asciidoc
@@ -3,7 +3,9 @@
 
 beta[]
 
-You can use the following APIs to manage policies on indices.
+You can use the following APIs to manage policies on indices. See
+<<index-lifecycle-management,Managing the index lifecycle>> for more information
+about Index Lifecycle Management.
 
 [float]
 [[ilm-api-policy-endpoint]]

--- a/docs/reference/ilm/apis/put-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/put-lifecycle.asciidoc
@@ -8,7 +8,8 @@
 
 beta[]
 
-Creates or updates lifecycle policy.
+Creates or updates lifecycle policy. See <<ilm-policy-definition,Policy phases and actions>>
+for definitions of policy components.
 
 ==== Request
 


### PR DESCRIPTION
Previously these were only linked in a circuitous way rather than being
available from the top level API documentation and "Put Lifecycle" API docs.
This makes them slightly easier to find for a user.
