### PR TITLE
xpack snapshot rest API YAML test: Specify index to include in snapshot and add teardown

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/snapshot/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/snapshot/10_basic.yml
@@ -22,6 +22,17 @@ setup:
       cluster.health:
         wait_for_status: green
 
+teardown:
+
+  - do:
+      snapshot.delete:
+        repository: test_repo_restore_1
+        snapshot: test_snapshot
+
+  - do:
+      indices.delete:
+        index: test_index
+
 ---
 "Create a source only snapshot and then restore it":
 
@@ -40,6 +51,7 @@ setup:
         repository: test_repo_restore_1
         snapshot: test_snapshot
         wait_for_completion: true
+        body:   { indices: test_index }
 
   - match: { snapshot.snapshot: test_snapshot }
   - match: { snapshot.state : SUCCESS }


### PR DESCRIPTION
Specifying the index to include in the snapshot ensures that the `snapshot.shards.successful` field will be 1. This number may vary depending on what other indices exist.

Adding a teardown to delete the snapshot and the index created in the test, `test_index` , ensures that there are no side effects for other tests.
