### PR TITLE
Remove types from watcher docs

### DIFF
--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -122,8 +122,7 @@ setups['my_inactive_watch'] = '''
             "actions": {
               "test_index": {
                 "index": {
-                  "index": "test",
-                  "doc_type": "test2"
+                  "index": "test"
                 }
               }
             }

--- a/x-pack/docs/en/rest-api/watcher/ack-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/ack-watch.asciidoc
@@ -68,8 +68,7 @@ PUT _watcher/watch/my_watch
     "test_index": {
       "throttle_period": "15m",
       "index": {
-        "index": "test",
-        "doc_type": "test2"
+        "index": "test"
       }
     }
   }

--- a/x-pack/docs/en/rest-api/watcher/execute-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/execute-watch.asciidoc
@@ -255,7 +255,7 @@ This is an example of the output:
           "index": {
             "response": {
               "index": "test",
-              "type": "test2",
+              "type": "_doc",
               "version": 1,
               "created": true,
               "result": "created",

--- a/x-pack/docs/en/rest-api/watcher/get-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/get-watch.asciidoc
@@ -81,8 +81,7 @@ Response:
     "actions": {
       "test_index": {
         "index": {
-          "index": "test",
-          "doc_type": "test2"
+          "index": "test"
         }
       }
     }

--- a/x-pack/docs/en/watcher/actions/index.asciidoc
+++ b/x-pack/docs/en/watcher/actions/index.asciidoc
@@ -16,8 +16,7 @@ The following snippet shows a simple `index` action definition:
     "transform": { ... }, <3>
     "index" : {
       "index" : "my-index", <4>
-      "doc_type" : "my-type", <5>
-      "doc_id": "my-id" <6>
+      "doc_id": "my-id" <5>
     }
   }
 }
@@ -27,8 +26,7 @@ The following snippet shows a simple `index` action definition:
 <2> An optional <<condition, condition>> to restrict action execution
 <3> An optional <<transform, transform>> to transform the payload and prepare the data that should be indexed
 <4> The elasticsearch index to store the data to
-<5> The document type to store the data as
-<6> An optional `_id` for the document, if it should always be the same document.
+<5> An optional `_id` for the document, if it should always be the same document.
 
 
 [[index-action-attributes]]
@@ -40,7 +38,6 @@ The following snippet shows a simple `index` action definition:
 
 | `index`                 | yes        | -          | The Elasticsearch index to index into.
 
-| `doc_type`              | yes        | -          | The type of the document the data will be indexed as.
 
 | `doc_id`                | no         | -          | The optional `_id` of the document.
 
@@ -75,5 +72,5 @@ When a `_doc` field exists, if the field holds an object, it is extracted and in
 as a single document. If the field holds an array of objects, each object is treated as
 a document and the index action indexes all of them in a bulk.
 
-An `_index`, `_type` or `_id` value can be added per document to dynamically set the ID
+An `_index`, or `_id` value can be added per document to dynamically set the ID
 of the indexed document.

--- a/x-pack/docs/en/watcher/input/search.asciidoc
+++ b/x-pack/docs/en/watcher/input/search.asciidoc
@@ -24,7 +24,6 @@ documents from the `logs` index:
   "search" : {
     "request" : {
       "indices" : [ "logs" ],
-      "types" : [ "event" ],
       "body" : {
         "query" : { "match_all" : {}}
       }
@@ -171,9 +170,6 @@ accurately.
 
 | `request.indices`                             | no        | -                   | The indices to search. If omitted, all indices are searched, which is the
                                                                                     default behaviour in Elasticsearch.
-
-| `request.types`                               | no        | -                   | The document types to search for. If omitted, all document types are are
-                                                                                    searched, which is the default behaviour in Elasticsearch.
 
 | `request.body`                                | no        | -                   | The body of the request. The {ref}/search-request-body.html[request body]
                                                                                     follows the same structure you normally send in the body of a REST `_search`

--- a/x-pack/docs/en/watcher/transform/search.asciidoc
+++ b/x-pack/docs/en/watcher/transform/search.asciidoc
@@ -56,10 +56,6 @@ The following table lists all available settings for the search transform:
 
 | `request.indices`                             | no        | all indices       | One or more indices to search on.
 
-| `request.types`                               | no        | all types         | One or more document types to search on (may be a
-                                                                                  comma-delimited string or an array of document types
-                                                                                  names)
-
 | `request.body`                                | no        | `match_all` query | The body of the request. The
                                                                                   {ref}/search-request-body.html[request body] follows
                                                                                   the same structure you normally send in the body of
@@ -105,7 +101,6 @@ time of the watch:
     "search" : {
       "request" : {
         "indices" : [ "logstash-*" ],
-        "types" : [ "event" ],
         "body" : {
           "size" : 0,
           "query" : {
@@ -145,7 +140,6 @@ The following is an example of using templates that refer to provided parameters
     "search" : {
       "request" : {
         "indices" : [ "logstash-*" ],
-        "types" : [ "event" ],
         "template" : {
           "source" : {
             "size" : 0,


### PR DESCRIPTION
Types have been deprecated and this commit removes the documentation
for specifying types in the index action, and search input/transform.

Relates #37594 #35190
