### PR TITLE
ML: Fix error race condition on stop _all datafeeds and close _all jobs

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
@@ -338,13 +338,13 @@ public class TransportCloseJobAction extends TransportTasksAction<TransportOpenJ
 
                             @Override
                             public void onFailure(Exception e) {
+                                final int slot = counter.incrementAndGet();
                                 if ((e instanceof ResourceNotFoundException &&
                                     Strings.isAllOrWildcard(new String[]{request.getJobId()})) == false) {
-                                    final int slot = counter.incrementAndGet();
                                     failures.set(slot - 1, e);
-                                    if (slot == numberOfJobs) {
-                                        sendResponseOrFailure(request.getJobId(), listener, failures);
-                                    }
+                                }
+                                if (slot == numberOfJobs) {
+                                    sendResponseOrFailure(request.getJobId(), listener, failures);
                                 }
                             }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.FailedNodeException;
@@ -16,6 +17,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
@@ -272,7 +274,12 @@ public class TransportCloseJobAction extends TransportTasksAction<TransportOpenJ
             threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(new AbstractRunnable() {
                 @Override
                 public void onFailure(Exception e) {
-                    listener.onFailure(e);
+                    if (e instanceof ResourceNotFoundException && Strings.isAllOrWildcard(new String[]{request.getJobId()})) {
+                        jobTask.closeJob("close job (api)");
+                        listener.onResponse(new CloseJobAction.Response(true));
+                    } else {
+                        listener.onFailure(e);
+                    }
                 }
 
                 @Override
@@ -331,10 +338,13 @@ public class TransportCloseJobAction extends TransportTasksAction<TransportOpenJ
 
                             @Override
                             public void onFailure(Exception e) {
-                                final int slot = counter.incrementAndGet();
-                                failures.set(slot - 1, e);
-                                if (slot == numberOfJobs) {
-                                    sendResponseOrFailure(request.getJobId(), listener, failures);
+                                if ((e instanceof ResourceNotFoundException &&
+                                    Strings.isAllOrWildcard(new String[]{request.getJobId()})) == false) {
+                                    final int slot = counter.incrementAndGet();
+                                    failures.set(slot - 1, e);
+                                    if (slot == numberOfJobs) {
+                                        sendResponseOrFailure(request.getJobId(), listener, failures);
+                                    }
                                 }
                             }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDatafeedAction.java
@@ -194,7 +194,7 @@ public class TransportStopDatafeedAction extends TransportTasksAction<TransportS
                         }
                         if (slot == startedDatafeeds.size()) {
                             sendResponseOrFailure(request.getDatafeedId(), listener, failures);
-                       }
+                        }
                     }
                 });
             } else {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDatafeedAction.java
@@ -187,15 +187,14 @@ public class TransportStopDatafeedAction extends TransportTasksAction<TransportS
 
                     @Override
                     public void onFailure(Exception e) {
+                        final int slot = counter.incrementAndGet();
                         if ((e instanceof ResourceNotFoundException &&
                             Strings.isAllOrWildcard(new String[]{request.getDatafeedId()})) == false) {
-
-                            final int slot = counter.incrementAndGet();
                             failures.set(slot - 1, e);
-                            if (slot == startedDatafeeds.size()) {
-                                sendResponseOrFailure(request.getDatafeedId(), listener, failures);
-                            }
                         }
+                        if (slot == startedDatafeeds.size()) {
+                            sendResponseOrFailure(request.getDatafeedId(), listener, failures);
+                       }
                     }
                 });
             } else {


### PR DESCRIPTION
The main issue resides around our task updating service. If the task went away us after gathering state info, and then we try to update it, it will fail. 

Only when `_all`, `*`, ` `, is passed do we ignore the `ResourceNotFound` thrown from the task service. 

The only endpoints where this sort of thing seems to be possible is in close jobs and stop datafeeds. All other endpoints that expand and store Ids/Configs either use a search/bulk action, or only use the state information that exists when the request is being handled. 

closes https://github.com/elastic/elasticsearch/issues/37959