### PR TITLE
libs:geo add missing eclipse-build.gradle files

### DIFF
--- a/libs/geo/src/main/eclipse-build.gradle
+++ b/libs/geo/src/main/eclipse-build.gradle
@@ -1,0 +1,3 @@
+
+// this is just shell gradle file for eclipse to have separate projects for geo src and tests
+apply from: '../../build.gradle'

--- a/libs/geo/src/test/eclipse-build.gradle
+++ b/libs/geo/src/test/eclipse-build.gradle
@@ -1,0 +1,6 @@
+
+// this is just shell gradle file for eclipse to have separate projects for geo src and tests
+apply from: '../../build.gradle'
+dependencies {
+  testCompile project(':libs:elasticsearch-geo')
+}


### PR DESCRIPTION
Eclipse build files were missing so .eclipse project files were not being generated.
Closes #37973

