### PR TITLE
Allow system privilege to execute proxied actions

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
@@ -175,6 +175,14 @@ public final class TransportActionProxy {
     }
 
     /**
+     * Unwraps a proxy action and returns the underlying action
+     */
+    public static String unwrapAction(String action) {
+        assert isProxyAction(action) : "Attempted to unwrap non-proxy action: " + action;
+        return action.substring(PROXY_ACTION_PREFIX.length());
+    }
+
+    /**
      * Returns <code>true</code> iff the given action is a proxy action
      */
     public static boolean isProxyAction(String action) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/SystemPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/SystemPrivilege.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.core.security.authz.privilege;
 
+import org.elasticsearch.transport.TransportActionProxy;
 import org.elasticsearch.xpack.core.security.support.Automatons;
 
 import java.util.Collections;
@@ -14,7 +15,7 @@ public final class SystemPrivilege extends Privilege {
 
     public static SystemPrivilege INSTANCE = new SystemPrivilege();
 
-    private static final Predicate<String> PREDICATE = Automatons.predicate(Automatons.
+    private static final Predicate<String> ALLOWED_ACTIONS = Automatons.predicate(Automatons.
             minusAndMinimize(Automatons.patterns(
             "internal:*",
             "indices:monitor/*", // added for monitoring
@@ -26,6 +27,15 @@ public final class SystemPrivilege extends Privilege {
             "indices:admin/seq_no/global_checkpoint_sync*", // needed for global checkpoint syncs
             "indices:admin/settings/update" // needed for DiskThresholdMonitor.markIndicesReadOnly
     ), Automatons.patterns("internal:transport/proxy/*"))); // no proxy actions for system user!
+
+    private static final Predicate<String> PREDICATE = (action) -> {
+        // Only allow a proxy action if the underlying action is allowed
+        if (TransportActionProxy.isProxyAction(action)) {
+            return ALLOWED_ACTIONS.test(TransportActionProxy.unwrapAction(action));
+        } else {
+            return ALLOWED_ACTIONS.test(action);
+        }
+    };
 
     private SystemPrivilege() {
         super(Collections.singleton("internal"));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
@@ -123,6 +123,7 @@ public class PrivilegeTests extends ESTestCase {
         assertThat(predicate.test("indices:admin/mapping/put"), is(true));
         assertThat(predicate.test("indices:admin/mapping/whatever"), is(false));
         assertThat(predicate.test("internal:transport/proxy/indices:data/read/query"), is(false));
+        assertThat(predicate.test("internal:transport/proxy/indices:monitor/whatever"), is(true));
         assertThat(predicate.test("indices:admin/seq_no/global_checkpoint_sync"), is(true));
         assertThat(predicate.test("indices:admin/seq_no/global_checkpoint_sync[p]"), is(true));
         assertThat(predicate.test("indices:admin/seq_no/global_checkpoint_sync[r]"), is(true));


### PR DESCRIPTION
Currently all proxied actions are denied for the SystemPrivilege.
Unfortunately, there are use cases (CCR) where we would like to proxy
actions to a remote node that are normally performed by the
system context. This commit allows the system context to perform
proxy actions if they are actions that the system context is normally
allowed to execute.