### PR TITLE
Freezing an index should increase its index settings version

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportFreezeIndexAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportFreezeIndexAction.java
@@ -183,6 +183,7 @@ public final class TransportFreezeIndexAction extends
                         throw new IllegalStateException("index [" + index.getName() + "] is not closed");
                     }
                     final IndexMetaData.Builder imdBuilder = IndexMetaData.builder(meta);
+                    imdBuilder.settingsVersion(meta.getSettingsVersion() + 1);
                     final Settings.Builder settingsBuilder =
                         Settings.builder()
                             .put(currentState.metaData().index(index).getSettings())


### PR DESCRIPTION
When an index is frozen, two index settings are updated (`index.frozen` and `index.search.throttled`) but the settings version is left unchanged and does not reflect the settings update. This pull request change the TransportFreezeIndexAction so that it also increases the settings version when an index is frozen/unfrozen.

This issue has been caught while working on the replication of closed indices (#3388) in which index metadata for a closed index are updated to frozen metadata and[ this specific assertion](https://github.com/elastic/elasticsearch/blob/43bfdd32eea161a9084d7b49b12261ea32a7983c/server/src/main/java/org/elasticsearch/index/IndexService.java#L643) tripped.