### PR TITLE
Remove more references to type in docs.

### DIFF
--- a/docs/painless/painless-debugging.asciidoc
+++ b/docs/painless/painless-debugging.asciidoc
@@ -18,10 +18,10 @@ context available to a {ref}/query-dsl-script-query.html[script query].
 
 [source,js]
 ---------------------------------------------------------
-PUT /hockey/player/1?refresh
+PUT /hockey/_doc/1?refresh
 {"first":"johnny","last":"gaudreau","goals":[9,27,1],"assists":[17,46,0],"gp":[26,82,1]}
 
-POST /hockey/player/1/_explain
+POST /hockey/_explain/1
 {
   "query": {
     "script": {
@@ -31,7 +31,7 @@ POST /hockey/player/1/_explain
 }
 ---------------------------------------------------------
 // CONSOLE
-// TEST[s/_explain/_explain?error_trace=false/ catch:/painless_explain_error/]
+// TEST[s/_explain\/1/_explain\/1?error_trace=false/ catch:/painless_explain_error/]
 // The test system sends error_trace=true by default for easier debugging so
 // we have to override it to get a normal shaped response
 
@@ -58,13 +58,13 @@ in the `_update` API:
 
 [source,js]
 ---------------------------------------------------------
-POST /hockey/player/1/_update
+POST /hockey/_update/1
 {
   "script": "Debug.explain(ctx._source)"
 }
 ---------------------------------------------------------
 // CONSOLE
-// TEST[continued s/_update/_update?error_trace=false/ catch:/painless_explain_error/]
+// TEST[continued s/_update\/1/_update\/1?error_trace=false/ catch:/painless_explain_error/]
 
 The response looks like:
 

--- a/docs/painless/painless-getting-started.asciidoc
+++ b/docs/painless/painless-getting-started.asciidoc
@@ -10,7 +10,7 @@ To illustrate how Painless works, let's load some hockey stats into an Elasticse
 
 [source,js]
 ----------------------------------------------------------------
-PUT hockey/player/_bulk?refresh
+PUT hockey/_bulk?refresh
 {"index":{"_id":1}}
 {"first":"johnny","last":"gaudreau","goals":[9,27,1],"assists":[17,46,0],"gp":[26,82,1],"born":"1993/08/13"}
 {"index":{"_id":2}}
@@ -158,7 +158,7 @@ To change player 1's last name to `hockey`, simply set `ctx._source.last` to the
 
 [source,js]
 ----------------------------------------------------------------
-POST hockey/player/1/_update
+POST hockey/_update/1
 {
   "script": {
     "lang": "painless",
@@ -176,7 +176,7 @@ the player's nickname,  _hockey_.
 
 [source,js]
 ----------------------------------------------------------------
-POST hockey/player/1/_update
+POST hockey/_update/1
 {
   "script": {
     "lang": "painless",

--- a/docs/reference/aggregations/metrics/cardinality-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/cardinality-aggregation.asciidoc
@@ -49,7 +49,7 @@ POST /sales/_search?size=0
     "aggs" : {
         "type_count" : {
             "cardinality" : {
-                "field" : "_doc",
+                "field" : "type",
                 "precision_threshold": 100 <1>
             }
         }
@@ -214,7 +214,7 @@ POST /sales/_search?size=0
                 "script" : {
                     "id": "my_script",
                     "params": {
-                        "type_field": "_doc",
+                        "type_field": "type",
                         "promoted_field": "promoted"
                     }
                 }

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -32,7 +32,7 @@ Now, we can execute a script that would increment the counter:
 
 [source,js]
 --------------------------------------------------
-POST test/_doc/1/_update
+POST test/_update/1
 {
     "script" : {
         "source": "ctx._source.counter += params.count",
@@ -51,7 +51,7 @@ will still add it, since it's a list):
 
 [source,js]
 --------------------------------------------------
-POST test/_doc/1/_update
+POST test/_update/1
 {
     "script" : {
         "source": "ctx._source.tags.add(params.tag)",
@@ -73,7 +73,7 @@ remove only one occurrence of it:
 
 [source,js]
 --------------------------------------------------
-POST test/_doc/1/_update
+POST test/_update/1
 {
     "script" : {
         "source": "if (ctx._source.tags.contains(params.tag)) { ctx._source.tags.remove(ctx._source.tags.indexOf(params.tag)) }",
@@ -95,7 +95,7 @@ We can also add a new field to the document:
 
 [source,js]
 --------------------------------------------------
-POST test/_doc/1/_update
+POST test/_update/1
 {
     "script" : "ctx._source.new_field = 'value_of_new_field'"
 }
@@ -107,7 +107,7 @@ Or remove a field from the document:
 
 [source,js]
 --------------------------------------------------
-POST test/_doc/1/_update
+POST test/_update/1
 {
     "script" : "ctx._source.remove('new_field')"
 }
@@ -121,7 +121,7 @@ the doc if the `tags` field contain `green`, otherwise it does nothing
 
 [source,js]
 --------------------------------------------------
-POST test/_doc/1/_update
+POST test/_update/1
 {
     "script" : {
         "source": "if (ctx._source.tags.contains(params.tag)) { ctx.op = 'delete' } else { ctx.op = 'none' }",
@@ -148,7 +148,7 @@ existing document:
 
 [source,js]
 --------------------------------------------------
-POST test/_doc/1/_update
+POST test/_update/1
 {
     "doc" : {
         "name" : "new_name"
@@ -169,7 +169,7 @@ By default updates that don't change anything detect that they don't change anyt
 
 [source,js]
 --------------------------------------------------
-POST test/_doc/1/_update
+POST test/_update/1
 {
     "doc" : {
         "name" : "new_name"
@@ -204,7 +204,7 @@ You can disable this behavior by setting "detect_noop": false like this:
 
 [source,js]
 --------------------------------------------------
-POST test/_doc/1/_update
+POST test/_update/1
 {
     "doc" : {
         "name" : "new_name"
@@ -225,7 +225,7 @@ will be inserted as a new document.  If the document does exist, then the
 
 [source,js]
 --------------------------------------------------
-POST test/_doc/1/_update
+POST test/_update/1
 {
     "script" : {
         "source": "ctx._source.counter += params.count",
@@ -251,7 +251,7 @@ or not -- i.e. the script handles initializing the document instead of the
 
 [source,js]
 --------------------------------------------------
-POST sessions/session/dh3sgudg8gsrgl/_update
+POST sessions/_update/dh3sgudg8gsrgl
 {
     "scripted_upsert":true,
     "script" : {
@@ -280,7 +280,7 @@ value:
 
 [source,js]
 --------------------------------------------------
-POST test/_doc/1/_update
+POST test/_update/1
 {
     "doc" : {
         "name" : "new_name"

--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -65,9 +65,7 @@ A type used to be a logical category/partition of your index to allow you to sto
 [float]
 === Document
 
-A document is a basic unit of information that can be indexed. For example, you can have a document for a single customer, another document for a single product, and yet another for a single order. This document is expressed in http://json.org/[JSON] (JavaScript Object Notation) which is a ubiquitous internet data interchange format.
-
-Within an index/type, you can store as many documents as you want. Note that although a document physically resides in an index, a document actually must be indexed/assigned to a type inside an index.
+A document is a basic unit of information that can be indexed. For example, you can have a document for a single customer, another document for a single product, and yet another for a single order. This document is expressed in http://json.org/[JSON] (JavaScript Object Notation) which is a ubiquitous internet data interchange format. Within an index, you can store as many documents as you want.
 
 [[getting-started-shards-and-replicas]]
 [float]
@@ -496,7 +494,7 @@ If we study the above commands carefully, we can actually see a pattern of how w
 
 [source,js]
 --------------------------------------------------
-<HTTP Verb> /<Index>/<Type>/<ID>
+<HTTP Verb> /<Index>/<Endpoint>/<ID>
 --------------------------------------------------
 // NOTCONSOLE
 
@@ -572,7 +570,7 @@ This example shows how to update our previous document (ID of 1) by changing the
 
 [source,js]
 --------------------------------------------------
-POST /customer/_doc/1/_update?pretty
+POST /customer/_update/1?pretty
 {
   "doc": { "name": "Jane Doe" }
 }
@@ -584,7 +582,7 @@ This example shows how to update our previous document (ID of 1) by changing the
 
 [source,js]
 --------------------------------------------------
-POST /customer/_doc/1/_update?pretty
+POST /customer/_update/1?pretty
 {
   "doc": { "name": "Jane Doe", "age": 20 }
 }
@@ -596,7 +594,7 @@ Updates can also be performed by using simple scripts. This example uses a scrip
 
 [source,js]
 --------------------------------------------------
-POST /customer/_doc/1/_update?pretty
+POST /customer/_update/1?pretty
 {
   "script" : "ctx._source.age += 5"
 }
@@ -719,7 +717,7 @@ yellow open   bank  l7sSYV2cQXmu6_4rJWVIww   5   1       1000            0    12
 // TESTRESPONSE[s/128.6kb/\\d+(\\.\\d+)?[mk]?b/]
 // TESTRESPONSE[s/l7sSYV2cQXmu6_4rJWVIww/.+/ _cat]
 
-Which means that we just successfully bulk indexed 1000 documents into the bank index (under the `_doc` type).
+Which means that we just successfully bulk indexed 1000 documents into the bank index.
 
 [[getting-started-search-API]]
 === The Search API


### PR DESCRIPTION
* Update the top-level 'getting started' guide.
* Remove custom types from the painless getting started documentation.
* Fix incorrect references to '_doc' in the cardinality query docs.
* Update the _update docs to use the typeless API format.