### PR TITLE
Remove the AbstracLifecycleComponent constructor with Settings

### DIFF
--- a/docs/reference/migration/migrate_7_0/java.asciidoc
+++ b/docs/reference/migration/migrate_7_0/java.asciidoc
@@ -39,3 +39,9 @@ because `Settings` is no longer needed.
 
 The client method `termVector`, deprecated in 2.0, has been removed. The method
 `termVectors` (plural) should be used instead.
+
+[float]
+==== Deprecated constructor `AbstractLifecycleComponent(Settings settings)` removed
+
+The constructor `AbstractLifecycleComponent(Settings settings)`, deprecated in 6.7
+has been removed. The parameterless constructor should be used instead.

--- a/server/src/main/java/org/elasticsearch/common/component/AbstractLifecycleComponent.java
+++ b/server/src/main/java/org/elasticsearch/common/component/AbstractLifecycleComponent.java
@@ -21,7 +21,6 @@ package org.elasticsearch.common.component;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.settings.Settings;
 
 import java.io.IOException;
 import java.util.List;

--- a/server/src/main/java/org/elasticsearch/common/component/AbstractLifecycleComponent.java
+++ b/server/src/main/java/org/elasticsearch/common/component/AbstractLifecycleComponent.java
@@ -36,11 +36,6 @@ public abstract class AbstractLifecycleComponent implements LifecycleComponent {
 
     protected AbstractLifecycleComponent() {}
 
-    @Deprecated
-    protected AbstractLifecycleComponent(Settings settings) {
-        // TODO drop settings from ctor
-    }
-
     @Override
     public Lifecycle.State lifecycleState() {
         return this.lifecycle.state();


### PR DESCRIPTION
Adding the migration guide and removing the deprecated in 6.x
constructor

relates #35560
relates #34488