### PR TITLE
SQL: Make error msg for validation of 2nd arg of PERCENTILE[_RANK] consistent

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Percentile.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Percentile.java
@@ -43,7 +43,7 @@ public class Percentile extends NumericAggregate implements EnclosedAgg {
     @Override
     protected TypeResolution resolveType() {
         if (!percent.foldable()) {
-            return new TypeResolution(format(null, "2nd argument of PERCENTILE must be a constant, received [{}]",
+            return new TypeResolution(format(null, "Second argument of PERCENTILE must be a constant, received [{}]",
                 Expressions.name(percent)));
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/PercentileRank.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/PercentileRank.java
@@ -43,7 +43,7 @@ public class PercentileRank extends AggregateFunction implements EnclosedAgg {
     @Override
     protected TypeResolution resolveType() {
         if (!value.foldable()) {
-            return new TypeResolution(format(null, "2nd argument of PERCENTILE_RANK must be a constant, received [{}]",
+            return new TypeResolution(format(null, "Second argument of PERCENTILE_RANK must be a constant, received [{}]",
                 Expressions.name(value)));
         }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -538,12 +538,12 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     }
 
     public void testErrorMessageForPercentileWithSecondArgBasedOnAField() {
-        assertEquals("1:8: 2nd argument of PERCENTILE must be a constant, received [ABS(int)]",
+        assertEquals("1:8: Second argument of PERCENTILE must be a constant, received [ABS(int)]",
             error("SELECT PERCENTILE(int, ABS(int)) FROM test"));
     }
 
     public void testErrorMessageForPercentileRankWithSecondArgBasedOnAField() {
-        assertEquals("1:8: 2nd argument of PERCENTILE_RANK must be a constant, received [ABS(int)]",
+        assertEquals("1:8: Second argument of PERCENTILE_RANK must be a constant, received [ABS(int)]",
             error("SELECT PERCENTILE_RANK(int, ABS(int)) FROM test"));
     }
 }


### PR DESCRIPTION
Use `first` and `second` instead of `1st` and `2nd`.
