### PR TITLE
Switch indices.get rest after backport of `include_type_name`

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
@@ -55,8 +55,8 @@ setup:
 ---
 "Test include_type_name":
   - skip:
-      version: " - 6.99.99"
-      reason: the include_type_name parameter is not backported to pre 7.0 versions yet
+      version: " - 6.6.99"
+      reason: the include_type_name parameter is not supported before 6.7
 
   - do:
       indices.get:
@@ -73,6 +73,12 @@ setup:
 
   - is_true: test_index.mappings
   - is_false: test_index.mappings.type_1
+
+---
+"Test include_type_name dafaults to false":
+  - skip:
+      version: " - 6.99.99"
+      reason: the include_type_name parameter default is different on 6.x and 7.0, so only test this on 7.0 clusters
 
   - do:
       indices.get:

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesActionTests.java
@@ -23,8 +23,8 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.test.rest.RestActionTestCase;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -33,7 +33,7 @@ import java.util.Map;
 import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
 import static org.mockito.Mockito.mock;
 
-public class RestGetIndicesActionTests extends ESTestCase {
+public class RestGetIndicesActionTests extends RestActionTestCase {
 
     /**
      * Test that setting the "include_type_name" parameter raises a warning


### PR DESCRIPTION
With the `include_type_name` available now for indices.get on 6.x after the
backport (#37267), the corresponsing yaml test can include 6.7 clusters.
Also changing the RestGetIndicesActionTests base test class.