### PR TITLE
Reenable BWC testing after retention lease stats

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,8 +159,8 @@ task verifyVersions {
  * the enabled state of every bwc task. It should be set back to true
  * after the backport of the backcompat code is complete.
  */
-final boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/37991" /* place a PR link here when committing bwc changes */
+final boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
@@ -130,7 +130,7 @@ public class ShardStats implements Streamable, Writeable, ToXContentFragment {
         if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
             seqNoStats = in.readOptionalWriteable(SeqNoStats::new);
         }
-        if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_6_7_0)) {
             retentionLeaseStats = in.readOptionalWriteable(RetentionLeaseStats::new);
         }
     }
@@ -146,7 +146,7 @@ public class ShardStats implements Streamable, Writeable, ToXContentFragment {
         if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
             out.writeOptionalWriteable(seqNoStats);
         }
-        if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_6_7_0)) {
             out.writeOptionalWriteable(retentionLeaseStats);
         }
     }


### PR DESCRIPTION
This commit adjusts the BWC version on retention leases in stats, so with this we also reenable BWC testing.

Relates #37991
Relates #38049