### PR TITLE
Remove initial_master_nodes on node restart

### DIFF
--- a/server/src/test/java/org/elasticsearch/gateway/QuorumGatewayIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/QuorumGatewayIT.java
@@ -22,7 +22,6 @@ package org.elasticsearch.gateway;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
@@ -66,11 +65,6 @@ public class QuorumGatewayIT extends ESIntegTestCase {
         }
         logger.info("--> restart all nodes");
         internalCluster().fullRestart(new RestartCallback() {
-            @Override
-            public Settings onNodeStopped(String nodeName) throws Exception {
-                return null;
-            }
-
             @Override
             public void doAfterNodes(int numNodes, final Client activeClient) throws Exception {
                 if (numNodes == 1) {

--- a/server/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -661,8 +661,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
                 .put(EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(), EnableAllocationDecider.Rebalance.NONE)
                 .build();
 
-        internalCluster().startNode(nodeSettings);
-        internalCluster().startNode(nodeSettings);
+        internalCluster().startNodes(2, nodeSettings);
         cluster().wipeIndices("_all");
 
         logger.info("--> create repository");

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -935,7 +935,8 @@ public final class InternalTestCluster extends TestCluster {
             }
             if (minMasterNodes >= 0) {
                 assert DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.exists(newSettings.build()) == false : "min master nodes is auto managed";
-                newSettings.put(DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.getKey(), minMasterNodes).build();
+                newSettings.put(DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.getKey(), minMasterNodes);
+                newSettings.putList(INITIAL_MASTER_NODES_SETTING.getKey());
             }
             // delete data folders now, before we start other nodes that may claim it
             clearDataIfNeeded(callback);

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -936,7 +936,7 @@ public final class InternalTestCluster extends TestCluster {
             if (minMasterNodes >= 0) {
                 assert DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.exists(newSettings.build()) == false : "min master nodes is auto managed";
                 newSettings.put(DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.getKey(), minMasterNodes);
-                if (INITIAL_MASTER_NODES_SETTING.exists(callbackSettings) == false) {
+                if (callbackSettings != null && INITIAL_MASTER_NODES_SETTING.exists(callbackSettings) == false) {
                     newSettings.putList(INITIAL_MASTER_NODES_SETTING.getKey());
                 }
             }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -936,7 +936,9 @@ public final class InternalTestCluster extends TestCluster {
             if (minMasterNodes >= 0) {
                 assert DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.exists(newSettings.build()) == false : "min master nodes is auto managed";
                 newSettings.put(DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.getKey(), minMasterNodes);
-                newSettings.putList(INITIAL_MASTER_NODES_SETTING.getKey());
+                if (INITIAL_MASTER_NODES_SETTING.exists(callbackSettings) == false) {
+                    newSettings.putList(INITIAL_MASTER_NODES_SETTING.getKey());
+                }
             }
             // delete data folders now, before we start other nodes that may claim it
             clearDataIfNeeded(callback);

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -929,14 +929,13 @@ public final class InternalTestCluster extends TestCluster {
             assert callback != null;
             close();
             Settings callbackSettings = callback.onNodeStopped(name);
+            assert callbackSettings != null;
             Settings.Builder newSettings = Settings.builder();
-            if (callbackSettings != null) {
-                newSettings.put(callbackSettings);
-            }
+            newSettings.put(callbackSettings);
             if (minMasterNodes >= 0) {
                 assert DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.exists(newSettings.build()) == false : "min master nodes is auto managed";
                 newSettings.put(DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.getKey(), minMasterNodes);
-                if (callbackSettings != null && INITIAL_MASTER_NODES_SETTING.exists(callbackSettings) == false) {
+                if (INITIAL_MASTER_NODES_SETTING.exists(callbackSettings) == false) {
                     newSettings.putList(INITIAL_MASTER_NODES_SETTING.getKey());
                 }
             }
@@ -1694,12 +1693,7 @@ public final class InternalTestCluster extends TestCluster {
         }
     }
 
-    public static final RestartCallback EMPTY_CALLBACK = new RestartCallback() {
-        @Override
-        public Settings onNodeStopped(String node) {
-            return null;
-        }
-    };
+    public static final RestartCallback EMPTY_CALLBACK = new RestartCallback();
 
     /**
      * Restarts all nodes in the cluster. It first stops all nodes and then restarts all the nodes again.


### PR DESCRIPTION
Some tests (DedicatedClusterSnapshotRestoreIT.testRestoreIndexWithShardsMissingInLocalGateway) were split-braining since being switched to Zen2 because the bootstrap setting was left around when nodes got restarted with data folders wiped.

The test in question here was starting one node (which autobootstrapped to that single node), then another node. The first node was then shut down (after excluding it from the voting configuration), its data folder wiped, and restarted. After restart, the node had an empty data folder yet initial_master_nodes set to itself (i.e. same name). This made the node sometimes form a cluster of its own, and not rejoin the existing cluster with the other node.

See e.g. https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+g1gc/278/console