### PR TITLE
Minor fixes in the release notes script.

### DIFF
--- a/dev-tools/es_release_notes.pl
+++ b/dev-tools/es_release_notes.pl
@@ -32,7 +32,7 @@ my @Groups = (
     ">enhancement", ">bug",           ">regression",  ">upgrade"
 );
 my %Ignore = map { $_ => 1 }
-    ( ">non-issue", ">refactoring", ">docs", ">test", ">test-failure", ":Core/Build", "backport" );
+    ( ">non-issue", ">refactoring", ">docs", ">test", ">test-failure", ":Core/Infra/Build", "backport" );
 
 my %Group_Labels = (
     '>breaking'      => 'Breaking changes',
@@ -48,7 +48,7 @@ my %Group_Labels = (
 
 my %Area_Overrides = (
     ':ml'            => 'Machine Learning',
-    ':beats'         => 'Beats Plugin',
+    ':Beats'         => 'Beats Plugin',
     ':Docs'          => 'Docs Infrastructure'
 );
 


### PR DESCRIPTION
The `:beats` label is actually `:Beats` in Github.
`:Core/Build` is now `:Core/Infra/Build`.
