### PR TITLE
Add a test.version_under_test property

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -212,6 +212,7 @@ if (project != rootProject) {
     if (isLuceneSnapshot) {
       systemProperty 'test.lucene-snapshot-revision', isLuceneSnapshot[0][1]
     }
+    systemProperty 'test.version_under_test', version
   }
   check.dependsOn(integTest)
 


### PR DESCRIPTION
The intention is to make the changes of
fa76a84fb78c7dfb6544f430b505c0ded5f5be73 work correctly in 6.5