### PR TITLE
[ML] Datafeed deprecation checks

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoAction.java
@@ -132,7 +132,7 @@ public class DeprecationInfoAction extends Action<DeprecationInfoAction.Response
                 .array("cluster_settings", clusterSettingsIssues.toArray())
                 .array("node_settings", nodeSettingsIssues.toArray())
                 .field("index_settings")
-                    .map(indexSettingsIssues)
+                .map(indexSettingsIssues)
                 .array("ml_settings", mlSettingsIssues.toArray())
                 .endObject();
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -665,7 +665,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             }
         }
 
-        void setQuery(Map<String, Object> query) {
+        public void setQuery(Map<String, Object> query) {
             this.query = ExceptionsHelper.requireNonNull(query, QUERY.getPreferredName());
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoActionResponseTests.java
@@ -22,6 +22,8 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfigTests;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -45,13 +47,15 @@ public class DeprecationInfoActionResponseTests extends AbstractStreamableTestCa
             .limit(randomIntBetween(0, 10)).collect(Collectors.toList());
         List<DeprecationIssue> nodeIssues = Stream.generate(DeprecationIssueTests::createTestInstance)
             .limit(randomIntBetween(0, 10)).collect(Collectors.toList());
+        List<DeprecationIssue> mlIssues = Stream.generate(DeprecationIssueTests::createTestInstance)
+                .limit(randomIntBetween(0, 10)).collect(Collectors.toList());
         Map<String, List<DeprecationIssue>> indexIssues = new HashMap<>();
         for (int i = 0; i < randomIntBetween(0, 10); i++) {
             List<DeprecationIssue> perIndexIssues = Stream.generate(DeprecationIssueTests::createTestInstance)
                 .limit(randomIntBetween(0, 10)).collect(Collectors.toList());
             indexIssues.put(randomAlphaOfLength(10), perIndexIssues);
         }
-        return new DeprecationInfoAction.Response(clusterIssues, nodeIssues, indexIssues);
+        return new DeprecationInfoAction.Response(clusterIssues, nodeIssues, indexIssues, mlIssues);
     }
 
     @Override
@@ -80,12 +84,14 @@ public class DeprecationInfoActionResponseTests extends AbstractStreamableTestCa
         List<NodeStats> nodeStats = Collections.singletonList(new NodeStats(discoveryNode, 0L, null,
             null, null, null, null, null, null, null, null,
             null, null, null, null));
+        List<DatafeedConfig> datafeeds = Collections.singletonList(DatafeedConfigTests.createRandomizedDatafeedConfig("foo"));
         IndexNameExpressionResolver resolver = new IndexNameExpressionResolver();
         IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false,
             true, true);
         boolean clusterIssueFound = randomBoolean();
         boolean nodeIssueFound = randomBoolean();
         boolean indexIssueFound = randomBoolean();
+        boolean mlIssueFound = randomBoolean();
         DeprecationIssue foundIssue = DeprecationIssueTests.createTestInstance();
         List<Function<ClusterState, DeprecationIssue>> clusterSettingsChecks =
             Collections.unmodifiableList(Arrays.asList(
@@ -100,10 +106,14 @@ public class DeprecationInfoActionResponseTests extends AbstractStreamableTestCa
             Collections.unmodifiableList(Arrays.asList(
                 (idx) -> indexIssueFound ? foundIssue : null
             ));
+        List<Function<DatafeedConfig, DeprecationIssue>> mlSettingsChecks =
+                Collections.unmodifiableList(Arrays.asList(
+                        (idx) -> mlIssueFound ? foundIssue : null
+                ));
 
         DeprecationInfoAction.Response response = DeprecationInfoAction.Response.from(nodeInfos, nodeStats, state,
-            resolver, Strings.EMPTY_ARRAY, indicesOptions,
-            clusterSettingsChecks, nodeSettingsChecks, indexSettingsChecks);
+            resolver, Strings.EMPTY_ARRAY, indicesOptions, datafeeds,
+            clusterSettingsChecks, nodeSettingsChecks, indexSettingsChecks, mlSettingsChecks);
 
         if (clusterIssueFound) {
             assertThat(response.getClusterSettingsIssues(), equalTo(Collections.singletonList(foundIssue)));
@@ -122,6 +132,12 @@ public class DeprecationInfoActionResponseTests extends AbstractStreamableTestCa
                 Collections.singletonList(foundIssue))));
         } else {
             assertTrue(response.getIndexSettingsIssues().isEmpty());
+        }
+
+        if (mlIssueFound) {
+            assertThat(response.getMlSettingsIssues(), equalTo(Collections.singletonList(foundIssue)));
+        } else {
+            assertTrue(response.getMlSettingsIssues().isEmpty());
         }
     }
 }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -11,6 +11,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.xpack.core.deprecation.DeprecationInfoAction;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,6 +41,12 @@ public class DeprecationChecks {
     static List<Function<IndexMetaData, DeprecationIssue>> INDEX_SETTINGS_CHECKS =
         Collections.unmodifiableList(Arrays.asList(
             IndexDeprecationChecks::oldIndicesCheck));
+
+    static List<Function<DatafeedConfig, DeprecationIssue>> ML_SETTINGS_CHECKS =
+            Collections.unmodifiableList(Arrays.asList(
+                    MlDeprecationChecks::checkDataFeedAggregations,
+                    MlDeprecationChecks::checkDataFeedQuery
+            ));
 
     /**
      * helper utility function to reduce repeat of running a specific {@link List} of checks.

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecks.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.deprecation;
+
+import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+
+import java.util.List;
+
+/**
+ * Check the {@link DatafeedConfig} query and aggregations for deprecated usages.
+ */
+final class MlDeprecationChecks {
+
+    private MlDeprecationChecks() {
+    }
+
+    static DeprecationIssue checkDataFeedQuery(DatafeedConfig datafeedConfig) {
+        List<String> deprecations = datafeedConfig.getQueryDeprecations();
+        if (deprecations.isEmpty()) {
+            return null;
+        } else {
+            return new DeprecationIssue(DeprecationIssue.Level.WARNING,
+                    "Datafeed [" + datafeedConfig.getId() + "] uses deprecated query options",
+                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html#breaking_70_search_changes",
+                    deprecations.toString());
+        }
+    }
+
+    static DeprecationIssue checkDataFeedAggregations(DatafeedConfig datafeedConfig) {
+        List<String> deprecations = datafeedConfig.getAggDeprecations();
+        if (deprecations.isEmpty()) {
+            return null;
+        } else {
+            return new DeprecationIssue(DeprecationIssue.Level.WARNING,
+                    "Datafeed [" + datafeedConfig.getId() + "] uses deprecated aggregation options",
+                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                            "#breaking_70_aggregations_changes", deprecations.toString());
+        }
+    }
+}

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -107,7 +107,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
                                              listener::onFailure
                                         ));
                                     }, listener::onFailure),
-                        client.admin().cluster()::nodesStats);
+                                client.admin().cluster()::nodesStats);
                     }, listener::onFailure), client.admin().cluster()::nodesInfo);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.DEPRECATION));

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
@@ -26,7 +27,13 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.deprecation.DeprecationInfoAction;
+import org.elasticsearch.xpack.core.ml.action.GetDatafeedsAction;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+
+import java.util.Collections;
+import java.util.List;
 
 public class TransportDeprecationInfoAction extends TransportMasterNodeReadAction<DeprecationInfoAction.Request,
         DeprecationInfoAction.Response> {
@@ -34,9 +41,10 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
     private final XPackLicenseState licenseState;
     private final NodeClient client;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final Settings settings;
 
     @Inject
-    public TransportDeprecationInfoAction(TransportService transportService, ClusterService clusterService,
+    public TransportDeprecationInfoAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                           ThreadPool threadPool, ActionFilters actionFilters,
                                           IndexNameExpressionResolver indexNameExpressionResolver,
                                           XPackLicenseState licenseState, NodeClient client) {
@@ -45,6 +53,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
         this.licenseState = licenseState;
         this.client = client;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
+        this.settings = settings;
     }
 
     @Override
@@ -73,26 +82,47 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
             final ThreadContext threadContext = client.threadPool().getThreadContext();
             ClientHelper.executeAsyncWithOrigin(threadContext, ClientHelper.DEPRECATION_ORIGIN, nodesInfoRequest,
                     ActionListener.<NodesInfoResponse>wrap(
-                    nodesInfoResponse -> {
-                        if (nodesInfoResponse.hasFailures()) {
-                            throw nodesInfoResponse.failures().get(0);
-                        }
-                        ClientHelper.executeAsyncWithOrigin(threadContext, ClientHelper.DEPRECATION_ORIGIN, nodesStatsRequest,
-                                ActionListener.<NodesStatsResponse>wrap(
-                                    nodesStatsResponse -> {
-                                        if (nodesStatsResponse.hasFailures()) {
-                                            throw nodesStatsResponse.failures().get(0);
-                                        }
-                                        listener.onResponse(DeprecationInfoAction.Response.from(nodesInfoResponse.getNodes(),
-                                                nodesStatsResponse.getNodes(), state, indexNameExpressionResolver,
-                                                request.indices(), request.indicesOptions(),
-                                                DeprecationChecks.CLUSTER_SETTINGS_CHECKS, DeprecationChecks.NODE_SETTINGS_CHECKS,
-                                                DeprecationChecks.INDEX_SETTINGS_CHECKS));
-                                    }, listener::onFailure),
-                                client.admin().cluster()::nodesStats);
-                    }, listener::onFailure), client.admin().cluster()::nodesInfo);
+                        nodesInfoResponse -> {
+                            if (nodesInfoResponse.hasFailures()) {
+                                throw nodesInfoResponse.failures().get(0);
+                            }
+                            ClientHelper.executeAsyncWithOrigin(threadContext, ClientHelper.DEPRECATION_ORIGIN, nodesStatsRequest,
+                                    ActionListener.<NodesStatsResponse>wrap(
+                                            nodesStatsResponse -> {
+                                                if (nodesStatsResponse.hasFailures()) {
+                                                    throw nodesStatsResponse.failures().get(0);
+                                                }
+
+                                                getDatafeedConfigs(ActionListener.wrap(
+                                                        datafeeds -> {
+                                                            listener.onResponse(
+                                                                    DeprecationInfoAction.Response.from(nodesInfoResponse.getNodes(),
+                                                                    nodesStatsResponse.getNodes(), state, indexNameExpressionResolver,
+                                                                    request.indices(), request.indicesOptions(), datafeeds,
+                                                                    DeprecationChecks.CLUSTER_SETTINGS_CHECKS,
+                                                                    DeprecationChecks.NODE_SETTINGS_CHECKS,
+                                                                    DeprecationChecks.INDEX_SETTINGS_CHECKS,
+                                                                    DeprecationChecks.ML_SETTINGS_CHECKS));
+                                                         },
+                                                         listener::onFailure
+                                                ));
+                                            }, listener::onFailure),
+                            client.admin().cluster()::nodesStats);
+                        }, listener::onFailure), client.admin().cluster()::nodesInfo);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.DEPRECATION));
+        }
+    }
+
+    private void getDatafeedConfigs(ActionListener<List<DatafeedConfig>> listener) {
+        if (XPackSettings.MACHINE_LEARNING_ENABLED.get(settings) == false) {
+            listener.onResponse(Collections.emptyList());
+        } else {
+            ClientHelper.executeAsyncWithOrigin(client, ClientHelper.DEPRECATION_ORIGIN, GetDatafeedsAction.INSTANCE,
+                    new GetDatafeedsAction.Request(GetDatafeedsAction.ALL), ActionListener.wrap(
+                            datafeedsResponse -> listener.onResponse(datafeedsResponse.getResponse().results()),
+                            listener::onFailure
+                    ));
         }
     }
 }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -82,33 +82,33 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
             final ThreadContext threadContext = client.threadPool().getThreadContext();
             ClientHelper.executeAsyncWithOrigin(threadContext, ClientHelper.DEPRECATION_ORIGIN, nodesInfoRequest,
                     ActionListener.<NodesInfoResponse>wrap(
-                        nodesInfoResponse -> {
-                            if (nodesInfoResponse.hasFailures()) {
-                                throw nodesInfoResponse.failures().get(0);
-                            }
-                            ClientHelper.executeAsyncWithOrigin(threadContext, ClientHelper.DEPRECATION_ORIGIN, nodesStatsRequest,
-                                    ActionListener.<NodesStatsResponse>wrap(
-                                            nodesStatsResponse -> {
-                                                if (nodesStatsResponse.hasFailures()) {
-                                                    throw nodesStatsResponse.failures().get(0);
-                                                }
+                    nodesInfoResponse -> {
+                        if (nodesInfoResponse.hasFailures()) {
+                            throw nodesInfoResponse.failures().get(0);
+                        }
+                        ClientHelper.executeAsyncWithOrigin(threadContext, ClientHelper.DEPRECATION_ORIGIN, nodesStatsRequest,
+                                ActionListener.<NodesStatsResponse>wrap(
+                                    nodesStatsResponse -> {
+                                        if (nodesStatsResponse.hasFailures()) {
+                                            throw nodesStatsResponse.failures().get(0);
+                                        }
 
-                                                getDatafeedConfigs(ActionListener.wrap(
-                                                        datafeeds -> {
-                                                            listener.onResponse(
-                                                                    DeprecationInfoAction.Response.from(nodesInfoResponse.getNodes(),
-                                                                    nodesStatsResponse.getNodes(), state, indexNameExpressionResolver,
-                                                                    request.indices(), request.indicesOptions(), datafeeds,
-                                                                    DeprecationChecks.CLUSTER_SETTINGS_CHECKS,
-                                                                    DeprecationChecks.NODE_SETTINGS_CHECKS,
-                                                                    DeprecationChecks.INDEX_SETTINGS_CHECKS,
-                                                                    DeprecationChecks.ML_SETTINGS_CHECKS));
-                                                         },
-                                                         listener::onFailure
-                                                ));
-                                            }, listener::onFailure),
-                            client.admin().cluster()::nodesStats);
-                        }, listener::onFailure), client.admin().cluster()::nodesInfo);
+                                        getDatafeedConfigs(ActionListener.wrap(
+                                            datafeeds -> {
+                                                listener.onResponse(
+                                                        DeprecationInfoAction.Response.from(nodesInfoResponse.getNodes(),
+                                                        nodesStatsResponse.getNodes(), state, indexNameExpressionResolver,
+                                                        request.indices(), request.indicesOptions(), datafeeds,
+                                                        DeprecationChecks.CLUSTER_SETTINGS_CHECKS,
+                                                        DeprecationChecks.NODE_SETTINGS_CHECKS,
+                                                        DeprecationChecks.INDEX_SETTINGS_CHECKS,
+                                                        DeprecationChecks.ML_SETTINGS_CHECKS));
+                                             },
+                                             listener::onFailure
+                                        ));
+                                    }, listener::onFailure),
+                        client.admin().cluster()::nodesStats);
+                    }, listener::onFailure), client.admin().cluster()::nodesInfo);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.DEPRECATION));
         }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecksTests.java
@@ -8,14 +8,9 @@ package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.hamcrest.Matchers.equalTo;
 
 public class MlDeprecationChecksTests extends ESTestCase {
 
@@ -32,6 +27,9 @@ public class MlDeprecationChecksTests extends ESTestCase {
 
         DatafeedConfig.Builder deprecatedDatafeed = new DatafeedConfig.Builder("df-with-deprecated-query", "job-id");
         deprecatedDatafeed.setIndices(Collections.singletonList("some-index"));
+        // TODO: once some query syntax has been removed from 8.0 and deprecated in 7.x reinstate this test
+        // to check that particular query syntax causes a deprecation warning
+        /*
         Map<String, Object> qs = new HashMap<>();
         qs.put("query", "foo");
         qs.put("use_dis_max", true);
@@ -43,7 +41,8 @@ public class MlDeprecationChecksTests extends ESTestCase {
         assertThat(issue.getDetails(), equalTo("[Deprecated field [use_dis_max] used, replaced by [Set [tie_breaker] to 1 instead]]"));
         assertThat(issue.getLevel(), equalTo(DeprecationIssue.Level.WARNING));
         assertThat(issue.getMessage(), equalTo("Datafeed [df-with-deprecated-query] uses deprecated query options"));
-        assertThat(issue.getUrl(), equalTo("https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
-                "#breaking_70_search_changes"));
+        assertThat(issue.getUrl(), equalTo("https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html" +
+                "#breaking_80_search_changes"));
+        */
     }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecksTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.deprecation;
+
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class MlDeprecationChecksTests extends ESTestCase {
+
+    @Override
+    protected boolean enableWarningsCheck() {
+        return false;
+    }
+
+    public void testCheckDataFeedQuery() {
+        DatafeedConfig.Builder goodDatafeed = new DatafeedConfig.Builder("good-df", "job-id");
+        goodDatafeed.setIndices(Collections.singletonList("some-index"));
+        goodDatafeed.setParsedQuery(new TermQueryBuilder("foo", "bar"));
+        assertNull(MlDeprecationChecks.checkDataFeedQuery(goodDatafeed.build()));
+
+        DatafeedConfig.Builder deprecatedDatafeed = new DatafeedConfig.Builder("df-with-deprecated-query", "job-id");
+        deprecatedDatafeed.setIndices(Collections.singletonList("some-index"));
+        Map<String, Object> qs = new HashMap<>();
+        qs.put("query", "foo");
+        qs.put("use_dis_max", true);
+        Map<String, Object> query = Collections.singletonMap("query_string", qs);
+        deprecatedDatafeed.setQuery(query);
+        
+        DeprecationIssue issue = MlDeprecationChecks.checkDataFeedQuery(deprecatedDatafeed.build());
+        assertNotNull(issue);
+        assertThat(issue.getDetails(), equalTo("[Deprecated field [use_dis_max] used, replaced by [Set [tie_breaker] to 1 instead]]"));
+        assertThat(issue.getLevel(), equalTo(DeprecationIssue.Level.WARNING));
+        assertThat(issue.getMessage(), equalTo("Datafeed [df-with-deprecated-query] uses deprecated query options"));
+        assertThat(issue.getUrl(), equalTo("https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                "#breaking_70_search_changes"));
+    }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/deprecation/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/deprecation/10_basic.yml
@@ -17,8 +17,9 @@ setup:
 ---
 "Test ml":
   - skip:
+      version: "7.0.0 - "
       features: ["headers", "warnings"]
-      reason: testing a deprecated field
+      reason: this test needs adjusting to contain syntax deprecated in 7.x and removed in 8.0
 
 # Index the config directly to prevent the deprecated
 # use_dis_max field being rewritten by the parser. This
@@ -49,6 +50,7 @@ setup:
       indices.refresh:
         index: [.ml-config]
 
+# TODO: change the query and expected warnings to one that makes sense for 7.x
   - do:
       warnings:
         - Deprecated field [use_dis_max] used, replaced by [Set [tie_breaker] to 1 instead]

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/deprecation/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/deprecation/10_basic.yml
@@ -12,4 +12,48 @@ setup:
   - length: { cluster_settings: 0 }
   - length: { node_settings: 0 }
   - length: { index_settings: 0 }
+  - length: { ml_settings: 0 }
 
+---
+"Test ml":
+  - skip:
+      features: ["headers", "warnings"]
+      reason: testing a deprecated field
+
+# Index the config directly to prevent the deprecated
+# use_dis_max field being rewritten by the parser. This
+# simulates the config being created in an older version
+# of elasticsearch
+  - do:
+      headers:
+        Content-Type: application/json
+      index:
+        index: .ml-config
+        type: doc
+        id: deprecation-datafeed-datafeed
+        body:  >
+          {
+            "datafeed_id" : "deprecation-datafeed",
+            "config_type" : "datafeed",
+            "job_id" : "deprecation-job",
+            "indices" : ["index-foo"],
+            "query" : {
+              "query_string" : {
+                "query" : "foo",
+                "use_dis_max" : true
+              }
+            }
+          }
+
+  - do:
+      indices.refresh:
+        index: [.ml-config]
+
+  - do:
+      warnings:
+        - Deprecated field [use_dis_max] used, replaced by [Set [tie_breaker] to 1 instead]
+      xpack.migration.deprecations:
+        index: "*"
+  - length: { ml_settings: 1 }
+  - match: { ml_settings.0.level : warning }
+  - match: { ml_settings.0.message : "Datafeed [deprecation-datafeed] uses deprecated query options" }


### PR DESCRIPTION
Forward port of #37932.

The actual deprecated syntax that #37932 used in its tests cannot be used in this PR, because that syntax has now been removed.  Sometime before 7.last we need to update the tests with syntax deprecated in 7.x and removed in 8.0.

It is useful to retain the code in the master branch as it is inevitable that some search or aggs syntax will be deprecated at some point in the future and it saves having to add the functionality from scratch in every major version.  A similar approach has been taken with index format deprecations.