### PR TITLE
Fix ILM explain response to allow unknown fields

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/IndexLifecycleExplainResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/IndexLifecycleExplainResponse.java
@@ -54,7 +54,7 @@ public class IndexLifecycleExplainResponse implements ToXContentObject {
     private static final ParseField PHASE_EXECUTION_INFO = new ParseField("phase_execution");
 
     public static final ConstructingObjectParser<IndexLifecycleExplainResponse, Void> PARSER = new ConstructingObjectParser<>(
-        "index_lifecycle_explain_response",
+        "index_lifecycle_explain_response", true,
         a -> new IndexLifecycleExplainResponse(
             (String) a[0],
             (boolean) a[1],

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/IndexLifecycleExplainResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/IndexLifecycleExplainResponseTests.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.containsString;
@@ -99,7 +100,16 @@ public class IndexLifecycleExplainResponseTests extends AbstractXContentTestCase
 
     @Override
     protected boolean supportsUnknownFields() {
-        return false;
+        return true;
+    }
+
+    @Override
+    protected Predicate<String> getRandomFieldsExcludeFilter() {
+        return (field) ->
+            // actions are plucked from the named registry, and it fails if the action is not in the named registry
+            field.endsWith("phase_definition.actions")
+            // This is a bytes reference, so any new fields are tested for equality in this bytes reference.
+            || field.contains("step_info");
     }
 
     private static class RandomStepInfo implements ToXContentObject {


### PR DESCRIPTION
IndexLifecycleExplainResponse did not allow unknown fields. This commit
fixes the test and ConstructingObjectParser such that it allows unknown
fields.

Relates #36938
Backport of #38054
