### PR TITLE
[BACKPORT] Skip unsupported languages for tests (#38328)

### DIFF
--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
@@ -77,6 +77,8 @@ public abstract class KerberosTestCase extends ESTestCase {
         unsupportedLocaleLanguages.add("ps");
         unsupportedLocaleLanguages.add("ur");
         unsupportedLocaleLanguages.add("pa");
+        unsupportedLocaleLanguages.add("ig");
+        unsupportedLocaleLanguages.add("sd");
     }
 
     @BeforeClass


### PR DESCRIPTION
Skip the languages in tests for which SimpleKdcServer
does not handle generalized time correctly.

Closes#38320
