### PR TITLE
Use zen2 with testclusters

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -342,6 +342,10 @@ public class ElasticsearchNode {
         if (Version.fromString(version).getMajor() >= 6) {
             config.put("cluster.routing.allocation.disk.watermark.flood_stage", "1b");
         }
+        if (Version.fromString(version).onOrAfter(Version.fromString("6.5.0"))) {
+            config.put("discovery.type", "zen2");
+            config.put("cluster.initial_master_nodes", "1");
+        }
         try {
             Files.write(
                 getConfigFile().toPath(),

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -324,8 +324,9 @@ public class ElasticsearchNode {
         getConfPathSharedData().mkdirs();
         getConfPathLogs().mkdirs();
         LinkedHashMap<String, String> config = new LinkedHashMap<>();
-        config.put("cluster.name", "cluster-" + safeName(name));
-        config.put("node.name", "node-" + safeName(name));
+        String nodeName = safeName(name);
+        config.put("cluster.name",nodeName);
+        config.put("node.name", nodeName);
         config.put("path.repo", getConfPathRepo().getAbsolutePath());
         config.put("path.data", getConfPathData().getAbsolutePath());
         config.put("path.logs", getConfPathLogs().getAbsolutePath());
@@ -342,9 +343,8 @@ public class ElasticsearchNode {
         if (Version.fromString(version).getMajor() >= 6) {
             config.put("cluster.routing.allocation.disk.watermark.flood_stage", "1b");
         }
-        if (Version.fromString(version).onOrAfter(Version.fromString("6.5.0"))) {
-            config.put("discovery.type", "zen2");
-            config.put("cluster.initial_master_nodes", "1");
+        if (Version.fromString(version).getMajor() >= 7) {
+            config.put("cluster.initial_master_nodes", "[" + nodeName + "]");
         }
         try {
             Files.write(

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/testclusters/TestClustersPluginIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/testclusters/TestClustersPluginIT.java
@@ -21,11 +21,9 @@ package org.elasticsearch.gradle.testclusters;
 import org.elasticsearch.gradle.test.GradleIntegrationTestCase;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
-import org.junit.Ignore;
 
 import java.util.Arrays;
 
-@Ignore // https://github.com/elastic/elasticsearch/issues/37218
 public class TestClustersPluginIT extends GradleIntegrationTestCase {
 
     public void testListClusters() {


### PR DESCRIPTION
Use Zen2 by default for test-clusters. 
More detailed configuration will be added as needed.

Closes #37218