### PR TITLE
Ensure date parsing BWC compatibility

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -108,9 +108,6 @@ public class DateFormatters {
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
         .optionalStart()
-        .appendFraction(NANO_OF_SECOND, 3, 3, true)
-        .optionalEnd()
-        .optionalStart()
         .appendFraction(NANO_OF_SECOND, 3, 9, true)
         .optionalEnd()
         .optionalEnd()
@@ -205,7 +202,7 @@ public class DateFormatters {
         .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
-        .appendFraction(NANO_OF_SECOND, 1, 3, true)
+        .appendFraction(NANO_OF_SECOND, 1, 9, true)
         .toFormatter(Locale.ROOT);
 
     private static final DateTimeFormatter BASIC_TIME_PRINTER = new DateTimeFormatterBuilder()
@@ -311,7 +308,7 @@ public class DateFormatters {
     private static final DateFormatter BASIC_ORDINAL_DATE_TIME = new JavaDateFormatter("basic_ordinal_date_time",
         new DateTimeFormatterBuilder().appendPattern("yyyyDDD").append(BASIC_T_TIME_PRINTER)
             .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().appendPattern("yyyyDDD").append(BASIC_T_TIME_PRINTER)
+        new DateTimeFormatterBuilder().appendPattern("yyyyDDD").append(BASIC_T_TIME_FORMATTER)
             .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
         new DateTimeFormatterBuilder().appendPattern("yyyyDDD").append(BASIC_T_TIME_FORMATTER)
             .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
@@ -419,7 +416,7 @@ public class DateFormatters {
             .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
             .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
             .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
-            .appendFraction(NANO_OF_SECOND, 3, 3, true)
+            .appendFraction(NANO_OF_SECOND, 3, 9, true)
             .appendZoneOrOffsetId()
             .toFormatter(Locale.ROOT),
         new DateTimeFormatterBuilder()
@@ -428,7 +425,7 @@ public class DateFormatters {
             .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
             .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
             .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
-            .appendFraction(NANO_OF_SECOND, 3, 3, true)
+            .appendFraction(NANO_OF_SECOND, 3, 9, true)
             .append(TIME_ZONE_FORMATTER_NO_COLON)
             .toFormatter(Locale.ROOT)
     );
@@ -485,7 +482,7 @@ public class DateFormatters {
         .appendLiteral('T')
         .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
         .optionalStart()
-        .appendFraction(NANO_OF_SECOND, 3, 3, true)
+        .appendFraction(NANO_OF_SECOND, 3, 9, true)
         .optionalEnd()
         .toFormatter(Locale.ROOT);
 
@@ -542,7 +539,7 @@ public class DateFormatters {
     // NOTE: this is not a strict formatter to retain the joda time based behaviour, even though it's named like this
     private static final DateTimeFormatter STRICT_HOUR_MINUTE_SECOND_MILLIS_FORMATTER = new DateTimeFormatterBuilder()
         .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
-        .appendFraction(NANO_OF_SECOND, 1, 3, true)
+        .appendFraction(NANO_OF_SECOND, 1, 9, true)
         .toFormatter(Locale.ROOT);
 
     private static final DateTimeFormatter STRICT_HOUR_MINUTE_SECOND_MILLIS_PRINTER = new DateTimeFormatterBuilder()
@@ -582,8 +579,8 @@ public class DateFormatters {
             .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
             .appendLiteral("T")
             .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
-            //  this one here is lenient as well to retain joda time based bwc compatibility
-            .appendFraction(NANO_OF_SECOND, 1, 3, true)
+            // this one here is lenient as well to retain joda time based bwc compatibility
+            .appendFraction(NANO_OF_SECOND, 1, 9, true)
             .toFormatter(Locale.ROOT)
     );
 
@@ -599,7 +596,7 @@ public class DateFormatters {
             .appendLiteral("T")
             .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
             //  this one here is lenient as well to retain joda time based bwc compatibility
-            .appendFraction(NANO_OF_SECOND, 1, 3, true)
+            .appendFraction(NANO_OF_SECOND, 1, 9, true)
             .toFormatter(Locale.ROOT)
     );
 
@@ -625,7 +622,7 @@ public class DateFormatters {
         .optionalStart()
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
-        .appendFraction(NANO_OF_SECOND, 3, 3, true)
+        .appendFraction(NANO_OF_SECOND, 3, 9, true)
         .optionalEnd()
         .toFormatter(Locale.ROOT);
 
@@ -649,7 +646,7 @@ public class DateFormatters {
         .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
-        .appendFraction(NANO_OF_SECOND, 1, 3, true)
+        .appendFraction(NANO_OF_SECOND, 1, 9, true)
         .toFormatter(Locale.ROOT);
 
     private static final DateTimeFormatter STRICT_TIME_PRINTER = new DateTimeFormatterBuilder()
@@ -880,7 +877,7 @@ public class DateFormatters {
             .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
             .optionalEnd()
             .optionalStart()
-            .appendFraction(NANO_OF_SECOND, 1, 3, true)
+            .appendFraction(NANO_OF_SECOND, 1, 9, true)
             .optionalEnd()
             .optionalStart().appendZoneOrOffsetId().optionalEnd()
             .optionalStart().appendOffset("+HHmm", "Z").optionalEnd()
@@ -902,6 +899,15 @@ public class DateFormatters {
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
         .appendFraction(NANO_OF_SECOND, 1, 3, true)
+        .toFormatter(Locale.ROOT);
+
+    private static final DateTimeFormatter HOUR_MINUTE_SECOND_FRACTION_FORMATTER = new DateTimeFormatterBuilder()
+        .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+        .appendFraction(NANO_OF_SECOND, 1, 9, true)
         .toFormatter(Locale.ROOT);
 
     private static final DateTimeFormatter ORDINAL_DATE_FORMATTER = new DateTimeFormatterBuilder()
@@ -936,7 +942,7 @@ public class DateFormatters {
 
     private static final DateTimeFormatter TIME_PREFIX = new DateTimeFormatterBuilder()
         .append(TIME_NO_MILLIS_FORMATTER)
-        .appendFraction(NANO_OF_SECOND, 1, 3, true)
+        .appendFraction(NANO_OF_SECOND, 1, 9, true)
         .toFormatter(Locale.ROOT);
 
     private static final DateTimeFormatter WEEK_DATE_FORMATTER = new DateTimeFormatterBuilder()
@@ -974,8 +980,7 @@ public class DateFormatters {
     /*
      * Returns a formatter that combines a full date, two digit hour of day,
      * two digit minute of hour, two digit second of minute, and three digit
-     * fraction of second (yyyy-MM-dd'T'HH:mm:ss.SSS). Parsing will parse up
-     * to 3 fractional second digits.
+     * fraction of second (yyyy-MM-dd'T'HH:mm:ss.SSS).
      */
     private static final DateFormatter DATE_HOUR_MINUTE_SECOND_MILLIS =
         new JavaDateFormatter("date_hour_minute_second_millis",
@@ -990,7 +995,8 @@ public class DateFormatters {
                 .append(HOUR_MINUTE_SECOND_MILLIS_FORMATTER)
                 .toFormatter(Locale.ROOT));
 
-    private static final DateFormatter DATE_HOUR_MINUTE_SECOND_FRACTION = new JavaDateFormatter("date_hour_minute_second_fraction",
+    private static final DateFormatter DATE_HOUR_MINUTE_SECOND_FRACTION =
+        new JavaDateFormatter("date_hour_minute_second_fraction",
             new DateTimeFormatterBuilder()
                 .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
                 .appendLiteral("T")
@@ -999,7 +1005,7 @@ public class DateFormatters {
             new DateTimeFormatterBuilder()
                 .append(DATE_FORMATTER)
                 .appendLiteral("T")
-                .append(HOUR_MINUTE_SECOND_MILLIS_FORMATTER)
+                .append(HOUR_MINUTE_SECOND_FRACTION_FORMATTER)
                 .toFormatter(Locale.ROOT));
 
     /*
@@ -1034,7 +1040,7 @@ public class DateFormatters {
         .optionalStart()
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
-        .appendFraction(NANO_OF_SECOND, 1, 3, true)
+        .appendFraction(NANO_OF_SECOND, 1, 9, true)
         .optionalEnd()
         .toFormatter(Locale.ROOT);
 
@@ -1106,7 +1112,7 @@ public class DateFormatters {
         STRICT_HOUR_MINUTE_SECOND_MILLIS_PRINTER, HOUR_MINUTE_SECOND_MILLIS_FORMATTER);
 
     private static final DateFormatter HOUR_MINUTE_SECOND_FRACTION = new JavaDateFormatter("hour_minute_second_fraction",
-        STRICT_HOUR_MINUTE_SECOND_MILLIS_PRINTER, HOUR_MINUTE_SECOND_MILLIS_FORMATTER);
+        STRICT_HOUR_MINUTE_SECOND_MILLIS_PRINTER, HOUR_MINUTE_SECOND_FRACTION_FORMATTER);
 
     /*
      * Returns a formatter for a two digit hour of day and two digit minute of
@@ -1142,7 +1148,7 @@ public class DateFormatters {
         .optionalStart()
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
-        .appendFraction(NANO_OF_SECOND, 1, 3, true)
+        .appendFraction(NANO_OF_SECOND, 1, 9, true)
         .optionalEnd()
         .toFormatter(Locale.ROOT);
 

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -97,18 +97,21 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("20181126T121212+0100", "basic_date_time_no_millis");
         assertSameDate("2018363", "basic_ordinal_date");
         assertSameDate("2018363T121212.123Z", "basic_ordinal_date_time");
+        assertSameDate("2018363T121212.123456789Z", "basic_ordinal_date_time");
         assertSameDate("2018363T121212.123+0100", "basic_ordinal_date_time");
         assertSameDate("2018363T121212.123+01:00", "basic_ordinal_date_time");
         assertSameDate("2018363T121212Z", "basic_ordinal_date_time_no_millis");
         assertSameDate("2018363T121212+0100", "basic_ordinal_date_time_no_millis");
         assertSameDate("2018363T121212+01:00", "basic_ordinal_date_time_no_millis");
         assertSameDate("121212.123Z", "basic_time");
+        assertSameDate("121212.123456789Z", "basic_time");
         assertSameDate("121212.123+0100", "basic_time");
         assertSameDate("121212.123+01:00", "basic_time");
         assertSameDate("121212Z", "basic_time_no_millis");
         assertSameDate("121212+0100", "basic_time_no_millis");
         assertSameDate("121212+01:00", "basic_time_no_millis");
         assertSameDate("T121212.123Z", "basic_t_time");
+        assertSameDate("T121212.123456789Z", "basic_t_time");
         assertSameDate("T121212.123+0100", "basic_t_time");
         assertSameDate("T121212.123+01:00", "basic_t_time");
         assertSameDate("T121212Z", "basic_t_time_no_millis");
@@ -118,6 +121,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("1W313", "basic_week_date");
         assertSameDate("18W313", "basic_week_date");
         assertSameDate("2018W313T121212.123Z", "basic_week_date_time");
+        assertSameDate("2018W313T121212.123456789Z", "basic_week_date_time");
         assertSameDate("2018W313T121212.123+0100", "basic_week_date_time");
         assertSameDate("2018W313T121212.123+01:00", "basic_week_date_time");
         assertSameDate("2018W313T121212Z", "basic_week_date_time_no_millis");
@@ -138,7 +142,9 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2018-12-31T12:12:1", "date_hour_minute_second");
 
         assertSameDate("2018-12-31T12:12:12.123", "date_hour_minute_second_fraction");
+        assertSameDate("2018-12-31T12:12:12.123456789", "date_hour_minute_second_fraction");
         assertSameDate("2018-12-31T12:12:12.123", "date_hour_minute_second_millis");
+        assertParseException("2018-12-31T12:12:12.123456789", "date_hour_minute_second_millis");
         assertSameDate("2018-12-31T12:12:12.1", "date_hour_minute_second_millis");
         assertSameDate("2018-12-31T12:12:12.1", "date_hour_minute_second_fraction");
 
@@ -148,7 +154,9 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2018-05-30T20:21", "date_optional_time");
         assertSameDate("2018-05-30T20:21:23", "date_optional_time");
         assertSameDate("2018-05-30T20:21:23.123", "date_optional_time");
+        assertSameDate("2018-05-30T20:21:23.123456789", "date_optional_time");
         assertSameDate("2018-05-30T20:21:23.123Z", "date_optional_time");
+        assertSameDate("2018-05-30T20:21:23.123456789Z", "date_optional_time");
         assertSameDate("2018-05-30T20:21:23.123+0100", "date_optional_time");
         assertSameDate("2018-05-30T20:21:23.123+01:00", "date_optional_time");
         assertSameDate("2018-12-1", "date_optional_time");
@@ -158,12 +166,14 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2018-12-31T1:15:30", "date_optional_time");
 
         assertSameDate("2018-12-31T10:15:30.123Z", "date_time");
+        assertSameDate("2018-12-31T10:15:30.123456789Z", "date_time");
         assertSameDate("2018-12-31T10:15:30.123+0100", "date_time");
         assertSameDate("2018-12-31T10:15:30.123+01:00", "date_time");
         assertSameDate("2018-12-31T10:15:30.11Z", "date_time");
         assertSameDate("2018-12-31T10:15:30.11+0100", "date_time");
         assertSameDate("2018-12-31T10:15:30.11+01:00", "date_time");
         assertSameDate("2018-12-31T10:15:3.123Z", "date_time");
+        assertSameDate("2018-12-31T10:15:3.123456789Z", "date_time");
         assertSameDate("2018-12-31T10:15:3.123+0100", "date_time");
         assertSameDate("2018-12-31T10:15:3.123+01:00", "date_time");
 
@@ -193,9 +203,11 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("12:12:1", "hour_minute_second");
 
         assertSameDate("12:12:12.123", "hour_minute_second_fraction");
+        assertSameDate("12:12:12.123456789", "hour_minute_second_fraction");
         assertSameDate("12:12:12.1", "hour_minute_second_fraction");
         assertParseException("12:12:12", "hour_minute_second_fraction");
         assertSameDate("12:12:12.123", "hour_minute_second_millis");
+        assertParseException("12:12:12.123456789", "hour_minute_second_millis");
         assertSameDate("12:12:12.1", "hour_minute_second_millis");
         assertParseException("12:12:12", "hour_minute_second_millis");
 
@@ -203,9 +215,11 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2018-1", "ordinal_date");
 
         assertSameDate("2018-128T10:15:30.123Z", "ordinal_date_time");
+        assertSameDate("2018-128T10:15:30.123456789Z", "ordinal_date_time");
         assertSameDate("2018-128T10:15:30.123+0100", "ordinal_date_time");
         assertSameDate("2018-128T10:15:30.123+01:00", "ordinal_date_time");
         assertSameDate("2018-1T10:15:30.123Z", "ordinal_date_time");
+        assertSameDate("2018-1T10:15:30.123456789Z", "ordinal_date_time");
         assertSameDate("2018-1T10:15:30.123+0100", "ordinal_date_time");
         assertSameDate("2018-1T10:15:30.123+01:00", "ordinal_date_time");
 
@@ -217,6 +231,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2018-1T10:15:30+01:00", "ordinal_date_time_no_millis");
 
         assertSameDate("10:15:30.123Z", "time");
+        assertSameDate("10:15:30.123456789Z", "time");
         assertSameDate("10:15:30.123+0100", "time");
         assertSameDate("10:15:30.123+01:00", "time");
         assertSameDate("1:15:30.123Z", "time");
@@ -249,6 +264,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertParseException("10:15:3", "time_no_millis");
 
         assertSameDate("T10:15:30.123Z", "t_time");
+        assertSameDate("T10:15:30.123456789Z", "t_time");
         assertSameDate("T10:15:30.123+0100", "t_time");
         assertSameDate("T10:15:30.123+01:00", "t_time");
         assertSameDate("T1:15:30.123Z", "t_time");
@@ -286,6 +302,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertJavaTimeParseException("2012-W1-8", "week_date");
 
         assertSameDate("2012-W48-6T10:15:30.123Z", "week_date_time");
+        assertSameDate("2012-W48-6T10:15:30.123456789Z", "week_date_time");
         assertSameDate("2012-W48-6T10:15:30.123+0100", "week_date_time");
         assertSameDate("2012-W48-6T10:15:30.123+01:00", "week_date_time");
         assertSameDate("2012-W1-6T10:15:30.123Z", "week_date_time");
@@ -326,9 +343,11 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2018W313", "strict_basic_week_date");
         assertParseException("18W313", "strict_basic_week_date");
         assertSameDate("2018W313T121212.123Z", "strict_basic_week_date_time");
+        assertSameDate("2018W313T121212.123456789Z", "strict_basic_week_date_time");
         assertSameDate("2018W313T121212.123+0100", "strict_basic_week_date_time");
         assertSameDate("2018W313T121212.123+01:00", "strict_basic_week_date_time");
         assertParseException("2018W313T12128.123Z", "strict_basic_week_date_time");
+        assertParseException("2018W313T12128.123456789Z", "strict_basic_week_date_time");
         assertParseException("2018W313T81212.123Z", "strict_basic_week_date_time");
         assertParseException("2018W313T12812.123Z", "strict_basic_week_date_time");
         assertParseException("2018W313T12812.1Z", "strict_basic_week_date_time");
@@ -354,6 +373,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2018-12-31T12:12:12", "strict_date_hour_minute_second");
         assertParseException("2018-12-31T12:12:1", "strict_date_hour_minute_second");
         assertSameDate("2018-12-31T12:12:12.123", "strict_date_hour_minute_second_fraction");
+        assertSameDate("2018-12-31T12:12:12.123456789", "strict_date_hour_minute_second_fraction");
         assertSameDate("2018-12-31T12:12:12.123", "strict_date_hour_minute_second_millis");
         assertSameDate("2018-12-31T12:12:12.1", "strict_date_hour_minute_second_millis");
         assertSameDate("2018-12-31T12:12:12.1", "strict_date_hour_minute_second_fraction");
@@ -373,6 +393,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertParseException("2018-12-31T9:15:30", "strict_date_optional_time");
         assertSameDate("2015-01-04T00:00Z", "strict_date_optional_time");
         assertSameDate("2018-12-31T10:15:30.123Z", "strict_date_time");
+        assertSameDate("2018-12-31T10:15:30.123456789Z", "strict_date_time");
         assertSameDate("2018-12-31T10:15:30.123+0100", "strict_date_time");
         assertSameDate("2018-12-31T10:15:30.123+01:00", "strict_date_time");
         assertSameDate("2018-12-31T10:15:30.11Z", "strict_date_time");
@@ -397,6 +418,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("12:12:01", "strict_hour_minute_second");
         assertParseException("12:12:1", "strict_hour_minute_second");
         assertSameDate("12:12:12.123", "strict_hour_minute_second_fraction");
+        assertSameDate("12:12:12.123456789", "strict_hour_minute_second_fraction");
         assertSameDate("12:12:12.1", "strict_hour_minute_second_fraction");
         assertParseException("12:12:12", "strict_hour_minute_second_fraction");
         assertSameDate("12:12:12.123", "strict_hour_minute_second_millis");
@@ -406,6 +428,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertParseException("2018-1", "strict_ordinal_date");
 
         assertSameDate("2018-128T10:15:30.123Z", "strict_ordinal_date_time");
+        assertSameDate("2018-128T10:15:30.123456789Z", "strict_ordinal_date_time");
         assertSameDate("2018-128T10:15:30.123+0100", "strict_ordinal_date_time");
         assertSameDate("2018-128T10:15:30.123+01:00", "strict_ordinal_date_time");
         assertParseException("2018-1T10:15:30.123Z", "strict_ordinal_date_time");
@@ -416,6 +439,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertParseException("2018-1T10:15:30Z", "strict_ordinal_date_time_no_millis");
 
         assertSameDate("10:15:30.123Z", "strict_time");
+        assertSameDate("10:15:30.123456789Z", "strict_time");
         assertSameDate("10:15:30.123+0100", "strict_time");
         assertSameDate("10:15:30.123+01:00", "strict_time");
         assertParseException("1:15:30.123Z", "strict_time");
@@ -436,6 +460,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertParseException("10:15:3", "strict_time_no_millis");
 
         assertSameDate("T10:15:30.123Z", "strict_t_time");
+        assertSameDate("T10:15:30.123456789Z", "strict_t_time");
         assertSameDate("T10:15:30.123+0100", "strict_t_time");
         assertSameDate("T10:15:30.123+01:00", "strict_t_time");
         assertParseException("T1:15:30.123Z", "strict_t_time");
@@ -466,6 +491,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertJavaTimeParseException("2012-W01-8", "strict_week_date");
 
         assertSameDate("2012-W48-6T10:15:30.123Z", "strict_week_date_time");
+        assertSameDate("2012-W48-6T10:15:30.123456789Z", "strict_week_date_time");
         assertSameDate("2012-W48-6T10:15:30.123+0100", "strict_week_date_time");
         assertSameDate("2012-W48-6T10:15:30.123+01:00", "strict_week_date_time");
         assertParseException("2012-W1-6T10:15:30.123Z", "strict_week_date_time");


### PR DESCRIPTION
In order to retain BWC this changes the java date formatters to be able to
parse nanoseconds resolution, even if only milliseconds are supported.
This used to work on joda time as well so that a user could store a date
like `2018-10-03T14:42:44.613469+0000` and then just loose the precision
on anything lower than millisecond level.

/cc @pgomulka @jsoriano 
