### PR TITLE
remove GeoHashGridAggregator.OrdinalBucket

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridBucket.java
@@ -38,6 +38,7 @@ public class GeoGridBucket extends InternalMultiBucketAggregation.InternalBucket
 
     protected long geohashAsLong;
     protected long docCount;
+    protected long bucketOrd; // used internally to build InternalAggregations. not serialized.
     protected InternalAggregations aggregations;
 
     GeoGridBucket(long geohashAsLong, long docCount, InternalAggregations aggregations) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
@@ -95,17 +95,6 @@ public class GeoHashGridAggregator extends BucketsAggregator {
         };
     }
 
-    // private impl that stores a bucket ord. This allows for computing the aggregations lazily.
-    static class OrdinalBucket extends GeoGridBucket {
-
-        long bucketOrd;
-
-        OrdinalBucket() {
-            super(0, 0, null);
-        }
-
-    }
-
     @Override
     public InternalGeoHashGrid buildAggregation(long owningBucketOrdinal) throws IOException {
         assert owningBucketOrdinal == 0;
@@ -113,21 +102,21 @@ public class GeoHashGridAggregator extends BucketsAggregator {
         consumeBucketsAndMaybeBreak(size);
 
         InternalGeoHashGrid.BucketPriorityQueue ordered = new InternalGeoHashGrid.BucketPriorityQueue(size);
-        OrdinalBucket spare = null;
+        GeoGridBucket spare = null;
         for (long i = 0; i < bucketOrds.size(); i++) {
             if (spare == null) {
-                spare = new OrdinalBucket();
+                spare = new GeoGridBucket(0, 0, null);
             }
 
             spare.geohashAsLong = bucketOrds.get(i);
             spare.docCount = bucketDocCount(i);
             spare.bucketOrd = i;
-            spare = (OrdinalBucket) ordered.insertWithOverflow(spare);
+            spare = ordered.insertWithOverflow(spare);
         }
 
         final GeoGridBucket[] list = new GeoGridBucket[ordered.size()];
         for (int i = ordered.size() - 1; i >= 0; --i) {
-            final OrdinalBucket bucket = (OrdinalBucket) ordered.pop();
+            final GeoGridBucket bucket = ordered.pop();
             bucket.aggregations = bucketAggregations(bucket.bucketOrd);
             list[i] = bucket;
         }


### PR DESCRIPTION
This commit removes the OrdinalBucket class
from GeoHashGridAggregator and pulls the `bucketOrd`
field up to the GeoGridBucket. `bucketOrd` is
only used internally and is not used in serialization
and equivalence testing. The goal here is to remove 
redundancy and more classes