### PR TITLE
Better message on unmapped principal attribute

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
@@ -417,8 +417,9 @@ public final class SamlRealm extends Realm implements Releasable {
     private void buildUser(SamlAttributes attributes, ActionListener<AuthenticationResult> baseListener) {
         final String principal = resolveSingleValueAttribute(attributes, principalAttribute, PRINCIPAL_ATTRIBUTE.name(config));
         if (Strings.isNullOrEmpty(principal)) {
-            baseListener.onResponse(AuthenticationResult.unsuccessful(
-                    principalAttribute + " not found in " + attributes.attributes(), null));
+            final String msg =
+                principalAttribute + " not found in saml attributes" + attributes.attributes() + " or NameID [" + attributes.name() + "]";
+            baseListener.onResponse(AuthenticationResult.unsuccessful(msg, null));
             return;
         }
 


### PR DESCRIPTION
When we can't map the principal attribute from the configured SAML
attribute in the realm settings, we can't complete the
authentication. We return an error to the user indicating this and
we present them with a list of attributes we did get from the SAML
response to point out that the expected one was not part of that
list. This list will never contain the NameIDs though as they are
not part of the SAMLAttribute list. So we might have a NameID but
just with a different format. 