### PR TITLE
SQL: [Docs] Add limitation for aggregate functions on scalars

### DIFF
--- a/docs/reference/sql/limitations.asciidoc
+++ b/docs/reference/sql/limitations.asciidoc
@@ -71,6 +71,12 @@ But this type of aggregation does come with a limitation: sorting can only be ap
 means that queries like `SELECT * FROM test GROUP BY age ORDER BY COUNT(*)` are not possible.
 
 [float]
+=== Use aggregation functions on top of scalar functions
+
+Aggregation functions like <<sql-functions-aggs-min,`MIN`>>, <<sql-functions-aggs-max,`MAX`>>, etc. can only be used
+directly on fields, and so queries like `SELECT MAX(abs(age)) FROM test` are not possible.
+
+[float]
 === Using a sub-select
 
 Using sub-selects (`SELECT X FROM (SELECT Y)`) is **supported to a small degree**: any sub-select that can be "flattened" into a single

--- a/docs/reference/sql/limitations.asciidoc
+++ b/docs/reference/sql/limitations.asciidoc
@@ -71,7 +71,7 @@ But this type of aggregation does come with a limitation: sorting can only be ap
 means that queries like `SELECT * FROM test GROUP BY age ORDER BY COUNT(*)` are not possible.
 
 [float]
-=== Use aggregation functions on top of scalar functions
+=== Using aggregation functions on top of scalar functions
 
 Aggregation functions like <<sql-functions-aggs-min,`MIN`>>, <<sql-functions-aggs-max,`MAX`>>, etc. can only be used
 directly on fields, and so queries like `SELECT MAX(abs(age)) FROM test` are not possible.
@@ -98,7 +98,7 @@ But, if the sub-select would include a `GROUP BY` or `HAVING` or the enclosing `
 FROM (SELECT ...) WHERE [simple_condition]`, this is currently **un-supported**.
 
 [float]
-=== Use <<sql-functions-aggs-first, `FIRST`>>/<<sql-functions-aggs-last,`LAST`>> aggregation functions in `HAVING` clause
+=== Using <<sql-functions-aggs-first, `FIRST`>>/<<sql-functions-aggs-last,`LAST`>> aggregation functions in `HAVING` clause
 
 Using `FIRST` and `LAST` in the `HAVING` clause is not supported. The same applies to
 <<sql-functions-aggs-min,`MIN`>> and <<sql-functions-aggs-max,`MAX`>> when their target column


### PR DESCRIPTION
Currently aggregate functions can operate only directly on fields.
They cannot be used on top of scalar functions as painless scripting
is currently not supported.
