### PR TITLE
TransportUnfollowAction should increase settings version

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowAction.java
@@ -105,18 +105,19 @@ public class TransportUnfollowAction extends TransportMasterNodeAction<UnfollowA
             }
         }
 
-        IndexMetaData.Builder newIMD = IndexMetaData.builder(followerIMD);
         // Remove index.xpack.ccr.following_index setting
         Settings.Builder builder = Settings.builder();
         builder.put(followerIMD.getSettings());
         builder.remove(CcrSettings.CCR_FOLLOWING_INDEX_SETTING.getKey());
 
-        newIMD.settings(builder);
+        final IndexMetaData.Builder newIndexMetaData = IndexMetaData.builder(followerIMD);
+        newIndexMetaData.settings(builder);
+        newIndexMetaData.settingsVersion(followerIMD.getSettingsVersion() + 1);
         // Remove ccr custom metadata
-        newIMD.removeCustom(Ccr.CCR_CUSTOM_METADATA_KEY);
+        newIndexMetaData.removeCustom(Ccr.CCR_CUSTOM_METADATA_KEY);
 
         MetaData newMetaData = MetaData.builder(current.metaData())
-            .put(newIMD)
+            .put(newIndexMetaData)
             .build();
         return ClusterState.builder(current)
             .metaData(newMetaData)

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowActionTests.java
@@ -49,7 +49,7 @@ public class TransportUnfollowActionTests extends ESTestCase {
         IndexMetaData resultIMD = result.metaData().index("follow_index");
         assertThat(resultIMD.getSettings().get(CcrSettings.CCR_FOLLOWING_INDEX_SETTING.getKey()), nullValue());
         assertThat(resultIMD.getCustomData(Ccr.CCR_CUSTOM_METADATA_KEY), nullValue());
-        assertThat(resultIMD.getSettingsVersion(), equalTo(settingsVersion+ 1));
+        assertThat(resultIMD.getSettingsVersion(), equalTo(settingsVersion + 1));
     }
 
     public void testUnfollowIndexOpen() {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowActionTests.java
@@ -30,8 +30,10 @@ import static org.hamcrest.Matchers.nullValue;
 public class TransportUnfollowActionTests extends ESTestCase {
 
     public void testUnfollow() {
+        final long settingsVersion = randomNonNegativeLong();
         IndexMetaData.Builder followerIndex = IndexMetaData.builder("follow_index")
             .settings(settings(Version.CURRENT).put(CcrSettings.CCR_FOLLOWING_INDEX_SETTING.getKey(), true))
+            .settingsVersion(settingsVersion)
             .numberOfShards(1)
             .numberOfReplicas(0)
             .state(IndexMetaData.State.CLOSE)
@@ -47,6 +49,7 @@ public class TransportUnfollowActionTests extends ESTestCase {
         IndexMetaData resultIMD = result.metaData().index("follow_index");
         assertThat(resultIMD.getSettings().get(CcrSettings.CCR_FOLLOWING_INDEX_SETTING.getKey()), nullValue());
         assertThat(resultIMD.getCustomData(Ccr.CCR_CUSTOM_METADATA_KEY), nullValue());
+        assertThat(resultIMD.getSettingsVersion(), equalTo(settingsVersion+ 1));
     }
 
     public void testUnfollowIndexOpen() {


### PR DESCRIPTION
The `TransportUnfollowAction` updates the index settings but does not increase the settings version to reflect that change.

This issue has been caught while working on the replication of closed indices (#33888). The `IndexFollowingIT.testUnfollowIndex()` started to fail and [this specific assertion](https://github.com/elastic/elasticsearch/blob/43bfdd32eea161a9084d7b49b12261ea32a7983c/server/src/main/java/org/elasticsearch/index/IndexService.java#L643) tripped. It does not happen on `master` branch today because index metadata for closed indices are never updated in `IndexService` instances, but this is something that is going to change with the replication of closed indices.