### PR TITLE
Remove beta marker from the synonym_graph docs

### DIFF
--- a/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
@@ -1,8 +1,6 @@
 [[analysis-synonym-graph-tokenfilter]]
 === Synonym Graph Token Filter
 
-beta[]
-
 The `synonym_graph` token filter allows to easily handle synonyms,
 including multi-word synonyms correctly during the analysis process.
 
@@ -187,3 +185,8 @@ multiple versions of a token may choose which version of the token to emit when
 parsing synonyms, e.g. `asciifolding` will only produce the folded version of the
 token.  Others, e.g. `multiplexer`, `word_delimiter_graph` or `ngram` will throw an
 error.
+
+WARNING:The synonym rules should not contain words that are removed by
+a filter that appears after in the chain (a `stop` filter for instance).
+Removing a term from a synonym rule breaks the matching at query time.
+


### PR DESCRIPTION
This change removes the beta marker from the synonym_graph docs and adds a warning about the compatibility with other filters.