### PR TITLE
Improve watcher SingleNodeTests

### DIFF
--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/AbstractWatcherIntegrationTestCase.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/AbstractWatcherIntegrationTestCase.java
@@ -433,7 +433,7 @@ public abstract class AbstractWatcherIntegrationTestCase extends ESIntegTestCase
         });
     }
 
-    private void ensureWatcherTemplatesAdded() throws Exception {
+    protected void ensureWatcherTemplatesAdded() throws Exception {
         // Verify that the index templates exist:
         assertBusy(() -> {
             GetIndexTemplatesResponse response = client().admin().indices().prepareGetTemplates(HISTORY_TEMPLATE_NAME).get();

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
@@ -8,14 +8,19 @@ package org.elasticsearch.xpack.watcher.test.integration;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchResponse;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.elasticsearch.xpack.core.watcher.transport.actions.activate.ActivateWatchResponse;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
+import org.elasticsearch.xpack.watcher.condition.CompareCondition;
 import org.elasticsearch.xpack.watcher.test.AbstractWatcherIntegrationTestCase;
 import org.elasticsearch.xpack.watcher.trigger.schedule.IntervalSchedule;
 
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.elasticsearch.test.ESIntegTestCase.Scope.SUITE;
 import static org.elasticsearch.xpack.watcher.actions.ActionBuilders.loggingAction;
 import static org.elasticsearch.xpack.watcher.client.WatchSourceBuilders.watchBuilder;
-import static org.elasticsearch.xpack.watcher.input.InputBuilders.simpleInput;
+import static org.elasticsearch.xpack.watcher.input.InputBuilders.searchInput;
+import static org.elasticsearch.xpack.watcher.test.WatcherTestUtils.templateRequest;
 import static org.elasticsearch.xpack.watcher.trigger.TriggerBuilders.schedule;
 import static org.elasticsearch.xpack.watcher.trigger.schedule.Schedules.interval;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -29,9 +34,10 @@ public class SingleNodeTests extends AbstractWatcherIntegrationTestCase {
         return false;
     }
 
-    // this is the standard setup when starting watcher in a regular cluster
-    // the index does not exist, a watch gets added
-    // the watch should be executed properly, despite the index being created and the cluster state listener being reloaded
+    // Tests the standard setup when starting watcher in a regular cluster:
+    // the index does not exist, a watch gets added and scheduled.
+    // The watch should be executed properly, despite the index being created
+    // and the cluster state listener being reloaded.
     public void testThatLoadingWithNonExistingIndexWorks() throws Exception {
         internalCluster().startNode();
         ensureLicenseEnabled();
@@ -40,21 +46,24 @@ public class SingleNodeTests extends AbstractWatcherIntegrationTestCase {
         assertFalse(client().admin().indices().prepareExists(Watch.INDEX).get().isExists());
         startWatcher();
 
-        String watchId = randomAlphaOfLength(20);
+        final String watchId = randomAlphaOfLength(20);
         // now we start with an empty set up, store a watch and expected it to be executed
         PutWatchResponse putWatchResponse = watcherClient().preparePutWatch(watchId)
             .setSource(watchBuilder()
-                .trigger(schedule(interval(1, IntervalSchedule.Interval.Unit.DAYS)))
-                .input(simpleInput())
-                .addAction("_logger", loggingAction("logging of watch _name")))
+                .trigger(schedule(interval(1, IntervalSchedule.Interval.Unit.SECONDS)))
+                .input(searchInput(templateRequest(searchSource().size(0).query(matchAllQuery()), ".watcher-history*")))
+                .condition(new CompareCondition("ctx.payload.hits.total.value", CompareCondition.Op.LTE, 1L))
+                .addAction("_logger", loggingAction("logging of watch " + watchId)))
             .get();
         assertThat(putWatchResponse.isCreated(), is(true));
 
         assertBusy(() -> {
-            watcherClient().prepareExecuteWatch(watchId).setRecordExecution(true).get();
             refresh(".watcher-history*");
-            final SearchResponse searchResponse = client().prepareSearch(".watcher-history*").setSize(0).get();
+            SearchResponse searchResponse = client().prepareSearch(".watcher-history*").setSize(0).get();
             assertThat(searchResponse.getHits().getTotalHits().value, greaterThanOrEqualTo(1L));
+
+            final ActivateWatchResponse activateWatchResponse = watcherClient().prepareActivateWatch(watchId, false).get();
+            assertThat(activateWatchResponse.getStatus().state().isActive(), is(false));
         });
     }
 


### PR DESCRIPTION
The `SingleNodeTests` test in watcher starts by stopping watcher (automatically started by parent class), removes the watcher index, starts watcher again, creates a watch and then waits for some documents to be indexed in the watcher history index. Because the watch is scheduled to run every 1 seconds, the test sometimes fails because there are still ongoing indexing (in the watcher history index) when the test is shutdown.

I think the test can be improve: the node can be started manually (so no automatic start by the parent class), then we can create a unique watch that won't be schedule but executed manually. This should make the test run faster for the same result.

Closes #36782
