### PR TITLE
Update jdk used by the docker builds

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -19,8 +19,8 @@ dependencies {
 ext.expansions = { oss ->
   return [
     'elasticsearch' : oss ? "elasticsearch-oss-${VersionProperties.elasticsearch}.tar.gz" : "elasticsearch-${VersionProperties.elasticsearch}.tar.gz",
-    'jdkUrl' : 'https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz',
-    'jdkVersion' : '11.0.1',
+    'jdkUrl' : 'https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz',
+    'jdkVersion' : '11.0.2',
     'license': oss ? 'Apache-2.0' : 'Elastic License',
     'version' : VersionProperties.elasticsearch
   ]
@@ -58,6 +58,7 @@ void addCopyDockerContextTask(final boolean oss) {
 
 void addCopyDockerfileTask(final boolean oss) {
   task(taskName("copy", oss, "Dockerfile"), type: Copy) {
+    inputs.properties(expansions(oss)) // ensure task is run when ext.expansions is changed
     mustRunAfter(taskName("copy", oss, "DockerContext"))
     into files(oss)
 
@@ -82,7 +83,7 @@ void addBuildDockerImage(final boolean oss) {
       ]
     }
     executable 'docker'
-    final List<String> dockerArgs = ['build', files(oss), '--pull']
+    final List<String> dockerArgs = ['build', files(oss), '--pull', '--no-cache']
     for (final String tag : tags) {
       dockerArgs.add('--tag')
       dockerArgs.add(tag)


### PR DESCRIPTION
With the release of 11.0.2, the old URLs no longer work. This exposed a
few small bugs in the gradle config. One was that --no-cache was not
present in the docker build command, so it was not failing at
first. Then once only the ext.expansions was changed and the docker
build task was not, it was not executing it.
