### PR TITLE
Add an alias for :server:integTest so it runs as part of internalClusterTest

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -338,4 +338,8 @@ if (isEclipse == false || project.path == ":server-tests") {
   }
   check.dependsOn integTest
   integTest.mustRunAfter test
+  task internalClusterTest {
+     dependsOn integTest    
+  }
 }
+


### PR DESCRIPTION
This change makes `:server:integTest` run with `./gradlew internalClusterTest`.
There's a new CI job that runs this.