### PR TITLE
Disable dynamic mapping in testSimpleGetFieldMappingsWithDefaults

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/mapping/SimpleGetFieldMappingsIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/mapping/SimpleGetFieldMappingsIT.java
@@ -134,8 +134,7 @@ public class SimpleGetFieldMappingsIT extends ESIntegTestCase {
     @SuppressWarnings("unchecked")
     public void testSimpleGetFieldMappingsWithDefaults() throws Exception {
         assertAcked(prepareCreate("test").addMapping("type", getMappingForType("type")));
-
-        client().prepareIndex("test", "type", "1").setSource("num", 1).get();
+        client().admin().indices().preparePutMapping("test").setType("type").setSource("num", "type=long").get();
 
         GetFieldMappingsResponse response = client().admin().indices().prepareGetFieldMappings()
             .setFields("num", "field1", "obj.subfield").includeDefaults(true).get();


### PR DESCRIPTION
Since #31140 we no longer require acking on the dynamic mapping of index
requests. Thus, a returned mapping from a get mapping request does not
necessarily contain the dynamic updates from the index request. This
commit replaces the dynamic mapping update with a manual put mapping.

Relates #31140
Closes #37928
