### PR TITLE
Enable CronEvalToolTest.testEnsureDateIsShownInRootLocale

### DIFF
--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/schedule/tool/CronEvalToolTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/schedule/tool/CronEvalToolTests.java
@@ -56,7 +56,6 @@ public class CronEvalToolTests extends CommandTestCase {
 
     // randomized testing sets arbitrary locales and timezones, and we do not care
     // we always have to output in standard locale and independent from timezone
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/35687")
     public void testEnsureDateIsShownInRootLocale() throws Exception {
         String output = execute("-c","1", "0 0 11 ? * MON-SAT 2040");
         if (ZoneId.systemDefault().equals(ZoneOffset.UTC)) {


### PR DESCRIPTION
The test is now expected to be always passing no matter what the random
locale is. This is fixed with using jdk ZoneId.systemDefault() in both
the test and CronEvalTool

closes #35687
