### PR TITLE
[ML] log minimum diskspace setting if forecast fails due to insufficient d…

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportForecastJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportForecastJobAction.java
@@ -97,8 +97,15 @@ public class TransportForecastJobAction extends TransportJobTaskAction<ForecastJ
             } else if (forecastRequestStats.getStatus() == ForecastRequestStats.ForecastRequestStatus.FAILED) {
                 List<String> messages = forecastRequestStats.getMessages();
                 if (messages.size() > 0) {
+                    String message = messages.get(0);
+
+                    // special case: if forecast failed due to insufficient disk space, log the settings
+                    if (message.contains("disk space is insufficient")) {
+                        message += " Minimum diskspace required: [" + processManager.getMinLocalStorageAvailable() + "]";
+                    }
+
                     listener.onFailure(ExceptionsHelper.badRequestException("Cannot run forecast: "
-                            + messages.get(0)));
+                            + message));
                 } else {
                     // paranoia case, it should not be possible to have an empty message list
                     listener.onFailure(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportForecastJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportForecastJobAction.java
@@ -99,9 +99,9 @@ public class TransportForecastJobAction extends TransportJobTaskAction<ForecastJ
                 if (messages.size() > 0) {
                     String message = messages.get(0);
 
-                    // special case: if forecast failed due to insufficient disk space, log the settings
+                    // special case: if forecast failed due to insufficient disk space, log the setting
                     if (message.contains("disk space is insufficient")) {
-                        message += " Minimum diskspace required: [" + processManager.getMinLocalStorageAvailable() + "]";
+                        message += " Minimum disk space required: [" + processManager.getMinLocalStorageAvailable() + "]";
                     }
 
                     listener.onFailure(ExceptionsHelper.badRequestException("Cannot run forecast: "

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -749,6 +749,10 @@ public class AutodetectProcessManager {
         return autoDetectWorkerExecutor;
     }
 
+    public ByteSizeValue getMinLocalStorageAvailable() {
+        return nativeStorageProvider.getMinLocalStorageAvailable();
+    }
+
     /*
      * The autodetect native process can only handle a single operation at a time. In order to guarantee that, all
      * operations are initially added to a queue and a worker thread from ml autodetect threadpool will process each

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/NativeStorageProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/NativeStorageProvider.java
@@ -111,6 +111,10 @@ public class NativeStorageProvider {
         }
     }
 
+    public ByteSizeValue getMinLocalStorageAvailable() {
+        return minLocalStorageAvailable;
+    }
+
     long getUsableSpace(Path path) throws IOException {
         long freeSpaceInBytes = Environment.getFileStore(path).getUsableSpace();
 


### PR DESCRIPTION
log minimum disk space setting if forecast fails due to insufficient disk space

Note:
 - marked as test, because the setting for limiting the minimum available disk space is only for testing and not documented for production
 - the message extension is supposed to help debugging test failures of forecast integration test
