### PR TITLE
Fix Failing Assertion in SnapshotsInProgress

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/core/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -240,8 +240,11 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         public ShardSnapshotStatus(String nodeId, State state, String reason) {
             this.nodeId = nodeId;
             this.state = state;
-            this.reason = reason;
             // If the state is failed we have to have a reason for this failure
+            if (state.failed() && reason == null) {
+                reason = "failed";
+            }
+            this.reason = reason;
             assert state.failed() == false || reason != null;
         }
 

--- a/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -2706,7 +2706,6 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertThat(createSnapshotResponse.getSnapshotInfo().snapshotId().getName(), equalTo(snapshotName));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/31054")
     public void testGetSnapshotsRequest() throws Exception {
         final String repositoryName = "test-repo";
         final String indexName = "test-idx";


### PR DESCRIPTION
* Fix assertion by workaround for `5.6`
* Reenable test that tripped this assertion
* Closes #31054

-----------------------

Just cleaning up random snapshot stability related issues :)