### PR TITLE
SyncedFlushService.getShardRoutingTable() should use metadata to check for index existence

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -32,7 +32,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -290,16 +289,14 @@ public class SyncedFlushService implements IndexEventListener {
         listener.onResponse(new ShardsSyncedFlushResult(shardId, existingSyncId, totalShards, results));
     }
 
-    final IndexShardRoutingTable getShardRoutingTable(ShardId shardId, ClusterState state) {
-        final IndexRoutingTable indexRoutingTable = state.routingTable().index(shardId.getIndexName());
-        if (indexRoutingTable == null) {
-            IndexMetaData index = state.getMetaData().index(shardId.getIndex());
-            if (index != null && index.getState() == IndexMetaData.State.CLOSE) {
-                throw new IndexClosedException(shardId.getIndex());
-            }
+    final IndexShardRoutingTable getShardRoutingTable(final ShardId shardId, final ClusterState state) {
+        final IndexMetaData indexMetaData = state.getMetaData().index(shardId.getIndex());
+        if (indexMetaData == null) {
             throw new IndexNotFoundException(shardId.getIndexName());
+        } else if (indexMetaData.getState() == IndexMetaData.State.CLOSE) {
+            throw new IndexClosedException(shardId.getIndex());
         }
-        final IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId.id());
+        final IndexShardRoutingTable shardRoutingTable = state.routingTable().index(indexMetaData.getIndex()).shard(shardId.id());
         if (shardRoutingTable == null) {
             throw new ShardNotFoundException(shardId);
         }


### PR DESCRIPTION
The method `SyncedFlushService.getShardRoutingTable()` checks the existence of a routing table to determine if the index to synced flush exists or not, and then it uses the index metadata to determine if the index is closed. It think it should instead check the existence of the index meta data upfront; if there are no metadata then the index does not exist. It can then check if the index is closed using the metadata.

This pull request changes the behavior of the `getShardRoutingTable()` to use index metadata first, and also resolves index routing table using the full index name + uuid. This change will also make this method more compliant with the replication of closed indices in which closed indices will have a routing table. It does not change the behavior of the existing method.

Related #33888 