### PR TITLE
IndexMetaData#mappingOrDefault doesn't need to take a type argument.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -351,7 +351,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                         case INDEX:
                             IndexRequest indexRequest = (IndexRequest) docWriteRequest;
                             final IndexMetaData indexMetaData = metaData.index(concreteIndex);
-                            MappingMetaData mappingMd = indexMetaData.mappingOrDefault(indexRequest.type());
+                            MappingMetaData mappingMd = indexMetaData.mappingOrDefault();
                             Version indexCreated = indexMetaData.getCreationVersion();
                             indexRequest.resolveRouting(metaData);
                             indexRequest.process(indexCreated, mappingMd, concreteIndex.getName());

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -191,7 +191,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                 case UPDATED:
                     IndexRequest indexRequest = updateResult.action();
                     IndexMetaData metaData = context.getPrimary().indexSettings().getIndexMetaData();
-                    MappingMetaData mappingMd = metaData.mappingOrDefault(indexRequest.type());
+                    MappingMetaData mappingMd = metaData.mappingOrDefault();
                     indexRequest.process(metaData.getCreationVersion(), mappingMd, updateRequest.concreteIndex());
                     context.setRequestToExecute(indexRequest);
                     break;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -505,12 +505,15 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
      * setting its routing, timestamp, and so on if needed.
      */
     @Nullable
-    public MappingMetaData mappingOrDefault(String mappingType) {
-        MappingMetaData mapping = mappings.get(mappingType);
-        if (mapping != null) {
-            return mapping;
+    public MappingMetaData mappingOrDefault() {
+        MappingMetaData mapping = null;
+        for (ObjectCursor<MappingMetaData> m : mappings.values()) {
+            if (mapping == null || mapping.type().equals(MapperService.DEFAULT_MAPPING)) {
+                mapping = m.value;
+            }
         }
-        return mappings.get(MapperService.DEFAULT_MAPPING);
+
+        return mapping;
     }
 
     ImmutableOpenMap<String, DiffableStringMap> getCustomData() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetaDataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetaDataTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.rollover.MaxAgeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxDocsCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
@@ -39,6 +40,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.test.ESTestCase;
@@ -286,5 +288,39 @@ public class IndexMetaDataTests extends ESTestCase {
         iae = expectThrows(IllegalArgumentException.class,
             () -> IndexMetaData.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.get(notAFactorySettings));
         assertEquals("the number of source shards [2] must be a factor of [3]", iae.getMessage());
+    }
+
+    public void testMappingOrDefault() throws IOException {
+        Settings settings = Settings.builder()
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 2)
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
+                .build();
+        IndexMetaData meta = IndexMetaData.builder("index")
+                .settings(settings)
+                .build();
+        assertNull(meta.mappingOrDefault());
+
+        meta = IndexMetaData.builder("index")
+                .settings(settings)
+                .putMapping("type", "{}")
+                .build();
+        assertNotNull(meta.mappingOrDefault());
+        assertEquals("type", meta.mappingOrDefault().type());
+
+        meta = IndexMetaData.builder("index")
+                .settings(settings)
+                .putMapping(MapperService.DEFAULT_MAPPING, "{}")
+                .build();
+        assertNotNull(meta.mappingOrDefault());
+        assertEquals(MapperService.DEFAULT_MAPPING, meta.mappingOrDefault().type());
+
+        meta = IndexMetaData.builder("index")
+                .settings(settings)
+                .putMapping("type", "{}")
+                .putMapping(MapperService.DEFAULT_MAPPING, "{}")
+                .build();
+        assertNotNull(meta.mappingOrDefault());
+        assertEquals("type", meta.mappingOrDefault().type());
     }
 }


### PR DESCRIPTION
Currently it takes a type, but this isn't really needed now that indices can
have at most one type. The only downside is that we might return a different
error when trying to index into a type that doesn't exist yet.
