### PR TITLE
[ML] TooManyJobsIT: Increase close job timeout and lower the number jobs tested 

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
@@ -124,11 +124,11 @@ public class TooManyJobsIT extends BaseMlIntegTestCase {
     }
 
     public void testSingleNode() throws Exception {
-        verifyMaxNumberOfJobsLimit(1, randomIntBetween(1, 100));
+        verifyMaxNumberOfJobsLimit(1, randomIntBetween(1, 20));
     }
 
     public void testMultipleNodes() throws Exception {
-        verifyMaxNumberOfJobsLimit(3, randomIntBetween(1, 100));
+        verifyMaxNumberOfJobsLimit(3, randomIntBetween(1, 20));
     }
 
     private void verifyMaxNumberOfJobsLimit(int numNodes, int maxNumberOfJobsPerNode) throws Exception {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
@@ -318,7 +318,7 @@ public abstract class BaseMlIntegTestCase extends ESIntegTestCase {
 
         try {
             CloseJobAction.Request closeRequest = new CloseJobAction.Request(MetaData.ALL);
-            closeRequest.setCloseTimeout(TimeValue.timeValueSeconds(20L));
+            closeRequest.setCloseTimeout(TimeValue.timeValueSeconds(30L));
             logger.info("Closing jobs using [{}]", MetaData.ALL);
             CloseJobAction.Response response = client.execute(CloseJobAction.INSTANCE, closeRequest)
                     .get();
@@ -327,7 +327,7 @@ public abstract class BaseMlIntegTestCase extends ESIntegTestCase {
             try {
                 CloseJobAction.Request closeRequest = new CloseJobAction.Request(MetaData.ALL);
                 closeRequest.setForce(true);
-                closeRequest.setCloseTimeout(TimeValue.timeValueSeconds(20L));
+                closeRequest.setCloseTimeout(TimeValue.timeValueSeconds(30L));
                 CloseJobAction.Response response =
                         client.execute(CloseJobAction.INSTANCE, closeRequest).get();
                 assertTrue(response.isClosed());


### PR DESCRIPTION
`TooManyJobsIT` occasionally fails with the the mysterious message `Had to resort to force-closing job, something went wrong?`. The something that went wrong is closing all jobs in the test teardown

```
   > Throwable #1: java.lang.RuntimeException: Had to resort to force-closing job, something went wrong?
...
   > Caused by: java.util.concurrent.ExecutionException: RemoteTransportException[[node_t1][127.0.0.1:33786][cluster:admin/xpack/ml/job/close]]; 
nested: IllegalStateException[Timed out when waiting for persistent tasks after 20s];
```

The close request timed out after 20 seconds which isn't surprising in this case as there were 285 jobs to close. TooManyJobsIT is testing that the `xpack.ml.max_open_jobs` limit is respected and doesn't have to create hundreds of jobs to do so as `xpack.ml.max_open_jobs` is set by the test. 

Closes #30300