### PR TITLE
Update Rollup Caps to allow unknown fields

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/RollableIndexCaps.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/RollableIndexCaps.java
@@ -44,7 +44,7 @@ public class RollableIndexCaps implements ToXContentFragment {
     public static final Function<String, ConstructingObjectParser<RollableIndexCaps, Void>> PARSER = indexName -> {
         @SuppressWarnings("unchecked")
         ConstructingObjectParser<RollableIndexCaps, Void> p
-            = new ConstructingObjectParser<>(indexName,
+            = new ConstructingObjectParser<>(indexName, true,
             a -> new RollableIndexCaps(indexName, (List<RollupJobCaps>) a[0]));
 
         p.declareObjectArray(ConstructingObjectParser.constructorArg(), RollupJobCaps.PARSER::apply,

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/RollupJobCaps.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/RollupJobCaps.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Represents the Rollup capabilities for a specific job on a single rollup index
@@ -45,15 +45,12 @@ public class RollupJobCaps implements ToXContentObject {
     private static final ParseField FIELDS = new ParseField("fields");
     private static final String NAME = "rollup_job_caps";
 
-    public static final ConstructingObjectParser<RollupJobCaps, Void> PARSER = new ConstructingObjectParser<>(NAME,
+    public static final ConstructingObjectParser<RollupJobCaps, Void> PARSER = new ConstructingObjectParser<>(NAME, true,
         a -> {
             @SuppressWarnings("unchecked")
             List<Tuple<String, RollupFieldCaps>> caps = (List<Tuple<String, RollupFieldCaps>>) a[3];
-            if (caps.isEmpty()) {
-                return new RollupJobCaps((String) a[0], (String) a[1], (String) a[2], Collections.emptyMap());
-            }
-            Map<String, RollupFieldCaps> mapCaps = new HashMap<>(caps.size());
-            caps.forEach(c -> mapCaps.put(c.v1(), c.v2()));
+            Map<String, RollupFieldCaps> mapCaps =
+                new HashMap<>(caps.stream().collect(Collectors.toMap(Tuple::v1, Tuple::v2)));
             return new RollupJobCaps((String) a[0], (String) a[1], (String) a[2], mapCaps);
         });
 
@@ -140,16 +137,6 @@ public class RollupJobCaps implements ToXContentObject {
         private static final String NAME = "rollup_field_caps";
         private final List<Map<String, Object>> aggs;
 
-        public static final Function<String, ConstructingObjectParser<RollupFieldCaps, Void>> PARSER = fieldName -> {
-            @SuppressWarnings("unchecked")
-            ConstructingObjectParser<RollupFieldCaps, Void> parser
-                = new ConstructingObjectParser<>(NAME, a -> new RollupFieldCaps((List<Map<String, Object>>) a[0]));
-
-            parser.declareObjectArray(ConstructingObjectParser.constructorArg(),
-                (p, c) -> p.map(), new ParseField(fieldName));
-            return parser;
-        };
-
         RollupFieldCaps(final List<Map<String, Object>> aggs) {
             this.aggs = Collections.unmodifiableList(Objects.requireNonNull(aggs));
         }
@@ -170,12 +157,11 @@ public class RollupJobCaps implements ToXContentObject {
             List<Map<String, Object>> aggs = new ArrayList<>();
             if (parser.nextToken().equals(XContentParser.Token.START_ARRAY)) {
                 while (parser.nextToken().equals(XContentParser.Token.START_OBJECT)) {
-                    aggs.add(Collections.unmodifiableMap(parser.map()));
+                    aggs.add(parser.map());
                 }
             }
-            return new RollupFieldCaps(Collections.unmodifiableList(aggs));
+            return new RollupFieldCaps(aggs);
         }
-
 
         @Override
         public boolean equals(Object other) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/rollup/GetRollupCapsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/rollup/GetRollupCapsResponseTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.Predicate;
 
 public class GetRollupCapsResponseTests extends RollupCapsResponseTestCase<GetRollupCapsResponse> {
 
@@ -38,6 +39,15 @@ public class GetRollupCapsResponseTests extends RollupCapsResponseTestCase<GetRo
             entry.getValue().toXContent(builder, null);
         }
         builder.endObject();
+    }
+
+    @Override
+    protected Predicate<String> randomFieldsExcludeFilter() {
+        return (field) ->
+            // base cannot have extra things in it
+            "".equals(field)
+            // the field list expects to be a nested object of a certain type
+            || field.contains("fields");
     }
 
     @Override

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/rollup/GetRollupIndexCapsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/rollup/GetRollupIndexCapsResponseTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.Predicate;
 
 public class GetRollupIndexCapsResponseTests extends RollupCapsResponseTestCase<GetRollupIndexCapsResponse> {
 
@@ -38,6 +39,15 @@ public class GetRollupIndexCapsResponseTests extends RollupCapsResponseTestCase<
             entry.getValue().toXContent(builder, null);
         }
         builder.endObject();
+    }
+
+    @Override
+    protected Predicate<String> randomFieldsExcludeFilter() {
+        return (field) ->
+            // base cannot have extra things in it
+            "".equals(field)
+                // the field list expects to be a nested object of a certain type
+                || field.contains("fields");
     }
 
     @Override

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/rollup/RollupCapsResponseTestCase.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/rollup/RollupCapsResponseTestCase.java
@@ -25,6 +25,7 @@ import org.elasticsearch.client.rollup.job.config.MetricConfig;
 import org.elasticsearch.client.rollup.job.config.RollupJobConfig;
 import org.elasticsearch.client.rollup.job.config.RollupJobConfigTests;
 import org.elasticsearch.client.rollup.job.config.TermsGroupConfig;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
@@ -40,6 +41,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonMap;
@@ -55,15 +57,23 @@ abstract class RollupCapsResponseTestCase<T> extends ESTestCase {
 
     protected abstract T fromXContent(XContentParser parser) throws IOException;
 
+    protected Predicate<String> randomFieldsExcludeFilter() {
+        return field -> false;
+    }
+
+    protected String[] shuffleFieldsExceptions() {
+        return Strings.EMPTY_ARRAY;
+    }
+
     public void testFromXContent() throws IOException {
         xContentTester(
             this::createParser,
             this::createTestInstance,
             this::toXContent,
             this::fromXContent)
-            .supportsUnknownFields(false)
-            .randomFieldsExcludeFilter(field ->
-                field.endsWith("job_id"))
+            .supportsUnknownFields(true)
+            .randomFieldsExcludeFilter(randomFieldsExcludeFilter())
+            .shuffleFieldsExceptions(shuffleFieldsExceptions())
             .test();
     }
 


### PR DESCRIPTION
This commit ensures that the parts of rollup caps that can allow unknown
fields will allow them. It also modifies the test such that we can use
the features we need for disallowing fields in spots where they would
not be allowed.

Relates #36938
Backport of #38339
