### PR TITLE
Ignore type-removal warnings in XPackRestTestHelper

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestTestHelper.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestTestHelper.java
@@ -14,6 +14,7 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.core.ml.MlMetaIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields;
@@ -76,7 +77,9 @@ public final class XPackRestTestHelper {
             ESTestCase.awaitBusy(() -> {
                 Map<?, ?> response;
                 try {
-                    String string = EntityUtils.toString(client.performRequest(new Request("GET", "/_template/" + template)).getEntity());
+                    final Request getRequest = new Request("GET", "_template/" + template);
+                    getRequest.setOptions(ESRestTestCase.allowTypeRemovalWarnings());
+                    String string = EntityUtils.toString(client.performRequest(getRequest).getEntity());
                     response = XContentHelper.convertToMap(JsonXContent.jsonXContent, string, false);
                 } catch (ResponseException e) {
                     if (e.getResponse().getStatusLine().getStatusCode() == 404) {


### PR DESCRIPTION
The backport of https://github.com/elastic/elasticsearch/pull/38022 introduced types-deprecation
warning for get/put template requests that cause problems on tests master in mixed cluster
scenarios. While these warnings are caught and ignored in regular Rest tests, the get template
requests in XPackRestTestHelper were missed.

Closes #38412