### PR TITLE
Move ML Optimistic Concurrency Control to Seq No

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -514,7 +514,7 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
     private void clearJobFinishedTime(String jobId, ActionListener<AcknowledgedResponse> listener) {
         JobUpdate update = new JobUpdate.Builder(jobId).setClearFinishTime(true).build();
 
-        jobConfigProvider.updateJob(jobId, update, null, ActionListener.wrap(
+        jobConfigProvider.updateJob(jobId, update, null, clusterService.state().nodes().getMinNodeVersion(), ActionListener.wrap(
                 job -> listener.onResponse(new AcknowledgedResponse(true)),
                 e  -> {
                     logger.error("[" + jobId + "] Failed to clear finished_time", e);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDatafeedAction.java
@@ -87,7 +87,7 @@ public class TransportUpdateDatafeedAction extends TransportMasterNodeAction<Upd
 
         CheckedConsumer<Boolean, Exception> updateConsumer = ok -> {
             datafeedConfigProvider.updateDatefeedConfig(request.getUpdate().getId(), request.getUpdate(), headers,
-                    jobConfigProvider::validateDatafeedJob,
+                    jobConfigProvider::validateDatafeedJob, clusterService.state().nodes().getMinNodeVersion(),
                     ActionListener.wrap(
                             updatedConfig -> listener.onResponse(new PutDatafeedAction.Response(updatedConfig)),
                             listener::onFailure

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateFilterAction.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetAction;
 import org.elasticsearch.action.get.GetRequest;
@@ -17,6 +18,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
@@ -52,14 +54,16 @@ public class TransportUpdateFilterAction extends HandledTransportAction<UpdateFi
 
     private final Client client;
     private final JobManager jobManager;
+    private final ClusterService clusterService;
 
     @Inject
     public TransportUpdateFilterAction(TransportService transportService, ActionFilters actionFilters, Client client,
-                                       JobManager jobManager) {
+                                       JobManager jobManager, ClusterService clusterService) {
         super(UpdateFilterAction.NAME, transportService, actionFilters,
             (Supplier<UpdateFilterAction.Request>) UpdateFilterAction.Request::new);
         this.client = client;
         this.jobManager = jobManager;
+        this.clusterService = clusterService;
     }
 
     @Override
@@ -95,13 +99,20 @@ public class TransportUpdateFilterAction extends HandledTransportAction<UpdateFi
         }
 
         MlFilter updatedFilter = MlFilter.builder(filter.getId()).setDescription(description).setItems(items).build();
-        indexUpdatedFilter(updatedFilter, filterWithVersion.version, request, listener);
+        indexUpdatedFilter(
+            updatedFilter, filterWithVersion.version, filterWithVersion.seqNo, filterWithVersion.primaryTerm, request, listener);
     }
 
-    private void indexUpdatedFilter(MlFilter filter, long version, UpdateFilterAction.Request request,
+    private void indexUpdatedFilter(MlFilter filter, final long version, final long seqNo, final long primaryTerm,
+                                    UpdateFilterAction.Request request,
                                     ActionListener<PutFilterAction.Response> listener) {
         IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, filter.documentId());
-        indexRequest.version(version);
+        if (clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_6_7_0)) {
+            indexRequest.setIfSeqNo(seqNo);
+            indexRequest.setIfPrimaryTerm(primaryTerm);
+        } else {
+            indexRequest.version(version);
+        }
         indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
@@ -146,7 +157,7 @@ public class TransportUpdateFilterAction extends HandledTransportAction<UpdateFi
                              XContentParser parser = XContentFactory.xContent(XContentType.JSON)
                                      .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
                             MlFilter filter = MlFilter.LENIENT_PARSER.apply(parser, null).build();
-                            listener.onResponse(new FilterWithVersion(filter, getDocResponse.getVersion()));
+                            listener.onResponse(new FilterWithVersion(filter, getDocResponse));
                         }
                     } else {
                         this.onFailure(new ResourceNotFoundException(Messages.getMessage(Messages.FILTER_NOT_FOUND, filterId)));
@@ -167,10 +178,15 @@ public class TransportUpdateFilterAction extends HandledTransportAction<UpdateFi
 
         private final MlFilter filter;
         private final long version;
+        private final long seqNo;
+        private final long primaryTerm;
 
-        private FilterWithVersion(MlFilter filter, long version) {
+        private  FilterWithVersion(MlFilter filter, GetResponse getDocResponse) {
             this.filter = filter;
-            this.version = version;
+            this.version = getDocResponse.getVersion();
+            this.seqNo = getDocResponse.getSeqNo();
+            this.primaryTerm = getDocResponse.getPrimaryTerm();
+
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -333,7 +333,7 @@ public class JobManager {
 
         Runnable doUpdate = () -> {
                 jobConfigProvider.updateJobWithValidation(request.getJobId(), request.getJobUpdate(), maxModelMemoryLimit,
-                        this::validate, ActionListener.wrap(
+                        this::validate, clusterService.state().nodes().getMinNodeVersion(), ActionListener.wrap(
                                 updatedJob -> postJobUpdate(request, updatedJob, actionListener),
                                 actionListener::onFailure
                         ));
@@ -603,8 +603,8 @@ public class JobManager {
             .setModelSnapshotId(modelSnapshot.getSnapshotId())
             .build();
 
-        jobConfigProvider.updateJob(request.getJobId(), update, maxModelMemoryLimit, ActionListener.wrap(
-            job -> {
+        jobConfigProvider.updateJob(request.getJobId(), update, maxModelMemoryLimit, clusterService.state().nodes().getMinNodeVersion(),
+            ActionListener.wrap(job -> {
                 auditor.info(request.getJobId(),
                     Messages.getMessage(Messages.JOB_AUDIT_REVERTED, modelSnapshot.getDescription()));
                 updateHandler.accept(Boolean.TRUE);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
@@ -86,7 +87,7 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
         AtomicReference<DatafeedConfig> configHolder = new AtomicReference<>();
         blockingCall(actionListener ->
                         datafeedConfigProvider.updateDatefeedConfig(datafeedId, update.build(), updateHeaders,
-                                (updatedConfig, listener) -> listener.onResponse(Boolean.TRUE), actionListener),
+                                (updatedConfig, listener) -> listener.onResponse(Boolean.TRUE), Version.CURRENT, actionListener),
                 configHolder, exceptionHolder);
         assertNull(exceptionHolder.get());
         assertThat(configHolder.get().getIndices(), equalTo(updateIndices));
@@ -167,7 +168,7 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
         AtomicReference<DatafeedConfig> configHolder = new AtomicReference<>();
         blockingCall(actionListener ->
                         datafeedConfigProvider.updateDatefeedConfig(datafeedId, update.build(), Collections.emptyMap(),
-                                (updatedConfig, listener) -> listener.onResponse(Boolean.TRUE), actionListener),
+                                (updatedConfig, listener) -> listener.onResponse(Boolean.TRUE), Version.CURRENT, actionListener),
                 configHolder, exceptionHolder);
         assertNull(configHolder.get());
         assertNotNull(exceptionHolder.get());
@@ -193,7 +194,7 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
         blockingCall(actionListener ->
                         datafeedConfigProvider.updateDatefeedConfig(datafeedId, update.build(), Collections.emptyMap(),
-                                validateErrorFunction, actionListener),
+                                validateErrorFunction, Version.CURRENT, actionListener),
                 configHolder, exceptionHolder);
 
         assertNull(configHolder.get());

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobConfigProviderIT.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml.integration;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexResponse;
@@ -147,8 +148,8 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
         JobUpdate jobUpdate = new JobUpdate.Builder(jobId).setDescription("This job has been updated").build();
 
         AtomicReference<Job> updateJobResponseHolder = new AtomicReference<>();
-        blockingCall(actionListener -> jobConfigProvider.updateJob(jobId, jobUpdate, new ByteSizeValue(32), actionListener),
-                updateJobResponseHolder, exceptionHolder);
+        blockingCall(actionListener -> jobConfigProvider.updateJob
+                (jobId, jobUpdate, new ByteSizeValue(32), Version.CURRENT, actionListener), updateJobResponseHolder, exceptionHolder);
         assertNull(exceptionHolder.get());
         assertEquals("This job has been updated", updateJobResponseHolder.get().getDescription());
 
@@ -205,8 +206,8 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
                 .build();
 
         AtomicReference<Job> updateJobResponseHolder = new AtomicReference<>();
-        blockingCall(actionListener -> jobConfigProvider.updateJob(jobId, invalidUpdate, new ByteSizeValue(32), actionListener),
-                updateJobResponseHolder, exceptionHolder);
+        blockingCall(actionListener -> jobConfigProvider.updateJob(jobId, invalidUpdate, new ByteSizeValue(32), Version.CURRENT,
+            actionListener), updateJobResponseHolder, exceptionHolder);
         assertNull(updateJobResponseHolder.get());
         assertNotNull(exceptionHolder.get());
         assertThat(exceptionHolder.get(), instanceOf(ElasticsearchStatusException.class));
@@ -229,9 +230,8 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
         AtomicReference<Job> updateJobResponseHolder = new AtomicReference<>();
         // update with the no-op validator
-        blockingCall(actionListener ->
-                        jobConfigProvider.updateJobWithValidation(jobId, jobUpdate, new ByteSizeValue(32), validator, actionListener),
-                updateJobResponseHolder, exceptionHolder);
+        blockingCall(actionListener -> jobConfigProvider.updateJobWithValidation(
+            jobId, jobUpdate, new ByteSizeValue(32), validator, Version.CURRENT, actionListener), updateJobResponseHolder, exceptionHolder);
 
         assertNull(exceptionHolder.get());
         assertNotNull(updateJobResponseHolder.get());
@@ -244,7 +244,7 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
         updateJobResponseHolder.set(null);
         // Update with a validator that errors
         blockingCall(actionListener -> jobConfigProvider.updateJobWithValidation(jobId, jobUpdate, new ByteSizeValue(32),
-                validatorWithAnError, actionListener),
+                validatorWithAnError, Version.CURRENT, actionListener),
                 updateJobResponseHolder, exceptionHolder);
 
         assertNull(updateJobResponseHolder.get());


### PR DESCRIPTION
This PR moves the usage of internal versioning for CAS operations to use sequence numbers and primary terms

Relates to #36148
Relates to #10708