### PR TITLE
Reenable BWC tests after backport of #37899

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,8 +159,8 @@ task verifyVersions {
  * the enabled state of every bwc task. It should be set back to true
  * after the backport of the backcompat code is complete.
  */
-final boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/37899" /* place a PR link here when committing bwc changes */
+final boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -606,7 +606,7 @@ public class ShardStateAction {
             if (in.getVersion().before(Version.V_6_3_0)) {
                 primaryTerm = in.readVLong();
                 assert primaryTerm == UNASSIGNED_PRIMARY_TERM : "shard is only started by itself: primary term [" + primaryTerm + "]";
-            } else if (in.getVersion().onOrAfter(Version.V_7_0_0)) {  // TODO update version to 6.7.0 after backport
+            } else if (in.getVersion().onOrAfter(Version.V_6_7_0)) {
                 primaryTerm = in.readVLong();
             } else {
                 primaryTerm = UNASSIGNED_PRIMARY_TERM;
@@ -632,7 +632,7 @@ public class ShardStateAction {
             out.writeString(allocationId);
             if (out.getVersion().before(Version.V_6_3_0)) {
                 out.writeVLong(0L);
-            } else if (out.getVersion().onOrAfter(Version.V_7_0_0)) {  // TODO update version to 6.7.0 after backport
+            } else if (out.getVersion().onOrAfter(Version.V_6_7_0)) {
                 out.writeVLong(primaryTerm);
             }
             out.writeString(message);

--- a/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
@@ -544,7 +544,7 @@ public class ShardStateActionTests extends ESTestCase {
             final StartedShardEntry deserialized = new StartedShardEntry(in);
             assertThat(deserialized.shardId, equalTo(shardId));
             assertThat(deserialized.allocationId, equalTo(allocationId));
-            if (version.onOrAfter(Version.V_7_0_0)) {  // TODO update version to 6.7.0 after backport
+            if (version.onOrAfter(Version.V_6_7_0)) {
                 assertThat(deserialized.primaryTerm, equalTo(primaryTerm));
             } else {
                 assertThat(deserialized.primaryTerm, equalTo(0L));


### PR DESCRIPTION
This commit adapts the version used in StartedShardEntry serialization
 after the backport of  #37899 and reenables bwc tests.

Related to #37899
Related to #38074
