### PR TITLE
[BACKPORT] Limit token expiry to 1 hour maximum (#38244)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -161,7 +161,7 @@ public final class TokenService extends AbstractComponent {
     public static final Setting<SecureString> TOKEN_PASSPHRASE = SecureSetting.secureString("xpack.security.authc.token.passphrase", null,
             Property.Deprecated);
     public static final Setting<TimeValue> TOKEN_EXPIRATION = Setting.timeSetting("xpack.security.authc.token.timeout",
-            TimeValue.timeValueMinutes(20L), TimeValue.timeValueSeconds(1L), Property.NodeScope);
+            TimeValue.timeValueMinutes(20L), TimeValue.timeValueSeconds(1L), TimeValue.timeValueHours(1L), Property.NodeScope);
     public static final Setting<TimeValue> DELETE_INTERVAL = Setting.timeSetting("xpack.security.authc.token.delete.interval",
             TimeValue.timeValueMinutes(30L), Property.NodeScope);
     public static final Setting<TimeValue> DELETE_TIMEOUT = Setting.timeSetting("xpack.security.authc.token.delete.timeout",

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -81,6 +81,7 @@ import javax.crypto.SecretKey;
 import static java.time.Clock.systemUTC;
 import static org.elasticsearch.repositories.ESBlobStoreTestCase.randomBytes;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.any;
@@ -494,6 +495,29 @@ public class TokenServiceTests extends ESTestCase {
         SecretKey key = TokenService.computeSecretKey("some random passphrase".toCharArray(), saltArr);
         SecretKey key2 = TokenService.computeSecretKey("some random passphrase".toCharArray(), saltArr);
         assertArrayEquals(key.getEncoded(), key2.getEncoded());
+    }
+
+    public void testTokenExpiryConfig() {
+        TimeValue expiration =  TokenService.TOKEN_EXPIRATION.get(tokenServiceEnabledSettings);
+        assertThat(expiration, equalTo(TimeValue.timeValueMinutes(20L)));
+        // Configure Minimum expiration
+        tokenServiceEnabledSettings = Settings.builder().put(TokenService.TOKEN_EXPIRATION.getKey(), "1s").build();
+        expiration =  TokenService.TOKEN_EXPIRATION.get(tokenServiceEnabledSettings);
+        assertThat(expiration, equalTo(TimeValue.timeValueSeconds(1L)));
+        // Configure Maximum expiration
+        tokenServiceEnabledSettings = Settings.builder().put(TokenService.TOKEN_EXPIRATION.getKey(), "60m").build();
+        expiration =  TokenService.TOKEN_EXPIRATION.get(tokenServiceEnabledSettings);
+        assertThat(expiration, equalTo(TimeValue.timeValueHours(1L)));
+        // Outside range should fail
+        tokenServiceEnabledSettings = Settings.builder().put(TokenService.TOKEN_EXPIRATION.getKey(), "1ms").build();
+        IllegalArgumentException ile = expectThrows(IllegalArgumentException.class,
+                () -> TokenService.TOKEN_EXPIRATION.get(tokenServiceEnabledSettings));
+        assertThat(ile.getMessage(),
+                containsString("failed to parse value [1ms] for setting [xpack.security.authc.token.timeout], must be >= [1s]"));
+        tokenServiceEnabledSettings = Settings.builder().put(TokenService.TOKEN_EXPIRATION.getKey(), "120m").build();
+        ile = expectThrows(IllegalArgumentException.class, () -> TokenService.TOKEN_EXPIRATION.get(tokenServiceEnabledSettings));
+        assertThat(ile.getMessage(),
+                containsString("failed to parse value [120m] for setting [xpack.security.authc.token.timeout], must be <= [1h]"));
     }
 
     public void testTokenExpiry() throws Exception {


### PR DESCRIPTION
We mention in our documentation for the token
expiration configuration maximum value is 1 hour
but do not enforce it. This commit adds max limit
to the TOKEN_EXPIRATION setting.

Note: Since this is a backport and the min max
time value support was not there in 6.x, I have
selectively picked the change from Setting.
The changes were done for zen2.