### PR TITLE
Check Java environment variables in buildBwcVersion

### DIFF
--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -24,6 +24,7 @@ import org.elasticsearch.gradle.VersionCollection
 
 import java.nio.charset.StandardCharsets
 
+import static org.elasticsearch.gradle.BuildPlugin.checkRequiredJavaVersions
 import static org.elasticsearch.gradle.BuildPlugin.getJavaHome
 
 /**
@@ -140,24 +141,25 @@ bwcVersions.forPreviousUnreleased { VersionCollection.UnreleasedVersionInfo unre
         doFirst {
             // Execution time so that the checkouts are available
             List<String> lines = file("${checkoutDir}/.ci/java-versions.properties").readLines()
-            environment(
-                    'JAVA_HOME',
-                    getJavaHome(it, Integer.parseInt(
-                            lines
-                                    .findAll({ it.startsWith("ES_BUILD_JAVA=java") })
-                                    .collect({ it.replace("ES_BUILD_JAVA=java", "").trim() })
-                                    .join("!!")
-                    ))
-            )
-            environment(
-                    'RUNTIME_JAVA_HOME',
-                    getJavaHome(it, Integer.parseInt(
-                            lines
-                                    .findAll({ it.startsWith("ES_RUNTIME_JAVA=java") })
-                                    .collect({ it.replace("ES_RUNTIME_JAVA=java", "").trim() })
-                                    .join("!!")
-                    ))
-            )
+            String javaHome = getJavaHome(it, Integer.parseInt(
+                    lines
+                            .findAll({ it.startsWith("ES_BUILD_JAVA=java") })
+                            .collect({ it.replace("ES_BUILD_JAVA=java", "").trim() })
+                            .join("!!")
+            ))
+            String runtimeJavaHome = getJavaHome(it, Integer.parseInt(
+                    lines
+                            .findAll({ it.startsWith("ES_RUNTIME_JAVA=java") })
+                            .collect({ it.replace("ES_RUNTIME_JAVA=java", "").trim() })
+                            .join("!!")
+            ))
+
+            // But execution time is *after* the TaskExecutionGraph.whenReady
+            // callback in BuildPlugin.requireJavaHome, so check manually here
+            checkRequiredJavaVersions(project)
+
+            environment('JAVA_HOME', javaHome)
+            environment('RUNTIME_JAVA_HOME', runtimeJavaHome)
         }
 
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {


### PR DESCRIPTION
Connected to #37586.

[BuildPlugin.groovy](https://github.com/elastic/elasticsearch/blob/6dcb3af4c8300d2d5f5fc9848c2a039956edda5d/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy) contains code to check if the correct `JAVA_HOME` environment variables are set, [here](https://github.com/elastic/elasticsearch/blob/6dcb3af4c8300d2d5f5fc9848c2a039956edda5d/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy#L396-L410).

However, these checks aren't effective in the `buildBwcVersion` task, because the environment variables are [read at execution time](https://github.com/elastic/elasticsearch/blob/6dcb3af4c8300d2d5f5fc9848c2a039956edda5d/distribution/bwc/build.gradle#L141), after the `whenReady` callback has run.

This gives the error `JAVA_HOME is set to an invalid directory: null`, when it's actually `JAVA11_HOME` that's missing.

If I move the check to a separate method and call it from [bwc/build.gradle](https://github.com/elastic/elasticsearch/blob/6dcb3af4c8300d2d5f5fc9848c2a039956edda5d/distribution/bwc/build.gradle), then the output becomes:

```
> Task :distribution:bwc:bugfix:buildBwcVersion FAILED

FAILURE: Build failed with an exception.

* Where:
Build file '/home/heather/code/git/elasticsearch/distribution/bwc/build.gradle' line: 159

* What went wrong:
Execution failed for task ':distribution:bwc:bugfix:buildBwcVersion'.
> JAVA11_HOME required to run tasks:
    :distribution:bwc:bugfix:buildBwcVersion
```
