### PR TITLE
Fix IndexAuditTrail rolling upgrade on rollover edge - take 2

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/index/IndexAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/index/IndexAuditTrail.java
@@ -451,7 +451,7 @@ public class IndexAuditTrail extends AbstractComponent implements AuditTrail, Cl
                     innerStart();
                 }, e2 -> {
                     // best effort only
-                    logger.debug("Failed to update mappings on next audit index [{}]", nextIndex, e2);
+                    logger.debug("Failed to update mappings on next audit index [{}]", nextIndex);
                     innerStart();
                 }));
             }, e -> {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/index/IndexAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/index/IndexAuditTrail.java
@@ -337,7 +337,7 @@ public class IndexAuditTrail extends AbstractComponent implements AuditTrail, Cl
                             updateCurrentIndexMappingsIfNecessary(clusterStateResponse.getState());
                         } else if (TemplateUtils.checkTemplateExistsAndVersionMatches(INDEX_TEMPLATE_NAME,
                                 SECURITY_VERSION_STRING, clusterStateResponse.getState(), logger,
-                                Version.CURRENT::onOrAfter) == false) {
+                                Version.CURRENT::onOrBefore) == false) {
                             putTemplate(customAuditIndexSettings(settings, logger),
                                     e -> {
                                         logger.error("failed to put audit trail template", e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/index/IndexAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/index/IndexAuditTrail.java
@@ -393,7 +393,7 @@ public class IndexAuditTrail extends AbstractComponent implements AuditTrail, Cl
                 if (indexToRemoteCluster || state.nodes().isLocalNodeElectedMaster() || hasStaleMessage()) {
                     putAuditIndexMappingsAndStart(index);
                 } else {
-                    logger.trace("audit index [{}] is missing mapping for type [{}]", index, DOC_TYPE);
+                    logger.debug("audit index [{}] is missing mapping for type [{}]", index, DOC_TYPE);
                     transitionStartingToInitialized();
                 }
             } else {
@@ -411,10 +411,10 @@ public class IndexAuditTrail extends AbstractComponent implements AuditTrail, Cl
                     if (indexToRemoteCluster || state.nodes().isLocalNodeElectedMaster() || hasStaleMessage()) {
                         putAuditIndexMappingsAndStart(index);
                     } else if (versionString == null) {
-                        logger.trace("audit index [{}] mapping is missing meta field [{}]", index, SECURITY_VERSION_STRING);
+                        logger.debug("audit index [{}] mapping is missing meta field [{}]", index, SECURITY_VERSION_STRING);
                         transitionStartingToInitialized();
                     } else {
-                        logger.trace("audit index [{}] has the incorrect version [{}]", index, versionString);
+                        logger.debug("audit index [{}] has the incorrect version [{}]", index, versionString);
                         transitionStartingToInitialized();
                     }
                 }
@@ -427,7 +427,7 @@ public class IndexAuditTrail extends AbstractComponent implements AuditTrail, Cl
     private void putAuditIndexMappingsAndStart(String index) {
         putAuditIndexMappings(index, getPutIndexTemplateRequest(Settings.EMPTY).mappings().get(DOC_TYPE),
                 ActionListener.wrap(ignore -> {
-                    logger.trace("updated mappings on audit index [{}]", index);
+                    logger.debug("updated mappings on audit index [{}]", index);
                     innerStart();
                 }, e -> {
                     logger.error(new ParameterizedMessage("failed to update mappings on audit index [{}]", index), e);
@@ -451,7 +451,7 @@ public class IndexAuditTrail extends AbstractComponent implements AuditTrail, Cl
             assert false : message;
             logger.error(message);
         } else {
-            logger.trace("successful state transition from starting to started, current value: [{}]", state.get());
+            logger.debug("successful state transition from starting to started, current value: [{}]", state.get());
         }
     }
 

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -175,6 +175,7 @@ subprojects {
         }
         setting 'xpack.watcher.encrypt_sensitive_data', 'true'
         setting 'logger.org.elasticsearch.xpack.ml.action', 'DEBUG'
+        setting 'logger.org.elasticsearch.xpack.security.audit.index', 'DEBUG'
       }
 
       if (version.onOrAfter('6.6.0')) {
@@ -234,6 +235,7 @@ subprojects {
           keystoreFile 'xpack.watcher.encryption_key', "${mainProject.projectDir}/src/test/resources/system_key"
         }
         setting 'logger.org.elasticsearch.xpack.ml.action', 'DEBUG'
+        setting 'logger.org.elasticsearch.xpack.security.audit.index', 'DEBUG'
       }
     }
 

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -157,6 +157,7 @@ subprojects {
       setting 'xpack.security.audit.outputs', 'index'
       setting 'xpack.security.transport.ssl.keystore.path', 'testnode.jks'
       setting 'xpack.security.transport.ssl.keystore.password', 'testnode'
+      setting 'logger.org.elasticsearch.xpack.security.audit.index', 'DEBUG'
       if (version.onOrAfter('6.0.0') == false) {
         // this is needed since in 5.6 we don't bootstrap the token service if there is no explicit initial password
         keystoreSetting 'xpack.security.authc.token.passphrase', 'xpack_token_passphrase'
@@ -175,7 +176,6 @@ subprojects {
         }
         setting 'xpack.watcher.encrypt_sensitive_data', 'true'
         setting 'logger.org.elasticsearch.xpack.ml.action', 'DEBUG'
-        setting 'logger.org.elasticsearch.xpack.security.audit.index', 'DEBUG'
       }
 
       if (version.onOrAfter('6.6.0')) {
@@ -218,6 +218,7 @@ subprojects {
         setting 'xpack.security.enabled', 'true'
         setting 'xpack.security.transport.ssl.enabled', 'true'
         setting 'xpack.security.transport.ssl.keystore.path', 'testnode.jks'
+        setting 'logger.org.elasticsearch.xpack.security.audit.index', 'DEBUG'
         keystoreSetting 'xpack.security.transport.ssl.keystore.secure_password', 'testnode'
         if (version.onOrAfter('6.0.0') == false) {
           // this is needed since in 5.6 we don't bootstrap the token service if there is no explicit initial password
@@ -235,7 +236,6 @@ subprojects {
           keystoreFile 'xpack.watcher.encryption_key', "${mainProject.projectDir}/src/test/resources/system_key"
         }
         setting 'logger.org.elasticsearch.xpack.ml.action', 'DEBUG'
-        setting 'logger.org.elasticsearch.xpack.security.audit.index', 'DEBUG'
       }
     }
 

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexAuditUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexAuditUpgradeIT.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.hasSize;
 
@@ -66,7 +67,7 @@ public class IndexAuditUpgradeIT extends AbstractUpgradeTestCase {
         assertBusy(() -> {
             assertAuditDocsExist();
             assertNumUniqueNodeNameBuckets(expectedNumUniqueNodeNameBuckets());
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     private int expectedNumUniqueNodeNameBuckets() throws IOException {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexAuditUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexAuditUpgradeIT.java
@@ -62,7 +62,6 @@ public class IndexAuditUpgradeIT extends AbstractUpgradeTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/33867")
     public void testAuditLogs() throws Exception {
         assertBusy(() -> {
             assertAuditDocsExist();


### PR DESCRIPTION
Fixes a race during the rolling upgrade with the index audit output enabled.

The race is that after the upgraded node is restarted, it installs the audit template and updates the mapping of the "current" (from his perspective) audit index. But the template might be installed after a new daily rolled-over index has been created by the other old nodes, using the old templates.
However, the new node, even if it installs the template after the rollover edge, can accumulate audit
events before the edge, and will correctly try to update the mapping of the audit index before the edge. But this way, the mapping of the index after the edge remains un-updated, because only the master node does the mapping updates.

The fix keeps the design of only allowing the master to update the mapping, but the master will try, on a best effort policy, to also possibly update the mapping of the next rollover audit index.

_This can be judged as a shoot in the dark because I don't have access to the failure data anymore, but I think the crumbles point in this direction. Moreover, turning up debugging will allow for easier future diagnosis._

Relates #35988

Closes #33867 #37062