### PR TITLE
Ensure JavaDateMathParserTests are calling java formatters

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -782,13 +782,11 @@ public class DateFormatters {
 
     private static final DateTimeFormatter DATE_FORMATTER = new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 1, 5, SignStyle.NORMAL)
-        .optionalStart()
         .appendLiteral('-')
         .appendValue(MONTH_OF_YEAR, 1, 2, SignStyle.NOT_NEGATIVE)
         .optionalStart()
         .appendLiteral('-')
         .appendValue(DAY_OF_MONTH, 1, 2, SignStyle.NOT_NEGATIVE)
-        .optionalEnd()
         .optionalEnd()
         .toFormatter(Locale.ROOT);
 

--- a/server/src/main/java/org/elasticsearch/common/time/EpochTime.java
+++ b/server/src/main/java/org/elasticsearch/common/time/EpochTime.java
@@ -106,7 +106,8 @@ class EpochTime {
     private static final EpochField NANOS_OF_MILLI = new EpochField(ChronoUnit.NANOS, ChronoUnit.MILLIS, ValueRange.of(0, 999_999)) {
         @Override
         public boolean isSupportedBy(TemporalAccessor temporal) {
-            return temporal.isSupported(ChronoField.NANO_OF_SECOND) && temporal.getLong(ChronoField.NANO_OF_SECOND) % 1_000_000 != 0;
+            return temporal.isSupported(ChronoField.INSTANT_SECONDS) &&
+                temporal.isSupported(ChronoField.NANO_OF_SECOND) && temporal.getLong(ChronoField.NANO_OF_SECOND) % 1_000_000 != 0;
         }
         @Override
         public long getFrom(TemporalAccessor temporal) {

--- a/server/src/main/java/org/elasticsearch/common/time/JavaDateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/JavaDateFormatter.java
@@ -91,7 +91,9 @@ class JavaDateFormatter implements DateFormatter {
         this.printer = printer;
 
         DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder();
-        builder.append(this.parser);
+        if (format.contains("||") == false) {
+            builder.append(this.parser);
+        }
         roundupParserConsumer.accept(builder);
         DateTimeFormatter roundupFormatter = builder.toFormatter(parser.getLocale());
         if (printer.getZone() != null) {
@@ -162,7 +164,7 @@ class JavaDateFormatter implements DateFormatter {
 
     @Override
     public DateMathParser toDateMathParser() {
-        return new JavaDateMathParser(parser, roundupParser);
+        return new JavaDateMathParser(format, parser, roundupParser);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/time/JavaDateMathParser.java
+++ b/server/src/main/java/org/elasticsearch/common/time/JavaDateMathParser.java
@@ -48,9 +48,11 @@ public class JavaDateMathParser implements DateMathParser {
 
     private final DateTimeFormatter formatter;
     private final DateTimeFormatter roundUpFormatter;
+    private final String format;
 
-    public JavaDateMathParser(DateTimeFormatter formatter, DateTimeFormatter roundUpFormatter) {
+    JavaDateMathParser(String format, DateTimeFormatter formatter, DateTimeFormatter roundUpFormatter) {
         Objects.requireNonNull(formatter);
+        this.format = format;
         this.formatter = formatter;
         this.roundUpFormatter = roundUpFormatter;
     }
@@ -226,7 +228,7 @@ public class JavaDateMathParser implements DateMathParser {
                 return DateFormatters.toZonedDateTime(accessor).withZoneSameLocal(timeZone).toInstant().toEpochMilli();
             }
         } catch (IllegalArgumentException | DateTimeException e) {
-            throw new ElasticsearchParseException("failed to parse date field [{}]: [{}]", e, value, e.getMessage());
+            throw new ElasticsearchParseException("failed to parse date field [{}] in format [{}]: [{}]", e, value, format, e.getMessage());
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -133,10 +133,6 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2018-12-31T12:12:12.1", "date_hour_minute_second_millis");
         assertSameDate("2018-12-31T12:12:12.1", "date_hour_minute_second_fraction");
 
-        assertSameDate("10000", "date_optional_time");
-        assertSameDate("10000T", "date_optional_time");
-        assertSameDate("2018", "date_optional_time");
-        assertSameDate("2018T", "date_optional_time");
         assertSameDate("2018-05", "date_optional_time");
         assertSameDate("2018-05-30", "date_optional_time");
         assertSameDate("2018-05-30T20", "date_optional_time");

--- a/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
@@ -35,12 +35,10 @@ import static org.hamcrest.Matchers.is;
 
 public class JavaDateMathParserTests extends ESTestCase {
 
-    private final DateFormatter formatter = DateFormatter.forPattern("dateOptionalTime||epoch_millis");
+    private final DateFormatter formatter = DateFormatter.forPattern("8dateOptionalTime||epoch_millis");
     private final DateMathParser parser = formatter.toDateMathParser();
 
     public void testBasicDates() {
-        assertDateMathEquals("2014", "2014-01-01T00:00:00.000");
-        assertDateMathEquals("2014-05", "2014-05-01T00:00:00.000");
         assertDateMathEquals("2014-05-30", "2014-05-30T00:00:00.000");
         assertDateMathEquals("2014-05-30T20", "2014-05-30T20:00:00.000");
         assertDateMathEquals("2014-05-30T20:21", "2014-05-30T20:21:00.000");
@@ -176,7 +174,6 @@ public class JavaDateMathParserTests extends ESTestCase {
     public void testExplicitRounding() {
         assertDateMathEquals("2014-11-18||/y", "2014-01-01", 0, false, null);
         assertDateMathEquals("2014-11-18||/y", "2014-12-31T23:59:59.999", 0, true, null);
-        assertDateMathEquals("2014||/y", "2014-01-01", 0, false, null);
         assertDateMathEquals("2014-01-01T00:00:00.001||/y", "2014-12-31T23:59:59.999", 0, true, null);
         // rounding should also take into account time zone
         assertDateMathEquals("2014-11-18||/y", "2013-12-31T23:00:00.000Z", 0, false, ZoneId.of("CET"));
@@ -244,11 +241,10 @@ public class JavaDateMathParserTests extends ESTestCase {
         assertDateEquals(datetime, "1418248078", "2014-12-10T21:47:58.000");
 
         // a timestamp before 10000 is a year
-        assertDateMathEquals("9999", "9999-01-01T00:00:00.000");
+        assertDateMathEquals("9999", "1970-01-01T00:00:09.999Z");
         // 10000 is also a year, breaking bwc, used to be a timestamp
-        assertDateMathEquals("10000", "10000-01-01T00:00:00.000");
-        // but 10000 with T is still a date format
-        assertDateMathEquals("10000T", "10000-01-01T00:00:00.000");
+        assertDateMathEquals("10000", "1970-01-01T00:00:10.000Z");
+        assertDateMathEquals("10000-01-01T", "10000-01-01T00:00:00.000");
     }
 
     void assertParseException(String msg, String date, String exc) {
@@ -266,7 +262,7 @@ public class JavaDateMathParserTests extends ESTestCase {
 
     public void testIllegalDateFormat() {
         assertParseException("Expected bad timestamp exception", Long.toString(Long.MAX_VALUE) + "0", "failed to parse date field");
-        assertParseException("Expected bad date format exception", "123bogus", "Unrecognized chars at the end of [123bogus]");
+        assertParseException("Expected bad date format exception", "123bogus", "could not be parsed, unparsed text found at index 3");
     }
 
     public void testOnlyCallsNowIfNecessary() {

--- a/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
@@ -240,9 +240,8 @@ public class JavaDateMathParserTests extends ESTestCase {
         long datetime = parser.parse("1418248078", () -> 0);
         assertDateEquals(datetime, "1418248078", "2014-12-10T21:47:58.000");
 
-        // a timestamp before 10000 is a year
+        // numbers only are always an epoch timestamp
         assertDateMathEquals("9999", "1970-01-01T00:00:09.999Z");
-        // 10000 is also a year, breaking bwc, used to be a timestamp
         assertDateMathEquals("10000", "1970-01-01T00:00:10.000Z");
         assertDateMathEquals("10000-01-01T", "10000-01-01T00:00:00.000");
     }


### PR DESCRIPTION
The existing JavaDateMathParserTests were using joda formatters instead
of java ones and thus the tests were not running the expected code.

This fixes the above and some follow up failures due to that.

First some round up formatter issues are fixed, especially when using
epoch dates, the parsing could be wrong and result in exceptions.

Second, some dates cannot be handled the same in java8 like in joda time
due to more strict parsing, when used in combination with epoch dates.

