### PR TITLE
Deprecate negative field boosts in analyzed queries

### DIFF
--- a/docs/reference/migration/migrate_6_0/search.asciidoc
+++ b/docs/reference/migration/migrate_6_0/search.asciidoc
@@ -153,10 +153,10 @@ information.
 [float]
 ===== Negative scores are deprecated in Function Score Query
 
-Negative scores in the Function Score Query are deprecated. If a negative 
+Negative scores in the Function Score Query are deprecated. If a negative
 score is produced as a result of computation (e.g. in `script_score` or
 `field_value_factor` functions), a deprecation warning will be issued in
-this major version, and an error will be thrown in the next major version. 
+this major version, and an error will be thrown in the next major version.
 
 [float]
 ==== Fielddata on `_uid`
@@ -266,8 +266,8 @@ rewrite any prefix query on the field to a a single term query that matches the 
 [float]
 ==== Negative boosts are deprecated
 
-Setting a negative `boost` in a query is deprecated and will throw an error in the next version.
-To deboost a specific query you can use a `boost` comprise between 0 and 1.
+Setting a negative `boost` for a query or a field is deprecated and will throw an error in the next
+major version. To deboost a specific query or field you can use a `boost` comprise between 0 and 1.
 
 [float]
 ==== Limit the number of open scroll contexts

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -162,7 +162,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
     protected final void checkNegativeBoost(float boost) {
         if (Float.compare(boost, 0f) < 0) {
             deprecationLogger.deprecatedAndMaybeLog("negative boost", "setting a negative [boost] on a query " +
-                "is deprecated and will throw an error in the next version. You can use a value between 0 and 1 to deboost.");
+                "is deprecated and will throw an error in the next major version. You can use a value between 0 and 1 to deboost.");
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -70,6 +70,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
 
     protected AbstractQueryBuilder(StreamInput in) throws IOException {
         boost = in.readFloat();
+        checkNegativeBoost(boost);
         queryName = in.readOptionalString();
     }
 
@@ -158,6 +159,13 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
         return this.boost;
     }
 
+    protected final void checkNegativeBoost(float boost) {
+        if (Float.compare(boost, 0f) < 0) {
+            deprecationLogger.deprecatedAndMaybeLog("negative boost", "setting a negative [boost] on a query " +
+                "is deprecated and will throw an error in the next version. You can use a value between 0 and 1 to deboost.");
+        }
+    }
+
     /**
      * Sets the boost for this query.  Documents matching this query will (in addition to the normal
      * weightings) have their score multiplied by the boost provided.
@@ -165,10 +173,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
     @SuppressWarnings("unchecked")
     @Override
     public final QB boost(float boost) {
-        if (Float.compare(boost, 0f) < 0) {
-            deprecationLogger.deprecatedAndMaybeLog("negative boost", "setting a negative [boost] on a query " +
-                "is deprecated and will throw an error in the next version. You can use a value between 0 and 1 to deboost.");
-        }
+        checkNegativeBoost(boost);
         this.boost = boost;
         return (QB) this;
     }

--- a/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -213,7 +213,10 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         int size = in.readVInt();
         fieldsBoosts = new TreeMap<>();
         for (int i = 0; i < size; i++) {
-            fieldsBoosts.put(in.readString(), in.readFloat());
+            String field = in.readString();
+            float boost = in.readFloat();
+            checkNegativeBoost(boost);
+            fieldsBoosts.put(field, boost);
         }
         type = Type.readFromStream(in);
         operator = Operator.readFromStream(in);
@@ -293,6 +296,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         if (Strings.isEmpty(field)) {
             throw new IllegalArgumentException("supplied field is null or empty.");
         }
+        checkNegativeBoost(boost);
         this.fieldsBoosts.put(field, boost);
         return this;
     }
@@ -301,6 +305,9 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
      * Add several fields to run the query against with a specific boost.
      */
     public MultiMatchQueryBuilder fields(Map<String, Float> fields) {
+        for (float fieldBoost : fields.values()) {
+            checkNegativeBoost(fieldBoost);
+        }
         this.fieldsBoosts.putAll(fields);
         return this;
     }

--- a/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -184,7 +184,10 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         defaultField = in.readOptionalString();
         int size = in.readVInt();
         for (int i = 0; i < size; i++) {
-            fieldsAndWeights.put(in.readString(), in.readFloat());
+            String field = in.readString();
+            Float weight = in.readFloat();
+            checkNegativeBoost(weight);
+            fieldsAndWeights.put(field, weight);
         }
         defaultOperator = Operator.readFromStream(in);
         analyzer = in.readOptionalString();
@@ -339,6 +342,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
      * Adds a field to run the query string against with a specific boost.
      */
     public QueryStringQueryBuilder field(String field, float boost) {
+        checkNegativeBoost(boost);
         this.fieldsAndWeights.put(field, boost);
         return this;
     }
@@ -347,6 +351,9 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
      * Add several fields to run the query against with a specific boost.
      */
     public QueryStringQueryBuilder fields(Map<String, Float> fields) {
+        for (float fieldBoost : fields.values()) {
+            checkNegativeBoost(fieldBoost);
+        }
         this.fieldsAndWeights.putAll(fields);
         return this;
     }

--- a/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -163,6 +163,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         for (int i = 0; i < size; i++) {
             String field = in.readString();
             Float weight = in.readFloat();
+            checkNegativeBoost(weight);
             fields.put(field, weight);
         }
         fieldsAndWeights.putAll(fields);
@@ -258,6 +259,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         if (Strings.isEmpty(field)) {
             throw new IllegalArgumentException("supplied field is null or empty");
         }
+        checkNegativeBoost(boost);
         this.fieldsAndWeights.put(field, boost);
         return this;
     }
@@ -265,6 +267,9 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
     /** Add several fields to run the query against with a specific boost. */
     public SimpleQueryStringBuilder fields(Map<String, Float> fields) {
         Objects.requireNonNull(fields, "fields cannot be null");
+        for (float fieldBoost : fields.values()) {
+            checkNegativeBoost(fieldBoost);
+        }
         this.fieldsAndWeights.putAll(fields);
         return this;
     }

--- a/server/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
@@ -96,11 +96,10 @@ public class MultiMatchQuery extends MatchQuery {
                 // ignore unmapped fields
                 continue;
             }
-            Float boostValue = fieldNames.get(fieldName);
+            float boostValue = fieldNames.getOrDefault(fieldName, 1.0f);
             Query query = parse(type.matchQueryType(), fieldName, value);
             query = Queries.maybeApplyMinimumShouldMatch(query, minimumShouldMatch);
             if (query != null
-                    && boostValue != null
                     && boostValue != AbstractQueryBuilder.DEFAULT_BOOST
                     && query instanceof MatchNoDocsQuery == false) {
                 query = new BoostQuery(query, boostValue);

--- a/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -483,10 +483,9 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
         assertEquals(expected, query);
     }
 
-<<<<<<< HEAD
     public void testDisMaxDeprecation() throws Exception {
         String json =
-                "{\n" +
+            "{\n" +
                 "  \"multi_match\" : {\n" +
                 "    \"query\" : \"foo:bar\",\n" +
                 "    \"use_dis_max\" : true\n" +
@@ -495,15 +494,15 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
 
         parseQuery(json);
         assertWarnings("Deprecated field [use_dis_max] used, replaced by [use tie_breaker instead]");
-=======
-    public void testNegativeFieldBoost() {
-        IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
-            () -> new MultiMatchQueryBuilder("the quick fox")
+    }
+
+    public void testNegativeFieldBoost() throws IOException {
+        Query query = new MultiMatchQueryBuilder("the quick fox")
                 .field(STRING_FIELD_NAME, -1.0f)
                 .field(STRING_FIELD_NAME_2)
-                .toQuery(createShardContext()));
-        assertThat(exc.getMessage(), containsString("negative [boost]"));
->>>>>>> 89e57f53acc... Forbid negative field boosts in analyzed queries
+                .toQuery(createShardContext());
+        assertWarnings("setting a negative [boost] on a query is deprecated and will throw an error in the next major " +
+            "version. You can use a value between 0 and 1 to deboost.");
     }
 
     private static IndexMetaData newIndexMeta(String name, Settings oldIndexSettings, Settings indexSettings) {

--- a/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -483,6 +483,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
         assertEquals(expected, query);
     }
 
+<<<<<<< HEAD
     public void testDisMaxDeprecation() throws Exception {
         String json =
                 "{\n" +
@@ -494,6 +495,15 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
 
         parseQuery(json);
         assertWarnings("Deprecated field [use_dis_max] used, replaced by [use tie_breaker instead]");
+=======
+    public void testNegativeFieldBoost() {
+        IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
+            () -> new MultiMatchQueryBuilder("the quick fox")
+                .field(STRING_FIELD_NAME, -1.0f)
+                .field(STRING_FIELD_NAME_2)
+                .toQuery(createShardContext()));
+        assertThat(exc.getMessage(), containsString("negative [boost]"));
+>>>>>>> 89e57f53acc... Forbid negative field boosts in analyzed queries
     }
 
     private static IndexMetaData newIndexMeta(String name, Settings oldIndexSettings, Settings indexSettings) {

--- a/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -59,6 +59,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.search.QueryStringQueryParser;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.AbstractQueryTestCase;
+import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.joda.time.DateTimeZone;
 
@@ -1486,6 +1487,15 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             .toQuery(createShardContext());
         Query expected = new PrefixQuery(new Term(STRING_FIELD_NAME, "quick"));
         assertEquals(expected, query);
+    }
+
+    public void testNegativeFieldBoost() {
+        IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
+            () -> new QueryStringQueryBuilder("the quick fox")
+                .field(STRING_FIELD_NAME, -1.0f)
+                .field(STRING_FIELD_NAME_2)
+                .toQuery(createShardContext()));
+        assertThat(exc.getMessage(), CoreMatchers.containsString("negative [boost]"));
     }
 
     private static IndexMetaData newIndexMeta(String name, Settings oldIndexSettings, Settings indexSettings) {

--- a/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -59,7 +59,6 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.search.QueryStringQueryParser;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.AbstractQueryTestCase;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.joda.time.DateTimeZone;
 
@@ -1489,13 +1488,13 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         assertEquals(expected, query);
     }
 
-    public void testNegativeFieldBoost() {
-        IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
-            () -> new QueryStringQueryBuilder("the quick fox")
-                .field(STRING_FIELD_NAME, -1.0f)
-                .field(STRING_FIELD_NAME_2)
-                .toQuery(createShardContext()));
-        assertThat(exc.getMessage(), CoreMatchers.containsString("negative [boost]"));
+    public void testNegativeFieldBoost() throws IOException {
+        Query query =  new QueryStringQueryBuilder("the quick fox")
+            .field(STRING_FIELD_NAME, -1.0f)
+            .field(STRING_FIELD_NAME_2)
+            .toQuery(createShardContext());
+        assertWarnings("setting a negative [boost] on a query is deprecated and will throw an error in the next major " +
+            "version. You can use a value between 0 and 1 to deboost.");
     }
 
     private static IndexMetaData newIndexMeta(String name, Settings oldIndexSettings, Settings indexSettings) {

--- a/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -58,6 +58,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
@@ -737,6 +738,15 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
                 .add(new TermQuery(new Term(STRING_FIELD_NAME, "second")), BooleanClause.Occur.MUST)
                 .build();
         assertEquals(expected, query);
+    }
+
+    public void testNegativeFieldBoost() {
+        IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
+            () -> new SimpleQueryStringBuilder("the quick fox")
+                .field(STRING_FIELD_NAME, -1.0f)
+                .field(STRING_FIELD_NAME_2)
+                .toQuery(createShardContext()));
+        assertThat(exc.getMessage(), containsString("negative [boost]"));
     }
 
     private static IndexMetaData newIndexMeta(String name, Settings oldIndexSettings, Settings indexSettings) {

--- a/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -58,7 +58,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
@@ -740,13 +739,13 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         assertEquals(expected, query);
     }
 
-    public void testNegativeFieldBoost() {
-        IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
-            () -> new SimpleQueryStringBuilder("the quick fox")
-                .field(STRING_FIELD_NAME, -1.0f)
-                .field(STRING_FIELD_NAME_2)
-                .toQuery(createShardContext()));
-        assertThat(exc.getMessage(), containsString("negative [boost]"));
+    public void testNegativeFieldBoost() throws IOException {
+        Query query =   new SimpleQueryStringBuilder("the quick fox")
+            .field(STRING_FIELD_NAME, -1.0f)
+            .field(STRING_FIELD_NAME_2)
+            .toQuery(createShardContext());
+        assertWarnings("setting a negative [boost] on a query is deprecated and will throw an error in the next major " +
+            "version. You can use a value between 0 and 1 to deboost.");
     }
 
     private static IndexMetaData newIndexMeta(String name, Settings oldIndexSettings, Settings indexSettings) {

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -105,7 +105,7 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
         QB testQuery = createTestQueryBuilder();
         testQuery.boost(-0.5f);
         assertWarnings("setting a negative [boost] on a query" +
-            " is deprecated and will throw an error in the next version. You can use a value between 0 and 1 to deboost.");
+            " is deprecated and will throw an error in the next major version. You can use a value between 0 and 1 to deboost.");
     }
 
     /**


### PR DESCRIPTION
Backport of #37930 that transforms the error into a deprecation warning for 6x.