### PR TITLE
Correct argument names in update mapping/settings from leader

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
@@ -133,21 +133,21 @@ public abstract class ShardFollowNodeTask extends AllocatedPersistentTask {
         }
 
         // updates follower mapping, this gets us the leader mapping version and makes sure that leader and follower mapping are identical
-        updateMapping(0L, followerMappingVersion -> {
+        updateMapping(0L, leaderMappingVersion -> {
             synchronized (ShardFollowNodeTask.this) {
-                currentMappingVersion = followerMappingVersion;
+                currentMappingVersion = leaderMappingVersion;
             }
-            updateSettings(followerSettingsVersion -> {
+            updateSettings(leaderSettingsVersion -> {
                 synchronized (ShardFollowNodeTask.this) {
-                    currentSettingsVersion = followerSettingsVersion;
+                    currentSettingsVersion = leaderSettingsVersion;
                 }
                 LOGGER.info(
                         "{} following leader shard {}, follower global checkpoint=[{}], mapping version=[{}], settings version=[{}]",
                         params.getFollowShardId(),
                         params.getLeaderShardId(),
                         followerGlobalCheckpoint,
-                        followerMappingVersion,
-                        followerSettingsVersion);
+                        leaderMappingVersion,
+                        leaderSettingsVersion);
                 coordinateReads();
             });
         });


### PR DESCRIPTION
These two lambda arguments are not named incorrectly and caused confusion.