### PR TITLE
Fix exporter tests to have reasonable dates

### DIFF
--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringTestUtils.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringTestUtils.java
@@ -23,6 +23,9 @@ import static org.elasticsearch.test.ESTestCase.buildNewFakeTransportAddress;
 
 public final class MonitoringTestUtils {
 
+    // maximum number of milliseconds before a five digit year comes in, which could change formatting
+    private static  final long MAX_MILLIS_BEFORE_10000 = 253402300799999L;
+
     private MonitoringTestUtils() {
     }
 
@@ -37,7 +40,7 @@ public final class MonitoringTestUtils {
         final String host = fakeTransportAddress.address().getHostString();
         final String transportAddress = fakeTransportAddress.toString();
         final String ip = fakeTransportAddress.getAddress();
-        final long timestamp = RandomNumbers.randomLongBetween(random, 0, Long.MAX_VALUE);
+        final long timestamp = RandomNumbers.randomLongBetween(random, 0, MAX_MILLIS_BEFORE_10000);
 
         return new MonitoringDoc.Node(id, host, transportAddress, ip, name, timestamp);
     }
@@ -87,7 +90,7 @@ public final class MonitoringTestUtils {
                                                             final MonitoredSystem system,
                                                             final String type) throws IOException {
         final String id = random.nextBoolean() ? RandomStrings.randomAsciiLettersOfLength(random, 5) : null;
-        final long timestamp = RandomNumbers.randomLongBetween(random, 0L, Long.MAX_VALUE);
+        final long timestamp = RandomNumbers.randomLongBetween(random, 0L, MAX_MILLIS_BEFORE_10000);
         final long interval = RandomNumbers.randomLongBetween(random, 0L, Long.MAX_VALUE);
         return new MonitoringBulkDoc(system, type, id, timestamp, interval, source, xContentType);
     }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterIntegTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterIntegTests.java
@@ -72,7 +72,6 @@ public class LocalExporterIntegTests extends LocalExporterIntegTestCase {
                                   .putNull("xpack.monitoring.exporters._local.index.name.time_format")));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/38378")
     public void testExport() throws Exception {
         try {
             if (randomBoolean()) {


### PR DESCRIPTION
The java time formatter used in the exporter adds a plus sign to the
year, if a year with more than five digits is used. This changes the
creation of those timestamp to only have a date up to 9999.

Closes #38378
