### PR TITLE
testHlrcFromXContent() should respect assertToXContentEquivalence()

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/AbstractHlrcXContentTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/AbstractHlrcXContentTestCase.java
@@ -21,7 +21,7 @@ public abstract class AbstractHlrcXContentTestCase<T extends ToXContent, H> exte
         AbstractXContentTestCase.testFromXContent(NUMBER_OF_TEST_RUNS, this::createTestInstance, supportsUnknownFields(),
             getShuffleFieldsExceptions(), getRandomFieldsExcludeFilter(), this::createParser,
             p -> convertHlrcToInternal(doHlrcParseInstance(p)),
-            this::assertEqualInstances, true, getToXContentParams());
+            this::assertEqualInstances, assertToXContentEquivalence(), getToXContentParams());
     }
 
     /**


### PR DESCRIPTION
Tests can override assertToXContentEquivalence() in case their xcontent cannot be directly compared (e.g. due to insertion order in maps affecting the xcontent ordering).  But the `testHlrcFromXContent` test hardcoded the equivalence test to `true` instead of consulting `assertToXContentEquivalence()`

@hub-cap tagged you for review because, while I think this is ok and good, I'm not entirely positive it wasn't intended to be hardcoded.  Wanted another pair of eyeballs :)

Fixes #36034
