### PR TITLE
Trim the JSON source in indexing slow logs

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexingSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexingSlowLog.java
@@ -194,7 +194,7 @@ public final class IndexingSlowLog implements IndexingOperationListener {
             }
             try {
                 String source = XContentHelper.convertToJson(doc.source(), reformat, doc.getXContentType());
-                sb.append(", source[").append(Strings.cleanTruncate(source, maxSourceCharsToLog)).append("]");
+                sb.append(", source[").append(Strings.cleanTruncate(source, maxSourceCharsToLog).trim()).append("]");
             } catch (IOException e) {
                 sb.append(", source[_failed_to_convert_[").append(e.getMessage()).append("]]");
                 /*

--- a/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -187,7 +187,8 @@ public final class SearchSlowLog implements SearchOperationListener {
             sb.append("search_type[").append(context.searchType()).append("], total_shards[")
                 .append(context.numberOfShards()).append("], ");
             if (context.request().source() != null) {
-                sb.append("source[").append(context.request().source().toString(FORMAT_PARAMS)).append("], ");
+                String source = context.request().source().toString(FORMAT_PARAMS).trim();
+                sb.append("source[").append(source).append("], ");
             } else {
                 sb.append("source[], ");
             }

--- a/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -187,8 +187,7 @@ public final class SearchSlowLog implements SearchOperationListener {
             sb.append("search_type[").append(context.searchType()).append("], total_shards[")
                 .append(context.numberOfShards()).append("], ");
             if (context.request().source() != null) {
-                String source = context.request().source().toString(FORMAT_PARAMS).trim();
-                sb.append("source[").append(source).append("], ");
+                sb.append("source[").append(context.request().source().toString(FORMAT_PARAMS)).append("], ");
             } else {
                 sb.append("source[], ");
             }

--- a/server/src/test/java/org/elasticsearch/index/IndexingSlowLogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexingSlowLogTests.java
@@ -47,10 +47,10 @@ import static org.hamcrest.Matchers.startsWith;
 public class IndexingSlowLogTests extends ESTestCase {
     public void testSlowLogParsedDocumentPrinterSourceToLog() throws IOException {
         BytesReference source = BytesReference.bytes(JsonXContent.contentBuilder()
-                                                                 .startObject().field("foo", "bar").endObject());
+            .startObject().field("foo", "bar").endObject());
         ParsedDocument pd = new ParsedDocument(new NumericDocValuesField("version", 1),
             SeqNoFieldMapper.SequenceIDFields.emptySeqID(), "id",
-            "test", null, null, source, XContentType.JSON, null);
+                "test", null, null, source, XContentType.JSON, null);
         Index index = new Index("foo", "123");
         // Turning off document logging doesn't log source[]
         SlowLogParsedDocumentPrinter p = new SlowLogParsedDocumentPrinter(index, pd, 10, true, 0);
@@ -83,15 +83,15 @@ public class IndexingSlowLogTests extends ESTestCase {
         assertNotNull(e.getCause());
         assertThat(e.getCause(), instanceOf(JsonParseException.class));
         assertThat(e.getCause(), hasToString(containsString("Unrecognized token 'invalid':"
-            + " was expecting ('true', 'false' or 'null')\n"
-            + " at [Source: org.elasticsearch.common.bytes.BytesReference$MarkSupportingStreamInputWrapper")));
+                + " was expecting ('true', 'false' or 'null')\n"
+                + " at [Source: org.elasticsearch.common.bytes.BytesReference$MarkSupportingStreamInputWrapper")));
     }
 
     public void testReformatSetting() {
         IndexMetaData metaData = newIndexMeta("index", Settings.builder()
-                                                               .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
-                                                               .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_REFORMAT_SETTING.getKey(), false)
-                                                               .build());
+            .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_REFORMAT_SETTING.getKey(), false)
+            .build());
         IndexSettings settings = new IndexSettings(metaData, Settings.EMPTY);
         IndexingSlowLog log = new IndexingSlowLog(settings);
         assertFalse(log.isReformat());
@@ -107,8 +107,8 @@ public class IndexingSlowLogTests extends ESTestCase {
         assertTrue(log.isReformat());
 
         metaData = newIndexMeta("index", Settings.builder()
-                                                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
-                                                 .build());
+            .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+            .build());
         settings = new IndexSettings(metaData, Settings.EMPTY);
         log = new IndexingSlowLog(settings);
         assertTrue(log.isReformat());
@@ -147,9 +147,9 @@ public class IndexingSlowLogTests extends ESTestCase {
     public void testLevelSetting() {
         SlowLogLevel level = randomFrom(SlowLogLevel.values());
         IndexMetaData metaData = newIndexMeta("index", Settings.builder()
-                                                               .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
-                                                               .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_LEVEL_SETTING.getKey(), level)
-                                                               .build());
+            .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_LEVEL_SETTING.getKey(), level)
+            .build());
         IndexSettings settings = new IndexSettings(metaData, Settings.EMPTY);
         IndexingSlowLog log = new IndexingSlowLog(settings);
         assertEquals(level, log.getLevel());
@@ -171,8 +171,8 @@ public class IndexingSlowLogTests extends ESTestCase {
         assertEquals(SlowLogLevel.TRACE, log.getLevel());
 
         metaData = newIndexMeta("index", Settings.builder()
-                                                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
-                                                 .build());
+            .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+            .build());
         settings = new IndexSettings(metaData, Settings.EMPTY);
         log = new IndexingSlowLog(settings);
         assertTrue(log.isReformat());
@@ -193,12 +193,12 @@ public class IndexingSlowLogTests extends ESTestCase {
 
     public void testSetLevels() {
         IndexMetaData metaData = newIndexMeta("index", Settings.builder()
-                                                               .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
-                                                               .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_TRACE_SETTING.getKey(), "100ms")
-                                                               .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_DEBUG_SETTING.getKey(), "200ms")
-                                                               .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_INFO_SETTING.getKey(), "300ms")
-                                                               .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_WARN_SETTING.getKey(), "400ms")
-                                                               .build());
+            .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_TRACE_SETTING.getKey(), "100ms")
+            .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_DEBUG_SETTING.getKey(), "200ms")
+            .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_INFO_SETTING.getKey(), "300ms")
+            .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_WARN_SETTING.getKey(), "400ms")
+            .build());
         IndexSettings settings = new IndexSettings(metaData, Settings.EMPTY);
         IndexingSlowLog log = new IndexingSlowLog(settings);
         assertEquals(TimeValue.timeValueMillis(100).nanos(), log.getIndexTraceThreshold());
@@ -208,9 +208,9 @@ public class IndexingSlowLogTests extends ESTestCase {
 
         settings.updateIndexMetaData(newIndexMeta("index",
             Settings.builder().put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_TRACE_SETTING.getKey(), "120ms")
-                    .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_DEBUG_SETTING.getKey(), "220ms")
-                    .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_INFO_SETTING.getKey(), "320ms")
-                    .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_WARN_SETTING.getKey(), "420ms").build()));
+            .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_DEBUG_SETTING.getKey(), "220ms")
+            .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_INFO_SETTING.getKey(), "320ms")
+            .put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_WARN_SETTING.getKey(), "420ms").build()));
 
 
         assertEquals(TimeValue.timeValueMillis(120).nanos(), log.getIndexTraceThreshold());
@@ -219,8 +219,8 @@ public class IndexingSlowLogTests extends ESTestCase {
         assertEquals(TimeValue.timeValueMillis(420).nanos(), log.getIndexWarnThreshold());
 
         metaData = newIndexMeta("index", Settings.builder()
-                                                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
-                                                 .build());
+            .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+            .build());
         settings.updateIndexMetaData(metaData);
         assertEquals(TimeValue.timeValueMillis(-1).nanos(), log.getIndexTraceThreshold());
         assertEquals(TimeValue.timeValueMillis(-1).nanos(), log.getIndexDebugThreshold());
@@ -237,7 +237,7 @@ public class IndexingSlowLogTests extends ESTestCase {
         try {
             settings.updateIndexMetaData(newIndexMeta("index",
                 Settings.builder().put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_TRACE_SETTING.getKey(), "NOT A TIME VALUE")
-                        .build()));
+                    .build()));
             fail();
         } catch (IllegalArgumentException ex) {
             assertTimeValueException(ex, "index.indexing.slowlog.threshold.index.trace");
@@ -246,7 +246,7 @@ public class IndexingSlowLogTests extends ESTestCase {
         try {
             settings.updateIndexMetaData(newIndexMeta("index",
                 Settings.builder().put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_DEBUG_SETTING.getKey(), "NOT A TIME VALUE")
-                        .build()));
+                    .build()));
             fail();
         } catch (IllegalArgumentException ex) {
             assertTimeValueException(ex, "index.indexing.slowlog.threshold.index.debug");
@@ -255,7 +255,7 @@ public class IndexingSlowLogTests extends ESTestCase {
         try {
             settings.updateIndexMetaData(newIndexMeta("index",
                 Settings.builder().put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_INFO_SETTING.getKey(), "NOT A TIME VALUE")
-                        .build()));
+                    .build()));
             fail();
         } catch (IllegalArgumentException ex) {
             assertTimeValueException(ex, "index.indexing.slowlog.threshold.index.info");
@@ -264,7 +264,7 @@ public class IndexingSlowLogTests extends ESTestCase {
         try {
             settings.updateIndexMetaData(newIndexMeta("index",
                 Settings.builder().put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_WARN_SETTING.getKey(), "NOT A TIME VALUE")
-                        .build()));
+                    .build()));
             fail();
         } catch (IllegalArgumentException ex) {
             assertTimeValueException(ex, "index.indexing.slowlog.threshold.index.warn");
@@ -278,16 +278,16 @@ public class IndexingSlowLogTests extends ESTestCase {
         assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
         final IllegalArgumentException cause = (IllegalArgumentException) e.getCause();
         final String causeExpected =
-            "failed to parse setting [" + key + "] with value [NOT A TIME VALUE] as a time value: unit is missing or unrecognized";
+                "failed to parse setting [" + key + "] with value [NOT A TIME VALUE] as a time value: unit is missing or unrecognized";
         assertThat(cause, hasToString(containsString(causeExpected)));
     }
 
     private IndexMetaData newIndexMeta(String name, Settings indexSettings) {
         Settings build = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
-                                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
-                                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
-                                 .put(indexSettings)
-                                 .build();
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(indexSettings)
+            .build();
         IndexMetaData metaData = IndexMetaData.builder(name).settings(build).build();
         return metaData;
     }


### PR DESCRIPTION
The '{' as a first character in log line is causing problems for beats when parsing plaintext logs. 
This is used to distinguish if the logs are in JSON or plaintext (they want to keep the logic consistent for docker and standalone deployments, so file extension can not be used).

When the JSON in source element is **not** reformatted (`index.indexing.slowlog.reformat: false`) and the user send a document with an additional `\n` like here:
```
curl --request PUT \
  --url http://localhost:9200/index1/doc/2 \
  --header 'content-type: application/json' \
  --data '
{
      "network":{
        "name":"lo0",
        "in":{
          "errors":0,
          "dropped":0,
          "bytes":77666873,
          "packets":244595},
          "out":{
            "packets":244595,
            "bytes":77666873,
            "errors":0,
            "dropped":0
          }
        }
      }'
```
Then the `{` will endup in a new line
```
[2018-07-04T21:51:30,411][INFO ][index.indexing.slowlog.index] [v_VJhjV] [metricbeat-6.3.0-2018.07.04/VLKxBLvUSYuIMKzpacGjRg] took[1.7ms], took_millis[1], type[doc], id[s01HZ2QBk9jw4gtgaFtn], routing[], source[
{
  "@timestamp":"2018-07-04T21:27:30.730Z",
  "metricset":{
...
```
**Trimming the source part of a SlowLog will solve the problem and will keep the logs readable.**
```
2018-07-04T21:51:30,411][INFO ][index.indexing.slowlog.index] [v_VJhjV] [metricbeat-6.3.0-2018.07.04/VLKxBLvUSYuIMKzpacGjRg] took[1.7ms], took_millis[1], type[doc], id[s01HZ2QBk9jw4gtgaFtn], routing[], source[{
  "@timestamp":"2018-07-04T21:27:30.730Z",
...
...
}]
```
This won't happen for Search slow logs, as we repackage the user's request into our own `SearchRequest` object.
closes #38080 
