### PR TITLE
Don't use Groovy's `withDefault` as it can lead to NPEs 

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -392,7 +392,7 @@ class BuildPlugin implements Plugin<Project> {
     static void requireJavaHome(Task task, int version) {
         Project rootProject = task.project.rootProject // use root project for global accounting
         if (rootProject.hasProperty('requiredJavaVersions') == false) {
-            rootProject.rootProject.ext.requiredJavaVersions = [:].withDefault{key -> return []}
+            rootProject.rootProject.ext.requiredJavaVersions = [:]
             rootProject.gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
                 List<String> messages = []
                 for (entry in rootProject.requiredJavaVersions) {
@@ -415,7 +415,7 @@ class BuildPlugin implements Plugin<Project> {
                 throw new GradleException("JAVA${version}_HOME required to run task:\n${task}")
             }
         } else {
-            rootProject.requiredJavaVersions.get(version).add(task)
+            rootProject.requiredJavaVersions.getOrDefault(version, []).add(task)
         }
     }
 


### PR DESCRIPTION
Closes #37061

We used to use a map and `[:].withDefault{key -> return []}` , then we do `requiredJavaVersions.get(version).add(task)` on the line where we got the `null` form the get call. 

The get should return an empty list instead of null, but this doesn't seem to be the case. Relevant SO: https://stackoverflow.com/questions/24738903/creating-map-using-withdefault-causing-null-when-putting-element
