### PR TITLE
Document the need for JAVA11_HOME

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ pointing to the Java home of a JDK 8 installation. Note that this mechanism can
 be used to test against other JDKs as well, this is not only limited to JDK 8.
 
 > Note: It is also required to have `JAVA8_HOME`, `JAVA9_HOME`, `JAVA10_HOME`
-and `JAVA11_HOME` are available so that the tests can pass.
+and `JAVA11_HOME` available so that the tests can pass.
 
 > Warning: do not use `sdkman` for Java installations which do not have proper
 `jrunscript` for jdk distributions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,8 +100,8 @@ JDK 11 and testing on a JDK 8 runtime; to do this, set `RUNTIME_JAVA_HOME`
 pointing to the Java home of a JDK 8 installation. Note that this mechanism can
 be used to test against other JDKs as well, this is not only limited to JDK 8.
 
-> Note: It is also required to have `JAVA8_HOME`, `JAVA9_HOME`, and
-`JAVA10_HOME` are available so that the tests can pass.
+> Note: It is also required to have `JAVA8_HOME`, `JAVA9_HOME`, `JAVA10_HOME`
+and `JAVA11_HOME` are available so that the tests can pass.
 
 > Warning: do not use `sdkman` for Java installations which do not have proper
 `jrunscript` for jdk distributions.


### PR DESCRIPTION
Connected to #37586.

The [contributor guidelines](https://github.com/elastic/elasticsearch/blob/6dcb3af4c8300d2d5f5fc9848c2a039956edda5d/CONTRIBUTING.md) mention `JAVA8_HOME`, `JAVA9_HOME` and `JAVA10_HOME`, but not `JAVA11_HOME`.

When I run `./gradlew buildBwcVersion`, it fails unless `JAVA11_HOME` is set, so I've added this to the list.

I can't find any mention of `JAVA9_HOME` or `JAVA10_HOME` other than in this file - are these still needed?
