### PR TITLE
mute test, as this one is failing also per #35450

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ClusterClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ClusterClientIT.java
@@ -182,6 +182,7 @@ public class ClusterClientIT extends ESRestHighLevelClientTestCase {
         assertThat(response.getIndices().size(), equalTo(0));
     }
 
+    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/35450")
     public void testClusterHealthYellowIndicesLevel() throws IOException {
         createIndex("index", Settings.EMPTY);
         createIndex("index2", Settings.EMPTY);


### PR DESCRIPTION
Mute intermittently failing test, per evidence in #35450. one test was muted already, but this one was not, and it was suggested in the thread that it is also periodically failing.