### PR TITLE
Add invalidated API keys remover

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -650,6 +650,8 @@ public class Security extends Plugin implements ActionPlugin, IngestPlugin, Netw
         settingsList.add(SecurityServerTransportInterceptor.TRANSPORT_TYPE_PROFILE_SETTING);
         settingsList.addAll(SSLConfigurationSettings.getProfileSettings());
         settingsList.add(ApiKeyService.PASSWORD_HASHING_ALGORITHM);
+        settingsList.add(ApiKeyService.DELETE_TIMEOUT);
+        settingsList.add(ApiKeyService.DELETE_INTERVAL);
 
         // hide settings
         settingsList.add(Setting.listSetting(SecurityField.setting("hide_settings"), Collections.emptyList(), Function.identity(),

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -126,7 +126,8 @@ public class ApiKeyService {
     private final Settings settings;
     private final ExpiredApiKeysRemover expiredApiKeysRemover;
     private final TimeValue deleteInterval;
-    private final TimeValue deleteInterval;
+
+    private volatile long lastExpirationRunMs;
 
     public ApiKeyService(Settings settings, Clock clock, Client client, SecurityIndexManager securityIndex, ClusterService clusterService) {
         this.clock = clock;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -125,7 +125,7 @@ public class ApiKeyService {
     private final boolean enabled;
     private final Settings settings;
     private final ExpiredApiKeysRemover expiredApiKeysRemover;
-    private volatile long lastExpirationRunMs;
+    private final TimeValue deleteInterval;
     private final TimeValue deleteInterval;
 
     public ApiKeyService(Settings settings, Clock clock, Client client, SecurityIndexManager securityIndex, ClusterService clusterService) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -115,7 +115,7 @@ public class ApiKeyService {
     public static final Setting<TimeValue> DELETE_TIMEOUT = Setting.timeSetting("xpack.security.authc.api_key.delete.timeout",
             TimeValue.MINUS_ONE, Property.NodeScope);
     public static final Setting<TimeValue> DELETE_INTERVAL = Setting.timeSetting("xpack.security.authc.api_key.delete.interval",
-            TimeValue.timeValueMinutes(30L), Property.NodeScope);
+            TimeValue.timeValueHours(24L), Property.NodeScope);
 
     private final Clock clock;
     private final Client client;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -36,7 +36,9 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -110,6 +112,10 @@ public class ApiKeyService {
             }
         }
     }, Setting.Property.NodeScope);
+    public static final Setting<TimeValue> DELETE_TIMEOUT = Setting.timeSetting("xpack.security.authc.api_key.delete.timeout",
+            TimeValue.MINUS_ONE, Property.NodeScope);
+    public static final Setting<TimeValue> DELETE_INTERVAL = Setting.timeSetting("xpack.security.authc.api_key.delete.interval",
+            TimeValue.timeValueMinutes(30L), Property.NodeScope);
 
     private final Clock clock;
     private final Client client;
@@ -118,6 +124,9 @@ public class ApiKeyService {
     private final Hasher hasher;
     private final boolean enabled;
     private final Settings settings;
+    private final ExpiredApiKeysRemover expiredApiKeysRemover;
+    private volatile long lastExpirationRunMs;
+    private final TimeValue deleteInterval;
 
     public ApiKeyService(Settings settings, Clock clock, Client client, SecurityIndexManager securityIndex, ClusterService clusterService) {
         this.clock = clock;
@@ -127,6 +136,8 @@ public class ApiKeyService {
         this.enabled = XPackSettings.API_KEY_SERVICE_ENABLED_SETTING.get(settings);
         this.hasher = Hasher.resolve(PASSWORD_HASHING_ALGORITHM.get(settings));
         this.settings = settings;
+        this.deleteInterval = DELETE_INTERVAL.get(settings);
+        this.expiredApiKeysRemover = new ExpiredApiKeysRemover(settings, client);
     }
 
     /**
@@ -559,6 +570,7 @@ public class ApiKeyService {
      */
     private void indexInvalidation(Collection<String> apiKeyIds, ActionListener<InvalidateApiKeyResponse> listener,
                                    @Nullable InvalidateApiKeyResponse previousResult) {
+        maybeStartApiKeyRemover();
         if (apiKeyIds.isEmpty()) {
             listener.onFailure(new ElasticsearchSecurityException("No api key ids provided for invalidation"));
         } else {
@@ -650,4 +662,16 @@ public class ApiKeyService {
         return exception;
     }
 
+    boolean isExpirationInProgress() {
+        return expiredApiKeysRemover.isExpirationInProgress();
+    }
+
+    private void maybeStartApiKeyRemover() {
+        if (securityIndex.isAvailable()) {
+            if (client.threadPool().relativeTimeInMillis() - lastExpirationRunMs > deleteInterval.getMillis()) {
+                expiredApiKeysRemover.submit(client.threadPool());
+                lastExpirationRunMs = client.threadPool().relativeTimeInMillis();
+            }
+        }
+    }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ExpiredApiKeysRemover.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ExpiredApiKeysRemover.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.security.authc;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.index.reindex.DeleteByQueryAction;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.index.reindex.ScrollableHitSource;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPool.Names;
+import org.elasticsearch.xpack.security.support.SecurityIndexManager;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.elasticsearch.action.support.TransportActions.isShardNotAvailableException;
+import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+/**
+ * Responsible for cleaning the invalidated and expired API keys from the security index.
+ */
+public final class ExpiredApiKeysRemover extends AbstractRunnable {
+    private static final Logger logger = LogManager.getLogger(ExpiredApiKeysRemover.class);
+
+    private final Client client;
+    private final AtomicBoolean inProgress = new AtomicBoolean(false);
+    private final TimeValue timeout;
+
+    ExpiredApiKeysRemover(Settings settings, Client client) {
+        this.client = client;
+        this.timeout = ApiKeyService.DELETE_TIMEOUT.get(settings);
+    }
+
+    @Override
+    public void doRun() {
+        DeleteByQueryRequest expiredDbq = new DeleteByQueryRequest(SecurityIndexManager.SECURITY_INDEX_NAME);
+        if (timeout != TimeValue.MINUS_ONE) {
+            expiredDbq.setTimeout(timeout);
+            expiredDbq.getSearchRequest().source().timeout(timeout);
+        }
+        final Instant now = Instant.now();
+        expiredDbq
+            .setQuery(QueryBuilders.boolQuery()
+                .filter(QueryBuilders.termsQuery("doc_type", "api_key"))
+                .should(QueryBuilders.termsQuery("api_key_invalidated", true))
+                .should(QueryBuilders.rangeQuery("expiration_time").lte(now.minus(24L, ChronoUnit.HOURS).toEpochMilli()))
+                .minimumShouldMatch(1)
+                );
+
+        logger.trace(() -> new ParameterizedMessage("Removing old api keys: [{}]", Strings.toString(expiredDbq)));
+        executeAsyncWithOrigin(client, SECURITY_ORIGIN, DeleteByQueryAction.INSTANCE, expiredDbq,
+                ActionListener.wrap(r -> {
+                    debugDbqResponse(r);
+                    markComplete();
+                }, this::onFailure));
+    }
+
+    void submit(ThreadPool threadPool) {
+        if (inProgress.compareAndSet(false, true)) {
+            threadPool.executor(Names.GENERIC).submit(this);
+        }
+    }
+
+    private void debugDbqResponse(BulkByScrollResponse response) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("delete by query of api keys finished with [{}] deletions, [{}] bulk failures, [{}] search failures",
+                    response.getDeleted(), response.getBulkFailures().size(), response.getSearchFailures().size());
+            for (BulkItemResponse.Failure failure : response.getBulkFailures()) {
+                logger.debug(new ParameterizedMessage("deletion failed for index [{}], type [{}], id [{}]",
+                        failure.getIndex(), failure.getType(), failure.getId()), failure.getCause());
+            }
+            for (ScrollableHitSource.SearchFailure failure : response.getSearchFailures()) {
+                logger.debug(new ParameterizedMessage("search failed for index [{}], shard [{}] on node [{}]",
+                        failure.getIndex(), failure.getShardId(), failure.getNodeId()), failure.getReason());
+            }
+        }
+    }
+
+    boolean isExpirationInProgress() {
+        return inProgress.get();
+    }
+
+    @Override
+    public void onFailure(Exception e) {
+        if (isShardNotAvailableException(e)) {
+            logger.debug("failed to delete expired or invalidated api keys", e);
+        } else {
+            logger.error("failed to delete expired or invalidated api keys", e);
+        }
+        markComplete();
+    }
+
+    private void markComplete() {
+        if (inProgress.compareAndSet(true, false) == false) {
+            throw new IllegalStateException("in progress was set to false but should have been true!");
+        }
+    }
+
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ExpiredApiKeysRemover.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ExpiredApiKeysRemover.java
@@ -60,7 +60,7 @@ public final class ExpiredApiKeysRemover extends AbstractRunnable {
             .setQuery(QueryBuilders.boolQuery()
                 .filter(QueryBuilders.termsQuery("doc_type", "api_key"))
                 .should(QueryBuilders.termsQuery("api_key_invalidated", true))
-                .should(QueryBuilders.rangeQuery("expiration_time").lte(now.minus(24L, ChronoUnit.HOURS).toEpochMilli()))
+                .should(QueryBuilders.rangeQuery("expiration_time").lte(now.minus(7L, ChronoUnit.DAYS).toEpochMilli()))
                 .minimumShouldMatch(1)
                 );
 


### PR DESCRIPTION
This commit adds support for deleting API
keys either after 24 hours from the expiration time
or if the keys have already been invalidated.
This is similar to ExpiredTokensRemover.