### PR TITLE
Fix testRestoreIncreasesPrimaryTerms on 6.x

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -3706,7 +3706,6 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/38223")
     public void testRestoreIncreasesPrimaryTerms() {
         final String indexName = randomAlphaOfLengthBetween(5, 10).toLowerCase(Locale.ROOT);
         createIndex(indexName, Settings.builder()
@@ -3719,7 +3718,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             // open and close the index to increase the primary terms
             for (int i = 0; i < randomInt(3); i++) {
                 assertAcked(client().admin().indices().prepareClose(indexName));
-                assertAcked(client().admin().indices().prepareOpen(indexName));
+                assertAcked(client().admin().indices().prepareOpen(indexName).setWaitForActiveShards(ActiveShardCount.DEFAULT));
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -3718,7 +3718,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             // open and close the index to increase the primary terms
             for (int i = 0; i < randomInt(3); i++) {
                 assertAcked(client().admin().indices().prepareClose(indexName));
-                assertAcked(client().admin().indices().prepareOpen(indexName).setWaitForActiveShards(ActiveShardCount.DEFAULT));
+                assertAcked(client().admin().indices().prepareOpen(indexName).setWaitForActiveShards(ActiveShardCount.ONE));
             }
         }
 


### PR DESCRIPTION
In 6.x the open index request does not wait for shards to be active and
returns immediately. In this specific test, we want to capture the
values of the primary terms before the snapshot and restore and if it
does not wait for shard to be active the captured values might not be
up to date.

Closes #38223

