### PR TITLE
Types removal fix FullClusterRestartIT warnings

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -518,6 +518,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
         if (isRunningAgainstOldCluster()) {
             Request rolloverRequest = new Request("POST", "/" + index + "_write/_rollover");
+            rolloverRequest.setOptions(allowTypeRemovalWarnings());
             rolloverRequest.setJsonEntity("{"
                     + "  \"conditions\": {"
                     + "    \"max_docs\": 5"


### PR DESCRIPTION
Backport PR #38389 for 6.7 produces warnings for rollover test.
This fixes FullClusterRestartIT warning expectations
for rollover request

Relates to #38389 

Test passes locally:
./gradlew :qa:full-cluster-restart:v6.7.0#oldClusterTestRunner -Dtests.class=org.elasticsearch.upgrades.FullClusterRestartIT -Dtests.method="testRollover" -Dtests.bwc.refspec.6.x=deprecate-types-rollover6.x 