### PR TITLE
Fix wrong logging statement during watch execution

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/ExecutionService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/ExecutionService.java
@@ -318,7 +318,8 @@ public class ExecutionService {
                             historyStore.put(record);
                         }
                     } catch (Exception e) {
-                        logger.error((Supplier<?>) () -> new ParameterizedMessage("failed to update watch record [{}]", ctx.id()), e);
+                        logger.error((Supplier<?>) () -> new ParameterizedMessage("failed to update watch status[{}]",
+                            ctx.id().watchId()), e);
                         // TODO log watch record in logger, when saving in history store failed, otherwise the info is gone!
                     }
                 }


### PR DESCRIPTION
In case that a watch record cannot be updated due to an unexpected
error, a log message containing the whole id of the watch recrod in case
of the watch id is emitted. This is confusing as the error message is
about not being able to update the watch in the .watches index and not
about any watch history entry.
