### PR TITLE
Add dispatching to `HandledTransportAction`

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
@@ -45,6 +45,11 @@ public abstract class HandledTransportAction<Request extends ActionRequest, Resp
         this(actionName, true, transportService, actionFilters, requestReader);
     }
 
+    protected HandledTransportAction(String actionName, TransportService transportService,
+                                     ActionFilters actionFilters, Writeable.Reader<Request> requestReader, String executor) {
+        this(actionName, true, transportService, actionFilters, requestReader, executor);
+    }
+
     protected HandledTransportAction(String actionName, boolean canTripCircuitBreaker,
                                      TransportService transportService, ActionFilters actionFilters, Supplier<Request> request) {
         super(actionName, actionFilters, transportService.getTaskManager());
@@ -55,8 +60,14 @@ public abstract class HandledTransportAction<Request extends ActionRequest, Resp
     protected HandledTransportAction(String actionName, boolean canTripCircuitBreaker,
                                      TransportService transportService, ActionFilters actionFilters,
                                      Writeable.Reader<Request> requestReader) {
+        this(actionName, canTripCircuitBreaker, transportService, actionFilters, requestReader, ThreadPool.Names.SAME);
+    }
+
+    protected HandledTransportAction(String actionName, boolean canTripCircuitBreaker,
+                                     TransportService transportService, ActionFilters actionFilters,
+                                     Writeable.Reader<Request> requestReader, String executor) {
         super(actionName, actionFilters, transportService.getTaskManager());
-        transportService.registerRequestHandler(actionName, ThreadPool.Names.SAME, false, canTripCircuitBreaker, requestReader,
+        transportService.registerRequestHandler(actionName, executor, false, canTripCircuitBreaker, requestReader,
             new TransportHandler());
     }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/ClearCcrRestoreSessionAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/ClearCcrRestoreSessionAction.java
@@ -43,26 +43,20 @@ public class ClearCcrRestoreSessionAction extends Action<ClearCcrRestoreSessionA
         extends HandledTransportAction<ClearCcrRestoreSessionRequest, ClearCcrRestoreSessionResponse> {
 
         private final CcrRestoreSourceService ccrRestoreService;
-        private final ThreadPool threadPool;
 
         @Inject
         public TransportDeleteCcrRestoreSessionAction(ActionFilters actionFilters, TransportService transportService,
                                                       CcrRestoreSourceService ccrRestoreService) {
-            super(NAME, transportService, actionFilters, ClearCcrRestoreSessionRequest::new);
+            super(NAME, transportService, actionFilters, ClearCcrRestoreSessionRequest::new, ThreadPool.Names.GENERIC);
             TransportActionProxy.registerProxyAction(transportService, NAME, ClearCcrRestoreSessionResponse::new);
             this.ccrRestoreService = ccrRestoreService;
-            this.threadPool = transportService.getThreadPool();
         }
 
         @Override
         protected void doExecute(Task task, ClearCcrRestoreSessionRequest request,
                                  ActionListener<ClearCcrRestoreSessionResponse> listener) {
-            // TODO: Currently blocking actions might occur in the session closed callbacks. This dispatch
-            //  may be unnecessary when we remove these callbacks.
-            threadPool.generic().execute(() ->  {
-                ccrRestoreService.closeSession(request.getSessionUUID());
-                listener.onResponse(new ClearCcrRestoreSessionResponse());
-            });
+            ccrRestoreService.closeSession(request.getSessionUUID());
+            listener.onResponse(new ClearCcrRestoreSessionResponse());
         }
     }
 


### PR DESCRIPTION
This commit allows implementors of the `HandledTransportAction` to
specify what thread the action should be executed on. The motivation for
this commit is that certain CCR requests should be performed on the
generic threadpool.