### PR TITLE
Add simple method to write collection of writeables

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/bootstrap/GetDiscoveredNodesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/bootstrap/GetDiscoveredNodesResponse.java
@@ -68,6 +68,6 @@ public class GetDiscoveredNodesResponse extends ActionResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeCollection(nodes, (o, v) -> v.writeTo(o));
+        out.writeCollection(nodes);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetaData.java
@@ -117,7 +117,7 @@ public class CoordinationMetaData implements Writeable, ToXContentFragment {
         out.writeLong(term);
         lastCommittedConfiguration.writeTo(out);
         lastAcceptedConfiguration.writeTo(out);
-        out.writeCollection(votingConfigExclusions, (o, v) -> v.writeTo(o));
+        out.writeCollection(votingConfigExclusions);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -1011,13 +1011,21 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
+     * Writes a collection to this stream. The corresponding collection can be read from a stream input using
+     * {@link StreamInput#readList(Writeable.Reader)}.
+     *
+     * @param collection the collection to write to this stream
+     * @throws IOException if an I/O exception occurs writing the collection
+     */
+    public void writeCollection(final Collection<? extends Writeable> collection) throws IOException {
+        writeCollection(collection, (o, v) -> v.writeTo(o));
+    }
+
+    /**
      * Writes a list of {@link Writeable} objects
      */
     public void writeList(List<? extends Writeable> list) throws IOException {
-        writeVInt(list.size());
-        for (Writeable obj: list) {
-            obj.writeTo(this);
-        }
+        writeCollection(list);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/io/stream/StreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/StreamTests.java
@@ -30,12 +30,14 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -252,6 +254,56 @@ public class StreamTests extends ESTestCase {
             deserialized = out.bytes().streamInput().readArray(reader, String[]::new);
         }
         assertThat(deserialized, equalTo(strings));
+    }
+
+    public void testCollection() throws IOException {
+        class FooBar implements Writeable {
+
+            private final int foo;
+            private final int bar;
+
+            private FooBar(final int foo, final int bar) {
+                this.foo = foo;
+                this.bar = bar;
+            }
+
+            private FooBar(final StreamInput in) throws IOException {
+                this.foo = in.readInt();
+                this.bar = in.readInt();
+            }
+
+            @Override
+            public void writeTo(final StreamOutput out) throws IOException {
+                out.writeInt(foo);
+                out.writeInt(bar);
+            }
+
+            @Override
+            public boolean equals(final Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+                final FooBar that = (FooBar) o;
+                return foo == that.foo && bar == that.bar;
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(foo, bar);
+            }
+
+        }
+
+        final int length = randomIntBetween(0, 16);
+        final Collection<FooBar> fooBars = new ArrayList<>(length);
+        for (int i = 0; i < length; i++) {
+            fooBars.add(new FooBar(randomInt(), randomInt()));
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeCollection(fooBars);
+            try (StreamInput in = out.bytes().streamInput()) {
+                assertThat(fooBars, equalTo(in.readList(FooBar::new)));
+            }
+        }
     }
 
     public void testSetOfLongs() throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUserPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUserPrivilegesResponse.java
@@ -86,8 +86,8 @@ public final class GetUserPrivilegesResponse extends ActionResponse {
         super.writeTo(out);
         out.writeCollection(cluster, StreamOutput::writeString);
         out.writeCollection(conditionalCluster, ConditionalClusterPrivileges.WRITER);
-        out.writeCollection(index, (o, p) -> p.writeTo(o));
-        out.writeCollection(application, (o, p) -> p.writeTo(o));
+        out.writeCollection(index);
+        out.writeCollection(application);
         out.writeCollection(runAs, StreamOutput::writeString);
     }
 


### PR DESCRIPTION
This commit adds a simple convenience method for writing a collection of writeables, and replaces existing call sites with the new method.

Relates #37398