### PR TITLE
[ML] Fix ML datafeed CCS with wildcarded cluster name

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -303,6 +303,14 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
         return remoteClusters.containsKey(clusterName);
     }
 
+    /**
+     * Returns the registered remote cluster names.
+     */
+    public Set<String> getRegisteredRemoteClusterNames() {
+        // remoteClusters is unmodifiable so its key set will be unmodifiable too
+        return remoteClusters.keySet();
+    }
+
     public void collectSearchShards(IndicesOptions indicesOptions, String preference, String routing,
                                     Map<String, OriginalIndices> remoteIndicesByCluster,
                                     ActionListener<Map<String, ClusterSearchShardsResponse>> listener) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/RemoteClusterLicenseCheckerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/RemoteClusterLicenseCheckerTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse;
 import org.elasticsearch.protocol.xpack.license.LicenseStatus;
 import org.elasticsearch.test.ESTestCase;
@@ -23,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -80,24 +82,49 @@ public final class RemoteClusterLicenseCheckerTests extends ESTestCase {
     }
 
     public void testNoRemoteClusterAliases() {
+        Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
         final List<String> indices = Arrays.asList("local-index1", "local-index2");
-        assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(indices), empty());
+        assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices), empty());
     }
 
     public void testOneRemoteClusterAlias() {
+        Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
         final List<String> indices = Arrays.asList("local-index1", "remote-cluster1:remote-index1");
-        assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(indices), contains("remote-cluster1"));
+        assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices), contains("remote-cluster1"));
     }
 
     public void testMoreThanOneRemoteClusterAlias() {
+        Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
         final List<String> indices = Arrays.asList("remote-cluster1:remote-index1", "local-index1", "remote-cluster2:remote-index1");
-        assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(indices), contains("remote-cluster1", "remote-cluster2"));
+        assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices),
+                containsInAnyOrder("remote-cluster1", "remote-cluster2"));
     }
 
     public void testDuplicateRemoteClusterAlias() {
+        Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
         final List<String> indices = Arrays.asList(
                 "remote-cluster1:remote-index1", "local-index1", "remote-cluster2:index1", "remote-cluster2:remote-index2");
-        assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(indices), contains("remote-cluster1", "remote-cluster2"));
+        assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices),
+                containsInAnyOrder("remote-cluster1", "remote-cluster2"));
+    }
+
+    public void testSimpleWildcardRemoteClusterAlias() {
+        Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
+        final List<String> indices = Arrays.asList("*:remote-index1", "local-index1");
+        assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices),
+                containsInAnyOrder("remote-cluster1", "remote-cluster2"));
+    }
+
+    public void testPartialWildcardRemoteClusterAlias() {
+        Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
+        final List<String> indices = Arrays.asList("*2:remote-index1", "local-index1");
+        assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices), contains("remote-cluster2"));
+    }
+
+    public void testNonMatchingWildcardRemoteClusterAlias() {
+        Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
+        final List<String> indices = Arrays.asList("*3:remote-index1", "local-index1");
+        assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices), empty());
     }
 
     public void testCheckRemoteClusterLicensesGivenCompatibleLicenses() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/RemoteClusterLicenseCheckerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/RemoteClusterLicenseCheckerTests.java
@@ -82,26 +82,26 @@ public final class RemoteClusterLicenseCheckerTests extends ESTestCase {
     }
 
     public void testNoRemoteClusterAliases() {
-        Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
+        final Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
         final List<String> indices = Arrays.asList("local-index1", "local-index2");
         assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices), empty());
     }
 
     public void testOneRemoteClusterAlias() {
-        Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
+        final Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
         final List<String> indices = Arrays.asList("local-index1", "remote-cluster1:remote-index1");
         assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices), contains("remote-cluster1"));
     }
 
     public void testMoreThanOneRemoteClusterAlias() {
-        Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
+        final Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
         final List<String> indices = Arrays.asList("remote-cluster1:remote-index1", "local-index1", "remote-cluster2:remote-index1");
         assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices),
                 containsInAnyOrder("remote-cluster1", "remote-cluster2"));
     }
 
     public void testDuplicateRemoteClusterAlias() {
-        Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
+        final Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
         final List<String> indices = Arrays.asList(
                 "remote-cluster1:remote-index1", "local-index1", "remote-cluster2:index1", "remote-cluster2:remote-index2");
         assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices),
@@ -109,20 +109,20 @@ public final class RemoteClusterLicenseCheckerTests extends ESTestCase {
     }
 
     public void testSimpleWildcardRemoteClusterAlias() {
-        Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
+        final Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
         final List<String> indices = Arrays.asList("*:remote-index1", "local-index1");
         assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices),
                 containsInAnyOrder("remote-cluster1", "remote-cluster2"));
     }
 
     public void testPartialWildcardRemoteClusterAlias() {
-        Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
+        final Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
         final List<String> indices = Arrays.asList("*2:remote-index1", "local-index1");
         assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices), contains("remote-cluster2"));
     }
 
     public void testNonMatchingWildcardRemoteClusterAlias() {
-        Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
+        final Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
         final List<String> indices = Arrays.asList("*3:remote-index1", "local-index1");
         assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices), empty());
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -174,7 +174,9 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
                     final RemoteClusterLicenseChecker remoteClusterLicenseChecker =
                             new RemoteClusterLicenseChecker(client, XPackLicenseState::isMachineLearningAllowedForOperationMode);
                     remoteClusterLicenseChecker.checkRemoteClusterLicenses(
-                            RemoteClusterLicenseChecker.remoteClusterAliases(params.getDatafeedIndices()),
+                            RemoteClusterLicenseChecker.remoteClusterAliases(
+                                    transportService.getRemoteClusterService().getRegisteredRemoteClusterNames(),
+                                    params.getDatafeedIndices()),
                             ActionListener.wrap(
                                     response -> {
                                         if (response.isSuccess() == false) {
@@ -311,7 +313,8 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
 
     private ElasticsearchStatusException createUnknownLicenseError(
             final String datafeedId, final List<String> remoteIndices, final Exception cause) {
-        final int numberOfRemoteClusters = RemoteClusterLicenseChecker.remoteClusterAliases(remoteIndices).size();
+        final int numberOfRemoteClusters = RemoteClusterLicenseChecker.remoteClusterAliases(
+                transportService.getRemoteClusterService().getRegisteredRemoteClusterNames(), remoteIndices).size();
         assert numberOfRemoteClusters > 0;
         final String remoteClusterQualifier = numberOfRemoteClusters == 1 ? "a remote cluster" : "remote clusters";
         final String licenseTypeQualifier = numberOfRemoteClusters == 1 ? "" : "s";


### PR DESCRIPTION
The test that remote clusters used by ML datafeeds have
a license that allows ML was not accounting for the
possibility that the remote cluster name could be
wildcarded.  This change fixes that omission.

Fixes #36228