### PR TITLE
Improve the deprecation messages around include_type_name.

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
@@ -42,8 +42,8 @@ public class RestCreateIndexAction extends BaseRestHandler {
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
         LogManager.getLogger(RestPutMappingAction.class));
     public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in create index " +
-        "requests is deprecated. To be compatible with 7.0, the mapping definition should not nested under the " +
-        "type name, and the parameter include_type_name must be provided and set to false.";
+        "requests is deprecated. To be compatible with 7.0, the mapping definition should not be nested under " +
+        "the type name, and the parameter include_type_name must be provided and set to false.";
 
     public RestCreateIndexAction(Settings settings, RestController controller) {
         super(settings);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
@@ -42,8 +42,8 @@ public class RestCreateIndexAction extends BaseRestHandler {
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
         LogManager.getLogger(RestPutMappingAction.class));
     public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in create index " +
-        "requests is deprecated. The parameter include_type_name should be provided and set to false to be " +
-        "compatible with the next major version.";
+        "requests is deprecated. To be compatible with 7.0, the mapping definition should not nested under the " +
+        "type name, and the parameter include_type_name must be provided and set to false.";
 
     public RestCreateIndexAction(Settings settings, RestController controller) {
         super(settings);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetFieldMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetFieldMappingAction.java
@@ -48,9 +48,9 @@ public class RestGetFieldMappingAction extends BaseRestHandler {
 
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
         LogManager.getLogger(RestGetFieldMappingAction.class));
-    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in get field mapping " +
-        "requests is deprecated. The parameter include_type_name should be provided and set to false to be " +
-        "compatible with the next major version.";
+    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] The response format of get field " +
+        "mapping requests will change in 7.0. Please start using the include_type_name parameter set to false " +
+        "to move to the new, typeless response format that will become the default.";
 
     public RestGetFieldMappingAction(Settings settings, RestController controller) {
         super(settings);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
@@ -46,10 +46,11 @@ import static org.elasticsearch.rest.RestRequest.Method.HEAD;
  */
 public class RestGetIndicesAction extends BaseRestHandler {
 
-    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestGetIndicesAction.class));
-    static final String TYPES_DEPRECATION_MESSAGE = "[types removal] The response format of get indices requests will change in "
-            + "the next major version. Please start using the `include_type_name` parameter set to `false` in the request to "
-            + "move to the new, typeless response format that will be the default in 7.0.";
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
+        LogManager.getLogger(RestGetIndicesAction.class));
+    static final String TYPES_DEPRECATION_MESSAGE = "[types removal] The response format of get indices requests " +
+        "will change in 7.0. Please start using the include_type_name parameter set to false to move to the new, " +
+        "typeless response format that will become the default.";
 
     private static final Set<String> allowedResponseParameters = Collections
             .unmodifiableSet(Stream.concat(Collections.singleton(INCLUDE_TYPE_NAME_PARAMETER).stream(), Settings.FORMAT_PARAMS.stream())

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
@@ -59,8 +59,8 @@ import static org.elasticsearch.rest.RestRequest.Method.HEAD;
 public class RestGetMappingAction extends BaseRestHandler {
     private static final Logger logger = LogManager.getLogger(RestGetMappingAction.class);
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
-    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] The response format of get index " +
-        "template requests will change in 7.0. Please start using the include_type_name parameter set to false to " +
+    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] The response format of get mapping " +
+        "requests will change in 7.0. Please start using the include_type_name parameter set to false to " +
         "move to the new, typeless response format that will become the default.";
 
     public RestGetMappingAction(final Settings settings, final RestController controller) {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
@@ -59,9 +59,9 @@ import static org.elasticsearch.rest.RestRequest.Method.HEAD;
 public class RestGetMappingAction extends BaseRestHandler {
     private static final Logger logger = LogManager.getLogger(RestGetMappingAction.class);
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
-    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Using include_type_name in get" +
-        " mapping requests is deprecated. The parameter will be removed in the next major version.";
-
+    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] The response format of get index " +
+        "template requests will change in 7.0. Please start using the include_type_name parameter set to false to " +
+        "move to the new, typeless response format that will become the default.";
 
     public RestGetMappingAction(final Settings settings, final RestController controller) {
         super(settings);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
@@ -41,9 +41,9 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestPutMappingAction extends BaseRestHandler {
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
         LogManager.getLogger(RestPutMappingAction.class));
-    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in put mapping " +
-        "requests is deprecated. The parameter include_type_name should be provided and set to false to be " +
-        "compatible with the next major version.";
+    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in create index " +
+        "requests is deprecated. To be compatible with 7.0, the mapping definition should not nested under the " +
+        "type name, and the parameter include_type_name must be provided and set to false.";
 
     public RestPutMappingAction(Settings settings, RestController controller) {
         super(settings);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
@@ -42,8 +42,8 @@ public class RestPutMappingAction extends BaseRestHandler {
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
         LogManager.getLogger(RestPutMappingAction.class));
     public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in create index " +
-        "requests is deprecated. To be compatible with 7.0, the mapping definition should not nested under the " +
-        "type name, and the parameter include_type_name must be provided and set to false.";
+        "requests is deprecated. To be compatible with 7.0, the mapping definition should not be nested under " +
+        "the type name, and the parameter include_type_name must be provided and set to false.";
 
     public RestPutMappingAction(Settings settings, RestController controller) {
         super(settings);


### PR DESCRIPTION
This PR standardizes the message across the different indices APIs and makes
sure to mention that mappings should no longer be nested under the type name.

Thanks @markharwood for this feedback in https://github.com/elastic/elasticsearch/pull/37944#discussion_r252279003.