### PR TITLE
Document that date math is locale independent

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -85,6 +85,9 @@ Where:
 `date_format`:: is the optional format in which the computed date should be rendered. Defaults to `YYYY.MM.dd`.
 `time_zone`:: is the optional time zone . Defaults to `utc`.
 
+Date math expressions are resolved locale-independent. Consequently, it is not possible to use any other
+calendars than the Gregorian calendar.
+
 You must enclose date math index name expressions within angle brackets, and
 all special characters should be URI encoded. For example:
 


### PR DESCRIPTION
With this commit we add a note to the API conventions documentation that
all date math expressions are resolved independently of any locale. This
behavior might be puzzling to users that try to specify a different
calendar than a Gregorian calendar.

Closes #37330