### PR TITLE
Contradictory type checks in Analyzer

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -887,17 +887,17 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 NamedExpression expr = exprs.get(i);
                 NamedExpression transformed = (NamedExpression) expr.transformUp(ua -> {
                     Expression child = ua.child();
-                    if (child instanceof NamedExpression) {
-                        return child;
-                    }
-                    if (!child.resolved()) {
-                        return ua;
-                    }
                     if (child instanceof Cast) {
                         Cast c = (Cast) child;
                         if (c.field() instanceof NamedExpression) {
                             return new Alias(c.source(), ((NamedExpression) c.field()).name(), c);
                         }
+                    }
+                    if (child instanceof NamedExpression) {
+                        return child;
+                    }
+                    if (!child.resolved()) {
+                        return ua;
                     }
                     return new Alias(child.source(), child.sourceText(), child);
                 }, UnresolvedAlias.class);


### PR DESCRIPTION
As requested, I will split #38033 into separate PRs. Here is the third part.

This one resolves:
* [Contradictory type checks](https://lgtm.com/projects/g/elastic/elasticsearch/snapshot/dist-1916470085-1548143539391/files/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java#xee9dfb4802f27c7f:1)
