### PR TITLE
Adds configuration file for backport tool

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,5 @@
+{
+  "upstream": "elastic/elasticsearch",
+  "branches": [{ "name": "6.x", "checked": true }, "6.6", "6.5", "6.4", "6.3", "6.2", "6.1", "6.0", "5.6"],
+  "labels": ["backport"]
+}


### PR DESCRIPTION
This PR adds a configuration file similar to https://github.com/elastic/kibana/blob/master/.backportrc.json to configure the backport tool for the Elasticsearch repo. See also https://github.com/sqren/backport/blob/master/docs/configuration.md
