### PR TITLE
Ingest node - user agent, move device to an object (#38115)

### DIFF
--- a/docs/reference/ingest/processors/user-agent.asciidoc
+++ b/docs/reference/ingest/processors/user-agent.asciidoc
@@ -69,7 +69,9 @@ Which returns
         "version": "10.10.5",
         "full": "Mac OS X 10.10.5"
       },
-      "device": "Other"
+      "device" : {
+        "name" : "Other"
+      },
     }
   }
 }

--- a/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
+++ b/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
@@ -139,11 +139,13 @@ public class UserAgentProcessor extends AbstractProcessor {
                         }
                         break;
                     case DEVICE:
+                        Map<String, String> deviceDetails = new HashMap<>(1);
                         if (uaClient.device != null && uaClient.device.name != null) {
-                            uaDetails.put("device", uaClient.device.name);
+                            deviceDetails.put("name", uaClient.device.name);
                         } else {
-                            uaDetails.put("device", "Other");
+                            deviceDetails.put("name", "Other");
                         }
+                        uaDetails.put("device", deviceDetails);
                         break;
                 }
             }

--- a/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
+++ b/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
@@ -110,7 +110,9 @@ public class UserAgentProcessorTests extends ESTestCase {
         os.put("version", "10.9.2");
         os.put("full", "Mac OS X 10.9.2");
         assertThat(target.get("os"), is(os));
-        assertThat(target.get("device"), is("Other"));
+        Map<String, String> device = new HashMap<>();
+        device.put("name", "Other");
+        assertThat(target.get("device"), is(device));
     }
 
     @SuppressWarnings("unchecked")
@@ -136,7 +138,9 @@ public class UserAgentProcessorTests extends ESTestCase {
         os.put("full", "Android 3.0");
         assertThat(target.get("os"), is(os));
 
-        assertThat(target.get("device"), is("Motorola Xoom"));
+        Map<String, String> device = new HashMap<>();
+        device.put("name", "Motorola Xoom");
+        assertThat(target.get("device"), is(device));
     }
 
     @SuppressWarnings("unchecked")
@@ -157,7 +161,9 @@ public class UserAgentProcessorTests extends ESTestCase {
         assertNull(target.get("version"));
         assertNull(target.get("os"));
 
-        assertThat(target.get("device"), is("Spider"));
+        Map<String, String> device = new HashMap<>();
+        device.put("name", "Spider");
+        assertThat(target.get("device"), is(device));
     }
 
     @SuppressWarnings("unchecked")
@@ -181,6 +187,8 @@ public class UserAgentProcessorTests extends ESTestCase {
 
         assertNull(target.get("os"));
 
-        assertThat(target.get("device"), is("Other"));
+        Map<String, String> device = new HashMap<>();
+        device.put("name", "Other");
+        assertThat(target.get("device"), is(device));
     }
 }

--- a/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
+++ b/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
@@ -35,7 +35,7 @@
   - match: { _source.user_agent.original: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36" }
   - match: { _source.user_agent.os: {"name":"Mac OS X", "version":"10.9.2", "full":"Mac OS X 10.9.2"} }
   - match: { _source.user_agent.version: "33.0.1750" }
-  - match: { _source.user_agent.device: "Other" }
+  - match: { _source.user_agent.device: {"name": "Other" }}
 
 ---
 "Test user agent processor with parameters":

--- a/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/30_custom_regex.yml
+++ b/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/30_custom_regex.yml
@@ -33,6 +33,6 @@
         id: 1
   - match: { _source.field1: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36" }
   - match: { _source.user_agent.name: "Test" }
-  - match: { _source.user_agent.device: "Other" }
+  - match: { _source.user_agent.device: {"name": "Other" }}
   - is_false: _source.user_agent.os
   - is_false: _source.user_agent.version


### PR DESCRIPTION
When the ingest node user_agent parses the device field, it
will result in a string value. To match the ecs schema
this commit moves the value of the parsed device to an
object with an inner field named 'name'. There are not
any passivity concerns since this modifies an unreleased change.

closes #38094
relates #37329

--------

Manual (not cherry-picked) backport of #38115