### PR TITLE
Mute DateProcessorTests#testJodaPatternLocale

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
@@ -112,9 +112,8 @@ public class DateProcessorTests extends ESTestCase {
         }
     }
 
-    // this fails only on FIPS 140 JVM but we cannot mute selectively
-    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/31724")
     public void testJavaPatternLocale() {
+        assumeFalse("Can't run in a FIPS JVM, Joda parse date error", inFipsJvm()); // @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/31724")
         DateProcessor dateProcessor = new DateProcessor(randomAlphaOfLength(10),
             templatize(ZoneId.of("Europe/Amsterdam")), templatize(Locale.ITALIAN),
                 "date_as_string", Collections.singletonList("yyyy dd MMMM"), "date_as_date");

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
@@ -112,6 +112,8 @@ public class DateProcessorTests extends ESTestCase {
         }
     }
 
+    // this fails only on FIPS 140 JVM but we cannot mute selectively
+    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/31724")
     public void testJavaPatternLocale() {
         DateProcessor dateProcessor = new DateProcessor(randomAlphaOfLength(10),
             templatize(ZoneId.of("Europe/Amsterdam")), templatize(Locale.ITALIAN),

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
@@ -113,7 +113,8 @@ public class DateProcessorTests extends ESTestCase {
     }
 
     public void testJavaPatternLocale() {
-        assumeFalse("Can't run in a FIPS JVM, Joda parse date error", inFipsJvm()); // @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/31724")
+        // @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/31724")
+        assumeFalse("Can't run in a FIPS JVM, Joda parse date error", inFipsJvm());
         DateProcessor dateProcessor = new DateProcessor(randomAlphaOfLength(10),
             templatize(ZoneId.of("Europe/Amsterdam")), templatize(Locale.ITALIAN),
                 "date_as_string", Collections.singletonList("yyyy dd MMMM"), "date_as_date");


### PR DESCRIPTION
Only fails on FIPS 8 but we cannot mute this selectively.