### PR TITLE
Add anchor to doc link in old index check

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -117,8 +117,8 @@ public class IndexDeprecationChecks {
             } else {
                 return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                     "Index created before 6.0",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/" +
-                        "breaking-changes-7.0.html",
+                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                        "#_indices_created_before_7_0",
                     "This index was created using version: " + createdWith);
             }
 

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -37,8 +37,8 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             .build();
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "Index created before 6.0",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/" +
-                "breaking-changes-7.0.html",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                "#_indices_created_before_7_0",
             "This index was created using version: " + createdWith);
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(indexMetaData));
         assertEquals(singletonList(expected), issues);
@@ -73,8 +73,8 @@ public class IndexDeprecationChecksTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "Index created before 6.0",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/" +
-                "breaking-changes-7.0.html",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                "#_indices_created_before_7_0",
             "This index was created using version: " + createdWith);
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(indexMetaData));
         assertEquals(singletonList(expected), issues);


### PR DESCRIPTION
The check for old indices did not include an anchor to the specific
part of the breaking changes list addressing the breaking change, unlike
all the other deprecation warnings. This commit add an anchor to that
link.