### PR TITLE
Remove deprecated pipeline request constructors

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineRequest.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
@@ -37,15 +36,6 @@ public class PutPipelineRequest extends AcknowledgedRequest<PutPipelineRequest> 
     private String id;
     private BytesReference source;
     private XContentType xContentType;
-
-    /**
-     * Create a new pipeline request
-     * @deprecated use {@link #PutPipelineRequest(String, BytesReference, XContentType)} to avoid content type auto-detection
-     */
-    @Deprecated
-    public PutPipelineRequest(String id, BytesReference source) {
-        this(id, source, XContentHelper.xContentType(source));
-    }
 
     /**
      * Create a new pipeline request with the id and source along with the content type of the source

--- a/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineRequestBuilder.java
@@ -31,11 +31,6 @@ public class PutPipelineRequestBuilder extends ActionRequestBuilder<PutPipelineR
         super(client, action, new PutPipelineRequest());
     }
 
-    @Deprecated
-    public PutPipelineRequestBuilder(ElasticsearchClient client, PutPipelineAction action, String id, BytesReference source) {
-        super(client, action, new PutPipelineRequest(id, source));
-    }
-
     public PutPipelineRequestBuilder(ElasticsearchClient client, PutPipelineAction action, String id, BytesReference source,
                                      XContentType xContentType) {
         super(client, action, new PutPipelineRequest(id, source, xContentType));

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
@@ -26,11 +26,11 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.ingest.ConfigurationUtils;
 import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.IngestDocument.MetaData;
 import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.ingest.Pipeline;
 
@@ -41,23 +41,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.elasticsearch.ingest.IngestDocument.MetaData;
-
 public class SimulatePipelineRequest extends ActionRequest implements ToXContentObject {
 
     private String id;
     private boolean verbose;
     private BytesReference source;
     private XContentType xContentType;
-
-    /**
-     * Create a new request
-     * @deprecated use {@link #SimulatePipelineRequest(BytesReference, XContentType)} that does not attempt content autodetection
-     */
-    @Deprecated
-    public SimulatePipelineRequest(BytesReference source) {
-        this(source, XContentHelper.xContentType(source));
-    }
 
     /**
      * Creates a new request with the given source and its content type

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequestBuilder.java
@@ -35,16 +35,6 @@ public class SimulatePipelineRequestBuilder extends ActionRequestBuilder<Simulat
 
     /**
      * Create a new builder for {@link SimulatePipelineRequest}s
-     * @deprecated use {@link #SimulatePipelineRequestBuilder(ElasticsearchClient, SimulatePipelineAction, BytesReference, XContentType)} to
-     *             avoid content type auto-detection on the source bytes
-     */
-    @Deprecated
-    public SimulatePipelineRequestBuilder(ElasticsearchClient client, SimulatePipelineAction action, BytesReference source) {
-        super(client, action, new SimulatePipelineRequest(source));
-    }
-
-    /**
-     * Create a new builder for {@link SimulatePipelineRequest}s
      */
     public SimulatePipelineRequestBuilder(ElasticsearchClient client, SimulatePipelineAction action, BytesReference source,
                                           XContentType xContentType) {

--- a/server/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
+++ b/server/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
@@ -578,13 +578,6 @@ public interface ClusterAdminClient extends ElasticsearchClient {
 
     /**
      * Stores an ingest pipeline
-     * @deprecated use {@link #preparePutPipeline(String, BytesReference, XContentType)}
-     */
-    @Deprecated
-    PutPipelineRequestBuilder preparePutPipeline(String id, BytesReference source);
-
-    /**
-     * Stores an ingest pipeline
      */
     PutPipelineRequestBuilder preparePutPipeline(String id, BytesReference source, XContentType xContentType);
 
@@ -632,12 +625,6 @@ public interface ClusterAdminClient extends ElasticsearchClient {
      * Simulates an ingest pipeline
      */
     ActionFuture<SimulatePipelineResponse> simulatePipeline(SimulatePipelineRequest request);
-
-    /**
-     * Simulates an ingest pipeline
-     */
-    @Deprecated
-    SimulatePipelineRequestBuilder prepareSimulatePipeline(BytesReference source);
 
     /**
      * Simulates an ingest pipeline

--- a/server/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -1067,11 +1067,6 @@ public abstract class AbstractClient implements Client {
         }
 
         @Override
-        public PutPipelineRequestBuilder preparePutPipeline(String id, BytesReference source) {
-            return new PutPipelineRequestBuilder(this, PutPipelineAction.INSTANCE, id, source);
-        }
-
-        @Override
         public PutPipelineRequestBuilder preparePutPipeline(String id, BytesReference source, XContentType xContentType) {
             return new PutPipelineRequestBuilder(this, PutPipelineAction.INSTANCE, id, source, xContentType);
         }
@@ -1119,11 +1114,6 @@ public abstract class AbstractClient implements Client {
         @Override
         public ActionFuture<SimulatePipelineResponse> simulatePipeline(SimulatePipelineRequest request) {
             return execute(SimulatePipelineAction.INSTANCE, request);
-        }
-
-        @Override
-        public SimulatePipelineRequestBuilder prepareSimulatePipeline(BytesReference source) {
-            return new SimulatePipelineRequestBuilder(this, SimulatePipelineAction.INSTANCE, source);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/common/io/UTF8StreamWriter.java
+++ b/server/src/main/java/org/elasticsearch/common/io/UTF8StreamWriter.java
@@ -326,12 +326,4 @@ public final class UTF8StreamWriter extends Writer {
         _index = 0;
         _outputStream = null;
     }
-
-    /**
-     * @deprecated Replaced by {@link #setOutput(OutputStream)}
-     */
-    @Deprecated
-    public UTF8StreamWriter setOutputStream(OutputStream out) {
-        return this.setOutput(out);
-    }
 }


### PR DESCRIPTION
The constructors in PutPipelineRequest and SimulatePipelineRequest that guess
the xContent type from the provided source are deprecated since 6.0 and each
have a counterpart that takes the xContent type as an explicit argument.
Removing these ctors together with the builders and methods in
ClusterAdminClient that don't have the xContent type as argument.