### PR TITLE
Replace joda time in ingest-common module

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
@@ -21,10 +21,6 @@ package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateFormatters;
-import org.elasticsearch.common.time.DateUtils;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.ISODateTimeFormat;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -48,26 +44,26 @@ import static java.time.temporal.ChronoField.SECOND_OF_DAY;
 enum DateFormat {
     Iso8601 {
         @Override
-        Function<String, DateTime> getFunction(String format, DateTimeZone timezone, Locale locale) {
-            return ISODateTimeFormat.dateTimeParser().withZone(timezone)::parseDateTime;
+        Function<String, ZonedDateTime> getFunction(String format, ZoneId timezone, Locale locale) {
+            return (date) -> DateFormatters.from(DateFormatter.forPattern("strict_date_time").parse(date)).withZoneSameInstant(timezone);
         }
     },
     Unix {
         @Override
-        Function<String, DateTime> getFunction(String format, DateTimeZone timezone, Locale locale) {
-            return (date) -> new DateTime((long)(Double.parseDouble(date) * 1000), timezone);
+        Function<String, ZonedDateTime> getFunction(String format, ZoneId timezone, Locale locale) {
+            return date -> Instant.ofEpochMilli((long) (Double.parseDouble(date) * 1000.0)).atZone(timezone);
         }
     },
     UnixMs {
         @Override
-        Function<String, DateTime> getFunction(String format, DateTimeZone timezone, Locale locale) {
-            return (date) -> new DateTime(Long.parseLong(date), timezone);
+        Function<String, ZonedDateTime> getFunction(String format, ZoneId timezone, Locale locale) {
+            return date -> Instant.ofEpochMilli(Long.parseLong(date)).atZone(timezone);
         }
     },
     Tai64n {
         @Override
-        Function<String, DateTime> getFunction(String format, DateTimeZone timezone, Locale locale) {
-            return (date) -> new DateTime(parseMillis(date), timezone);
+        Function<String, ZonedDateTime> getFunction(String format, ZoneId timezone, Locale locale) {
+            return date -> Instant.ofEpochMilli(parseMillis(date)).atZone(timezone);
         }
 
         private long parseMillis(String date) {
@@ -85,13 +81,12 @@ enum DateFormat {
             Arrays.asList(NANO_OF_SECOND, SECOND_OF_DAY, MINUTE_OF_DAY, HOUR_OF_DAY, DAY_OF_MONTH, MONTH_OF_YEAR);
 
         @Override
-        Function<String, DateTime> getFunction(String format, DateTimeZone timezone, Locale locale) {
+        Function<String, ZonedDateTime> getFunction(String format, ZoneId zoneId, Locale locale) {
             // support the 6.x BWC compatible way of parsing java 8 dates
             if (format.startsWith("8")) {
                 format = format.substring(1);
             }
 
-            ZoneId zoneId = DateUtils.dateTimeZoneToZoneId(timezone);
             int year = LocalDate.now(ZoneOffset.UTC).getYear();
             DateFormatter formatter = DateFormatter.forPattern(format)
                 .withLocale(locale)
@@ -111,13 +106,12 @@ enum DateFormat {
                     accessor = newTime.withZoneSameLocal(zoneId);
                 }
 
-                long millis = DateFormatters.from(accessor).toInstant().toEpochMilli();
-                return new DateTime(millis, timezone);
+                return DateFormatters.from(accessor);
             };
         }
     };
 
-    abstract Function<String, DateTime> getFunction(String format, DateTimeZone timezone, Locale locale);
+    abstract Function<String, ZonedDateTime> getFunction(String format, ZoneId timezone, Locale locale);
 
     static DateFormat fromString(String format) {
         switch (format) {

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateIndexNameProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateIndexNameProcessor.java
@@ -19,6 +19,18 @@
 
 package org.elasticsearch.ingest.common;
 
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.ingest.AbstractProcessor;
+import org.elasticsearch.ingest.ConfigurationUtils;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.Processor;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.TemplateScript;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IllformedLocaleException;
@@ -26,18 +38,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
-
-import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.ingest.AbstractProcessor;
-import org.elasticsearch.ingest.ConfigurationUtils;
-import org.elasticsearch.ingest.IngestDocument;
-import org.elasticsearch.ingest.Processor;
-import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.script.TemplateScript;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 
 public final class DateIndexNameProcessor extends AbstractProcessor {
 
@@ -47,10 +47,10 @@ public final class DateIndexNameProcessor extends AbstractProcessor {
     private final TemplateScript.Factory indexNamePrefixTemplate;
     private final TemplateScript.Factory dateRoundingTemplate;
     private final TemplateScript.Factory indexNameFormatTemplate;
-    private final DateTimeZone timezone;
-    private final List<Function<String, DateTime>> dateFormats;
+    private final ZoneId timezone;
+    private final List<Function<String, ZonedDateTime>> dateFormats;
 
-    DateIndexNameProcessor(String tag, String field, List<Function<String, DateTime>> dateFormats, DateTimeZone timezone,
+    DateIndexNameProcessor(String tag, String field, List<Function<String, ZonedDateTime>> dateFormats, ZoneId timezone,
                            TemplateScript.Factory indexNamePrefixTemplate, TemplateScript.Factory dateRoundingTemplate,
                            TemplateScript.Factory indexNameFormatTemplate) {
         super(tag);
@@ -72,9 +72,9 @@ public final class DateIndexNameProcessor extends AbstractProcessor {
             date = obj.toString();
         }
 
-        DateTime dateTime = null;
+        ZonedDateTime dateTime = null;
         Exception lastException = null;
-        for (Function<String, DateTime> dateParser : dateFormats) {
+        for (Function<String, ZonedDateTime> dateParser : dateFormats) {
             try {
                 dateTime = dateParser.apply(date);
             } catch (Exception e) {
@@ -90,13 +90,13 @@ public final class DateIndexNameProcessor extends AbstractProcessor {
         String indexNameFormat = ingestDocument.renderTemplate(indexNameFormatTemplate);
         String dateRounding = ingestDocument.renderTemplate(dateRoundingTemplate);
 
-        DateTimeFormatter formatter = DateTimeFormat.forPattern(indexNameFormat);
+        DateFormatter formatter = DateFormatter.forPattern(indexNameFormat);;
         StringBuilder builder = new StringBuilder()
                 .append('<')
                 .append(indexNamePrefix)
                     .append('{')
-                        .append(formatter.print(dateTime)).append("||/").append(dateRounding)
-                            .append('{').append(indexNameFormat).append('|').append(timezone).append('}')
+                        .append(formatter.format(dateTime)).append("||/").append(dateRounding)
+                            .append('{').append(indexNameFormat).append('|').append(timezone.getId()).append('}')
                     .append('}')
                 .append('>');
         String dynamicIndexName  = builder.toString();
@@ -125,11 +125,11 @@ public final class DateIndexNameProcessor extends AbstractProcessor {
         return indexNameFormatTemplate;
     }
 
-    DateTimeZone getTimezone() {
+    ZoneId getTimezone() {
         return timezone;
     }
 
-    List<Function<String, DateTime>> getDateFormats() {
+    List<Function<String, ZonedDateTime>> getDateFormats() {
         return dateFormats;
     }
 
@@ -146,7 +146,7 @@ public final class DateIndexNameProcessor extends AbstractProcessor {
                                              Map<String, Object> config) throws Exception {
             String localeString = ConfigurationUtils.readOptionalStringProperty(TYPE, tag, config, "locale");
             String timezoneString = ConfigurationUtils.readOptionalStringProperty(TYPE, tag, config, "timezone");
-            DateTimeZone timezone = timezoneString == null ? DateTimeZone.UTC : DateTimeZone.forID(timezoneString);
+            ZoneId timezone = timezoneString == null ? ZoneOffset.UTC : ZoneId.of(timezoneString);
             Locale locale = Locale.ENGLISH;
             if (localeString != null) {
                 try {
@@ -159,7 +159,7 @@ public final class DateIndexNameProcessor extends AbstractProcessor {
             if (dateFormatStrings == null) {
                 dateFormatStrings = Collections.singletonList("yyyy-MM-dd'T'HH:mm:ss.SSSXX");
             }
-            List<Function<String, DateTime>> dateFormats = new ArrayList<>(dateFormatStrings.size());
+            List<Function<String, ZonedDateTime>> dateFormats = new ArrayList<>(dateFormatStrings.size());
             for (String format : dateFormatStrings) {
                 DateFormat dateFormat = DateFormat.fromString(format);
                 dateFormats.add(dateFormat.getFunction(format, timezone, locale));

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateIndexNameProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateIndexNameProcessor.java
@@ -90,13 +90,15 @@ public final class DateIndexNameProcessor extends AbstractProcessor {
         String indexNameFormat = ingestDocument.renderTemplate(indexNameFormatTemplate);
         String dateRounding = ingestDocument.renderTemplate(dateRoundingTemplate);
 
-        DateFormatter formatter = DateFormatter.forPattern(indexNameFormat);;
+        DateFormatter formatter = DateFormatter.forPattern(indexNameFormat);
+        // use UTC instead of Z is string representation of UTC, so behaviour is the same between 6.x and 7
+        String zone = timezone.equals(ZoneOffset.UTC) ? "UTC" : timezone.getId();
         StringBuilder builder = new StringBuilder()
                 .append('<')
                 .append(indexNamePrefix)
                     .append('{')
                         .append(formatter.format(dateTime)).append("||/").append(dateRounding)
-                            .append('{').append(indexNameFormat).append('|').append(timezone.getId()).append('}')
+                            .append('{').append(indexNameFormat).append('|').append(zone).append('}')
                     .append('}')
                 .append('>');
         String dynamicIndexName  = builder.toString();

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
@@ -21,6 +21,7 @@ package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.ConfigurationUtils;
@@ -28,10 +29,10 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.TemplateScript;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.ISODateTimeFormat;
 
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -42,13 +43,14 @@ public final class DateProcessor extends AbstractProcessor {
 
     public static final String TYPE = "date";
     static final String DEFAULT_TARGET_FIELD = "@timestamp";
+    public static final DateFormatter FORMATTER = DateFormatter.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
 
     private final TemplateScript.Factory timezone;
     private final TemplateScript.Factory locale;
     private final String field;
     private final String targetField;
     private final List<String> formats;
-    private final List<Function<Map<String, Object>, Function<String, DateTime>>> dateParsers;
+    private final List<Function<Map<String, Object>, Function<String, ZonedDateTime>>> dateParsers;
 
     DateProcessor(String tag, @Nullable TemplateScript.Factory timezone, @Nullable TemplateScript.Factory locale,
                   String field, List<String> formats, String targetField) {
@@ -65,8 +67,8 @@ public final class DateProcessor extends AbstractProcessor {
         }
     }
 
-    private DateTimeZone newDateTimeZone(Map<String, Object> params) {
-        return timezone == null ? DateTimeZone.UTC : DateTimeZone.forID(timezone.newInstance(params).execute());
+    private ZoneId newDateTimeZone(Map<String, Object> params) {
+        return timezone == null ? ZoneOffset.UTC : ZoneId.of(timezone.newInstance(params).execute());
     }
 
     private Locale newLocale(Map<String, Object> params) {
@@ -82,9 +84,9 @@ public final class DateProcessor extends AbstractProcessor {
             value = obj.toString();
         }
 
-        DateTime dateTime = null;
+        ZonedDateTime dateTime = null;
         Exception lastException = null;
-        for (Function<Map<String, Object>, Function<String, DateTime>> dateParser : dateParsers) {
+        for (Function<Map<String, Object>, Function<String, ZonedDateTime>> dateParser : dateParsers) {
             try {
                 dateTime = dateParser.apply(ingestDocument.getSourceAndMetadata()).apply(value);
             } catch (Exception e) {
@@ -97,7 +99,7 @@ public final class DateProcessor extends AbstractProcessor {
             throw new IllegalArgumentException("unable to parse date [" + value + "]", lastException);
         }
 
-        ingestDocument.setFieldValue(targetField, ISODateTimeFormat.dateTime().print(dateTime));
+        ingestDocument.setFieldValue(targetField, FORMATTER.format(dateTime));
         return ingestDocument;
     }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateFormatTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateFormatTests.java
@@ -21,10 +21,7 @@ package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.test.ESTestCase;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
-import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -38,9 +35,9 @@ import static org.hamcrest.core.IsEqual.equalTo;
 public class DateFormatTests extends ESTestCase {
 
     public void testParseJava() {
-        Function<String, DateTime> javaFunction = DateFormat.Java.getFunction("MMM dd HH:mm:ss Z",
-                DateTimeZone.forOffsetHours(-8), Locale.ENGLISH);
-        assertThat(Instant.ofEpochMilli(javaFunction.apply("Nov 24 01:29:01 -0800").getMillis())
+        Function<String, ZonedDateTime> javaFunction = DateFormat.Java.getFunction("MMM dd HH:mm:ss Z",
+                ZoneOffset.ofHours(-8), Locale.ENGLISH);
+        assertThat(javaFunction.apply("Nov 24 01:29:01 -0800").toInstant()
                         .atZone(ZoneId.of("GMT-8"))
                         .format(DateTimeFormatter.ofPattern("MM dd HH:mm:ss", Locale.ENGLISH)),
                 equalTo("11 24 01:29:01"));
@@ -48,33 +45,35 @@ public class DateFormatTests extends ESTestCase {
 
     public void testParseJavaDefaultYear() {
         String format = randomFrom("8dd/MM", "dd/MM");
-        DateTimeZone timezone = DateUtils.zoneIdToDateTimeZone(ZoneId.of("Europe/Amsterdam"));
-        Function<String, DateTime> javaFunction = DateFormat.Java.getFunction(format, timezone, Locale.ENGLISH);
+        ZoneId timezone = DateUtils.of("Europe/Amsterdam");
+        Function<String, ZonedDateTime> javaFunction = DateFormat.Java.getFunction(format, timezone, Locale.ENGLISH);
         int year = ZonedDateTime.now(ZoneOffset.UTC).getYear();
-        DateTime dateTime = javaFunction.apply("12/06");
+        ZonedDateTime dateTime = javaFunction.apply("12/06");
         assertThat(dateTime.getYear(), is(year));
-        assertThat(dateTime.toString(), is(year + "-06-12T00:00:00.000+02:00"));
     }
 
     public void testParseUnixMs() {
-        assertThat(DateFormat.UnixMs.getFunction(null, DateTimeZone.UTC, null).apply("1000500").getMillis(), equalTo(1000500L));
+        assertThat(DateFormat.UnixMs.getFunction(null, ZoneOffset.UTC, null).apply("1000500").toInstant().toEpochMilli(),
+            equalTo(1000500L));
     }
 
     public void testParseUnix() {
-        assertThat(DateFormat.Unix.getFunction(null, DateTimeZone.UTC, null).apply("1000.5").getMillis(), equalTo(1000500L));
+        assertThat(DateFormat.Unix.getFunction(null, ZoneOffset.UTC, null).apply("1000.5").toInstant().toEpochMilli(),
+            equalTo(1000500L));
     }
 
     public void testParseUnixWithMsPrecision() {
-        assertThat(DateFormat.Unix.getFunction(null, DateTimeZone.UTC, null).apply("1495718015").getMillis(), equalTo(1495718015000L));
+        assertThat(DateFormat.Unix.getFunction(null, ZoneOffset.UTC, null).apply("1495718015").toInstant().toEpochMilli(),
+            equalTo(1495718015000L));
     }
 
     public void testParseISO8601() {
-        assertThat(DateFormat.Iso8601.getFunction(null, DateTimeZone.UTC, null).apply("2001-01-01T00:00:00-0800").getMillis(),
+        assertThat(DateFormat.Iso8601.getFunction(null, ZoneOffset.UTC, null).apply("2001-01-01T00:00:00-0800").toInstant().toEpochMilli(),
                 equalTo(978336000000L));
     }
 
     public void testParseISO8601Failure() {
-        Function<String, DateTime> function = DateFormat.Iso8601.getFunction(null, DateTimeZone.UTC, null);
+        Function<String, ZonedDateTime> function = DateFormat.Iso8601.getFunction(null, ZoneOffset.UTC, null);
         try {
             function.apply("2001-01-0:00-0800");
             fail("parse should have failed");
@@ -86,7 +85,7 @@ public class DateFormatTests extends ESTestCase {
     public void testTAI64NParse() {
         String input = "4000000050d506482dbdf024";
         String expected = "2012-12-22T03:00:46.767+02:00";
-        assertThat(DateFormat.Tai64n.getFunction(null, DateTimeZone.forOffsetHours(2), null)
+        assertThat(DateFormat.Tai64n.getFunction(null, ZoneOffset.ofHours(2), null)
                 .apply((randomBoolean() ? "@" : "") + input).toString(), equalTo(expected));
     }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateIndexNameFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateIndexNameFactoryTests.java
@@ -23,8 +23,8 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ingest.TestTemplateService;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
-import org.joda.time.DateTimeZone;
 
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,7 +44,7 @@ public class DateIndexNameFactoryTests extends ESTestCase {
         assertThat(processor.getIndexNamePrefixTemplate().newInstance(Collections.emptyMap()).execute(), Matchers.equalTo(""));
         assertThat(processor.getDateRoundingTemplate().newInstance(Collections.emptyMap()).execute(), Matchers.equalTo("y"));
         assertThat(processor.getIndexNameFormatTemplate().newInstance(Collections.emptyMap()).execute(), Matchers.equalTo("yyyy-MM-dd"));
-        assertThat(processor.getTimezone(), Matchers.equalTo(DateTimeZone.UTC));
+        assertThat(processor.getTimezone(), Matchers.equalTo(ZoneOffset.UTC));
     }
 
     public void testSpecifyOptionalSettings() throws Exception {
@@ -74,7 +74,7 @@ public class DateIndexNameFactoryTests extends ESTestCase {
         config.put("timezone", "+02:00");
 
         processor = factory.create(null, null, config);
-        assertThat(processor.getTimezone(), Matchers.equalTo(DateTimeZone.forOffsetHours(2)));
+        assertThat(processor.getTimezone(), Matchers.equalTo(ZoneOffset.ofHours(2)));
 
         config = new HashMap<>();
         config.put("field", "_field");

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateIndexNameProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateIndexNameProcessorTests.java
@@ -42,7 +42,7 @@ public class DateIndexNameProcessorTests extends ESTestCase {
         IngestDocument document = new IngestDocument("_index", "_type", "_id", null, null, null,
                 Collections.singletonMap("_field", "2016-04-25T12:24:20.101Z"));
         processor.execute(document);
-        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{20160425||/y{yyyyMMdd|Z}}>"));
+        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{20160425||/y{yyyyMMdd|UTC}}>"));
     }
 
     public void testTAI64N()throws Exception {
@@ -52,7 +52,7 @@ public class DateIndexNameProcessorTests extends ESTestCase {
         IngestDocument document = new IngestDocument("_index", "_type", "_id", null, null, null,
                 Collections.singletonMap("_field", (randomBoolean() ? "@" : "") + "4000000050d506482dbdf024"));
         dateProcessor.execute(document);
-        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{20121222||/m{yyyyMMdd|Z}}>"));
+        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{20121222||/m{yyyyMMdd|UTC}}>"));
     }
 
     public void testUnixMs()throws Exception {
@@ -62,12 +62,12 @@ public class DateIndexNameProcessorTests extends ESTestCase {
         IngestDocument document = new IngestDocument("_index", "_type", "_id", null, null, null,
                 Collections.singletonMap("_field", "1000500"));
         dateProcessor.execute(document);
-        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{19700101||/m{yyyyMMdd|Z}}>"));
+        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{19700101||/m{yyyyMMdd|UTC}}>"));
 
         document = new IngestDocument("_index", "_type", "_id", null, null, null,
                 Collections.singletonMap("_field", 1000500L));
         dateProcessor.execute(document);
-        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{19700101||/m{yyyyMMdd|Z}}>"));
+        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{19700101||/m{yyyyMMdd|UTC}}>"));
     }
 
     public void testUnix()throws Exception {
@@ -77,7 +77,7 @@ public class DateIndexNameProcessorTests extends ESTestCase {
         IngestDocument document = new IngestDocument("_index", "_type", "_id", null, null, null,
                 Collections.singletonMap("_field", "1000.5"));
         dateProcessor.execute(document);
-        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{19700101||/m{yyyyMMdd|Z}}>"));
+        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{19700101||/m{yyyyMMdd|UTC}}>"));
     }
 
     public void testTemplatedFields() throws Exception {
@@ -97,7 +97,7 @@ public class DateIndexNameProcessorTests extends ESTestCase {
 
         assertThat(document.getSourceAndMetadata().get("_index"),
             equalTo("<"+indexNamePrefix+"{" + DateFormatter.forPattern(indexNameFormat)
-                .format(dateTimeFunction.apply(date))+"||/"+dateRounding+"{"+indexNameFormat+"|Z}}>"));
+                .format(dateTimeFunction.apply(date))+"||/"+dateRounding+"{"+indexNameFormat+"|UTC}}>"));
     }
 
     private DateIndexNameProcessor createProcessor(String field, List<Function<String, ZonedDateTime>> dateFormats,

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateIndexNameProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateIndexNameProcessorTests.java
@@ -18,13 +18,14 @@
  */
 package org.elasticsearch.ingest.common;
 
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.TestTemplateService;
 import org.elasticsearch.test.ESTestCase;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
 
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -35,48 +36,48 @@ import static org.hamcrest.CoreMatchers.equalTo;
 public class DateIndexNameProcessorTests extends ESTestCase {
 
     public void testJavaPattern() throws Exception {
-        Function<String, DateTime> function = DateFormat.Java.getFunction("yyyy-MM-dd'T'HH:mm:ss.SSSXX", DateTimeZone.UTC, Locale.ROOT);
+        Function<String, ZonedDateTime> function = DateFormat.Java.getFunction("yyyy-MM-dd'T'HH:mm:ss.SSSXX", ZoneOffset.UTC, Locale.ROOT);
         DateIndexNameProcessor processor = createProcessor("_field", Collections.singletonList(function),
-            DateTimeZone.UTC, "events-", "y", "yyyyMMdd");
+            ZoneOffset.UTC, "events-", "y", "yyyyMMdd");
         IngestDocument document = new IngestDocument("_index", "_type", "_id", null, null, null,
                 Collections.singletonMap("_field", "2016-04-25T12:24:20.101Z"));
         processor.execute(document);
-        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{20160425||/y{yyyyMMdd|UTC}}>"));
+        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{20160425||/y{yyyyMMdd|Z}}>"));
     }
 
     public void testTAI64N()throws Exception {
-        Function<String, DateTime> function = DateFormat.Tai64n.getFunction(null, DateTimeZone.UTC, null);
+        Function<String, ZonedDateTime> function = DateFormat.Tai64n.getFunction(null, ZoneOffset.UTC, null);
         DateIndexNameProcessor dateProcessor = createProcessor("_field", Collections.singletonList(function),
-                DateTimeZone.UTC, "events-", "m", "yyyyMMdd");
+                ZoneOffset.UTC, "events-", "m", "yyyyMMdd");
         IngestDocument document = new IngestDocument("_index", "_type", "_id", null, null, null,
                 Collections.singletonMap("_field", (randomBoolean() ? "@" : "") + "4000000050d506482dbdf024"));
         dateProcessor.execute(document);
-        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{20121222||/m{yyyyMMdd|UTC}}>"));
+        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{20121222||/m{yyyyMMdd|Z}}>"));
     }
 
     public void testUnixMs()throws Exception {
-        Function<String, DateTime> function = DateFormat.UnixMs.getFunction(null, DateTimeZone.UTC, null);
+        Function<String, ZonedDateTime> function = DateFormat.UnixMs.getFunction(null, ZoneOffset.UTC, null);
         DateIndexNameProcessor dateProcessor = createProcessor("_field", Collections.singletonList(function),
-                DateTimeZone.UTC, "events-", "m", "yyyyMMdd");
+                ZoneOffset.UTC, "events-", "m", "yyyyMMdd");
         IngestDocument document = new IngestDocument("_index", "_type", "_id", null, null, null,
                 Collections.singletonMap("_field", "1000500"));
         dateProcessor.execute(document);
-        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{19700101||/m{yyyyMMdd|UTC}}>"));
+        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{19700101||/m{yyyyMMdd|Z}}>"));
 
         document = new IngestDocument("_index", "_type", "_id", null, null, null,
                 Collections.singletonMap("_field", 1000500L));
         dateProcessor.execute(document);
-        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{19700101||/m{yyyyMMdd|UTC}}>"));
+        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{19700101||/m{yyyyMMdd|Z}}>"));
     }
 
     public void testUnix()throws Exception {
-        Function<String, DateTime> function = DateFormat.Unix.getFunction(null, DateTimeZone.UTC, null);
+        Function<String, ZonedDateTime> function = DateFormat.Unix.getFunction(null, ZoneOffset.UTC, null);
         DateIndexNameProcessor dateProcessor = createProcessor("_field", Collections.singletonList(function),
-                DateTimeZone.UTC, "events-", "m", "yyyyMMdd");
+                ZoneOffset.UTC, "events-", "m", "yyyyMMdd");
         IngestDocument document = new IngestDocument("_index", "_type", "_id", null, null, null,
                 Collections.singletonMap("_field", "1000.5"));
         dateProcessor.execute(document);
-        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{19700101||/m{yyyyMMdd|UTC}}>"));
+        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{19700101||/m{yyyyMMdd|Z}}>"));
     }
 
     public void testTemplatedFields() throws Exception {
@@ -84,10 +85,10 @@ public class DateIndexNameProcessorTests extends ESTestCase {
         String dateRounding = randomFrom("y", "M", "w", "d", "h", "m", "s");
         String indexNameFormat = randomFrom("yyyy-MM-dd'T'HH:mm:ss.SSSZZ", "yyyyMMdd", "MM/dd/yyyy");
         String date = Integer.toString(randomInt());
-        Function<String, DateTime> dateTimeFunction = DateFormat.Unix.getFunction(null, DateTimeZone.UTC, null);
+        Function<String, ZonedDateTime> dateTimeFunction = DateFormat.Unix.getFunction(null, ZoneOffset.UTC, null);
 
         DateIndexNameProcessor dateProcessor = createProcessor("_field",
-            Collections.singletonList(dateTimeFunction),  DateTimeZone.UTC, indexNamePrefix,
+            Collections.singletonList(dateTimeFunction),  ZoneOffset.UTC, indexNamePrefix,
             dateRounding, indexNameFormat);
 
         IngestDocument document = new IngestDocument("_index", "_type", "_id", null, null, null,
@@ -95,12 +96,12 @@ public class DateIndexNameProcessorTests extends ESTestCase {
         dateProcessor.execute(document);
 
         assertThat(document.getSourceAndMetadata().get("_index"),
-            equalTo("<"+indexNamePrefix+"{"+DateTimeFormat.forPattern(indexNameFormat)
-                .print(dateTimeFunction.apply(date))+"||/"+dateRounding+"{"+indexNameFormat+"|UTC}}>"));
+            equalTo("<"+indexNamePrefix+"{" + DateFormatter.forPattern(indexNameFormat)
+                .format(dateTimeFunction.apply(date))+"||/"+dateRounding+"{"+indexNameFormat+"|Z}}>"));
     }
 
-    private DateIndexNameProcessor createProcessor(String field, List<Function<String, DateTime>> dateFormats,
-                                                   DateTimeZone timezone, String indexNamePrefix, String dateRounding,
+    private DateIndexNameProcessor createProcessor(String field, List<Function<String, ZonedDateTime>> dateFormats,
+                                                   ZoneId timezone, String indexNamePrefix, String dateRounding,
                                                    String indexNameFormat) {
         return new DateIndexNameProcessor(randomAlphaOfLength(10), field, dateFormats, timezone,
             new TestTemplateService.MockTemplateScript.Factory(indexNamePrefix),

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorFactoryTests.java
@@ -22,9 +22,9 @@ package org.elasticsearch.ingest.common;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ingest.TestTemplateService;
 import org.elasticsearch.test.ESTestCase;
-import org.joda.time.DateTimeZone;
 import org.junit.Before;
 
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -105,10 +105,10 @@ public class DateProcessorFactoryTests extends ESTestCase {
         config.put("field", sourceField);
         config.put("formats", Collections.singletonList("dd/MM/yyyyy"));
 
-        DateTimeZone timezone = randomDateTimeZone();
-        config.put("timezone", timezone.getID());
+        ZoneId timezone = randomZone();
+        config.put("timezone", timezone.getId());
         DateProcessor processor = factory.create(null, null, config);
-        assertThat(processor.getTimezone().newInstance(Collections.emptyMap()).execute(), equalTo(timezone.getID()));
+        assertThat(processor.getTimezone().newInstance(Collections.emptyMap()).execute(), equalTo(timezone.getId()));
     }
 
     public void testParseMatchFormats() throws Exception {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
@@ -45,9 +45,7 @@ public class DateProcessorTests extends ESTestCase {
     }
 
     private TemplateScript.Factory templatize(ZoneId timezone) {
-        // prevent writing "UTC" as string, as joda time does not parse it
-        String id = timezone.equals(ZoneOffset.UTC) ? "UTC" : timezone.getId();
-        return new TestTemplateService.MockTemplateScript.Factory(id);
+        return new TestTemplateService.MockTemplateScript.Factory(timezone.getId());
     }
 
     public void testJavaPattern() {
@@ -186,7 +184,7 @@ public class DateProcessorTests extends ESTestCase {
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
             () -> processor.execute(RandomDocumentPicks.randomIngestDocument(random(), document)));
         assertThat(e.getMessage(), equalTo("unable to parse date [2010]"));
-        assertThat(e.getCause().getMessage(), equalTo("The datetime zone id 'invalid_timezone' is not recognised"));
+        assertThat(e.getCause().getMessage(), equalTo("Unknown time-zone ID: invalid_timezone"));
     }
 
     public void testInvalidLocale() {


### PR DESCRIPTION
This commit fully replaces any remaining joda time time classes with
java time implementations.

Relates #27330