### PR TITLE
Update serialization versions for ClusterBlock after backport to 6.x

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlock.java
+++ b/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlock.java
@@ -138,7 +138,7 @@ public class ClusterBlock implements Streamable, ToXContentFragment {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         id = in.readVInt();
-        if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_6_7_0)) {
             uuid = in.readOptionalString();
         } else {
             uuid = null;
@@ -159,7 +159,7 @@ public class ClusterBlock implements Streamable, ToXContentFragment {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(id);
-        if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_6_7_0)) {
             out.writeOptionalString(uuid);
         }
         out.writeString(description);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexStateService.java
@@ -225,7 +225,7 @@ public class MetaDataIndexStateService {
 
         // If the cluster is in a mixed version that does not support the shard close action,
         // we use the previous way to close indices and directly close them without sanity checks
-        final boolean useDirectClose = currentState.nodes().getMinNodeVersion().before(Version.V_7_0_0);
+        final boolean useDirectClose = currentState.nodes().getMinNodeVersion().before(Version.V_6_7_0);
 
         final ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
         final RoutingTable.Builder routingTable = RoutingTable.builder(currentState.routingTable());

--- a/server/src/test/java/org/elasticsearch/cluster/block/ClusterBlockTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/block/ClusterBlockTests.java
@@ -65,7 +65,7 @@ public class ClusterBlockTests extends ESTestCase {
     public void testBwcSerialization() throws Exception {
         for (int runs = 0; runs < randomIntBetween(5, 20); runs++) {
             // Generate a random cluster block in version < 7.0.0
-            final Version version = randomVersionBetween(random(), Version.V_6_0_0, getPreviousVersion(Version.V_7_0_0));
+            final Version version = randomVersionBetween(random(), Version.V_6_0_0, getPreviousVersion(Version.V_6_7_0));
             final ClusterBlock expected = randomClusterBlock(version);
             assertNull(expected.uuid());
 
@@ -84,7 +84,7 @@ public class ClusterBlockTests extends ESTestCase {
 
             // Serialize to node in version < 7.0.0
             final BytesStreamOutput out = new BytesStreamOutput();
-            out.setVersion(randomVersionBetween(random(), Version.V_6_0_0, getPreviousVersion(Version.V_7_0_0)));
+            out.setVersion(randomVersionBetween(random(), Version.V_6_0_0, getPreviousVersion(Version.V_6_7_0)));
             expected.writeTo(out);
 
             // Deserialize and check the cluster block
@@ -171,7 +171,7 @@ public class ClusterBlockTests extends ESTestCase {
     }
 
     private ClusterBlock randomClusterBlock(final Version version) {
-        final String uuid = (version.onOrAfter(Version.V_7_0_0) && randomBoolean()) ? UUIDs.randomBase64UUID() : null;
+        final String uuid = (version.onOrAfter(Version.V_6_7_0) && randomBoolean()) ? UUIDs.randomBase64UUID() : null;
         final List<ClusterBlockLevel> levels = Arrays.asList(ClusterBlockLevel.values());
         return new ClusterBlock(randomInt(), uuid, "cluster block #" + randomInt(), randomBoolean(), randomBoolean(), randomBoolean(),
             randomFrom(RestStatus.values()), copyOf(randomSubsetOf(randomIntBetween(1, levels.size()), levels)));


### PR DESCRIPTION
This pull request changes the versions in the serialization logic of `ClusterBlock` after the backport to 6.x of the Close Index API refactoring (#37359).

I also adapts the version used to detect if a direct close is needed when closing indices (see change in `MetaDataIndexStateService`)
