### PR TITLE
Fix ILM status to allow unknown fields

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/LifecycleManagementStatusResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/LifecycleManagementStatusResponse.java
@@ -34,7 +34,7 @@ public class LifecycleManagementStatusResponse {
     private static final String OPERATION_MODE = "operation_mode";
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<LifecycleManagementStatusResponse, Void> PARSER = new ConstructingObjectParser<>(
-        OPERATION_MODE, a -> new LifecycleManagementStatusResponse((String) a[0]));
+        OPERATION_MODE, true, a -> new LifecycleManagementStatusResponse((String) a[0]));
 
     static {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), new ParseField(OPERATION_MODE));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/LifecycleManagementStatusResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/LifecycleManagementStatusResponseTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.client.indexlifecycle;
 
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
@@ -30,7 +31,30 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
+
 public class LifecycleManagementStatusResponseTests extends ESTestCase {
+
+    public void testFromXContent() throws IOException {
+        xContentTester(this::createParser,
+            LifecycleManagementStatusResponseTests::createTestInstance,
+            LifecycleManagementStatusResponseTests::toXContent,
+            LifecycleManagementStatusResponse::fromXContent)
+            .supportsUnknownFields(true)
+            .assertToXContentEquivalence(false)
+            .test();
+    }
+
+    private static XContentBuilder toXContent(LifecycleManagementStatusResponse response, XContentBuilder builder) throws IOException {
+        builder.startObject();
+        builder.field("operation_mode", response.getOperationMode());
+        builder.endObject();
+        return builder;
+    }
+
+    private static LifecycleManagementStatusResponse createTestInstance() {
+        return new LifecycleManagementStatusResponse(randomFrom(OperationMode.values()).name());
+    }
 
     public void testAllValidStatuses() {
         EnumSet.allOf(OperationMode.class)


### PR DESCRIPTION
The ILM status parser did not allow for unknown fields. This commit
fixes that and adds an xContentTester to the response test.

Relates #36938
Backport of #38043
