### PR TITLE
Fix random bound in testSoftDeletesRetentionLock

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/SoftDeletesPolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/SoftDeletesPolicyTests.java
@@ -74,7 +74,7 @@ public class SoftDeletesPolicyTests extends ESTestCase  {
             // Advances the global checkpoint and the local checkpoint of a safe commit
             globalCheckpoint.addAndGet(between(0, 1000));
             for (final AtomicLong retainingSequenceNumber : retainingSequenceNumbers) {
-                retainingSequenceNumber.set(randomLongBetween(retainingSequenceNumber.get(), globalCheckpoint.get()));
+                retainingSequenceNumber.set(randomLongBetween(retainingSequenceNumber.get(), Math.max(globalCheckpoint.get(), 0L)));
             }
             safeCommitCheckpoint = randomLongBetween(safeCommitCheckpoint, globalCheckpoint.get());
             policy.setLocalCheckpointOfSafeCommit(safeCommitCheckpoint);


### PR DESCRIPTION
Since #37992 the retainingSequenceNumber is initialized with 0 while the global checkpoint can be -1.

Relates #37992 