### PR TITLE
SQL: change the Intervals milliseconds precision to 3 digits

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/literal/Intervals.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/literal/Intervals.java
@@ -332,7 +332,7 @@ public final class Intervals {
         int MAX_HOUR = 23;
         int MAX_MINUTE = 59;
         int MAX_SECOND = 59;
-        int MAX_MILLI = 999999999;
+        int MAX_MILLI = 999;
         
         char DOT = '.';
         char SPACE = ' ';

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/literal/IntervalsTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/literal/IntervalsTests.java
@@ -83,7 +83,7 @@ public class IntervalsTests extends ESTestCase {
 
     public void testSecondInterval() throws Exception {
         int randomSeconds = randomNonNegativeInt();
-        int randomMillis = randomBoolean() ? (randomBoolean() ? 0 : 999999999) : randomInt(999999999);
+        int randomMillis = randomBoolean() ? (randomBoolean() ? 0 : 999) : randomInt(999);
         String value = format(Locale.ROOT, "%s%d.%d", sign, randomSeconds, randomMillis);
         TemporalAmount amount = parseInterval(EMPTY, value, INTERVAL_SECOND);
         assertEquals(maybeNegate(sign, Duration.ofSeconds(randomSeconds).plusMillis(randomMillis)), amount);
@@ -128,7 +128,7 @@ public class IntervalsTests extends ESTestCase {
         int randomSecond = randomInt(59);
 
         boolean withMillis = randomBoolean();
-        int randomMilli = withMillis ? randomInt(999999999) : 0;
+        int randomMilli = withMillis ? randomInt(999) : 0;
         String millisString = withMillis ? "." + randomMilli : "";
 
         String value = format(Locale.ROOT, "%s%d %d:%d:%d%s", sign, randomDay, randomHour, randomMinute, randomSecond, millisString);
@@ -151,7 +151,7 @@ public class IntervalsTests extends ESTestCase {
         int randomSecond = randomInt(59);
 
         boolean withMillis = randomBoolean();
-        int randomMilli = withMillis ? randomInt(999999999) : 0;
+        int randomMilli = withMillis ? randomInt(999) : 0;
         String millisString = withMillis ? "." + randomMilli : "";
 
         String value = format(Locale.ROOT, "%s%d:%d:%d%s", sign, randomHour, randomMinute, randomSecond, millisString);
@@ -165,7 +165,7 @@ public class IntervalsTests extends ESTestCase {
         int randomSecond = randomInt(59);
 
         boolean withMillis = randomBoolean();
-        int randomMilli = withMillis ? randomInt(999999999) : 0;
+        int randomMilli = withMillis ? randomInt(999) : 0;
         String millisString = withMillis ? "." + randomMilli : "";
 
         String value = format(Locale.ROOT, "%s%d:%d%s", sign, randomMinute, randomSecond, millisString);
@@ -186,11 +186,11 @@ public class IntervalsTests extends ESTestCase {
 
     public void testMillisTooBig() throws Exception {
         int randomSeconds = randomNonNegativeInt();
-        int millisTooLarge = 1234567890;
+        int millisTooLarge = 1234;
         String value = format(Locale.ROOT, "%s%d.%d", sign, randomSeconds, millisTooLarge);
         ParsingException pe = expectThrows(ParsingException.class, () -> parseInterval(EMPTY, value, INTERVAL_SECOND));
         assertEquals("line -1:0: Invalid [INTERVAL SECOND] value [" + value + "]: [MILLISECOND] unit has illegal value [" + millisTooLarge
-                + "], expected a positive number up to [999999999]", pe.getMessage());
+                + "], expected a positive number up to [999]", pe.getMessage());
     }
 
     public void testDayToMinuteTooBig() throws Exception {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/ExpressionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/ExpressionTests.java
@@ -150,7 +150,7 @@ public class ExpressionTests extends ESTestCase {
         int randomHour = randomInt(23);
         int randomMinute = randomInt(59);
         int randomSecond = randomInt(59);
-        int randomMilli = randomInt(999999999);
+        int randomMilli = randomInt(999);
 
         String value = format(Locale.ROOT, "INTERVAL '%d %d:%d:%d.%d' DAY TO SECOND", randomDay, randomHour, randomMinute, randomSecond,
                 randomMilli);
@@ -163,7 +163,7 @@ public class ExpressionTests extends ESTestCase {
         int randomHour = randomInt(23);
         int randomMinute = randomInt(59);
         int randomSecond = randomInt(59);
-        int randomMilli = randomInt(999999999);
+        int randomMilli = randomInt(999);
 
         String value = format(Locale.ROOT, "INTERVAL -'%d %d:%d:%d.%d' DAY TO SECOND", randomDay, randomHour, randomMinute, randomSecond,
                 randomMilli);


### PR DESCRIPTION
This PR changes the way milliseconds are treated inside Intervals by lowering their precision to 3 digits (from 9). Before this change, the seconds in an interval were calculated by dividing the milliseconds to 1000 and adding this result to the existent seconds value showing an apparently incorrect result, like this one:

```
sql> select interval -'22 22:21:20.19182' day to second;
INTERVAL '22 22:21:20.19182' DAY TO SECOND
------------------------------------------
PT-550H-21M-39.182S
```

If we decide to increase the precision in future, we should probably treat the new value after `.` (dot) as nanoseconds.

Fixes https://github.com/elastic/elasticsearch/issues/37423.