### PR TITLE
Use explicit version for build-tools in example plugin integ tests

### DIFF
--- a/buildSrc/src/test/java/org/elasticsearch/gradle/BuildExamplePluginsIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/BuildExamplePluginsIT.java
@@ -98,8 +98,8 @@ public class BuildExamplePluginsIT extends GradleIntegrationTestCase {
 
     private void adaptBuildScriptForTest() throws IOException {
         // Add the local repo as a build script URL so we can pull in build-tools and apply the plugin under test
-        // we need to specify the exact version of build-tools because the esplugin plugin will add more repos, we want to get
-        // the version
+        // we need to specify the exact version of build-tools because gradle automatically adds its plugin portal
+        // which appears to mirror jcenter, opening us up to pulling a "later" version of build-tools
         writeBuildScript(
             "buildscript {\n" +
                 "    repositories {\n" +

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/BuildExamplePluginsIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/BuildExamplePluginsIT.java
@@ -40,14 +40,14 @@ import java.util.stream.Collectors;
 
 public class BuildExamplePluginsIT extends GradleIntegrationTestCase {
 
-    private static List<File> EXAMPLE_PLUGINS = Collections.unmodifiableList(
+    private static final List<File> EXAMPLE_PLUGINS = Collections.unmodifiableList(
         Arrays.stream(
             Objects.requireNonNull(System.getProperty("test.build-tools.plugin.examples"))
                 .split(File.pathSeparator)
         ).map(File::new).collect(Collectors.toList())
     );
 
-    private static String BUILD_TOOLS_VERSION = Objects.requireNonNull(System.getProperty("test.version_under_test"));
+    private static final String BUILD_TOOLS_VERSION = Objects.requireNonNull(System.getProperty("test.version_under_test"));
 
     @Rule
     public TemporaryFolder tmpDir = new TemporaryFolder();

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/BuildExamplePluginsIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/BuildExamplePluginsIT.java
@@ -47,6 +47,8 @@ public class BuildExamplePluginsIT extends GradleIntegrationTestCase {
         ).map(File::new).collect(Collectors.toList())
     );
 
+    private static String BUILD_TOOLS_VERSION = Objects.requireNonNull(System.getProperty("test.version_under_test"));
+
     @Rule
     public TemporaryFolder tmpDir = new TemporaryFolder();
 
@@ -96,7 +98,8 @@ public class BuildExamplePluginsIT extends GradleIntegrationTestCase {
 
     private void adaptBuildScriptForTest() throws IOException {
         // Add the local repo as a build script URL so we can pull in build-tools and apply the plugin under test
-        // + is ok because we have no other repo and just want to pick up latest
+        // we need to specify the exact version of build-tools because the esplugin plugin will add more repos, we want to get
+        // the version
         writeBuildScript(
             "buildscript {\n" +
                 "    repositories {\n" +
@@ -105,7 +108,7 @@ public class BuildExamplePluginsIT extends GradleIntegrationTestCase {
                 "        }\n" +
                 "    }\n" +
                 "    dependencies {\n" +
-                "        classpath \"org.elasticsearch.gradle:build-tools:+\"\n" +
+                "        classpath \"org.elasticsearch.gradle:build-tools:" + BUILD_TOOLS_VERSION + "\"\n" +
                 "    }\n" +
                 "}\n"
         );


### PR DESCRIPTION
The example plugins are currently built within the build-tools integ
tests as a means to ensure the gradle plugin works for external plugin
builds. These tests generate a dummy build.gradle, and a dummy local
maven repository to find the local builds dependencies in. Currently
that build-tools dependency uses "+" as the version. However, this
allows gradle to find the "latest" version, and unfortunately gradle has
its own plugin repository which is apparently connected to jcenter. This
recently triggered a flood of CI failures when jcenter suddenly pulled
alpha2, and all builds started trying to use that instead of the locally
built build-tools. This commit uses the explicit version of build-tools
that was build locally, which will cause resolution to stop when the
local repo is first checked.