### PR TITLE
Modified indices shard count as global count And add Test in indicesS…

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -310,7 +310,14 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         }
     }
 
-    public synchronized IndexShard createShard(ShardRouting routing, Consumer<ShardId> globalCheckpointSyncer) throws IOException {
+    public synchronized IndexShard createShard(ShardRouting routing,
+                                               Consumer<ShardId> globalCheckpointSyncer) throws IOException {
+        return createShard(routing, globalCheckpointSyncer, new HashMap<NodeEnvironment.NodePath, Long>(0));
+    }
+    public synchronized IndexShard createShard(ShardRouting routing,
+                                               Consumer<ShardId> globalCheckpointSyncer,
+                                               Map<NodeEnvironment.NodePath, Long> pathToShardCount)
+        throws IOException {
         /*
          * TODO: we execute this in parallel but it's a synced method. Yet, we might
          * be able to serialize the execution via the cluster state in the future. for now we just
@@ -347,14 +354,20 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 // that's being relocated/replicated we know how large it will become once it's done copying:
                 // Count up how many shards are currently on each data path:
                 Map<Path, Integer> dataPathToShardCount = new HashMap<>();
-                for (IndexShard shard : this) {
-                    Path dataPath = shard.shardPath().getRootStatePath();
-                    Integer curCount = dataPathToShardCount.get(dataPath);
-                    if (curCount == null) {
-                        curCount = 0;
-                    }
-                    dataPathToShardCount.put(dataPath, curCount + 1);
+
+                //use Global dataPathToShardCount as Path Select Consideration
+                for (Map.Entry<NodeEnvironment.NodePath, Long> entry : pathToShardCount.entrySet()) {
+                    dataPathToShardCount.put(entry.getKey().path, entry.getValue().intValue());
                 }
+//                for (IndexShard shard : this) {
+//                    Path dataPath = shard.shardPath().getRootStatePath();
+//                    Integer curCount = dataPathToShardCount.get(dataPath);
+//                    if (curCount == null) {
+//                        curCount = 0;
+//                    }
+//                    dataPathToShardCount.put(dataPath, curCount + 1);
+//                }
+
                 path = ShardPath.selectNewPathForShard(nodeEnv, shardId, this.indexSettings,
                     routing.getExpectedShardSize() == ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE
                         ? getAvgShardSizeInBytes() : routing.getExpectedShardSize(),

--- a/server/src/test/java/org/elasticsearch/indices/IndicesShardPathSingleNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesShardPathSingleNodeTests.java
@@ -1,0 +1,77 @@
+package org.elasticsearch.indices;
+
+
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.Index;
+
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import java.nio.file.Path;
+import java.util.*;
+
+
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+
+
+public class IndicesShardPathSingleNodeTests extends ESSingleNodeTestCase {
+
+
+    public NodeEnvironment getNodeEnvironment() {
+        return getInstanceFromNode(NodeEnvironment.class);
+    }
+
+    public void testSelectNewPathForMultiIndexShardEvenly() throws Throwable {
+
+        IndicesService indicesService = getInstanceFromNode(IndicesService.class);
+        assertAcked(client().admin().indices().prepareCreate("test")
+            .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0)));
+        ensureGreen();
+        NodeEnvironment env = getNodeEnvironment();
+        Index idx = resolveIndex("test");
+        Path[] idxPath = env.indexPaths(idx);
+        logger.info("IndexPaths.Length:" + idxPath.length);
+        assertEquals(2, idxPath.length);
+        logger.info("==>IndexPaths:" + idxPath[0].toString() + "," + idxPath[1].toString() );
+
+        Map<NodeEnvironment.NodePath, Long> nodePathLongMap = env.shardCountPerPath(idx);
+
+        for(Map.Entry<NodeEnvironment.NodePath, Long> entry :nodePathLongMap.entrySet()) {
+            logger.info("==>Index:{}, shardCountPerPath Path {}, Count {}", "test", entry.getKey().path, entry.getValue());
+        }
+
+        assertAcked(client().admin().indices().prepareCreate("test2")
+            .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0)));
+        ensureGreen();
+
+        Index idx2 = resolveIndex("test2");
+        Map<NodeEnvironment.NodePath, Long> nodePathLongMap2 = env.shardCountPerPath(idx2);
+        for(Map.Entry<NodeEnvironment.NodePath, Long> entry :nodePathLongMap2.entrySet()) {
+            logger.info("==>Index:{}, shardCountPerPath Path {}, Count {}", "test2", entry.getKey().path, entry.getValue());
+        }
+
+        nodePathLongMap2.forEach(
+            (k, v) ->nodePathLongMap.merge(k, v, (v1, v2) -> Long.valueOf(v1 + v2))
+        );
+        for(Map.Entry<NodeEnvironment.NodePath, Long> entry :nodePathLongMap.entrySet()) {
+            logger.info("==>Merge: shardCountPerPath Path {}, Count {}", entry.getKey().path, entry.getValue());
+            //Every Path Only have 1 shard
+            assertEquals(1, entry.getValue().intValue());
+        }
+
+    }
+
+    @Override
+    protected Settings nodeSettings() {
+        final Path tempDir = createTempDir();
+        String[] paths = new String[] {tempDir.resolve("a").toString(),
+            tempDir.resolve("b").toString()};
+        return Settings.builder()
+            .putList(Environment.PATH_DATA_SETTING.getKey(), paths).build();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/indices/IndicesShardPathSingleNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesShardPathSingleNodeTests.java
@@ -1,18 +1,30 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.elasticsearch.indices;
 
-
-import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.Index;
-
 import org.elasticsearch.test.ESSingleNodeTestCase;
-
 import java.nio.file.Path;
-import java.util.*;
-
+import java.util.Map;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;


### PR DESCRIPTION
As we see this PR: [https://github.com/elastic/elasticsearch/pull/35931](https://github.com/elastic/elasticsearch/pull/35931)
#35931 
When i use elasticsearch we met the same questions about shard path selection.
Originally, ES chose the multi path only consider about local index shard into {dataPathToShardCount}, but when multi shard created it is prefer to consider about global shard count in data Paths, as we wanna make good use of IO performance
I checked the PR #35931 mentioned above, it is too complicated. 
As the code has considered about shard count, so this commit just reuse "dataPathToShardCount", it take all indices shard into consideration and this can modified less code，get more efficient. 
At the same time, I added a new test case, which is IndicesShardPathSingleNodeTests , in indices tests to verify it: When we use 2 paths, and create 2 indices with 1 shard, 0 replications. In original method, it may let 2 shards assign into 1 path. In this commits, it may let 2 shards assign into 2 paths.

Thanks
yunchenglu

