### PR TITLE
Add some deprecation optimizations

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -364,16 +364,16 @@ public class DeprecationLogger {
          * We want a fast path check to avoid creating the string builder and copying characters if needed. So we walk the string looking
          * for either of the characters that we need to escape. If we find a character that needs escaping, we start over and
          */
-        boolean encodingNeeded = false;
+        boolean escapingNeeded = false;
         for (int i = 0; i < s.length(); i++) {
             final char c = s.charAt(i);
             if (c == '\\' || c == '"') {
-                encodingNeeded = true;
+                escapingNeeded = true;
                 break;
             }
         }
 
-        if (encodingNeeded) {
+        if (escapingNeeded) {
             final StringBuilder sb = new StringBuilder();
             for (final char c : s.toCharArray()) {
                 if (c == '\\' || c == '"') {
@@ -409,7 +409,7 @@ public class DeprecationLogger {
         for (int i = 0x80; i <= 0xFF; i++) {
             doesNotNeedEncoding.set(i);
         }
-        assert doesNotNeedEncoding.get('%') == false;
+        assert doesNotNeedEncoding.get('%') == false : doesNotNeedEncoding;
     }
 
     private static final Charset UTF_8 = Charset.forName("UTF-8");

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -157,15 +157,6 @@ public class DeprecationLogger {
      * arbitrary token; here we use the Elasticsearch version and build hash. The warn text must be quoted. The warn-date is an optional
      * quoted field that can be in a variety of specified date formats; here we use RFC 1123 format.
      */
-    private static final String WARNING_FORMAT =
-            String.format(
-                    Locale.ROOT,
-                    "299 Elasticsearch-%s%s-%s ",
-                    Version.CURRENT.toString(),
-                    Build.CURRENT.isSnapshot() ? "-SNAPSHOT" : "",
-                    Build.CURRENT.shortHash()) +
-                    "\"%s\" \"%s\"";
-
     private static final String WARNING_PREFIX =
             String.format(
                     Locale.ROOT,

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -340,7 +340,7 @@ public class DeprecationLogger {
     public static String formatWarning(final String s) {
         return WARNING_PREFIX + " "
                 + "\"" + escapeAndEncode(s) + "\"" + " "
-                + "\"" + STARTUP_TIME;
+                + "\"" + STARTUP_TIME + "\"";
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -222,9 +222,7 @@ public class DeprecationLogger {
                 .toFormatter(Locale.getDefault(Locale.Category.FORMAT));
     }
 
-    private static final ZoneId GMT = ZoneId.of("GMT");
-
-    private static final String STARTUP_TIME = RFC_7231_DATE_TIME.format(ZonedDateTime.now(GMT));
+    private static final String STARTUP_TIME = RFC_7231_DATE_TIME.format(ZonedDateTime.now(ZoneId.of("GMT")));
 
     /**
      * Regular expression to test if a string matches the RFC7234 specification for warning headers. This pattern assumes that the warn code


### PR DESCRIPTION
This commit optimizes some of the performance issues from using deprecation logging:
 - we optimize encoding the deprecation value
 - we optimize formatting the deprecation string
 - we optimize away getting the current time (by using cached startup time)

Relates #35754
Relates #37530