### PR TITLE
Remove Redundandant Loop in SnapshotShardsService

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -284,12 +284,10 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                             notifyFailedSnapshotShard(snapshot, shard.key, lastSnapshotStatus.getFailure());
                         }
                     } else {
-                        for (ObjectObjectCursor<ShardId, ShardSnapshotStatus> curr : entry.shards()) {
-                            // due to CS batching we might have missed the INIT state and straight went into ABORTED
-                            // notify master that abort has completed by moving to FAILED
-                            if (curr.value.state() == State.ABORTED) {
-                                notifyFailedSnapshotShard(snapshot, curr.key, curr.value.reason());
-                            }
+                        // due to CS batching we might have missed the INIT state and straight went into ABORTED
+                        // notify master that abort has completed by moving to FAILED
+                        if (shard.value.state() == State.ABORTED) {
+                            notifyFailedSnapshotShard(snapshot, shard.key, shard.value.reason());
                         }
                     }
                 }


### PR DESCRIPTION
* This was a merge-mistake on my end I think (when handling #38025 ), obviously we only need to loop over the shards once not twice here to find those that we missed in INIT state (or put differently ... the `else` block changed here is already inside a loop over `entry.shards()`)

