### PR TITLE
[ML] Audit all errors during job deletion

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
@@ -181,7 +181,10 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
         // The listener that will be executed at the end of the chain will notify all listeners
         ActionListener<AcknowledgedResponse> finalListener = ActionListener.wrap(
                 ack -> notifyListeners(request.getJobId(), ack, null),
-                e -> notifyListeners(request.getJobId(), null, e)
+                e -> {
+                    notifyListeners(request.getJobId(), null, e);
+                    auditor.error(request.getJobId(), Messages.getMessage(Messages.JOB_AUDIT_DELETING_FAILED, e.getMessage()));
+                }
         );
 
         ActionListener<Boolean> markAsDeletingListener = ActionListener.wrap(
@@ -192,10 +195,7 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
                         normalDeleteJob(parentTaskClient, request, finalListener);
                     }
                 },
-                e -> {
-                    auditor.error(request.getJobId(), Messages.getMessage(Messages.JOB_AUDIT_DELETING_FAILED, e.getMessage()));
-                    finalListener.onFailure(e);
-                });
+                finalListener::onFailure);
 
         ActionListener<Boolean> jobExistsListener = ActionListener.wrap(
             response -> {


### PR DESCRIPTION
This commit moves the auditing of job deletion related errors
to the final listener in the job delete action. This ensures
any error that occurs during job deletion is audited.
