### PR TITLE
Fix testReplicaIgnoresOlderRetentionLeasesVersion

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerRetentionLeaseTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerRetentionLeaseTests.java
@@ -340,8 +340,8 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             for (int j = 0; j < innerLength; j++) {
                 leases.add(
                         new RetentionLease(i + "-" + j, randomNonNegativeLong(), randomNonNegativeLong(), randomAlphaOfLength(8)));
-                version++;
             }
+            version++;
             if (rarely()) {
                 primaryTerm++;
             }


### PR DESCRIPTION
If the innerLength is 0, the version won't be increased; then there will
be two RetentionLeases with the same term and version, but their leases
are different.

Relates #37951
Closes #38245