### PR TITLE
Adapt LLRest warning exception in FullClusterRestartIT

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.WarningFailureException;
 import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Booleans;
@@ -1059,15 +1060,19 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             Request clearRoutingFromSettings = new Request("PUT", "/_cluster/settings");
             clearRoutingFromSettings.setJsonEntity("{\"persistent\":{\"cluster.routing.allocation.exclude.test_attr\": null}}");
             client().performRequest(clearRoutingFromSettings);
-        } catch (ResponseException e) {
-            if (e.getResponse().hasWarnings()
-                    && (isRunningAgainstOldCluster() == false || getOldClusterVersion().onOrAfter(Version.V_6_5_0))) {
-                e.getResponse().getWarnings().stream().forEach(warning -> {
+        } catch (WarningFailureException e) {
+            /*
+             * If this test is executed on the upgraded mode before testRemoteClusterSettingsUpgraded,
+             * we will hit a warning exception because we put some deprecated settings in that test.
+             */
+            if (isRunningAgainstOldCluster() == false
+                && getOldClusterVersion().onOrAfter(Version.V_6_1_0) && getOldClusterVersion().before(Version.V_6_5_0)) {
+                for (String warning : e.getResponse().getWarnings()) {
                     assertThat(warning, containsString(
-                            "setting was deprecated in Elasticsearch and will be removed in a future release! "
+                        "setting was deprecated in Elasticsearch and will be removed in a future release! "
                             + "See the breaking changes documentation for the next major version."));
                     assertThat(warning, startsWith("[search.remote."));
-                });
+                }
             } else {
                 throw e;
             }


### PR DESCRIPTION
We now [throw a WarningFailureException instead of ResponseException](https://github.com/elastic/elasticsearch/pull/37247/files#diff-d5bb3520f960a753d8f8a3a2686dfd6bL304) if there's any warning in a response. This change leads to the failures of `testSnapshotRestore` in the BWC builds for the last two days.

Relates #37247

CI:
- https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+bwc-tests/394/console
- https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+bwc-tests/399/console
- https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+default-distro-bwc-tests/326/console
- https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+default-distro-bwc-tests/324/console




