### PR TITLE
Types removal - fix FullClusterRestartIT warning expectations

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -36,8 +36,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.rest.action.admin.indices.RestGetIndexTemplateAction;
-import org.elasticsearch.rest.action.admin.indices.RestPutIndexTemplateAction;
 import org.elasticsearch.rest.action.document.RestBulkAction;
 import org.elasticsearch.rest.action.document.RestGetAction;
 import org.elasticsearch.rest.action.document.RestUpdateAction;
@@ -925,7 +923,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         // We therefore use the deprecated typed APIs when running against the current version.
         if (isRunningAgainstOldCluster() == false) {
             createTemplateRequest.addParameter(INCLUDE_TYPE_NAME_PARAMETER, "true");
-            createTemplateRequest.setOptions(expectWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE));
+            createTemplateRequest.setOptions(expectTypeRemovalWarnings());
         }
 
         client().performRequest(createTemplateRequest);
@@ -1135,7 +1133,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         // We therefore use the deprecated typed APIs when running against the current version.
         if (isRunningAgainstOldCluster() == false) {
             getTemplateRequest.addParameter(INCLUDE_TYPE_NAME_PARAMETER, "true");
-            getTemplateRequest.setOptions(expectWarnings(RestGetIndexTemplateAction.TYPES_DEPRECATION_MESSAGE));
+            getTemplateRequest.setOptions(expectTypeRemovalWarnings());
         }
 
         Map<String, Object> getTemplateResponse = entityAsMap(client().performRequest(getTemplateRequest));

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -923,8 +923,8 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         // We therefore use the deprecated typed APIs when running against the current version.
         if (isRunningAgainstOldCluster() == false) {
             createTemplateRequest.addParameter(INCLUDE_TYPE_NAME_PARAMETER, "true");
-            createTemplateRequest.setOptions(expectTypeRemovalWarnings());
         }
+        createTemplateRequest.setOptions(allowTypeRemovalWarnings());
 
         client().performRequest(createTemplateRequest);
 
@@ -1133,8 +1133,8 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         // We therefore use the deprecated typed APIs when running against the current version.
         if (isRunningAgainstOldCluster() == false) {
             getTemplateRequest.addParameter(INCLUDE_TYPE_NAME_PARAMETER, "true");
-            getTemplateRequest.setOptions(expectTypeRemovalWarnings());
         }
+        getTemplateRequest.setOptions(allowTypeRemovalWarnings());
 
         Map<String, Object> getTemplateResponse = entityAsMap(client().performRequest(getTemplateRequest));
         Map<String, Object> expectedTemplate = new HashMap<>();

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -257,6 +257,28 @@ public abstract class ESRestTestCase extends ESTestCase {
     public static RequestOptions expectWarnings(String... warnings) {
         return expectVersionSpecificWarnings(consumer -> consumer.current(warnings));
     }
+    
+    /**
+     * Creates RequestOptions designed to ignore [types removal] warnings but nothing else 
+     * @deprecated this method is only required while we deprecate types and can be removed in 8.0
+     */
+    @Deprecated
+    public static RequestOptions expectTypeRemovalWarnings() {
+        Builder builder = RequestOptions.DEFAULT.toBuilder();
+        builder.setWarningsHandler(new WarningsHandler() {
+                @Override
+                public boolean warningsShouldFailRequest(List<String> warnings) {
+                    for (String warning : warnings) {
+                        if(warning.startsWith("[types removal]") == false) {
+                            //Something other than a types removal message - return true
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+            });
+        return builder.build();
+    }    
 
     /**
      * Construct an HttpHost from the given host and port

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -263,7 +263,7 @@ public abstract class ESRestTestCase extends ESTestCase {
      * @deprecated this method is only required while we deprecate types and can be removed in 8.0
      */
     @Deprecated
-    public static RequestOptions expectTypeRemovalWarnings() {
+    public static RequestOptions allowTypeRemovalWarnings() {
         Builder builder = RequestOptions.DEFAULT.toBuilder();
         builder.setWarningsHandler(new WarningsHandler() {
                 @Override


### PR DESCRIPTION
Relax test warning message checking to pre-empt PR 38022 landing in 6.7 with new warning messages.
The relaxed test now just assumes any warning message starting with “[types removal]” is tolerated rather than the precise phrasing used in the 6.7 branch.