### PR TITLE
Correct deprec log in RestGetFieldMappingAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
@@ -40,7 +40,7 @@ import java.util.Map;
 
 public class RestCreateIndexAction extends BaseRestHandler {
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
-        LogManager.getLogger(RestPutMappingAction.class));
+        LogManager.getLogger(RestCreateIndexAction.class));
     public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Using include_type_name in create " +
         "index requests is deprecated. The parameter will be removed in the next major version.";
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetFieldMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetFieldMappingAction.java
@@ -47,7 +47,7 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class RestGetFieldMappingAction extends BaseRestHandler {
 
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
-        LogManager.getLogger(RestPutMappingAction.class));
+        LogManager.getLogger(RestGetFieldMappingAction.class));
     public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Using include_type_name in get " +
         "field mapping requests is deprecated. The parameter will be removed in the next major version.";
 


### PR DESCRIPTION
Correct a class used for deprecation logging in
RestGetFieldMappingAction

Relates to #37667