### PR TITLE
Fix edge case in PutMappingRequestTests

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/PutMappingRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/PutMappingRequestTests.java
@@ -19,15 +19,14 @@
 
 package org.elasticsearch.client.indices;
 
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.RandomCreateIndexGenerator;
 import org.elasticsearch.test.AbstractXContentTestCase;
 
 import java.io.IOException;
+import java.util.Map;
 
-@AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/37654")
 public class PutMappingRequestTests extends AbstractXContentTestCase<PutMappingRequest> {
 
     @Override
@@ -47,7 +46,10 @@ public class PutMappingRequestTests extends AbstractXContentTestCase<PutMappingR
     @Override
     protected PutMappingRequest doParseInstance(XContentParser parser) throws IOException {
         PutMappingRequest request = new PutMappingRequest();
-        request.source(parser.map());
+        Map<String, Object> map = parser.map();
+        if (map.isEmpty() == false) {
+            request.source(map);
+        }
         return request;
     }
 
@@ -58,11 +60,16 @@ public class PutMappingRequestTests extends AbstractXContentTestCase<PutMappingR
 
     @Override
     protected void assertEqualInstances(PutMappingRequest expected, PutMappingRequest actual) {
-        try (XContentParser expectedJson = createParser(expected.xContentType().xContent(), expected.source());
-             XContentParser actualJson = createParser(actual.xContentType().xContent(), actual.source())) {
-            assertEquals(expectedJson.mapOrdered(), actualJson.mapOrdered());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        if (actual.source() != null) {
+            try (XContentParser expectedJson = createParser(expected.xContentType().xContent(), expected.source());
+                    XContentParser actualJson = createParser(actual.xContentType().xContent(), actual.source())) {
+                assertEquals(expectedJson.mapOrdered(), actualJson.mapOrdered());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            // if the original `source` is null, the parsed source should be so too
+            assertNull(expected.source());
         }
     }
 }


### PR DESCRIPTION
The recently introduced client side PutMappingRequestTests has an edge case that
leads to failing tests. When the "source" or the original request is `null` it
gets rendered to xContent as an empty object, which by the test class itself is
parsed back as an empty map. For this reason the original and the parsed request
differ (one has an empty source, one an empty map). This fixes this edge case by
assuming an empty map means a null source in the request. In practice the
distinction doesn't matter because all the client side request does is write
itself to xContent, which gives the same result regardless of whether `source`
is null or empty.

Closes #37654