### PR TITLE
SQL: [Docs] Add an ES-SQL column for data types

### DIFF
--- a/docs/reference/sql/language/data-types.asciidoc
+++ b/docs/reference/sql/language/data-types.asciidoc
@@ -7,39 +7,40 @@ beta[]
 
 Most of {es} <<mapping-types, data types>> are available in {es-sql}, as indicated below:
 
-[cols="^,^m,^"]
+[cols="^,^m,^,^"]
 
 |===
 s|{es} type
+s|{es}-SQL type
 s|SQL type
 s|SQL precision
 
-3+h| Core types
+4+h| Core types
 
-| <<null-value, `null`>>      | null        | 0
-| <<boolean, `boolean`>>      | boolean     | 1
-| <<number, `byte`>>          | tinyint     | 3
-| <<number, `short`>>         | smallint    | 5
-| <<number, `integer`>>       | integer     | 10
-| <<number, `long`>>          | bigint      | 19
-| <<number, `double`>>        | double      | 15
-| <<number, `float`>>         | real        | 7
-| <<number, `half_float`>>    | float       | 16
-| <<number, `scaled_float`>>  | float       | 19
-| <<keyword, `keyword`>>      | varchar     | based on <<ignore-above>>
-| <<text, `text`>>            | varchar     | 2,147,483,647
-| <<binary, `binary`>>        | varbinary   | 2,147,483,647
-| <<date, `date`>>            | timestamp   | 24
-| <<ip, `ip`>>                | varchar     | 39
-                                
-3+h| Complex types              
-                                
-| <<object, `object`>>        | struct      | 0
-| <<nested, `nested`>>        | struct      | 0
+| <<null-value, `null`>>      | null          | NULL        | 0
+| <<boolean, `boolean`>>      | boolean       | BOOLEAN     | 1
+| <<number, `byte`>>          | byte          | TINYINT     | 3
+| <<number, `short`>>         | short         | SMALLINT    | 5
+| <<number, `integer`>>       | integer       | INTEGER     | 10
+| <<number, `long`>>          | long          | BIGINT      | 19
+| <<number, `double`>>        | double        | DOUBLE      | 15
+| <<number, `float`>>         | float         | REAL        | 7
+| <<number, `half_float`>>    | half_float    | FLOAT       | 16
+| <<number, `scaled_float`>>  | scaled_float  | FLOAT       | 19
+| <<keyword, `keyword`>>      | keyword       | VARCHAR     | based on <<ignore-above>>
+| <<text, `text`>>            | text          | VARCHAR     | 2,147,483,647
+| <<binary, `binary`>>        | binary        | VARBINARY   | 2,147,483,647
+| <<date, `date`>>            | datetime      | TIMESTAMP   | 24
+| <<ip, `ip`>>                | ip            | VARCHAR     | 39
 
-3+h| Unsupported types
+4+h| Complex types
 
-| _types not mentioned above_ | unsupported | 0
+| <<object, `object`>>        | object        | STRUCT      | 0
+| <<nested, `nested`>>        | nested        | STRUCT      | 0
+
+4+h| Unsupported types
+
+| _types not mentioned above_ | unsupported   | OTHER       | 0
 
 |===
 

--- a/docs/reference/sql/language/data-types.asciidoc
+++ b/docs/reference/sql/language/data-types.asciidoc
@@ -5,13 +5,15 @@
 
 beta[]
 
-Most of {es} <<mapping-types, data types>> are available in {es-sql}, as indicated below:
+Most of {es} <<mapping-types, data types>> are available in {es-sql}, as indicated below.
+As one can see, all of {es} <<mapping-types, data types>> are mapped to the data type with the same
+name in {es-sql}, with the exception of **date** data type which is mapped to **datetime** in {es-sql}:
 
 [cols="^,^m,^,^"]
 
 |===
 s|{es} type
-s|{es}-SQL type
+s|{es-sql} type
 s|SQL type
 s|SQL precision
 


### PR DESCRIPTION
In order to distinguish the ES-SQL type from the standard SQL type
add a new ES-SQL column that will make clear this distingstion,
e.g.: datetime vs TIMSTAMP

Fixes: #37519
