### PR TITLE
Support both typed and typeless 'get mapping' requests in the HLRC (backport to 6.x).

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesClient.java
@@ -38,8 +38,6 @@ import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.client.indices.GetFieldMappingsRequest;
 import org.elasticsearch.client.indices.GetFieldMappingsResponse;
-import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
-import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
 import org.elasticsearch.action.admin.indices.open.OpenIndexResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
@@ -62,6 +60,8 @@ import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.CreateIndexResponse;
 import org.elasticsearch.client.indices.FreezeIndexRequest;
 import org.elasticsearch.client.indices.GetIndexTemplatesRequest;
+import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.GetMappingsResponse;
 import org.elasticsearch.client.indices.IndexTemplatesExistRequest;
 import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.client.indices.UnfreezeIndexRequest;
@@ -358,8 +358,11 @@ public final class IndicesClient {
      * @throws IOException in case there is a problem sending the request or parsing back the response
      */
     public GetMappingsResponse getMapping(GetMappingsRequest getMappingsRequest, RequestOptions options) throws IOException {
-        return restHighLevelClient.performRequestAndParseEntity(getMappingsRequest, IndicesRequestConverters::getMappings, options,
-            GetMappingsResponse::fromXContent, emptySet());
+        return restHighLevelClient.performRequestAndParseEntity(getMappingsRequest,
+            IndicesRequestConverters::getMappings,
+            options,
+            GetMappingsResponse::fromXContent,
+            emptySet());
     }
 
     /**
@@ -372,8 +375,60 @@ public final class IndicesClient {
      */
     public void getMappingAsync(GetMappingsRequest getMappingsRequest, RequestOptions options,
                                 ActionListener<GetMappingsResponse> listener) {
-        restHighLevelClient.performRequestAsyncAndParseEntity(getMappingsRequest, IndicesRequestConverters::getMappings, options,
-            GetMappingsResponse::fromXContent, listener, emptySet());
+        restHighLevelClient.performRequestAsyncAndParseEntity(getMappingsRequest,
+            IndicesRequestConverters::getMappings,
+            options,
+            GetMappingsResponse::fromXContent,
+            listener,
+            emptySet());
+    }
+
+    /**
+     * Retrieves the mappings on an index or indices using the Get Mapping API.
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-mapping.html">
+     * Get Mapping API on elastic.co</a>
+     * @param getMappingsRequest the request
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @return the response
+     * @throws IOException in case there is a problem sending the request or parsing back the response
+     *
+     * @deprecated This method uses old request and response objects which still refer to types, a deprecated
+     * feature. The method {@link #getMapping(GetMappingsRequest, RequestOptions)} should be used instead, which
+     * accepts a new request object.
+     */
+    @Deprecated
+    public org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse getMapping(
+            org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest getMappingsRequest,
+            RequestOptions options) throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(getMappingsRequest,
+            IndicesRequestConverters::getMappings,
+            options,
+            org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse::fromXContent,
+            emptySet());
+    }
+
+    /**
+     * Asynchronously retrieves the mappings on an index on indices using the Get Mapping API.
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-mapping.html">
+     * Get Mapping API on elastic.co</a>
+     * @param getMappingsRequest the request
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @param listener the listener to be notified upon request completion
+     *
+     * @deprecated This method uses old request and response objects which still refer to types, a deprecated feature.
+     * The method {@link #getMapping(GetMappingsRequest, RequestOptions)} should be used instead, which accepts a new
+     * request object.
+     */
+    @Deprecated
+    public void getMappingAsync(org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest getMappingsRequest,
+                                RequestOptions options,
+                                ActionListener<org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse> listener) {
+        restHighLevelClient.performRequestAsyncAndParseEntity(getMappingsRequest,
+            IndicesRequestConverters::getMappings,
+            options,
+            org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse::fromXContent,
+            listener,
+            emptySet());
     }
 
     /**
@@ -385,8 +440,9 @@ public final class IndicesClient {
      * @return the response
      * @throws IOException in case there is a problem sending the request or parsing back the response
      *
-     * @deprecated This method uses an old request object which still refers to types, a deprecated feature. The method
-     * {@link #getFieldMapping(GetFieldMappingsRequest, RequestOptions)} should be used instead, which accepts a new request object.
+     * @deprecated This method uses old request and response objects which still refer to types, a deprecated feature.
+     * The method {@link #getFieldMapping(GetFieldMappingsRequest, RequestOptions)} should be used instead, which
+     * accepts a new request object.
      */
     @Deprecated
     public org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse getFieldMapping(
@@ -404,9 +460,9 @@ public final class IndicesClient {
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
      *
-     * @deprecated This method uses an old request object which still refers to types, a deprecated feature. The
-     * method {@link #getFieldMappingAsync(GetFieldMappingsRequest, RequestOptions, ActionListener)} should be used instead,
-     * which accepts a new request object.
+     * @deprecated This method uses old request and response objects which still refer to types, a deprecated feature.
+     * The method {@link #getFieldMappingAsync(GetFieldMappingsRequest, RequestOptions, ActionListener)} should be
+     * used instead, which accepts a new request object.
      */
     @Deprecated
     public void getFieldMappingAsync(org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest getFieldMappingsRequest,

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
@@ -35,7 +35,6 @@ import org.elasticsearch.action.admin.indices.flush.SyncedFlushRequest;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.client.indices.GetFieldMappingsRequest;
-import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
 import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
@@ -50,6 +49,7 @@ import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.FreezeIndexRequest;
 import org.elasticsearch.client.indices.GetIndexTemplatesRequest;
+import org.elasticsearch.client.indices.GetMappingsRequest;
 import org.elasticsearch.client.indices.IndexTemplatesExistRequest;
 import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.client.indices.UnfreezeIndexRequest;
@@ -151,6 +151,7 @@ final class IndicesRequestConverters {
         return request;
     }
 
+    @Deprecated
     static Request putMapping(org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest putMappingRequest) throws IOException {
         // The concreteIndex is an internal concept, not applicable to requests made over the REST API.
         if (putMappingRequest.getConcreteIndex() != null) {
@@ -169,7 +170,21 @@ final class IndicesRequestConverters {
         return request;
     }
 
-    static Request getMappings(GetMappingsRequest getMappingsRequest) throws IOException {
+    static Request getMappings(GetMappingsRequest getMappingsRequest) {
+        String[] indices = getMappingsRequest.indices() == null ? Strings.EMPTY_ARRAY : getMappingsRequest.indices();
+
+        Request request = new Request(HttpGet.METHOD_NAME, RequestConverters.endpoint(indices, "_mapping"));
+
+        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        parameters.withMasterTimeout(getMappingsRequest.masterNodeTimeout());
+        parameters.withIndicesOptions(getMappingsRequest.indicesOptions());
+        parameters.withLocal(getMappingsRequest.local());
+
+        return request;
+    }
+
+    @Deprecated
+    static Request getMappings(org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest getMappingsRequest) {
         String[] indices = getMappingsRequest.indices() == null ? Strings.EMPTY_ARRAY : getMappingsRequest.indices();
         String[] types = getMappingsRequest.types() == null ? Strings.EMPTY_ARRAY : getMappingsRequest.types();
 
@@ -179,6 +194,8 @@ final class IndicesRequestConverters {
         parameters.withMasterTimeout(getMappingsRequest.masterNodeTimeout());
         parameters.withIndicesOptions(getMappingsRequest.indicesOptions());
         parameters.withLocal(getMappingsRequest.local());
+        parameters.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
+
         return request;
     }
 
@@ -204,6 +221,7 @@ final class IndicesRequestConverters {
         return request;
     }
 
+    @Deprecated
     static Request getFieldMapping(org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest getFieldMappingsRequest) {
         String[] indices = getFieldMappingsRequest.indices() == null ? Strings.EMPTY_ARRAY : getFieldMappingsRequest.indices();
         String[] types = getFieldMappingsRequest.types() == null ? Strings.EMPTY_ARRAY : getFieldMappingsRequest.types();

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
@@ -179,6 +179,7 @@ final class IndicesRequestConverters {
         parameters.withMasterTimeout(getMappingsRequest.masterNodeTimeout());
         parameters.withIndicesOptions(getMappingsRequest.indicesOptions());
         parameters.withLocal(getMappingsRequest.local());
+        parameters.putParam(INCLUDE_TYPE_NAME_PARAMETER, "false");
 
         return request;
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetMappingsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetMappingsRequest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.indices;
+
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.TimedRequest;
+import org.elasticsearch.common.Strings;
+
+public class GetMappingsRequest extends TimedRequest {
+
+    private boolean local = false;
+    private boolean includeDefaults = false;
+    private String[] indices = Strings.EMPTY_ARRAY;
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+
+    /**
+     * Indicates whether the receiving node should operate based on local index information or
+     * forward requests, where needed, to other nodes. If running locally, request will not
+     * raise errors if local index information is missing.
+     */
+    public GetMappingsRequest local(boolean local) {
+        this.local = local;
+        return this;
+    }
+
+    public boolean local() {
+        return local;
+    }
+
+    public GetMappingsRequest indices(String... indices) {
+        this.indices = indices;
+        return this;
+    }
+
+    public GetMappingsRequest indicesOptions(IndicesOptions indicesOptions) {
+        this.indicesOptions = indicesOptions;
+        return this;
+    }
+
+    public String[] indices() {
+        return indices;
+    }
+
+    public IndicesOptions indicesOptions() {
+        return indicesOptions;
+    }
+
+    public boolean includeDefaults() {
+        return includeDefaults;
+    }
+
+    /** Indicates whether default mapping settings should be returned */
+    public GetMappingsRequest includeDefaults(boolean includeDefaults) {
+        this.includeDefaults = includeDefaults;
+        return this;
+    }
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetMappingsResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetMappingsResponse.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.indices;
+
+import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParserUtils;
+import org.elasticsearch.index.mapper.MapperService;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GetMappingsResponse {
+
+    static final ParseField MAPPINGS = new ParseField("mappings");
+
+    private Map<String, MappingMetaData> mappings;
+
+    public GetMappingsResponse(Map<String, MappingMetaData> mappings) {
+        this.mappings = mappings;
+    }
+
+    public Map<String, MappingMetaData> mappings() {
+        return mappings;
+    }
+
+    public static GetMappingsResponse fromXContent(XContentParser parser) throws IOException {
+        if (parser.currentToken() == null) {
+            parser.nextToken();
+        }
+
+        XContentParserUtils.ensureExpectedToken(parser.currentToken(),
+            XContentParser.Token.START_OBJECT,
+            parser::getTokenLocation);
+
+        Map<String, Object> parts = parser.map();
+
+        Map<String, MappingMetaData> mappings = new HashMap<>();
+        for (Map.Entry<String, Object> entry : parts.entrySet()) {
+            String indexName = entry.getKey();
+            assert entry.getValue() instanceof Map : "expected a map as type mapping, but got: " + entry.getValue().getClass();
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> fieldMappings = (Map<String, Object>) ((Map<String, ?>) entry.getValue())
+                    .get(MAPPINGS.getPreferredName());
+
+            mappings.put(indexName, new MappingMetaData(MapperService.SINGLE_MAPPING_NAME, fieldMappings));
+        }
+
+        return new GetMappingsResponse(mappings);
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -592,7 +592,8 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse getMappingsResponse = execute(
             request,
             highLevelClient().indices()::getMapping,
-            highLevelClient().indices()::getMappingAsync);
+            highLevelClient().indices()::getMappingAsync,
+            expectWarnings(RestGetMappingAction.TYPES_DEPRECATION_MESSAGE));
 
         Map<String, Object> mappings = getMappingsResponse.getMappings().get(indexName).get("_doc").sourceAsMap();
         Map<String, String> type = new HashMap<>();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -43,8 +43,6 @@ import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.client.indices.GetFieldMappingsRequest;
 import org.elasticsearch.client.indices.GetFieldMappingsResponse;
-import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
-import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
 import org.elasticsearch.action.admin.indices.open.OpenIndexResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
@@ -73,6 +71,8 @@ import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.CreateIndexResponse;
 import org.elasticsearch.client.indices.FreezeIndexRequest;
 import org.elasticsearch.client.indices.GetIndexTemplatesRequest;
+import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.GetMappingsResponse;
 import org.elasticsearch.client.indices.IndexTemplatesExistRequest;
 import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.client.indices.UnfreezeIndexRequest;
@@ -96,6 +96,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.admin.indices.RestCreateIndexAction;
 import org.elasticsearch.rest.action.admin.indices.RestGetFieldMappingAction;
+import org.elasticsearch.rest.action.admin.indices.RestGetMappingAction;
 import org.elasticsearch.rest.action.admin.indices.RestPutMappingAction;
 
 import java.io.IOException;
@@ -538,19 +539,60 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         mappingBuilder.endObject().endObject().endObject();
         putMappingRequest.source(mappingBuilder);
 
-        AcknowledgedResponse putMappingResponse =
-            execute(putMappingRequest, highLevelClient().indices()::putMapping, highLevelClient().indices()::putMappingAsync);
+        AcknowledgedResponse putMappingResponse = execute(putMappingRequest,
+            highLevelClient().indices()::putMapping,
+            highLevelClient().indices()::putMappingAsync);
         assertTrue(putMappingResponse.isAcknowledged());
 
         Map<String, Object> getIndexResponse = getAsMap(indexName);
         assertEquals("text", XContentMapValues.extractValue(indexName + ".mappings._doc.properties.field.type", getIndexResponse));
 
         GetMappingsRequest request = new GetMappingsRequest()
-            .indices(indexName)
-            .types("_doc");
+            .indices(indexName);
 
-        GetMappingsResponse getMappingsResponse =
-            execute(request, highLevelClient().indices()::getMapping, highLevelClient().indices()::getMappingAsync);
+        GetMappingsResponse getMappingsResponse = execute(
+            request,
+            highLevelClient().indices()::getMapping,
+            highLevelClient().indices()::getMappingAsync);
+
+        Map<String, Object> mappings = getMappingsResponse.mappings().get(indexName).sourceAsMap();
+        Map<String, String> type = new HashMap<>();
+        type.put("type", "text");
+        Map<String, Object> field = new HashMap<>();
+        field.put("field", type);
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("properties", field);
+        assertThat(mappings, equalTo(expected));
+    }
+
+    public void testGetMappingWithTypes() throws IOException {
+        String indexName = "test";
+        createIndex(indexName, Settings.EMPTY);
+
+        PutMappingRequest putMappingRequest = new PutMappingRequest(indexName);
+        XContentBuilder mappingBuilder = JsonXContent.contentBuilder();
+        mappingBuilder.startObject().startObject("properties").startObject("field");
+        mappingBuilder.field("type", "text");
+        mappingBuilder.endObject().endObject().endObject();
+        putMappingRequest.source(mappingBuilder);
+
+        AcknowledgedResponse putMappingResponse = execute(putMappingRequest,
+            highLevelClient().indices()::putMapping,
+            highLevelClient().indices()::putMappingAsync);
+        assertTrue(putMappingResponse.isAcknowledged());
+
+        Map<String, Object> getIndexResponse = getAsMap(indexName);
+        assertEquals("text", XContentMapValues.extractValue(indexName + ".mappings._doc.properties.field.type", getIndexResponse));
+
+        org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest request =
+            new org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest()
+                .indices(indexName)
+                .types("_doc");
+
+        org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse getMappingsResponse = execute(
+            request,
+            highLevelClient().indices()::getMapping,
+            highLevelClient().indices()::getMappingAsync);
 
         Map<String, Object> mappings = getMappingsResponse.getMappings().get(indexName).get("_doc").sourceAsMap();
         Map<String, String> type = new HashMap<>();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
@@ -249,6 +249,7 @@ public class IndicesRequestConvertersTests extends ESTestCase {
             getMappingRequest::indicesOptions, expectedParams);
         RequestConvertersTests.setRandomMasterTimeout(getMappingRequest, expectedParams);
         RequestConvertersTests.setRandomLocal(getMappingRequest::local, expectedParams);
+        expectedParams.put(INCLUDE_TYPE_NAME_PARAMETER, "false");
 
         Request request = IndicesRequestConverters.getMappings(getMappingRequest);
         StringJoiner endpoint = new StringJoiner("/", "/", "");

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -42,8 +42,6 @@ import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.client.indices.GetFieldMappingsRequest;
 import org.elasticsearch.client.indices.GetFieldMappingsResponse;
-import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
-import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
 import org.elasticsearch.action.admin.indices.open.OpenIndexResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
@@ -76,6 +74,8 @@ import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.CreateIndexResponse;
 import org.elasticsearch.client.indices.FreezeIndexRequest;
 import org.elasticsearch.client.indices.GetIndexTemplatesRequest;
+import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.GetMappingsResponse;
 import org.elasticsearch.client.indices.IndexTemplatesExistRequest;
 import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.client.indices.UnfreezeIndexRequest;
@@ -589,12 +589,10 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             // tag::get-mappings-request
             GetMappingsRequest request = new GetMappingsRequest(); // <1>
             request.indices("twitter"); // <2>
-            request.types("_doc"); // <3>
             // end::get-mappings-request
 
             // tag::get-mappings-request-masterTimeout
-            request.masterNodeTimeout(TimeValue.timeValueMinutes(1)); // <1>
-            request.masterNodeTimeout("1m"); // <2>
+            request.setMasterTimeout(TimeValue.timeValueMinutes(1)); // <1>
             // end::get-mappings-request-masterTimeout
 
             // tag::get-mappings-request-indicesOptions
@@ -606,9 +604,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             // end::get-mappings-execute
 
             // tag::get-mappings-response
-            ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> allMappings = getMappingResponse.mappings(); // <1>
-            MappingMetaData typeMapping = allMappings.get("twitter").get("_doc"); // <2>
-            Map<String, Object> mapping = typeMapping.sourceAsMap(); // <3>
+            Map<String, MappingMetaData> allMappings = getMappingResponse.mappings(); // <1>
+            MappingMetaData indexMapping = allMappings.get("twitter"); // <2>
+            Map<String, Object> mapping = indexMapping.sourceAsMap(); // <3>
             // end::get-mappings-response
 
             Map<String, String> type = new HashMap<>();
@@ -644,7 +642,6 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         {
             GetMappingsRequest request = new GetMappingsRequest();
             request.indices("twitter");
-            request.types("_doc");
 
             // tag::get-mappings-execute-listener
             ActionListener<GetMappingsResponse> listener =
@@ -665,9 +662,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             final CountDownLatch latch = new CountDownLatch(1);
             final ActionListener<GetMappingsResponse> latchListener = new LatchedActionListener<>(listener, latch);
             listener = ActionListener.wrap(r -> {
-                ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> allMappings = r.mappings();
-                MappingMetaData typeMapping = allMappings.get("twitter").get("_doc");
-                Map<String, Object> mapping = typeMapping.sourceAsMap();
+                Map<String, MappingMetaData> allMappings = r.mappings();
+                MappingMetaData indexMapping = allMappings.get("twitter");
+                Map<String, Object> mapping = indexMapping.sourceAsMap();
 
                 Map<String, String> type = new HashMap<>();
                 type.put("type", "text");

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/GetFieldMappingsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/GetFieldMappingsResponseTests.java
@@ -44,14 +44,14 @@ public class GetFieldMappingsResponseTests extends ESTestCase {
             .test();
     }
 
-    Predicate<String> getRandomFieldsExcludeFilter() {
+    private Predicate<String> getRandomFieldsExcludeFilter() {
         // allow random fields at the level of `index` and `index.mappings.field`
         // otherwise random field could be evaluated as index name or type name
         return s -> false == (s.matches("(?<index>[^.]+)")
             || s.matches("(?<index>[^.]+)\\.mappings\\.(?<field>[^.]+)"));
     }
 
-    static GetFieldMappingsResponse createTestInstance() {
+    private static GetFieldMappingsResponse createTestInstance() {
         Map<String, Map<String, FieldMappingMetaData>> mappings = new HashMap<>();
         // if mappings is empty, means that fields are not found
         if (randomBoolean()) {
@@ -72,12 +72,11 @@ public class GetFieldMappingsResponseTests extends ESTestCase {
     }
 
     // As the client class GetFieldMappingsResponse doesn't have toXContent method, adding this method here only for the test
-    static void toXContent(GetFieldMappingsResponse response, XContentBuilder builder) throws IOException {
+    private static void toXContent(GetFieldMappingsResponse response, XContentBuilder builder) throws IOException {
         builder.startObject();
         for (Map.Entry<String, Map<String, FieldMappingMetaData>> indexEntry : response.mappings().entrySet()) {
             builder.startObject(indexEntry.getKey());
             builder.startObject("mappings");
-            Map<String, FieldMappingMetaData> mappings = null;
             for (Map.Entry<String, FieldMappingMetaData> fieldEntry : indexEntry.getValue().entrySet()) {
                 builder.startObject(fieldEntry.getKey());
                 builder.field("full_name", fieldEntry.getValue().fullName());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/GetMappingsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/GetMappingsResponseTests.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.indices;
+
+import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContent.Params;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import static org.elasticsearch.client.indices.GetMappingsResponse.MAPPINGS;
+import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
+
+public class GetMappingsResponseTests extends ESTestCase {
+
+    // Because the client-side class does not have a toXContent method, we test xContent serialization by creating
+    // a random client object, converting it to a server object then serializing it to xContent, and finally
+    // parsing it back as a client object. We check equality between the original client object, and the parsed one.
+    public void testFromXContent() throws IOException {
+        xContentTester(
+            this::createParser,
+            GetMappingsResponseTests::createTestInstance,
+            GetMappingsResponseTests::toXContent,
+            GetMappingsResponse::fromXContent)
+            .supportsUnknownFields(true)
+            .assertEqualsConsumer(GetMappingsResponseTests::assertEqualInstances)
+            .randomFieldsExcludeFilter(randomFieldsExcludeFilter())
+            .test();
+    }
+
+    private static GetMappingsResponse createTestInstance() {
+        Map<String, MappingMetaData> mappings = Collections.singletonMap(
+            "index-" + randomAlphaOfLength(5), randomMappingMetaData());
+        return new GetMappingsResponse(mappings);
+    }
+
+    private static void assertEqualInstances(GetMappingsResponse expected, GetMappingsResponse actual) {
+        assertEquals(expected.mappings(), actual.mappings());
+    }
+
+    private Predicate<String> randomFieldsExcludeFilter() {
+        return field -> !field.equals(MAPPINGS.getPreferredName());
+    }
+
+    public static MappingMetaData randomMappingMetaData() {
+        Map<String, Object> mappings = new HashMap<>();
+
+        if (frequently()) { // rarely have no fields
+            mappings.put("field1", randomFieldMapping());
+            if (randomBoolean()) {
+                mappings.put("field2", randomFieldMapping());
+            }
+        }
+
+        try {
+            return new MappingMetaData(MapperService.SINGLE_MAPPING_NAME, mappings);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Map<String, Object> randomFieldMapping() {
+        Map<String, Object> mappings = new HashMap<>();
+        if (randomBoolean()) {
+            mappings.put("type", randomFrom("text", "keyword"));
+            mappings.put("index", "analyzed");
+            mappings.put("analyzer", "english");
+        } else {
+            mappings.put("type", randomFrom("integer", "float", "long", "double"));
+            mappings.put("index", Objects.toString(randomBoolean()));
+        }
+        return mappings;
+    }
+
+    private static void toXContent(GetMappingsResponse response, XContentBuilder builder) throws IOException {
+        Params params = new ToXContent.MapParams(
+            Collections.singletonMap(BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER, "false"));
+        ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetaData>> allMappings = ImmutableOpenMap.builder();
+
+        for (Map.Entry<String, MappingMetaData> indexEntry : response.mappings().entrySet()) {
+            ImmutableOpenMap.Builder<String, MappingMetaData> mappings = ImmutableOpenMap.builder();
+            mappings.put(MapperService.SINGLE_MAPPING_NAME, indexEntry.getValue());
+            allMappings.put(indexEntry.getKey(), mappings.build());
+        }
+
+        org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse serverResponse =
+            new org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse(allMappings.build());
+
+        builder.startObject();
+        serverResponse.toXContent(builder, params);
+        builder.endObject();
+    }
+}

--- a/docs/java-rest/high-level/indices/get_mappings.asciidoc
+++ b/docs/java-rest/high-level/indices/get_mappings.asciidoc
@@ -10,15 +10,14 @@
 [id="{upid}-{api}-request"]
 ==== Get Mappings Request
 
-A +{request}+ can have an optional list of indices and optional list of types:
+A +{request}+ can have an optional list of indices:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> An empty request that will return all indices and types
+<1> An empty request that will return all indices
 <2> Setting the indices to fetch mapping for
-<3> The types to be returned
 
 ==== Optional arguments
 The following arguments can also optionally be provided:
@@ -28,7 +27,6 @@ The following arguments can also optionally be provided:
 include-tagged::{doc-tests-file}[{api}-request-masterTimeout]
 --------------------------------------------------
 <1> Timeout to connect to the master node as a `TimeValue`
-<2> Timeout to connect to the master node as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -49,5 +47,5 @@ executed operation as follows:
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Returning all indices' mappings
-<2> Retrieving the mappings for a particular index and type
+<2> Retrieving the mappings for a particular index
 <3> Getting the mappings as a Java Map

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponse.java
@@ -31,9 +31,12 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.BaseRestHandler;
 
 import java.io.IOException;
 import java.util.Map;
+
+import static org.elasticsearch.rest.BaseRestHandler.DEFAULT_INCLUDE_TYPE_NAME_POLICY;
 import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
 
 public class GetMappingsResponse extends ActionResponse implements ToXContentFragment {
@@ -45,7 +48,7 @@ public class GetMappingsResponse extends ActionResponse implements ToXContentFra
 
     private ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> mappings = ImmutableOpenMap.of();
 
-    GetMappingsResponse(ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> mappings) {
+    public GetMappingsResponse(ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> mappings) {
         this.mappings = mappings;
     }
 
@@ -121,10 +124,9 @@ public class GetMappingsResponse extends ActionResponse implements ToXContentFra
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return toXContent(builder, params, true);
-    }
+        boolean includeTypeName = params.paramAsBoolean(BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER,
+            DEFAULT_INCLUDE_TYPE_NAME_POLICY);
 
-    public XContentBuilder toXContent(XContentBuilder builder, Params params, boolean includeTypeName) throws IOException {
         for (final ObjectObjectCursor<String, ImmutableOpenMap<String, MappingMetaData>> indexEntry : getMappings()) {
             builder.startObject(indexEntry.key);
             {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
@@ -20,8 +20,8 @@
 package org.elasticsearch.rest.action.admin.indices;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -33,7 +33,6 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.indices.TypeMissingException;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -60,6 +59,8 @@ import static org.elasticsearch.rest.RestRequest.Method.HEAD;
 public class RestGetMappingAction extends BaseRestHandler {
     private static final Logger logger = LogManager.getLogger(RestGetMappingAction.class);
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
+    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Using include_type_name in get" +
+        " mapping requests is deprecated. The parameter will be removed in the next major version.";
 
     public RestGetMappingAction(final Settings settings, final RestController controller) {
         super(settings);
@@ -134,7 +135,7 @@ public class RestGetMappingAction extends BaseRestHandler {
                         builder.field("error", message);
                         builder.field("status", status.getStatus());
                     }
-                    response.toXContent(builder, ToXContent.EMPTY_PARAMS, includeTypeName);
+                    response.toXContent(builder, request);
                 }
                 builder.endObject();
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponseTests.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.admin.indices.mapping.get;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -82,12 +81,6 @@ public class GetMappingsResponseTests extends AbstractStreamableXContentTestCase
         return mutate(instance);
     }
 
-    public static ImmutableOpenMap<String, MappingMetaData> createMappingsForIndex() {
-        // rarely have no types
-        int typeCount = rarely() ? 0 : scaledRandomIntBetween(1, 3);
-        return createMappingsForIndex(typeCount);
-    }
-
     public static ImmutableOpenMap<String, MappingMetaData> createMappingsForIndex(int typeCount) {
         List<MappingMetaData> typeMappings = new ArrayList<>(typeCount);
 
@@ -112,11 +105,12 @@ public class GetMappingsResponseTests extends AbstractStreamableXContentTestCase
         typeMappings.forEach(mmd -> typeBuilder.put(mmd.type(), mmd));
         return typeBuilder.build();
     }
-
+    
     @Override
     protected GetMappingsResponse createTestInstance() {
         ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetaData>> indexBuilder = ImmutableOpenMap.builder();
-        indexBuilder.put("index-" + randomAlphaOfLength(5), createMappingsForIndex());
+        int typeCount = rarely() ? 0 : scaledRandomIntBetween(1, 3);
+        indexBuilder.put("index-" + randomAlphaOfLength(5), createMappingsForIndex(typeCount));
         GetMappingsResponse resp = new GetMappingsResponse(indexBuilder.build());
         logger.debug("--> created: {}", resp);
         return resp;
@@ -124,7 +118,6 @@ public class GetMappingsResponseTests extends AbstractStreamableXContentTestCase
 
     // Not meant to be exhaustive
     private static Map<String, Object> randomFieldMapping() {
-        Map<String, Object> mappings = new HashMap<>();
         if (randomBoolean()) {
             Map<String, Object> regularMapping = new HashMap<>();
             regularMapping.put("type", randomBoolean() ? "text" : "keyword");

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingActionTests.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.indices;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.rest.FakeRestChannel;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.test.rest.RestActionTestCase;
+import org.junit.Before;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
+
+public class RestGetMappingActionTests extends RestActionTestCase {
+
+    @Before
+    public void setUpAction() {
+        new RestGetMappingAction(Settings.EMPTY, controller());
+    }
+
+    public void testTypeInPath() {
+        // Test that specifying a type while setting include_type_name to false
+        // results in an illegal argument exception.
+        Map<String, String> params = new HashMap<>();
+        params.put(INCLUDE_TYPE_NAME_PARAMETER, "false");
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.GET)
+            .withPath("some_index/some_type/_mapping/some_field")
+            .withParams(params)
+            .build();
+
+        FakeRestChannel channel = new FakeRestChannel(request, false, 1);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        controller().dispatchRequest(request, channel, threadContext);
+
+        assertEquals(1, channel.errors().get());
+        assertEquals(RestStatus.BAD_REQUEST, channel.capturedResponse().status());
+    }
+
+    public void testIncludeTypeName() {
+        RestRequest deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.GET)
+            .withPath("/some_index/_mappings")
+            .build();
+
+        dispatchRequest(deprecatedRequest);
+        assertWarnings(RestGetMappingAction.TYPES_DEPRECATION_MESSAGE);
+
+        Map<String, String> params = new HashMap<>();
+        params.put(INCLUDE_TYPE_NAME_PARAMETER, "false");
+        RestRequest validRequest = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.GET)
+            .withPath("/some_index/_mappings")
+            .withParams(params)
+            .build();
+        dispatchRequest(validRequest);
+    }
+
+}


### PR DESCRIPTION
Backport of #37796, opening a PR to get a full build. This PR also makes the relevant
changes to account for the difference in the default for `include_type_name`.

I also needed to backport parts of #37492 that affected tests and documentation.
