### PR TITLE
Update ilm-api.asciidoc, point to REMOVE policy

### DIFF
--- a/docs/reference/ilm/apis/ilm-api.asciidoc
+++ b/docs/reference/ilm/apis/ilm-api.asciidoc
@@ -21,6 +21,7 @@ about Index Lifecycle Management.
 
 * <<ilm-move-to-step,Move index to step>>
 * <<ilm-retry-policy,Retry policy on indices>>
+* <<ilm-remove-policy,Remove policy from index>>
 
 [float]
 [[ilm-api-management-endpoint]]


### PR DESCRIPTION
In index-lifecycle-management-api.html, under subsection Index management APIs, in addition to links to (1) Move index to Step and (2) Retry Policy, add missing link to subsection (3) Remove Policy. 