### PR TITLE
Support unknown fields in ingest pipeline map configuration

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -23,6 +23,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -42,7 +43,7 @@ import java.util.Objects;
  */
 public final class PipelineConfiguration extends AbstractDiffable<PipelineConfiguration> implements ToXContentObject {
 
-    private static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>("pipeline_config", Builder::new);
+    private static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>("pipeline_config", true, Builder::new);
     static {
         PARSER.declareString(Builder::setId, new ParseField("id"));
         PARSER.declareField((parser, builder, aVoid) -> {
@@ -128,6 +129,11 @@ public final class PipelineConfiguration extends AbstractDiffable<PipelineConfig
 
     public static Diff<PipelineConfiguration> readDiffFrom(StreamInput in) throws IOException {
         return readDiffFrom(PipelineConfiguration::readFrom, in);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
@@ -31,12 +31,13 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.AbstractXContentTestCase;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Predicate;
 
-public class PipelineConfigurationTests extends ESTestCase {
+public class PipelineConfigurationTests extends AbstractXContentTestCase<PipelineConfiguration> {
 
     public void testSerialization() throws IOException {
         PipelineConfiguration configuration = new PipelineConfiguration("1",
@@ -67,5 +68,31 @@ public class PipelineConfigurationTests extends ESTestCase {
         assertEquals(xContentType, parsed.getXContentType());
         assertEquals("{}", XContentHelper.convertToJson(parsed.getConfig(), false, parsed.getXContentType()));
         assertEquals("1", parsed.getId());
+    }
+
+    @Override
+    protected PipelineConfiguration createTestInstance() {
+        BytesArray config;
+        if (randomBoolean()) {
+            config = new BytesArray("{}".getBytes(StandardCharsets.UTF_8));
+        } else {
+            config = new BytesArray("{\"foo\": \"bar\"}".getBytes(StandardCharsets.UTF_8));
+        }
+        return new PipelineConfiguration(randomAlphaOfLength(4), config, XContentType.JSON);
+    }
+
+    @Override
+    protected PipelineConfiguration doParseInstance(XContentParser parser) throws IOException {
+        return PipelineConfiguration.getParser().parse(parser, null);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return true;
+    }
+
+    @Override
+    protected Predicate<String> getRandomFieldsExcludeFilter() {
+        return field -> field.equals("config");
     }
 }


### PR DESCRIPTION
Backport of #38352

We already support unknown objects in the list of pipelines, this changes the
`PipelineConfiguration` to support fields other than just `id` and `config`.

Relates to #36938
