### PR TITLE
ML: Fix error race condition on stop _all datafeeds and close _all jo…

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.FailedNodeException;
@@ -17,6 +18,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
@@ -291,7 +293,12 @@ public class TransportCloseJobAction extends TransportTasksAction<TransportOpenJ
             threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(new AbstractRunnable() {
                 @Override
                 public void onFailure(Exception e) {
-                    listener.onFailure(e);
+                    if (e instanceof ResourceNotFoundException && Strings.isAllOrWildcard(new String[]{request.getJobId()})) {
+                        jobTask.closeJob("close job (api)");
+                        listener.onResponse(new CloseJobAction.Response(true));
+                    } else {
+                        listener.onFailure(e);
+                    }
                 }
 
                 @Override
@@ -356,7 +363,10 @@ public class TransportCloseJobAction extends TransportTasksAction<TransportOpenJ
                             @Override
                             public void onFailure(Exception e) {
                                 final int slot = counter.incrementAndGet();
-                                failures.set(slot - 1, e);
+                                if ((e instanceof ResourceNotFoundException &&
+                                    Strings.isAllOrWildcard(new String[]{request.getJobId()})) == false) {
+                                    failures.set(slot - 1, e);
+                                }
                                 if (slot == numberOfJobs) {
                                     sendResponseOrFailure(request.getJobId(), listener, failures);
                                 }


### PR DESCRIPTION
The main issue resides around our task updating service. If the task went away us after gathering state info, and then we try to update it, it will fail.

Only when _all, *, , is passed do we ignore the ResourceNotFound thrown from the task service.

The only endpoints where this sort of thing seems to be possible is in close jobs and stop datafeeds. All other endpoints that expand and store Ids/Configs either use a search/bulk action, or only use the state information that exists when the request is being handled.

backport of (#38113)