### PR TITLE
Enable bwc tests for #37871 and #38032.

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/20_mix_typeless_typeful.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/20_mix_typeless_typeful.yml
@@ -2,8 +2,8 @@
 "Create a typeless index while there is a typed template":
 
  - skip:
-      version: " - 6.99.99"
-      reason: needs change to be backported to 6.7
+      version: " - 6.6.99"
+      reason: Merging typeless/typed mappings/templates was added in 6.7
 
  - do:
       indices.put_template:
@@ -41,8 +41,8 @@
 "Create a typed index while there is a typeless template":
 
  - skip:
-      version: " - 6.99.99"
-      reason: needs change to be backported to 6.7
+      version: " - 6.6.99"
+      reason: Merging typeless/typed mappings/templates was added in 6.7
 
  - do:
       indices.put_template:
@@ -81,7 +81,7 @@
 
  - skip:
       version: " - 6.99.99"
-      reason: needs change to be backported to 6.7
+      reason: include_type_name only supported as of 6.7
 
  - do:
       indices.put_template:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/20_mix_typeless_typeful.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/20_mix_typeless_typeful.yml
@@ -55,8 +55,8 @@
 "PUT mapping with _doc on an index that has types":
 
  - skip:
-      version: " - 6.99.99"
-      reason: Backport first
+      version: " - 6.6.99"
+      reason: include_type_name is only supported as of 6.7
 
 
  - do:


### PR DESCRIPTION
Mixed-version clusters tests had been disabled initially since they wouldn't
work until the functionality would be backported.
