### PR TITLE
Fix instant parsing with custom timezone

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateFormatTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateFormatTests.java
@@ -43,6 +43,13 @@ public class DateFormatTests extends ESTestCase {
                 equalTo("11 24 01:29:01"));
     }
 
+    public void testParseJavaWithTimeZone() {
+        Function<String, ZonedDateTime> javaFunction = DateFormat.Java.getFunction("yyyy-MM-dd'T'HH:mm:ss.SSSZZ",
+            ZoneOffset.UTC, Locale.ROOT);
+        ZonedDateTime datetime = javaFunction.apply("2018-02-05T13:44:56.657+0100");
+        assertThat(datetime.toString(), is("2018-02-05T12:44:56.657Z"));
+    }
+
     public void testParseJavaDefaultYear() {
         String format = randomFrom("8dd/MM", "dd/MM");
         ZoneId timezone = DateUtils.of("Europe/Amsterdam");

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -1590,17 +1590,20 @@ public class DateFormatters {
         if (zoneId == null) {
             zoneId = ZoneOffset.UTC;
         }
-        
+
+        // this is a very common case and should be handled first
+        if (accessor.isSupported(ChronoField.INSTANT_SECONDS) && accessor.isSupported(NANO_OF_SECOND)) {
+            return Instant.from(accessor).atZone(zoneId);
+        }
+
         LocalDate localDate = accessor.query(TemporalQueries.localDate());
         LocalTime localTime = accessor.query(TemporalQueries.localTime());
         boolean isLocalDateSet = localDate != null;
         boolean isLocalTimeSet = localTime != null;
 
-        // the first two cases are the most common, so this allows us to exit early when parsing dates
+        // try to start with most common cases, so this allows us to exit early when parsing dates
         if (isLocalDateSet && isLocalTimeSet) {
             return of(localDate, localTime, zoneId);
-        } else if (accessor.isSupported(ChronoField.INSTANT_SECONDS) && accessor.isSupported(NANO_OF_SECOND)) {
-            return Instant.from(accessor).atZone(zoneId);
         } else if (isLocalDateSet) {
             return localDate.atStartOfDay(zoneId);
         } else if (isLocalTimeSet) {

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
@@ -218,6 +219,18 @@ public class DateFormattersTests extends ESTestCase {
         assertRoundupFormatter("strict_date_optional_time||epoch_second", "2018-10-10", 1539215999999L);
         assertRoundupFormatter("uuuu-MM-dd'T'HH:mm:ss.SSS||epoch_second", "2018-10-10T12:13:14.123", 1539173594123L);
         assertRoundupFormatter("uuuu-MM-dd'T'HH:mm:ss.SSS||epoch_second", "1234567890", 1234567890999L);
+    }
+
+    public void testFromParsingWithCustomTimezone() {
+        assertOffsetParsing("yyyy-MM-dd'T'HH:mm:ss.SSSZZ", "2018-02-05T13:44:56.657+0100", "2018-02-05T12:44:56.657Z");
+        assertOffsetParsing("dd/MMM/yyyy:H:m:s Z", "10/Aug/2018:09:45:56 +0200", "2018-08-10T07:45:56Z");
+        assertOffsetParsing("yyyy-MM-dd HH:mm:ss Z", "2017-04-04 13:43:09 +0200", "2017-04-04T11:43:09Z");
+        assertOffsetParsing("dd/MMM/yyyy:H:m:s Z", "07/Dec/2016:11:05:07 +0100", "2016-12-07T10:05:07Z");
+    }
+
+    private void assertOffsetParsing(String format, String input, String expectedOutput) {
+        TemporalAccessor accessor = DateFormatter.forPattern(format).withZone(ZoneOffset.UTC).parse(input);
+        assertThat(DateFormatters.from(accessor).toString(), is(expectedOutput));
     }
 
     private void assertRoundupFormatter(String format, String input, long expectedMilliSeconds) {


### PR DESCRIPTION
When parsing a temporal accessor as localtime and localdate first in the 
`from()` method resulted in losing the timezone offset.

Parsing the temporal accessor as an instant first when possible, fixes a
bug when not a zone, but an offset was used when converting to a zoned
date time, as this was encoded in the seconds/nanos, but not in a local
date.

