### PR TITLE
Upgrade ASM for java 12 comparability

### DIFF
--- a/x-pack/test/feature-aware/build.gradle
+++ b/x-pack/test/feature-aware/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'elasticsearch.build'
 
 dependencies {
-  compile 'org.ow2.asm:asm:6.2'
+  compile 'org.ow2.asm:asm:7.0'
   compile "org.elasticsearch:elasticsearch:${version}"
   compile "org.elasticsearch.plugin:x-pack-core:${version}"
   testCompile "org.elasticsearch.test:framework:${version}"


### PR DESCRIPTION
Old version of ASM was displeased with  `java.runtime=12`, happily the latest version can handle it.

Closes #37371
