### PR TITLE
Update the deprecation message for typed put mapping requests.

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
@@ -41,8 +41,9 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestPutMappingAction extends BaseRestHandler {
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
         LogManager.getLogger(RestPutMappingAction.class));
-    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Using include_type_name in put " +
-        "mapping requests is deprecated. The parameter will be removed in the next major version.";
+    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in put mapping " +
+        "requests is deprecated. The parameter include_type_name should be provided and set to false to be " +
+        "compatible with the next major version.";
 
     public RestPutMappingAction(Settings settings, RestController controller) {
         super(settings);


### PR DESCRIPTION
The message was originally intended for 7.0, and needs to be updated
to make sense for 6.7.