### PR TITLE
SQL: Remove exceptions from Analyzer (#38260)

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/AbstractBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/AbstractBuilder.java
@@ -102,6 +102,15 @@ abstract class AbstractBuilder extends SqlBaseBaseVisitor<Object> {
         return new Source(new Location(start.getLine(), start.getCharPositionInLine()), text);
     }
 
+    static Source source(TerminalNode begin, ParserRuleContext end) {
+        Check.notNull(begin, "begin is null");
+        Check.notNull(end, "end is null");
+        Token start = begin.getSymbol();
+        Token stop = end.stop != null ? end.stop : start;
+        String text = start.getInputStream().getText(new Interval(start.getStartIndex(), stop.getStopIndex()));
+        return new Source(new Location(start.getLine(), start.getCharPositionInLine()), text);
+    }
+
     /**
      * Retrieves the raw text of the node (without interpreting it as a string literal).
      */

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.sql.analysis.analyzer;
 
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.TestUtils;
-import org.elasticsearch.xpack.sql.analysis.AnalysisException;
 import org.elasticsearch.xpack.sql.analysis.index.EsIndex;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolution;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolverTests;
@@ -42,7 +41,7 @@ public class VerifierErrorMessagesTests extends ESTestCase {
 
     private String error(IndexResolution getIndexResult, String sql) {
         Analyzer analyzer = new Analyzer(TestUtils.TEST_CFG, new FunctionRegistry(), getIndexResult, new Verifier(new Metrics()));
-        AnalysisException e = expectThrows(AnalysisException.class, () -> analyzer.analyze(parser.createStatement(sql), true));
+        VerificationException e = expectThrows(VerificationException.class, () -> analyzer.analyze(parser.createStatement(sql), true));
         assertTrue(e.getMessage().startsWith("Found "));
         String header = "Found 1 problem(s)\nline ";
         return e.getMessage().substring(header.length());
@@ -170,6 +169,11 @@ public class VerifierErrorMessagesTests extends ESTestCase {
         assertEquals("1:41: Unknown column [xxx]", error("SELECT * FROM test GROUP BY DAY_OF_YEAR(xxx)"));
     }
 
+    public void testInvalidOrdinalInOrderBy() {
+        assertEquals("1:56: Invalid ordinal [3] specified in [ORDER BY 2, 3] (valid range is [1, 2])",
+                error("SELECT bool, MIN(int) FROM test GROUP BY 1 ORDER BY 2, 3"));
+    }
+
     public void testFilterOnUnknownColumn() {
         assertEquals("1:26: Unknown column [xxx]", error("SELECT * FROM test WHERE xxx = 1"));
     }
@@ -237,6 +241,21 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     public void testGroupByOrderByNonGrouped_WithHaving() {
         assertEquals("1:71: Cannot order by non-grouped column [bool], expected [text]",
             error("SELECT MAX(int) FROM test GROUP BY text HAVING MAX(int) > 10 ORDER BY bool"));
+    }
+
+    public void testGroupByOrdinalPointingToAggregate() {
+        assertEquals("1:42: Ordinal [2] in [GROUP BY 2] refers to an invalid argument, aggregate function [MIN(int)]",
+                error("SELECT bool, MIN(int) FROM test GROUP BY 2"));
+    }
+
+    public void testGroupByInvalidOrdinal() {
+        assertEquals("1:42: Invalid ordinal [3] specified in [GROUP BY 3] (valid range is [1, 2])",
+                error("SELECT bool, MIN(int) FROM test GROUP BY 3"));
+    }
+
+    public void testGroupByNegativeOrdinal() {
+        assertEquals("1:42: Invalid ordinal [-1] specified in [GROUP BY -1] (valid range is [1, 2])",
+                error("SELECT bool, MIN(int) FROM test GROUP BY -1"));
     }
 
     public void testGroupByOrderByAliasedInSelectAllowed() {


### PR DESCRIPTION
Instead of throwing an exception, use an unresolved attribute to pass
the message to the Verifier.
Additionally improve the parser to save the extended source for the
Aggregate and OrderBy.

Close #38208

(cherry picked from commit 75f0750ff7495073557a0dd6bc274fb1a26a1d12)