### PR TITLE
Handle requiring versioned java home during execution

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -395,7 +395,6 @@ class BuildPlugin implements Plugin<Project> {
             rootProject.rootProject.ext.requiredJavaVersions = [:].withDefault{key -> return []}
             rootProject.gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
                 List<String> messages = []
-                println("Checking for java versions: " + rootProject.requiredJavaVersions.keySet())
                 for (entry in rootProject.requiredJavaVersions) {
                     if (rootProject.javaVersions.get(entry.key) != null) {
                         continue

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -395,6 +395,7 @@ class BuildPlugin implements Plugin<Project> {
             rootProject.rootProject.ext.requiredJavaVersions = [:].withDefault{key -> return []}
             rootProject.gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
                 List<String> messages = []
+                println("Checking for java versions: " + rootProject.requiredJavaVersions.keySet())
                 for (entry in rootProject.requiredJavaVersions) {
                     if (rootProject.javaVersions.get(entry.key) != null) {
                         continue
@@ -407,9 +408,16 @@ class BuildPlugin implements Plugin<Project> {
                 if (messages.isEmpty() == false) {
                     throw new GradleException(messages.join('\n'))
                 }
+                rootProject.rootProject.ext.requiredJavaVersions = null // reset to null to indicate the pre-execution checks have executed
             }
+        } else if (rootProject.rootProject.requiredJavaVersions == null) {
+            // check directly if the version is present since we are already executing
+            if (rootProject.javaVersions.get(version) == null) {
+                throw new GradleException("JAVA${version}_HOME required to run task:\n${task}")
+            }
+        } else {
+            rootProject.requiredJavaVersions.get(version).add(task)
         }
-        rootProject.requiredJavaVersions.get(version).add(task)
     }
 
     /** A convenience method for getting java home for a version of java and requiring that version for the given task to execute */


### PR DESCRIPTION
Currently bwc builds require different java home environment variables
depending on the version of elasticsearch being built. The java home
version checks are run at the end of gradle configuration, when the task
graph is ready. However, we do not know which versions are needed for
bwc builds until execution time, when we have finished checking out the
version of elasticsearch to be built. This commit accounts for late java
home checks, checking immediately instead of delaying the check.

closes #37586
