### PR TITLE
Allow open indices to be restored

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -588,6 +588,8 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
                     } else {
                         throw new IllegalArgumentException("malformed ignore_index_settings section, should be an array of strings");
                     }
+            } else if (name.equals("restore_open_index")) {
+                restoreOpenIndex(nodeBooleanValue(entry.getValue(), "restore_open_index"));
             } else {
                 if (IndicesOptions.isIndicesOptions(name) == false) {
                     throw new IllegalArgumentException("Unknown parameter " + name);
@@ -617,6 +619,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         }
         builder.field("include_global_state", includeGlobalState);
         builder.field("partial", partial);
+        builder.field("restore_open_index", restoreOpenIndex);
         builder.field("include_aliases", includeAliases);
         if (settings != null) {
             builder.startObject("settings");

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestBuilder.java
@@ -193,6 +193,19 @@ public class RestoreSnapshotRequestBuilder extends MasterNodeOperationRequestBui
     }
 
     /**
+     * If set to true, the restore procedure will restore an open index from this
+     * snapshot. This will overwrite all the existing shards with new data.
+     *
+     * @param restoreOpenIndex true if open index should be restored from this snapshot
+     * @return this builder
+     */
+    public RestoreSnapshotRequestBuilder setRestoreOpenIndex(boolean restoreOpenIndex) {
+        request.restoreOpenIndex(restoreOpenIndex);
+        return this;
+    }
+
+
+    /**
      * If set to true the restore procedure will restore global cluster state.
      * <p>
      * The global cluster state includes persistent settings and index template definitions.

--- a/server/src/main/java/org/elasticsearch/index/query/IntervalBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalBuilder.java
@@ -275,10 +275,10 @@ public class IntervalBuilder {
             return null;
         }
 
-//        @Override
-//        public int minExtent() {
-//            return 0;
-//        }
+        @Override
+        public int minExtent() {
+            return 0;
+        }
 
         @Override
         public void extractTerms(String field, Set<Term> terms) {

--- a/server/src/main/java/org/elasticsearch/index/query/IntervalBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalBuilder.java
@@ -275,10 +275,10 @@ public class IntervalBuilder {
             return null;
         }
 
-        @Override
-        public int minExtent() {
-            return 0;
-        }
+//        @Override
+//        public int minExtent() {
+//            return 0;
+//        }
 
         @Override
         public void extractTerms(String field, Set<Term> terms) {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTests.java
@@ -55,9 +55,11 @@ public class RestoreSnapshotRequestTests extends AbstractWireSerializingTestCase
         if (randomBoolean()) {
             instance.renamePattern(randomUnicodeOfLengthBetween(1, 100));
         }
+
         if (randomBoolean()) {
             instance.renameReplacement(randomUnicodeOfLengthBetween(1, 100));
         }
+        instance.restoreOpenIndex(randomBoolean());
         instance.partial(randomBoolean());
         instance.includeAliases(randomBoolean());
 

--- a/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -3791,7 +3791,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> and try to restore this open index again");
         restoreSnapshotResponse = client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap2")
-            .setRenamePattern("(.+)").setRenameReplacement("$1-copy").setRestoreOpenIndex(true).setWaitForCompletion(true).execute().actionGet();
+            .setRenamePattern("(.+)").setRenameReplacement("$1-copy").setRestoreOpenIndex(true).setWaitForCompletion(true).execute().get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         assertThat(client.prepareSearch("test-idx-1-copy").setSize(0).get().getHits().getTotalHits().value, equalTo(200L));

--- a/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
@@ -95,6 +96,7 @@ import org.elasticsearch.script.StoredScriptsIT;
 import org.elasticsearch.snapshots.mockstore.MockRepository;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.RemoteTransportException;
 
 import java.io.IOException;
 import java.nio.channels.SeekableByteChannel;
@@ -113,6 +115,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -142,6 +145,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
@@ -3791,6 +3795,91 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         assertThat(client.prepareSearch("test-idx-1-copy").setSize(0).get().getHits().getTotalHits().value, equalTo(200L));
+    }
+
+    public void testCannotConcurrentlyRestoreSameIndex() throws Exception {
+        Client client = client();
+
+        logger.info("-->  creating repository");
+        assertAcked(client.admin().cluster().preparePutRepository("test-repo")
+            .setType("mock").setSettings(Settings.builder()
+                .put("location", randomRepoPath())));
+
+        createIndex("test-idx-1", "test-idx-2", "test-idx-3");
+        ensureGreen();
+
+        logger.info("--> snapshot");
+        CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot("test-repo", "test-snap")
+            .setWaitForCompletion(true).setIndices("test-idx-1", "test-idx-2", "test-idx-3").get();
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(),
+            equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
+
+        blockAllDataNodes("test-repo");
+
+        logger.info("--> restore index with different name");
+        ActionFuture<RestoreSnapshotResponse> restorefuture1 = client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap")
+            .setIndices("test-idx-1", "test-idx-2", "test-idx-3").setRenamePattern("(.+)").setRenameReplacement("$1-copy")
+            .setWaitForCompletion(true).execute();
+
+        logger.info("--> concurrently restore index with another different name");
+        ActionFuture<RestoreSnapshotResponse> restorefuture2 = client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap")
+            .setIndices("test-idx-3").setRenamePattern("(.+)").setRenameReplacement("$1-copy2")
+            .setWaitForCompletion(true).execute();
+
+        unblockAllDataNodes("test-repo");
+
+        assertThat(restorefuture1.get().getRestoreInfo().totalShards(), greaterThan(0));
+        assertThat(restorefuture2.get().getRestoreInfo().totalShards(), greaterThan(0));
+
+        cluster().wipeIndices("test-idx-1-copy", "test-idx-2-copy", "test-idx-3-copy", "test-idx-1-copy2");
+
+        blockAllDataNodes("test-repo");
+
+        AtomicReference<RestoreSnapshotResponse> responseReference = new AtomicReference<>();
+        AtomicReference<Throwable> exReference = new AtomicReference<>();
+
+        ActionListener<RestoreSnapshotResponse> listener = new ActionListener<RestoreSnapshotResponse>() {
+            @Override
+            public void onResponse(RestoreSnapshotResponse response) {
+                responseReference.set(response);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                if (e instanceof RemoteTransportException) {
+                    exReference.set(((RemoteTransportException) e).getRootCause());
+                } else {
+                    exReference.set(e);
+                }
+            }
+        };
+
+        logger.info("--> restore index with different name");
+        client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap").setIndices("test-idx-1", "test-idx-2", "test-idx-3")
+            .setRestoreOpenIndex(true).setRenamePattern("(.+)").setRenameReplacement("$1-copy").setWaitForCompletion(true)
+            .execute(listener);
+
+        logger.info("--> restore index with same different name");
+        client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap").setIndices("test-idx-2", "test-idx-3")
+            .setRestoreOpenIndex(true).setRenamePattern("(.+)").setRenameReplacement("$1-copy").setWaitForCompletion(true)
+            .execute(listener);
+
+        assertBusy(() -> {
+            Throwable exception = exReference.get();
+            assertNotNull(exception);
+            assertThat(exception, instanceOf(ConcurrentSnapshotExecutionException.class));
+            assertThat(exception.getMessage(), not(containsString("test-idx-1")));
+            assertThat(exception.getMessage(), containsString("test-idx-2"));
+            assertThat(exception.getMessage(), containsString("test-idx-3"));
+        });
+
+        unblockAllDataNodes("test-repo");
+
+        assertBusy(() -> {
+            assertNotNull(responseReference.get());
+            assertThat(responseReference.get().getRestoreInfo().totalShards(), greaterThan(0));
+        });
     }
 
     private RepositoryData getRepositoryData(Repository repository) throws InterruptedException {


### PR DESCRIPTION
Currently, open indices cannot be restored. However, in CCR we have a
use case where we would like to restore an follower index if it has
fallen too far behind a leader index. This commit allows a
`restoreOpenIndex` parameter to be passed to the restore request. If
this parameter is true, an open index can be restored. This introduces
some concurrency issues (multiple attempts to restore the same index).
So this PR fails a restore request if there is already an in-process
restore for the requested index.