### PR TITLE
Fix erroneous docstrings for abstract bulk by scroll request

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -185,14 +185,14 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
     }
 
     /**
-     * Should version conflicts cause aborts? Defaults to false.
+     * Whether or not version conflicts cause the action to abort.
      */
     public boolean isAbortOnVersionConflict() {
         return abortOnVersionConflict;
     }
 
     /**
-     * Should version conflicts cause aborts? Defaults to false.
+     * Set whether or not version conflicts cause the action to abort.
      */
     public Self setAbortOnVersionConflict(boolean abortOnVersionConflict) {
         this.abortOnVersionConflict = abortOnVersionConflict;

--- a/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequestBuilder.java
@@ -75,7 +75,7 @@ public abstract class AbstractBulkByScrollRequestBuilder<
     }
 
     /**
-     * Should we version conflicts cause the action to abort?
+     * Set whether or not version conflicts cause the action to abort.
      */
     public Self abortOnVersionConflict(boolean abortOnVersionConflict) {
         request.setAbortOnVersionConflict(abortOnVersionConflict);


### PR DESCRIPTION
Fix erroneous docstrings indicating that `AbstractBulkByScrollRequest::abortOnVersionConflict` defaults to `false`, when it indeed actually [defaults to `true`](https://github.com/elastic/elasticsearch/blob/c1fe4b7d07794869ea7ac0036714552dcc15b47c/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java#L68),