### PR TITLE
[ML-DataFrame] add query support

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
@@ -36,7 +36,7 @@ public class DataFrameMessages {
     public static final String DATA_FRAME_TRANSFORM_PIVOT_FAILED_TO_CREATE_COMPOSITE_AGGREGATION =
             "Failed to create composite aggregation from pivot function";
     public static final String DATA_FRAME_TRANSFORM_CONFIGURATION_INVALID =
-            "Data frame transform configuration [{}] has invalid elements";
+            "Data frame transform configuration [{0}] has invalid elements";
 
     public static final String LOG_DATA_FRAME_TRANSFORM_CONFIGURATION_BAD_QUERY =
             "Failed to parse query for data frame transform";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
@@ -35,6 +35,11 @@ public class DataFrameMessages {
             "Data frame transform configuration must specify exactly 1 function";
     public static final String DATA_FRAME_TRANSFORM_PIVOT_FAILED_TO_CREATE_COMPOSITE_AGGREGATION =
             "Failed to create composite aggregation from pivot function";
+    public static final String DATA_FRAME_TRANSFORM_CONFIGURATION_INVALID =
+            "Data frame transform configuration [{}] has invalid elements";
+
+    public static final String LOG_DATA_FRAME_TRANSFORM_CONFIGURATION_BAD_QUERY =
+            "Failed to parse query for data frame transform";
 
     private DataFrameMessages() {
     }

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameRestTestCase.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameRestTestCase.java
@@ -101,12 +101,20 @@ public abstract class DataFrameRestTestCase extends ESRestTestCase {
         client().performRequest(bulkRequest);
     }
 
-    protected void createPivotReviewsTransform(String transformId, String dataFrameIndex) throws IOException {
+    protected void createPivotReviewsTransform(String transformId, String dataFrameIndex, String query) throws IOException {
         final Request createDataframeTransformRequest = new Request("PUT", DATAFRAME_ENDPOINT + transformId);
-        createDataframeTransformRequest.setJsonEntity("{"
+
+        String config = "{"
                 + " \"source\": \"reviews\","
-                + " \"dest\": \"" + dataFrameIndex + "\","
-                + " \"pivot\": {"
+                + " \"dest\": \"" + dataFrameIndex + "\",";
+
+        if (query != null) {
+            config += "\"query\": {"
+                    + query
+                    + "},";
+        }
+
+        config += " \"pivot\": {"
                 + "   \"group_by\": [ {"
                 + "     \"reviewer\": {"
                 + "       \"terms\": {"
@@ -117,7 +125,9 @@ public abstract class DataFrameRestTestCase extends ESRestTestCase {
                 + "       \"avg\": {"
                 + "         \"field\": \"stars\""
                 + " } } } }"
-                + "}");
+                + "}";
+
+        createDataframeTransformRequest.setJsonEntity(config);
         Map<String, Object> createDataframeTransformResponse = entityAsMap(client().performRequest(createDataframeTransformRequest));
         assertThat(createDataframeTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
         assertTrue(indexExists(dataFrameIndex));

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameUsageIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameUsageIT.java
@@ -46,7 +46,7 @@ public class DataFrameUsageIT extends DataFrameRestTestCase {
         assertEquals(null, XContentMapValues.extractValue("data_frame.stats", usageAsMap));
 
         // create a transform
-        createPivotReviewsTransform("test_usage", "pivot_reviews");
+        createPivotReviewsTransform("test_usage", "pivot_reviews", null);
 
         usageResponse = client().performRequest(new Request("GET", "_xpack/usage"));
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/GetDataFrameTransformsAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/GetDataFrameTransformsAction.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.dataframe.action;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
@@ -15,10 +16,12 @@ import org.elasticsearch.action.support.tasks.BaseTasksRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksResponse;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -35,6 +38,9 @@ public class GetDataFrameTransformsAction extends Action<GetDataFrameTransformsA
 
     public static final GetDataFrameTransformsAction INSTANCE = new GetDataFrameTransformsAction();
     public static final String NAME = "cluster:monitor/data_frame/get";
+
+    private static final ParseField INVALID_TRANSFORMS = new ParseField("invalid_transforms_count");
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(GetDataFrameTransformsAction.class));
 
     private GetDataFrameTransformsAction() {
         super(NAME);
@@ -161,6 +167,8 @@ public class GetDataFrameTransformsAction extends Action<GetDataFrameTransformsA
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            int invalidTransforms = 0;
+
             builder.startObject();
             builder.field(DataFrameField.COUNT.getPreferredName(), transformConfigurations.size());
             // XContentBuilder does not support passing the params object for Iterables
@@ -168,8 +176,16 @@ public class GetDataFrameTransformsAction extends Action<GetDataFrameTransformsA
             builder.startArray();
             for (DataFrameTransformConfig configResponse : transformConfigurations) {
                 configResponse.toXContent(builder, params);
+                if (configResponse.isValid() == false) {
+                    ++invalidTransforms;
+                }
             }
             builder.endArray();
+            if (invalidTransforms != 0) {
+                builder.field(INVALID_TRANSFORMS.getPreferredName(), invalidTransforms);
+                deprecationLogger.deprecated("Found [{}] invalid transforms", invalidTransforms);
+            }
+
             builder.endObject();
             return builder;
         }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/GetDataFrameTransformsAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/GetDataFrameTransformsAction.java
@@ -40,7 +40,8 @@ public class GetDataFrameTransformsAction extends Action<GetDataFrameTransformsA
     public static final String NAME = "cluster:monitor/data_frame/get";
 
     private static final ParseField INVALID_TRANSFORMS = new ParseField("invalid_transforms_count");
-    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(GetDataFrameTransformsAction.class));
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
+            LogManager.getLogger(GetDataFrameTransformsAction.class));
 
     private GetDataFrameTransformsAction() {
         super(NAME);

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
 import org.elasticsearch.xpack.core.dataframe.transform.DataFrameIndexerTransformStats;
@@ -46,8 +45,7 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
 
     @Override
     protected void onStartJob(long now) {
-        // for now a match all, to be replaced
-        QueryBuilder queryBuilder = new MatchAllQueryBuilder();
+        QueryBuilder queryBuilder = getConfig().getQueryConfig().getQuery();
         pivot = new Pivot(getConfig().getSource(), queryBuilder, getConfig().getPivotConfig());
     }
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
 import org.elasticsearch.xpack.core.dataframe.transform.DataFrameIndexerTransformStats;
@@ -45,7 +46,9 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
 
     @Override
     protected void onStartJob(long now) {
-        QueryBuilder queryBuilder = getConfig().getQueryConfig().getQuery();
+        QueryConfig queryConfig = getConfig().getQueryConfig();
+        QueryBuilder queryBuilder = queryConfig != null ? queryConfig.getQuery() : new MatchAllQueryBuilder();
+
         pivot = new Pivot(getConfig().getSource(), queryBuilder, getConfig().getPivotConfig());
     }
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformConfig.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformConfig.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.dataframe.transforms;
 
+import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
@@ -30,7 +31,7 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optiona
 /**
  * This class holds the configuration details of a data frame transform
  */
-public class DataFrameTransformConfig implements Writeable, ToXContentObject {
+public class DataFrameTransformConfig extends AbstractDiffable<DataFrameTransformConfig> implements Writeable, ToXContentObject {
 
     private static final String NAME = "data_frame_transforms";
     private static final ParseField SOURCE = new ParseField("source");
@@ -40,28 +41,32 @@ public class DataFrameTransformConfig implements Writeable, ToXContentObject {
     // types of transforms
     private static final ParseField PIVOT_TRANSFORM = new ParseField("pivot");
 
-    private static final ConstructingObjectParser<DataFrameTransformConfig, String> PARSER = createParser(false);
+    private static final ConstructingObjectParser<DataFrameTransformConfig, String> STRICT_PARSER = createParser(false);
     private static final ConstructingObjectParser<DataFrameTransformConfig, String> LENIENT_PARSER = createParser(true);
 
     private final String id;
     private final String source;
     private final String dest;
+
+    private final QueryConfig queryConfig;
     private final PivotConfig pivotConfig;
 
-    private static ConstructingObjectParser<DataFrameTransformConfig, String> createParser(boolean ignoreUnknownFields) {
-        ConstructingObjectParser<DataFrameTransformConfig, String> parser = new ConstructingObjectParser<>(NAME, ignoreUnknownFields,
+    private static ConstructingObjectParser<DataFrameTransformConfig, String> createParser(boolean lenient) {
+        ConstructingObjectParser<DataFrameTransformConfig, String> parser = new ConstructingObjectParser<>(NAME, lenient,
                 (args, optionalId) -> {
                     String id = args[0] != null ? (String) args[0] : optionalId;
                     String source = (String) args[1];
                     String dest = (String) args[2];
-                    PivotConfig pivotConfig = (PivotConfig) args[3];
-                    return new DataFrameTransformConfig(id, source, dest, pivotConfig);
+                    QueryConfig queryConfig = (QueryConfig) args[3];
+                    PivotConfig pivotConfig = (PivotConfig) args[4];
+                    return new DataFrameTransformConfig(id, source, dest, queryConfig, pivotConfig);
                 });
 
         parser.declareString(optionalConstructorArg(), DataFrameField.ID);
         parser.declareString(constructorArg(), SOURCE);
         parser.declareString(constructorArg(), DESTINATION);
-        parser.declareObject(optionalConstructorArg(), (p, c) -> PivotConfig.fromXContent(p, ignoreUnknownFields), PIVOT_TRANSFORM);
+        parser.declareObject(optionalConstructorArg(), (p, c) -> QueryConfig.fromXContent(p, lenient), QUERY);
+        parser.declareObject(optionalConstructorArg(), (p, c) -> PivotConfig.fromXContent(p, lenient), PIVOT_TRANSFORM);
 
         return parser;
     }
@@ -73,13 +78,15 @@ public class DataFrameTransformConfig implements Writeable, ToXContentObject {
     public DataFrameTransformConfig(final String id,
                                     final String source,
                                     final String dest,
+                                    final QueryConfig queryConfig,
                                     final PivotConfig pivotConfig) {
         this.id = ExceptionsHelper.requireNonNull(id, DataFrameField.ID.getPreferredName());
         this.source = ExceptionsHelper.requireNonNull(source, SOURCE.getPreferredName());
         this.dest = ExceptionsHelper.requireNonNull(dest, DESTINATION.getPreferredName());
+        this.queryConfig = queryConfig;
         this.pivotConfig = pivotConfig;
 
-        // at least one transform must be defined
+        // at least one function must be defined
         if (this.pivotConfig == null) {
             throw new IllegalArgumentException(DataFrameMessages.DATA_FRAME_TRANSFORM_CONFIGURATION_NO_TRANSFORM);
         }
@@ -89,6 +96,7 @@ public class DataFrameTransformConfig implements Writeable, ToXContentObject {
         id = in.readString();
         source = in.readString();
         dest = in.readString();
+        queryConfig = in.readOptionalWriteable(QueryConfig::new);
         pivotConfig = in.readOptionalWriteable(PivotConfig::new);
     }
 
@@ -112,11 +120,24 @@ public class DataFrameTransformConfig implements Writeable, ToXContentObject {
         return pivotConfig;
     }
 
+    public QueryConfig getQueryConfig() {
+        return queryConfig;
+    }
+
+    public boolean isValid() {
+        // collect validation results from all child objects
+        if (queryConfig != null && queryConfig.isValid() == false) {
+            return false;
+        }
+        return true;
+    }
+
     @Override
     public void writeTo(final StreamOutput out) throws IOException {
         out.writeString(id);
         out.writeString(source);
         out.writeString(dest);
+        out.writeOptionalWriteable(queryConfig);
         out.writeOptionalWriteable(pivotConfig);
     }
 
@@ -126,6 +147,9 @@ public class DataFrameTransformConfig implements Writeable, ToXContentObject {
         builder.field(DataFrameField.ID.getPreferredName(), id);
         builder.field(SOURCE.getPreferredName(), source);
         builder.field(DESTINATION.getPreferredName(), dest);
+        if (queryConfig != null) {
+            builder.field(QUERY.getPreferredName(), queryConfig);
+        }
         if (pivotConfig != null) {
             builder.field(PIVOT_TRANSFORM.getPreferredName(), pivotConfig);
         }
@@ -148,12 +172,13 @@ public class DataFrameTransformConfig implements Writeable, ToXContentObject {
         return Objects.equals(this.id, that.id)
                 && Objects.equals(this.source, that.source)
                 && Objects.equals(this.dest, that.dest)
+                && Objects.equals(this.queryConfig, that.queryConfig)
                 && Objects.equals(this.pivotConfig, that.pivotConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, source, dest, pivotConfig);
+        return Objects.hash(id, source, dest, queryConfig, pivotConfig);
     }
 
     @Override
@@ -164,6 +189,6 @@ public class DataFrameTransformConfig implements Writeable, ToXContentObject {
     public static DataFrameTransformConfig fromXContent(final XContentParser parser, @Nullable final String optionalTransformId,
             boolean ignoreUnknownFields) throws IOException {
 
-        return ignoreUnknownFields ? LENIENT_PARSER.apply(parser, optionalTransformId) : PARSER.apply(parser, optionalTransformId);
+        return ignoreUnknownFields ? LENIENT_PARSER.apply(parser, optionalTransformId) : STRICT_PARSER.apply(parser, optionalTransformId);
     }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -265,6 +265,13 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
                             DataFrameMessages.getMessage(DataFrameMessages.FAILED_TO_LOAD_TRANSFORM_CONFIGURATION, transformId), e);
                 }
             }
+
+            // todo: set job into failed state
+            if (transformConfig.isValid() == false) {
+                throw new RuntimeException(
+                        DataFrameMessages.getMessage(DataFrameMessages.DATA_FRAME_TRANSFORM_CONFIGURATION_INVALID, transformId));
+            }
+
             return super.maybeTriggerAsyncJob(now);
         }
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/QueryConfig.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/QueryConfig.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.dataframe.transforms;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.AbstractDiffable;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.xpack.core.dataframe.DataFrameMessages;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+public class QueryConfig extends AbstractDiffable<QueryConfig> implements Writeable, ToXContentObject {
+    private static final Logger logger = LogManager.getLogger(QueryConfig.class);
+
+    // we store the query in 2 formats: the raw format and the parsed format, because:
+    // - the parsed format adds defaults, which were not part of the original and looks odd on XContent retrieval
+    // - if parsing fails (e.g. query uses removed functionality), the source can be retrieved
+    private final Map<String, Object> source;
+    private final QueryBuilder query;
+
+    public QueryConfig(final Map<String, Object> source, final QueryBuilder query) {
+        this.source = Objects.requireNonNull(source);
+        this.query = query;
+    }
+
+    public QueryConfig(final StreamInput in) throws IOException {
+        this.source = in.readMap();
+        this.query = in.readOptionalNamedWriteable(QueryBuilder.class);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.map(source);
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeMap(source);
+        out.writeOptionalNamedWriteable(query);
+    }
+
+    public QueryBuilder getQuery() {
+        return query;
+    }
+
+    public static QueryConfig fromXContent(final XContentParser parser, boolean lenient) throws IOException {
+        // we need 2 passes, but the parser can not be cloned, so we parse 1st into a map and then re-parse that for syntax checking
+
+        // remember the registry, needed for the 2nd pass
+        NamedXContentRegistry registry = parser.getXContentRegistry();
+
+        Map<String, Object> source = parser.mapOrdered();
+        QueryBuilder query = null;
+
+        try (XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(source);
+                XContentParser sourceParser = XContentType.JSON.xContent().createParser(registry, LoggingDeprecationHandler.INSTANCE,
+                        BytesReference.bytes(xContentBuilder).streamInput())) {
+            query = AbstractQueryBuilder.parseInnerQueryBuilder(sourceParser);
+        } catch (Exception e) {
+            if (lenient) {
+                logger.warn(DataFrameMessages.LOG_DATA_FRAME_TRANSFORM_CONFIGURATION_BAD_QUERY, e);
+            } else {
+                throw e;
+            }
+        }
+
+        return new QueryConfig(source, query);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(source, query);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        final QueryConfig that = (QueryConfig) other;
+
+        return Objects.equals(this.source, that.source) && Objects.equals(this.query, that.query);
+    }
+
+    public boolean isValid() {
+        return this.query != null;
+    }
+}

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/AbstractSerializingDataFrameTestCase.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/AbstractSerializingDataFrameTestCase.java
@@ -6,14 +6,18 @@
 
 package org.elasticsearch.xpack.dataframe.transforms;
 
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.junit.Before;
+
+import java.util.List;
 
 import static java.util.Collections.emptyList;
 
@@ -21,9 +25,8 @@ public abstract class AbstractSerializingDataFrameTestCase<T extends ToXContent 
         extends AbstractSerializingTestCase<T> {
 
     /**
-     * Test case that ensure aggregation named objects are registered
+     * Test case that ensures aggregation named objects are registered
      */
-
     private NamedWriteableRegistry namedWriteableRegistry;
     private NamedXContentRegistry namedXContentRegistry;
 
@@ -31,8 +34,17 @@ public abstract class AbstractSerializingDataFrameTestCase<T extends ToXContent 
     public void registerAggregationNamedObjects() throws Exception {
         // register aggregations as NamedWriteable
         SearchModule searchModule = new SearchModule(Settings.EMPTY, false, emptyList());
-        namedWriteableRegistry = new NamedWriteableRegistry(searchModule.getNamedWriteables());
-        namedXContentRegistry = new NamedXContentRegistry(searchModule.getNamedXContents());
+
+        List<NamedWriteableRegistry.Entry> namedWriteables = searchModule.getNamedWriteables();
+        namedWriteables.add(new NamedWriteableRegistry.Entry(QueryBuilder.class, MockDeprecatedQueryBuilder.NAME,
+                MockDeprecatedQueryBuilder::new));
+
+        List<NamedXContentRegistry.Entry> namedXContents = searchModule.getNamedXContents();
+        namedXContents.add(new NamedXContentRegistry.Entry(QueryBuilder.class,
+                new ParseField(MockDeprecatedQueryBuilder.NAME), (p, c) -> MockDeprecatedQueryBuilder.fromXContent(p)));
+
+        namedWriteableRegistry = new NamedWriteableRegistry(namedWriteables);
+        namedXContentRegistry = new NamedXContentRegistry(namedXContents);
     }
 
     @Override

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformConfigTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformConfigTests.java
@@ -19,7 +19,7 @@ public class DataFrameTransformConfigTests extends AbstractSerializingDataFrameT
 
     public static DataFrameTransformConfig randomDataFrameTransformConfig() {
         return new DataFrameTransformConfig(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10),
-                randomAlphaOfLengthBetween(1, 10), PivotConfigTests.randomPivotConfig());
+                randomAlphaOfLengthBetween(1, 10), QueryConfigTests.randomQueryConfig(), PivotConfigTests.randomPivotConfig());
     }
 
     @Before

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/MockDeprecatedQueryBuilder.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/MockDeprecatedQueryBuilder.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.dataframe.transforms;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+
+import java.io.IOException;
+
+/*
+ * Utility test class to write a deprecation message on usage
+ */
+class MockDeprecatedQueryBuilder extends AbstractQueryBuilder<MockDeprecatedQueryBuilder> {
+
+    public static final String NAME = "deprecated_match_all";
+    public static final String DEPRECATION_MESSAGE = "expected deprecation message from MockDeprecatedQueryBuilder";
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
+            LogManager.getLogger(MockDeprecatedQueryBuilder.class));
+
+    private static final ObjectParser<MockDeprecatedQueryBuilder, Void> PARSER = new ObjectParser<>(NAME, MockDeprecatedQueryBuilder::new);
+
+    static {
+        declareStandardFields(PARSER);
+    }
+
+    MockDeprecatedQueryBuilder() {
+    }
+
+    public MockDeprecatedQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    public static MockDeprecatedQueryBuilder fromXContent(XContentParser parser) {
+        try {
+            deprecationLogger.deprecatedAndMaybeLog("deprecated_mock", DEPRECATION_MESSAGE);
+
+            return PARSER.apply(parser, null);
+        } catch (IllegalArgumentException e) {
+            throw new ParsingException(parser.getTokenLocation(), e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        printBoostAndQueryName(builder);
+        builder.endObject();
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) throws IOException {
+        return Queries.newMatchAllQuery();
+    }
+
+    @Override
+    protected boolean doEquals(MockDeprecatedQueryBuilder other) {
+        return true;
+    }
+
+    @Override
+    protected int doHashCode() {
+        return 0;
+    }
+}

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/MockDeprecatedQueryBuilder.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/MockDeprecatedQueryBuilder.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 /*
  * Utility test class to write a deprecation message on usage
  */
-class MockDeprecatedQueryBuilder extends AbstractQueryBuilder<MockDeprecatedQueryBuilder> {
+public class MockDeprecatedQueryBuilder extends AbstractQueryBuilder<MockDeprecatedQueryBuilder> {
 
     public static final String NAME = "deprecated_match_all";
     public static final String DEPRECATION_MESSAGE = "expected deprecation message from MockDeprecatedQueryBuilder";
@@ -38,7 +38,7 @@ class MockDeprecatedQueryBuilder extends AbstractQueryBuilder<MockDeprecatedQuer
         declareStandardFields(PARSER);
     }
 
-    MockDeprecatedQueryBuilder() {
+    public MockDeprecatedQueryBuilder() {
     }
 
     public MockDeprecatedQueryBuilder(StreamInput in) throws IOException {

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/QueryConfigTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/QueryConfigTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.dataframe.transforms;
+
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.MatchNoneQueryBuilder;
+import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+
+public class QueryConfigTests extends AbstractSerializingDataFrameTestCase<QueryConfig> {
+
+    private boolean lenient;
+
+    public static QueryConfig randomQueryConfig() {
+
+        QueryBuilder queryBuilder = randomBoolean() ? new MatchAllQueryBuilder() : new MatchNoneQueryBuilder();
+        LinkedHashMap<String, Object> source = null;
+
+        try (XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()) {
+            XContentBuilder content = queryBuilder.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+            source = (LinkedHashMap<String, Object>) XContentHelper.convertToMap(BytesReference.bytes(content), true, XContentType.JSON)
+                    .v2();
+        } catch (IOException e) {
+            // should not happen
+            fail("failed to create random query config");
+        }
+
+        return new QueryConfig(source, queryBuilder);
+    }
+
+    public static QueryConfig randomInvalidQueryConfig() {
+        // create something broken but with a source
+        LinkedHashMap<String, Object> source = new LinkedHashMap<>();
+        for (String key : randomUnique(() -> randomAlphaOfLengthBetween(1, 20), randomIntBetween(1, 10))) {
+            source.put(key, randomAlphaOfLengthBetween(1, 20));
+        }
+
+        return new QueryConfig(source, null);
+    }
+
+    @Before
+    public void setRandomFeatures() {
+        lenient = randomBoolean();
+    }
+
+    @Override
+    protected QueryConfig doParseInstance(XContentParser parser) throws IOException {
+        return QueryConfig.fromXContent(parser, lenient);
+    }
+
+    @Override
+    protected QueryConfig createTestInstance() {
+        return lenient ? randomBoolean() ? randomQueryConfig() : randomInvalidQueryConfig() : randomQueryConfig();
+    }
+
+    @Override
+    protected Reader<QueryConfig> instanceReader() {
+        return QueryConfig::new;
+    }
+
+    public void testValidQueryParsing() throws IOException {
+        QueryBuilder query = new MatchQueryBuilder("key", "value");
+        String source = query.toString();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
+            QueryConfig queryConfig = QueryConfig.fromXContent(parser, true);
+            assertEquals(query, queryConfig.getQuery());
+            assertTrue(queryConfig.isValid());
+        }
+    }
+
+    public void testFailOnStrictPassOnLenient() throws IOException {
+        String source = "{\"query_element_does_not_exist\" : {}}";
+
+        // lenient, passes but reports invalid
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
+            QueryConfig query = QueryConfig.fromXContent(parser, true);
+            assertFalse(query.isValid());
+        }
+
+        // strict throws
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
+            expectThrows(ParsingException.class, () -> QueryConfig.fromXContent(parser, false));
+        }
+    }
+
+    public void testDeprecation() throws IOException {
+        String source = "{\"" + MockDeprecatedQueryBuilder.NAME + "\" : {}}";
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
+            QueryConfig query = QueryConfig.fromXContent(parser, false);
+            assertTrue(query.isValid());
+            assertWarnings(MockDeprecatedQueryBuilder.DEPRECATION_MESSAGE);
+        }
+    }
+}


### PR DESCRIPTION
adds query support to data frame transforms

Notes:

- queries builders add default parameters to the query, visible when getting the config, therefore we store the surface format in the configuration while still executing parsers for validation
- I plan to implement similar validation for the pivot function in a follow up PR