### PR TITLE
Reenable PingAndInfoIT.testXPackInfo() on 6.x

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
@@ -30,6 +30,10 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+
 public class PingAndInfoIT extends ESRestHighLevelClientTestCase {
 
     public void testPing() throws IOException {
@@ -56,7 +60,6 @@ public class PingAndInfoIT extends ESRestHighLevelClientTestCase {
         assertEquals(versionMap.get("lucene_version"), info.getVersion().luceneVersion.toString());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/34386")
     public void testXPackInfo() throws IOException {
         XPackInfoRequest request = new XPackInfoRequest();
         request.setCategories(EnumSet.allOf(XPackInfoRequest.Category.class));
@@ -85,8 +88,8 @@ public class PingAndInfoIT extends ESRestHighLevelClientTestCase {
         assertNotNull(ml.description());
         assertTrue(ml.available());
         assertTrue(ml.enabled());
-        assertEquals(mainResponse.getVersion().toString(),
-                ml.nativeCodeInfo().get("version").toString().replace("-SNAPSHOT", ""));
+        assertThat(ml.nativeCodeInfo().get("version").toString().replace("-SNAPSHOT", ""),
+            anyOf(equalTo(mainResponse.getVersion().toString()), startsWith("based on " + mainResponse.getVersion().toString())));
     }
 
     public void testXPackInfoEmptyRequest() throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
@@ -21,18 +21,14 @@ package org.elasticsearch.client;
 
 import org.apache.http.client.methods.HttpGet;
 import org.elasticsearch.action.main.MainResponse;
+import org.elasticsearch.client.license.LicenseStatus;
 import org.elasticsearch.client.xpack.XPackInfoRequest;
 import org.elasticsearch.client.xpack.XPackInfoResponse;
 import org.elasticsearch.client.xpack.XPackInfoResponse.FeatureSetsInfo.FeatureSet;
-import org.elasticsearch.client.license.LicenseStatus;
 
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Map;
-
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.startsWith;
 
 public class PingAndInfoIT extends ESRestHighLevelClientTestCase {
 
@@ -88,8 +84,8 @@ public class PingAndInfoIT extends ESRestHighLevelClientTestCase {
         assertNotNull(ml.description());
         assertTrue(ml.available());
         assertTrue(ml.enabled());
-        assertThat(ml.nativeCodeInfo().get("version").toString().replace("-SNAPSHOT", ""),
-            anyOf(equalTo(mainResponse.getVersion().toString()), startsWith("based on " + mainResponse.getVersion().toString())));
+        assertEquals(mainResponse.getVersion().toString(),
+                ml.nativeCodeInfo().get("version").toString().replace("-SNAPSHOT", ""));
     }
 
     public void testXPackInfoEmptyRequest() throws IOException {


### PR DESCRIPTION
The version exposed in ML feature set are extracted from the ML engine.
The format of the version have changed (see https://github.com/elastic/elasticsearch/pull/38168#pullrequestreview-199014466) . 

This PR unmutes the test.

Closes #34386

