### PR TITLE
Update the scroll example ascii and Java docs

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchDocumentationIT.java
@@ -715,12 +715,12 @@ public class SearchDocumentationIT extends ESRestHighLevelClientTestCase {
             SearchHit[] searchHits = searchResponse.getHits().getHits();
 
             while (searchHits != null && searchHits.length > 0) { // <2>
-                SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId); // <3>
+                // <3>
+                SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId); // <4>
                 scrollRequest.scroll(scroll);
                 searchResponse = client.scroll(scrollRequest, RequestOptions.DEFAULT);
                 scrollId = searchResponse.getScrollId();
                 searchHits = searchResponse.getHits().getHits();
-                // <4>
             }
 
             ClearScrollRequest clearScrollRequest = new ClearScrollRequest(); // <5>

--- a/docs/java-rest/high-level/search/scroll.asciidoc
+++ b/docs/java-rest/high-level/search/scroll.asciidoc
@@ -128,9 +128,9 @@ include-tagged::{doc-tests}/SearchDocumentationIT.java[search-scroll-example]
 <1> Initialize the search context by sending the initial `SearchRequest`
 <2> Retrieve all the search hits by calling the Search Scroll api in a loop
 until no documents are returned
-<3> Create a new `SearchScrollRequest` holding the last returned scroll
+<3> Process the returned search results
+<4> Create a new `SearchScrollRequest` holding the last returned scroll
 identifier and the scroll interval
-<4> Process the returned search results
 <5> Clear the scroll context once the scroll is completed
 
 [[java-rest-high-clear-scroll]]


### PR DESCRIPTION
Update the scroll example ascii and Java docs, so it is more clear when to consume the scroll documents.
Before this change the user would loose the first results if one uses copy/paste (someone like me)

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
