### PR TITLE
[DOCS] Breaking change for Watcher metric stats names

### DIFF
--- a/docs/reference/migration/migrate_6_6.asciidoc
+++ b/docs/reference/migration/migrate_6_6.asciidoc
@@ -8,7 +8,6 @@ This section discusses the changes that you need to be aware of when migrating
 your application to Elasticsearch 6.6.
 
 * <<breaking_66_api_changes>>
-* <<breaking_66_ml_changes>>
 * <<breaking_66_mapping_changes>>
 * <<breaking_66_search_changes>>
 * <<breaking_66_setting_changes>>
@@ -16,7 +15,7 @@ your application to Elasticsearch 6.6.
 See also <<release-highlights>> and <<es-release-notes>>.
 
 [float]
-[[breaking_63_api_changes]]
+[[breaking_66_api_changes]]
 === API changes
 
 [float]

--- a/docs/reference/migration/migrate_6_6.asciidoc
+++ b/docs/reference/migration/migrate_6_6.asciidoc
@@ -11,6 +11,7 @@ your application to Elasticsearch 6.6.
 * <<breaking_66_mapping_changes>>
 * <<breaking_66_search_changes>>
 * <<breaking_66_setting_changes>>
+* <<breaking_66_watcher_changes>>
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
@@ -151,3 +152,14 @@ The get jobs API and get job stats API can retrieve a maximum of 10,000 jobs.
 Likewise, the get datafeeds API and get datafeed stats API can retrieve a
 maximum of 10,000 datafeeds. Prior to version 6.6, there were no limits on the
 results from these APIs. 
+
+[float]
+[[breaking_66_watcher_changes]]
+=== {watcher} changes
+
+If you used the `metric` parameter with the
+{ref}/watcher-api-stats.html[stats API], the response contained incorrect labels,
+which are fixed in 6.6 and later releases. If you choose to retrieve
+`queued_watches` metrics, it now returns a `queued_watches` list instead of a  `current_watches` list. Likewise, if you retrieve `pending_watches` metrics, it
+returns a `current_watches` list instead of a `queued_watches` list. The
+`pending_watches` metric is deprecated; use `current_watches` instead.

--- a/docs/reference/migration/migrate_6_6.asciidoc
+++ b/docs/reference/migration/migrate_6_6.asciidoc
@@ -7,13 +7,35 @@
 This section discusses the changes that you need to be aware of when migrating
 your application to Elasticsearch 6.6.
 
+* <<breaking_66_api_changes>>
 * <<breaking_66_ml_changes>>
 * <<breaking_66_mapping_changes>>
 * <<breaking_66_search_changes>>
 * <<breaking_66_setting_changes>>
-* <<breaking_66_watcher_changes>>
 
 See also <<release-highlights>> and <<es-release-notes>>.
+
+[float]
+[[breaking_63_api_changes]]
+=== API changes
+
+[float]
+==== Machine learning API changes
+
+The get jobs API and get job stats API can retrieve a maximum of 10,000 jobs.
+Likewise, the get datafeeds API and get datafeed stats API can retrieve a
+maximum of 10,000 datafeeds. Prior to version 6.6, there were no limits on the
+results from these APIs. 
+
+[float]
+==== {watcher} API changes
+
+If you used the `metric` parameter with the
+{ref}/watcher-api-stats.html[stats API], the response contained incorrect labels,
+which are fixed in 6.6 and later releases. If you choose to retrieve
+`queued_watches` metrics, it now returns a `queued_watches` list instead of a  `current_watches` list. Likewise, if you retrieve `pending_watches` metrics, it
+returns a `current_watches` list instead of a `queued_watches` list. The
+`pending_watches` metric is deprecated; use `current_watches` instead.
 
 [float]
 [[breaking_66_search_changes]]
@@ -143,23 +165,3 @@ previously created indexes.
 The following type parameters are deprecated for the `geo_shape` field type: `tree`,
 `precision`, `tree_levels`, `distance_error_pct`, `points_only`, and `strategy`. They
 will be removed in a future version.
-
-[float]
-[[breaking_66_ml_changes]]
-=== Machine learning changes
-
-The get jobs API and get job stats API can retrieve a maximum of 10,000 jobs.
-Likewise, the get datafeeds API and get datafeed stats API can retrieve a
-maximum of 10,000 datafeeds. Prior to version 6.6, there were no limits on the
-results from these APIs. 
-
-[float]
-[[breaking_66_watcher_changes]]
-=== {watcher} changes
-
-If you used the `metric` parameter with the
-{ref}/watcher-api-stats.html[stats API], the response contained incorrect labels,
-which are fixed in 6.6 and later releases. If you choose to retrieve
-`queued_watches` metrics, it now returns a `queued_watches` list instead of a  `current_watches` list. Likewise, if you retrieve `pending_watches` metrics, it
-returns a `current_watches` list instead of a `queued_watches` list. The
-`pending_watches` metric is deprecated; use `current_watches` instead.


### PR DESCRIPTION
This PR adds an "API changes" section to the Breaking changes page (https://www.elastic.co/guide/en/elasticsearch/reference/6.6/breaking-changes-6.6.html) and adds a subsection for the Watcher changes implemented in https://github.com/elastic/elasticsearch/pull/34951