### PR TITLE
Update Delete Watch to allow unknown fields

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/DeleteWatchResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/DeleteWatchResponse.java
@@ -20,8 +20,6 @@ package org.elasticsearch.client.watcher;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ObjectParser;
-import org.elasticsearch.common.xcontent.ToXContentObject;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/DeleteWatchResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/DeleteWatchResponse.java
@@ -27,10 +27,10 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.Objects;
 
-public class DeleteWatchResponse implements ToXContentObject {
+public class DeleteWatchResponse {
 
     private static final ObjectParser<DeleteWatchResponse, Void> PARSER
-        = new ObjectParser<>("x_pack_delete_watch_response", DeleteWatchResponse::new);
+        = new ObjectParser<>("x_pack_delete_watch_response", true, DeleteWatchResponse::new);
     static {
         PARSER.declareString(DeleteWatchResponse::setId, new ParseField("_id"));
         PARSER.declareLong(DeleteWatchResponse::setVersion, new ParseField("_version"));
@@ -87,15 +87,6 @@ public class DeleteWatchResponse implements ToXContentObject {
     @Override
     public int hashCode() {
         return Objects.hash(id, version, found);
-    }
-
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return builder.startObject()
-            .field("_id", id)
-            .field("_version", version)
-            .field("found", found)
-            .endObject();
     }
 
     public static DeleteWatchResponse fromXContent(XContentParser parser) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/DeleteWatchResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/DeleteWatchResponseTests.java
@@ -18,28 +18,37 @@
  */
 package org.elasticsearch.client.watcher;
 
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 
-public class DeleteWatchResponseTests extends AbstractXContentTestCase<DeleteWatchResponse> {
+import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
 
-    @Override
-    protected DeleteWatchResponse createTestInstance() {
+public class DeleteWatchResponseTests extends ESTestCase {
+
+    public void testFromXContent() throws IOException {
+        xContentTester(this::createParser,
+            DeleteWatchResponseTests::createTestInstance,
+            DeleteWatchResponseTests::toXContent,
+            DeleteWatchResponse::fromXContent)
+            .supportsUnknownFields(true)
+            .assertToXContentEquivalence(false)
+            .test();
+    }
+
+    private static XContentBuilder toXContent(DeleteWatchResponse response, XContentBuilder builder) throws IOException {
+        return builder.startObject()
+            .field("_id", response.getId())
+            .field("_version", response.getVersion())
+            .field("found", response.isFound())
+            .endObject();
+    }
+
+    private static DeleteWatchResponse createTestInstance() {
         String id = randomAlphaOfLength(10);
         long version = randomLongBetween(1, 10);
         boolean found = randomBoolean();
         return new DeleteWatchResponse(id, version, found);
-    }
-
-    @Override
-    protected DeleteWatchResponse doParseInstance(XContentParser parser) throws IOException {
-        return DeleteWatchResponse.fromXContent(parser);
-    }
-
-    @Override
-    protected boolean supportsUnknownFields() {
-        return false;
     }
 }


### PR DESCRIPTION
DeleteWatchResponse did not allow unknown fields. This commit fixes the
test and ConstructingObjectParser such that it does now allow unknown
fields.

Relates #36938