### PR TITLE
Clarify `expunge_deletes_allowed` purpose in ForceMerge docs

### DIFF
--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -38,7 +38,9 @@ deletes in it. In Lucene, a document is not deleted from a segment, just marked
 as deleted. During a merge process of segments, a new segment is created that
 does not have those deletes. This flag allows to only merge segments that have
 deletes. Defaults to `false`.  Note that this won't override the
-`index.merge.policy.expunge_deletes_allowed` threshold.
+`index.merge.policy.expunge_deletes_allowed` threshold. Defaults to `10` % by 
+quantity, that can be changed by <<indices-update-settings,settings>>.
+
 
 `flush`::  Should a flush be performed after the forced merge. Defaults to
 `true`.


### PR DESCRIPTION
After:
Note that this won't override the
`index.merge.policy.expunge_deletes_allowed` threshold.
Added:
Defaults to `10` % by 
quantity, that can be changed by <<indices-update-settings,settings>>.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
