### PR TITLE
Don't load global ordinals with the `map` execution_hint

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -760,6 +760,7 @@ setup:
       index:
         refresh: true
         index: test_1
+        type: test
         id: 1
         routing: 1
         body: { "str": "abc" }
@@ -768,6 +769,7 @@ setup:
       index:
         refresh: true
         index: test_1
+        type: test
         id: 2
         routing: 1
         body: { "str": "abc" }
@@ -776,6 +778,7 @@ setup:
       index:
         refresh: true
         index: test_1
+        type: test
         id: 3
         routing: 1
         body: { "str": "bcd" }
@@ -788,7 +791,6 @@ setup:
         index: test_1
         body: { "size" : 0, "aggs" : { "str_terms" : { "terms" : { "field" : "str", "execution_hint" : "map" } } } }
 
-  - match: { hits.total.value: 3}
   - length: { aggregations.str_terms.buckets: 2 }
 
   - do:
@@ -804,7 +806,6 @@ setup:
         index: test_1
         body: { "size" : 0, "aggs" : { "str_terms" : { "terms" : { "field" : "str", "execution_hint" : "global_ordinals" } } } }
 
-  - match: { hits.total.value: 3}
   - length: { aggregations.str_terms.buckets: 2 }
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -748,3 +748,74 @@ setup:
   - is_false: aggregations.str_terms.buckets.1.key_as_string
 
   - match: { aggregations.str_terms.buckets.1.doc_count: 2 }
+
+---
+"Global ordinals are not loaded with the map execution hint":
+
+  - skip:
+      version: " - 6.99.99"
+      reason:  bug fixed in 7.0
+
+  - do:
+      index:
+        refresh: true
+        index: test_1
+        id: 1
+        routing: 1
+        body: { "str": "abc" }
+
+  - do:
+      index:
+        refresh: true
+        index: test_1
+        id: 2
+        routing: 1
+        body: { "str": "abc" }
+
+  - do:
+      index:
+        refresh: true
+        index: test_1
+        id: 3
+        routing: 1
+        body: { "str": "bcd" }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: test_1
+        body: { "size" : 0, "aggs" : { "str_terms" : { "terms" : { "field" : "str", "execution_hint" : "map" } } } }
+
+  - match: { hits.total.value: 3}
+  - length: { aggregations.str_terms.buckets: 2 }
+
+  - do:
+      indices.stats:
+        index: test_1
+        metric: fielddata
+        fielddata_fields: str
+
+  - match: { indices.test_1.total.fielddata.memory_size_in_bytes: 0}
+
+  - do:
+      search:
+        index: test_1
+        body: { "size" : 0, "aggs" : { "str_terms" : { "terms" : { "field" : "str", "execution_hint" : "global_ordinals" } } } }
+
+  - match: { hits.total.value: 3}
+  - length: { aggregations.str_terms.buckets: 2 }
+
+  - do:
+      indices.stats:
+        index: test_1
+        metric: fielddata
+        fielddata_fields: str
+
+  - gt: { indices.test_1.total.fielddata.memory_size_in_bytes: 0}
+
+
+
+
+

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -753,8 +753,8 @@ setup:
 "Global ordinals are not loaded with the map execution hint":
 
   - skip:
-      version: " - 6.99.99"
-      reason:  bug fixed in 7.0
+      version: " - 6.6.99"
+      reason:  bug fixed in 6.7
 
   - do:
       index:
@@ -814,8 +814,3 @@ setup:
         fielddata_fields: str
 
   - gt: { indices.test_1.total.fielddata.memory_size_in_bytes: 0}
-
-
-
-
-

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.apache.logging.log4j.LogManager;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.logging.DeprecationLogger;
@@ -133,7 +134,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory<Values
             if (valuesSource instanceof ValuesSource.Bytes.WithOrdinals == false) {
                 execution = ExecutionMode.MAP;
             }
-            final long maxOrd = getMaxOrd(valuesSource, context.searcher());
+            final long maxOrd = getMaxOrd(context.searcher(), valuesSource, execution);
             if (execution == null) {
                 execution = ExecutionMode.GLOBAL_ORDINALS;
             }
@@ -205,13 +206,23 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory<Values
     }
 
     /**
-     * Get the maximum global ordinal value for the provided {@link ValuesSource} or -1
+     * Get the maximum ordinal value for the provided {@link ValuesSource} or -1
      * if the values source is not an instance of {@link ValuesSource.Bytes.WithOrdinals}.
      */
-    static long getMaxOrd(ValuesSource source, IndexSearcher searcher) throws IOException {
+    static long getMaxOrd(IndexSearcher searcher, ValuesSource source, ExecutionMode executionMode) throws IOException {
         if (source instanceof ValuesSource.Bytes.WithOrdinals) {
             ValuesSource.Bytes.WithOrdinals valueSourceWithOrdinals = (ValuesSource.Bytes.WithOrdinals) source;
-            return valueSourceWithOrdinals.globalMaxOrd(searcher);
+            if (executionMode == ExecutionMode.MAP) {
+                // global ordinals are not requested so we don't load them
+                // and return the biggest cardinality per segment instead.
+                long maxOrd = -1;
+                for (LeafReaderContext leaf : searcher.getIndexReader().leaves()) {
+                    maxOrd = Math.max(maxOrd, valueSourceWithOrdinals.ordinalsValues(leaf).getValueCount());
+                }
+                return maxOrd;
+            } else {
+                return valueSourceWithOrdinals.globalMaxOrd(searcher);
+            }
         } else {
             return -1;
         }
@@ -256,7 +267,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory<Values
                               List<PipelineAggregator> pipelineAggregators,
                               Map<String, Object> metaData) throws IOException {
 
-                final long maxOrd = getMaxOrd(valuesSource, context.searcher());
+                final long maxOrd = getMaxOrd(context.searcher(), valuesSource, ExecutionMode.GLOBAL_ORDINALS);
                 assert maxOrd != -1;
                 final double ratio = maxOrd / ((double) context.searcher().getIndexReader().numDocs());
 


### PR DESCRIPTION
Backport of #37833 