### PR TITLE
Deprecate implicit security on trial licenses

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
@@ -33,7 +33,7 @@ public class XPackLicenseStateTests extends ESTestCase {
     /** Creates a license state with the given license type and active state, and checks the given method returns expected. */
     void assertAllowed(OperationMode mode, boolean active, Predicate<XPackLicenseState> predicate, boolean expected) {
         XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
-        licenseState.update(mode, active, null);
+        licenseState.update(mode, active, Version.CURRENT);
         assertEquals(expected, predicate.test(licenseState));
     }
 
@@ -90,6 +90,9 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(true));
         assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.ALL));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(true));
+
+        assertWarnings("Automatically enabling security because [xpack.security.transport.ssl.enabled] is true." +
+            " This behaviour will be removed in a future version of Elasticsearch. Please set [xpack.security.enabled] to true");
 
         licenseState = new XPackLicenseState(Settings.EMPTY);
         assertThat(licenseState.isAuthAllowed(), is(false));
@@ -239,6 +242,9 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(true));
         assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.ALL));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(true));
+
+        assertWarnings("Automatically enabling security because the current trial license was generated before 6.3.0." +
+            " This behaviour will be removed in a future version of Elasticsearch. Please set [xpack.security.enabled] to true");
     }
 
     public void testSecurityAckBasicToNotGoldOrStandard() {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -51,6 +51,7 @@ public class DeprecationChecks {
             NodeDeprecationChecks::gcsRepositoryChanges,
             NodeDeprecationChecks::fileDiscoveryPluginRemoved,
             NodeDeprecationChecks::defaultSSLSettingsRemoved,
+            NodeDeprecationChecks::transportSslEnabledWithoutSecurityEnabled,
             NodeDeprecationChecks::watcherNotificationsSecureSettingsCheck,
             NodeDeprecationChecks::auditIndexSettingsCheck
         ));

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -15,6 +15,8 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_HOSTS_PROVIDER_SETTING;
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_TYPE_SETTING;
 import static org.elasticsearch.discovery.zen.SettingsBasedHostsProvider.DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING;
+import static org.elasticsearch.xpack.core.XPackSettings.SECURITY_ENABLED;
+import static org.elasticsearch.xpack.core.XPackSettings.TRANSPORT_SSL_ENABLED;
 
 /**
  * Node-specific deprecation checks
@@ -186,6 +188,19 @@ public class NodeDeprecationChecks {
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#tls-setting-fallback",
                 "each component must have TLS/SSL configured explicitly");
+        }
+        return null;
+    }
+
+    static DeprecationIssue transportSslEnabledWithoutSecurityEnabled(Settings nodeSettings, PluginsAndModules plugins) {
+        if (TRANSPORT_SSL_ENABLED.get(nodeSettings) && nodeSettings.hasValue(SECURITY_ENABLED.getKey()) == false) {
+            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
+                "TLS/SSL in use, but security not explicitly enabled",
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                    "#trial-explicit-security",
+                "security should be explicitly enabled (with [" + SECURITY_ENABLED.getKey() +
+                    "]), it will no longer be automatically enabled when transport SSL is enabled ([" +
+                    TRANSPORT_SSL_ENABLED.getKey() + "])");
         }
         return null;
     }


### PR DESCRIPTION
In 6.x security is implicitly enabled on a trial license if transport
SSL is enabled, or the trial is from pre-6.3.

This is no longer true on 7.0, so this behaviour is now deprecated.

Relates: #38009, #38075