### PR TITLE
[DOCS] Adds size limitation to the get jobs API

### DIFF
--- a/docs/reference/ml/apis/get-job.asciidoc
+++ b/docs/reference/ml/apis/get-job.asciidoc
@@ -27,6 +27,8 @@ group name, a comma-separated list of jobs, or a wildcard expression. You can
 get information for all jobs by using `_all`, by specifying `*` as the
 `<job_id>`, or by omitting the `<job_id>`.
 
+IMPORTANT: This API returns a maximum of 10,000 jobs. 
+
 
 ==== Path Parameters
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/34864 and https://github.com/elastic/elasticsearch/pull/36792

This PR updates the get jobs API to include the search size limitation.