### PR TITLE
Fixes for several LGTM alerts

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -294,8 +294,6 @@ public class MetaDataCreateIndexService {
                 List<IndexTemplateMetaData> templates =
                         MetaDataIndexTemplateService.findTemplates(currentState.metaData(), request.index());
 
-                Map<String, Map<String, String>> customs = new HashMap<>();
-
                 // add the request mapping
                 Map<String, Map<String, Object>> mappings = new HashMap<>();
 
@@ -511,10 +509,6 @@ public class MetaDataCreateIndexService {
                     AliasMetaData aliasMetaData = AliasMetaData.builder(alias.name()).filter(alias.filter())
                         .indexRouting(alias.indexRouting()).searchRouting(alias.searchRouting()).writeIndex(alias.writeIndex()).build();
                     indexMetaDataBuilder.putAlias(aliasMetaData);
-                }
-
-                for (Map.Entry<String, Map<String, String>> customEntry : customs.entrySet()) {
-                    indexMetaDataBuilder.putCustom(customEntry.getKey(), customEntry.getValue());
                 }
 
                 indexMetaDataBuilder.state(request.state());

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -193,7 +193,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     private static final String DATA_BLOB_PREFIX = "__";
 
-    private final Settings settings;
+    protected final Settings settings;
 
     private final RateLimiter snapshotRateLimiter;
 

--- a/server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
@@ -66,10 +66,12 @@ public class FsRepository extends BlobStoreRepository {
         Setting.boolSetting("repositories.fs.compress", false, Property.NodeScope);
     private final Environment environment;
 
+    private boolean chunkSizeInitialized = false;
     private ByteSizeValue chunkSize;
 
     private final BlobPath basePath;
 
+    private boolean compressInitialized = false;
     private boolean compress;
 
     /**
@@ -100,13 +102,6 @@ public class FsRepository extends BlobStoreRepository {
             }
         }
 
-        if (CHUNK_SIZE_SETTING.exists(metadata.settings())) {
-            this.chunkSize = CHUNK_SIZE_SETTING.get(metadata.settings());
-        } else {
-            this.chunkSize = REPOSITORIES_CHUNK_SIZE_SETTING.get(environment.settings());
-        }
-        this.compress = COMPRESS_SETTING.exists(metadata.settings())
-            ? COMPRESS_SETTING.get(metadata.settings()) : REPOSITORIES_COMPRESS_SETTING.get(environment.settings());
         this.basePath = BlobPath.cleanPath();
     }
 
@@ -117,13 +112,36 @@ public class FsRepository extends BlobStoreRepository {
         return new FsBlobStore(environment.settings(), locationFile);
     }
 
+    /*
+     * Note: this method gets called by the super constructor, so we can't rely on instance fields in this class having been initialized
+     * yet.
+     */
     @Override
     protected boolean isCompress() {
+        if (!compressInitialized) {
+            this.compress = COMPRESS_SETTING.exists(metadata.settings()) ? COMPRESS_SETTING.get(metadata.settings())
+                    : REPOSITORIES_COMPRESS_SETTING.get(settings);
+            compressInitialized = true;
+        }
+        
         return compress;
     }
 
+    /*
+     * Note: this method gets called by the super constructor, so we can't rely on instance fields in this class having been initialized
+     * yet.
+     */
     @Override
     protected ByteSizeValue chunkSize() {
+        if (!chunkSizeInitialized) {
+            if (CHUNK_SIZE_SETTING.exists(metadata.settings())) {
+                this.chunkSize = CHUNK_SIZE_SETTING.get(metadata.settings());
+            } else {
+                this.chunkSize = REPOSITORIES_CHUNK_SIZE_SETTING.get(settings);
+            }
+            chunkSizeInitialized = true;
+        }
+        
         return chunkSize;
     }
 

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/Debug.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/Debug.java
@@ -91,11 +91,11 @@ final class Debug {
     static Statement proxy(Object statement, StatementProxy handler) {
         Class<? extends Statement> i = Statement.class;
 
-        if (statement instanceof PreparedStatement) {
-            i = PreparedStatement.class;
-        }
-        else if (statement instanceof CallableStatement) {
+        if (statement instanceof CallableStatement) {
             i = CallableStatement.class;
+        }
+        else if (statement instanceof PreparedStatement) {
+            i = PreparedStatement.class;
         }
 
         return createProxy(i, handler);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -887,17 +887,17 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 NamedExpression expr = exprs.get(i);
                 NamedExpression transformed = (NamedExpression) expr.transformUp(ua -> {
                     Expression child = ua.child();
-                    if (child instanceof NamedExpression) {
-                        return child;
-                    }
-                    if (!child.resolved()) {
-                        return ua;
-                    }
                     if (child instanceof Cast) {
                         Cast c = (Cast) child;
                         if (c.field() instanceof NamedExpression) {
                             return new Alias(c.source(), ((NamedExpression) c.field()).name(), c);
                         }
+                    }
+                    if (child instanceof NamedExpression) {
+                        return child;
+                    }
+                    if (!child.resolved()) {
+                        return ua;
                     }
                     return new Alias(child.source(), child.sourceText(), child);
                 }, UnresolvedAlias.class);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
@@ -404,11 +404,11 @@ final class QueryTranslator {
         if (e instanceof DateTimeFunction) {
             return nameOf(((DateTimeFunction) e).field());
         }
-        if (e instanceof NamedExpression) {
-            return ((NamedExpression) e).name();
-        }
         if (e instanceof Literal) {
             return String.valueOf(e.fold());
+        }
+        if (e instanceof NamedExpression) {
+            return ((NamedExpression) e).name();
         }
         throw new SqlIllegalArgumentException("Cannot determine name for {}", e);
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/container/QueryContainer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/container/QueryContainer.java
@@ -179,9 +179,6 @@ public class QueryContainer {
     }
 
     private Tuple<QueryContainer, FieldExtraction> nestedHitFieldRef(FieldAttribute attr) {
-        // Find the nested query for this field. If there isn't one then create it
-        List<FieldExtraction> nestedRefs = new ArrayList<>();
-
         String name = aliasName(attr);
         String format = attr.field().getDataType() == DataType.DATETIME ? "epoch_millis" : DocValueFieldsContext.USE_DEFAULT_FORMAT;
         Query q = rewriteToContainNestedField(query, attr.source(),
@@ -189,7 +186,6 @@ public class QueryContainer {
 
         SearchHitFieldRef nestedFieldRef = new SearchHitFieldRef(name, attr.field().getDataType(),
                 attr.field().isAggregatable(), attr.parent().name());
-        nestedRefs.add(nestedFieldRef);
 
         return new Tuple<>(new QueryContainer(q, aggs, columns, aliases, pseudoFunctions, scalarFunctions, sort, limit), nestedFieldRef);
     }


### PR DESCRIPTION
Hi. I'm an [LGTM](https://lgtm.com/) developer, and had some time to fix a few alerts flagged in Elasticsearch by our analyses.

There should be one commit per file, and the commit messages have links back to the original alerts to make it easy for you to check what each thing is about.

Let me know if this is helpful or not, what I can do better, or if there are any specific (types of) alerts you're interested in which I can look at in the future.