### PR TITLE
Add TestLogging annotation to testAutoQueueSizingWithMin

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/QueueResizingEsThreadPoolExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/QueueResizingEsThreadPoolExecutorTests.java
@@ -125,6 +125,7 @@ public class QueueResizingEsThreadPoolExecutorTests extends ESTestCase {
         context.close();
     }
 
+    @TestLogging("org.elasticsearch.common.util.concurrent:DEBUG")
     public void testAutoQueueSizingWithMin() throws Exception {
         ThreadContext context = new ThreadContext(Settings.EMPTY);
         ResizableBlockingQueue<Runnable> queue =


### PR DESCRIPTION
It was already added to `testAutoQueueSizingWithMax`, however, that has not
recently failed. There was a failure for `testAutoQueueSizingWithMin` in mid
December without any extra logs.

Relates to #30740
