### PR TITLE
Fix IndexShardTestCase.recoverReplica(IndexShard, IndexShard, boolean)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -540,7 +540,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
         recoverReplica(replica, primary,
             (r, sourceNode) -> new RecoveryTarget(r, sourceNode, recoveryListener, version -> {
             }),
-            true, true);
+            true, startReplica);
     }
 
     /** recovers a replica from the given primary **/


### PR DESCRIPTION
This pull requests fixes the `IndexShardTestCase.recoverReplica(IndexShard, IndexShard, boolean)` method where the `startReplica` was not correctly propagated and the value `true` always used instead.