### PR TITLE
increase thread(masterService#updateTask) uncaught exception handling

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/service/TaskBatcher.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/TaskBatcher.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cluster.service;
 
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.unit.TimeValue;
@@ -185,6 +186,7 @@ public abstract class TaskBatcher {
 
         @Override
         public void run() {
+            Thread.currentThread().setUncaughtExceptionHandler((t, e) -> logger.error(() -> new ParameterizedMessage("fatal error in thread [{}], continue", t.getName()), e));
             runIfNotProcessed(this);
         }
 


### PR DESCRIPTION
When the thread throws an exception that cannot be caught, such as java.lang.NoClassDefFoundError, the exception is handled by the default ElasticsearchUncaughtExceptionHandler, which eventually terminates the program.

When the ClusterState is changed, the master node sends a new ClusterState to all nodes and waits for responses from all nodes. When the thread hangs, the master node will wait for the response from the node, knowing the timeout. For clusters where metadata operations are very frequent, tasks are stacked.