### PR TITLE
[ML] Add _meta information to all ML indices

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetaIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetaIndex.java
@@ -29,6 +29,7 @@ public final class MlMetaIndex {
         XContentBuilder builder = jsonBuilder();
         builder.startObject();
             builder.startObject(TYPE);
+                ElasticsearchMappings.addMetaInformation(builder);
                 ElasticsearchMappings.addDefaultMapping(builder);
                 builder.startObject(ElasticsearchMappings.PROPERTIES)
                     .startObject(Calendar.ID.getPreferredName())

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationIndex.java
@@ -109,10 +109,11 @@ public class AnnotationIndex {
     }
 
     public static XContentBuilder annotationsMapping() throws IOException {
-        return jsonBuilder()
+        XContentBuilder builder = jsonBuilder()
             .startObject()
-                .startObject(ElasticsearchMappings.DOC_TYPE)
-                    .startObject(ElasticsearchMappings.PROPERTIES)
+                .startObject(ElasticsearchMappings.DOC_TYPE);
+        ElasticsearchMappings.addMetaInformation(builder);
+        builder.startObject(ElasticsearchMappings.PROPERTIES)
                         .startObject(Annotation.ANNOTATION.getPreferredName())
                             .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.TEXT)
                         .endObject()
@@ -143,5 +144,6 @@ public class AnnotationIndex {
                     .endObject()
                 .endObject()
             .endObject();
+        return builder;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -960,10 +960,10 @@ public class ElasticsearchMappings {
     }
 
     public static XContentBuilder auditMessageMapping() throws IOException {
-        return jsonBuilder()
-                .startObject()
-                    .startObject(AuditMessage.TYPE.getPreferredName())
-                        .startObject(PROPERTIES)
+        XContentBuilder builder = jsonBuilder().startObject()
+            .startObject(AuditMessage.TYPE.getPreferredName());
+        addMetaInformation(builder);
+        builder.startObject(PROPERTIES)
                             .startObject(Job.ID.getPreferredName())
                                 .field(TYPE, KEYWORD)
                             .endObject()
@@ -987,6 +987,7 @@ public class ElasticsearchMappings {
                         .endObject()
                     .endObject()
                 .endObject();
+        return builder;
     }
 
     static String[] mappingRequiresUpdate(ClusterState state, String[] concreteIndices, Version minVersion) throws IOException {


### PR DESCRIPTION
This change adds a _meta field storing the version in which
the index mappings were last updated to the 3 ML indices
that didn't previously have one:

- .ml-annotations
- .ml-meta
- .ml-notifications

All other ML indices already had such a _meta field.

This field will be useful if we ever need to automatically
update the index mappings during a future upgrade.