### PR TITLE
[DOCS] Edits rollup API description

### DIFF
--- a/docs/reference/rollup/apis/rollup-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-caps.asciidoc
@@ -8,16 +8,19 @@
 
 experimental[]
 
-This API returns the rollup capabilities that have been configured for an index or index pattern.  This API is useful
-because a rollup job is often configured to rollup only a subset of fields from the source index.  Furthermore, only
-certain aggregations can be configured for various fields, leading to a limited subset of functionality depending on
-that configuration.
+This API returns the capabilities of any rollup jobs that have been configured
+for a specific index or index pattern.
 
-This API will allow you to inspect an index and determine:
+This API is useful because a rollup job is often configured to rollup only a
+subset of fields from the source index. Furthermore, only certain aggregations
+can be configured for various fields, leading to a limited subset of
+functionality depending on that configuration.
+
+This API enables you to inspect an index and determine:
 
 1. Does this index have associated rollup data somewhere in the cluster?
-2. If yes to the first question, what fields were rolled up, what aggregations can be performed, and where does the data
-live?
+2. If yes to the first question, what fields were rolled up, what aggregations
+can be performed, and where does the data live?
 
 ==== Request
 


### PR DESCRIPTION
This PR clarifies the description of the get rollup caps API. It also ends some long lines of text.