### PR TITLE
Assert job is not null in FullClusterRestartIT

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -659,9 +659,8 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         }
         Map<String, Object> getRollupJobResponse = entityAsMap(client().performRequest(getRollupJobRequest));
         Map<String, Object> job = getJob(getRollupJobResponse, rollupJob);
-        if (job != null) {
-            assertThat(ObjectPath.eval("status.job_state", job), expectedStates);
-        }
+        assertNotNull(job);
+        assertThat(ObjectPath.eval("status.job_state", job), expectedStates);
 
         // check that the rollup job is started using the Tasks API
         final Request taskRequest = new Request("GET", "_tasks");
@@ -712,9 +711,8 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             assertThat(getRollupJobResponse.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
 
             Map<String, Object> job = getJob(getRollupJobResponse, rollupJob);
-            if (job != null) {
-                assertThat(ObjectPath.eval("status.job_state", job), expectedStates);
-            }
+            assertNotNull(job);
+            assertThat(ObjectPath.eval("status.job_state", job), expectedStates);
         }, 30L, TimeUnit.SECONDS);
     }
 


### PR DESCRIPTION
I still haven't been able to reproduce #32773, but I think this is the cause.

In `FullClusterRestartIT`, `waitForRollUpJob` is an assertBusy that waits for the rollup job to appear in the tasks list, and waits for it to be a certain state.

However, there was a null check around the state assertion, which meant if the job _was_ null, the assertion would be skipped, and the assertBusy would pass without an exception.  This could then lead to downstream assertions to fail because the job was not actually ready, or in the wrong state.

This changes the test to assert the job is not null, so the assertBusy operates as intended.

Closes #32773
