### PR TITLE
Update get users to allow unknown fields

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/security/GetUsersResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/security/GetUsersResponse.java
@@ -95,7 +95,7 @@ public class GetUsersResponse {
     public static final ParseField ENABLED = new ParseField("enabled");
 
     @SuppressWarnings("unchecked")
-    public static final ConstructingObjectParser<ParsedUser, String> USER_PARSER = new ConstructingObjectParser<>("user_info",
+    public static final ConstructingObjectParser<ParsedUser, String> USER_PARSER = new ConstructingObjectParser<>("user_info", true,
         (constructorObjects) -> {
             int i = 0;
             final String username = (String) constructorObjects[i++];

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/GetUsersResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/GetUsersResponseTests.java
@@ -19,58 +19,97 @@
 package org.elasticsearch.client.security;
 
 import org.elasticsearch.client.security.user.User;
-import org.elasticsearch.common.xcontent.DeprecationHandler;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.test.XContentTestUtils;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.equalTo;
+import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
 
 /** tests the Response for getting users from the security HLRC */
 public class GetUsersResponseTests extends ESTestCase {
-    public void testFromXContent() throws IOException {
-        String json =
-            "{\n" +
-                "  \"jacknich\": {\n" +
-                "    \"username\": \"jacknich\",\n" +
-                "    \"roles\": [\n" +
-                "      \"admin\", \"other_role1\"\n" +
-                "    ],\n" +
-                "    \"full_name\": \"Jack Nicholson\",\n" +
-                "    \"email\": \"jacknich@example.com\",\n" +
-                "    \"metadata\": { \"intelligence\" : 7 },\n" +
-                "    \"enabled\": true\n" +
-                "  }\n" +
-                "}";
-        final GetUsersResponse response = GetUsersResponse.fromXContent((XContentType.JSON.xContent().createParser(
-            new NamedXContentRegistry(Collections.emptyList()), new DeprecationHandler() {
-                @Override
-                public void usedDeprecatedName(String usedName, String modernName) {
-                }
 
-                @Override
-                public void usedDeprecatedField(String usedName, String replacedWith) {
-                }
-            }, json)));
-        assertThat(response.getUsers().size(), equalTo(1));
-        final User user = response.getUsers().iterator().next();
-        assertThat(user.getUsername(), equalTo("jacknich"));
-        assertThat(user.getRoles().size(), equalTo(2));
-        assertThat(user.getFullName(), equalTo("Jack Nicholson"));
-        assertThat(user.getEmail(), equalTo("jacknich@example.com"));
-        final Map<String, Object> metadata = new HashMap<>();
-        metadata.put("intelligence", 7);
-        assertThat(metadata, equalTo(user.getMetadata()));
+    public void testFromXContent() throws IOException {
+        xContentTester(this::createParser,
+            GetUsersResponseTests::createTestInstance,
+            this::toXContent,
+            GetUsersResponse::fromXContent)
+            .supportsUnknownFields(false)
+            .assertToXContentEquivalence(false)
+            .test();
+    }
+
+    private XContentBuilder toXContentUser(User user, boolean enabled, XContentBuilder builder) throws IOException {
+        XContentBuilder tempBuilder = JsonXContent.contentBuilder();
+        tempBuilder.startObject();
+        tempBuilder.field("username", user.getUsername());
+        tempBuilder.array("roles", user.getRoles().toArray());
+        tempBuilder.field("full_name", user.getFullName());
+        tempBuilder.field("email", user.getEmail());
+        tempBuilder.field("metadata", user.getMetadata());
+        tempBuilder.field("enabled", enabled);
+        tempBuilder.endObject();
+
+        // This sub object should support unknown fields, but metadata cannot contain complex extra objects or it will fail
+        Predicate<String> excludeFilter = path -> path.equals("metadata");
+        BytesReference newBytes = XContentTestUtils.insertRandomFields(XContentType.JSON, BytesReference.bytes(tempBuilder),
+            excludeFilter, random());
+        builder.rawValue(newBytes.streamInput(), XContentType.JSON);
+        return builder;
+    }
+
+    private XContentBuilder toXContent(GetUsersResponse response, XContentBuilder builder) throws IOException {
+        builder.startObject();
+
+        List<User> disabledUsers = new ArrayList<>(response.getUsers());
+        disabledUsers.removeAll(response.getEnabledUsers());
+
+        for (User user : disabledUsers) {
+            builder.field(user.getUsername());
+            toXContentUser(user, false, builder);
+        }
+        for (User user : response.getEnabledUsers()) {
+            builder.field(user.getUsername());
+            toXContentUser(user, true, builder);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    private static GetUsersResponse createTestInstance() {
+        final Set<User> users = new HashSet<>();
+        final Set<User> enabledUsers = new HashSet<>();
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(randomAlphaOfLengthBetween(1, 5), randomInt());
+
+        final User user1 = new User(randomAlphaOfLength(8),
+            Arrays.asList(new String[] {randomAlphaOfLength(5), randomAlphaOfLength(5)}),
+            metadata, randomAlphaOfLength(10), null);
+        users.add(user1);
+        enabledUsers.add(user1);
+        Map<String, Object> metadata2 = new HashMap<>();
+        metadata2.put(randomAlphaOfLengthBetween(1, 5), randomInt());
+        metadata2.put(randomAlphaOfLengthBetween(1, 5), randomBoolean());
+
+        final User user2 = new User(randomAlphaOfLength(8),
+            Arrays.asList(new String[] {randomAlphaOfLength(5), randomAlphaOfLength(5)}),
+            metadata2, randomAlphaOfLength(10), null);
+        users.add(user2);
+        return new GetUsersResponse(users, enabledUsers);
     }
 
     public void testEqualsHashCode() {


### PR DESCRIPTION
The subparser in get users allows for unknown fields. This commit sets
the value to true for the parser and modifies the test such that it
accurately tests it.

Relates #36938
