### PR TITLE
Relax cluster metadata version check

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -119,20 +119,19 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
         assertThat(clusterStateResponse.getState().metaData().indices().size(), is(0));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/37820")
     public void testMetadataVersion() {
         createIndex("index-1");
         createIndex("index-2");
-        long metadataVersion = client().admin().cluster().prepareState().get().getState().metaData().version();
-        assertThat(metadataVersion, greaterThan(0L));
+        long baselineVersion = client().admin().cluster().prepareState().get().getState().metaData().version();
+        assertThat(baselineVersion, greaterThan(0L));
         assertThat(client().admin().cluster().prepareState().setIndices("index-1").get().getState().metaData().version(),
-            equalTo(metadataVersion));
+            greaterThanOrEqualTo(baselineVersion));
         assertThat(client().admin().cluster().prepareState().setIndices("index-2").get().getState().metaData().version(),
-            equalTo(metadataVersion));
+            greaterThanOrEqualTo(baselineVersion));
         assertThat(client().admin().cluster().prepareState().setIndices("*").get().getState().metaData().version(),
-            equalTo(metadataVersion));
+            greaterThanOrEqualTo(baselineVersion));
         assertThat(client().admin().cluster().prepareState().setIndices("not-found").get().getState().metaData().version(),
-            equalTo(metadataVersion));
+            greaterThanOrEqualTo(baselineVersion));
         assertThat(client().admin().cluster().prepareState().clear().setMetaData(false).get().getState().metaData().version(),
             equalTo(0L));
     }


### PR DESCRIPTION
If the `in_sync_allocations` of `index-1` or `index-2` is changed,
the metadata version will be increased. This leads to the failure in
the metadata version checks. We need to relax them.

Relates #37674
Closes #37820