### PR TITLE
Use PEM files for PkiOptionalClientAuthTests

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/PkiOptionalClientAuthTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/PkiOptionalClientAuthTests.java
@@ -49,27 +49,30 @@ public class PkiOptionalClientAuthTests extends SecuritySingleNodeTestCase {
         String randomClientPortRange = randomClientPort + "-" + (randomClientPort+100);
 
         Settings.Builder builder = Settings.builder()
-                .put(super.nodeSettings())
-                .put("xpack.security.http.ssl.enabled", true)
-                .put("xpack.security.http.ssl.client_authentication", SSLClientAuth.OPTIONAL)
-                .put("xpack.security.http.ssl.keystore.path",
-                        getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks"))
-                .put("xpack.security.http.ssl.keystore.password", "testnode")
-                .put("xpack.security.authc.realms.file.file.order", "0")
-                .put("xpack.security.authc.realms.pki.pki1.order", "1")
-                .put("xpack.security.authc.realms.pki.pki1.truststore.path",
-                        getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/truststore-testnode-only.jks"))
-                .put("xpack.security.authc.realms.pki.pki1.files.role_mapping", getDataPath("role_mapping.yml"))
-                .put("transport.profiles.want_client_auth.port", randomClientPortRange)
-                .put("transport.profiles.want_client_auth.bind_host", "localhost")
-                .put("transport.profiles.want_client_auth.xpack.security.ssl.keystore.path",
-                        getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks"))
-                .put("transport.profiles.want_client_auth.xpack.security.ssl.keystore.password", "testnode")
-                .put("transport.profiles.want_client_auth.xpack.security.ssl.client_authentication", SSLClientAuth.OPTIONAL);
+            .put(super.nodeSettings())
+            .put("xpack.security.http.ssl.enabled", true)
+            .put("xpack.security.http.ssl.client_authentication", SSLClientAuth.OPTIONAL)
+            .put("xpack.security.http.ssl.key",
+                getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem"))
+            .put("xpack.security.http.ssl.certificate",
+                getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt"))
+            .put("xpack.security.authc.realms.file.file.order", "0")
+            .put("xpack.security.authc.realms.pki.pki1.order", "1")
+            .put("xpack.security.authc.realms.pki.pki1.truststore.path",
+                getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/truststore-testnode-only.jks"))
+            .put("xpack.security.authc.realms.pki.pki1.files.role_mapping", getDataPath("role_mapping.yml"))
+            .put("transport.profiles.want_client_auth.port", randomClientPortRange)
+            .put("transport.profiles.want_client_auth.bind_host", "localhost")
+            .put("transport.profiles.want_client_auth.xpack.security.ssl.key",
+                getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem"))
+            .put("transport.profiles.want_client_auth.xpack.security.ssl.certificate",
+                getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt"))
+            .put("transport.profiles.want_client_auth.xpack.security.ssl.client_authentication", SSLClientAuth.OPTIONAL);
 
         SecuritySettingsSource.addSecureSettings(builder, secureSettings -> {
             secureSettings.setString("xpack.security.authc.realms.pki.pki1.truststore.secure_password", "truststore-testnode-only");
-            secureSettings.setString("xpack.security.http.ssl.keystore.secure_password", "testnode");
+            secureSettings.setString("xpack.security.http.ssl.secure_key_passphrase", "testnode");
+            secureSettings.setString("transport.profiles.want_client_auth.xpack.security.ssl.secure_key_passphrase", "testnode");
         });
         return builder.build();
 


### PR DESCRIPTION
Use PEM files for the key/cert for TLS on the http layer of the
node instead of a JKS keystore so that the tests can also run 
in a FIPS 140 JVM .

Resolves:  #37682