### PR TITLE
Fix testCanRunUnsafeBootstrapAfterErroneousDetachWithoutLoosingMetaData

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ElasticsearchNodeCommandIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ElasticsearchNodeCommandIT.java
@@ -391,7 +391,6 @@ public class ElasticsearchNodeCommandIT extends ESIntegTestCase {
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(node));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/38267")
     public void testCanRunUnsafeBootstrapAfterErroneousDetachWithoutLoosingMetaData() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
         internalCluster().startMasterOnlyNode();
@@ -410,7 +409,7 @@ public class ElasticsearchNodeCommandIT extends ESIntegTestCase {
         unsafeBootstrap(environment);
 
         internalCluster().startMasterOnlyNode();
-        ensureStableCluster(1);
+        ensureGreen();
 
         state = internalCluster().client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(state.metaData().settings().get(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()),


### PR DESCRIPTION
The reason for the test failure was the check `ensureStableCluster`, which can return before state (including persistent settings) is recovered.
The failure could be reliably reproduced if you add sleep in the following place in `GatewayService`

```
threadPool.generic().execute(new AbstractRunnable() {
                    @Override
                    public void onFailure(final Exception e) {
                        logger.warn("Recovery failed", e);
                        // we reset `recovered` in the listener don't reset it here otherwise there might be a race
                        // that resets it to false while a new recover is already running?
                        GatewayService.this.onFailure("state recovery failed: " + e.getMessage());
                    }

                    @Override
                    protected void doRun() {
--> add sleep here
                        recoveryRunnable.run();
                    }
                });
```

`ensureGreen` ensures green status of the cluster and it will become green after state recovery.

Closes https://github.com/elastic/elasticsearch/issues/38267