### PR TITLE
[DOCS] Remove beta tag from metricbeat monitoring

### DIFF
--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Collecting monitoring data with {metricbeat}</titleabbrev>
 ++++
 
-beta[]
-
 In 6.5 and later, you can use {metricbeat} to collect data about {es} 
 and ship it to the monitoring cluster, rather than routing it through exporters 
 as described in <<collecting-monitoring-data>>. 

--- a/docs/reference/monitoring/index.asciidoc
+++ b/docs/reference/monitoring/index.asciidoc
@@ -33,7 +33,7 @@ indexing (storage). The routing and indexing processes in {es} are handled by
 what are called <<es-monitoring-collectors,collectors>> and 
 <<es-monitoring-exporters,exporters>>. 
 
-beta[] Alternatively, in 6.4 and later, you can use {metricbeat} to collect 
+Alternatively, in 6.4 and later, you can use {metricbeat} to collect 
 monitoring data about {kib} and ship it directly to the monitoring cluster, 
 rather than routing it through the production cluster. In 6.5 and later, you 
 can also use {metricbeat} to collect and ship data about {es}. 


### PR DESCRIPTION
Related to elastic/beats#10222

This PR removes the "beta[]" tags from the Metricbeat monitoring information in the Elasticsearch Reference.