### PR TITLE
[ML] Use String rep of Version in map for serialisation

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
@@ -402,7 +402,8 @@ public class MlConfigMigrator {
     public static Job updateJobForMigration(Job job) {
         Job.Builder builder = new Job.Builder(job);
         Map<String, Object> custom = job.getCustomSettings() == null ? new HashMap<>() : new HashMap<>(job.getCustomSettings());
-        custom.put(MIGRATED_FROM_VERSION, job.getJobVersion());
+        String version = job.getJobVersion() != null ? job.getJobVersion().toString() : null;
+        custom.put(MIGRATED_FROM_VERSION, version);
         builder.setCustomSettings(custom);
         // Increase the model memory limit for 6.1 - 6.3 jobs
         Version jobVersion = job.getJobVersion();


### PR DESCRIPTION
The ml config migrator inserts the job's original version into the custom settings map but a `Version` object cannot be serialised in a Map as it is not handled in `StreamOutput.writeGenericValue`. Use the string representation instead. 

Non issue as the bug is in unreleased code