### PR TITLE
Don't Assert Ack on when Publish Timeout is 0 in Test

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/state/RareClusterStateIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/state/RareClusterStateIT.java
@@ -333,12 +333,12 @@ public class RareClusterStateIT extends ESIntegTestCase {
 
         // Force allocation of the primary on the master node by first only allocating on the master
         // and then allowing all nodes so that the replica gets allocated on the other node
-        assertAcked(prepareCreate("index").setSettings(Settings.builder()
+        prepareCreate("index").setSettings(Settings.builder()
                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
-                .put("index.routing.allocation.include._name", master)).get());
-        assertAcked(client().admin().indices().prepareUpdateSettings("index").setSettings(Settings.builder()
-                .put("index.routing.allocation.include._name", "")).get());
+                .put("index.routing.allocation.include._name", master)).get();
+        client().admin().indices().prepareUpdateSettings("index").setSettings(Settings.builder()
+                .put("index.routing.allocation.include._name", "")).get();
         ensureGreen();
 
         // Check routing tables


### PR DESCRIPTION
* Publish timeout is set to `0` so out of order processing of states on the node can lead to a `false` ack response
  * Relaxing this should be safe as we're verifying the expected routing table state afterwards anyway right?
  * See #30672
* Closes #36813