### PR TITLE
[DOCS] Add ML breaking change for 6.6

### DIFF
--- a/docs/reference/migration/migrate_6_6.asciidoc
+++ b/docs/reference/migration/migrate_6_6.asciidoc
@@ -143,6 +143,7 @@ The following type parameters are deprecated for the `geo_shape` field type: `tr
 `precision`, `tree_levels`, `distance_error_pct`, `points_only`, and `strategy`. They
 will be removed in a future version.
 
+[float]
 [[breaking_66_ml_changes]]
 === Machine learning changes
 

--- a/docs/reference/migration/migrate_6_6.asciidoc
+++ b/docs/reference/migration/migrate_6_6.asciidoc
@@ -7,7 +7,10 @@
 This section discusses the changes that you need to be aware of when migrating
 your application to Elasticsearch 6.6.
 
+* <<breaking_66_ml_changes>>
+* <<breaking_66_mapping_changes>>
 * <<breaking_66_search_changes>>
+* <<breaking_66_setting_changes>>
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
@@ -81,6 +84,7 @@ GET /stackoverflow/_search
 // TEST[setup:stackoverflow]
 
 [float]
+[[breaking_66_setting_changes]]
 === Settings changes
 
 [float]
@@ -108,6 +112,7 @@ the cluster settings API.
 `xpack.notification.slack.account.<id>.secure_url`
 
 [float]
+[[breaking_66_mapping_changes]]
 === Mappings changes
 
 [float]
@@ -137,3 +142,11 @@ previously created indexes.
 The following type parameters are deprecated for the `geo_shape` field type: `tree`,
 `precision`, `tree_levels`, `distance_error_pct`, `points_only`, and `strategy`. They
 will be removed in a future version.
+
+[[breaking_66_ml_changes]]
+=== Machine learning changes
+
+The get jobs API and get job stats API can retrieve a maximum of 10,000 jobs.
+Likewise, the get datafeeds API and get datafeed stats API can retrieve a
+maximum of 10,000 datafeeds. Prior to version 6.6, there were no limits on the
+results from these APIs. 


### PR DESCRIPTION
Related to #34864 and #36792

This PR adds a breaking change for the search size limitation in the get jobs, get job stats, get datafeeds, and get datafeed stats APIs.

It also adds missing anchors for other sections in the breaking changes. 