### PR TITLE
Fix duplicate note x-refs in mapping.asciidoc

### DIFF
--- a/docs/reference/mapping.asciidoc
+++ b/docs/reference/mapping.asciidoc
@@ -133,7 +133,7 @@ an <<alias, `alias`>> field.
 [float]
 == Example mapping
 
-A mapping could be specified when creating an index, as follows:
+A mapping can be specified when creating an index, as follows:
 
 [source,js]
 ---------------------------------------
@@ -142,10 +142,10 @@ PUT my_index <1>
   "mappings": {
     "properties": { <2>
       "title":    { "type": "text"  }, <3>
-      "name":     { "type": "text"  }, <3>
-      "age":      { "type": "integer" },  <3>
+      "name":     { "type": "text"  }, <4>
+      "age":      { "type": "integer" },  <5>
       "created":  {
-        "type":   "date", <3>
+        "type":   "date", <6>
         "format": "strict_date_optional_time||epoch_millis"
       }
     }
@@ -154,9 +154,11 @@ PUT my_index <1>
 ---------------------------------------
 // CONSOLE
 <1> Create an index called `my_index`.
-<2> Specify fields or _properties_.
-<3> Specify the data `type` and mapping for each field.
-
+<2> Specify the fields or _properties_ in the mapping.
+<3> Specify that the `title` field contains `text` values.
+<4> Specify that the `name` field contains `text` values.
+<5> Specify that the `age` field contains `integer` values.
+<6> Specify that the `created` field contains `date` values in two possible formats.
 
 --
 


### PR DESCRIPTION
The docs silently accept duplicate note markers (such as `<3>` here) but
formats them in an unexpected way. This change removes this duplication so that
the rendered documentation looks as intended.