### PR TITLE
Fix the clock resolution to millis in GetWatchResponseTests

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/xpack/watcher/GetWatchResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/protocol/xpack/watcher/GetWatchResponseTests.java
@@ -128,8 +128,6 @@ public class GetWatchResponseTests extends
         long version = randomLongBetween(-1, Long.MAX_VALUE);
         WatchStatus.State state = new WatchStatus.State(randomBoolean(), nowWithMillisResolution());
         ExecutionState executionState = randomFrom(ExecutionState.values());
-
-//Instant.ofEpochMilli(fixedClock.millis()).atZone(ZoneOffset.UTC);
         ZonedDateTime lastChecked = rarely() ? null : nowWithMillisResolution();
         ZonedDateTime lastMetCondition = rarely() ? null : nowWithMillisResolution();
         int size = randomIntBetween(0, 5);


### PR DESCRIPTION
the clock resolution changed from jdk8->jdk10, hence the test is passing
in jdk8 but failing in jdk10. The Watcher's objects are serialised and
deserialised with milliseconds precision, making test to fail in jdk 10
and higher

closes #38400
