### PR TITLE
Consistently use loopback address for ssl profile

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ssl/SslMultiPortTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ssl/SslMultiPortTests.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.security.transport.ssl;
 
 import org.elasticsearch.client.transport.NoNodeAvailableException;
 import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.SecurityIntegTestCase;
@@ -34,11 +35,13 @@ public class SslMultiPortTests extends SecurityIntegTestCase {
 
     private static int randomClientPort;
     private static int randomNoClientAuthPort;
+    private static InetAddress localAddress;
 
     @BeforeClass
     public static void getRandomPort() {
         randomClientPort = randomIntBetween(49000, 65500); // ephemeral port
         randomNoClientAuthPort = randomIntBetween(49000, 65500);
+        localAddress = InetAddress.getLoopbackAddress();
     }
 
     /**
@@ -65,12 +68,11 @@ public class SslMultiPortTests extends SecurityIntegTestCase {
         Settings.Builder builder = Settings.builder().put(super.nodeSettings(nodeOrdinal));
         addSSLSettingsForNodePEMFiles(builder, "transport.profiles.client.xpack.security.", true);
         builder.put("transport.profiles.client.port", randomClientPortRange)
-            // make sure this is "localhost", no matter if ipv4 or ipv6, but be consistent
-            .put("transport.profiles.client.bind_host", "localhost")
+            .put("transport.profiles.client.bind_host", NetworkAddress.format(localAddress))
             .put("transport.profiles.client.xpack.security.ssl.certificate_authorities", trustCert.toAbsolutePath());
         addSSLSettingsForNodePEMFiles(builder, "transport.profiles.no_client_auth.xpack.security.", true);
         builder.put("transport.profiles.no_client_auth.port", randomNoClientAuthPortRange)
-            .put("transport.profiles.no_client_auth.bind_host", "localhost")
+            .put("transport.profiles.no_client_auth.bind_host", NetworkAddress.format(localAddress))
             .put("transport.profiles.no_client_auth.xpack.security.ssl.client_authentication", SSLClientAuth.NONE);
         final Settings settings = builder.build();
         logger.info("node {} settings:\n{}", nodeOrdinal, settings);
@@ -117,7 +119,7 @@ public class SslMultiPortTests extends SecurityIntegTestCase {
                 .put("node.name", "programmatic_transport_client")
                 .put("cluster.name", internalCluster().getClusterName())
                 .build(), LocalStateSecurity.class)) {
-            transportClient.addTransportAddress(new TransportAddress(InetAddress.getLoopbackAddress(),
+            transportClient.addTransportAddress(new TransportAddress(localAddress,
                     getProfilePort("no_client_auth")));
             assertGreenClusterState(transportClient);
         }
@@ -132,7 +134,7 @@ public class SslMultiPortTests extends SecurityIntegTestCase {
      */
     public void testThatStandardTransportClientCannotConnectToClientProfile() throws Exception {
         try (TransportClient transportClient = createTransportClient(Settings.EMPTY)) {
-            transportClient.addTransportAddress(new TransportAddress(InetAddress.getLoopbackAddress(), getProfilePort("client")));
+            transportClient.addTransportAddress(new TransportAddress(localAddress, getProfilePort("client")));
             transportClient.admin().cluster().prepareHealth().get();
             fail("Expected NoNodeAvailableException");
         } catch (NoNodeAvailableException e) {
@@ -154,7 +156,7 @@ public class SslMultiPortTests extends SecurityIntegTestCase {
             "/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testclient-client-profile.crt",
             Arrays.asList("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt"));
         try (TransportClient transportClient = createTransportClient(builder.build())) {
-            transportClient.addTransportAddress(new TransportAddress(InetAddress.getLoopbackAddress(), getProfilePort("client")));
+            transportClient.addTransportAddress(new TransportAddress(localAddress, getProfilePort("client")));
             assertGreenClusterState(transportClient);
         }
     }
@@ -174,7 +176,7 @@ public class SslMultiPortTests extends SecurityIntegTestCase {
             "/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testclient-client-profile.crt",
             Arrays.asList("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt"));
         try (TransportClient transportClient = createTransportClient(builder.build())) {
-            transportClient.addTransportAddress(new TransportAddress(InetAddress.getLoopbackAddress(),
+            transportClient.addTransportAddress(new TransportAddress(localAddress,
                     getProfilePort("no_client_auth")));
             assertGreenClusterState(transportClient);
         }
@@ -234,7 +236,7 @@ public class SslMultiPortTests extends SecurityIntegTestCase {
                 .build();
         try (TransportClient transportClient = new TestXPackTransportClient(settings,
                                                                             Collections.singletonList(LocalStateSecurity.class))) {
-            transportClient.addTransportAddress(new TransportAddress(InetAddress.getLoopbackAddress(), getProfilePort("client")));
+            transportClient.addTransportAddress(new TransportAddress(localAddress, getProfilePort("client")));
             assertGreenClusterState(transportClient);
             fail("Expected NoNodeAvailableException");
         } catch (NoNodeAvailableException e) {
@@ -253,7 +255,7 @@ public class SslMultiPortTests extends SecurityIntegTestCase {
                 .build();
         try (TransportClient transportClient = new TestXPackTransportClient(settings,
                                                                             Collections.singletonList(LocalStateSecurity.class))) {
-            transportClient.addTransportAddress(new TransportAddress(InetAddress.getLoopbackAddress(),
+            transportClient.addTransportAddress(new TransportAddress(localAddress,
                     getProfilePort("no_client_auth")));
             assertGreenClusterState(transportClient);
             fail("Expected NoNodeAvailableException");
@@ -276,7 +278,7 @@ public class SslMultiPortTests extends SecurityIntegTestCase {
             .build();
         try (TransportClient transportClient = new TestXPackTransportClient(settings,
                                                                             Collections.singletonList(LocalStateSecurity.class))) {
-            transportClient.addTransportAddress(new TransportAddress(InetAddress.getLoopbackAddress(),
+            transportClient.addTransportAddress(new TransportAddress(localAddress,
                     getProfilePort("no_client_auth")));
         }
     }
@@ -297,7 +299,7 @@ public class SslMultiPortTests extends SecurityIntegTestCase {
             .build();
         try (TransportClient transportClient = new TestXPackTransportClient(settings,
                                                                             Collections.singletonList(LocalStateSecurity.class))) {
-            transportClient.addTransportAddress(new TransportAddress(InetAddress.getLoopbackAddress(), getProfilePort("client")));
+            transportClient.addTransportAddress(new TransportAddress(localAddress, getProfilePort("client")));
             assertGreenClusterState(transportClient);
             fail("Expected NoNodeAvailableException");
         } catch (NoNodeAvailableException e) {
@@ -365,7 +367,7 @@ public class SslMultiPortTests extends SecurityIntegTestCase {
             .build();
         try (TransportClient transportClient = new TestXPackTransportClient(settings,
                                                                             Collections.singletonList(LocalStateSecurity.class))) {
-            transportClient.addTransportAddress(new TransportAddress(InetAddress.getLoopbackAddress(), getProfilePort("client")));
+            transportClient.addTransportAddress(new TransportAddress(localAddress, getProfilePort("client")));
             assertGreenClusterState(transportClient);
             fail("Expected NoNodeAvailableException");
         } catch (NoNodeAvailableException e) {
@@ -387,7 +389,7 @@ public class SslMultiPortTests extends SecurityIntegTestCase {
             .build();
         try (TransportClient transportClient = new TestXPackTransportClient(settings,
                                                                             Collections.singletonList(LocalStateSecurity.class))) {
-            transportClient.addTransportAddress(new TransportAddress(InetAddress.getLoopbackAddress(),
+            transportClient.addTransportAddress(new TransportAddress(localAddress,
                     getProfilePort("no_client_auth")));
             assertGreenClusterState(transportClient);
             fail("Expected NoNodeAvailableException");
@@ -397,8 +399,14 @@ public class SslMultiPortTests extends SecurityIntegTestCase {
     }
 
     private static int getProfilePort(String profile) {
-        TransportAddress transportAddress =
-                randomFrom(internalCluster().getInstance(Transport.class).profileBoundAddresses().get(profile).boundAddresses());
-        return transportAddress.address().getPort();
+        TransportAddress[] transportAddresses =
+            internalCluster().getInstance(Transport.class).profileBoundAddresses().get(profile).boundAddresses();
+        for (TransportAddress address : transportAddresses) {
+            if (address.address().getAddress().equals(localAddress)) {
+                return address.address().getPort();
+            }
+        }
+        throw new IllegalStateException("failed to find transport address equal to [" + NetworkAddress.format(localAddress) + "] " +
+            " in the following bound addresses " + Arrays.toString(transportAddresses));
     }
 }


### PR DESCRIPTION
This change fixes failures in the SslMultiPortTests where we attempt to
connect to a profile on a port it is listening on but the connection
fails. The failure is due to the profile being bound to multiple
addresses and randomization will pick one of these addresses to
determine the listening port. However, the address we get the port for
may not be the address we are actually connecting to. In order to
resolve this, the test now sets the bind host for profiles to the
loopback address and uses the same address for connecting.

Closes #37481