### PR TITLE
Update Put Watch to allow unknown fields

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/PutWatchResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/PutWatchResponse.java
@@ -20,17 +20,15 @@ package org.elasticsearch.client.watcher;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ObjectParser;
-import org.elasticsearch.common.xcontent.ToXContentObject;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Objects;
 
-public class PutWatchResponse implements ToXContentObject {
+public class PutWatchResponse {
 
     private static final ObjectParser<PutWatchResponse, Void> PARSER
-        = new ObjectParser<>("x_pack_put_watch_response", PutWatchResponse::new);
+        = new ObjectParser<>("x_pack_put_watch_response", true, PutWatchResponse::new);
 
     static {
         PARSER.declareString(PutWatchResponse::setId, new ParseField("_id"));
@@ -88,15 +86,6 @@ public class PutWatchResponse implements ToXContentObject {
     @Override
     public int hashCode() {
         return Objects.hash(id, version, created);
-    }
-
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return builder.startObject()
-            .field("_id", id)
-            .field("_version", version)
-            .field("created", created)
-            .endObject();
     }
 
     public static PutWatchResponse fromXContent(XContentParser parser) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/PutWatchResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/PutWatchResponseTests.java
@@ -18,28 +18,37 @@
  */
 package org.elasticsearch.client.watcher;
 
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 
-public class PutWatchResponseTests extends AbstractXContentTestCase<PutWatchResponse> {
+import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
 
-    @Override
-    protected PutWatchResponse createTestInstance() {
+public class PutWatchResponseTests extends ESTestCase {
+
+    public void testFromXContent() throws IOException {
+        xContentTester(this::createParser,
+            PutWatchResponseTests::createTestInstance,
+            PutWatchResponseTests::toXContent,
+            PutWatchResponse::fromXContent)
+            .supportsUnknownFields(true)
+            .assertToXContentEquivalence(false)
+            .test();
+    }
+
+    private static XContentBuilder toXContent(PutWatchResponse response, XContentBuilder builder) throws IOException {
+        return builder.startObject()
+            .field("_id", response.getId())
+            .field("_version", response.getVersion())
+            .field("created", response.isCreated())
+            .endObject();
+    }
+
+    private static PutWatchResponse createTestInstance() {
         String id = randomAlphaOfLength(10);
         long version = randomLongBetween(1, 10);
         boolean created = randomBoolean();
         return new PutWatchResponse(id, version, created);
-    }
-
-    @Override
-    protected PutWatchResponse doParseInstance(XContentParser parser) throws IOException {
-        return PutWatchResponse.fromXContent(parser);
-    }
-
-    @Override
-    protected boolean supportsUnknownFields() {
-        return false;
     }
 }


### PR DESCRIPTION
PutWatchResponse did not allow unknown fields. This commit fixes the
test and ConstructingObjectParser such that it does now allow unknown
fields.

Relates #36938