### PR TITLE
Remove fedora from 5.6 packaging tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -23,8 +23,6 @@ class VagrantTestPlugin implements Plugin<Project> {
             'centos-7',
             'debian-8',
             'debian-9',
-            'fedora-26',
-            'fedora-27',
             'oel-6',
             'oel-7',
             'opensuse-42',


### PR DESCRIPTION
Fedora's version of rpm got upgraded at some point, to a version with
stricter checks on tags in the rpm files which most of our 5.6 packages
had incorrect. This commit removes fedora from the vagrant tests as most
of the testing just fails anyways.
