### PR TITLE
Deprecate common_terms query and cutoff_frequency

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
@@ -49,6 +49,7 @@ import java.util.Objects;
  * optional clause is only executed if the required "low-frequency' clause
  * matches.
  */
+@Deprecated
 public class CommonTermsQueryBuilder extends AbstractQueryBuilder<CommonTermsQueryBuilder> {
 
     public static final String NAME = "common";

--- a/server/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -44,6 +44,7 @@ import java.util.Objects;
  */
 public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
     public static final ParseField ZERO_TERMS_QUERY_FIELD = new ParseField("zero_terms_query");
+    @Deprecated
     public static final ParseField CUTOFF_FREQUENCY_FIELD = new ParseField("cutoff_frequency");
     public static final ParseField LENIENT_FIELD = new ParseField("lenient");
     public static final ParseField FUZZY_TRANSPOSITIONS_FIELD = new ParseField("fuzzy_transpositions");


### PR DESCRIPTION
Hello @jimczi

Can you please check this addresses the deprecation.

Also, I wasn't sure if I had to call the deprecationLogger somewhere. Any feedback would be appreciated.

Closes Issue #37096