### PR TITLE
Fix the packer cache script

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -16,4 +16,9 @@ while [ -h "$SCRIPT" ] ; do
 done
 
 source $(dirname "${SCRIPT}")/java-versions.properties
-JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA} ./gradlew --parallel  resolveAllDependencies composePull
+export JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA}
+# We are caching BWC versions too, need these so we can build those
+export JAVA8_HOME="${HOME}"/.java/java8
+export JAVA11_HOME="${HOME}"/.java/java11
+export JAVA12_HOME="${HOME}"/.java/java12
+./gradlew --parallel  clean pullFixture  --scan -Porg.elasticsearch.acceptScanTOS=true -s resolveAllDependencies

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
@@ -59,14 +59,17 @@ public class TestFixturesPlugin implements Plugin<Project> {
             disableTaskByType(tasks, JarHellTask.class);
 
             Task buildFixture = project.getTasks().create("buildFixture");
+            Task pullFixture = project.getTasks().create("pullFixture");
             Task preProcessFixture = project.getTasks().create("preProcessFixture");
             buildFixture.dependsOn(preProcessFixture);
+            pullFixture.dependsOn(preProcessFixture);
             Task postProcessFixture = project.getTasks().create("postProcessFixture");
 
             if (dockerComposeSupported(project) == false) {
                 preProcessFixture.setEnabled(false);
                 postProcessFixture.setEnabled(false);
                 buildFixture.setEnabled(false);
+                pullFixture.setEnabled(false);
                 return;
             }
 
@@ -81,7 +84,9 @@ public class TestFixturesPlugin implements Plugin<Project> {
             );
 
             buildFixture.dependsOn(tasks.getByName("composeUp"));
+            pullFixture.dependsOn(tasks.getByName("composePull"));
             tasks.getByName("composeUp").mustRunAfter(preProcessFixture);
+            tasks.getByName("composePull").mustRunAfter(preProcessFixture);
             postProcessFixture.dependsOn(buildFixture);
 
             configureServiceInfoForTask(


### PR DESCRIPTION
The script is used to create a cache on ephemeral CI workers.
Changes:
    - create and use a `pullFixture` task that always exists regardless
    of docker support
    - wire dependencies correctly so any pre fixture setup runs for pull
    as well
    - set up java env vars so bwc versions can build

This should fix the network related failures in CI.