### PR TITLE
 Add local session timeouts to leader node

### DIFF
--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -369,9 +369,13 @@ public class ThreadPool implements Scheduler, Closeable {
         return getThreadContext().preserveContext(command);
     }
 
-    public void shutdown() {
+    protected final void stopCachedTimeThread() {
         cachedTimeThread.running = false;
         cachedTimeThread.interrupt();
+    }
+
+    public void shutdown() {
+        stopCachedTimeThread();
         scheduler.shutdown();
         for (ExecutorHolder executor : executors.values()) {
             if (executor.executor() instanceof ThreadPoolExecutor) {
@@ -381,8 +385,7 @@ public class ThreadPool implements Scheduler, Closeable {
     }
 
     public void shutdownNow() {
-        cachedTimeThread.running = false;
-        cachedTimeThread.interrupt();
+        stopCachedTimeThread();
         scheduler.shutdownNow();
         for (ExecutorHolder executor : executors.values()) {
             if (executor.executor() instanceof ThreadPoolExecutor) {

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueue.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueue.java
@@ -1,0 +1,553 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.coordination;
+
+import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.Counter;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPoolInfo;
+import org.elasticsearch.threadpool.ThreadPoolStats;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+public class DeterministicTaskQueue {
+
+    private static final Logger logger = LogManager.getLogger(DeterministicTaskQueue.class);
+
+    private final Settings settings;
+    private final List<Runnable> runnableTasks = new ArrayList<>();
+    private final Random random;
+    private List<DeferredTask> deferredTasks = new ArrayList<>();
+    private long currentTimeMillis;
+    private long nextDeferredTaskExecutionTimeMillis = Long.MAX_VALUE;
+    private long executionDelayVariabilityMillis;
+    private long latestDeferredExecutionTime;
+
+    public DeterministicTaskQueue(Settings settings, Random random) {
+        this.settings = settings;
+        this.random = random;
+    }
+
+    public long getExecutionDelayVariabilityMillis() {
+        return executionDelayVariabilityMillis;
+    }
+
+    public void setExecutionDelayVariabilityMillis(long executionDelayVariabilityMillis) {
+        assert executionDelayVariabilityMillis >= 0 : executionDelayVariabilityMillis;
+        this.executionDelayVariabilityMillis = executionDelayVariabilityMillis;
+    }
+
+    public void runAllRunnableTasks() {
+        while (hasRunnableTasks()) {
+            runRandomTask();
+        }
+    }
+
+    public void runAllTasks() {
+        while (hasDeferredTasks() || hasRunnableTasks()) {
+            if (hasDeferredTasks() && random.nextBoolean()) {
+                advanceTime();
+            } else if (hasRunnableTasks()) {
+                runRandomTask();
+            }
+        }
+    }
+
+    public void runAllTasksInTimeOrder() {
+        while (hasDeferredTasks() || hasRunnableTasks()) {
+            if (hasRunnableTasks()) {
+                runRandomTask();
+            } else {
+                advanceTime();
+            }
+        }
+    }
+
+    /**
+     * @return whether there are any runnable tasks.
+     */
+    public boolean hasRunnableTasks() {
+        return runnableTasks.isEmpty() == false;
+    }
+
+    /**
+     * @return whether there are any deferred tasks, i.e. tasks that are scheduled for the future.
+     */
+    public boolean hasDeferredTasks() {
+        return deferredTasks.isEmpty() == false;
+    }
+
+    /**
+     * @return the current (simulated) time, in milliseconds.
+     */
+    public long getCurrentTimeMillis() {
+        return currentTimeMillis;
+    }
+
+    /**
+     * Runs an arbitrary runnable task.
+     */
+    public void runRandomTask() {
+        assert hasRunnableTasks();
+        runTask(RandomNumbers.randomIntBetween(random, 0, runnableTasks.size() - 1));
+    }
+
+    private void runTask(final int index) {
+        final Runnable task = runnableTasks.remove(index);
+        logger.trace("running task {} of {}: {}", index, runnableTasks.size() + 1, task);
+        task.run();
+    }
+
+    /**
+     * Schedule a task for immediate execution.
+     */
+    public void scheduleNow(final Runnable task) {
+        if (executionDelayVariabilityMillis > 0 && random.nextBoolean()) {
+            final long executionDelay = RandomNumbers.randomLongBetween(random, 1, executionDelayVariabilityMillis);
+            final DeferredTask deferredTask = new DeferredTask(currentTimeMillis + executionDelay, task);
+            logger.trace("scheduleNow: delaying [{}ms], scheduling {}", executionDelay, deferredTask);
+            scheduleDeferredTask(deferredTask);
+        } else {
+            logger.trace("scheduleNow: adding runnable {}", task);
+            runnableTasks.add(task);
+        }
+    }
+
+    /**
+     * Schedule a task for future execution.
+     */
+    public void scheduleAt(final long executionTimeMillis, final Runnable task) {
+        final long extraDelayMillis = RandomNumbers.randomLongBetween(random, 0, executionDelayVariabilityMillis);
+        final long actualExecutionTimeMillis = executionTimeMillis + extraDelayMillis;
+        if (actualExecutionTimeMillis <= currentTimeMillis) {
+            logger.trace("scheduleAt: [{}ms] is not in the future, adding runnable {}", executionTimeMillis, task);
+            runnableTasks.add(task);
+        } else {
+            final DeferredTask deferredTask = new DeferredTask(actualExecutionTimeMillis, task);
+            logger.trace("scheduleAt: adding {} with extra delay of [{}ms]", deferredTask, extraDelayMillis);
+            scheduleDeferredTask(deferredTask);
+        }
+    }
+
+    private void scheduleDeferredTask(DeferredTask deferredTask) {
+        nextDeferredTaskExecutionTimeMillis = Math.min(nextDeferredTaskExecutionTimeMillis, deferredTask.getExecutionTimeMillis());
+        latestDeferredExecutionTime = Math.max(latestDeferredExecutionTime, deferredTask.getExecutionTimeMillis());
+        deferredTasks.add(deferredTask);
+    }
+
+    /**
+     * Advance the current time to the time of the next deferred task, and update the sets of deferred and runnable tasks accordingly.
+     */
+    public void advanceTime() {
+        assert hasDeferredTasks();
+        assert currentTimeMillis < nextDeferredTaskExecutionTimeMillis;
+
+        logger.trace("advanceTime: from [{}ms] to [{}ms]", currentTimeMillis, nextDeferredTaskExecutionTimeMillis);
+        currentTimeMillis = nextDeferredTaskExecutionTimeMillis;
+        assert currentTimeMillis <= latestDeferredExecutionTime : latestDeferredExecutionTime + " < " + currentTimeMillis;
+
+        nextDeferredTaskExecutionTimeMillis = Long.MAX_VALUE;
+        List<DeferredTask> remainingDeferredTasks = new ArrayList<>();
+        for (final DeferredTask deferredTask : deferredTasks) {
+            assert currentTimeMillis <= deferredTask.getExecutionTimeMillis();
+            if (deferredTask.getExecutionTimeMillis() == currentTimeMillis) {
+                logger.trace("advanceTime: no longer deferred: {}", deferredTask);
+                runnableTasks.add(deferredTask.getTask());
+            } else {
+                remainingDeferredTasks.add(deferredTask);
+                nextDeferredTaskExecutionTimeMillis = Math.min(nextDeferredTaskExecutionTimeMillis, deferredTask.getExecutionTimeMillis());
+            }
+        }
+        deferredTasks = remainingDeferredTasks;
+
+        assert deferredTasks.isEmpty() == (nextDeferredTaskExecutionTimeMillis == Long.MAX_VALUE);
+    }
+
+    /**
+     * @return A <code>ExecutorService</code> that uses this task queue.
+     */
+    public ExecutorService getExecutorService() {
+        return getExecutorService(Function.identity());
+    }
+
+    /**
+     * @return A <code>ExecutorService</code> that uses this task queue and wraps <code>Runnable</code>s in the given wrapper.
+     */
+    public ExecutorService getExecutorService(Function<Runnable, Runnable> runnableWrapper) {
+        return new ExecutorService() {
+
+            @Override
+            public void shutdown() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public List<Runnable> shutdownNow() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isShutdown() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isTerminated() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean awaitTermination(long timeout, TimeUnit unit) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> Future<T> submit(Callable<T> task) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> Future<T> submit(Runnable task, T result) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Future<?> submit(Runnable task) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> T invokeAny(Collection<? extends Callable<T>> tasks) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void execute(Runnable command) {
+                scheduleNow(runnableWrapper.apply(command));
+            }
+        };
+    }
+
+    /**
+     * @return A <code>ThreadPool</code> that uses this task queue.
+     */
+    public ThreadPool getThreadPool() {
+        return getThreadPool(Function.identity());
+    }
+
+    /**
+     * @return A <code>ThreadPool</code> that uses this task queue and wraps <code>Runnable</code>s in the given wrapper.
+     */
+    public ThreadPool getThreadPool(Function<Runnable, Runnable> runnableWrapper) {
+        return new ThreadPool(settings) {
+
+            {
+                stopCachedTimeThread();
+            }
+
+            @Override
+            public long relativeTimeInMillis() {
+                return currentTimeMillis;
+            }
+
+            @Override
+            public long absoluteTimeInMillis() {
+                return currentTimeMillis;
+            }
+
+            @Override
+            public Counter estimatedTimeInMillisCounter() {
+                return new Counter() {
+                    @Override
+                    public long addAndGet(long delta) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public long get() {
+                        return currentTimeMillis;
+                    }
+                };
+            }
+
+            @Override
+            public ThreadPoolInfo info() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Info info(String name) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ThreadPoolStats stats() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ExecutorService generic() {
+                return getExecutorService(runnableWrapper);
+            }
+
+            @Override
+            public ExecutorService executor(String name) {
+                return getExecutorService(runnableWrapper);
+            }
+
+            @Override
+            public ScheduledFuture<?> schedule(TimeValue delay, String executor, Runnable command) {
+                final int NOT_STARTED = 0;
+                final int STARTED = 1;
+                final int CANCELLED = 2;
+                final AtomicInteger taskState = new AtomicInteger(NOT_STARTED);
+
+                scheduleAt(currentTimeMillis + delay.millis(), runnableWrapper.apply(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (taskState.compareAndSet(NOT_STARTED, STARTED)) {
+                            command.run();
+                        }
+                    }
+
+                    @Override
+                    public String toString() {
+                        return command.toString();
+                    }
+                }));
+
+                return new ScheduledFuture<Object>() {
+                    @Override
+                    public long getDelay(TimeUnit unit) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public int compareTo(Delayed o) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public boolean cancel(boolean mayInterruptIfRunning) {
+                        assert mayInterruptIfRunning == false;
+                        return taskState.compareAndSet(NOT_STARTED, CANCELLED);
+                    }
+
+                    @Override
+                    public boolean isCancelled() {
+                        return taskState.get() == CANCELLED;
+                    }
+
+                    @Override
+                    public boolean isDone() {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public Object get() {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public Object get(long timeout, TimeUnit unit) {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+
+            @Override
+            public Cancellable scheduleWithFixedDelay(Runnable command, TimeValue interval, String executor) {
+                return super.scheduleWithFixedDelay(command, interval, executor);
+            }
+
+            @Override
+            public Runnable preserveContext(Runnable command) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void shutdown() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void shutdownNow() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean awaitTermination(long timeout, TimeUnit unit) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ScheduledExecutorService scheduler() {
+                return new ScheduledExecutorService() {
+                    @Override
+                    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public void shutdown() {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public List<Runnable> shutdownNow() {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public boolean isShutdown() {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public boolean isTerminated() {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public boolean awaitTermination(long timeout, TimeUnit unit) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public <T> Future<T> submit(Callable<T> task) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public <T> Future<T> submit(Runnable task, T result) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public Future<?> submit(Runnable task) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public void execute(Runnable command) {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        };
+    }
+
+    public long getLatestDeferredExecutionTime() {
+        return latestDeferredExecutionTime;
+    }
+
+    private static class DeferredTask {
+        private final long executionTimeMillis;
+        private final Runnable task;
+
+        DeferredTask(long executionTimeMillis, Runnable task) {
+            this.executionTimeMillis = executionTimeMillis;
+            this.task = task;
+            assert executionTimeMillis < Long.MAX_VALUE : "Long.MAX_VALUE is special, cannot be an execution time";
+        }
+
+        long getExecutionTimeMillis() {
+            return executionTimeMillis;
+        }
+
+        Runnable getTask() {
+            return task;
+        }
+
+        @Override
+        public String toString() {
+            return "DeferredTask{" +
+                "executionTimeMillis=" + executionTimeMillis +
+                ", task=" + task +
+                '}';
+        }
+    }
+}

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/Ccr.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/Ccr.java
@@ -168,10 +168,10 @@ public class Ccr extends Plugin implements ActionPlugin, PersistentTaskPlugin, E
             return emptyList();
         }
 
-        CcrRestoreSourceService restoreSourceService = new CcrRestoreSourceService();
-        this.restoreSourceService.set(restoreSourceService);
         CcrSettings ccrSettings = new CcrSettings(settings, clusterService.getClusterSettings());
         this.ccrSettings.set(ccrSettings);
+        CcrRestoreSourceService restoreSourceService = new CcrRestoreSourceService(threadPool, ccrSettings);
+        this.restoreSourceService.set(restoreSourceService);
         return Arrays.asList(
             ccrLicenseChecker,
             restoreSourceService,

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRestoreSourceService.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRestoreSourceService.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.KeyedLock;
@@ -28,6 +29,9 @@ import org.elasticsearch.index.shard.IndexShardClosedException;
 import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.Store;
+import org.elasticsearch.threadpool.Scheduler;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.ccr.CcrSettings;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -45,8 +49,14 @@ public class CcrRestoreSourceService extends AbstractLifecycleComponent implemen
 
     private final Map<String, RestoreSession> onGoingRestores = ConcurrentCollections.newConcurrentMap();
     private final Map<IndexShard, HashSet<String>> sessionsForShard = new HashMap<>();
-    private final CopyOnWriteArrayList<Consumer<String>> openSessionListeners = new CopyOnWriteArrayList<>();
     private final CopyOnWriteArrayList<Consumer<String>> closeSessionListeners = new CopyOnWriteArrayList<>();
+    private final ThreadPool threadPool;
+    private final CcrSettings ccrSettings;
+
+    public CcrRestoreSourceService(ThreadPool threadPool, CcrSettings ccrSettings) {
+        this.threadPool = threadPool;
+        this.ccrSettings = ccrSettings;
+    }
 
     @Override
     public synchronized void afterIndexShardClosed(ShardId shardId, @Nullable IndexShard indexShard, Settings indexSettings) {
@@ -81,26 +91,10 @@ public class CcrRestoreSourceService extends AbstractLifecycleComponent implemen
 
     // TODO: The listeners are for testing. Once end-to-end file restore is implemented and can be tested,
     //  these should be removed.
-    public void addOpenSessionListener(Consumer<String> listener) {
-        openSessionListeners.add(listener);
-    }
-
     public void addCloseSessionListener(Consumer<String> listener) {
         closeSessionListeners.add(listener);
     }
 
-    // default visibility for testing
-    synchronized HashSet<String> getSessionsForShard(IndexShard indexShard) {
-        return sessionsForShard.get(indexShard);
-    }
-
-    // default visibility for testing
-    synchronized RestoreSession getOngoingRestore(String sessionUUID) {
-        return onGoingRestores.get(sessionUUID);
-    }
-
-    // TODO: Add a local timeout for the session. This timeout might might be for the entire session to be
-    //  complete. Or it could be for session to have been touched.
     public synchronized Store.MetadataSnapshot openSession(String sessionUUID, IndexShard indexShard) throws IOException {
         boolean success = false;
         RestoreSession restore = null;
@@ -113,9 +107,8 @@ public class CcrRestoreSourceService extends AbstractLifecycleComponent implemen
                 if (indexShard.state() == IndexShardState.CLOSED) {
                     throw new IndexShardClosedException(indexShard.shardId(), "cannot open ccr restore session if shard closed");
                 }
-                restore = new RestoreSession(sessionUUID, indexShard, indexShard.acquireSafeIndexCommit());
+                restore = new RestoreSession(sessionUUID, indexShard, indexShard.acquireSafeIndexCommit(), scheduleTimeout(sessionUUID));
                 onGoingRestores.put(sessionUUID, restore);
-                openSessionListeners.forEach(c -> c.accept(sessionUUID));
                 HashSet<String> sessions = sessionsForShard.computeIfAbsent(indexShard, (s) -> new HashSet<>());
                 sessions.add(sessionUUID);
             }
@@ -133,25 +126,7 @@ public class CcrRestoreSourceService extends AbstractLifecycleComponent implemen
     }
 
     public void closeSession(String sessionUUID) {
-        final RestoreSession restore;
-        synchronized (this) {
-            closeSessionListeners.forEach(c -> c.accept(sessionUUID));
-            restore = onGoingRestores.remove(sessionUUID);
-            if (restore == null) {
-                logger.debug("could not close session [{}] because session not found", sessionUUID);
-                throw new IllegalArgumentException("session [" + sessionUUID + "] not found");
-            }
-            HashSet<String> sessions = sessionsForShard.get(restore.indexShard);
-            assert sessions != null : "No session UUIDs for shard even though one [" + sessionUUID + "] is active in ongoing restores";
-            if (sessions != null) {
-                boolean removed = sessions.remove(sessionUUID);
-                assert removed : "No session found for UUID [" + sessionUUID +"]";
-                if (sessions.isEmpty()) {
-                    sessionsForShard.remove(restore.indexShard);
-                }
-            }
-        }
-        restore.decRef();
+        internalCloseSession(sessionUUID, true);
     }
 
     public synchronized SessionReader getSessionReader(String sessionUUID) {
@@ -160,7 +135,51 @@ public class CcrRestoreSourceService extends AbstractLifecycleComponent implemen
             logger.debug("could not get session [{}] because session not found", sessionUUID);
             throw new IllegalArgumentException("session [" + sessionUUID + "] not found");
         }
+        restore.idle = false;
         return new SessionReader(restore);
+    }
+
+    private void internalCloseSession(String sessionUUID, boolean throwIfSessionMissing) {
+        final RestoreSession restore;
+        synchronized (this) {
+            restore = onGoingRestores.remove(sessionUUID);
+            if (restore == null) {
+                if (throwIfSessionMissing) {
+                    logger.debug("could not close session [{}] because session not found", sessionUUID);
+                    throw new IllegalArgumentException("session [" + sessionUUID + "] not found");
+                } else {
+                    return;
+                }
+            }
+            HashSet<String> sessions = sessionsForShard.get(restore.indexShard);
+            assert sessions != null : "No session UUIDs for shard even though one [" + sessionUUID + "] is active in ongoing restores";
+            if (sessions != null) {
+                boolean removed = sessions.remove(sessionUUID);
+                assert removed : "No session found for UUID [" + sessionUUID + "]";
+                if (sessions.isEmpty()) {
+                    sessionsForShard.remove(restore.indexShard);
+                }
+            }
+        }
+        closeSessionListeners.forEach(c -> c.accept(sessionUUID));
+        restore.decRef();
+
+    }
+
+    private Scheduler.Cancellable scheduleTimeout(String sessionUUID) {
+        TimeValue idleTimeout = ccrSettings.getRecoveryActivityTimeout();
+        return threadPool.scheduleWithFixedDelay(() -> maybeTimeout(sessionUUID), idleTimeout, ThreadPool.Names.GENERIC);
+    }
+
+    private void maybeTimeout(String sessionUUID) {
+        RestoreSession restoreSession = onGoingRestores.get(sessionUUID);
+        if (restoreSession != null) {
+            if (restoreSession.idle) {
+                internalCloseSession(sessionUUID, false);
+            } else {
+                restoreSession.idle = true;
+            }
+        }
     }
 
     private static class RestoreSession extends AbstractRefCounted {
@@ -168,14 +187,18 @@ public class CcrRestoreSourceService extends AbstractLifecycleComponent implemen
         private final String sessionUUID;
         private final IndexShard indexShard;
         private final Engine.IndexCommitRef commitRef;
+        private final Scheduler.Cancellable timeoutTask;
         private final KeyedLock<String> keyedLock = new KeyedLock<>();
         private final Map<String, IndexInput> cachedInputs = new ConcurrentHashMap<>();
+        private volatile boolean idle = false;
 
-        private RestoreSession(String sessionUUID, IndexShard indexShard, Engine.IndexCommitRef commitRef) {
+        private RestoreSession(String sessionUUID, IndexShard indexShard, Engine.IndexCommitRef commitRef,
+                               Scheduler.Cancellable timeoutTask) {
             super("restore-session");
             this.sessionUUID = sessionUUID;
             this.indexShard = indexShard;
             this.commitRef = commitRef;
+            this.timeoutTask = timeoutTask;
         }
 
         private Store.MetadataSnapshot getMetaData() throws IOException {
@@ -223,6 +246,7 @@ public class CcrRestoreSourceService extends AbstractLifecycleComponent implemen
         protected void closeInternal() {
             logger.debug("closing session [{}] for shard [{}]", sessionUUID, indexShard.shardId());
             assert keyedLock.hasLockedKeys() == false : "Should not hold any file locks when closing";
+            timeoutTask.cancel();
             IOUtils.closeWhileHandlingException(cachedInputs.values());
         }
     }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/repository/CcrRestoreSourceServiceTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/repository/CcrRestoreSourceServiceTests.java
@@ -8,28 +8,41 @@ package org.elasticsearch.xpack.ccr.repository;
 
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
+import org.elasticsearch.cluster.coordination.DeterministicTaskQueue;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardTestCase;
 import org.elasticsearch.index.store.StoreFileMetaData;
+import org.elasticsearch.xpack.ccr.CcrSettings;
 import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Set;
+
+import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
 
 public class CcrRestoreSourceServiceTests extends IndexShardTestCase {
 
     private CcrRestoreSourceService restoreSourceService;
+    private DeterministicTaskQueue taskQueue;
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        restoreSourceService = new CcrRestoreSourceService();
+        Settings settings = Settings.builder().put(NODE_NAME_SETTING.getKey(), "node").build();
+        taskQueue = new DeterministicTaskQueue(settings, random());
+        Set<Setting<?>> registeredSettings = Sets.newHashSet(CcrSettings.INDICES_RECOVERY_ACTIVITY_TIMEOUT_SETTING,
+            CcrSettings.RECOVERY_MAX_BYTES_PER_SECOND);
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, registeredSettings);
+        restoreSourceService = new CcrRestoreSourceService(taskQueue.getThreadPool(), new CcrSettings(Settings.EMPTY, clusterSettings));
     }
 
     public void testOpenSession() throws IOException {
@@ -39,22 +52,21 @@ public class CcrRestoreSourceServiceTests extends IndexShardTestCase {
         final String sessionUUID2 = UUIDs.randomBase64UUID();
         final String sessionUUID3 = UUIDs.randomBase64UUID();
 
-        assertNull(restoreSourceService.getSessionsForShard(indexShard1));
+        restoreSourceService.openSession(sessionUUID1, indexShard1);
+        restoreSourceService.openSession(sessionUUID2, indexShard1);
 
-        assertNotNull(restoreSourceService.openSession(sessionUUID1, indexShard1));
-        HashSet<String> sessionsForShard = restoreSourceService.getSessionsForShard(indexShard1);
-        assertEquals(1, sessionsForShard.size());
-        assertTrue(sessionsForShard.contains(sessionUUID1));
-        assertNotNull(restoreSourceService.openSession(sessionUUID2, indexShard1));
-        sessionsForShard = restoreSourceService.getSessionsForShard(indexShard1);
-        assertEquals(2, sessionsForShard.size());
-        assertTrue(sessionsForShard.contains(sessionUUID2));
+        try (CcrRestoreSourceService.SessionReader reader1 = restoreSourceService.getSessionReader(sessionUUID1);
+             CcrRestoreSourceService.SessionReader reader2 = restoreSourceService.getSessionReader(sessionUUID2)) {
+            // Would throw exception if missing
+        }
 
-        assertNull(restoreSourceService.getSessionsForShard(indexShard2));
-        assertNotNull(restoreSourceService.openSession(sessionUUID3, indexShard2));
-        sessionsForShard = restoreSourceService.getSessionsForShard(indexShard2);
-        assertEquals(1, sessionsForShard.size());
-        assertTrue(sessionsForShard.contains(sessionUUID3));
+        restoreSourceService.openSession(sessionUUID3, indexShard2);
+
+        try (CcrRestoreSourceService.SessionReader reader1 = restoreSourceService.getSessionReader(sessionUUID1);
+             CcrRestoreSourceService.SessionReader reader2 = restoreSourceService.getSessionReader(sessionUUID2);
+             CcrRestoreSourceService.SessionReader reader3 = restoreSourceService.getSessionReader(sessionUUID3)) {
+            // Would throw exception if missing
+        }
 
         restoreSourceService.closeSession(sessionUUID1);
         restoreSourceService.closeSession(sessionUUID2);
@@ -68,7 +80,6 @@ public class CcrRestoreSourceServiceTests extends IndexShardTestCase {
         closeShards(indexShard);
         String sessionUUID = UUIDs.randomBase64UUID();
         expectThrows(IllegalIndexShardStateException.class, () -> restoreSourceService.openSession(sessionUUID, indexShard));
-        assertNull(restoreSourceService.getOngoingRestore(sessionUUID));
     }
 
     public void testCloseSession() throws IOException {
@@ -82,25 +93,26 @@ public class CcrRestoreSourceServiceTests extends IndexShardTestCase {
         restoreSourceService.openSession(sessionUUID2, indexShard1);
         restoreSourceService.openSession(sessionUUID3, indexShard2);
 
-        assertEquals(2, restoreSourceService.getSessionsForShard(indexShard1).size());
-        assertEquals(1, restoreSourceService.getSessionsForShard(indexShard2).size());
-        assertNotNull(restoreSourceService.getOngoingRestore(sessionUUID1));
-        assertNotNull(restoreSourceService.getOngoingRestore(sessionUUID2));
-        assertNotNull(restoreSourceService.getOngoingRestore(sessionUUID3));
+        try (CcrRestoreSourceService.SessionReader reader1 = restoreSourceService.getSessionReader(sessionUUID1);
+             CcrRestoreSourceService.SessionReader reader2 = restoreSourceService.getSessionReader(sessionUUID2);
+             CcrRestoreSourceService.SessionReader reader3 = restoreSourceService.getSessionReader(sessionUUID3)) {
+            // Would throw exception if missing
+        }
+
+        assertTrue(taskQueue.hasDeferredTasks());
 
         restoreSourceService.closeSession(sessionUUID1);
-        assertEquals(1, restoreSourceService.getSessionsForShard(indexShard1).size());
-        assertNull(restoreSourceService.getOngoingRestore(sessionUUID1));
-        assertFalse(restoreSourceService.getSessionsForShard(indexShard1).contains(sessionUUID1));
-        assertTrue(restoreSourceService.getSessionsForShard(indexShard1).contains(sessionUUID2));
+        expectThrows(IllegalArgumentException.class, () -> restoreSourceService.getSessionReader(sessionUUID1));
 
         restoreSourceService.closeSession(sessionUUID2);
-        assertNull(restoreSourceService.getSessionsForShard(indexShard1));
-        assertNull(restoreSourceService.getOngoingRestore(sessionUUID2));
+        expectThrows(IllegalArgumentException.class, () -> restoreSourceService.getSessionReader(sessionUUID2));
 
         restoreSourceService.closeSession(sessionUUID3);
-        assertNull(restoreSourceService.getSessionsForShard(indexShard2));
-        assertNull(restoreSourceService.getOngoingRestore(sessionUUID3));
+        expectThrows(IllegalArgumentException.class, () -> restoreSourceService.getSessionReader(sessionUUID3));
+
+        taskQueue.runAllTasks();
+        // The tasks will not be rescheduled as the sessions are closed.
+        assertFalse(taskQueue.hasDeferredTasks());
 
         closeShards(indexShard1, indexShard2);
     }
@@ -116,14 +128,20 @@ public class CcrRestoreSourceServiceTests extends IndexShardTestCase {
         restoreSourceService.openSession(sessionUUID2, indexShard1);
         restoreSourceService.openSession(sessionUUID3, indexShard2);
 
-        assertEquals(2, restoreSourceService.getSessionsForShard(indexShard1).size());
-        assertEquals(1, restoreSourceService.getSessionsForShard(indexShard2).size());
+        try (CcrRestoreSourceService.SessionReader reader1 = restoreSourceService.getSessionReader(sessionUUID1);
+             CcrRestoreSourceService.SessionReader reader2 = restoreSourceService.getSessionReader(sessionUUID2);
+             CcrRestoreSourceService.SessionReader reader3 = restoreSourceService.getSessionReader(sessionUUID3)) {
+            // Would throw exception if missing
+        }
 
         restoreSourceService.afterIndexShardClosed(indexShard1.shardId(), indexShard1, Settings.EMPTY);
 
-        assertNull(restoreSourceService.getSessionsForShard(indexShard1));
-        assertNull(restoreSourceService.getOngoingRestore(sessionUUID1));
-        assertNull(restoreSourceService.getOngoingRestore(sessionUUID2));
+        expectThrows(IllegalArgumentException.class, () -> restoreSourceService.getSessionReader(sessionUUID1));
+        expectThrows(IllegalArgumentException.class, () -> restoreSourceService.getSessionReader(sessionUUID2));
+
+        try (CcrRestoreSourceService.SessionReader reader3 = restoreSourceService.getSessionReader(sessionUUID3)) {
+            // Would throw exception if missing
+        }
 
         restoreSourceService.closeSession(sessionUUID3);
         closeShards(indexShard1, indexShard2);
@@ -167,24 +185,59 @@ public class CcrRestoreSourceServiceTests extends IndexShardTestCase {
             indexDoc(indexShard, "_doc", Integer.toString(i));
             flushShard(indexShard, true);
         }
-        final String sessionUUID1 = UUIDs.randomBase64UUID();
+        final String sessionUUID = UUIDs.randomBase64UUID();
 
-        restoreSourceService.openSession(sessionUUID1, indexShard);
+        restoreSourceService.openSession(sessionUUID, indexShard);
 
         ArrayList<StoreFileMetaData> files = new ArrayList<>();
         indexShard.snapshotStoreMetadata().forEach(files::add);
 
-        try (CcrRestoreSourceService.SessionReader sessionReader = restoreSourceService.getSessionReader(sessionUUID1)) {
+        try (CcrRestoreSourceService.SessionReader sessionReader = restoreSourceService.getSessionReader(sessionUUID)) {
             sessionReader.readFileBytes(files.get(0).name(), new BytesArray(new byte[10]));
         }
 
         // Request a second file to ensure that original file is not leaked
-        try (CcrRestoreSourceService.SessionReader sessionReader = restoreSourceService.getSessionReader(sessionUUID1)) {
+        try (CcrRestoreSourceService.SessionReader sessionReader = restoreSourceService.getSessionReader(sessionUUID)) {
             sessionReader.readFileBytes(files.get(1).name(), new BytesArray(new byte[10]));
         }
 
-        restoreSourceService.closeSession(sessionUUID1);
+        restoreSourceService.closeSession(sessionUUID);
         closeShards(indexShard);
         // Exception will be thrown if file is not closed.
+    }
+
+    public void testSessionCanTimeout() throws Exception {
+        IndexShard indexShard = newStartedShard(true);
+
+        final String sessionUUID = UUIDs.randomBase64UUID();
+
+        restoreSourceService.openSession(sessionUUID, indexShard);
+
+        // Session starts as not idle. First task will mark it as idle
+        assertTrue(taskQueue.hasDeferredTasks());
+        taskQueue.advanceTime();
+        taskQueue.runAllRunnableTasks();
+        // Task is still scheduled
+        assertTrue(taskQueue.hasDeferredTasks());
+
+        // Accessing session marks it as not-idle
+        try (CcrRestoreSourceService.SessionReader reader = restoreSourceService.getSessionReader(sessionUUID)) {
+            // Check session exists
+        }
+
+        assertTrue(taskQueue.hasDeferredTasks());
+        taskQueue.advanceTime();
+        taskQueue.runAllRunnableTasks();
+        // Task is still scheduled
+        assertTrue(taskQueue.hasDeferredTasks());
+
+        taskQueue.advanceTime();
+        taskQueue.runAllRunnableTasks();
+        // Task is cancelled when the session times out
+        assertFalse(taskQueue.hasDeferredTasks());
+
+        expectThrows(IllegalArgumentException.class, () -> restoreSourceService.getSessionReader(sessionUUID));
+
+        closeShards(indexShard);
     }
 }


### PR DESCRIPTION
This is related to #35975. This commit adds timeout functionality to
the local session on a leader node. When a session is started, a timeout
is scheduled using a repeatable runnable. If the session is not accessed
in between two runs the session is closed. When the sssion is closed,
the repeating task is cancelled.

Additionally, this commit moves session uuid generation to the leader
cluster. And renames the PutCcrRestoreSessionRequest to
StartCcrRestoreSessionRequest to reflect that change.