### PR TITLE
ML: ignore unknown fields for JobTaskState

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobTaskState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobTaskState.java
@@ -29,8 +29,7 @@ public class JobTaskState implements PersistentTaskState {
     private static ParseField ALLOCATION_ID = new ParseField("allocation_id");
 
     private static final ConstructingObjectParser<JobTaskState, Void> PARSER =
-            new ConstructingObjectParser<>(NAME,
-                    args -> new JobTaskState((JobState) args[0], (Long) args[1]));
+            new ConstructingObjectParser<>(NAME, true, args -> new JobTaskState((JobState) args[0], (Long) args[1]));
 
     static {
         PARSER.declareField(constructorArg(), p -> {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/config/JobTaskStateTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/config/JobTaskStateTests.java
@@ -27,4 +27,9 @@ public class JobTaskStateTests extends AbstractSerializingTestCase<JobTaskState>
     protected JobTaskState doParseInstance(XContentParser parser) {
         return JobTaskState.fromXContent(parser);
     }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return true;
+    }
 }


### PR DESCRIPTION
Adds support for Unknown Fields for org.elasticsearch.xpack.core.ml.job.config.JobTaskState

This blocks https://github.com/elastic/elasticsearch/issues/34431