### PR TITLE
Remove remaining occurances of "include_type_name=true" in docs

### DIFF
--- a/docs/reference/aggregations/metrics/geocentroid-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/geocentroid-aggregation.asciidoc
@@ -7,20 +7,18 @@ Example:
 
 [source,js]
 --------------------------------------------------
-PUT /museums?include_type_name=true
+PUT /museums
 {
     "mappings": {
-        "_doc": {
-            "properties": {
-                "location": {
-                    "type": "geo_point"
-                }
+        "properties": {
+            "location": {
+                "type": "geo_point"
             }
         }
     }
 }
 
-POST /museums/_doc/_bulk?refresh
+POST /museums/_bulk?refresh
 {"index":{"_id":1}}
 {"location": "52.374081,4.912350", "city": "Amsterdam", "name": "NEMO Science Museum"}
 {"index":{"_id":2}}

--- a/docs/reference/analysis/analyzers/configuring.asciidoc
+++ b/docs/reference/analysis/analyzers/configuring.asciidoc
@@ -8,7 +8,7 @@ to support a list of stop words:
 
 [source,js]
 --------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "settings": {
     "analysis": {
@@ -21,16 +21,14 @@ PUT my_index?include_type_name=true
     }
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "my_text": {
-          "type":     "text",
-          "analyzer": "standard", <2>
-          "fields": {
-            "english": {
-              "type":     "text",
-              "analyzer": "std_english" <3>
-            }
+    "properties": {
+      "my_text": {
+        "type":     "text",
+        "analyzer": "standard", <2>
+        "fields": {
+          "english": {
+            "type":     "text",
+            "analyzer": "std_english" <3>
           }
         }
       }

--- a/docs/reference/analysis/charfilters/pattern-replace-charfilter.asciidoc
+++ b/docs/reference/analysis/charfilters/pattern-replace-charfilter.asciidoc
@@ -49,7 +49,7 @@ replace any embedded dashes in numbers with underscores, i.e `123-456-789` ->
 
 [source,js]
 ----------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "settings": {
     "analysis": {
@@ -100,7 +100,7 @@ camelCase words to be queried individually:
 
 [source,js]
 ----------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "settings": {
     "analysis": {
@@ -125,12 +125,10 @@ PUT my_index?include_type_name=true
     }
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "text": {
-          "type": "text",
-          "analyzer": "my_analyzer"
-        }
+    "properties": {
+      "text": {
+        "type": "text",
+        "analyzer": "my_analyzer"
       }
     }
   }

--- a/docs/reference/analysis/tokenizers/edgengram-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/edgengram-tokenizer.asciidoc
@@ -104,7 +104,7 @@ length `10`:
 
 [source,js]
 ----------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "settings": {
     "analysis": {
@@ -222,7 +222,7 @@ Below is an example of how to set up a field for _search-as-you-type_:
 
 [source,js]
 -----------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "settings": {
     "analysis": {
@@ -250,13 +250,11 @@ PUT my_index?include_type_name=true
     }
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "title": {
-          "type": "text",
-          "analyzer": "autocomplete",
-          "search_analyzer": "autocomplete_search"
-        }
+    "properties": {
+      "title": {
+        "type": "text",
+        "analyzer": "autocomplete",
+        "search_analyzer": "autocomplete_search"
       }
     }
   }

--- a/docs/reference/docs/termvectors.asciidoc
+++ b/docs/reference/docs/termvectors.asciidoc
@@ -125,21 +125,19 @@ First, we create an index that stores term vectors, payloads etc. :
 
 [source,js]
 --------------------------------------------------
-PUT /twitter?include_type_name=true
+PUT /twitter
 { "mappings": {
-    "_doc": {
-      "properties": {
-        "text": {
-          "type": "text",
-          "term_vector": "with_positions_offsets_payloads",
-          "store" : true,
-          "analyzer" : "fulltext_analyzer"
-         },
-         "fullname": {
-          "type": "text",
-          "term_vector": "with_positions_offsets_payloads",
-          "analyzer" : "fulltext_analyzer"
-        }
+    "properties": {
+      "text": {
+        "type": "text",
+        "term_vector": "with_positions_offsets_payloads",
+        "store" : true,
+        "analyzer" : "fulltext_analyzer"
+       },
+       "fullname": {
+        "type": "text",
+        "term_vector": "with_positions_offsets_payloads",
+        "analyzer" : "fulltext_analyzer"
       }
     }
   },

--- a/docs/reference/how-to/disk-usage.asciidoc
+++ b/docs/reference/how-to/disk-usage.asciidoc
@@ -12,15 +12,13 @@ filter on, you can safely disable indexing on this field in your
 
 [source,js]
 --------------------------------------------------
-PUT index?include_type_name=true
+PUT index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "foo": {
-          "type": "integer",
-          "index": false
-        }
+    "properties": {
+      "foo": {
+        "type": "integer",
+        "index": false
       }
     }
   }
@@ -35,15 +33,13 @@ to not write norms to the index:
 
 [source,js]
 --------------------------------------------------
-PUT index?include_type_name=true
+PUT index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "foo": {
-          "type": "text",
-          "norms": false
-        }
+    "properties": {
+      "foo": {
+        "type": "text",
+        "norms": false
       }
     }
   }
@@ -58,15 +54,13 @@ Elasticsearch to not index positions:
 
 [source,js]
 --------------------------------------------------
-PUT index?include_type_name=true
+PUT index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "foo": {
-          "type": "text",
-          "index_options": "freqs"
-        }
+    "properties": {
+      "foo": {
+        "type": "text",
+        "index_options": "freqs"
       }
     }
   }
@@ -81,16 +75,14 @@ and scoring will assume that terms appear only once in every document.
 
 [source,js]
 --------------------------------------------------
-PUT index?include_type_name=true
+PUT index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "foo": {
-          "type": "text",
-          "norms": false,
-          "index_options": "freqs"
-        }
+    "properties": {
+      "foo": {
+        "type": "text",
+        "norms": false,
+        "index_options": "freqs"
       }
     }
   }
@@ -115,21 +107,19 @@ fields as `keyword`:
 
 [source,js]
 --------------------------------------------------
-PUT index?include_type_name=true
+PUT index
 {
   "mappings": {
-    "_doc": {
-      "dynamic_templates": [
-        {
-          "strings": {
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "keyword"
-            }
+    "dynamic_templates": [
+      {
+        "strings": {
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
           }
         }
-      ]
-    }
+      }
+    ]
   }
 }
 --------------------------------------------------

--- a/docs/reference/how-to/recipes/stemming.asciidoc
+++ b/docs/reference/how-to/recipes/stemming.asciidoc
@@ -9,7 +9,7 @@ content indexed in two different ways:
 
 [source,js]
 --------------------------------------------------
-PUT index?include_type_name=true
+PUT index
 {
   "settings": {
     "analysis": {
@@ -24,16 +24,14 @@ PUT index?include_type_name=true
     }
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "body": {
-          "type": "text",
-          "analyzer": "english",
-          "fields": {
-            "exact": {
-              "type": "text",
-              "analyzer": "english_exact"
-            }
+    "properties": {
+      "body": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "exact": {
+            "type": "text",
+            "analyzer": "english_exact"
           }
         }
       }

--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -50,22 +50,20 @@ field.
 
 [source,js]
 --------------------------------------------------
-PUT movies?include_type_name=true
+PUT movies
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "name_and_plot": {
-          "type": "text"
-        },
-        "name": {
-          "type": "text",
-          "copy_to": "name_and_plot"
-        },
-        "plot": {
-          "type": "text",
-          "copy_to": "name_and_plot"
-        }
+    "properties": {
+      "name_and_plot": {
+        "type": "text"
+      },
+      "name": {
+        "type": "text",
+        "copy_to": "name_and_plot"
+      },
+      "plot": {
+        "type": "text",
+        "copy_to": "name_and_plot"
       }
     }
   }
@@ -123,14 +121,12 @@ should be mapped as a <<keyword,`keyword`>>:
 
 [source,js]
 --------------------------------------------------
-PUT index?include_type_name=true
+PUT index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "price_range": {
-          "type": "keyword"
-        }
+    "properties": {
+      "price_range": {
+        "type": "keyword"
       }
     }
   }
@@ -322,15 +318,13 @@ eagerly at refresh-time by configuring mappings as described below:
 
 [source,js]
 --------------------------------------------------
-PUT index?include_type_name=true
+PUT index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "foo": {
-          "type": "keyword",
-          "eager_global_ordinals": true
-        }
+    "properties": {
+      "foo": {
+        "type": "keyword",
+        "eager_global_ordinals": true
       }
     }
   }

--- a/docs/reference/index-modules/index-sorting.asciidoc
+++ b/docs/reference/index-modules/index-sorting.asciidoc
@@ -14,7 +14,7 @@ For instance the following example shows how to define a sort on a single field:
 
 [source,js]
 --------------------------------------------------
-PUT twitter?include_type_name=true
+PUT twitter
 {
     "settings" : {
         "index" : {
@@ -23,11 +23,9 @@ PUT twitter?include_type_name=true
         }
     },
     "mappings": {
-        "_doc": {
-            "properties": {
-                "date": {
-                    "type": "date"
-                }
+        "properties": {
+            "date": {
+                "type": "date"
             }
         }
     }
@@ -42,7 +40,7 @@ It is also possible to sort the index by more than one field:
 
 [source,js]
 --------------------------------------------------
-PUT twitter?include_type_name=true
+PUT twitter
 {
     "settings" : {
         "index" : {
@@ -51,15 +49,13 @@ PUT twitter?include_type_name=true
         }
     },
     "mappings": {
-        "_doc": {
-            "properties": {
-                "username": {
-                    "type": "keyword",
-                    "doc_values": true
-                },
-                "date": {
-                    "type": "date"
-                }
+        "properties": {
+            "username": {
+                "type": "keyword",
+                "doc_values": true
+            },
+            "date": {
+                "type": "date"
             }
         }
     }
@@ -118,7 +114,7 @@ For example, let's say we have an index that contains events sorted by a timesta
 
 [source,js]
 --------------------------------------------------
-PUT events?include_type_name=true
+PUT events
 {
     "settings" : {
         "index" : {
@@ -127,11 +123,9 @@ PUT events?include_type_name=true
         }
     },
     "mappings": {
-        "doc": {
-            "properties": {
-                "timestamp": {
-                    "type": "date"
-                }
+        "properties": {
+            "timestamp": {
+                "type": "date"
             }
         }
     }

--- a/docs/reference/index-modules/similarity.asciidoc
+++ b/docs/reference/index-modules/similarity.asciidoc
@@ -20,7 +20,7 @@ settings.
 
 [source,js]
 --------------------------------------------------
-PUT /index?include_type_name=true
+PUT /index
 {
     "settings" : {
         "index" : {
@@ -200,7 +200,7 @@ TF-IDF:
 
 [source,js]
 --------------------------------------------------
-PUT /index?include_type_name=true
+PUT /index
 {
   "settings": {
     "number_of_shards": 1, 
@@ -214,12 +214,10 @@ PUT /index?include_type_name=true
     }
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "field": {
-          "type": "text",
-          "similarity": "scripted_tfidf"
-        }
+    "properties": {
+      "field": {
+        "type": "text",
+        "similarity": "scripted_tfidf"
       }
     }
   }
@@ -369,7 +367,7 @@ more efficient:
 
 [source,js]
 --------------------------------------------------
-PUT /index?include_type_name=true
+PUT /index
 {
   "settings": {
     "number_of_shards": 1, 
@@ -386,12 +384,10 @@ PUT /index?include_type_name=true
     }
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "field": {
-          "type": "text",
-          "similarity": "scripted_tfidf"
-        }
+    "properties": {
+      "field": {
+        "type": "text",
+        "similarity": "scripted_tfidf"
       }
     }
   }
@@ -537,7 +533,7 @@ it is <<indices-create-index,created>>:
 
 [source,js]
 --------------------------------------------------
-PUT /index?include_type_name=true
+PUT /index
 {
   "settings": {
     "index": {

--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -196,15 +196,13 @@ You can use the following mapping for the example index above:
 
 [source,js]
 --------------------------------------------------
-PUT my_ip_locations?include_type_name=true
+PUT my_ip_locations
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "geoip": {
-          "properties": {
-            "location": { "type": "geo_point" }
-          }
+    "properties": {
+      "geoip": {
+        "properties": {
+          "location": { "type": "geo_point" }
         }
       }
     }

--- a/docs/reference/mapping/dynamic/field-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic/field-mapping.asciidoc
@@ -66,12 +66,10 @@ Dynamic date detection can be disabled by setting `date_detection` to `false`:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "date_detection": false
-    }
+    "date_detection": false
   }
 }
 
@@ -91,12 +89,10 @@ own <<mapping-date-format,date formats>>:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "dynamic_date_formats": ["MM/dd/yyyy"]
-    }
+    "dynamic_date_formats": ["MM/dd/yyyy"]
   }
 }
 
@@ -119,12 +115,10 @@ correct solution is to map these fields explicitly, but numeric detection
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "numeric_detection": true
-    }
+    "numeric_detection": true
   }
 }
 

--- a/docs/reference/mapping/dynamic/templates.asciidoc
+++ b/docs/reference/mapping/dynamic/templates.asciidoc
@@ -69,35 +69,33 @@ could use the following template:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "dynamic_templates": [
-        {
-          "integers": {
-            "match_mapping_type": "long",
-            "mapping": {
-              "type": "integer"
-            }
+    "dynamic_templates": [
+      {
+        "integers": {
+          "match_mapping_type": "long",
+          "mapping": {
+            "type": "integer"
           }
-        },
-        {
-          "strings": {
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "text",
-              "fields": {
-                "raw": {
-                  "type":  "keyword",
-                  "ignore_above": 256
-                }
+        }
+      },
+      {
+        "strings": {
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "text",
+            "fields": {
+              "raw": {
+                "type":  "keyword",
+                "ignore_above": 256
               }
             }
           }
         }
-      ]
-    }
+      }
+    ]
   }
 }
 
@@ -125,23 +123,21 @@ fields:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "dynamic_templates": [
-        {
-          "longs_as_strings": {
-            "match_mapping_type": "string",
-            "match":   "long_*",
-            "unmatch": "*_text",
-            "mapping": {
-              "type": "long"
-            }
+    "dynamic_templates": [
+      {
+        "longs_as_strings": {
+          "match_mapping_type": "string",
+          "match":   "long_*",
+          "unmatch": "*_text",
+          "mapping": {
+            "type": "long"
           }
         }
-      ]
-    }
+      }
+    ]
   }
 }
 
@@ -181,23 +177,21 @@ top-level `full_name` field, except for the `middle` field:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "dynamic_templates": [
-        {
-          "full_name": {
-            "path_match":   "name.*",
-            "path_unmatch": "*.middle",
-            "mapping": {
-              "type":       "text",
-              "copy_to":    "full_name"
-            }
+    "dynamic_templates": [
+      {
+        "full_name": {
+          "path_match":   "name.*",
+          "path_unmatch": "*.middle",
+          "mapping": {
+            "type":       "text",
+            "copy_to":    "full_name"
           }
         }
-      ]
-    }
+      }
+    ]
   }
 }
 
@@ -222,32 +216,30 @@ field, and disables <<doc-values,`doc_values`>> for all non-string fields:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "dynamic_templates": [
-        {
-          "named_analyzers": {
-            "match_mapping_type": "string",
-            "match": "*",
-            "mapping": {
-              "type": "text",
-              "analyzer": "{name}"
-            }
-          }
-        },
-        {
-          "no_doc_values": {
-            "match_mapping_type":"*",
-            "mapping": {
-              "type": "{dynamic_type}",
-              "doc_values": false
-            }
+    "dynamic_templates": [
+      {
+        "named_analyzers": {
+          "match_mapping_type": "string",
+          "match": "*",
+          "mapping": {
+            "type": "text",
+            "analyzer": "{name}"
           }
         }
-      ]
-    }
+      },
+      {
+        "no_doc_values": {
+          "match_mapping_type":"*",
+          "mapping": {
+            "type": "{dynamic_type}",
+            "doc_values": false
+          }
+        }
+      }
+    ]
   }
 }
 
@@ -276,21 +268,19 @@ you will have to search on the exact same value that was indexed.
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "dynamic_templates": [
-        {
-          "strings_as_keywords": {
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "keyword"
-            }
+    "dynamic_templates": [
+      {
+        "strings_as_keywords": {
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
           }
         }
-      ]
-    }
+      }
+    ]
   }
 }
 --------------------------------------------------
@@ -306,21 +296,19 @@ before 5.0):
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "dynamic_templates": [
-        {
-          "strings_as_text": {
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "text"
-            }
+    "dynamic_templates": [
+      {
+        "strings_as_text": {
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "text"
           }
         }
-      ]
-    }
+      }
+    ]
   }
 }
 --------------------------------------------------
@@ -334,28 +322,26 @@ disable the storage of these scoring factors in the index and save some space.
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "dynamic_templates": [
-        {
-          "strings_as_keywords": {
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "text",
-              "norms": false,
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
+    "dynamic_templates": [
+      {
+        "strings_as_keywords": {
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "text",
+            "norms": false,
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
               }
             }
           }
         }
-      ]
-    }
+      }
+    ]
   }
 }
 --------------------------------------------------
@@ -375,31 +361,29 @@ maybe gain some indexing speed:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "dynamic_templates": [
-        {
-          "unindexed_longs": {
-            "match_mapping_type": "long",
-            "mapping": {
-              "type": "long",
-              "index": false
-            }
-          }
-        },
-        {
-          "unindexed_doubles": {
-            "match_mapping_type": "double",
-            "mapping": {
-              "type": "float", <1>
-              "index": false
-            }
+    "dynamic_templates": [
+      {
+        "unindexed_longs": {
+          "match_mapping_type": "long",
+          "mapping": {
+            "type": "long",
+            "index": false
           }
         }
-      ]
-    }
+      },
+      {
+        "unindexed_doubles": {
+          "match_mapping_type": "double",
+          "mapping": {
+            "type": "float", <1>
+            "index": false
+          }
+        }
+      }
+    ]
   }
 }
 --------------------------------------------------

--- a/docs/reference/mapping/fields/field-names-field.asciidoc
+++ b/docs/reference/mapping/fields/field-names-field.asciidoc
@@ -21,13 +21,11 @@ execute `exists` queries using those fields you might want to disable
 
 [source,js]
 --------------------------------------------------
-PUT tweets?include_type_name=true
+PUT tweets
 {
   "mappings": {
-    "_doc": {
-      "_field_names": {
-        "enabled": false
-      }
+    "_field_names": {
+      "enabled": false
     }
   }
 }

--- a/docs/reference/mapping/fields/meta-field.asciidoc
+++ b/docs/reference/mapping/fields/meta-field.asciidoc
@@ -7,16 +7,14 @@ metadata, such as the class that a document belongs to:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "_meta": { <1>
-        "class": "MyApp::User",
-        "version": {
-          "min": "1.0",
-          "max": "1.3"
-        }
+    "_meta": { <1>
+      "class": "MyApp::User",
+      "version": {
+        "min": "1.0",
+        "max": "1.3"
       }
     }
   }

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -79,13 +79,11 @@ custom `routing` value required for all CRUD operations:
 
 [source,js]
 ------------------------------
-PUT my_index2?include_type_name=true
+PUT my_index2
 {
   "mappings": {
-    "_doc": {
-      "_routing": {
-        "required": true <1>
-      }
+    "_routing": {
+      "required": true <1>
     }
   }
 }

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -13,13 +13,11 @@ within the index. For this reason, it can be disabled as follows:
 
 [source,js]
 --------------------------------------------------
-PUT tweets?include_type_name=true
+PUT tweets
 {
   "mappings": {
-    "_doc": {
-      "_source": {
-        "enabled": false
-      }
+    "_source": {
+      "enabled": false
     }
   }
 }
@@ -85,20 +83,18 @@ as follows:
 
 [source,js]
 --------------------------------------------------
-PUT logs?include_type_name=true
+PUT logs
 {
   "mappings": {
-    "_doc": {
-      "_source": {
-        "includes": [
-          "*.count",
-          "meta.*"
-        ],
-        "excludes": [
-          "meta.description",
-          "meta.other.*"
-        ]
-      }
+    "_source": {
+      "includes": [
+        "*.count",
+        "meta.*"
+      ],
+      "excludes": [
+        "meta.description",
+        "meta.other.*"
+      ]
     }
   }
 }

--- a/docs/reference/mapping/params/analyzer.asciidoc
+++ b/docs/reference/mapping/params/analyzer.asciidoc
@@ -41,18 +41,16 @@ in the field mapping, as follows:
 
 [source,js]
 --------------------------------------------------
-PUT /my_index?include_type_name=true
+PUT /my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "text": { <1>
-          "type": "text",
-          "fields": {
-            "english": { <2>
-              "type":     "text",
-              "analyzer": "english"
-            }
+    "properties": {
+      "text": { <1>
+        "type": "text",
+        "fields": {
+          "english": { <2>
+            "type":     "text",
+            "analyzer": "english"
           }
         }
       }
@@ -93,7 +91,7 @@ To disable stop words for phrases a field utilising three analyzer settings will
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
    "settings":{
       "analysis":{
@@ -123,14 +121,12 @@ PUT my_index?include_type_name=true
       }
    },
    "mappings":{
-      "_doc":{
-         "properties":{
-            "title": {
-               "type":"text",
-               "analyzer":"my_analyzer", <3>
-               "search_analyzer":"my_stop_analyzer", <4>
-               "search_quote_analyzer":"my_analyzer" <5>
-            }
+       "properties":{
+          "title": {
+             "type":"text",
+             "analyzer":"my_analyzer", <3>
+             "search_analyzer":"my_stop_analyzer", <4>
+             "search_quote_analyzer":"my_analyzer" <5>
          }
       }
    }

--- a/docs/reference/mapping/params/boost.asciidoc
+++ b/docs/reference/mapping/params/boost.asciidoc
@@ -6,18 +6,16 @@ Individual fields can be _boosted_ automatically -- count more towards the relev
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "title": {
-          "type": "text",
-          "boost": 2 <1>
-        },
-        "content": {
-          "type": "text"
-        }
+    "properties": {
+      "title": {
+        "type": "text",
+        "boost": 2 <1>
+      },
+      "content": {
+        "type": "text"
       }
     }
   }

--- a/docs/reference/mapping/params/coerce.asciidoc
+++ b/docs/reference/mapping/params/coerce.asciidoc
@@ -17,18 +17,16 @@ For instance:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "number_one": {
-          "type": "integer"
-        },
-        "number_two": {
-          "type": "integer",
-          "coerce": false
-        }
+    "properties": {
+      "number_one": {
+        "type": "integer"
+      },
+      "number_two": {
+        "type": "integer",
+        "coerce": false
       }
     }
   }
@@ -61,21 +59,19 @@ coercion globally across all mapping types:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "settings": {
     "index.mapping.coerce": false
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "number_one": {
-          "type": "integer",
-          "coerce": true
-        },
-        "number_two": {
-          "type": "integer"
-        }
+    "properties": {
+      "number_one": {
+        "type": "integer",
+        "coerce": true
+      },
+      "number_two": {
+        "type": "integer"
       }
     }
   }

--- a/docs/reference/mapping/params/copy-to.asciidoc
+++ b/docs/reference/mapping/params/copy-to.asciidoc
@@ -8,22 +8,20 @@ the `full_name` field as follows:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "first_name": {
-          "type": "text",
-          "copy_to": "full_name" <1>
-        },
-        "last_name": {
-          "type": "text",
-          "copy_to": "full_name" <1>
-        },
-        "full_name": {
-          "type": "text"
-        }
+    "properties": {
+      "first_name": {
+        "type": "text",
+        "copy_to": "full_name" <1>
+      },
+      "last_name": {
+        "type": "text",
+        "copy_to": "full_name" <1>
+      },
+      "full_name": {
+        "type": "text"
       }
     }
   }

--- a/docs/reference/mapping/params/doc-values.asciidoc
+++ b/docs/reference/mapping/params/doc-values.asciidoc
@@ -23,18 +23,16 @@ value from a script, you can disable doc values in order to save disk space:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "status_code": { <1>
-          "type":       "keyword"
-        },
-        "session_id": { <2>
-          "type":       "keyword",
-          "doc_values": false
-        }
+    "properties": {
+      "status_code": { <1>
+        "type":       "keyword"
+      },
+      "session_id": { <2>
+        "type":       "keyword",
+        "doc_values": false
       }
     }
   }

--- a/docs/reference/mapping/params/dynamic.asciidoc
+++ b/docs/reference/mapping/params/dynamic.asciidoc
@@ -58,21 +58,19 @@ object or from the mapping type.  For instance:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "dynamic": false, <1>
-      "properties": {
-        "user": { <2>
-          "properties": {
-            "name": {
-              "type": "text"
-            },
-            "social_networks": { <3>
-              "dynamic": true,
-              "properties": {}
-            }
+    "dynamic": false, <1>
+    "properties": {
+      "user": { <2>
+        "properties": {
+          "name": {
+            "type": "text"
+          },
+          "social_networks": { <3>
+            "dynamic": true,
+            "properties": {}
           }
         }
       }

--- a/docs/reference/mapping/params/enabled.asciidoc
+++ b/docs/reference/mapping/params/enabled.asciidoc
@@ -64,7 +64,7 @@ retrieved, but none of its contents are indexed in any way:
 PUT my_index
 {
   "mappings": {
-      "enabled": false
+    "enabled": false <1>
   }
 }
 
@@ -84,7 +84,7 @@ GET my_index/_doc/session_1 <2>
 GET my_index/_mapping <3>
 --------------------------------------------------
 // CONSOLE
-<1> The entire `_doc` mapping type is disabled.
+<1> The entire mapping type is disabled.
 <2> The document can be retrieved.
 <3> Checking the mapping reveals that no fields have been added.
 

--- a/docs/reference/mapping/params/enabled.asciidoc
+++ b/docs/reference/mapping/params/enabled.asciidoc
@@ -15,20 +15,18 @@ in any other way:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "user_id": {
-          "type":  "keyword"
-        },
-        "last_updated": {
-          "type": "date"
-        },
-        "session_data": { <1>
-          "enabled": false
-        }
+    "properties": {
+      "user_id": {
+        "type":  "keyword"
+      },
+      "last_updated": {
+        "type": "date"
+      },
+      "session_data": { <1>
+        "enabled": false
       }
     }
   }
@@ -63,12 +61,10 @@ retrieved, but none of its contents are indexed in any way:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": { <1>
       "enabled": false
-    }
   }
 }
 

--- a/docs/reference/mapping/params/fielddata.asciidoc
+++ b/docs/reference/mapping/params/fielddata.asciidoc
@@ -55,17 +55,15 @@ enabled for aggregations, as follows:
 
 [source,js]
 ---------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "my_field": { <1>
-          "type": "text",
-          "fields": {
-            "keyword": { <2>
-              "type": "keyword"
-            }
+    "properties": {
+      "my_field": { <1>
+        "type": "text",
+        "fields": {
+          "keyword": { <2>
+            "type": "keyword"
           }
         }
       }
@@ -118,19 +116,17 @@ number of docs that the segment should contain with `min_segment_size`:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "tag": {
-          "type": "text",
-          "fielddata": true,
-          "fielddata_frequency_filter": {
-            "min": 0.001,
-            "max": 0.1,
-            "min_segment_size": 500
-          }
+    "properties": {
+      "tag": {
+        "type": "text",
+        "fielddata": true,
+        "fielddata_frequency_filter": {
+          "min": 0.001,
+          "max": 0.1,
+          "min_segment_size": 500
         }
       }
     }

--- a/docs/reference/mapping/params/format.asciidoc
+++ b/docs/reference/mapping/params/format.asciidoc
@@ -11,15 +11,13 @@ Besides the <<built-in-date-formats,built-in formats>>, your own
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "date": {
-          "type":   "date",
-          "format": "yyyy-MM-dd"
-        }
+    "properties": {
+      "date": {
+        "type":   "date",
+        "format": "yyyy-MM-dd"
       }
     }
   }

--- a/docs/reference/mapping/params/ignore-above.asciidoc
+++ b/docs/reference/mapping/params/ignore-above.asciidoc
@@ -8,15 +8,13 @@ NOTE: All strings/array elements will still be present in the `_source` field, i
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "message": {
-          "type": "keyword",
-          "ignore_above": 20 <1>
-        }
+    "properties": {
+      "message": {
+        "type": "keyword",
+        "ignore_above": 20 <1>
       }
     }
   }

--- a/docs/reference/mapping/params/ignore-malformed.asciidoc
+++ b/docs/reference/mapping/params/ignore-malformed.asciidoc
@@ -14,18 +14,16 @@ For example:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "number_one": {
-          "type": "integer",
-          "ignore_malformed": true
-        },
-        "number_two": {
-          "type": "integer"
-        }
+    "properties": {
+      "number_one": {
+        "type": "integer",
+        "ignore_malformed": true
+      },
+      "number_two": {
+        "type": "integer"
       }
     }
   }
@@ -61,21 +59,19 @@ allow to ignore malformed content globally across all mapping types.
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "settings": {
     "index.mapping.ignore_malformed": true <1>
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "number_one": { <1>
-          "type": "byte"
-        },
-        "number_two": {
-          "type": "integer",
-          "ignore_malformed": false <2>
-        }
+    "properties": {
+      "number_one": { <1>
+        "type": "byte"
+      },
+      "number_two": {
+        "type": "integer",
+        "ignore_malformed": false <2>
       }
     }
   }

--- a/docs/reference/mapping/params/index-options.asciidoc
+++ b/docs/reference/mapping/params/index-options.asciidoc
@@ -35,15 +35,13 @@ all other fields use `docs` as the default.
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "text": {
-          "type": "text",
-          "index_options": "offsets"
-        }
+    "properties": {
+      "text": {
+        "type": "text",
+        "index_options": "offsets"
       }
     }
   }

--- a/docs/reference/mapping/params/index-prefixes.asciidoc
+++ b/docs/reference/mapping/params/index-prefixes.asciidoc
@@ -19,15 +19,13 @@ This example creates a text field using the default prefix length settings:
 
 [source,js]
 --------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "body_text": {
-          "type": "text",
-          "index_prefixes": { }    <1>
-        }
+    "properties": {
+      "body_text": {
+        "type": "text",
+        "index_prefixes": { }    <1>
       }
     }
   }
@@ -42,17 +40,15 @@ This example uses custom prefix length settings:
 
 [source,js]
 --------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "full_name": {
-          "type": "text",
-          "index_prefixes": {
-            "min_chars" : 1,
-            "max_chars" : 10
-          }
+    "properties": {
+      "full_name": {
+        "type": "text",
+        "index_prefixes": {
+          "min_chars" : 1,
+          "max_chars" : 10
         }
       }
     }

--- a/docs/reference/mapping/params/multi-fields.asciidoc
+++ b/docs/reference/mapping/params/multi-fields.asciidoc
@@ -8,17 +8,15 @@ search, and as a `keyword` field for sorting or aggregations:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "city": {
-          "type": "text",
-          "fields": {
-            "raw": { <1>
-              "type":  "keyword"
-            }
+    "properties": {
+      "city": {
+        "type": "text",
+        "fields": {
+          "raw": { <1>
+            "type":  "keyword"
           }
         }
       }
@@ -76,18 +74,16 @@ which stems words into their root form:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "text": { <1>
-          "type": "text",
-          "fields": {
-            "english": { <2>
-              "type":     "text",
-              "analyzer": "english"
-            }
+    "properties": {
+      "text": { <1>
+        "type": "text",
+        "fields": {
+          "english": { <2>
+            "type":     "text",
+            "analyzer": "english"
           }
         }
       }

--- a/docs/reference/mapping/params/normalizer.asciidoc
+++ b/docs/reference/mapping/params/normalizer.asciidoc
@@ -12,7 +12,7 @@ such as the <<query-dsl-term-query,`term`>> query.
 
 [source,js]
 --------------------------------
-PUT index?include_type_name=true
+PUT index
 {
   "settings": {
     "analysis": {
@@ -26,12 +26,10 @@ PUT index?include_type_name=true
     }
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "foo": {
-          "type": "keyword",
-          "normalizer": "my_normalizer"
-        }
+    "properties": {
+      "foo": {
+        "type": "keyword",
+        "normalizer": "my_normalizer"
       }
     }
   }

--- a/docs/reference/mapping/params/null-value.asciidoc
+++ b/docs/reference/mapping/params/null-value.asciidoc
@@ -10,15 +10,13 @@ the specified value so that it can be indexed and searched.  For instance:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "status_code": {
-          "type":       "keyword",
-          "null_value": "NULL" <1>
-        }
+    "properties": {
+      "status_code": {
+        "type":       "keyword",
+        "null_value": "NULL" <1>
       }
     }
   }

--- a/docs/reference/mapping/params/position-increment-gap.asciidoc
+++ b/docs/reference/mapping/params/position-increment-gap.asciidoc
@@ -51,15 +51,13 @@ The `position_increment_gap` can be specified in the mapping.  For instance:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "names": {
-          "type": "text",
-          "position_increment_gap": 0 <1>
-        }
+    "properties": {
+      "names": {
+        "type": "text",
+        "position_increment_gap": 0 <1>
       }
     }
   }

--- a/docs/reference/mapping/params/properties.asciidoc
+++ b/docs/reference/mapping/params/properties.asciidoc
@@ -15,23 +15,21 @@ field, and a `nested` field:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": { <1>
-      "properties": {
-        "manager": { <2>
-          "properties": {
-            "age":  { "type": "integer" },
-            "name": { "type": "text"  }
-          }
-        },
-        "employees": { <3>
-          "type": "nested",
-          "properties": {
-            "age":  { "type": "integer" },
-            "name": { "type": "text"  }
-          }
+    "properties": {
+      "manager": { <2>
+        "properties": {
+          "age":  { "type": "integer" },
+          "name": { "type": "text"  }
+        }
+      },
+      "employees": { <3>
+        "type": "nested",
+        "properties": {
+          "age":  { "type": "integer" },
+          "name": { "type": "text"  }
         }
       }
     }

--- a/docs/reference/mapping/params/properties.asciidoc
+++ b/docs/reference/mapping/params/properties.asciidoc
@@ -18,16 +18,16 @@ field, and a `nested` field:
 PUT my_index
 {
   "mappings": {
-    "properties": {
-      "manager": { <1>
-        "properties": {
+    "properties": { <1>
+      "manager": {
+        "properties": { <2>
           "age":  { "type": "integer" },
           "name": { "type": "text"  }
         }
       },
-      "employees": { <2>
+      "employees": {
         "type": "nested",
-        "properties": {
+        "properties": { <3>
           "age":  { "type": "integer" },
           "name": { "type": "text"  }
         }
@@ -36,7 +36,7 @@ PUT my_index
   }
 }
 
-PUT my_index/_doc/1 <3>
+PUT my_index/_doc/1 <4>
 {
   "region": "US",
   "manager": {
@@ -56,9 +56,10 @@ PUT my_index/_doc/1 <3>
 }
 --------------------------------------------------
 // CONSOLE
-<1> Properties under the `manager` object field.
-<2> Properties under the `employees` nested field.
-<3> An example document which corresponds to the above mapping.
+<1> Properties in the top-level mappings definition.
+<2> Properties under the `manager` object field.
+<3> Properties under the `employees` nested field.
+<4> An example document which corresponds to the above mapping.
 
 TIP: The `properties` setting is allowed to have different settings for fields
 of the same name in the same index.  New properties can be added to existing

--- a/docs/reference/mapping/params/properties.asciidoc
+++ b/docs/reference/mapping/params/properties.asciidoc
@@ -19,13 +19,13 @@ PUT my_index
 {
   "mappings": {
     "properties": {
-      "manager": { <2>
+      "manager": { <1>
         "properties": {
           "age":  { "type": "integer" },
           "name": { "type": "text"  }
         }
       },
-      "employees": { <3>
+      "employees": { <2>
         "type": "nested",
         "properties": {
           "age":  { "type": "integer" },
@@ -36,7 +36,7 @@ PUT my_index
   }
 }
 
-PUT my_index/_doc/1 <4>
+PUT my_index/_doc/1 <3>
 {
   "region": "US",
   "manager": {
@@ -56,10 +56,9 @@ PUT my_index/_doc/1 <4>
 }
 --------------------------------------------------
 // CONSOLE
-<1> Properties under the `_doc` mapping type.
-<2> Properties under the `manager` object field.
-<3> Properties under the `employees` nested field.
-<4> An example document which corresponds to the above mapping.
+<1> Properties under the `manager` object field.
+<2> Properties under the `employees` nested field.
+<3> An example document which corresponds to the above mapping.
 
 TIP: The `properties` setting is allowed to have different settings for fields
 of the same name in the same index.  New properties can be added to existing

--- a/docs/reference/mapping/params/search-analyzer.asciidoc
+++ b/docs/reference/mapping/params/search-analyzer.asciidoc
@@ -14,7 +14,7 @@ this can be overridden with the `search_analyzer` setting:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "settings": {
     "analysis": {
@@ -38,13 +38,11 @@ PUT my_index?include_type_name=true
     }
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "text": {
-          "type": "text",
-          "analyzer": "autocomplete", <2>
-          "search_analyzer": "standard" <2>
-        }
+    "properties": {
+      "text": {
+        "type": "text",
+        "analyzer": "autocomplete", <2>
+        "search_analyzer": "standard" <2>
       }
     }
   }

--- a/docs/reference/mapping/params/similarity.asciidoc
+++ b/docs/reference/mapping/params/similarity.asciidoc
@@ -36,18 +36,16 @@ as follows:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "default_field": { <1>
-          "type": "text"
-        },
-        "boolean_sim_field": {
-          "type": "text",
-          "similarity": "boolean" <2>
-        }
+    "properties": {
+      "default_field": { <1>
+        "type": "text"
+      },
+      "boolean_sim_field": {
+        "type": "text",
+        "similarity": "boolean" <2>
       }
     }
   }

--- a/docs/reference/mapping/params/store.asciidoc
+++ b/docs/reference/mapping/params/store.asciidoc
@@ -18,22 +18,20 @@ to extract those fields from a large `_source` field:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "title": {
-          "type": "text",
-          "store": true <1>
-        },
-        "date": {
-          "type": "date",
-          "store": true <1>
-        },
-        "content": {
-          "type": "text"
-        }
+    "properties": {
+      "title": {
+        "type": "text",
+        "store": true <1>
+      },
+      "date": {
+        "type": "date",
+        "store": true <1>
+      },
+      "content": {
+        "type": "text"
       }
     }
   }

--- a/docs/reference/mapping/params/term-vector.asciidoc
+++ b/docs/reference/mapping/params/term-vector.asciidoc
@@ -29,15 +29,13 @@ index.
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "text": {
-          "type":        "text",
-          "term_vector": "with_positions_offsets"
-        }
+    "properties": {
+      "text": {
+        "type":        "text",
+        "term_vector": "with_positions_offsets"
       }
     }
   }

--- a/docs/reference/mapping/types/alias.asciidoc
+++ b/docs/reference/mapping/types/alias.asciidoc
@@ -7,21 +7,19 @@ and selected other APIs like <<search-field-caps, field capabilities>>.
 
 [source,js]
 --------------------------------
-PUT trips?include_type_name=true
+PUT trips
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "distance": {
-          "type": "long"
-        },
-        "route_length_miles": {
-          "type": "alias",
-          "path": "distance" // <1>
-        },
-        "transit_mode": {
-          "type": "keyword"
-        }
+    "properties": {
+      "distance": {
+        "type": "long"
+      },
+      "route_length_miles": {
+        "type": "alias",
+        "path": "distance" // <1>
+      },
+      "transit_mode": {
+        "type": "keyword"
       }
     }
   }

--- a/docs/reference/mapping/types/binary.asciidoc
+++ b/docs/reference/mapping/types/binary.asciidoc
@@ -7,17 +7,15 @@ stored by default and is not searchable:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "name": {
-          "type": "text"
-        },
-        "blob": {
-          "type": "binary"
-        }
+    "properties": {
+      "name": {
+        "type": "text"
+      },
+      "blob": {
+        "type": "binary"
       }
     }
   }

--- a/docs/reference/mapping/types/boolean.asciidoc
+++ b/docs/reference/mapping/types/boolean.asciidoc
@@ -17,14 +17,12 @@ For example:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "is_published": {
-          "type": "boolean"
-        }
+    "properties": {
+      "is_published": {
+        "type": "boolean"
       }
     }
   }

--- a/docs/reference/mapping/types/date.asciidoc
+++ b/docs/reference/mapping/types/date.asciidoc
@@ -30,14 +30,12 @@ For instance:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "date": {
-          "type": "date" <1>
-        }
+    "properties": {
+      "date": {
+        "type": "date" <1>
       }
     }
   }
@@ -74,15 +72,13 @@ into a string.
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "date": {
-          "type":   "date",
-          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
-        }
+    "properties": {
+      "date": {
+        "type":   "date",
+        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
       }
     }
   }

--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -17,17 +17,15 @@ You index a dense vector as an array of floats.
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "my_vector": {
-          "type": "dense_vector"
-        },
-        "my_text" : {
-          "type" : "keyword"
-        }
+    "properties": {
+      "my_vector": {
+        "type": "dense_vector"
+      },
+      "my_text" : {
+        "type" : "keyword"
       }
     }
   }

--- a/docs/reference/mapping/types/feature-vector.asciidoc
+++ b/docs/reference/mapping/types/feature-vector.asciidoc
@@ -11,14 +11,12 @@ one field to the mappings for each of them.
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "topics": {
-          "type": "feature_vector" <1>
-        }
+    "properties": {
+      "topics": {
+        "type": "feature_vector" <1>
       }
     }
   }

--- a/docs/reference/mapping/types/feature.asciidoc
+++ b/docs/reference/mapping/types/feature.asciidoc
@@ -6,18 +6,16 @@ documents in queries with a <<query-dsl-feature-query,`feature`>> query.
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "pagerank": {
-          "type": "feature" <1>
-        },
-        "url_length": {
-          "type": "feature",
-          "positive_score_impact": false <2>
-        }
+    "properties": {
+      "pagerank": {
+        "type": "feature" <1>
+      },
+      "url_length": {
+        "type": "feature",
+        "positive_score_impact": false <2>
       }
     }
   }

--- a/docs/reference/mapping/types/geo-point.asciidoc
+++ b/docs/reference/mapping/types/geo-point.asciidoc
@@ -15,14 +15,12 @@ There are four ways that a geo-point may be specified, as demonstrated below:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "location": {
-          "type": "geo_point"
-        }
+    "properties": {
+      "location": {
+        "type": "geo_point"
       }
     }
   }

--- a/docs/reference/mapping/types/ip.asciidoc
+++ b/docs/reference/mapping/types/ip.asciidoc
@@ -6,14 +6,12 @@ https://en.wikipedia.org/wiki/IPv6[IPv6] addresses.
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "ip_addr": {
-          "type": "ip"
-        }
+    "properties": {
+      "ip_addr": {
+        "type": "ip"
       }
     }
   }

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -15,14 +15,12 @@ Below is an example of a mapping for a keyword field:
 
 [source,js]
 --------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "tags": {
-          "type":  "keyword"
-        }
+    "properties": {
+      "tags": {
+        "type":  "keyword"
       }
     }
   }

--- a/docs/reference/mapping/types/nested.asciidoc
+++ b/docs/reference/mapping/types/nested.asciidoc
@@ -75,14 +75,12 @@ queried independently of the others, with the <<query-dsl-nested-query,`nested` 
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "user": {
-          "type": "nested" <1>
-        }
+    "properties": {
+      "user": {
+        "type": "nested" <1>
       }
     }
   }

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -17,21 +17,19 @@ Below is an example of configuring a mapping with numeric fields:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "number_of_bytes": {
-          "type": "integer"
-        },
-        "time_in_seconds": {
-          "type": "float"
-        },
-        "price": {
-          "type": "scaled_float",
-          "scaling_factor": 100
-        }
+    "properties": {
+      "number_of_bytes": {
+        "type": "integer"
+      },
+      "time_in_seconds": {
+        "type": "float"
+      },
+      "price": {
+        "type": "scaled_float",
+        "scaling_factor": 100
       }
     }
   }

--- a/docs/reference/mapping/types/object.asciidoc
+++ b/docs/reference/mapping/types/object.asciidoc
@@ -44,14 +44,14 @@ An explicit mapping for the above document could look like this:
 PUT my_index
 {
   "mappings": {
-    "properties": {
+    "properties": { <1>
       "region": {
         "type": "keyword"
       },
-      "manager": { <1>
+      "manager": { <2>
         "properties": {
           "age":  { "type": "integer" },
-          "name": { <2>
+          "name": { <3>
             "properties": {
               "first": { "type": "text" },
               "last":  { "type": "text" }
@@ -64,8 +64,9 @@ PUT my_index
 }
 --------------------------------------------------
 // CONSOLE
-<1> The `manager` field is an inner `object` field.
-<2> The `manager.name` field is an inner `object` field within the `manager` field.
+<1> Properties in the top-level mappings definition.
+<2> The `manager` field is an inner `object` field.
+<3> The `manager.name` field is an inner `object` field within the `manager` field.
 
 You are not required to set the field `type` to `object` explicitly, as this is the default value.
 

--- a/docs/reference/mapping/types/object.asciidoc
+++ b/docs/reference/mapping/types/object.asciidoc
@@ -41,22 +41,20 @@ An explicit mapping for the above document could look like this:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": { <1>
-      "properties": {
-        "region": {
-          "type": "keyword"
-        },
-        "manager": { <2>
-          "properties": {
-            "age":  { "type": "integer" },
-            "name": { <3>
-              "properties": {
-                "first": { "type": "text" },
-                "last":  { "type": "text" }
-              }
+    "properties": {
+      "region": {
+        "type": "keyword"
+      },
+      "manager": { <1>
+        "properties": {
+          "age":  { "type": "integer" },
+          "name": { <2>
+            "properties": {
+              "first": { "type": "text" },
+              "last":  { "type": "text" }
             }
           }
         }
@@ -66,9 +64,8 @@ PUT my_index?include_type_name=true
 }
 --------------------------------------------------
 // CONSOLE
-<1> The mapping type is a type of object, and has a `properties` field.
-<2> The `manager` field is an inner `object` field.
-<3> The `manager.name` field is an inner `object` field within the `manager` field.
+<1> The `manager` field is an inner `object` field.
+<2> The `manager.name` field is an inner `object` field within the `manager` field.
 
 You are not required to set the field `type` to `object` explicitly, as this is the default value.
 

--- a/docs/reference/mapping/types/parent-join.asciidoc
+++ b/docs/reference/mapping/types/parent-join.asciidoc
@@ -1,3 +1,4 @@
+[[parent-join]]
 === `join` datatype
 
 The `join` datatype is a special field that creates

--- a/docs/reference/mapping/types/parent-join.asciidoc
+++ b/docs/reference/mapping/types/parent-join.asciidoc
@@ -1,4 +1,3 @@
-[[parent-join]]
 === `join` datatype
 
 The `join` datatype is a special field that creates
@@ -9,16 +8,14 @@ A parent/child relation can be defined as follows:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "my_join_field": { <1>
-          "type": "join",
-          "relations": {
-            "question": "answer" <2>
-          }
+    "properties": {
+      "my_join_field": { <1>
+        "type": "join",
+        "relations": {
+          "question": "answer" <2>
         }
       }
     }
@@ -319,18 +316,16 @@ make sense to disable eager loading:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "my_join_field": {
-          "type": "join",
-          "relations": {
-             "question": "answer"
-          },
-          "eager_global_ordinals": false
-        }
+    "properties": {
+      "my_join_field": {
+        "type": "join",
+        "relations": {
+           "question": "answer"
+        },
+        "eager_global_ordinals": false
       }
     }
   }
@@ -358,16 +353,14 @@ It is also possible to define multiple children for a single parent:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "my_join_field": {
-          "type": "join",
-          "relations": {
-            "question": ["answer", "comment"]  <1>
-          }
+    "properties": {
+      "my_join_field": {
+        "type": "join",
+        "relations": {
+          "question": ["answer", "comment"]  <1>
         }
       }
     }
@@ -388,17 +381,15 @@ Multiple levels of parent/child:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "my_join_field": {
-          "type": "join",
-          "relations": {
-            "question": ["answer", "comment"],  <1>
-            "answer": "vote" <2>
-          }
+    "properties": {
+      "my_join_field": {
+        "type": "join",
+        "relations": {
+          "question": ["answer", "comment"],  <1>
+          "answer": "vote" <2>
         }
       }
     }

--- a/docs/reference/mapping/types/percolator.asciidoc
+++ b/docs/reference/mapping/types/percolator.asciidoc
@@ -15,17 +15,15 @@ If the following mapping configures the `percolator` field type for the
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
     "mappings": {
-        "_doc": {
-            "properties": {
-                "query": {
-                    "type": "percolator"
-                },
-                "field": {
-                    "type": "text"
-                }
+        "properties": {
+            "query": {
+                "type": "percolator"
+            },
+            "field": {
+                "type": "text"
             }
         }
     }
@@ -69,17 +67,15 @@ Lets take a look at the following index with a percolator field type:
 
 [source,js]
 --------------------------------------------------
-PUT index?include_type_name=true
+PUT index
 {
   "mappings": {
-    "_doc" : {
-      "properties": {
-        "query" : {
-          "type" : "percolator"
-        },
-        "body" : {
-          "type": "text"
-        }
+    "properties": {
+      "query" : {
+        "type" : "percolator"
+      },
+      "body" : {
+        "type": "text"
       }
     }
   }
@@ -117,17 +113,15 @@ to read your queries you need to reindex your queries into a new index on the cu
 
 [source,js]
 --------------------------------------------------
-PUT new_index?include_type_name=true
+PUT new_index
 {
   "mappings": {
-    "_doc" : {
-      "properties": {
-        "query" : {
-          "type" : "percolator"
-        },
-        "body" : {
-          "type": "text"
-        }
+    "properties": {
+      "query" : {
+        "type" : "percolator"
+      },
+      "body" : {
+        "type": "text"
       }
     }
   }
@@ -269,7 +263,7 @@ with these settings and mapping:
 
 [source,js]
 --------------------------------------------------
-PUT /test_index?include_type_name=true
+PUT /test_index
 {
   "settings": {
     "analysis": {
@@ -282,15 +276,13 @@ PUT /test_index?include_type_name=true
     }
   },
   "mappings": {
-    "_doc" : {
-      "properties": {
-        "query" : {
-          "type": "percolator"
-        },
-        "body" : {
-          "type": "text",
-          "analyzer": "my_analyzer" <1>
-        }
+    "properties": {
+      "query" : {
+        "type": "percolator"
+      },
+      "body" : {
+        "type": "text",
+        "analyzer": "my_analyzer" <1>
       }
     }
   }
@@ -442,7 +434,7 @@ Creating an index with custom analysis settings:
 
 [source,js]
 --------------------------------------------------
-PUT my_queries1?include_type_name=true
+PUT my_queries1
 {
   "settings": {
     "analysis": {
@@ -466,19 +458,17 @@ PUT my_queries1?include_type_name=true
     }
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "query": {
-          "type": "percolator"
-        },
-        "my_field": {
-          "type": "text",
-          "fields": {
-            "prefix": { <3>
-              "type": "text",
-              "analyzer": "wildcard_prefix",
-              "search_analyzer": "standard"
-            }
+    "properties": {
+      "query": {
+        "type": "percolator"
+      },
+      "my_field": {
+        "type": "text",
+        "fields": {
+          "prefix": { <3>
+            "type": "text",
+            "analyzer": "wildcard_prefix",
+            "search_analyzer": "standard"
           }
         }
       }
@@ -595,7 +585,7 @@ before the `edge_ngram` token filter.
 
 [source,js]
 --------------------------------------------------
-PUT my_queries2?include_type_name=true
+PUT my_queries2
 {
   "settings": {
     "analysis": {
@@ -628,19 +618,17 @@ PUT my_queries2?include_type_name=true
     }
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "query": {
-          "type": "percolator"
-        },
-        "my_field": {
-          "type": "text",
-          "fields": {
-            "suffix": {
-              "type": "text",
-              "analyzer": "wildcard_suffix",
-              "search_analyzer": "wildcard_suffix_search_time" <1>
-            }
+    "properties": {
+      "query": {
+        "type": "percolator"
+      },
+      "my_field": {
+        "type": "text",
+        "fields": {
+          "suffix": {
+            "type": "text",
+            "analyzer": "wildcard_suffix",
+            "search_analyzer": "wildcard_suffix_search_time" <1>
           }
         }
       }

--- a/docs/reference/mapping/types/range.asciidoc
+++ b/docs/reference/mapping/types/range.asciidoc
@@ -16,21 +16,19 @@ Below is an example of configuring a mapping with various range fields followed 
 
 [source,js]
 --------------------------------------------------
-PUT range_index?include_type_name=true
+PUT range_index
 {
   "settings": {
     "number_of_shards": 2
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "expected_attendees": {
-          "type": "integer_range"
-        },
-        "time_frame": {
-          "type": "date_range", <1>
-          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
-        }
+    "properties": {
+      "expected_attendees": {
+        "type": "integer_range"
+      },
+      "time_frame": {
+        "type": "date_range", <1>
+        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
       }
     }
   }

--- a/docs/reference/mapping/types/sparse-vector.asciidoc
+++ b/docs/reference/mapping/types/sparse-vector.asciidoc
@@ -20,17 +20,15 @@ Dimensions don't need to be in order.
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "my_vector": {
-          "type": "sparse_vector"
-        },
-        "my_text" : {
-          "type" : "keyword"
-        }
+    "properties": {
+      "my_vector": {
+        "type": "sparse_vector"
+      },
+      "my_text" : {
+        "type" : "keyword"
       }
     }
   }

--- a/docs/reference/mapping/types/text.asciidoc
+++ b/docs/reference/mapping/types/text.asciidoc
@@ -17,14 +17,12 @@ Below is an example of a mapping for a text field:
 
 [source,js]
 --------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "full_name": {
-          "type":  "text"
-        }
+    "properties": {
+      "full_name": {
+        "type":  "text"
       }
     }
   }

--- a/docs/reference/mapping/types/token-count.asciidoc
+++ b/docs/reference/mapping/types/token-count.asciidoc
@@ -9,18 +9,16 @@ For instance:
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "name": { <1>
-          "type": "text",
-          "fields": {
-            "length": { <2>
-              "type":     "token_count",
-              "analyzer": "standard"
-            }
+    "properties": {
+      "name": { <1>
+        "type": "text",
+        "fields": {
+          "length": { <2>
+            "type":     "token_count",
+            "analyzer": "standard"
           }
         }
       }

--- a/docs/reference/ml/transforms.asciidoc
+++ b/docs/reference/ml/transforms.asciidoc
@@ -26,51 +26,49 @@ subsequent examples:
 
 [source,js]
 ----------------------------------
-PUT /my_index?include_type_name=true
+PUT /my_index
 {
   "mappings":{
-    "_doc":{
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
-        "aborted_count": {
-          "type": "long"
-        },
-        "another_field": {
-          "type": "keyword" <1>
-        },
-        "clientip": {
-          "type": "keyword"
-        },
-        "coords": {
-          "properties": {
-            "lat": {
-              "type": "keyword"
-            },
-            "lon": {
-              "type": "keyword"
-            }
+    "properties": {
+      "@timestamp": {
+        "type": "date"
+      },
+      "aborted_count": {
+        "type": "long"
+      },
+      "another_field": {
+        "type": "keyword" <1>
+      },
+      "clientip": {
+        "type": "keyword"
+      },
+      "coords": {
+        "properties": {
+          "lat": {
+            "type": "keyword"
+          },
+          "lon": {
+            "type": "keyword"
           }
-        },
-        "error_count": {
-          "type": "long"
-        },
-        "query": {
-          "type": "keyword"
-        },
-        "some_field": {
-          "type": "keyword"
-        },
-        "tokenstring1":{
-          "type":"keyword"
-        },
-        "tokenstring2":{
-          "type":"keyword"
-        },
-        "tokenstring3":{
-          "type":"keyword"
         }
+      },
+      "error_count": {
+        "type": "long"
+      },
+      "query": {
+        "type": "keyword"
+      },
+      "some_field": {
+        "type": "keyword"
+      },
+      "tokenstring1":{
+        "type":"keyword"
+      },
+      "tokenstring2":{
+        "type":"keyword"
+      },
+      "tokenstring3":{
+        "type":"keyword"
       }
     }
   }

--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -52,15 +52,13 @@ instance, if the `user` field were mapped as follows:
 
 [source,js]
 --------------------------------------------------
-PUT /example?include_type_name=true
+PUT /example
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "user": {
-          "type": "keyword",
-          "null_value": "_null_"
-        }
+    "properties": {
+      "user": {
+        "type": "keyword",
+        "null_value": "_null_"
       }
     }
   }

--- a/docs/reference/query-dsl/feature-query.asciidoc
+++ b/docs/reference/query-dsl/feature-query.asciidoc
@@ -27,21 +27,19 @@ based or `pagerank`, `url_length` and the `sports` topic.
 
 [source,js]
 --------------------------------------------------
-PUT test?include_type_name=true
+PUT test
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "pagerank": {
-          "type": "feature"
-        },
-        "url_length": {
-          "type": "feature",
-          "positive_score_impact": false
-        },
-        "topics": {
-          "type": "feature_vector"
-        }
+    "properties": {
+      "pagerank": {
+        "type": "feature"
+      },
+      "url_length": {
+        "type": "feature",
+        "positive_score_impact": false
+      },
+      "topics": {
+        "type": "feature_vector"
       }
     }
   }

--- a/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
+++ b/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
@@ -6,16 +6,14 @@ bounding box. Assuming the following indexed document:
 
 [source,js]
 --------------------------------------------------
-PUT /my_locations?include_type_name=true
+PUT /my_locations
 {
     "mappings": {
-        "_doc": {
-            "properties": {
-                "pin": {
-                    "properties": {
-                        "location": {
-                            "type": "geo_point"
-                        }
+        "properties": {
+            "pin": {
+                "properties": {
+                    "location": {
+                        "type": "geo_point"
                     }
                 }
             }

--- a/docs/reference/query-dsl/geo-distance-query.asciidoc
+++ b/docs/reference/query-dsl/geo-distance-query.asciidoc
@@ -7,16 +7,14 @@ document:
 
 [source,js]
 --------------------------------------------------
-PUT /my_locations?include_type_name=true
+PUT /my_locations
 {
     "mappings": {
-        "_doc": {
-            "properties": {
-                "pin": {
-                    "properties": {
-                        "location": {
-                            "type": "geo_point"
-                        }
+        "properties": {
+            "pin": {
+                "properties": {
+                    "location": {
+                        "type": "geo_point"
                     }
                 }
             }

--- a/docs/reference/query-dsl/geo-shape-query.asciidoc
+++ b/docs/reference/query-dsl/geo-shape-query.asciidoc
@@ -24,14 +24,12 @@ Given the following index:
 
 [source,js]
 --------------------------------------------------
-PUT /example?include_type_name=true
+PUT /example
 {
     "mappings": {
-        "_doc": {
-            "properties": {
-                "location": {
-                    "type": "geo_shape"
-                }
+        "properties": {
+            "location": {
+                "type": "geo_shape"
             }
         }
     }
@@ -99,14 +97,12 @@ shape:
 
 [source,js]
 --------------------------------------------------
-PUT /shapes?include_type_name=true
+PUT /shapes
 {
     "mappings": {
-        "_doc": {
-            "properties": {
-                "location": {
-                    "type": "geo_shape"
-                }
+        "properties": {
+            "location": {
+                "type": "geo_shape"
             }
         }
     }

--- a/docs/reference/query-dsl/nested-query.asciidoc
+++ b/docs/reference/query-dsl/nested-query.asciidoc
@@ -10,14 +10,12 @@ will work with:
 
 [source,js]
 --------------------------------------------------
-PUT /my_index?include_type_name=true
+PUT /my_index
 {
     "mappings": {
-        "_doc" : {
-            "properties" : {
-                "obj1" : {
-                    "type" : "nested"
-                }
+        "properties" : {
+            "obj1" : {
+                "type" : "nested"
             }
         }
     }

--- a/docs/reference/query-dsl/parent-id-query.asciidoc
+++ b/docs/reference/query-dsl/parent-id-query.asciidoc
@@ -6,16 +6,14 @@ Given the following mapping definition:
 
 [source,js]
 --------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "my_join_field": {
-          "type": "join",
-          "relations": {
-            "my_parent": "my_child"
-          }
+    "properties": {
+      "my_join_field": {
+        "type": "join",
+        "relations": {
+          "my_parent": "my_child"
         }
       }
     }

--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -13,18 +13,16 @@ Create an index with two fields:
 
 [source,js]
 --------------------------------------------------
-PUT /my-index?include_type_name=true
+PUT /my-index
 {
     "mappings": {
-        "_doc": {
-            "properties": {
-                "message": {
-                    "type": "text"
-                },
-                "query": {
-                    "type": "percolator"
-                }
-            }
+        "properties": {
+             "message": {
+                 "type": "text"
+             },
+             "query": {
+                 "type": "percolator"
+             }
         }
     }
 }

--- a/docs/reference/query-dsl/term-query.asciidoc
+++ b/docs/reference/query-dsl/term-query.asciidoc
@@ -87,17 +87,15 @@ To demonstrate, try out the example below.  First, create an index, specifying t
 
 [source,js]
 --------------------------------------------------
-PUT my_index?include_type_name=true
+PUT my_index
 {
   "mappings": {
-    "_doc": {
-      "properties": {
-        "full_text": {
-          "type":  "text" <1>
-        },
-        "exact_value": {
-          "type":  "keyword" <2>
-        }
+    "properties": {
+      "full_text": {
+        "type":  "text" <1>
+      },
+      "exact_value": {
+        "type":  "keyword" <2>
       }
     }
   }

--- a/docs/reference/query-dsl/terms-set-query.asciidoc
+++ b/docs/reference/query-dsl/terms-set-query.asciidoc
@@ -12,14 +12,12 @@ be a number field:
 
 [source,js]
 --------------------------------------------------
-PUT /my-index?include_type_name=true
+PUT /my-index
 {
     "mappings": {
-        "_doc": {
-            "properties": {
-                "required_matches": {
-                    "type": "long"
-                }
+        "properties": {
+            "required_matches": {
+                "type": "long"
             }
         }
     }

--- a/docs/reference/search/request/highlighters-internal.asciidoc
+++ b/docs/reference/search/request/highlighters-internal.asciidoc
@@ -87,15 +87,13 @@ using `english` analyzer, and will be indexed without offsets or term vectors.
 
 [source,js]
 --------------------------------------------------
-PUT test_index?include_type_name=true
+PUT test_index
 {
     "mappings": {
-        "_doc": {
-            "properties": {
-                "content" : {
-                    "type" : "text",
-                    "analyzer" : "english"
-                }
+        "properties": {
+            "content" : {
+                "type" : "text",
+                "analyzer" : "english"
             }
         }
     }

--- a/docs/reference/search/request/post-filter.asciidoc
+++ b/docs/reference/search/request/post-filter.asciidoc
@@ -9,15 +9,13 @@ Imagine that you are selling shirts that have the following properties:
 
 [source,js]
 --------------------------------------------------
-PUT /shirts?include_type_name=true
+PUT /shirts
 {
     "mappings": {
-        "_doc": {
-            "properties": {
-                "brand": { "type": "keyword"},
-                "color": { "type": "keyword"},
-                "model": { "type": "keyword"}
-            }
+        "properties": {
+            "brand": { "type": "keyword"},
+            "color": { "type": "keyword"},
+            "model": { "type": "keyword"}
         }
     }
 }

--- a/docs/reference/search/request/sort.asciidoc
+++ b/docs/reference/search/request/sort.asciidoc
@@ -9,20 +9,18 @@ Assuming the following index mapping:
 
 [source,js]
 --------------------------------------------------
-PUT /my_index?include_type_name=true
+PUT /my_index
 {
     "mappings": {
-        "_doc": {
-            "properties": {
-                "post_date": { "type": "date" },
-                "user": {
-                    "type": "keyword"
-                },
-                "name": {
-                    "type": "keyword"
-                },
-                "age": { "type": "integer" }
-            }
+        "properties": {
+            "post_date": { "type": "date" },
+            "user": {
+                "type": "keyword"
+            },
+            "name": {
+                "type": "keyword"
+            },
+            "age": { "type": "integer" }
         }
     }
 }

--- a/docs/reference/search/suggesters/completion-suggest.asciidoc
+++ b/docs/reference/search/suggesters/completion-suggest.asciidoc
@@ -24,17 +24,15 @@ which indexes the field values for fast completions.
 
 [source,js]
 --------------------------------------------------
-PUT music?include_type_name=true
+PUT music
 {
     "mappings": {
-        "_doc" : {
-            "properties" : {
-                "suggest" : {
-                    "type" : "completion"
-                },
-                "title" : {
-                    "type": "keyword"
-                }
+        "properties" : {
+            "suggest" : {
+                "type" : "completion"
+            },
+            "title" : {
+                "type": "keyword"
             }
         }
     }

--- a/docs/reference/search/suggesters/context-suggest.asciidoc
+++ b/docs/reference/search/suggesters/context-suggest.asciidoc
@@ -21,53 +21,49 @@ field:
 
 [source,js]
 --------------------------------------------------
-PUT place?include_type_name=true
+PUT place
 {
     "mappings": {
-        "_doc" : {
-            "properties" : {
-                "suggest" : {
-                    "type" : "completion",
-                    "contexts": [
-                        { <1>
-                            "name": "place_type",
-                            "type": "category"
-                        },
-                        { <2>
-                            "name": "location",
-                            "type": "geo",
-                            "precision": 4
-                        }
-                    ]
-                }
+        "properties" : {
+            "suggest" : {
+                "type" : "completion",
+                "contexts": [
+                    { <1>
+                        "name": "place_type",
+                        "type": "category"
+                    },
+                    { <2>
+                        "name": "location",
+                        "type": "geo",
+                        "precision": 4
+                    }
+                ]
             }
         }
     }
 }
-PUT place_path_category?include_type_name=true
+PUT place_path_category
 {
     "mappings": {
-        "_doc" : {
-            "properties" : {
-                "suggest" : {
-                    "type" : "completion",
-                    "contexts": [
-                        { <3>
-                            "name": "place_type",
-                            "type": "category",
-                            "path": "cat"
-                        },
-                        { <4>
-                            "name": "location",
-                            "type": "geo",
-                            "precision": 4,
-                            "path": "loc"
-                        }
-                    ]
-                },
-                "loc": {
-                    "type": "geo_point"
-                }
+        "properties" : {
+            "suggest" : {
+                "type" : "completion",
+                "contexts": [
+                    { <3>
+                        "name": "place_type",
+                        "type": "category",
+                        "path": "cat"
+                    },
+                    { <4>
+                        "name": "location",
+                        "type": "geo",
+                        "precision": 4,
+                        "path": "loc"
+                    }
+                ]
+            },
+            "loc": {
+                "type": "geo_point"
             }
         }
     }

--- a/docs/reference/search/suggesters/phrase-suggest.asciidoc
+++ b/docs/reference/search/suggesters/phrase-suggest.asciidoc
@@ -23,7 +23,7 @@ work. The `reverse` analyzer is used only in the last example.
 
 [source,js]
 --------------------------------------------------
-PUT test?include_type_name=true
+PUT test
 {
   "settings": {
     "index": {
@@ -52,19 +52,17 @@ PUT test?include_type_name=true
     }
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "title": {
-          "type": "text",
-          "fields": {
-            "trigram": {
-              "type": "text",
-              "analyzer": "trigram"
-            },
-            "reverse": {
-              "type": "text",
-              "analyzer": "reverse"
-            }
+    "properties": {
+      "title": {
+        "type": "text",
+        "fields": {
+          "trigram": {
+            "type": "text",
+            "analyzer": "trigram"
+          },
+          "reverse": {
+            "type": "text",
+            "analyzer": "reverse"
           }
         }
       }

--- a/x-pack/docs/en/security/authorization/alias-privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/alias-privileges.asciidoc
@@ -54,7 +54,7 @@ added to an index directly as part of the index creation:
 
 [source,shell]
 -------------------------------------------------------------------------------
-PUT /2015?include_type_name=true
+PUT /2015
 {
     "aliases" : {
         "current_year" : {}


### PR DESCRIPTION
This removes all the remaining uses of the "include_type_name" parameter
in the asciidocs that were temporary introduced in #37285. The only remaining
instances are in `removal_of_types.asciidoc` which warants a separate treatment
in a follow up.