### PR TITLE
Emit a deprecation warning when a typed index template is triggered.

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
@@ -154,6 +154,11 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
         return this.aliases;
     }
 
+    public boolean isTypeless() {
+        return mappings.size() == 0 ||
+            (mappings.size()) == 1 && mappings.containsKey(MapperService.SINGLE_MAPPING_NAME);
+    }
+
     public static Builder builder(String name) {
         return new Builder(name);
     }


### PR DESCRIPTION
**This is an experiment/ work in progress and is not ready for review.**

This PR adds a deprecation warning each time an index template is triggered that has a custom mapping type. If the template metadata has no mappings, or a single type with name `_doc`, then we do not emit a warning.

For context, even if an index template's mapping was created without a type, we are continuing to store the template with the dummy type name `_doc`. This makes the code easier to reason about, because in 7.x we need to be able to support typed templates as well, and potentially communicate with 6.x nodes. In 8.x, once we know there are no more custom types, we can likely migrate all stored templates to be typeless.

Note that there is a separate PR to deprecate types in put + get index template requests (#37484).