### PR TITLE
Special-case .tasks index in deprecation checks

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.deprecation;
 
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
@@ -105,6 +104,15 @@ public class IndexDeprecationChecks {
         boolean hasDefaultMapping = indexMetaData.getMappings().containsKey(DEFAULT_MAPPING);
         int mappingCount = indexMetaData.getMappings().size();
         if (createdWith.before(Version.V_6_0_0)) {
+            if (".tasks".equals(indexMetaData.getIndex().getName())) {
+                return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
+                    ".tasks index must be re-created",
+                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/removal-of-types.html" +
+                        "#_indices_created_before_7_0",
+                    "The .tasks index was created before version 6.0 and cannot be opened in 7.0. " +
+                        "You must delete this index and allow it to be re-created by Elasticsearch. If you wish to preserve task history, " +
+                        "reindex this index to a new index before deleting it.");
+            }
             if ((mappingCount == 2 && !hasDefaultMapping)
                 || mappingCount > 2) {
                 return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -110,7 +110,7 @@ public class IndexDeprecationChecks {
                     "https://www.elastic.co/guide/en/elasticsearch/reference/master/removal-of-types.html" +
                         "#_indices_created_before_7_0",
                     "The .tasks index was created before version 6.0 and cannot be opened in 7.0. " +
-                        "You must delete this index and allow it to be re-created by Elasticsearch. If you wish to preserve task history, " +
+                        "You must delete this index and allow it to be re-created by Elasticsearch. If you wish to preserve task history, "+
                         "reindex this index to a new index before deleting it.");
             }
             if ((mappingCount == 2 && !hasDefaultMapping)

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -107,7 +107,7 @@ public class IndexDeprecationChecks {
             if (".tasks".equals(indexMetaData.getIndex().getName())) {
                 return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                     ".tasks index must be re-created",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/removal-of-types.html" +
+                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                         "#_indices_created_before_7_0",
                     "The .tasks index was created before version 6.0 and cannot be opened in 7.0. " +
                         "You must delete this index and allow it to be re-created by Elasticsearch. If you wish to preserve task history, "+

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -54,7 +54,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             .build();
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             ".tasks index must be re-created",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/removal-of-types.html" +
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                 "#_indices_created_before_7_0",
             "The .tasks index was created before version 6.0 and cannot be opened in 7.0. " +
                 "You must delete this index and allow it to be re-created by Elasticsearch. If you wish to preserve task history, " +


### PR DESCRIPTION
The .tasks index is difficult to reindex, because reindexing writes a
task to the .tasks index, so if we block writes to the .tasks index,
reindexing it will fail. This special case in the deprecation check
should help prevent user confusion and allow Kibana to more easily
handle this case.

Relates to https://github.com/elastic/kibana/issues/29454