### PR TITLE
Relax NoOpEngine constraints on translog

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
@@ -24,54 +24,20 @@ import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.store.Directory;
-import org.elasticsearch.common.Nullable;
-import org.elasticsearch.core.internal.io.IOUtils;
-import org.elasticsearch.index.translog.Translog;
-import org.elasticsearch.index.translog.TranslogConfig;
-import org.elasticsearch.index.translog.TranslogCorruptedException;
-import org.elasticsearch.index.translog.TranslogDeletionPolicy;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import java.util.function.LongSupplier;
-import java.util.stream.Stream;
+import java.util.function.Function;
 
 /**
  * NoOpEngine is an engine implementation that does nothing but the bare minimum
  * required in order to have an engine. All attempts to do something (search,
- * index, get), throw {@link UnsupportedOperationException}. This does maintain
- * a translog with a deletion policy so that when flushing, no translog is
- * retained on disk (setting a retention size and age of 0).
- *
- * It's also important to notice that this does list the commits of the Store's
- * Directory so that the last commit's user data can be read for the historyUUID
- * and last committed segment info.
+ * index, get), throw {@link UnsupportedOperationException}.
  */
 public final class NoOpEngine extends ReadOnlyEngine {
 
-    public NoOpEngine(EngineConfig engineConfig) {
-        super(engineConfig, null, null, true, directoryReader -> directoryReader);
-        boolean success = false;
-        try {
-            // The deletion policy for the translog should not keep any translogs around, so the min age/size is set to -1
-            final TranslogDeletionPolicy translogDeletionPolicy = new TranslogDeletionPolicy(-1, -1);
-
-            // The translog is opened and closed to validate that the translog UUID from lucene is the same as the one in the translog
-            try (Translog translog = openTranslog(engineConfig, translogDeletionPolicy, engineConfig.getGlobalCheckpointSupplier())) {
-                final int nbOperations = translog.totalOperations();
-                if (nbOperations != 0) {
-                    throw new IllegalArgumentException("Expected 0 translog operations but there were " + nbOperations);
-                }
-            }
-            success = true;
-        } catch (IOException | TranslogCorruptedException e) {
-            throw new EngineCreationFailureException(shardId, "failed to create engine", e);
-        } finally {
-            if (success == false) {
-                IOUtils.closeWhileHandlingException(this);
-            }
-        }
+    public NoOpEngine(EngineConfig config) {
+        super(config, null, null, true, Function.identity());
     }
 
     @Override
@@ -120,31 +86,5 @@ public final class NoOpEngine extends ReadOnlyEngine {
                 return null;
             }
         };
-    }
-
-    private Translog openTranslog(EngineConfig engineConfig, TranslogDeletionPolicy translogDeletionPolicy,
-                                  LongSupplier globalCheckpointSupplier) throws IOException {
-        final TranslogConfig translogConfig = engineConfig.getTranslogConfig();
-        final String translogUUID = loadTranslogUUIDFromLastCommit();
-        // We expect that this shard already exists, so it must already have an existing translog else something is badly wrong!
-        return new Translog(translogConfig, translogUUID, translogDeletionPolicy, globalCheckpointSupplier,
-                engineConfig.getPrimaryTermSupplier());
-    }
-
-    /**
-     * Reads the current stored translog ID from the last commit data.
-     */
-    @Nullable
-    private String loadTranslogUUIDFromLastCommit() {
-        final Map<String, String> commitUserData = getLastCommittedSegmentInfos().getUserData();
-        if (commitUserData.containsKey(Translog.TRANSLOG_GENERATION_KEY) == false) {
-            throw new IllegalStateException("Commit doesn't contain translog generation id");
-        }
-        return commitUserData.get(Translog.TRANSLOG_UUID_KEY);
-    }
-
-    @Override
-    public boolean ensureTranslogSynced(Stream<Translog.Location> locations) {
-        throw new UnsupportedOperationException("Translog synchronization should never be needed");
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineRecoveryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineRecoveryTests.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.engine;
+
+import org.elasticsearch.cluster.routing.RecoverySource.ExistingStoreRecoverySource;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardTestCase;
+
+import java.io.IOException;
+
+import static org.elasticsearch.cluster.routing.ShardRoutingHelper.initWithSameId;
+
+public class NoOpEngineRecoveryTests extends IndexShardTestCase {
+
+    public void testRecoverFromNoOp() throws IOException {
+        final int nbDocs = scaledRandomIntBetween(1, 100);
+
+        final IndexShard indexShard = newStartedShard(true);
+        for (int i = 0; i < nbDocs; i++) {
+            indexDoc(indexShard, "_doc", String.valueOf(i));
+        }
+        indexShard.close("test", true);
+
+        final ShardRouting shardRouting = indexShard.routingEntry();
+        IndexShard primary = reinitShard(indexShard, initWithSameId(shardRouting, ExistingStoreRecoverySource.INSTANCE), NoOpEngine::new);
+        recoverShardFromStore(primary);
+        assertEquals(primary.seqNoStats().getMaxSeqNo(), primary.getMaxSeqNoOfUpdatesOrDeletes());
+        assertEquals(nbDocs, primary.docStats().getCount());
+
+        IndexShard replica = newShard(false, Settings.EMPTY, NoOpEngine::new);
+        recoverReplica(replica, primary, true);
+        assertEquals(replica.seqNoStats().getMaxSeqNo(), replica.getMaxSeqNoOfUpdatesOrDeletes());
+        assertEquals(nbDocs, replica.docStats().getCount());
+        closeShards(primary, replica);
+    }
+}


### PR DESCRIPTION
Note: this pull request is against the `replicated-closed-indices` feature branch.

When a `NoOpEngine` is instanciated, the current implementation verifies that the translog contains no operations and that it contains the same UUID as the last Lucene commit data. I think that we can relax those two constraints because the Close Index API now ensure that all translog operations are flushed before closing a shard. The detection of coherence between translog UUID / Lucene commit data is not specific to NoOpEngine, and is already done by IndexShard.innerOpenEngineAndTranslog().

This pull request also adds a test for recovery from a NoOpEngine.