### PR TITLE
Make numbers comparable in yml tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/GreaterThanAssertion.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/GreaterThanAssertion.java
@@ -61,6 +61,14 @@ public class GreaterThanAssertion extends Assertion {
         assertThat("expected value of [" + getField() + "] is not comparable (got [" + expectedValue.getClass() + "])",
                 expectedValue, instanceOf(Comparable.class));
         try {
+            // make numbers comparable with each other: Float 1.0 can be compared to Double 1.0
+            if (actualValue.getClass().equals(safeClass(expectedValue)) == false) {
+                if (actualValue instanceof Number && expectedValue instanceof Number) {
+                    assertThat(errorMessage(), (Comparable) ((Number) actualValue).doubleValue(),
+                        greaterThan((Comparable) ((Number) expectedValue).doubleValue()));
+                    return;
+                }
+            }
             assertThat(errorMessage(), (Comparable) actualValue, greaterThan((Comparable) expectedValue));
         } catch (ClassCastException e) {
             fail("cast error while checking (" + errorMessage() + "): " + e);

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/GreaterThanEqualToAssertion.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/GreaterThanEqualToAssertion.java
@@ -62,6 +62,14 @@ public class GreaterThanEqualToAssertion extends Assertion {
         assertThat("expected value of [" + getField() + "] is not comparable (got [" + expectedValue.getClass() + "])",
                 expectedValue, instanceOf(Comparable.class));
         try {
+            // make numbers comparable with each other: Float 1.0 can be compared to Double 1.0
+            if (actualValue.getClass().equals(safeClass(expectedValue)) == false) {
+                if (actualValue instanceof Number && expectedValue instanceof Number) {
+                    assertThat(errorMessage(), (Comparable) ((Number) actualValue).doubleValue(),
+                        greaterThanOrEqualTo((Comparable) ((Number) expectedValue).doubleValue()));
+                    return;
+                 }
+            }
             assertThat(errorMessage(), (Comparable) actualValue, greaterThanOrEqualTo((Comparable) expectedValue));
         } catch (ClassCastException e) {
             fail("cast error while checking (" + errorMessage() + "): " + e);

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/LessThanAssertion.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/LessThanAssertion.java
@@ -62,6 +62,14 @@ public class LessThanAssertion extends Assertion {
         assertThat("expected value of [" + getField() + "] is not comparable (got [" + expectedValue.getClass() + "])",
                 expectedValue, instanceOf(Comparable.class));
         try {
+            // make numbers comparable with each other: Float 1.0 can be compared to Double 1.0
+            if (actualValue.getClass().equals(safeClass(expectedValue)) == false) {
+                if (actualValue instanceof Number && expectedValue instanceof Number) {
+                    assertThat(errorMessage(), (Comparable) ((Number) actualValue).doubleValue(),
+                        lessThan((Comparable) ((Number) expectedValue).doubleValue()));
+                    return;
+                }
+            }
             assertThat(errorMessage(), (Comparable) actualValue, lessThan((Comparable) expectedValue));
         } catch (ClassCastException e) {
             fail("cast error while checking (" + errorMessage() + "): " + e);

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/LessThanOrEqualToAssertion.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/LessThanOrEqualToAssertion.java
@@ -62,6 +62,14 @@ public class LessThanOrEqualToAssertion  extends Assertion {
         assertThat("expected value of [" + getField() + "] is not comparable (got [" + expectedValue.getClass() + "])",
                 expectedValue, instanceOf(Comparable.class));
         try {
+            // make numbers comparable with each other: Float 1.0 can be compared to Double 1.0
+            if (actualValue.getClass().equals(safeClass(expectedValue)) == false) {
+                if (actualValue instanceof Number && expectedValue instanceof Number) {
+                    assertThat(errorMessage(), (Comparable) ((Number) actualValue).doubleValue(),
+                        lessThanOrEqualTo((Comparable) ((Number) expectedValue).doubleValue()));
+                    return;
+                }
+            }
             assertThat(errorMessage(), (Comparable) actualValue, lessThanOrEqualTo((Comparable) expectedValue));
         } catch (ClassCastException e) {
             fail("cast error while checking (" + errorMessage() + "): " + e);

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/AssertionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/AssertionTests.java
@@ -19,12 +19,6 @@
 package org.elasticsearch.test.rest.yaml.section;
 
 import org.elasticsearch.common.xcontent.yaml.YamlXContent;
-import org.elasticsearch.test.rest.yaml.section.GreaterThanAssertion;
-import org.elasticsearch.test.rest.yaml.section.IsFalseAssertion;
-import org.elasticsearch.test.rest.yaml.section.IsTrueAssertion;
-import org.elasticsearch.test.rest.yaml.section.LengthAssertion;
-import org.elasticsearch.test.rest.yaml.section.LessThanAssertion;
-import org.elasticsearch.test.rest.yaml.section.MatchAssertion;
 
 import java.util.List;
 import java.util.Map;
@@ -66,6 +60,8 @@ public class AssertionTests extends AbstractClientYamlTestFragmentParserTestCase
         assertThat(greaterThanAssertion.getField(), equalTo("field"));
         assertThat(greaterThanAssertion.getExpectedValue(), instanceOf(Integer.class));
         assertThat((Integer) greaterThanAssertion.getExpectedValue(), equalTo(3));
+        greaterThanAssertion.doAssert(3.1, greaterThanAssertion.getExpectedValue());
+        greaterThanAssertion.doAssert(4, greaterThanAssertion.getExpectedValue());
     }
 
     public void testParseLessThan() throws Exception {
@@ -78,6 +74,8 @@ public class AssertionTests extends AbstractClientYamlTestFragmentParserTestCase
         assertThat(lessThanAssertion.getField(), equalTo("field"));
         assertThat(lessThanAssertion.getExpectedValue(), instanceOf(Integer.class));
         assertThat((Integer) lessThanAssertion.getExpectedValue(), equalTo(3));
+        lessThanAssertion.doAssert(2.9, lessThanAssertion.getExpectedValue());
+        lessThanAssertion.doAssert(2, lessThanAssertion.getExpectedValue());
     }
 
     public void testParseLength() throws Exception {


### PR DESCRIPTION
Currently gt, gte, lt, lte assertions in yml tests fail
if compared numbers are of different types
(e.g floats are not comparable with doubles).
This is the problem for writing yml tests as it is not predictable
how numbers will be parsed by a parser.
For example,  1.0 can be parsed as float or a double.
And depending how it is parsed, the  test 
`- lte: {hits.hits.1._score: 1.0}`
may fail or succeed.

This PR makes gt, gte, lt, lte  assertions similar to `MatchAssertion`,
in allowing to compare numbers of different types.
