### PR TITLE
Ensure that max seq # is equal to the global checkpoint when creating ReadOnlyEngines

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -101,8 +101,9 @@ public class ReadOnlyEngine extends Engine {
                 this.translogStats = translogStats == null ? new TranslogStats(0, 0, 0, 0, 0) : translogStats;
                 if (seqNoStats == null) {
                     seqNoStats = buildSeqNoStats(lastCommittedSegmentInfos);
-                    if (engineConfig.getIndexSettings().getIndexVersionCreated().onOrAfter(Version.V_6_7_0)) {
-                        final long globalCheckpoint = engineConfig.getGlobalCheckpointSupplier().getAsLong();
+                    final long globalCheckpoint = engineConfig.getGlobalCheckpointSupplier().getAsLong();
+                    if (globalCheckpoint != SequenceNumbers.UNASSIGNED_SEQ_NO
+                        && engineConfig.getIndexSettings().getIndexVersionCreated().onOrAfter(Version.V_6_7_0)) {
                         if (seqNoStats.getMaxSeqNo() != globalCheckpoint) {
                             throw new IllegalStateException("Maximum sequence number [" + seqNoStats.getMaxSeqNo()
                                 + "] from last commit does not match global checkpoint [" + globalCheckpoint + "]");

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -101,6 +101,12 @@ public class ReadOnlyEngine extends Engine {
                 this.translogStats = translogStats == null ? new TranslogStats(0, 0, 0, 0, 0) : translogStats;
                 if (seqNoStats == null) {
                     seqNoStats = buildSeqNoStats(lastCommittedSegmentInfos);
+                    // the global checkpoint is not always known and up to date when the engine is created,
+                    // so we only check the max seq no / global checkpoint coherency when the global checkpoint
+                    // is different from the unassigned sequence number value. In addition to that we only execute
+                    // the check if the index the engine belongs to has been created after the refactoring of the
+                    // Close Index API and its TransportVerifyShardBeforeCloseAction that guarantee that all
+                    // operations have been flushed to Lucene.
                     final long globalCheckpoint = engineConfig.getGlobalCheckpointSupplier().getAsLong();
                     if (globalCheckpoint != SequenceNumbers.UNASSIGNED_SEQ_NO
                         && engineConfig.getIndexSettings().getIndexVersionCreated().onOrAfter(Version.V_6_7_0)) {

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -101,16 +101,17 @@ public class ReadOnlyEngine extends Engine {
                 this.translogStats = translogStats == null ? new TranslogStats(0, 0, 0, 0, 0) : translogStats;
                 if (seqNoStats == null) {
                     seqNoStats = buildSeqNoStats(lastCommittedSegmentInfos);
-                    // the global checkpoint is not always known and up to date when the engine is created,
-                    // so we only check the max seq no / global checkpoint coherency when the global checkpoint
-                    // is different from the unassigned sequence number value. In addition to that we only execute
-                    // the check if the index the engine belongs to has been created after the refactoring of the
-                    // Close Index API and its TransportVerifyShardBeforeCloseAction that guarantee that all
-                    // operations have been flushed to Lucene.
+                    // During a peer-recovery the global checkpoint is not known and up to date when the engine
+                    // is created, so we only check the max seq no / global checkpoint coherency when the global
+                    // checkpoint is different from the unassigned sequence number value.
+                    // In addition to that we only execute the check if the index the engine belongs to has been
+                    // created after the refactoring of the Close Index API and its TransportVerifyShardBeforeCloseAction
+                    // that guarantee that all operations have been flushed to Lucene.
                     final long globalCheckpoint = engineConfig.getGlobalCheckpointSupplier().getAsLong();
                     if (globalCheckpoint != SequenceNumbers.UNASSIGNED_SEQ_NO
                         && engineConfig.getIndexSettings().getIndexVersionCreated().onOrAfter(Version.V_6_7_0)) {
                         if (seqNoStats.getMaxSeqNo() != globalCheckpoint) {
+                            assert false : "max seq. no. [" + seqNoStats.getMaxSeqNo() + "] does not match [" + globalCheckpoint + "]";
                             throw new IllegalStateException("Maximum sequence number [" + seqNoStats.getMaxSeqNo()
                                 + "] from last commit does not match global checkpoint [" + globalCheckpoint + "]");
                         }

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -30,6 +30,7 @@ import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.Lock;
+import org.elasticsearch.Assertions;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
@@ -111,7 +112,7 @@ public class ReadOnlyEngine extends Engine {
                     if (globalCheckpoint != SequenceNumbers.UNASSIGNED_SEQ_NO
                         && engineConfig.getIndexSettings().getIndexVersionCreated().onOrAfter(Version.V_6_7_0)) {
                         if (seqNoStats.getMaxSeqNo() != globalCheckpoint) {
-                            assert false : "max seq. no. [" + seqNoStats.getMaxSeqNo() + "] does not match [" + globalCheckpoint + "]";
+                            assertMaxSeqNoEqualsToGlobalCheckpoint(seqNoStats.getMaxSeqNo(), globalCheckpoint);
                             throw new IllegalStateException("Maximum sequence number [" + seqNoStats.getMaxSeqNo()
                                 + "] from last commit does not match global checkpoint [" + globalCheckpoint + "]");
                         }
@@ -132,6 +133,12 @@ public class ReadOnlyEngine extends Engine {
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e); // this is stupid
+        }
+    }
+
+    protected void assertMaxSeqNoEqualsToGlobalCheckpoint(final long maxSeqNo, final long globalCheckpoint) {
+        if (Assertions.ENABLED) {
+            assert false : "max seq. no. [" + maxSeqNo + "] does not match [" + globalCheckpoint + "]";
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
@@ -70,7 +70,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
                 lastDocIds = getDocIds(engine, true);
                 assertThat(readOnlyEngine.getLocalCheckpoint(), equalTo(lastSeqNoStats.getLocalCheckpoint()));
                 assertThat(readOnlyEngine.getSeqNoStats(globalCheckpoint.get()).getMaxSeqNo(), equalTo(lastSeqNoStats.getMaxSeqNo()));
-                    assertThat(getDocIds(readOnlyEngine, false), equalTo(lastDocIds));
+                assertThat(getDocIds(readOnlyEngine, false), equalTo(lastDocIds));
                 for (int i = 0; i < numDocs; i++) {
                     if (randomBoolean()) {
                         String delId = Integer.toString(i);
@@ -126,13 +126,42 @@ public class ReadOnlyEngineTests extends EngineTestCase {
                     if (rarely()) {
                         engine.flush();
                     }
-                    globalCheckpoint.set(randomLongBetween(globalCheckpoint.get(), engine.getLocalCheckpoint()));
+                    globalCheckpoint.set(i);
                 }
                 engine.syncTranslog();
                 engine.flushAndClose();
                 readOnlyEngine = new ReadOnlyEngine(engine.engineConfig, null , null, true, Function.identity());
                 Engine.CommitId flush = readOnlyEngine.flush(randomBoolean(), randomBoolean());
                 assertEquals(flush, readOnlyEngine.flush(randomBoolean(), randomBoolean()));
+            } finally {
+                IOUtils.close(readOnlyEngine);
+            }
+        }
+    }
+
+    public void testEnsureMaxSeqNoIsEqualToGlobalCheckpoint() throws IOException {
+        IOUtils.close(engine, store);
+        Engine readOnlyEngine = null;
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+        try (Store store = createStore()) {
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            final int numDocs = scaledRandomIntBetween(10, 100);
+            try (InternalEngine engine = createEngine(config)) {
+                long maxSeqNo = SequenceNumbers.NO_OPS_PERFORMED;
+                for (int i = 0; i < numDocs; i++) {
+                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+                    engine.index(new Engine.Index(newUid(doc), doc, i, primaryTerm.get(), 1, null, Engine.Operation.Origin.REPLICA,
+                        System.nanoTime(), -1, false, SequenceNumbers.UNASSIGNED_SEQ_NO, 0));
+                    maxSeqNo = engine.getLocalCheckpoint();
+                }
+                globalCheckpoint.set(engine.getLocalCheckpoint() - 1);
+                engine.syncTranslog();
+                engine.flushAndClose();
+
+                IllegalStateException exception = expectThrows(IllegalStateException.class,
+                    () -> new ReadOnlyEngine(engine.engineConfig, null, null, true, Function.identity()));
+                assertThat(exception.getMessage(), equalTo("Maximum sequence number [" + maxSeqNo
+                    + "] from last commit does not match global checkpoint [" + globalCheckpoint.get() + "]"));
             } finally {
                 IOUtils.close(readOnlyEngine);
             }

--- a/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
@@ -159,7 +159,12 @@ public class ReadOnlyEngineTests extends EngineTestCase {
                 engine.flushAndClose();
 
                 IllegalStateException exception = expectThrows(IllegalStateException.class,
-                    () -> new ReadOnlyEngine(engine.engineConfig, null, null, true, Function.identity()));
+                    () -> new ReadOnlyEngine(engine.engineConfig, null, null, true, Function.identity()) {
+                        @Override
+                        protected void assertMaxSeqNoEqualsToGlobalCheckpoint(final long maxSeqNo, final long globalCheckpoint) {
+                            // we don't want the assertion to trip in this test
+                        }
+                    });
                 assertThat(exception.getMessage(), equalTo("Maximum sequence number [" + maxSeqNo
                     + "] from last commit does not match global checkpoint [" + globalCheckpoint.get() + "]"));
             } finally {


### PR DESCRIPTION
Since version 6.7.0 the Close Index API guarantees that all translog operations have been correctly flushed before the index is closed. If the index is reopened as a Frozen index (which uses a `ReadOnlyEngine`) we can verify that the maximum sequence number from the last Lucene commit is indeed equal to the last known global checkpoint and refuses to open the read only engine if it's not the case. In this PR the check is only done for indices created on or after 6.7.0 as they are guaranteed to be closed using the new Close Index API. 