### PR TITLE
[6.1] [Docs] Add example for updating meta field (#35893)

### DIFF
--- a/docs/reference/mapping/fields/meta-field.asciidoc
+++ b/docs/reference/mapping/fields/meta-field.asciidoc
@@ -27,4 +27,20 @@ PUT my_index
     <<indices-get-mapping,GET mapping>> API.
 
 The `_meta` field can be updated on an existing type using the
-<<indices-put-mapping,PUT mapping>> API.
+<<indices-put-mapping,PUT mapping>> API:
+
+[source,js]
+--------------------------------------------------
+PUT my_index/_mapping/_doc
+{
+  "_meta": {
+    "class": "MyApp2::User3",
+    "version": {
+      "min": "1.3",
+      "max": "1.5"
+    }
+  }
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]

--- a/docs/reference/mapping/fields/meta-field.asciidoc
+++ b/docs/reference/mapping/fields/meta-field.asciidoc
@@ -31,7 +31,7 @@ The `_meta` field can be updated on an existing type using the
 
 [source,js]
 --------------------------------------------------
-PUT my_index/_mapping/_doc
+PUT my_index/_mapping/user
 {
   "_meta": {
     "class": "MyApp2::User3",


### PR DESCRIPTION
Backports the following commits to 6.1:
 - [Docs] Add example for updating meta field  (#35893)