### PR TITLE
Update verify repository to allow unknown fields

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/VerifyRepositoryResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/VerifyRepositoryResponseTests.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.watcher;
+
+import org.elasticsearch.action.admin.cluster.repositories.verify.VerifyRepositoryResponse;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
+
+public class VerifyRepositoryResponseTests extends ESTestCase {
+
+    public void testFromXContent() throws IOException {
+        xContentTester(this::createParser,
+            VerifyRepositoryResponseTests::createTestInstance,
+            VerifyRepositoryResponseTests::toXContent,
+            VerifyRepositoryResponse::fromXContent)
+            .supportsUnknownFields(true)
+            .shuffleFieldsExceptions(new String[] {"nodes"}) // do not mix up the order of nodes, it will cause the tests to fail
+            .randomFieldsExcludeFilter((f) -> f.equals("nodes")) // everything in nodes needs to be a particular parseable object
+            .assertToXContentEquivalence(false)
+            .test();
+    }
+
+    private static VerifyRepositoryResponse createTestInstance() {
+        List<VerifyRepositoryResponse.NodeView> nodes = new ArrayList<>();
+        for (int i = 0; i < randomIntBetween(0, 2); i++) {
+            nodes.add(new VerifyRepositoryResponse.NodeView(randomAlphaOfLength(5), randomAlphaOfLength(5)));
+        }
+
+        return new VerifyRepositoryResponse(nodes);
+    }
+
+    private static XContentBuilder toXContent(VerifyRepositoryResponse response, XContentBuilder builder) throws IOException {
+        return response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponse.java
@@ -52,7 +52,7 @@ public class VerifyRepositoryResponse extends ActionResponse implements ToXConte
     public static class NodeView implements Writeable, ToXContentObject {
         private static final ObjectParser.NamedObjectParser<NodeView, Void> PARSER;
         static {
-            ObjectParser<NodeView, Void> internalParser = new ObjectParser<>(NODES);
+            ObjectParser<NodeView, Void> internalParser = new ObjectParser<>(NODES, true, null);
             internalParser.declareString(NodeView::setName, new ParseField(NAME));
             PARSER = (p, v, name) -> internalParser.parse(p, new NodeView(name), null);
         }
@@ -131,7 +131,7 @@ public class VerifyRepositoryResponse extends ActionResponse implements ToXConte
 
 
     private static final ObjectParser<VerifyRepositoryResponse, Void> PARSER =
-        new ObjectParser<>(VerifyRepositoryResponse.class.getName(), VerifyRepositoryResponse::new);
+        new ObjectParser<>(VerifyRepositoryResponse.class.getName(), true, VerifyRepositoryResponse::new);
     static {
         PARSER.declareNamedObjects(VerifyRepositoryResponse::setNodes, NodeView.PARSER, new ParseField("nodes"));
     }
@@ -142,6 +142,10 @@ public class VerifyRepositoryResponse extends ActionResponse implements ToXConte
     public VerifyRepositoryResponse(ClusterName clusterName, DiscoveryNode[] nodes) {
         this.clusterName = clusterName;
         this.nodes = Arrays.asList(nodes);
+    }
+
+    public VerifyRepositoryResponse(List<NodeView> nodes) {
+        setNodes(nodes);
     }
 
     @Override
@@ -208,19 +212,15 @@ public class VerifyRepositoryResponse extends ActionResponse implements ToXConte
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        VerifyRepositoryResponse other = (VerifyRepositoryResponse) obj;
-        return nodes.equals(other.nodes);
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VerifyRepositoryResponse that = (VerifyRepositoryResponse) o;
+        return Objects.equals(nodes, that.nodes);
     }
 
     @Override
     public int hashCode() {
-        return nodes.hashCode();
+        return Objects.hash(nodes);
     }
 }


### PR DESCRIPTION
The subparser in verify repository allows for unknown fields. This
commit sets the value to true for the parser and modifies the test such
that it accurately tests it.

Relates #36938
Relates #37619