### PR TITLE
ILM setPriority corrections for a 0 value

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/SetPriorityAction.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/SetPriorityAction.java
@@ -55,7 +55,7 @@ public class SetPriorityAction implements LifecycleAction, ToXContentObject {
     }
 
     public SetPriorityAction(@Nullable Integer recoveryPriority) {
-        if (recoveryPriority != null && recoveryPriority <= 0) {
+        if (recoveryPriority != null && recoveryPriority < 0) {
             throw new IllegalArgumentException("[" + RECOVERY_PRIORITY_FIELD.getPreferredName() + "] must be 0 or greater");
         }
         this.recoveryPriority = recoveryPriority;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/SetPriorityActionTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/SetPriorityActionTests.java
@@ -48,7 +48,7 @@ public class SetPriorityActionTests extends AbstractXContentTestCase<SetPriority
     }
 
     public void testNonPositivePriority() {
-        Exception e = expectThrows(Exception.class, () -> new SetPriorityAction(randomIntBetween(-100, 0)));
+        Exception e = expectThrows(Exception.class, () -> new SetPriorityAction(randomIntBetween(-100, -1)));
         assertThat(e.getMessage(), equalTo("[priority] must be 0 or greater"));
     }
 

--- a/x-pack/docs/en/watcher/transform/search.asciidoc
+++ b/x-pack/docs/en/watcher/transform/search.asciidoc
@@ -56,10 +56,6 @@ The following table lists all available settings for the search transform:
 
 | `request.indices`                             | no        | all indices       | One or more indices to search on.
 
-| `request.types`                               | no        | all types         | One or more document types to search on (may be a
-                                                                                  comma-delimited string or an array of document types
-                                                                                  names)
-
 | `request.body`                                | no        | `match_all` query | The body of the request. The
                                                                                   {ref}/search-request-body.html[request body] follows
                                                                                   the same structure you normally send in the body of
@@ -105,7 +101,6 @@ time of the watch:
     "search" : {
       "request" : {
         "indices" : [ "logstash-*" ],
-        "types" : [ "event" ],
         "body" : {
           "size" : 0,
           "query" : {
@@ -145,7 +140,6 @@ The following is an example of using templates that refer to provided parameters
     "search" : {
       "request" : {
         "indices" : [ "logstash-*" ],
-        "types" : [ "event" ],
         "template" : {
           "source" : {
             "size" : 0,

--- a/x-pack/docs/en/watcher/transform/search.asciidoc
+++ b/x-pack/docs/en/watcher/transform/search.asciidoc
@@ -56,6 +56,10 @@ The following table lists all available settings for the search transform:
 
 | `request.indices`                             | no        | all indices       | One or more indices to search on.
 
+| `request.types`                               | no        | all types         | One or more document types to search on (may be a
+                                                                                  comma-delimited string or an array of document types
+                                                                                  names)
+
 | `request.body`                                | no        | `match_all` query | The body of the request. The
                                                                                   {ref}/search-request-body.html[request body] follows
                                                                                   the same structure you normally send in the body of
@@ -101,6 +105,7 @@ time of the watch:
     "search" : {
       "request" : {
         "indices" : [ "logstash-*" ],
+        "types" : [ "event" ],
         "body" : {
           "size" : 0,
           "query" : {
@@ -140,6 +145,7 @@ The following is an example of using templates that refer to provided parameters
     "search" : {
       "request" : {
         "indices" : [ "logstash-*" ],
+        "types" : [ "event" ],
         "template" : {
           "source" : {
             "size" : 0,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/SetPriorityActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/SetPriorityActionTests.java
@@ -38,9 +38,8 @@ public class SetPriorityActionTests extends AbstractActionTestCase<SetPriorityAc
         return SetPriorityAction::new;
     }
 
-    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/37652")
     public void testNonPositivePriority() {
-        Exception e = expectThrows(Exception.class, () -> new SetPriorityAction(randomIntBetween(-100, 0)));
+        Exception e = expectThrows(Exception.class, () -> new SetPriorityAction(randomIntBetween(-100, -1)));
         assertThat(e.getMessage(), equalTo("[priority] must be 0 or greater"));
     }
 


### PR DESCRIPTION
This commit fixes the test case that ensures only a priority
less then 0 is used with testNonPositivePriority. This also
allows the HLRC to support a value of 0.

Closes #37652
