### PR TITLE
Document discovery.zen.commit_timeout treats negative values like 0. Issue 36632

### DIFF
--- a/server/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
+++ b/server/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
@@ -51,6 +51,7 @@ public class DiscoverySettings {
     /**
      * sets the timeout for receiving enough acks for a specific cluster state and committing it. failing
      * to receive responses within this window will cause the cluster state change to be rejected.
+     * negative values are treated like 0.
      */
     public static final Setting<TimeValue> COMMIT_TIMEOUT_SETTING =
         new Setting<>("discovery.zen.commit_timeout", (s) -> PUBLISH_TIMEOUT_SETTING.getRaw(s),


### PR DESCRIPTION
The scope of this PR is document the `discovery.zen.commit_timeout` treats negative values as 0.

A different PR will be required to update the Docs.

## Supporting Research

This test proves the setting can be negative

```java
public void testReadsNegativeCommitTimeout() {
    Settings settings = Settings.builder()
        .put(DiscoverySettings.COMMIT_TIMEOUT_SETTING.getKey(), "-10s")
        .build();

    TimeValue timeoutValue = DiscoverySettings.COMMIT_TIMEOUT_SETTING.get(settings);

    assertEquals(timeoutValue, new TimeValue(-10, TimeUnit.SECONDS));
}
```

However, the usage of `DiscoverySettings.getCommitTimeout()` leads down to this

```java
private boolean doAcquireSharedNanos(int arg, long nanosTimeout) throws InterruptedException {
        if (nanosTimeout <= 0L)
            return false;
        ...
}
```
