### PR TITLE
Use cancel instead of timeout verb for early-terminating publications

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -455,7 +455,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
 
         if (mode != Mode.CANDIDATE) {
             mode = Mode.CANDIDATE;
-            cancelActivePublication();
+            cancelActivePublication("become candidate: " + method);
             joinAccumulator.close(mode);
             joinAccumulator = joinHelper.new CandidateJoinAccumulator();
 
@@ -527,7 +527,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         discoveryUpgradeService.deactivate();
         clusterFormationFailureHelper.stop();
         closePrevotingAndElectionScheduler();
-        cancelActivePublication();
+        cancelActivePublication("become follower: " + method);
         preVoteCollector.update(getPreVoteResponse(), leaderNode);
 
         if (restartLeaderChecker) {
@@ -935,7 +935,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                     @Override
                     public void run() {
                         synchronized (mutex) {
-                            publication.onTimeout();
+                            publication.cancel("timed out after " + publishTimeout);
                         }
                     }
 
@@ -991,10 +991,10 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         };
     }
 
-    private void cancelActivePublication() {
+    private void cancelActivePublication(String reason) {
         assert Thread.holdsLock(mutex) : "Coordinator mutex not held";
         if (currentPublication.isPresent()) {
-            currentPublication.get().onTimeout();
+            currentPublication.get().cancel(reason);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTests.java
@@ -346,7 +346,7 @@ public class PublicationTests extends ESTestCase {
         publication.pendingPublications.entrySet().stream().collect(shuffle()).forEach(e -> {
             if (e.getKey().equals(n2)) {
                 if (timeOut) {
-                    publication.onTimeout();
+                    publication.cancel("timed out");
                 } else {
                     e.getValue().onFailure(new TransportException(new Exception("dummy failure")));
                 }
@@ -407,7 +407,7 @@ public class PublicationTests extends ESTestCase {
             }
         });
 
-        publication.onTimeout();
+        publication.cancel("timed out");
         assertTrue(publication.completed);
         assertTrue(publication.committed);
         assertEquals(committingNodes, ackListener.await(0L, TimeUnit.SECONDS));


### PR DESCRIPTION
When publications were cancelled because a node turned to follower or candidate, it would still show as time out, which can be confusing in the logs. This change adapts the improper call of `onTimeout` by generalizing it to a `cancel` method.