### PR TITLE
[DOCS] Adds size limitation to the get datafeeds APIs

### DIFF
--- a/docs/reference/ml/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/apis/get-datafeed-stats.asciidoc
@@ -32,6 +32,7 @@ statistics for all {dfeeds} by using `_all`, by specifying `*` as the
 If the {dfeed} is stopped, the only information you receive is the
 `datafeed_id` and the `state`.
 
+IMPORTANT: This API returns a maximum of 10,000 {dfeeds}.
 
 ==== Path Parameters
 

--- a/docs/reference/ml/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/apis/get-datafeed.asciidoc
@@ -27,6 +27,8 @@ comma-separated list of {dfeeds} or a wildcard expression. You can get
 information for all {dfeeds} by using `_all`, by specifying `*` as the
 `<feed_id>`, or by omitting the `<feed_id>`.
 
+IMPORTANT: This API returns a maximum of 10,000 {dfeeds}. 
+
 ==== Path Parameters
 
 `feed_id`::

--- a/docs/reference/ml/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/apis/get-job-stats.asciidoc
@@ -29,6 +29,8 @@ group name, a comma-separated list of jobs, or a wildcard expression. You can
 get statistics for all jobs by using `_all`, by specifying `*` as the
 `<job_id>`, or by omitting the `<job_id>`.
 
+IMPORTANT: This API returns a maximum of 10,000 jobs.
+
 
 ==== Path Parameters
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/37549, #34864 and #36792

This PR updates the get job stats, get datafeeds, and get datafeed stats APIs to include the search size limitation.