### PR TITLE
Expose minimum_master_nodes in cluster state

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -128,6 +128,8 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
         ClusterState.Builder builder = ClusterState.builder(currentState.getClusterName());
         builder.version(currentState.version());
         builder.stateUUID(currentState.stateUUID());
+        builder.minimumMasterNodesOnPublishingMaster(currentState.getMinimumMasterNodesOnPublishingMaster());
+
         if (request.nodes()) {
             builder.nodes(currentState.nodes());
         }

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -22,6 +22,8 @@ package org.elasticsearch.cluster;
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+
+import org.elasticsearch.Version;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlocks;
@@ -172,16 +174,19 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
 
     private final boolean wasReadFromDiff;
 
+    private final int minimumMasterNodesOnPublishingMaster;
+
     // built on demand
     private volatile RoutingNodes routingNodes;
 
     public ClusterState(long version, String stateUUID, ClusterState state) {
         this(state.clusterName, version, stateUUID, state.metaData(), state.routingTable(), state.nodes(), state.blocks(), state.customs(),
-            false);
+            -1, false);
     }
 
     public ClusterState(ClusterName clusterName, long version, String stateUUID, MetaData metaData, RoutingTable routingTable,
-                        DiscoveryNodes nodes, ClusterBlocks blocks, ImmutableOpenMap<String, Custom> customs, boolean wasReadFromDiff) {
+                        DiscoveryNodes nodes, ClusterBlocks blocks, ImmutableOpenMap<String, Custom> customs,
+                        int minimumMasterNodesOnPublishingMaster, boolean wasReadFromDiff) {
         this.version = version;
         this.stateUUID = stateUUID;
         this.clusterName = clusterName;
@@ -190,6 +195,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
         this.nodes = nodes;
         this.blocks = blocks;
         this.customs = customs;
+        this.minimumMasterNodesOnPublishingMaster = minimumMasterNodesOnPublishingMaster;
         this.wasReadFromDiff = wasReadFromDiff;
     }
 
@@ -255,6 +261,17 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
 
     public ClusterName getClusterName() {
         return this.clusterName;
+    }
+
+    /**
+     * The node-level `discovery.zen.minimum_master_nodes` setting on the master node that published this cluster state, for use in rolling
+     * upgrades from 6.x to 7.x. Once all the 6.x master-eligible nodes have left the cluster, the 7.x nodes use this value to determine how
+     * many master-eligible nodes must be discovered before the cluster can be bootstrapped. Note that this method returns the node-level
+     * value of this setting, and ignores any cluster-level override that was set via the API. Callers are expected to combine this value
+     * with any value set in the cluster-level settings. This should be removed once we no longer need support for {@link Version#V_6_7_0}.
+     */
+    public int getMinimumMasterNodesOnPublishingMaster() {
+        return minimumMasterNodesOnPublishingMaster;
     }
 
     // Used for testing and logging to determine how this cluster state was send over the wire
@@ -598,7 +615,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
         private ClusterBlocks blocks = ClusterBlocks.EMPTY_CLUSTER_BLOCK;
         private final ImmutableOpenMap.Builder<String, Custom> customs;
         private boolean fromDiff;
-
+        private int minimumMasterNodesOnPublishingMaster = -1;
 
         public Builder(ClusterState state) {
             this.clusterName = state.clusterName;
@@ -609,6 +626,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
             this.metaData = state.metaData();
             this.blocks = state.blocks();
             this.customs = ImmutableOpenMap.builder(state.customs());
+            this.minimumMasterNodesOnPublishingMaster = state.minimumMasterNodesOnPublishingMaster;
             this.fromDiff = false;
         }
 
@@ -669,6 +687,11 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
             return this;
         }
 
+        public Builder minimumMasterNodesOnPublishingMaster(int minimumMasterNodesOnPublishingMaster) {
+            this.minimumMasterNodesOnPublishingMaster = minimumMasterNodesOnPublishingMaster;
+            return this;
+        }
+
         public Builder putCustom(String type, Custom custom) {
             customs.put(type, custom);
             return this;
@@ -693,7 +716,8 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
             if (UNKNOWN_UUID.equals(uuid)) {
                 uuid = UUIDs.randomBase64UUID();
             }
-            return new ClusterState(clusterName, version, uuid, metaData, routingTable, nodes, blocks, customs.build(), fromDiff);
+            return new ClusterState(clusterName, version, uuid, metaData, routingTable, nodes, blocks, customs.build(),
+                minimumMasterNodesOnPublishingMaster, fromDiff);
         }
 
         public static byte[] toBytes(ClusterState state) throws IOException {
@@ -736,6 +760,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
             Custom customIndexMetaData = in.readNamedWriteable(Custom.class);
             builder.putCustom(customIndexMetaData.getWriteableName(), customIndexMetaData);
         }
+        builder.minimumMasterNodesOnPublishingMaster = in.getVersion().onOrAfter(Version.V_6_7_0) ? in.readVInt() : -1;
         return builder.build();
     }
 
@@ -761,6 +786,9 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
                 out.writeNamedWriteable(cursor.value);
             }
         }
+        if (out.getVersion().onOrAfter(Version.V_6_7_0)) {
+            out.writeVInt(minimumMasterNodesOnPublishingMaster);
+        }
     }
 
     private static class ClusterStateDiff implements Diff<ClusterState> {
@@ -783,6 +811,8 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
 
         private final Diff<ImmutableOpenMap<String, Custom>> customs;
 
+        private final int minimumMasterNodesOnPublishingMaster;
+
         ClusterStateDiff(ClusterState before, ClusterState after) {
             fromUuid = before.stateUUID;
             toUuid = after.stateUUID;
@@ -793,6 +823,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
             metaData = after.metaData.diff(before.metaData);
             blocks = after.blocks.diff(before.blocks);
             customs = DiffableUtils.diff(before.customs, after.customs, DiffableUtils.getStringKeySerializer(), CUSTOM_VALUE_SERIALIZER);
+            minimumMasterNodesOnPublishingMaster = after.minimumMasterNodesOnPublishingMaster;
         }
 
         ClusterStateDiff(StreamInput in, DiscoveryNode localNode) throws IOException {
@@ -805,6 +836,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
             metaData = MetaData.readDiffFrom(in);
             blocks = ClusterBlocks.readDiffFrom(in);
             customs = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), CUSTOM_VALUE_SERIALIZER);
+            minimumMasterNodesOnPublishingMaster = in.getVersion().onOrAfter(Version.V_6_7_0) ? in.readVInt() : -1;
         }
 
         @Override
@@ -818,6 +850,9 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
             metaData.writeTo(out);
             blocks.writeTo(out);
             customs.writeTo(out);
+            if (out.getVersion().onOrAfter(Version.V_6_7_0)) {
+                out.writeVInt(minimumMasterNodesOnPublishingMaster);
+            }
         }
 
         @Override
@@ -837,6 +872,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
             builder.metaData(metaData.apply(state.metaData));
             builder.blocks(blocks.apply(state.blocks));
             builder.customs(customs.apply(state.customs));
+            builder.minimumMasterNodesOnPublishingMaster(minimumMasterNodesOnPublishingMaster);
             builder.fromDiff(true);
             return builder.build();
         }

--- a/server/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
@@ -35,6 +35,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.discovery.DiscoverySettings;
@@ -67,9 +68,10 @@ public class NodeJoinController {
     private ElectionContext electionContext = null;
 
 
-    public NodeJoinController(MasterService masterService, AllocationService allocationService, ElectMasterService electMaster) {
+    public NodeJoinController(Settings settings, MasterService masterService, AllocationService allocationService,
+                              ElectMasterService electMaster) {
         this.masterService = masterService;
-        joinTaskExecutor = new JoinTaskExecutor(allocationService, electMaster, logger);
+        joinTaskExecutor = new JoinTaskExecutor(settings, allocationService, electMaster, logger);
     }
 
     /**
@@ -410,10 +412,13 @@ public class NodeJoinController {
 
         private final Logger logger;
 
-        public JoinTaskExecutor(AllocationService allocationService, ElectMasterService electMasterService, Logger logger) {
+        private final int minimumMasterNodesOnLocalNode;
+
+        public JoinTaskExecutor(Settings settings, AllocationService allocationService, ElectMasterService electMasterService, Logger logger) {
             this.allocationService = allocationService;
             this.electMasterService = electMasterService;
             this.logger = logger;
+            minimumMasterNodesOnLocalNode = ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.get(settings);
         }
 
         @Override
@@ -509,7 +514,9 @@ public class NodeJoinController {
             // or removed by us above
             ClusterState tmpState = ClusterState.builder(currentState).nodes(nodesBuilder).blocks(ClusterBlocks.builder()
                 .blocks(currentState.blocks())
-                .removeGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID)).build();
+                .removeGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID))
+                .minimumMasterNodesOnPublishingMaster(minimumMasterNodesOnLocalNode)
+                .build();
             tmpState = PersistentTasksCustomMetaData.disassociateDeadNodes(tmpState);
             return ClusterState.builder(allocationService.disassociateDeadNodes(tmpState, false,
                 "removed dead nodes on election"));

--- a/server/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
@@ -414,7 +414,8 @@ public class NodeJoinController {
 
         private final int minimumMasterNodesOnLocalNode;
 
-        public JoinTaskExecutor(Settings settings, AllocationService allocationService, ElectMasterService electMasterService, Logger logger) {
+        public JoinTaskExecutor(Settings settings, AllocationService allocationService, ElectMasterService electMasterService,
+                                Logger logger) {
             this.allocationService = allocationService;
             this.electMasterService = electMasterService;
             this.logger = logger;

--- a/server/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -219,7 +219,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
         this.membership = new MembershipAction(transportService, new MembershipListener(), onJoinValidators);
         this.joinThreadControl = new JoinThreadControl();
 
-        this.nodeJoinController = new NodeJoinController(masterService, allocationService, electMaster);
+        this.nodeJoinController = new NodeJoinController(settings, masterService, allocationService, electMaster);
         this.nodeRemovalExecutor = new NodeRemovalClusterStateTaskExecutor(allocationService, electMaster, this::submitRejoin, logger);
 
         masterService.setClusterStateSupplier(this::clusterState);

--- a/server/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
@@ -67,7 +67,8 @@ public class ClusterSerializationTests extends ESAllocationTestCase {
             .add(newNode("node3")).localNodeId("node1").masterNodeId("node2").build();
 
         ClusterState clusterState = ClusterState.builder(new ClusterName("clusterName1"))
-            .nodes(nodes).metaData(metaData).routingTable(routingTable).build();
+            .nodes(nodes).metaData(metaData).routingTable(routingTable)
+            .minimumMasterNodesOnPublishingMaster(randomIntBetween(-1, 10)).build();
 
         AllocationService strategy = createAllocationService();
         clusterState = ClusterState.builder(clusterState).routingTable(strategy.reroute(clusterState, "reroute").routingTable()).build();
@@ -78,6 +79,9 @@ public class ClusterSerializationTests extends ESAllocationTestCase {
         assertThat(serializedClusterState.getClusterName().value(), equalTo(clusterState.getClusterName().value()));
 
         assertThat(serializedClusterState.routingTable().toString(), equalTo(clusterState.routingTable().toString()));
+
+        assertThat(serializedClusterState.getMinimumMasterNodesOnPublishingMaster(),
+            equalTo(clusterState.getMinimumMasterNodesOnPublishingMaster()));
     }
 
     public void testRoutingTableSerialization() throws Exception {

--- a/server/src/test/java/org/elasticsearch/discovery/zen/MinimumMasterNodesInClusterStateIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/zen/MinimumMasterNodesInClusterStateIT.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.discovery.zen;
+
+import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.discovery.zen.ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING;
+import static org.elasticsearch.test.InternalTestCluster.nameFilter;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.isIn;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 0, numClientNodes = 0)
+public class MinimumMasterNodesInClusterStateIT extends ESIntegTestCase {
+
+    public void testMasterPublishes() throws Exception {
+        final String firstNode = internalCluster().startNode();
+
+        {
+            final ClusterState localState
+                = client(firstNode).admin().cluster().state(new ClusterStateRequest().local(true)).get().getState();
+            assertThat(localState.getMinimumMasterNodesOnPublishingMaster(), equalTo(1));
+            assertFalse(DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.exists(localState.metaData().settings()));
+        }
+
+        final List<String> secondThirdNodes = internalCluster().startNodes(2);
+        assertThat(internalCluster().getMasterName(), equalTo(firstNode));
+
+        final List<String> allNodes = Stream.concat(Stream.of(firstNode), secondThirdNodes.stream()).collect(Collectors.toList());
+        for (final String node : allNodes) {
+            final ClusterState localState = client(node).admin().cluster().state(new ClusterStateRequest().local(true)).get().getState();
+            assertThat(localState.getMinimumMasterNodesOnPublishingMaster(), equalTo(1));
+            assertThat(DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.get(localState.metaData().settings()), equalTo(2));
+        }
+
+        internalCluster().stopRandomNode(nameFilter(firstNode));
+        assertThat(internalCluster().getMasterName(), isIn(secondThirdNodes));
+
+        for (final String node : secondThirdNodes) {
+            final ClusterState localState = client(node).admin().cluster().state(new ClusterStateRequest().local(true)).get().getState();
+            assertThat(localState.getMinimumMasterNodesOnPublishingMaster(), equalTo(2));
+            assertThat(DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.get(localState.metaData().settings()), equalTo(2));
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/discovery/zen/NodeJoinControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/zen/NodeJoinControllerTests.java
@@ -141,7 +141,7 @@ public class NodeJoinControllerTests extends ESTestCase {
             throw new IllegalStateException("method setupMasterServiceAndNodeJoinController can only be called once");
         }
         masterService = ClusterServiceUtils.createMasterService(threadPool, initialState);
-        nodeJoinController = new NodeJoinController(masterService, createAllocationService(Settings.EMPTY),
+        nodeJoinController = new NodeJoinController(Settings.EMPTY, masterService, createAllocationService(Settings.EMPTY),
             new ElectMasterService(Settings.EMPTY));
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -215,7 +215,7 @@ public class ClusterStateChanges extends AbstractComponent {
         ElectMasterService electMasterService = new ElectMasterService(SETTINGS);
         nodeRemovalExecutor = new ZenDiscovery.NodeRemovalClusterStateTaskExecutor(allocationService, electMasterService,
             s -> { throw new AssertionError("rejoin not implemented"); }, logger);
-        joinTaskExecutor = new NodeJoinController.JoinTaskExecutor(allocationService, electMasterService, logger);
+        joinTaskExecutor = new NodeJoinController.JoinTaskExecutor(Settings.EMPTY, allocationService, electMasterService, logger);
     }
 
     public ClusterState createIndex(ClusterState state, CreateIndexRequest request) {


### PR DESCRIPTION
To safely support rolling upgrades from 6.x to 7.x we need the 7.x nodes to
have access to the `minimum_master_nodes` setting, but this setting is
otherwise unnecessary in 7.x and we would like to remove it.  Since a rolling
upgrade from 6.x to 7.x involves the 7.x nodes joining a 6.x master, we can
avoid the need for setting `minimum_master_nodes` on the 7.x nodes by copying
the value set on the 6.x master.

This change exposes the master's node-level value for `minimum_master_nodes`
via a field in the cluster state.

Relates #37701