### PR TITLE
Geo: Fix Empty Geometry Collection Handling

### DIFF
--- a/libs/geo/src/main/java/org/elasticsearch/geo/utils/WellKnownText.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geo/utils/WellKnownText.java
@@ -121,6 +121,10 @@ public class WellKnownText {
 
                 @Override
                 public Void visit(MultiPoint multiPoint) {
+                    if (multiPoint.isEmpty()) {
+                        sb.append(EMPTY);
+                        return null;
+                    }
                     // walk through coordinates:
                     sb.append(LPAREN);
                     visitPoint(multiPoint.get(0).getLon(), multiPoint.get(0).getLat());

--- a/server/src/main/java/org/elasticsearch/common/geo/builders/GeometryCollectionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/builders/GeometryCollectionBuilder.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.geo.parsers.ShapeParser;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.geo.geometry.GeometryCollection;
 import org.locationtech.spatial4j.shape.Shape;
 
 import java.io.IOException;
@@ -186,6 +187,9 @@ public class GeometryCollectionBuilder extends ShapeBuilder<Shape,
 
     @Override
     public org.elasticsearch.geo.geometry.GeometryCollection<org.elasticsearch.geo.geometry.Geometry> buildGeometry() {
+        if (this.shapes.isEmpty()) {
+            return GeometryCollection.EMPTY;
+        }
         List<org.elasticsearch.geo.geometry.Geometry> shapes = new ArrayList<>(this.shapes.size());
 
         for (ShapeBuilder shape : this.shapes) {

--- a/server/src/main/java/org/elasticsearch/common/geo/builders/MultiLineStringBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/builders/MultiLineStringBuilder.java
@@ -151,6 +151,9 @@ public class MultiLineStringBuilder extends ShapeBuilder<JtsGeometry, org.elasti
 
     @Override
     public org.elasticsearch.geo.geometry.Geometry buildGeometry() {
+        if (lines.isEmpty()) {
+            return MultiLine.EMPTY;
+        }
         if (wrapdateline) {
             List<org.elasticsearch.geo.geometry.Line> parts = new ArrayList<>();
             for (LineStringBuilder line : lines) {

--- a/server/src/main/java/org/elasticsearch/common/geo/builders/MultiPointBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/builders/MultiPointBuilder.java
@@ -46,6 +46,13 @@ public class MultiPointBuilder extends ShapeBuilder<XShapeCollection<Point>, Mul
     }
 
     /**
+     * Creates a new empty MultiPoint builder
+     */
+    public MultiPointBuilder() {
+        super();
+    }
+
+    /**
      * Read from a stream.
      */
     public MultiPointBuilder(StreamInput in) throws IOException {
@@ -77,6 +84,9 @@ public class MultiPointBuilder extends ShapeBuilder<XShapeCollection<Point>, Mul
 
     @Override
     public MultiPoint buildGeometry() {
+        if (coordinates.isEmpty()) {
+            return MultiPoint.EMPTY;
+        }
         return new MultiPoint(coordinates.stream().map(coord -> new org.elasticsearch.geo.geometry.Point(coord.y, coord.x))
             .collect(Collectors.toList()));
     }

--- a/server/src/main/java/org/elasticsearch/common/geo/builders/MultiPolygonBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/builders/MultiPolygonBuilder.java
@@ -198,6 +198,9 @@ public class MultiPolygonBuilder extends ShapeBuilder<Shape, MultiPolygon, Multi
                 shapes.add((org.elasticsearch.geo.geometry.Polygon)poly);
             }
         }
+        if (shapes.isEmpty()) {
+            return MultiPolygon.EMPTY;
+        }
         return new MultiPolygon(shapes);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/geo/parsers/GeoWKTParser.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/parsers/GeoWKTParser.java
@@ -198,7 +198,7 @@ public class GeoWKTParser {
             throws IOException, ElasticsearchParseException {
         String token = nextEmptyOrOpen(stream);
         if (token.equals(EMPTY)) {
-            return null;
+            return new MultiPointBuilder();
         }
         return new MultiPointBuilder(parseCoordinateList(stream, ignoreZValue, coerce));
     }
@@ -242,7 +242,7 @@ public class GeoWKTParser {
             throws IOException, ElasticsearchParseException {
         String token = nextEmptyOrOpen(stream);
         if (token.equals(EMPTY)) {
-            return null;
+            return new MultiLineStringBuilder();
         }
         MultiLineStringBuilder builder = new MultiLineStringBuilder();
         builder.linestring(parseLine(stream, ignoreZValue, coerce));


### PR DESCRIPTION
Fixes handling empty geometry collection and re-enables
testParseGeometryCollection test.

Fixes #37894 