### PR TITLE
Adjust SearchRequest version checks

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -205,17 +205,14 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
             localClusterAlias = in.readOptionalString();
             if (localClusterAlias != null) {
                 absoluteStartMillis = in.readVLong();
+                finalReduce = in.readBoolean();
             } else {
                 absoluteStartMillis = DEFAULT_ABSOLUTE_START_MILLIS;
+                finalReduce = true;
             }
         } else {
             localClusterAlias = null;
             absoluteStartMillis = DEFAULT_ABSOLUTE_START_MILLIS;
-        }
-        //TODO move to the 6_7_0 branch once backported to 6.x
-        if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
-            finalReduce = in.readBoolean();
-        } else {
             finalReduce = true;
         }
         if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
@@ -245,11 +242,8 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
             out.writeOptionalString(localClusterAlias);
             if (localClusterAlias != null) {
                 out.writeVLong(absoluteStartMillis);
+                out.writeBoolean(finalReduce);
             }
-        }
-        //TODO move to the 6_7_0 branch once backported to 6.x
-        if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-            out.writeBoolean(finalReduce);
         }
         if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
             out.writeBoolean(ccsMinimizeRoundtrips);

--- a/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
@@ -91,14 +91,10 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         if (version.before(Version.V_6_7_0)) {
             assertNull(deserializedRequest.getLocalClusterAlias());
             assertAbsoluteStartMillisIsCurrentTime(deserializedRequest);
+            assertTrue(deserializedRequest.isFinalReduce());
         } else {
             assertEquals(searchRequest.getLocalClusterAlias(), deserializedRequest.getLocalClusterAlias());
             assertEquals(searchRequest.getOrCreateAbsoluteStartMillis(), deserializedRequest.getOrCreateAbsoluteStartMillis());
-        }
-        //TODO move to the 6_7_0 branch once backported to 6.x
-        if (version.before(Version.V_7_0_0)) {
-            assertTrue(deserializedRequest.isFinalReduce());
-        } else {
             assertEquals(searchRequest.isFinalReduce(), deserializedRequest.isFinalReduce());
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionSingleNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionSingleNodeTests.java
@@ -171,6 +171,7 @@ public class TransportSearchActionSingleNodeTests extends ESSingleNodeTestCase {
             assertEquals(2, searchResponse.getHits().getTotalHits().value);
             Aggregations aggregations = searchResponse.getAggregations();
             LongTerms longTerms = aggregations.get("terms");
+            assertEquals(2, longTerms.getBuckets().size());
         }
     }
 }


### PR DESCRIPTION
The finalReduce flag is now supported on 6.x too, hence we need to update the version checks in master.

Depends on #38180
Relates to #38104