### PR TITLE
Migration doc for audit json log file

### DIFF
--- a/docs/reference/migration/migrate_7_0/logging.asciidoc
+++ b/docs/reference/migration/migrate_7_0/logging.asciidoc
@@ -32,7 +32,6 @@ Note: GC logs which are written to the file `gc.log` will not be changed.
 
 All Docker console logs are now in JSON format. You can distinguish logs streams with the `type` field.
 
-
 [float]
 ==== Audit plaintext log file removed, JSON file renamed
 

--- a/docs/reference/migration/migrate_7_0/logging.asciidoc
+++ b/docs/reference/migration/migrate_7_0/logging.asciidoc
@@ -35,6 +35,8 @@ All Docker console logs are now in JSON format. You can distinguish logs streams
 [float]
 ==== Audit plaintext log file removed, JSON file renamed
 
-Elasticsearch no longer produces a plaintext audit log file `${cluster_name}_access.log`.
-Use the JSON log file (`${cluster_name}_audit.json`) instead.
-`${cluster_name}_audit.log` to  `${cluster_name}_audit.json`.
+Elasticsearch no longer produces the `${cluster_name}_access.log` plaintext
+audit log file. The `${cluster_name}_audit.log` files also no longer exist; they
+are replaced by `${cluster_name}_audit.json` files. When auditing is enabled,
+auditing events are stored in these dedicated JSON log files on each node.
+

--- a/docs/reference/migration/migrate_7_0/logging.asciidoc
+++ b/docs/reference/migration/migrate_7_0/logging.asciidoc
@@ -35,6 +35,6 @@ All Docker console logs are now in JSON format. You can distinguish logs streams
 [float]
 ==== Audit plaintext log file removed, JSON file renamed
 
-Elasticsearch will no longer produce a plaintext audit log file `${cluster_name}_access.log`.
+Elasticsearch no longer produces a plaintext audit log file `${cluster_name}_access.log`.
 Use the JSON log file (`${cluster_name}_audit.json`) instead.
 `${cluster_name}_audit.log` to  `${cluster_name}_audit.json`.

--- a/docs/reference/migration/migrate_7_0/logging.asciidoc
+++ b/docs/reference/migration/migrate_7_0/logging.asciidoc
@@ -36,5 +36,5 @@ All Docker console logs are now in JSON format. You can distinguish logs streams
 ==== Audit plaintext log file removed, JSON file renamed
 
 Elasticsearch will no longer produce a plaintext audit log file `${cluster_name}_access.log`.
-The JSON log file should be used instead. The name of this file was changed from
+Use the JSON log file (`${cluster_name}_audit.json`) instead.
 `${cluster_name}_audit.log` to  `${cluster_name}_audit.json`.

--- a/docs/reference/migration/migrate_7_0/logging.asciidoc
+++ b/docs/reference/migration/migrate_7_0/logging.asciidoc
@@ -31,3 +31,11 @@ Note: GC logs which are written to the file `gc.log` will not be changed.
 ==== Docker output in JSON format
 
 All Docker console logs are now in JSON format. You can distinguish logs streams with the `type` field.
+
+
+[float]
+==== Audit plaintext log file removed, JSON file renamed
+
+Elasticsearch will no longer produce a plaintext audit log file `${cluster_name}_access.log`.
+The JSON log file should be used instead. The name of this file was changed from
+`${cluster_name}_audit.log` to  `${cluster_name}_audit.json`.


### PR DESCRIPTION
The migration documentation for an audit logging changes. Removal of plaintext logs and rename of json log file

relates #32850
