### PR TITLE
Remove more include_type_name and types from docs

### DIFF
--- a/docs/painless/painless-execute-script.asciidoc
+++ b/docs/painless/painless-execute-script.asciidoc
@@ -71,14 +71,12 @@ index:: The name of an index containing a mapping that is compatible with the do
 
 [source,js]
 ----------------------------------------------------------------
-PUT /my-index?include_type_name=true
+PUT /my-index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "field": {
-          "type": "keyword"
-        }
+    "properties": {
+      "field": {
+        "type": "keyword"
       }
     }
   }
@@ -129,17 +127,15 @@ query:: If `_score` is used in the script then a query can specified that will b
 
 [source,js]
 ----------------------------------------------------------------
-PUT /my-index?include_type_name=true
+PUT /my-index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "field": {
-          "type": "keyword"
-        },
-        "rank": {
-          "type": "long"
-        }
+    "properties": {
+      "field": {
+        "type": "keyword"
+      },
+      "rank": {
+        "type": "long"
       }
     }
   }

--- a/docs/plugins/analysis-icu.asciidoc
+++ b/docs/plugins/analysis-icu.asciidoc
@@ -64,7 +64,7 @@ Here are two examples, the default usage and a customised character filter:
 
 [source,js]
 --------------------------------------------------
-PUT icu_sample?include_type_name=true
+PUT icu_sample
 {
   "settings": {
     "index": {
@@ -112,7 +112,7 @@ using custom rules to break Myanmar and Khmer text into syllables.
 
 [source,js]
 --------------------------------------------------
-PUT icu_sample?include_type_name=true
+PUT icu_sample
 {
   "settings": {
     "index": {
@@ -153,7 +153,7 @@ Then create an analyzer to use this rule file as follows:
 
 [source,js]
 --------------------------------------------------
-PUT icu_sample?include_type_name=true
+PUT icu_sample
 {
     "settings": {
         "index":{
@@ -221,7 +221,7 @@ Here are two examples, the default usage and a customised token filter:
 
 [source,js]
 --------------------------------------------------
-PUT icu_sample?include_type_name=true
+PUT icu_sample
 {
   "settings": {
     "index": {
@@ -267,7 +267,7 @@ available to all indices:
 
 [source,js]
 --------------------------------------------------
-PUT icu_sample?include_type_name=true
+PUT icu_sample
 {
   "settings": {
     "index": {
@@ -301,7 +301,7 @@ these filtered character are not lowercased which is why we add the
 
 [source,js]
 --------------------------------------------------
-PUT icu_sample?include_type_name=true
+PUT icu_sample
 {
   "settings": {
     "index": {
@@ -354,21 +354,19 @@ Below is an example of how to set up a field for sorting German names in
 
 [source,js]
 --------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "name": {   <1>
-          "type": "text",
-          "fields": {
-            "sort": {  <2>
-              "type": "icu_collation_keyword",
-              "index": false,
-              "language": "de",
-              "country": "DE",
-              "variant": "@collation=phonebook"
-            }
+    "properties": {
+      "name": {   <1>
+        "type": "text",
+        "fields": {
+          "sort": {  <2>
+            "type": "icu_collation_keyword",
+            "index": false,
+            "language": "de",
+            "country": "DE",
+            "variant": "@collation=phonebook"
           }
         }
       }
@@ -503,7 +501,7 @@ For example:
 
 [source,js]
 --------------------------------------------------
-PUT icu_sample?include_type_name=true
+PUT icu_sample
 {
   "settings": {
     "index": {

--- a/docs/plugins/mapper-annotated-text.asciidoc
+++ b/docs/plugins/mapper-annotated-text.asciidoc
@@ -24,14 +24,12 @@ the search index:
 
 [source,js]
 --------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "my_field": {
-          "type": "annotated_text"
-        }
+    "properties": {
+      "my_field": {
+        "type": "annotated_text"
       }
     }
   }
@@ -168,20 +166,18 @@ sense to include them in dedicated structured fields to support discovery via ag
 
 [source,js]
 --------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "my_unstructured_text_field": {
-          "type": "annotated_text"
-        },
-        "my_structured_people_field": {
-          "type": "text",
-          "fields": {
-          	"keyword" :{
-          	  "type": "keyword"
-          	}
+    "properties": {
+      "my_unstructured_text_field": {
+        "type": "annotated_text"
+      },
+      "my_structured_people_field": {
+        "type": "text",
+        "fields": {
+          "keyword" : {
+            "type": "keyword"
           }
         }
       }

--- a/docs/plugins/mapper-murmur3.asciidoc
+++ b/docs/plugins/mapper-murmur3.asciidoc
@@ -16,17 +16,15 @@ value and its hash are stored in the index:
 
 [source,js]
 --------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "my_field": {
-          "type": "keyword",
-          "fields": {
-            "hash": {
-              "type": "murmur3"
-            }
+    "properties": {
+      "my_field": {
+        "type": "keyword",
+        "fields": {
+          "hash": {
+            "type": "murmur3"
           }
         }
       }

--- a/docs/plugins/mapper-size.asciidoc
+++ b/docs/plugins/mapper-size.asciidoc
@@ -15,13 +15,11 @@ In order to enable the `_size` field, set the mapping as follows:
 
 [source,js]
 --------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "_size": {
-        "enabled": true
-      }
+    "_size": {
+      "enabled": true
     }
   }
 }

--- a/docs/reference/aggregations/bucket/children-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/children-aggregation.asciidoc
@@ -11,16 +11,14 @@ For example, let's say we have an index of questions and answers. The answer typ
 
 [source,js]
 --------------------------------------------------
-PUT child_example?include_type_name=true
+PUT child_example
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "join": {
-          "type": "join",
-          "relations": {
-            "question": "answer"
-          }
+    "properties": {
+      "join": {
+        "type": "join",
+        "relations": {
+          "question": "answer"
         }
       }
     }

--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -16,29 +16,27 @@ a composite bucket.
 
 [source,js]
 --------------------------------------------------
-PUT /sales?include_type_name=true
+PUT /sales
 {
-    "mappings": {
-        "_doc": {
-            "properties": {
-                "product": {
-                    "type": "keyword"
-                },
-                "timestamp": {
-                    "type": "date"
-                },
-                "price": {
-                    "type": "long"
-                },
-                "shop": {
-                    "type": "keyword"
-                }
-            }
-        }
+  "mappings": {
+    "properties": {
+      "product": {
+          "type": "keyword"
+      },
+      "timestamp": {
+          "type": "date"
+      },
+      "price": {
+          "type": "long"
+      },
+      "shop": {
+          "type": "keyword"
+      }
     }
+  }
 }
 
-POST /sales/_doc/_bulk?refresh
+POST /sales/_bulk?refresh
 {"index":{"_id":0}}
 {"product": "mad max", "price": "20", "timestamp": "2017-05-09T14:35"}
 {"index":{"_id":1}}

--- a/docs/reference/aggregations/bucket/geodistance-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/geodistance-aggregation.asciidoc
@@ -5,20 +5,18 @@ A multi-bucket aggregation that works on `geo_point` fields and conceptually wor
 
 [source,js]
 --------------------------------------------------
-PUT /museums?include_type_name=true
+PUT /museums
 {
     "mappings": {
-        "_doc": {
-            "properties": {
-                "location": {
-                    "type": "geo_point"
-                }
+        "properties": {
+            "location": {
+                "type": "geo_point"
             }
         }
     }
 }
 
-POST /museums/_doc/_bulk?refresh
+POST /museums/_bulk?refresh
 {"index":{"_id":1}}
 {"location": "52.374081,4.912350", "name": "NEMO Science Museum"}
 {"index":{"_id":2}}

--- a/docs/reference/aggregations/bucket/geohashgrid-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/geohashgrid-aggregation.asciidoc
@@ -19,20 +19,18 @@ The specified field must be of type `geo_point` (which can only be set explicitl
 
 [source,js]
 --------------------------------------------------
-PUT /museums?include_type_name=true
+PUT /museums
 {
     "mappings": {
-        "_doc": {
-            "properties": {
-                "location": {
-                    "type": "geo_point"
-                }
-            }
-        }
+          "properties": {
+              "location": {
+                  "type": "geo_point"
+              }
+          }
     }
 }
 
-POST /museums/_doc/_bulk?refresh
+POST /museums/_bulk?refresh
 {"index":{"_id":1}}
 {"location": "52.374081,4.912350", "name": "NEMO Science Museum"}
 {"index":{"_id":2}}

--- a/docs/reference/aggregations/bucket/parent-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/parent-aggregation.asciidoc
@@ -11,19 +11,17 @@ For example, let's say we have an index of questions and answers. The answer typ
 
 [source,js]
 --------------------------------------------------
-PUT parent_example?include_type_name=true
+PUT parent_example
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "join": {
-          "type": "join",
-          "relations": {
-            "question": "answer"
-          }
-        }
-      }
-    }
+     "properties": {
+       "join": {
+         "type": "join",
+         "relations": {
+           "question": "answer"
+         }
+       }
+     }
   }
 }
 --------------------------------------------------

--- a/docs/reference/aggregations/metrics/geobounds-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/geobounds-aggregation.asciidoc
@@ -8,20 +8,18 @@ Example:
 
 [source,js]
 --------------------------------------------------
-PUT /museums?include_type_name=true
+PUT /museums
 {
     "mappings": {
-        "_doc": {
-            "properties": {
-                "location": {
-                    "type": "geo_point"
-                }
+        "properties": {
+            "location": {
+                "type": "geo_point"
             }
         }
     }
 }
 
-POST /museums/_doc/_bulk?refresh
+POST /museums/_bulk?refresh
 {"index":{"_id":1}}
 {"location": "52.374081,4.912350", "name": "NEMO Science Museum"}
 {"index":{"_id":2}}

--- a/docs/reference/aggregations/metrics/tophits-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/tophits-aggregation.asciidoc
@@ -240,18 +240,16 @@ Let's see how it works with a real sample. Considering the following mapping:
 
 [source,js]
 --------------------------------------------------
-PUT /sales?include_type_name=true
+PUT /sales
 {
     "mappings": {
-        "_doc" : {
-            "properties" : {
-                "tags" : { "type" : "keyword" },
-                "comments" : { <1>
-                    "type" : "nested",
-                    "properties" : {
-                        "username" : { "type" : "keyword" },
-                        "comment" : { "type" : "text" }
-                    }
+        "properties" : {
+            "tags" : { "type" : "keyword" },
+            "comments" : { <1>
+                "type" : "nested",
+                "properties" : {
+                    "username" : { "type" : "keyword" },
+                    "comment" : { "type" : "text" }
                 }
             }
         }

--- a/docs/reference/analysis.asciidoc
+++ b/docs/reference/analysis.asciidoc
@@ -39,15 +39,13 @@ Each <<text,`text`>> field in a mapping can specify its own
 
 [source,js]
 -------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "title": {
-          "type":     "text",
-          "analyzer": "standard"
-        }
+    "properties": {
+      "title": {
+        "type":     "text",
+        "analyzer": "standard"
       }
     }
   }

--- a/docs/reference/analysis/normalizers.asciidoc
+++ b/docs/reference/analysis/normalizers.asciidoc
@@ -23,7 +23,7 @@ to get one is by building a custom one. Custom normalizers take a list of char
 
 [source,js]
 --------------------------------
-PUT index?include_type_name=true
+PUT index
 {
   "settings": {
     "analysis": {
@@ -46,12 +46,10 @@ PUT index?include_type_name=true
     }
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "foo": {
-          "type": "keyword",
-          "normalizer": "my_normalizer"
-        }
+    "properties": {
+      "foo": {
+        "type": "keyword",
+        "normalizer": "my_normalizer"
       }
     }
   }

--- a/docs/reference/analysis/testing.asciidoc
+++ b/docs/reference/analysis/testing.asciidoc
@@ -41,7 +41,7 @@ referred to when running the `analyze` API on a specific index:
 
 [source,js]
 -------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "settings": {
     "analysis": {
@@ -58,12 +58,10 @@ PUT my_index?include_type_name=true
     }
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "my_text": {
-          "type": "text",
-          "analyzer": "std_folded" <2>
-        }
+    "properties": {
+      "my_text": {
+        "type": "text",
+        "analyzer": "std_folded" <2>
       }
     }
   }

--- a/docs/reference/cat/fielddata.asciidoc
+++ b/docs/reference/cat/fielddata.asciidoc
@@ -9,19 +9,17 @@ on every data node in the cluster.
 Hidden setup snippet to build an index with fielddata so our results are real:
 [source,js]
 --------------------------------------------------
-PUT test?include_type_name=true
+PUT test
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "body": {
-          "type": "text",
-          "fielddata":true
-        },
-        "soul": {
-          "type": "text",
-          "fielddata":true
-        }
+    "properties": {
+      "body": {
+        "type": "text",
+        "fielddata":true
+      },
+      "soul": {
+        "type": "text",
+        "fielddata":true
       }
     }
   }

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -107,21 +107,19 @@ Consider for instance the following mapping:
 
 [source,js]
 --------------------------------------------------
-PUT twitter?include_type_name=true
+PUT twitter
 {
    "mappings": {
-      "_doc": {
-         "properties": {
-            "counter": {
-               "type": "integer",
-               "store": false
-            },
-            "tags": {
-               "type": "keyword",
-               "store": true
-            }
-         }
-      }
+       "properties": {
+          "counter": {
+             "type": "integer",
+             "store": false
+          },
+          "tags": {
+             "type": "keyword",
+             "store": true
+          }
+       }
    }
 }
 --------------------------------------------------

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -637,14 +637,12 @@ added a mapping value to pick up more fields from the data:
 
 [source,js]
 --------------------------------------------------
-PUT test?include_type_name=true
+PUT test
 {
   "mappings": {
-    "_doc": {
-      "dynamic": false,   <1>
-      "properties": {
-        "text": {"type": "text"}
-      }
+    "dynamic": false,   <1>
+    "properties": {
+      "text": {"type": "text"}
     }
   }
 }

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -142,14 +142,12 @@ exist in the mapping:
 
 [source,js]
 --------------------------------------------------
-PUT /test1?include_type_name=true
+PUT /test1
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "user" : {
-          "type": "keyword"
-        }
+    "properties": {
+      "user" : {
+        "type": "keyword"
       }
     }
   }
@@ -376,13 +374,11 @@ First create the index and add a mapping for the `user_id` field:
 
 [source,js]
 --------------------------------------------------
-PUT /users?include_type_name=true
+PUT /users
 {
     "mappings" : {
-        "_doc" : {
-            "properties" : {
-                "user_id" : {"type" : "integer"}
-            }
+        "properties" : {
+            "user_id" : {"type" : "integer"}
         }
     }
 }
@@ -416,13 +412,11 @@ Aliases can also be specified during <<create-index-aliases,index creation>>:
 
 [source,js]
 --------------------------------------------------
-PUT /logs_20162801?include_type_name=true
+PUT /logs_20162801
 {
     "mappings" : {
-        "_doc" : {
-            "properties" : {
-                "year" : {"type" : "integer"}
-            }
+        "properties" : {
+            "year" : {"type" : "integer"}
         }
     },
     "aliases" : {

--- a/docs/reference/indices/get-field-mapping.asciidoc
+++ b/docs/reference/indices/get-field-mapping.asciidoc
@@ -9,19 +9,17 @@ For example, consider the following mapping:
 
 [source,js]
 --------------------------------------------------
-PUT publications?include_type_name=true
+PUT publications
 {
     "mappings": {
-        "_doc": {
-            "properties": {
-                "id": { "type": "text" },
-                "title":  { "type": "text"},
-                "abstract": { "type": "text"},
-                "author": {
-                    "properties": {
-                        "id": { "type": "text" },
-                        "name": { "type": "text" }
-                    }
+        "properties": {
+            "id": { "type": "text" },
+            "title":  { "type": "text"},
+            "abstract": { "type": "text"},
+            "author": {
+                "properties": {
+                    "id": { "type": "text" },
+                    "name": { "type": "text" }
                 }
             }
         }

--- a/docs/reference/indices/put-mapping.asciidoc
+++ b/docs/reference/indices/put-mapping.asciidoc
@@ -68,21 +68,19 @@ For example:
 
 [source,js]
 -----------------------------------
-PUT my_index?include_type_name=true <1>
+PUT my_index <1>
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "name": {
-          "properties": {
-            "first": {
-              "type": "text"
-            }
+    "properties": {
+      "name": {
+        "properties": {
+          "first": {
+            "type": "text"
           }
-        },
-        "user_id": {
-          "type": "keyword"
         }
+      },
+      "user_id": {
+        "type": "keyword"
       }
     }
   }

--- a/docs/reference/mapping.asciidoc
+++ b/docs/reference/mapping.asciidoc
@@ -145,7 +145,7 @@ PUT my_index <1>
       "name":     { "type": "text"  }, <3>
       "age":      { "type": "integer" },  <3>
       "created":  {
-        "type":   "date", <4>
+        "type":   "date", <3>
         "format": "strict_date_optional_time||epoch_millis"
       }
     }

--- a/docs/reference/mapping.asciidoc
+++ b/docs/reference/mapping.asciidoc
@@ -137,18 +137,16 @@ A mapping could be specified when creating an index, as follows:
 
 [source,js]
 ---------------------------------------
-PUT my_index?include_type_name=true <1>
+PUT my_index <1>
 {
   "mappings": {
-    "_doc": { <2>
-      "properties": { <3>
-        "title":    { "type": "text"  }, <4>
-        "name":     { "type": "text"  }, <4>
-        "age":      { "type": "integer" },  <4>
-        "created":  {
-          "type":   "date", <4>
-          "format": "strict_date_optional_time||epoch_millis"
-        }
+    "properties": { <2>
+      "title":    { "type": "text"  }, <3>
+      "name":     { "type": "text"  }, <3>
+      "age":      { "type": "integer" },  <3>
+      "created":  {
+        "type":   "date", <4>
+        "format": "strict_date_optional_time||epoch_millis"
       }
     }
   }
@@ -156,9 +154,8 @@ PUT my_index?include_type_name=true <1>
 ---------------------------------------
 // CONSOLE
 <1> Create an index called `my_index`.
-<2> Add a mapping type called `doc`.
-<3> Specify fields or _properties_.
-<4> Specify the data `type` and mapping for each field.
+<2> Specify fields or _properties_.
+<3> Specify the data `type` and mapping for each field.
 
 
 --

--- a/docs/reference/modules/scripting/fields.asciidoc
+++ b/docs/reference/modules/scripting/fields.asciidoc
@@ -172,22 +172,20 @@ For instance:
 
 [source,js]
 -------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "title": { <1>
-          "type": "text"
-        },
-        "first_name": {
-          "type": "text",
-          "store": true
-        },
-        "last_name": {
-          "type": "text",
-          "store": true
-        }
+    "properties": {
+      "title": { <1>
+        "type": "text"
+      },
+      "first_name": {
+        "type": "text",
+        "store": true
+      },
+      "last_name": {
+        "type": "text",
+        "store": true
       }
     }
   }

--- a/docs/reference/search/request/inner-hits.asciidoc
+++ b/docs/reference/search/request/inner-hits.asciidoc
@@ -84,14 +84,12 @@ The nested `inner_hits` can be used to include nested inner objects as inner hit
 
 [source,js]
 --------------------------------------------------
-PUT test?include_type_name=true
+PUT test
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "comments": {
-          "type": "nested"
-        }
+    "properties": {
+      "comments": {
+        "type": "nested"
       }
     }
   }
@@ -210,14 +208,12 @@ including the source and solely rely on doc values fields. Like this:
 
 [source,js]
 --------------------------------------------------
-PUT test?include_type_name=true
+PUT test
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "comments": {
-          "type": "nested"
-        }
+    "properties": {
+      "comments": {
+        "type": "nested"
       }
     }
   }
@@ -329,17 +325,15 @@ with the root hits then the following path can be defined:
 
 [source,js]
 --------------------------------------------------
-PUT test?include_type_name=true
+PUT test
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "comments": {
-          "type": "nested",
-          "properties": {
-            "votes": {
-              "type": "nested"
-            }
+    "properties": {
+      "comments": {
+        "type": "nested",
+        "properties": {
+          "votes": {
+            "type": "nested"
           }
         }
       }
@@ -451,16 +445,14 @@ The parent/child `inner_hits` can be used to include parent or child:
 
 [source,js]
 --------------------------------------------------
-PUT test?include_type_name=true
+PUT test
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "my_join_field": {
-          "type": "join",
-          "relations": {
-            "my_parent": "my_child"
-          }
+    "properties": {
+      "my_join_field": {
+        "type": "join",
+        "relations": {
+          "my_parent": "my_child"
         }
       }
     }


### PR DESCRIPTION
Follow up to https://github.com/elastic/elasticsearch/pull/37568.

Use of `?include_type_name=true` in docs on index creation down to ~120.