### PR TITLE
Mute testCannotShrinkLeaderIndex

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/indexlifecycle/CCRIndexLifecycleIT.java
+++ b/x-pack/plugin/ilm/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/indexlifecycle/CCRIndexLifecycleIT.java
@@ -326,6 +326,9 @@ public class CCRIndexLifecycleIT extends ESCCRRestTestCase {
         }
     }
 
+    // Specifically, this is waiting for this bullet to be complete:
+    // - integrate shard history retention leases with cross-cluster replication
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/37165")
     public void testCannotShrinkLeaderIndex() throws Exception {
         String indexName = "shrink-leader-test";
         String shrunkenIndexName = "shrink-" + indexName;


### PR DESCRIPTION
This test should not pass until CCR finishes integrating shard history
retention leases. It currently sometimes passes (which is a bug in the
test), but cannot pass reliably until the linked issue is resolved.

Relates https://github.com/elastic/elasticsearch/issues/37165