### PR TITLE
Handle scheduler exceptions

### DIFF
--- a/buildSrc/src/main/resources/forbidden/es-all-signatures.txt
+++ b/buildSrc/src/main/resources/forbidden/es-all-signatures.txt
@@ -63,3 +63,6 @@ java.util.concurrent.ScheduledThreadPoolExecutor#<init>(int)
 java.util.concurrent.ScheduledThreadPoolExecutor#<init>(int, java.util.concurrent.ThreadFactory)
 java.util.concurrent.ScheduledThreadPoolExecutor#<init>(int, java.util.concurrent.RejectedExecutionHandler)
 java.util.concurrent.ScheduledThreadPoolExecutor#<init>(int, java.util.concurrent.ThreadFactory, java.util.concurrent.RejectedExecutionHandler)
+
+@defaultMessage use Scheduler.schedule(Runnable, delay, executor) instead (mocking tests typically rely on that signature).
+org.elasticsearch.threadpool.Scheduler#schedule(org.elasticsearch.common.unit.TimeValue, java.lang.String, java.lang.Runnable)

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
@@ -215,7 +215,7 @@ public class RemoteScrollableHitSource extends ScrollableHitSource {
                                         logger.trace(
                                             (Supplier<?>) () -> new ParameterizedMessage("retrying rejected search after [{}]", delay), e);
                                         countSearchRetry.run();
-                                        threadPool.schedule(delay, ThreadPool.Names.SAME, RetryHelper.this);
+                                        threadPool.schedule(RetryHelper.this, delay, ThreadPool.Names.SAME);
                                         return;
                                     }
                                 }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/AsyncBulkByScrollActionTests.java
@@ -90,7 +90,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -320,7 +319,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         worker.rethrottle(1);
         setupClient(new TestThreadPool(getTestName()) {
             @Override
-            public ScheduledFuture<?> schedule(TimeValue delay, String name, Runnable command) {
+            public ScheduledCancellable schedule(Runnable command, TimeValue delay, String name) {
                 // While we're here we can check that the sleep made it through
                 assertThat(delay.nanos(), greaterThan(0L));
                 assertThat(delay.seconds(), lessThanOrEqualTo(10L));
@@ -439,7 +438,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         AtomicReference<Runnable> capturedCommand = new AtomicReference<>();
         setupClient(new TestThreadPool(getTestName()) {
             @Override
-            public ScheduledFuture<?> schedule(TimeValue delay, String name, Runnable command) {
+            public ScheduledCancellable schedule(Runnable command, TimeValue delay, String name) {
                 capturedDelay.set(delay);
                 capturedCommand.set(command);
                 return null;
@@ -615,7 +614,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
          */
         setupClient(new TestThreadPool(getTestName()) {
             @Override
-            public ScheduledFuture<?> schedule(TimeValue delay, String name, Runnable command) {
+            public ScheduledCancellable schedule(Runnable command, TimeValue delay, String name) {
                 /*
                  * This is called twice:
                  * 1. To schedule the throttling. When that happens we immediately cancel the task.
@@ -626,7 +625,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                 if (delay.nanos() > 0) {
                     generic().execute(() -> taskManager.cancel(testTask, reason, () -> {}));
                 }
-                return super.schedule(delay, name, command);
+                return super.schedule(command, delay, name);
             }
         });
 

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
@@ -69,7 +69,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -104,7 +103,7 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
             }
 
             @Override
-            public ScheduledFuture<?> schedule(TimeValue delay, String name, Runnable command) {
+            public ScheduledCancellable schedule(Runnable command, TimeValue delay, String name) {
                 command.run();
                 return null;
             }

--- a/server/src/main/java/org/elasticsearch/action/bulk/Retry.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/Retry.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -32,7 +31,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.ScheduledFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
@@ -121,7 +119,7 @@ public class Retry {
         // needed to construct the next bulk request based on the response to the previous one
         // volatile as we're called from a scheduled thread
         private volatile BulkRequest currentBulkRequest;
-        private volatile ScheduledFuture<?> scheduledRequestFuture;
+        private volatile Scheduler.Cancellable retryCancellable;
 
         RetryHandler(BackoffPolicy backoffPolicy, BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer,
                      ActionListener<BulkResponse> listener, Scheduler scheduler) {
@@ -155,7 +153,9 @@ public class Retry {
             try {
                 listener.onFailure(e);
             } finally {
-                FutureUtils.cancel(scheduledRequestFuture);
+                if (retryCancellable != null) {
+                    retryCancellable.cancel();
+                }
             }
         }
 
@@ -164,7 +164,7 @@ public class Retry {
             TimeValue next = backoff.next();
             logger.trace("Retry of bulk request scheduled in {} ms.", next.millis());
             Runnable command = scheduler.preserveContext(() -> this.execute(bulkRequestForRetry));
-            scheduledRequestFuture = scheduler.schedule(next, ThreadPool.Names.SAME, command);
+            retryCancellable = scheduler.schedule(command, next, ThreadPool.Names.SAME);
         }
 
         private BulkRequest createBulkRequestForRetry(BulkResponse bulkItemResponses) {
@@ -198,7 +198,9 @@ public class Retry {
             try {
                 listener.onResponse(getAccumulatedResponse());
             } finally {
-                FutureUtils.cancel(scheduledRequestFuture);
+                if (retryCancellable != null) {
+                    retryCancellable.cancel();
+                }
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -132,7 +132,7 @@ public class InternalClusterInfoService implements ClusterInfoService, LocalNode
         }
         try {
             // Submit a job that will start after DEFAULT_STARTING_INTERVAL, and reschedule itself after running
-            threadPool.schedule(updateFrequency, executorName(), new SubmitReschedulingClusterInfoUpdatedJob());
+            threadPool.schedule(new SubmitReschedulingClusterInfoUpdatedJob(), updateFrequency, executorName());
             if (clusterService.state().getNodes().getDataNodes().size() > 1) {
                 // Submit an info update job to be run immediately
                 threadPool.executor(executorName()).execute(() -> maybeRefresh());
@@ -224,7 +224,7 @@ public class InternalClusterInfoService implements ClusterInfoService, LocalNode
                                 logger.trace("Scheduling next run for updating cluster info in: {}", updateFrequency.toString());
                             }
                             try {
-                                threadPool.schedule(updateFrequency, executorName(), this);
+                                threadPool.schedule(this, updateFrequency, executorName());
                             } catch (EsRejectedExecutionException ex) {
                                 logger.debug("Reschedule cluster info service was rejected", ex);
                             }

--- a/server/src/main/java/org/elasticsearch/cluster/NodeConnectionsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/NodeConnectionsService.java
@@ -31,10 +31,10 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
-import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.util.concurrent.KeyedLock;
 import org.elasticsearch.discovery.zen.MasterFaultDetection;
 import org.elasticsearch.discovery.zen.NodesFaultDetection;
+import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -42,7 +42,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ScheduledFuture;
 
 import static org.elasticsearch.common.settings.Setting.Property;
 import static org.elasticsearch.common.settings.Setting.positiveTimeSetting;
@@ -71,7 +70,7 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
 
     private final TimeValue reconnectInterval;
 
-    private volatile ScheduledFuture<?> backgroundFuture = null;
+    private volatile Scheduler.Cancellable backgroundCancellable = null;
 
     @Inject
     public NodeConnectionsService(Settings settings, ThreadPool threadPool, TransportService transportService) {
@@ -187,19 +186,21 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
         @Override
         public void onAfter() {
             if (lifecycle.started()) {
-                backgroundFuture = threadPool.schedule(reconnectInterval, ThreadPool.Names.GENERIC, this);
+                backgroundCancellable = threadPool.schedule(this, reconnectInterval, ThreadPool.Names.GENERIC);
             }
         }
     }
 
     @Override
     protected void doStart() {
-        backgroundFuture = threadPool.schedule(reconnectInterval, ThreadPool.Names.GENERIC, new ConnectionChecker());
+        backgroundCancellable = threadPool.schedule(new ConnectionChecker(), reconnectInterval, ThreadPool.Names.GENERIC);
     }
 
     @Override
     protected void doStop() {
-        FutureUtils.cancel(backgroundFuture);
+        if (backgroundCancellable != null) {
+            backgroundCancellable.cancel();
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
@@ -32,10 +32,9 @@ import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
-import org.elasticsearch.common.util.concurrent.FutureUtils;
+import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -69,7 +68,7 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
     class DelayedRerouteTask extends ClusterStateUpdateTask {
         final TimeValue nextDelay; // delay until submitting the reroute command
         final long baseTimestampNanos; // timestamp (in nanos) upon which delay was calculated
-        volatile ScheduledFuture future;
+        volatile Scheduler.Cancellable cancellable;
         final AtomicBoolean cancelScheduling = new AtomicBoolean();
 
         DelayedRerouteTask(TimeValue nextDelay, long baseTimestampNanos) {
@@ -83,12 +82,14 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
 
         public void cancelScheduling() {
             cancelScheduling.set(true);
-            FutureUtils.cancel(future);
+            if (cancellable != null) {
+                cancellable.cancel();
+            }
             removeIfSameTask(this);
         }
 
         public void schedule() {
-            future = threadPool.schedule(nextDelay, ThreadPool.Names.SAME, new AbstractRunnable() {
+            cancellable = threadPool.schedule(new AbstractRunnable() {
                 @Override
                 protected void doRun() throws Exception {
                     if (cancelScheduling.get()) {
@@ -102,7 +103,7 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
                     logger.warn("failed to submit schedule/execute reroute post unassigned shard", e);
                     removeIfSameTask(DelayedRerouteTask.this);
                 }
-            });
+            }, nextDelay, ThreadPool.Names.SAME);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -45,10 +45,10 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.discovery.Discovery;
+import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Arrays;
@@ -57,7 +57,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
@@ -563,7 +562,7 @@ public class MasterService extends AbstractLifecycleComponent {
         private final DiscoveryNode masterNode;
         private final ThreadPool threadPool;
         private final long clusterStateVersion;
-        private volatile Future<?> ackTimeoutCallback;
+        private volatile Scheduler.Cancellable ackTimeoutCallback;
         private Exception lastFailure;
 
         AckCountDownListener(AckedClusterStateTaskListener ackedTaskListener, long clusterStateVersion, DiscoveryNodes nodes,
@@ -595,10 +594,10 @@ public class MasterService extends AbstractLifecycleComponent {
             } else if (countDown.countDown()) {
                 finish();
             } else {
-                this.ackTimeoutCallback = threadPool.schedule(timeLeft, ThreadPool.Names.GENERIC, this::onTimeout);
+                this.ackTimeoutCallback = threadPool.schedule(this::onTimeout, timeLeft, ThreadPool.Names.GENERIC);
                 // re-check if onNodeAck has not completed while we were scheduling the timeout
                 if (countDown.isCountedDown()) {
-                    FutureUtils.cancel(ackTimeoutCallback);
+                    ackTimeoutCallback.cancel();
                 }
             }
         }
@@ -623,7 +622,9 @@ public class MasterService extends AbstractLifecycleComponent {
 
         private void finish() {
             logger.trace("all expected nodes acknowledged cluster_state update (version: {})", clusterStateVersion);
-            FutureUtils.cancel(ackTimeoutCallback);
+            if (ackTimeoutCallback != null) {
+                ackTimeoutCallback.cancel();
+            }
             ackedTaskListener.onAllNodesAcked(lastFailure);
         }
 

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -118,8 +118,11 @@ public class EsExecutors {
      * Checks if the runnable arose from asynchronous submission of a task to an executor. If an uncaught exception was thrown
      * during the execution of this task, we need to inspect this runnable and see if it is an error that should be propagated
      * to the uncaught exception handler.
+     *
+     * @param runnable the runnable to inspect, should be a RunnableFuture
+     * @return non fatal exception or null if no exception.
      */
-    public static void rethrowErrors(Runnable runnable) {
+    public static Throwable rethrowErrors(Runnable runnable) {
         if (runnable instanceof RunnableFuture) {
             try {
                 ((RunnableFuture) runnable).get();
@@ -143,8 +146,13 @@ public class EsExecutors {
                     // restore the interrupt status
                     Thread.currentThread().interrupt();
                 }
+                if (e instanceof ExecutionException) {
+                    return e.getCause();
+                }
             }
         }
+
+        return null;
     }
 
     private static final class DirectExecutorService extends AbstractExecutorService {

--- a/server/src/main/java/org/elasticsearch/discovery/zen/MasterFaultDetection.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/MasterFaultDetection.java
@@ -127,7 +127,7 @@ public class MasterFaultDetection extends FaultDetection {
         this.masterPinger = new MasterPinger();
 
         // we start pinging slightly later to allow the chosen master to complete it's own master election
-        threadPool.schedule(pingInterval, ThreadPool.Names.SAME, masterPinger);
+        threadPool.schedule(masterPinger, pingInterval, ThreadPool.Names.SAME);
     }
 
     public void stop(String reason) {
@@ -173,7 +173,7 @@ public class MasterFaultDetection extends FaultDetection {
                     }
                     this.masterPinger = new MasterPinger();
                     // we use schedule with a 0 time value to run the pinger on the pool as it will run on later
-                    threadPool.schedule(TimeValue.timeValueMillis(0), ThreadPool.Names.SAME, masterPinger);
+                    threadPool.schedule(masterPinger, TimeValue.timeValueMillis(0), ThreadPool.Names.SAME);
                 } catch (Exception e) {
                     logger.trace("[master] [{}] transport disconnected (with verified connect)", masterNode);
                     notifyMasterFailure(masterNode, null, "transport disconnected (with verified connect)");
@@ -217,7 +217,7 @@ public class MasterFaultDetection extends FaultDetection {
             final DiscoveryNode masterToPing = masterNode;
             if (masterToPing == null) {
                 // master is null, should not happen, but we are still running, so reschedule
-                threadPool.schedule(pingInterval, ThreadPool.Names.SAME, MasterPinger.this);
+                threadPool.schedule(MasterPinger.this, pingInterval, ThreadPool.Names.SAME);
                 return;
             }
 
@@ -242,7 +242,7 @@ public class MasterFaultDetection extends FaultDetection {
                             // check if the master node did not get switched on us..., if it did, we simply return with no reschedule
                             if (masterToPing.equals(MasterFaultDetection.this.masterNode())) {
                                 // we don't stop on disconnection from master, we keep pinging it
-                                threadPool.schedule(pingInterval, ThreadPool.Names.SAME, MasterPinger.this);
+                                threadPool.schedule(MasterPinger.this, pingInterval, ThreadPool.Names.SAME);
                             }
                         }
 

--- a/server/src/main/java/org/elasticsearch/discovery/zen/NodesFaultDetection.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/NodesFaultDetection.java
@@ -131,7 +131,7 @@ public class NodesFaultDetection extends FaultDetection {
                 // it's OK to overwrite an existing nodeFD - it will just stop and the new one will pick things up.
                 nodesFD.put(node, fd);
                 // we use schedule with a 0 time value to run the pinger on the pool as it will run on later
-                threadPool.schedule(TimeValue.timeValueMillis(0), ThreadPool.Names.SAME, fd);
+                threadPool.schedule(fd, TimeValue.timeValueMillis(0), ThreadPool.Names.SAME);
             }
         }
     }
@@ -160,7 +160,7 @@ public class NodesFaultDetection extends FaultDetection {
                 transportService.connectToNode(node);
                 nodesFD.put(node, fd);
                 // we use schedule with a 0 time value to run the pinger on the pool as it will run on later
-                threadPool.schedule(TimeValue.timeValueMillis(0), ThreadPool.Names.SAME, fd);
+                threadPool.schedule(fd, TimeValue.timeValueMillis(0), ThreadPool.Names.SAME);
             } catch (Exception e) {
                 logger.trace("[node  ] [{}] transport disconnected (with verified connect)", node);
                 // clean up if needed, just to be safe..
@@ -239,7 +239,7 @@ public class NodesFaultDetection extends FaultDetection {
                                 return;
                             }
                             retryCount = 0;
-                            threadPool.schedule(pingInterval, ThreadPool.Names.SAME, NodeFD.this);
+                            threadPool.schedule(NodeFD.this, pingInterval, ThreadPool.Names.SAME);
                         }
 
                         @Override

--- a/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
@@ -303,9 +303,9 @@ public class UnicastZenPing implements ZenPing {
             }
         };
         threadPool.generic().execute(pingSender);
-        threadPool.schedule(TimeValue.timeValueMillis(scheduleDuration.millis() / 3), ThreadPool.Names.GENERIC, pingSender);
-        threadPool.schedule(TimeValue.timeValueMillis(scheduleDuration.millis() / 3 * 2), ThreadPool.Names.GENERIC, pingSender);
-        threadPool.schedule(scheduleDuration, ThreadPool.Names.GENERIC, new AbstractRunnable() {
+        threadPool.schedule(pingSender, TimeValue.timeValueMillis(scheduleDuration.millis() / 3), ThreadPool.Names.GENERIC);
+        threadPool.schedule(pingSender, TimeValue.timeValueMillis(scheduleDuration.millis() / 3 * 2), ThreadPool.Names.GENERIC);
+        threadPool.schedule(new AbstractRunnable() {
             @Override
             protected void doRun() throws Exception {
                 finishPingingRound(pingingRound);
@@ -315,7 +315,7 @@ public class UnicastZenPing implements ZenPing {
             public void onFailure(Exception e) {
                 logger.warn("unexpected error while finishing pinging round", e);
             }
-        });
+        }, scheduleDuration, ThreadPool.Names.GENERIC);
     }
 
     // for testing
@@ -556,8 +556,8 @@ public class UnicastZenPing implements ZenPing {
         temporalResponses.add(request.pingResponse);
         // add to any ongoing pinging
         activePingingRounds.values().forEach(p -> p.addPingResponseToCollection(request.pingResponse));
-        threadPool.schedule(TimeValue.timeValueMillis(request.timeout.millis() * 2), ThreadPool.Names.SAME,
-            () -> temporalResponses.remove(request.pingResponse));
+        threadPool.schedule(() -> temporalResponses.remove(request.pingResponse),
+            TimeValue.timeValueMillis(request.timeout.millis() * 2), ThreadPool.Names.SAME);
 
         List<PingResponse> pingResponses = CollectionUtils.iterableAsArrayList(temporalResponses);
         pingResponses.add(createPingResponse(contextProvider.clusterState()));

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -204,12 +204,12 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
         if (enforceRecoverAfterTime && recoverAfterTime != null) {
             if (scheduledRecovery.compareAndSet(false, true)) {
                 logger.info("delaying initial state recovery for [{}]. {}", recoverAfterTime, reason);
-                threadPool.schedule(recoverAfterTime, ThreadPool.Names.GENERIC, () -> {
+                threadPool.schedule(() -> {
                     if (recovered.compareAndSet(false, true)) {
                         logger.info("recover_after_time [{}] elapsed. performing state recovery...", recoverAfterTime);
                         gateway.performStateRecovery(recoveryListener);
                     }
-                });
+                }, recoverAfterTime, ThreadPool.Names.GENERIC);
             }
         } else {
             if (recovered.compareAndSet(false, true)) {

--- a/server/src/main/java/org/elasticsearch/index/reindex/ClientScrollableHitSource.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ClientScrollableHitSource.java
@@ -156,7 +156,7 @@ public class ClientScrollableHitSource extends ScrollableHitSource {
                         TimeValue delay = retries.next();
                         logger.trace(() -> new ParameterizedMessage("retrying rejected search after [{}]", delay), e);
                         countSearchRetry.run();
-                        threadPool.schedule(delay, ThreadPool.Names.SAME, retryWithContext);
+                        threadPool.schedule(retryWithContext, delay, ThreadPool.Names.SAME);
                     } else {
                         logger.warn(() -> new ParameterizedMessage(
                                 "giving up on search because we retried [{}] times without success", retryCount), e);

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -212,7 +212,7 @@ public class IndicesService extends AbstractLifecycleComponent
     @Override
     protected void doStart() {
         // Start thread that will manage cleaning the field data cache periodically
-        threadPool.schedule(this.cleanInterval, ThreadPool.Names.SAME, this.cacheCleaner);
+        threadPool.schedule(this.cacheCleaner, this.cleanInterval, ThreadPool.Names.SAME);
     }
 
     public IndicesService(Settings settings, PluginsService pluginsService, NodeEnvironment nodeEnv, NamedXContentRegistry xContentRegistry,
@@ -1178,7 +1178,7 @@ public class IndicesService extends AbstractLifecycleComponent
             }
             // Reschedule itself to run again if not closed
             if (closed.get() == false) {
-                threadPool.schedule(interval, ThreadPool.Names.SAME, this);
+                threadPool.schedule(this, interval, ThreadPool.Names.SAME);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -163,7 +163,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
     private void retryRecovery(final long recoveryId, final TimeValue retryAfter, final TimeValue activityTimeout) {
         RecoveryTarget newTarget = onGoingRecoveries.resetRecovery(recoveryId, activityTimeout);
         if (newTarget != null) {
-            threadPool.schedule(retryAfter, ThreadPool.Names.GENERIC, new RecoveryRunner(newTarget.recoveryId()));
+            threadPool.schedule(new RecoveryRunner(newTarget.recoveryId()), retryAfter, ThreadPool.Names.GENERIC);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
@@ -76,8 +76,8 @@ public class RecoveriesCollection {
         assert existingTarget == null : "found two RecoveryStatus instances with the same id";
         logger.trace("{} started recovery from {}, id [{}]", recoveryTarget.shardId(), recoveryTarget.sourceNode(),
             recoveryTarget.recoveryId());
-        threadPool.schedule(activityTimeout, ThreadPool.Names.GENERIC,
-                new RecoveryMonitor(recoveryTarget.recoveryId(), recoveryTarget.lastAccessTime(), activityTimeout));
+        threadPool.schedule(new RecoveryMonitor(recoveryTarget.recoveryId(), recoveryTarget.lastAccessTime(), activityTimeout),
+            activityTimeout, ThreadPool.Names.GENERIC);
     }
 
     /**
@@ -289,7 +289,7 @@ public class RecoveriesCollection {
             }
             lastSeenAccessTime = accessTime;
             logger.trace("[monitor] rescheduling check for [{}]. last access time is [{}]", recoveryId, lastSeenAccessTime);
-            threadPool.schedule(checkInterval, ThreadPool.Names.GENERIC, this);
+            threadPool.schedule(this, checkInterval, ThreadPool.Names.GENERIC);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -90,7 +90,7 @@ public class IngestService implements ClusterStateApplier {
             new Processor.Parameters(
                 env, scriptService, analysisRegistry,
                 threadPool.getThreadContext(), threadPool::relativeTimeInMillis,
-                (delay, command) -> threadPool.schedule(
+                (delay, command) -> threadPool.scheduleDeprecated(
                     TimeValue.timeValueMillis(delay), ThreadPool.Names.GENERIC, command
                 ), this
             )

--- a/server/src/main/java/org/elasticsearch/tasks/TaskResultsService.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskResultsService.java
@@ -190,7 +190,7 @@ public class TaskResultsService {
                 } else {
                     TimeValue wait = backoff.next();
                     logger.warn(() -> new ParameterizedMessage("failed to store task result, retrying in [{}]", wait), e);
-                    threadPool.schedule(wait, ThreadPool.Names.SAME, () -> doStoreResult(backoff, index, listener));
+                    threadPool.schedule(() -> doStoreResult(backoff, index, listener), wait, ThreadPool.Names.SAME);
                 }
             }
         });

--- a/server/src/main/java/org/elasticsearch/threadpool/CancellableAdapter.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/CancellableAdapter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.threadpool;
+
+import org.elasticsearch.common.util.concurrent.FutureUtils;
+
+import java.util.concurrent.Future;
+
+class CancellableAdapter implements Scheduler.Cancellable {
+    private Future<?> future;
+
+    CancellableAdapter(Future<?> future) {
+        assert future != null;
+        this.future = future;
+    }
+
+    @Override
+    public boolean cancel() {
+        return FutureUtils.cancel(future);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return future.isCancelled();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/threadpool/ScheduledCancellableAdapter.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ScheduledCancellableAdapter.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.threadpool;
+
+import org.elasticsearch.common.util.concurrent.FutureUtils;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+class ScheduledCancellableAdapter implements Scheduler.ScheduledCancellable {
+    private final ScheduledFuture<?> scheduledFuture;
+
+    ScheduledCancellableAdapter(ScheduledFuture<?> scheduledFuture) {
+        assert scheduledFuture != null;
+        this.scheduledFuture = scheduledFuture;
+    }
+
+    @Override
+    public long getDelay(TimeUnit unit) {
+        return scheduledFuture.getDelay(unit);
+    }
+
+    @Override
+    public int compareTo(Delayed other) {
+        // unwrap other by calling on it.
+        return -other.compareTo(scheduledFuture);
+    }
+
+    @Override
+    public boolean cancel() {
+        return FutureUtils.cancel(scheduledFuture);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return scheduledFuture.isCancelled();
+    }
+
+    static ScheduledFuture<?> toScheduledFuture(Scheduler.ScheduledCancellable cancellable) {
+        if (cancellable instanceof ScheduledCancellableAdapter)
+            return ((ScheduledCancellableAdapter) cancellable).scheduledFuture;
+        else
+            return new ScheduledFuture<Object>() {
+                @Override
+                public long getDelay(TimeUnit unit) {
+                    return cancellable.getDelay(unit);
+                }
+
+                @Override
+                public int compareTo(Delayed o) {
+                    return -o.compareTo(cancellable);
+                }
+
+                @Override
+                public boolean cancel(boolean mayInterruptIfRunning) {
+                    assert mayInterruptIfRunning == false;
+                    return cancellable.cancel();
+                }
+
+                @Override
+                public boolean isCancelled() {
+                    return cancellable.isCancelled();
+                }
+
+                @Override
+                public boolean isDone() {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Object get() throws InterruptedException, ExecutionException {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Object get(long timeout, TimeUnit unit) {
+                    throw new UnsupportedOperationException();
+                }
+            };
+    }
+}

--- a/server/src/main/java/org/elasticsearch/threadpool/Scheduler.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/Scheduler.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.threadpool;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -27,6 +30,8 @@ import org.elasticsearch.common.util.concurrent.EsAbortPolicy;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 
+import java.util.concurrent.Delayed;
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -39,6 +44,14 @@ import java.util.function.Consumer;
  */
 public interface Scheduler {
 
+    /**
+     * Create a scheduler that can be used client side. Server side, please use <code>ThreadPool.schedule</code> instead.
+     *
+     * Notice that if any scheduled jobs fail with an exception, they will be logged as a warning. This includes jobs started
+     * using execute, submit and schedule.
+     * @param settings the settings to use
+     * @return executor
+     */
     static ScheduledThreadPoolExecutor initScheduler(Settings settings) {
         final ScheduledThreadPoolExecutor scheduler = new SafeScheduledThreadPoolExecutor(1,
                 EsExecutors.daemonThreadFactory(settings, "scheduler"), new EsAbortPolicy());
@@ -85,6 +98,24 @@ public interface Scheduler {
      * The command runs on scheduler thread. Do not run blocking calls on the scheduler thread. Subclasses may allow
      * to execute on a different executor, in which case blocking calls are allowed.
      *
+     * @param command the command to run
+     * @param delay delay before the task executes
+     * @param executor the name of the executor that has to execute this task. Ignored in the default implementation but can be used
+     *                 by subclasses that support multiple executors.
+     * @return a ScheduledFuture who's get will return when the task has been added to its target thread pool and throws an exception if
+     *         the task is canceled before it was added to its target thread pool. Once the task has been added to its target thread pool
+     *         the ScheduledFuture cannot interact with it.
+     * @throws EsRejectedExecutionException if the task cannot be scheduled for execution
+     */
+    ScheduledCancellable schedule(Runnable command, TimeValue delay, String executor);
+
+    /**
+     * Schedules a one-shot command to be run after a given delay. The command is not run in the context of the calling thread.
+     * To preserve the context of the calling thread you may call {@link #preserveContext(Runnable)} on the runnable before passing
+     * it to this method.
+     * The command runs on scheduler thread. Do not run blocking calls on the scheduler thread. Subclasses may allow
+     * to execute on a different executor, in which case blocking calls are allowed.
+     *
      * @param delay delay before the task executes
      * @param executor the name of the executor that has to execute this task. Ignored in the default implementation but can be used
      *                 by subclasses that support multiple executors.
@@ -93,8 +124,12 @@ public interface Scheduler {
      *         the task is canceled before it was added to its target thread pool. Once the task has been added to its target thread pool
      *         the ScheduledFuture cannot interact with it.
      * @throws EsRejectedExecutionException if the task cannot be scheduled for execution
+     * @deprecated use {@link #schedule(Runnable, TimeValue, String)} instead
      */
-    ScheduledFuture<?> schedule(TimeValue delay, String executor, Runnable command);
+    @Deprecated
+    default ScheduledFuture<?> schedule(TimeValue delay, String executor, Runnable command) {
+        return ScheduledCancellableAdapter.toScheduledFuture(schedule(command, delay, executor));
+    }
 
     /**
      * Schedules a periodic action that runs on scheduler thread. Do not run blocking calls on the scheduler thread. Subclasses may allow
@@ -112,6 +147,25 @@ public interface Scheduler {
     }
 
     /**
+     * Utility method to wrap a <code>Future</code> as a <code>Cancellable</code>
+     * @param future the future to wrap
+     * @return a cancellable delegating to the future
+     */
+    static Cancellable wrapAsCancellable(Future<?> future) {
+        return new CancellableAdapter(future);
+    }
+
+    /**
+     * Utility method to wrap a <code>ScheduledFuture</code> as a <code>ScheduledCancellable</code>
+     * @param scheduledFuture the scheduled future to wrap
+     * @return a SchedulecCancellable delegating to the scheduledFuture
+     */
+    static ScheduledCancellable wrapAsScheduledCancellable(ScheduledFuture<?> scheduledFuture) {
+        return new ScheduledCancellableAdapter(scheduledFuture);
+    }
+
+
+    /**
      * This interface represents an object whose execution may be cancelled during runtime.
      */
     interface Cancellable {
@@ -119,7 +173,7 @@ public interface Scheduler {
         /**
          * Cancel the execution of this object. This method is idempotent.
          */
-        void cancel();
+        boolean cancel();
 
         /**
          * Check if the execution has been cancelled
@@ -127,6 +181,11 @@ public interface Scheduler {
          */
         boolean isCancelled();
     }
+
+    /**
+     * A scheduled cancellable allow cancelling and reading the remaining delay of a scheduled task.
+     */
+    interface ScheduledCancellable extends Delayed, Cancellable { }
 
     /**
      * This class encapsulates the scheduling of a {@link Runnable} that needs to be repeated on a interval. For example, checking a value
@@ -165,12 +224,14 @@ public interface Scheduler {
             this.scheduler = scheduler;
             this.rejectionConsumer = rejectionConsumer;
             this.failureConsumer = failureConsumer;
-            scheduler.schedule(interval, executor, this);
+            scheduler.schedule(this, interval, executor);
         }
 
         @Override
-        public void cancel() {
+        public boolean cancel() {
+            final boolean result = run;
             run = false;
+            return result;
         }
 
         @Override
@@ -202,7 +263,7 @@ public interface Scheduler {
             // if this has not been cancelled reschedule it to run again
             if (run) {
                 try {
-                    scheduler.schedule(interval, executor, this);
+                    scheduler.schedule(this, interval, executor);
                 } catch (final EsRejectedExecutionException e) {
                     onRejection(e);
                 }
@@ -211,9 +272,10 @@ public interface Scheduler {
     }
 
     /**
-     * This subclass ensures to properly bubble up Throwable instances of type Error.
+     * This subclass ensures to properly bubble up Throwable instances of type Error and logs exceptions thrown in submitted/scheduled tasks
      */
     class SafeScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor {
+        private static final Logger logger = LogManager.getLogger(SafeScheduledThreadPoolExecutor.class);
 
         @SuppressForbidden(reason = "properly rethrowing errors, see EsExecutors.rethrowErrors")
         public SafeScheduledThreadPoolExecutor(int corePoolSize, ThreadFactory threadFactory, RejectedExecutionHandler handler) {
@@ -232,7 +294,12 @@ public interface Scheduler {
 
         @Override
         protected void afterExecute(Runnable r, Throwable t) {
-            EsExecutors.rethrowErrors(r);
+            Throwable exception = EsExecutors.rethrowErrors(r);
+            if (exception != null) {
+                logger.warn(() ->
+                    new ParameterizedMessage("uncaught exception in scheduled thread [{}]", Thread.currentThread().getName()),
+                    exception);
+            }
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -326,7 +326,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         }
 
         TimeValue connectTimeout = connectionProfile.getConnectTimeout();
-        threadPool.schedule(connectTimeout, ThreadPool.Names.GENERIC, channelsConnectedListener::onTimeout);
+        threadPool.schedule(channelsConnectedListener::onTimeout, connectTimeout, ThreadPool.Names.GENERIC);
         return channels;
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
@@ -73,8 +73,10 @@ final class TransportHandshaker {
             final Version minCompatVersion = version.minimumCompatibilityVersion();
             handshakeRequestSender.sendRequest(node, channel, requestId, minCompatVersion);
 
-            threadPool.schedule(timeout, ThreadPool.Names.GENERIC,
-                () -> handler.handleLocalException(new ConnectTransportException(node, "handshake_timeout[" + timeout + "]")));
+            threadPool.schedule(
+                () -> handler.handleLocalException(new ConnectTransportException(node, "handshake_timeout[" + timeout + "]")),
+                timeout,
+                ThreadPool.Names.GENERIC);
             success = true;
         } catch (Exception e) {
             handler.handleLocalException(new ConnectTransportException(node, "failure to send " + HANDSHAKE_ACTION_NAME, e));

--- a/server/src/main/java/org/elasticsearch/transport/TransportKeepAlive.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportKeepAlive.java
@@ -158,7 +158,7 @@ final class TransportKeepAlive implements Closeable {
 
         void ensureStarted() {
             if (isStarted.get() == false && isStarted.compareAndSet(false, true)) {
-                threadPool.schedule(pingInterval, ThreadPool.Names.GENERIC, this);
+                threadPool.schedule(this, pingInterval, ThreadPool.Names.GENERIC);
             }
         }
 
@@ -186,7 +186,7 @@ final class TransportKeepAlive implements Closeable {
         @Override
         protected void onAfterInLifecycle() {
             try {
-                threadPool.schedule(pingInterval, ThreadPool.Names.GENERIC, this);
+                threadPool.schedule(this, pingInterval, ThreadPool.Names.GENERIC);
             } catch (EsRejectedExecutionException ex) {
                 if (ex.isExecutorShutdown()) {
                     logger.debug("couldn't schedule new ping execution, executor is shutting down", ex);

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -42,14 +42,15 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -65,7 +66,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -621,7 +621,7 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
             }
             if (timeoutHandler != null) {
                 assert options.timeout() != null;
-                timeoutHandler.future = threadPool.schedule(options.timeout(), ThreadPool.Names.GENERIC, timeoutHandler);
+                timeoutHandler.scheduleTimeout(options.timeout());
             }
             connection.sendRequest(requestId, action, request, options); // local node optimization happens upstream
         } catch (final Exception e) {
@@ -988,7 +988,7 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         private final long sentTime = threadPool.relativeTimeInMillis();
         private final String action;
         private final DiscoveryNode node;
-        volatile ScheduledFuture future;
+        volatile Scheduler.Cancellable cancellable;
 
         TimeoutHandler(long requestId, DiscoveryNode node, String action) {
             this.requestId = requestId;
@@ -1023,12 +1023,18 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         public void cancel() {
             assert responseHandlers.contains(requestId) == false :
                 "cancel must be called after the requestId [" + requestId + "] has been removed from clientHandlers";
-            FutureUtils.cancel(future);
+            if (cancellable != null) {
+                cancellable.cancel();
+            }
         }
 
         @Override
         public String toString() {
             return "timeout handler for [" + requestId + "][" + action + "]";
+        }
+
+        private void scheduleTimeout(TimeValue timeout) {
+            this.cancellable = threadPool.schedule(this, timeout, ThreadPool.Names.GENERIC);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessorTests.java
@@ -96,7 +96,7 @@ public class BulkProcessorTests extends ESTestCase {
         BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer = (request, listener) -> {};
         BulkProcessor bulkProcessor = new BulkProcessor(consumer, BackoffPolicy.noBackoff(), emptyListener(),
             0, 10, new ByteSizeValue(1000), null,
-            (delay, executor, command) -> null, () -> called.set(true), BulkRequest::new);
+            (command, delay, executor) -> null, () -> called.set(true), BulkRequest::new);
 
         assertFalse(called.get());
         bulkProcessor.awaitClose(100, TimeUnit.MILLISECONDS);

--- a/server/src/test/java/org/elasticsearch/index/reindex/WorkerBulkByScrollTaskStateTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/WorkerBulkByScrollTaskStateTests.java
@@ -33,10 +33,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Delayed;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.common.unit.TimeValue.timeValueNanos;
@@ -149,9 +146,9 @@ public class WorkerBulkByScrollTaskStateTests extends ESTestCase {
         int batchSizeForMaxDelay = (int) (maxDelay.seconds() * originalRequestsPerSecond);
         ThreadPool threadPool = new TestThreadPool(getTestName()) {
             @Override
-            public ScheduledFuture<?> schedule(TimeValue delay, String name, Runnable command) {
+            public ScheduledCancellable schedule(Runnable command, TimeValue delay, String name) {
                 assertThat(delay.nanos(), both(greaterThanOrEqualTo(0L)).and(lessThanOrEqualTo(maxDelay.nanos())));
-                return super.schedule(delay, name, command);
+                return super.schedule(command, delay, name);
             }
         };
         try {
@@ -202,8 +199,8 @@ public class WorkerBulkByScrollTaskStateTests extends ESTestCase {
     public void testDelayNeverNegative() throws IOException {
         // Thread pool that returns a ScheduledFuture that claims to have a negative delay
         ThreadPool threadPool = new TestThreadPool("test") {
-            public ScheduledFuture<?> schedule(TimeValue delay, String name, Runnable command) {
-                return new ScheduledFuture<Void>() {
+            public ScheduledCancellable schedule(Runnable command, TimeValue delay, String name) {
+                return new ScheduledCancellable() {
                     @Override
                     public long getDelay(TimeUnit unit) {
                         return -1;
@@ -215,27 +212,12 @@ public class WorkerBulkByScrollTaskStateTests extends ESTestCase {
                     }
 
                     @Override
-                    public boolean cancel(boolean mayInterruptIfRunning) {
+                    public boolean cancel() {
                         throw new UnsupportedOperationException();
                     }
 
                     @Override
                     public boolean isCancelled() {
-                        throw new UnsupportedOperationException();
-                    }
-
-                    @Override
-                    public boolean isDone() {
-                        throw new UnsupportedOperationException();
-                    }
-
-                    @Override
-                    public Void get() throws InterruptedException, ExecutionException {
-                        throw new UnsupportedOperationException();
-                    }
-
-                    @Override
-                    public Void get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
                         throw new UnsupportedOperationException();
                     }
                 };

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/JvmGcMonitorServiceSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/JvmGcMonitorServiceSettingsTests.java
@@ -175,7 +175,8 @@ public class JvmGcMonitorServiceSettingsTests extends ESTestCase {
     private static class MockCancellable implements Cancellable {
 
         @Override
-        public void cancel() {
+        public boolean cancel() {
+            return true;
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/threadpool/ScheduleWithFixedDelayTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ScheduleWithFixedDelayTests.java
@@ -33,7 +33,6 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -83,7 +82,7 @@ public class ScheduleWithFixedDelayTests extends ESTestCase {
         ReschedulingRunnable reschedulingRunnable = new ReschedulingRunnable(runnable, delay, Names.GENERIC, threadPool,
                 (e) -> {}, (e) -> {});
         // this call was made during construction of the runnable
-        verify(threadPool, times(1)).schedule(delay, Names.GENERIC, reschedulingRunnable);
+        verify(threadPool, times(1)).schedule(reschedulingRunnable, delay, Names.GENERIC);
 
         // create a thread and start the runnable
         Thread runThread = new Thread() {
@@ -103,7 +102,7 @@ public class ScheduleWithFixedDelayTests extends ESTestCase {
         runThread.join();
 
         // validate schedule was called again
-        verify(threadPool, times(2)).schedule(delay, Names.GENERIC, reschedulingRunnable);
+        verify(threadPool, times(2)).schedule(reschedulingRunnable, delay, Names.GENERIC);
     }
 
     public void testThatRunnableIsRescheduled() throws Exception {
@@ -251,7 +250,7 @@ public class ScheduleWithFixedDelayTests extends ESTestCase {
         terminate(threadPool);
         threadPool = new ThreadPool(Settings.builder().put(Node.NODE_NAME_SETTING.getKey(), "fixed delay tests").build()) {
             @Override
-            public ScheduledFuture<?> schedule(TimeValue delay, String executor, Runnable command) {
+            public ScheduledCancellable schedule(Runnable command, TimeValue delay, String executor) {
                 if (command instanceof ReschedulingRunnable) {
                     ((ReschedulingRunnable) command).onRejection(new EsRejectedExecutionException());
                 } else {

--- a/server/src/test/java/org/elasticsearch/threadpool/SchedulerTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/SchedulerTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.threadpool;
 
+import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
@@ -157,15 +158,19 @@ public class SchedulerTests extends ESTestCase {
         }
     }
 
+    @SuppressForbidden(reason = "this tests that the deprecated method still works")
     public void testDeprecatedSchedule() throws ExecutionException, InterruptedException {
-        verifyDeprecatedSchedule(((threadPool, runnable) -> threadPool.schedule(TimeValue.timeValueMillis(randomInt(10)), ThreadPool.Names.SAME, runnable)));
+        verifyDeprecatedSchedule(((threadPool, runnable)
+            -> threadPool.schedule(TimeValue.timeValueMillis(randomInt(10)), ThreadPool.Names.SAME, runnable)));
     }
 
     public void testThreadPoolScheduleDeprecated() throws ExecutionException, InterruptedException {
-        verifyDeprecatedSchedule(((threadPool, runnable) -> threadPool.scheduleDeprecated(TimeValue.timeValueMillis(randomInt(10)), ThreadPool.Names.SAME, runnable)));
+        verifyDeprecatedSchedule(((threadPool, runnable)
+            -> threadPool.scheduleDeprecated(TimeValue.timeValueMillis(randomInt(10)), ThreadPool.Names.SAME, runnable)));
     }
 
-    private void verifyDeprecatedSchedule(BiFunction<ThreadPool, Runnable, ScheduledFuture<?>> scheduleFunction) throws InterruptedException, ExecutionException {
+    private void verifyDeprecatedSchedule(BiFunction<ThreadPool,
+        Runnable, ScheduledFuture<?>> scheduleFunction) throws InterruptedException, ExecutionException {
         ThreadPool threadPool = new TestThreadPool("test");
         CountDownLatch missingExecutions = new CountDownLatch(1);
         try {

--- a/server/src/test/java/org/elasticsearch/threadpool/SchedulerTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/SchedulerTests.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.threadpool;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.Matchers;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+public class SchedulerTests extends ESTestCase {
+
+    public void testCancelOnThreadPool() {
+        ThreadPool threadPool = new TestThreadPool("test");
+        AtomicLong executed = new AtomicLong();
+        try {
+            ThreadPool.THREAD_POOL_TYPES.keySet().forEach(type ->
+                scheduleAndCancel(threadPool, executed, type));
+            assertEquals(0, executed.get());
+        } finally {
+            ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+        }
+    }
+
+    private void scheduleAndCancel(ThreadPool threadPool, AtomicLong executed, String type) {
+        Scheduler.ScheduledCancellable scheduled = threadPool.schedule(executed::incrementAndGet, TimeValue.timeValueSeconds(20), type);
+        assertEquals(1, schedulerQueueSize(threadPool));
+        assertFalse(scheduled.isCancelled());
+        assertTrue(scheduled.cancel());
+        assertTrue(scheduled.isCancelled());
+        assertEquals("Cancel must auto-remove", 0, schedulerQueueSize(threadPool));
+    }
+
+    private int schedulerQueueSize(ThreadPool threadPool) {
+        return ((Scheduler.SafeScheduledThreadPoolExecutor) threadPool.scheduler()).getQueue().size();
+    }
+
+    public void testCancelOnScheduler() {
+        ScheduledThreadPoolExecutor executor = Scheduler.initScheduler(Settings.EMPTY);
+        Scheduler scheduler = (command, delay, name) ->
+            Scheduler.wrapAsScheduledCancellable(executor.schedule(command, delay.millis(), TimeUnit.MILLISECONDS));
+
+        AtomicLong executed = new AtomicLong();
+        try {
+            Scheduler.ScheduledCancellable scheduled =
+                scheduler.schedule(executed::incrementAndGet, TimeValue.timeValueSeconds(20), ThreadPool.Names.SAME);
+            assertEquals(1, executor.getQueue().size());
+            assertFalse(scheduled.isCancelled());
+            assertTrue(scheduled.cancel());
+            assertTrue(scheduled.isCancelled());
+            assertEquals("Cancel must auto-remove", 0, executor.getQueue().size());
+            assertEquals(0, executed.get());
+        } finally {
+            Scheduler.terminate(executor, 10, TimeUnit.SECONDS);
+        }
+    }
+
+
+    public void testDelay() throws InterruptedException {
+        ThreadPool threadPool = new TestThreadPool("test");
+        try {
+            List<Scheduler.ScheduledCancellable> jobs = LongStream.range(20,30)
+                .mapToObj(delay -> threadPool.schedule(() -> {},
+                    TimeValue.timeValueSeconds(delay),
+                    ThreadPool.Names.SAME))
+                .collect(Collectors.toCollection(ArrayList::new));
+
+            Collections.reverse(jobs);
+
+            List<Long> initialDelays = verifyJobDelays(jobs);
+            Thread.sleep(50);
+            List<Long> laterDelays = verifyJobDelays(jobs);
+
+            assertThat(laterDelays,
+                Matchers.contains(initialDelays.stream().map(Matchers::lessThan).collect(Collectors.toList())));
+        } finally {
+            ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+        }
+    }
+
+    private List<Long> verifyJobDelays(List<Scheduler.ScheduledCancellable> jobs) {
+        List<Long> delays = new ArrayList<>(jobs.size());
+        Scheduler.ScheduledCancellable previous = null;
+        for (Scheduler.ScheduledCancellable job : jobs) {
+            if (previous != null) {
+                long previousDelay = previous.getDelay(TimeUnit.MILLISECONDS);
+                long delay = job.getDelay(TimeUnit.MILLISECONDS);
+                assertThat(delay, Matchers.lessThan(previousDelay));
+                assertThat(job, Matchers.lessThan(previous));
+            }
+            assertThat(job.getDelay(TimeUnit.SECONDS), Matchers.greaterThan(1L));
+            assertThat(job.getDelay(TimeUnit.SECONDS), Matchers.lessThanOrEqualTo(30L));
+
+            delays.add(job.getDelay(TimeUnit.NANOSECONDS));
+            previous = job;
+        }
+
+        return delays;
+    }
+
+    // simple test for successful scheduling, exceptions tested more thoroughly in EvilThreadPoolTests
+    public void testScheduledOnThreadPool() throws InterruptedException {
+        ThreadPool threadPool = new TestThreadPool("test");
+        CountDownLatch missingExecutions = new CountDownLatch(ThreadPool.THREAD_POOL_TYPES.keySet().size());
+        try {
+            ThreadPool.THREAD_POOL_TYPES.keySet()
+                .forEach(type ->
+                    threadPool.schedule(missingExecutions::countDown, TimeValue.timeValueMillis(randomInt(5)), type));
+
+            assertTrue(missingExecutions.await(30, TimeUnit.SECONDS));
+        } finally {
+            ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+        }
+    }
+
+    // simple test for successful scheduling, exceptions tested more thoroughly in EvilThreadPoolTests
+    public void testScheduledOnScheduler() throws InterruptedException {
+        ScheduledThreadPoolExecutor executor = Scheduler.initScheduler(Settings.EMPTY);
+        Scheduler scheduler = (command, delay, name) ->
+            Scheduler.wrapAsScheduledCancellable(executor.schedule(command, delay.millis(), TimeUnit.MILLISECONDS));
+
+        CountDownLatch missingExecutions = new CountDownLatch(1);
+        try {
+            scheduler.schedule(missingExecutions::countDown, TimeValue.timeValueMillis(randomInt(5)), ThreadPool.Names.SAME);
+            assertTrue(missingExecutions.await(30, TimeUnit.SECONDS));
+        } finally {
+            Scheduler.terminate(executor, 10, TimeUnit.SECONDS);
+        }
+    }
+
+    public void testDeprecatedSchedule() throws ExecutionException, InterruptedException {
+        verifyDeprecatedSchedule(((threadPool, runnable) -> threadPool.schedule(TimeValue.timeValueMillis(randomInt(10)), ThreadPool.Names.SAME, runnable)));
+    }
+
+    public void testThreadPoolScheduleDeprecated() throws ExecutionException, InterruptedException {
+        verifyDeprecatedSchedule(((threadPool, runnable) -> threadPool.scheduleDeprecated(TimeValue.timeValueMillis(randomInt(10)), ThreadPool.Names.SAME, runnable)));
+    }
+
+    private void verifyDeprecatedSchedule(BiFunction<ThreadPool, Runnable, ScheduledFuture<?>> scheduleFunction) throws InterruptedException, ExecutionException {
+        ThreadPool threadPool = new TestThreadPool("test");
+        CountDownLatch missingExecutions = new CountDownLatch(1);
+        try {
+            scheduleFunction.apply(threadPool, missingExecutions::countDown)
+                .get();
+            assertEquals(0, missingExecutions.getCount());
+
+            ExecutionException exception = expectThrows(ExecutionException.class,
+                "schedule(...).get() must throw exception from runnable",
+                () -> scheduleFunction.apply(threadPool,
+                    () -> { throw new IllegalArgumentException("FAIL"); }
+                ).get());
+
+            assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
+        } finally {
+            ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+        }
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/transport/TransportKeepAliveTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportKeepAliveTests.java
@@ -32,7 +32,6 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.concurrent.ScheduledFuture;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -212,7 +211,7 @@ public class TransportKeepAliveTests extends ESTestCase {
         }
 
         @Override
-        public ScheduledFuture<?> schedule(TimeValue delay, String executor, Runnable task) {
+        public ScheduledCancellable schedule(Runnable task, TimeValue delay, String executor) {
             scheduledTasks.add(new Tuple<>(delay, task));
             return null;
         }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueue.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueue.java
@@ -344,7 +344,7 @@ public class DeterministicTaskQueue {
             }
 
             @Override
-            public ScheduledFuture<?> schedule(TimeValue delay, String executor, Runnable command) {
+            public ScheduledCancellable schedule(Runnable command, TimeValue delay, String executor) {
                 final int NOT_STARTED = 0;
                 final int STARTED = 1;
                 final int CANCELLED = 2;
@@ -364,7 +364,7 @@ public class DeterministicTaskQueue {
                     }
                 }));
 
-                return new ScheduledFuture<Object>() {
+                return new ScheduledCancellable() {
                     @Override
                     public long getDelay(TimeUnit unit) {
                         throw new UnsupportedOperationException();
@@ -376,8 +376,7 @@ public class DeterministicTaskQueue {
                     }
 
                     @Override
-                    public boolean cancel(boolean mayInterruptIfRunning) {
-                        assert mayInterruptIfRunning == false;
+                    public boolean cancel() {
                         return taskState.compareAndSet(NOT_STARTED, CANCELLED);
                     }
 
@@ -386,20 +385,6 @@ public class DeterministicTaskQueue {
                         return taskState.get() == CANCELLED;
                     }
 
-                    @Override
-                    public boolean isDone() {
-                        throw new UnsupportedOperationException();
-                    }
-
-                    @Override
-                    public Object get() {
-                        throw new UnsupportedOperationException();
-                    }
-
-                    @Override
-                    public Object get(long timeout, TimeUnit unit) {
-                        throw new UnsupportedOperationException();
-                    }
                 };
             }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -375,7 +375,7 @@ public final class MockTransportService extends TransportService {
                         runnable.run();
                     } else {
                         requestsToSendWhenCleared.add(runnable);
-                        threadPool.schedule(delay, ThreadPool.Names.GENERIC, runnable);
+                        threadPool.schedule(runnable, delay, ThreadPool.Names.GENERIC);
                     }
                 }
             }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -104,7 +104,7 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
         Client followerClient = wrapClient(client, params.getHeaders());
         BiConsumer<TimeValue, Runnable> scheduler = (delay, command) -> {
             try {
-                threadPool.schedule(delay, Ccr.CCR_THREAD_POOL_NAME, command);
+                threadPool.schedule(command, delay, Ccr.CCR_THREAD_POOL_NAME);
             } catch (EsRejectedExecutionException e) {
                 if (e.isExecutorShutdown()) {
                     logger.debug("couldn't schedule command, executor is shutting down", e);
@@ -310,7 +310,7 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
             if (ShardFollowNodeTask.shouldRetry(params.getRemoteCluster(), e)) {
                 logger.debug(new ParameterizedMessage("failed to fetch follow shard global {} checkpoint and max sequence number",
                     shardFollowNodeTask), e);
-                threadPool.schedule(params.getMaxRetryDelay(), Ccr.CCR_THREAD_POOL_NAME, () -> nodeOperation(task, params, state));
+                threadPool.schedule(() -> nodeOperation(task, params, state), params.getMaxRetryDelay(), Ccr.CCR_THREAD_POOL_NAME);
             } else {
                 shardFollowNodeTask.markAsFailed(e);
             }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskRandomTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskRandomTests.java
@@ -98,7 +98,7 @@ public class ShardFollowNodeTaskRandomTests extends ESTestCase {
         BiConsumer<TimeValue, Runnable> scheduler = (delay, task) -> {
             assert delay.millis() < 100 : "The delay should be kept to a minimum, so that this test does not take to long to run";
             if (stopped.get() == false) {
-                threadPool.schedule(delay, ThreadPool.Names.GENERIC, task);
+                threadPool.schedule(task, delay, ThreadPool.Names.GENERIC);
             }
         };
         List<Translog.Operation> receivedOperations = Collections.synchronizedList(new ArrayList<>());

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
@@ -382,7 +382,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
         );
         final String recordedLeaderIndexHistoryUUID = leaderGroup.getPrimary().getHistoryUUID();
 
-        BiConsumer<TimeValue, Runnable> scheduler = (delay, task) -> threadPool.schedule(delay, ThreadPool.Names.GENERIC, task);
+        BiConsumer<TimeValue, Runnable> scheduler = (delay, task) -> threadPool.schedule(task, delay, ThreadPool.Names.GENERIC);
         AtomicBoolean stopped = new AtomicBoolean(false);
         LongSet fetchOperations = new LongHashSet();
         return new ShardFollowNodeTask(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceService.java
@@ -13,7 +13,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.common.util.concurrent.FutureUtils;
+import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction;
 import org.joda.time.DateTime;
@@ -21,7 +21,6 @@ import org.joda.time.chrono.ISOChronology;
 
 import java.util.Objects;
 import java.util.Random;
-import java.util.concurrent.ScheduledFuture;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
@@ -45,7 +44,7 @@ public class MlDailyMaintenanceService implements Releasable {
      */
     private final Supplier<TimeValue> schedulerProvider;
 
-    private volatile ScheduledFuture<?> future;
+    private volatile Scheduler.Cancellable cancellable;
 
     MlDailyMaintenanceService(ThreadPool threadPool, Client client, Supplier<TimeValue> scheduleProvider) {
         this.threadPool = Objects.requireNonNull(threadPool);
@@ -82,13 +81,13 @@ public class MlDailyMaintenanceService implements Releasable {
 
     public void stop() {
         LOGGER.debug("Stopping ML daily maintenance service");
-        if (future != null && future.isCancelled() == false) {
-            FutureUtils.cancel(future);
+        if (cancellable != null && cancellable.isCancelled() == false) {
+            cancellable.cancel();
         }
     }
 
     public boolean isStarted() {
-        return future != null;
+        return cancellable != null;
     }
 
     @Override
@@ -98,7 +97,7 @@ public class MlDailyMaintenanceService implements Releasable {
 
     private void scheduleNext() {
         try {
-            future = threadPool.schedule(schedulerProvider.get(), ThreadPool.Names.GENERIC, this::triggerTasks);
+            cancellable = threadPool.schedule(this::triggerTasks, schedulerProvider.get(), ThreadPool.Names.GENERIC);
         } catch (EsRejectedExecutionException e) {
             if (e.isExecutorShutdown()) {
                 LOGGER.debug("failed to schedule next maintenance task; shutting down", e);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlInitializationServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlInitializationServiceTests.java
@@ -10,11 +10,11 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledFuture;
 
 import static org.elasticsearch.mock.orig.Mockito.doAnswer;
 import static org.hamcrest.Matchers.is;
@@ -46,8 +46,8 @@ public class MlInitializationServiceTests extends ESTestCase {
         }).when(executorService).execute(any(Runnable.class));
         when(threadPool.executor(ThreadPool.Names.GENERIC)).thenReturn(executorService);
 
-        ScheduledFuture scheduledFuture = mock(ScheduledFuture.class);
-        when(threadPool.schedule(any(), any(), any())).thenReturn(scheduledFuture);
+        Scheduler.ScheduledCancellable scheduledCancellable = mock(Scheduler.ScheduledCancellable.class);
+        when(threadPool.schedule(any(Runnable.class), any(), any())).thenReturn(scheduledCancellable);
 
         when(clusterService.getClusterName()).thenReturn(CLUSTER_NAME);
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManagerTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData.PersistentTask;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
@@ -48,7 +49,7 @@ import java.net.InetAddress;
 import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -114,7 +115,7 @@ public class DatafeedManagerTests extends ESTestCase {
         ExecutorService executorService = mock(ExecutorService.class);
         doAnswer(invocation -> {
             ((Runnable) invocation.getArguments()[0]).run();
-            return null;
+            return mock(Future.class);
         }).when(executorService).submit(any(Runnable.class));
         when(threadPool.executor(MachineLearning.DATAFEED_THREAD_POOL_NAME)).thenReturn(executorService);
         when(threadPool.executor(ThreadPool.Names.GENERIC)).thenReturn(executorService);
@@ -148,7 +149,7 @@ public class DatafeedManagerTests extends ESTestCase {
         datafeedManager.run(task, handler);
 
         verify(threadPool, times(1)).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
-        verify(threadPool, never()).schedule(any(), any(), any());
+        verify(threadPool, never()).schedule(any(Runnable.class), any(), any());
         verify(auditor).warning("job_id", "Datafeed lookback retrieved no data");
     }
 
@@ -159,7 +160,7 @@ public class DatafeedManagerTests extends ESTestCase {
         datafeedManager.run(task, handler);
 
         verify(threadPool, times(1)).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
-        verify(threadPool, never()).schedule(any(), any(), any());
+        verify(threadPool, never()).schedule(any(Runnable.class), any(), any());
     }
 
     public void testStart_extractionProblem() throws Exception {
@@ -169,7 +170,7 @@ public class DatafeedManagerTests extends ESTestCase {
         datafeedManager.run(task, handler);
 
         verify(threadPool, times(1)).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
-        verify(threadPool, never()).schedule(any(), any(), any());
+        verify(threadPool, never()).schedule(any(Runnable.class), any(), any());
         verify(auditor, times(1)).error(eq("job_id"), anyString());
     }
 
@@ -178,12 +179,12 @@ public class DatafeedManagerTests extends ESTestCase {
         int[] counter = new int[] {0};
         doAnswer(invocationOnMock -> {
             if (counter[0]++ < 10) {
-                Runnable r = (Runnable) invocationOnMock.getArguments()[2];
+                Runnable r = (Runnable) invocationOnMock.getArguments()[0];
                 currentTime += 600000;
                 r.run();
             }
-            return mock(ScheduledFuture.class);
-        }).when(threadPool).schedule(any(), any(), any());
+            return mock(Scheduler.ScheduledCancellable.class);
+        }).when(threadPool).schedule(any(Runnable.class), any(), any());
 
         when(datafeedJob.runLookBack(anyLong(), anyLong())).thenThrow(new DatafeedJob.EmptyDataCountException(0L));
         when(datafeedJob.runRealtime()).thenThrow(new DatafeedJob.EmptyDataCountException(0L));
@@ -192,7 +193,7 @@ public class DatafeedManagerTests extends ESTestCase {
         DatafeedTask task = createDatafeedTask("datafeed_id", 0L, null);
         datafeedManager.run(task, handler);
 
-        verify(threadPool, times(11)).schedule(any(), eq(MachineLearning.DATAFEED_THREAD_POOL_NAME), any());
+        verify(threadPool, times(11)).schedule(any(), any(), eq(MachineLearning.DATAFEED_THREAD_POOL_NAME));
         verify(auditor, times(1)).warning(eq("job_id"), anyString());
     }
 
@@ -248,7 +249,7 @@ public class DatafeedManagerTests extends ESTestCase {
             verify(handler).accept(null);
             assertThat(datafeedManager.isRunning(task.getAllocationId()), is(false));
         } else {
-            verify(threadPool, times(1)).schedule(eq(new TimeValue(1)), eq(MachineLearning.DATAFEED_THREAD_POOL_NAME), any());
+            verify(threadPool, times(1)).schedule(any(), eq(new TimeValue(1)), eq(MachineLearning.DATAFEED_THREAD_POOL_NAME));
             assertThat(datafeedManager.isRunning(task.getAllocationId()), is(true));
         }
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutoDetectResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutoDetectResultProcessorTests.java
@@ -537,7 +537,8 @@ public class AutoDetectResultProcessorTests extends ESTestCase {
     }
 
     private void setupScheduleDelayTime(TimeValue delay) {
-        when(threadPool.schedule(any(TimeValue.class), anyString(), any(Runnable.class)))
-            .thenAnswer(i -> executor.schedule((Runnable) i.getArguments()[2], delay.nanos(), TimeUnit.NANOSECONDS));
+        when(threadPool.schedule(any(Runnable.class), any(TimeValue.class), anyString()))
+            .thenAnswer(i -> Scheduler.wrapAsScheduledCancellable(executor.schedule((Runnable) i.getArguments()[0],
+                delay.nanos(), TimeUnit.NANOSECONDS)));
     }
 }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerService.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerService.java
@@ -13,8 +13,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractLifecycleRunnable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.monitoring.MonitoringField;
 import org.joda.time.DateTime;
@@ -22,7 +22,6 @@ import org.joda.time.chrono.ISOChronology;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ScheduledFuture;
 
 /**
  * {@code CleanerService} takes care of deleting old monitoring indices.
@@ -57,7 +56,7 @@ public class CleanerService extends AbstractLifecycleComponent {
     @Override
     protected void doStart() {
         logger.debug("starting cleaning service");
-        threadPool.schedule(executionScheduler.nextExecutionDelay(new DateTime(ISOChronology.getInstance())), executorName(), runnable);
+        threadPool.schedule(runnable, executionScheduler.nextExecutionDelay(new DateTime(ISOChronology.getInstance())), executorName());
         logger.debug("cleaning service started");
     }
 
@@ -153,7 +152,7 @@ public class CleanerService extends AbstractLifecycleComponent {
      */
     class IndicesCleaner extends AbstractLifecycleRunnable {
 
-        private volatile ScheduledFuture<?> future;
+        private volatile Scheduler.Cancellable cancellable;
 
         /**
          * Enable automatic logging and stopping of the runnable based on the {@link #lifecycle}.
@@ -197,7 +196,7 @@ public class CleanerService extends AbstractLifecycleComponent {
             logger.debug("scheduling next execution in [{}] seconds", delay.seconds());
 
             try {
-                future = threadPool.schedule(delay, executorName(), this);
+                cancellable = threadPool.schedule(this, delay, executorName());
             } catch (EsRejectedExecutionException e) {
                 if (e.isExecutorShutdown()) {
                     logger.debug("couldn't schedule new execution of the cleaner, executor is shutting down", e);
@@ -215,13 +214,13 @@ public class CleanerService extends AbstractLifecycleComponent {
         /**
          * Cancel/stop the cleaning service.
          * <p>
-         * This will kill any scheduled {@link #future} from running. It's possible that this will be executed concurrently with the
+         * This will kill any scheduled {@link #cancellable} from running. It's possible that this will be executed concurrently with the
          * {@link #onAfter() rescheduling code}, at which point it will be stopped during the next execution <em>if</em> the service is
          * stopped.
          */
         public void cancel() {
-            if (future != null && future.isCancelled() == false) {
-                FutureUtils.cancel(future);
+            if (cancellable != null && cancellable.isCancelled() == false) {
+                cancellable.cancel();
             }
         }
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealm.java
@@ -130,7 +130,7 @@ public final class LdapRealm extends CachingUsernamePasswordRealm {
                         contextPreservingListener(new LdapSessionActionListener("authenticate", token.principal(), listener))), logger
         );
         threadPool.generic().execute(cancellableLdapRunnable);
-        threadPool.schedule(executionTimeout, Names.SAME, cancellableLdapRunnable::maybeTimeout);
+        threadPool.schedule(cancellableLdapRunnable::maybeTimeout, executionTimeout, Names.SAME);
     }
 
     @Override
@@ -145,7 +145,7 @@ public final class LdapRealm extends CachingUsernamePasswordRealm {
                     () -> sessionFactory.unauthenticatedSession(username,
                             contextPreservingListener(new LdapSessionActionListener("lookup", username, sessionListener))), logger);
             threadPool.generic().execute(cancellableLdapRunnable);
-            threadPool.schedule(executionTimeout, Names.SAME, cancellableLdapRunnable::maybeTimeout);
+            threadPool.schedule(cancellableLdapRunnable::maybeTimeout, executionTimeout, Names.SAME);
         } else {
             userActionListener.onResponse(null);
         }


### PR DESCRIPTION
Scheduler.schedule(...) would previously assume that caller handles
exception by calling get() on the returned ScheduledFuture.
schedule() now returns a ScheduledCancellable that no longer gives
access to the exception. Instead, any exception thrown out of a
scheduled Runnable is logged as a warning.

In this backport to 6.x, source backwards compatibility is maintained
and some of the changes has therefore not been carried out (notably
the signature change on Processor.Parameters.scheduler).

This is a continuation of #28667, #36137 and also fixes #37708.

The main new changes compared to the master PR (#38014) is the original Scheduler.schedule overload, added ThreadPool.scheduleDeprecated, es-all-signatures.txt and one more Scheduler.schedule usage fix in AutoDetectResultProcessor.