### PR TITLE
Deprecate types in rollover index API (#38389)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesClient.java
@@ -42,8 +42,6 @@ import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
 import org.elasticsearch.action.admin.indices.open.OpenIndexResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
-import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
-import org.elasticsearch.action.admin.indices.rollover.RolloverResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
@@ -65,6 +63,8 @@ import org.elasticsearch.client.indices.GetMappingsResponse;
 import org.elasticsearch.client.indices.IndexTemplatesExistRequest;
 import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.client.indices.UnfreezeIndexRequest;
+import org.elasticsearch.client.indices.rollover.RolloverRequest;
+import org.elasticsearch.client.indices.rollover.RolloverResponse;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
@@ -1235,19 +1235,6 @@ public final class IndicesClient {
     }
 
     /**
-     * Rolls over an index using the Rollover Index API.
-     * <p>
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html">
-     * Rollover Index API on elastic.co</a>
-     * @deprecated Prefer {@link #rollover(RolloverRequest, RequestOptions)}
-     */
-    @Deprecated
-    public RolloverResponse rollover(RolloverRequest rolloverRequest, Header... headers) throws IOException {
-        return restHighLevelClient.performRequestAndParseEntity(rolloverRequest, IndicesRequestConverters::rollover,
-                RolloverResponse::fromXContent, emptySet(), headers);
-    }
-
-    /**
      * Asynchronously rolls over an index using the Rollover Index API.
      * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html">
      * Rollover Index API on elastic.co</a>
@@ -1261,16 +1248,76 @@ public final class IndicesClient {
     }
 
     /**
+     * Rolls over an index using the Rollover Index API.
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html">
+     * Rollover Index API on elastic.co</a>
+     * @param rolloverRequest the request
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @return the response
+     * @throws IOException in case there is a problem sending the request or parsing back the response
+     *
+     * @deprecated This method uses deprecated request and response objects.
+     * The method {@link #rollover(RolloverRequest, RequestOptions)} should be used instead, which accepts a new request object.
+     */
+    @Deprecated
+    public org.elasticsearch.action.admin.indices.rollover.RolloverResponse rollover(
+            org.elasticsearch.action.admin.indices.rollover.RolloverRequest rolloverRequest, 
+            RequestOptions options) throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(rolloverRequest, IndicesRequestConverters::rollover, options,
+                org.elasticsearch.action.admin.indices.rollover.RolloverResponse::fromXContent, emptySet());
+    }
+
+    /**
+     * Rolls over an index using the Rollover Index API.
+     * <p>
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html">
+     * Rollover Index API on elastic.co</a>
+     * 
+     * @deprecated This method uses deprecated request and response objects.
+     * The method {@link #rollover(RolloverRequest, RequestOptions)} should be used instead, which accepts a new request object.
+     */
+    @Deprecated
+    public org.elasticsearch.action.admin.indices.rollover.RolloverResponse rollover(
+            org.elasticsearch.action.admin.indices.rollover.RolloverRequest rolloverRequest, 
+            Header... headers) throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(rolloverRequest, IndicesRequestConverters::rollover,
+                org.elasticsearch.action.admin.indices.rollover.RolloverResponse::fromXContent, emptySet(), headers);
+    }
+
+    /**
+     * Asynchronously rolls over an index using the Rollover Index API.
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html">
+     * Rollover Index API on elastic.co</a>
+     * @param rolloverRequest the request
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @param listener the listener to be notified upon request completion
+     *
+     * @deprecated This method uses deprecated request and response objects.
+     * The method {@link #rolloverAsync(RolloverRequest, RequestOptions, ActionListener)} should be used instead, which
+     * accepts a new request object.
+     */
+    @Deprecated
+    public void rolloverAsync(org.elasticsearch.action.admin.indices.rollover.RolloverRequest rolloverRequest, 
+        RequestOptions options, ActionListener<org.elasticsearch.action.admin.indices.rollover.RolloverResponse> listener) {
+        restHighLevelClient.performRequestAsyncAndParseEntity(rolloverRequest, IndicesRequestConverters::rollover, options,
+                org.elasticsearch.action.admin.indices.rollover.RolloverResponse::fromXContent, listener, emptySet());
+    }
+
+    /**
      * Asynchronously rolls over an index using the Rollover Index API.
      * <p>
      * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html">
      * Rollover Index API on elastic.co</a>
-     * @deprecated Prefer {@link #rolloverAsync(RolloverRequest, RequestOptions, ActionListener)}
+     *
+     * @deprecated This method uses deprecated request and response objects.
+     * The method {@link #rolloverAsync(RolloverRequest, RequestOptions, ActionListener)} should be used instead, which
+     * accepts a new request object.
      */
     @Deprecated
-    public void rolloverAsync(RolloverRequest rolloverRequest, ActionListener<RolloverResponse> listener, Header... headers) {
+    public void rolloverAsync(org.elasticsearch.action.admin.indices.rollover.RolloverRequest rolloverRequest, 
+        ActionListener<org.elasticsearch.action.admin.indices.rollover.RolloverResponse> listener, Header... headers) {
         restHighLevelClient.performRequestAsyncAndParseEntity(rolloverRequest, IndicesRequestConverters::rollover,
-                RolloverResponse::fromXContent, listener, emptySet(), headers);
+                org.elasticsearch.action.admin.indices.rollover.RolloverResponse::fromXContent, listener, emptySet(), headers);
     }
 
     /**

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
@@ -37,7 +37,6 @@ import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.client.indices.GetFieldMappingsRequest;
 import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
-import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.admin.indices.shrink.ResizeRequest;
@@ -53,6 +52,7 @@ import org.elasticsearch.client.indices.GetMappingsRequest;
 import org.elasticsearch.client.indices.IndexTemplatesExistRequest;
 import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.client.indices.UnfreezeIndexRequest;
+import org.elasticsearch.client.indices.rollover.RolloverRequest;
 import org.elasticsearch.common.Strings;
 
 import java.io.IOException;
@@ -344,7 +344,7 @@ final class IndicesRequestConverters {
 
     static Request rollover(RolloverRequest rolloverRequest) throws IOException {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPart(rolloverRequest.getAlias()).addPathPartAsIs("_rollover")
-                .addPathPart(rolloverRequest.getNewIndexName()).build();
+            .addPathPart(rolloverRequest.getNewIndexName()).build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
         RequestConverters.Params params = new RequestConverters.Params(request);
@@ -354,8 +354,28 @@ final class IndicesRequestConverters {
         if (rolloverRequest.isDryRun()) {
             params.putParam("dry_run", Boolean.TRUE.toString());
         }
+        params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "false");
 
         request.setEntity(RequestConverters.createEntity(rolloverRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        return request;
+    }
+
+    @Deprecated
+    static Request rollover(org.elasticsearch.action.admin.indices.rollover.RolloverRequest rolloverRequest) throws IOException {
+        String endpoint = new RequestConverters.EndpointBuilder().addPathPart(rolloverRequest.getAlias()).addPathPartAsIs("_rollover")
+            .addPathPart(rolloverRequest.getNewIndexName()).build();
+        Request request = new Request(HttpPost.METHOD_NAME, endpoint);
+
+        RequestConverters.Params params = new RequestConverters.Params(request);
+        params.withTimeout(rolloverRequest.timeout());
+        params.withMasterTimeout(rolloverRequest.masterNodeTimeout());
+        params.withWaitForActiveShards(rolloverRequest.getCreateIndexRequest().waitForActiveShards());
+        if (rolloverRequest.isDryRun()) {
+            params.putParam("dry_run", Boolean.TRUE.toString());
+        }
+        params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
+        request.setEntity(RequestConverters.createEntity(rolloverRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+
         return request;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/TimedRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/TimedRequest.java
@@ -36,11 +36,19 @@ public abstract class TimedRequest implements Validatable {
     private TimeValue timeout = DEFAULT_ACK_TIMEOUT;
     private TimeValue masterTimeout = DEFAULT_MASTER_NODE_TIMEOUT;
 
+    /**
+     * Sets the timeout to wait for the all the nodes to acknowledge
+     * @param timeout timeout as a {@link TimeValue}
+     */
     public void setTimeout(TimeValue timeout) {
         this.timeout = timeout;
 
     }
 
+    /**
+     * Sets the timeout to connect to the master node
+     * @param masterTimeout timeout as a {@link TimeValue}
+     */
     public void setMasterTimeout(TimeValue masterTimeout) {
         this.masterTimeout = masterTimeout;
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/CreateIndexRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/CreateIndexRequest.java
@@ -338,10 +338,14 @@ public class CreateIndexRequest extends TimedRequest implements Validatable, ToX
         return this;
     }
 
-    @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
+        innerToXContent(builder, params);
+        builder.endObject();
+        return builder;
+    }
 
+    public XContentBuilder innerToXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(SETTINGS.getPreferredName());
         settings.toXContent(builder, params);
         builder.endObject();
@@ -356,8 +360,6 @@ public class CreateIndexRequest extends TimedRequest implements Validatable, ToX
         for (Alias alias : aliases) {
             alias.toXContent(builder, params);
         }
-        builder.endObject();
-
         builder.endObject();
         return builder;
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/rollover/RolloverRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/rollover/RolloverRequest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.indices.rollover;
+
+import org.elasticsearch.action.admin.indices.rollover.Condition;
+import org.elasticsearch.action.admin.indices.rollover.MaxAgeCondition;
+import org.elasticsearch.action.admin.indices.rollover.MaxDocsCondition;
+import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
+import org.elasticsearch.client.TimedRequest;
+import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Request class to swap index under an alias upon satisfying conditions
+ */
+public class RolloverRequest extends TimedRequest implements ToXContentObject {
+
+    private final String alias;
+    private final String newIndexName;
+    private boolean dryRun;
+    private final Map<String, Condition<?>> conditions = new HashMap<>(2);
+    //the index name "_na_" is never read back, what matters are settings, mappings and aliases
+    private final CreateIndexRequest createIndexRequest = new CreateIndexRequest("_na_");
+
+    public RolloverRequest(String alias, String newIndexName) {
+        if (alias == null) {
+            throw new IllegalArgumentException("The index alias cannot be null!");
+        }
+        this.alias = alias;
+        this.newIndexName = newIndexName;
+    }
+
+    /**
+     * Returns the alias of the rollover operation
+     */
+    public String getAlias() {
+        return alias;
+    }
+
+    /**
+     * Returns the new index name for the rollover
+     */
+    public String getNewIndexName() {
+        return newIndexName;
+    }
+
+
+    /**
+     * Sets if the rollover should not be executed when conditions are met
+     */
+    public RolloverRequest dryRun(boolean dryRun) {
+        this.dryRun = dryRun;
+        return this;
+    }
+    /**
+     * Returns if the rollover should not be executed when conditions are met
+     */
+    public boolean isDryRun() {
+        return dryRun;
+    }
+
+    /**
+     * Adds condition to check if the index is at least <code>age</code> old
+     */
+    public RolloverRequest addMaxIndexAgeCondition(TimeValue age) {
+        MaxAgeCondition maxAgeCondition = new MaxAgeCondition(age);
+        if (this.conditions.containsKey(maxAgeCondition.name())) {
+            throw new IllegalArgumentException(maxAgeCondition.name() + " condition is already set");
+        }
+        this.conditions.put(maxAgeCondition.name(), maxAgeCondition);
+        return this;
+    }
+
+    /**
+     * Adds condition to check if the index has at least <code>numDocs</code>
+     */
+    public RolloverRequest addMaxIndexDocsCondition(long numDocs) {
+        MaxDocsCondition maxDocsCondition = new MaxDocsCondition(numDocs);
+        if (this.conditions.containsKey(maxDocsCondition.name())) {
+            throw new IllegalArgumentException(maxDocsCondition.name() + " condition is already set");
+        }
+        this.conditions.put(maxDocsCondition.name(), maxDocsCondition);
+        return this;
+    }
+    /**
+     * Adds a size-based condition to check if the index size is at least <code>size</code>.
+     */
+    public RolloverRequest addMaxIndexSizeCondition(ByteSizeValue size) {
+        MaxSizeCondition maxSizeCondition = new MaxSizeCondition(size);
+        if (this.conditions.containsKey(maxSizeCondition.name())) {
+            throw new IllegalArgumentException(maxSizeCondition + " condition is already set");
+        }
+        this.conditions.put(maxSizeCondition.name(), maxSizeCondition);
+        return this;
+    }
+    /**
+     * Returns all set conditions
+     */
+    public Map<String, Condition<?>> getConditions() {
+        return conditions;
+    }
+
+    /**
+     * Returns the inner {@link CreateIndexRequest}. Allows to configure mappings, settings and aliases for the new index.
+     */
+    public CreateIndexRequest getCreateIndexRequest() {
+        return createIndexRequest;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        createIndexRequest.innerToXContent(builder, params);
+
+        builder.startObject("conditions");
+        for (Condition<?> condition : conditions.values()) {
+            condition.toXContent(builder, params);
+        }
+        builder.endObject();
+
+        builder.endObject();
+        return builder;
+    }
+
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/rollover/RolloverResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/rollover/RolloverResponse.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.indices.rollover;
+
+import org.elasticsearch.action.support.master.ShardsAcknowledgedResponse;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+
+/**
+ * Response object for {@link RolloverRequest} API
+ */
+public final class RolloverResponse extends ShardsAcknowledgedResponse {
+
+    private static final ParseField NEW_INDEX = new ParseField("new_index");
+    private static final ParseField OLD_INDEX = new ParseField("old_index");
+    private static final ParseField DRY_RUN = new ParseField("dry_run");
+    private static final ParseField ROLLED_OVER = new ParseField("rolled_over");
+    private static final ParseField CONDITIONS = new ParseField("conditions");
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<RolloverResponse, Void> PARSER = new ConstructingObjectParser<>("rollover",
+            true, args -> new RolloverResponse((String) args[0], (String) args[1], (Map<String,Boolean>) args[2],
+            (Boolean)args[3], (Boolean)args[4], (Boolean) args[5], (Boolean) args[6]));
+
+    static {
+        PARSER.declareString(constructorArg(), OLD_INDEX);
+        PARSER.declareString(constructorArg(), NEW_INDEX);
+        PARSER.declareObject(constructorArg(), (parser, context) -> parser.map(), CONDITIONS);
+        PARSER.declareBoolean(constructorArg(), DRY_RUN);
+        PARSER.declareBoolean(constructorArg(), ROLLED_OVER);
+        declareAcknowledgedAndShardsAcknowledgedFields(PARSER);
+    }
+
+    private final String oldIndex;
+    private final String newIndex;
+    private final Map<String, Boolean> conditionStatus;
+    private final boolean dryRun;
+    private final boolean rolledOver;
+
+    public RolloverResponse(String oldIndex, String newIndex, Map<String, Boolean> conditionResults,
+                            boolean dryRun, boolean rolledOver, boolean acknowledged, boolean shardsAcknowledged) {
+        super(acknowledged, shardsAcknowledged);
+        this.oldIndex = oldIndex;
+        this.newIndex = newIndex;
+        this.dryRun = dryRun;
+        this.rolledOver = rolledOver;
+        this.conditionStatus = conditionResults;
+    }
+
+    /**
+     * Returns the name of the index that the request alias was pointing to
+     */
+    public String getOldIndex() {
+        return oldIndex;
+    }
+
+    /**
+     * Returns the name of the index that the request alias currently points to
+     */
+    public String getNewIndex() {
+        return newIndex;
+    }
+
+    /**
+     * Returns the statuses of all the request conditions
+     */
+    public Map<String, Boolean> getConditionStatus() {
+        return conditionStatus;
+    }
+
+    /**
+     * Returns if the rollover execution was skipped even when conditions were met
+     */
+    public boolean isDryRun() {
+        return dryRun;
+    }
+
+    /**
+     * Returns true if the rollover was not simulated and the conditions were met
+     */
+    public boolean isRolledOver() {
+        return rolledOver;
+    }
+
+    public static RolloverResponse fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (super.equals(o)) {
+            RolloverResponse that = (RolloverResponse) o;
+            return dryRun == that.dryRun &&
+                    rolledOver == that.rolledOver &&
+                    Objects.equals(oldIndex, that.oldIndex) &&
+                    Objects.equals(newIndex, that.newIndex) &&
+                    Objects.equals(conditionStatus, that.conditionStatus);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), oldIndex, newIndex, conditionStatus, dryRun, rolledOver);
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -47,8 +47,6 @@ import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
 import org.elasticsearch.action.admin.indices.open.OpenIndexResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
-import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
-import org.elasticsearch.action.admin.indices.rollover.RolloverResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
@@ -76,6 +74,8 @@ import org.elasticsearch.client.indices.GetMappingsResponse;
 import org.elasticsearch.client.indices.IndexTemplatesExistRequest;
 import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.client.indices.UnfreezeIndexRequest;
+import org.elasticsearch.client.indices.rollover.RolloverRequest;
+import org.elasticsearch.client.indices.rollover.RolloverResponse;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
@@ -89,6 +89,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -98,6 +99,7 @@ import org.elasticsearch.rest.action.admin.indices.RestCreateIndexAction;
 import org.elasticsearch.rest.action.admin.indices.RestGetFieldMappingAction;
 import org.elasticsearch.rest.action.admin.indices.RestGetMappingAction;
 import org.elasticsearch.rest.action.admin.indices.RestPutMappingAction;
+import org.elasticsearch.rest.action.admin.indices.RestRolloverIndexAction;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -1106,7 +1108,6 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
 
         {
             RolloverResponse rolloverResponse = execute(rolloverRequest, highLevelClient().indices()::rollover,
-                    highLevelClient().indices()::rolloverAsync, highLevelClient().indices()::rollover,
                     highLevelClient().indices()::rolloverAsync);
             assertFalse(rolloverResponse.isRolledOver());
             assertFalse(rolloverResponse.isDryRun());
@@ -1126,7 +1127,6 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
             rolloverRequest.addMaxIndexAgeCondition(new TimeValue(1));
             rolloverRequest.dryRun(true);
             RolloverResponse rolloverResponse = execute(rolloverRequest, highLevelClient().indices()::rollover,
-                    highLevelClient().indices()::rolloverAsync, highLevelClient().indices()::rollover,
                     highLevelClient().indices()::rolloverAsync);
             assertFalse(rolloverResponse.isRolledOver());
             assertTrue(rolloverResponse.isDryRun());
@@ -1138,10 +1138,11 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
             assertEquals("test_new", rolloverResponse.getNewIndex());
         }
         {
+            String mappings = "{\"properties\":{\"field2\":{\"type\":\"keyword\"}}}";
+            rolloverRequest.getCreateIndexRequest().mapping(mappings, XContentType.JSON);
             rolloverRequest.dryRun(false);
             rolloverRequest.addMaxIndexSizeCondition(new ByteSizeValue(1, ByteSizeUnit.MB));
             RolloverResponse rolloverResponse = execute(rolloverRequest, highLevelClient().indices()::rollover,
-                    highLevelClient().indices()::rolloverAsync, highLevelClient().indices()::rollover,
                     highLevelClient().indices()::rolloverAsync);
             assertTrue(rolloverResponse.isRolledOver());
             assertFalse(rolloverResponse.isDryRun());
@@ -1153,6 +1154,34 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
             assertEquals("test", rolloverResponse.getOldIndex());
             assertEquals("test_new", rolloverResponse.getNewIndex());
         }
+    }
+
+    public void testRolloverWithTypes() throws IOException {
+        highLevelClient().indices().create(new CreateIndexRequest("test").alias(new Alias("alias")), RequestOptions.DEFAULT);
+        highLevelClient().index(new IndexRequest("test", "_doc", "1").source("field", "value"), RequestOptions.DEFAULT);
+        highLevelClient().index(new IndexRequest("test", "_doc", "2").source("field", "value")
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL), RequestOptions.DEFAULT);
+
+        org.elasticsearch.action.admin.indices.rollover.RolloverRequest rolloverRequest =
+            new org.elasticsearch.action.admin.indices.rollover.RolloverRequest("alias", "test_new");
+        rolloverRequest.addMaxIndexDocsCondition(1);
+
+        Settings.Builder settings = Settings.builder().put("number_of_shards", 1);
+        rolloverRequest.getCreateIndexRequest().mapping("_doc", "field2", "type=keyword")
+            .settings(settings);
+
+        org.elasticsearch.action.admin.indices.rollover.RolloverResponse rolloverResponse = execute(
+            rolloverRequest,
+            highLevelClient().indices()::rollover,
+            highLevelClient().indices()::rolloverAsync,
+            expectWarnings(RestRolloverIndexAction.TYPES_DEPRECATION_MESSAGE)
+        );
+        assertTrue(rolloverResponse.isRolledOver());
+        assertFalse(rolloverResponse.isDryRun());
+        Map<String, Boolean> conditionStatus = rolloverResponse.getConditionStatus();
+        assertTrue(conditionStatus.get("[max_docs: 1]"));
+        assertEquals("test", rolloverResponse.getOldIndex());
+        assertEquals("test_new", rolloverResponse.getNewIndex());
     }
 
     public void testGetAlias() throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
@@ -39,7 +39,6 @@ import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
-import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.admin.indices.shrink.ResizeRequest;
@@ -56,6 +55,7 @@ import org.elasticsearch.client.indices.GetMappingsRequest;
 import org.elasticsearch.client.indices.IndexTemplatesExistRequest;
 import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.client.indices.RandomCreateIndexGenerator;
+import org.elasticsearch.client.indices.rollover.RolloverRequest;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
@@ -75,7 +75,8 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.elasticsearch.index.RandomCreateIndexGenerator.randomAliases;
+import static org.elasticsearch.client.indices.RandomCreateIndexGenerator.randomAliases;
+import static org.elasticsearch.client.indices.RandomCreateIndexGenerator.randomMapping;
 import static org.elasticsearch.index.RandomCreateIndexGenerator.randomIndexSettings;
 import static org.elasticsearch.index.alias.RandomAliasActionsGenerator.randomAliasAction;
 import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
@@ -812,7 +813,7 @@ public class IndicesRequestConvertersTests extends ESTestCase {
                 createIndexRequest.settings(randomIndexSettings());
             }
             if (ESTestCase.randomBoolean()) {
-                randomAliases(createIndexRequest);
+                org.elasticsearch.index.RandomCreateIndexGenerator.randomAliases(createIndexRequest);
             }
             resizeRequest.setTargetIndex(createIndexRequest);
         }
@@ -831,6 +832,47 @@ public class IndicesRequestConvertersTests extends ESTestCase {
         RolloverRequest rolloverRequest = new RolloverRequest(ESTestCase.randomAlphaOfLengthBetween(3, 10),
                 ESTestCase.randomBoolean() ? null : ESTestCase.randomAlphaOfLengthBetween(3, 10));
         Map<String, String> expectedParams = new HashMap<>();
+        RequestConvertersTests.setRandomTimeout(rolloverRequest, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT, expectedParams);
+        RequestConvertersTests.setRandomMasterTimeout(rolloverRequest, expectedParams);
+        if (ESTestCase.randomBoolean()) {
+            rolloverRequest.dryRun(ESTestCase.randomBoolean());
+            if (rolloverRequest.isDryRun()) {
+                expectedParams.put("dry_run", "true");
+            }
+        }
+        expectedParams.put(INCLUDE_TYPE_NAME_PARAMETER, "false");
+        if (ESTestCase.randomBoolean()) {
+            rolloverRequest.addMaxIndexAgeCondition(new TimeValue(ESTestCase.randomNonNegativeLong()));
+        }
+        if (ESTestCase.randomBoolean()) {
+            rolloverRequest.getCreateIndexRequest().mapping(randomMapping());
+        }
+        if (ESTestCase.randomBoolean()) {
+            randomAliases(rolloverRequest.getCreateIndexRequest());
+        }
+        if (ESTestCase.randomBoolean()) {
+            rolloverRequest.getCreateIndexRequest().settings(
+                org.elasticsearch.index.RandomCreateIndexGenerator.randomIndexSettings());
+        }
+        RequestConvertersTests.setRandomWaitForActiveShards(rolloverRequest.getCreateIndexRequest()::waitForActiveShards, expectedParams);
+
+        Request request = IndicesRequestConverters.rollover(rolloverRequest);
+        if (rolloverRequest.getNewIndexName() == null) {
+            Assert.assertEquals("/" + rolloverRequest.getAlias() + "/_rollover", request.getEndpoint());
+        } else {
+            Assert.assertEquals("/" + rolloverRequest.getAlias() + "/_rollover/" + rolloverRequest.getNewIndexName(),
+                request.getEndpoint());
+        }
+        Assert.assertEquals(HttpPost.METHOD_NAME, request.getMethod());
+        RequestConvertersTests.assertToXContentBody(rolloverRequest, request.getEntity());
+        Assert.assertEquals(expectedParams, request.getParameters());
+    }
+
+    public void testRolloverWithTypes() throws IOException {
+        org.elasticsearch.action.admin.indices.rollover.RolloverRequest rolloverRequest =
+            new  org.elasticsearch.action.admin.indices.rollover.RolloverRequest(ESTestCase.randomAlphaOfLengthBetween(3, 10),
+            ESTestCase.randomBoolean() ? null : ESTestCase.randomAlphaOfLengthBetween(3, 10));
+        Map<String, String> expectedParams = new HashMap<>();
         RequestConvertersTests.setRandomTimeout(rolloverRequest::timeout, rolloverRequest.timeout(), expectedParams);
         RequestConvertersTests.setRandomMasterTimeout(rolloverRequest, expectedParams);
         if (ESTestCase.randomBoolean()) {
@@ -839,6 +881,7 @@ public class IndicesRequestConvertersTests extends ESTestCase {
                 expectedParams.put("dry_run", "true");
             }
         }
+        expectedParams.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
         if (ESTestCase.randomBoolean()) {
             rolloverRequest.addMaxIndexAgeCondition(new TimeValue(ESTestCase.randomNonNegativeLong()));
         }
@@ -848,7 +891,7 @@ public class IndicesRequestConvertersTests extends ESTestCase {
                 org.elasticsearch.index.RandomCreateIndexGenerator.randomMapping(type));
         }
         if (ESTestCase.randomBoolean()) {
-            randomAliases(rolloverRequest.getCreateIndexRequest());
+            org.elasticsearch.index.RandomCreateIndexGenerator.randomAliases(rolloverRequest.getCreateIndexRequest());
         }
         if (ESTestCase.randomBoolean()) {
             rolloverRequest.getCreateIndexRequest().settings(

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -46,8 +46,6 @@ import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
 import org.elasticsearch.action.admin.indices.open.OpenIndexResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
-import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
-import org.elasticsearch.action.admin.indices.rollover.RolloverResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
@@ -79,6 +77,8 @@ import org.elasticsearch.client.indices.GetMappingsResponse;
 import org.elasticsearch.client.indices.IndexTemplatesExistRequest;
 import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.client.indices.UnfreezeIndexRequest;
+import org.elasticsearch.client.indices.rollover.RolloverRequest;
+import org.elasticsearch.client.indices.rollover.RolloverResponse;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
@@ -1824,18 +1824,16 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         // end::rollover-index-request
 
         // tag::rollover-index-request-timeout
-        request.timeout(TimeValue.timeValueMinutes(2)); // <1>
-        request.timeout("2m"); // <2>
+        request.setTimeout(TimeValue.timeValueMinutes(2)); // <1>
         // end::rollover-index-request-timeout
         // tag::rollover-index-request-masterTimeout
-        request.masterNodeTimeout(TimeValue.timeValueMinutes(1)); // <1>
-        request.masterNodeTimeout("1m"); // <2>
+        request.setMasterTimeout(TimeValue.timeValueMinutes(1)); // <1>
         // end::rollover-index-request-masterTimeout
         // tag::rollover-index-request-dryRun
         request.dryRun(true); // <1>
         // end::rollover-index-request-dryRun
         // tag::rollover-index-request-waitForActiveShards
-        request.getCreateIndexRequest().waitForActiveShards(2); // <1>
+        request.getCreateIndexRequest().waitForActiveShards(ActiveShardCount.from(2)); // <1>
         request.getCreateIndexRequest().waitForActiveShards(ActiveShardCount.DEFAULT); // <2>
         // end::rollover-index-request-waitForActiveShards
         // tag::rollover-index-request-settings
@@ -1843,7 +1841,8 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                 .put("index.number_of_shards", 4)); // <1>
         // end::rollover-index-request-settings
         // tag::rollover-index-request-mapping
-        request.getCreateIndexRequest().mapping("type", "field", "type=keyword"); // <1>
+        String mappings = "{\"properties\":{\"field-1\":{\"type\":\"keyword\"}}}";
+        request.getCreateIndexRequest().mapping(mappings, XContentType.JSON); // <1>
         // end::rollover-index-request-mapping
         // tag::rollover-index-request-alias
         request.getCreateIndexRequest().alias(new Alias("another_alias")); // <1>

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/RandomCreateIndexGenerator.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/RandomCreateIndexGenerator.java
@@ -24,6 +24,9 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.io.IOException;
 
+import static org.elasticsearch.index.RandomCreateIndexGenerator.randomAlias;
+import static org.elasticsearch.test.ESTestCase.randomIntBetween;
+
 public class RandomCreateIndexGenerator {
 
     /**
@@ -57,5 +60,15 @@ public class RandomCreateIndexGenerator {
         org.elasticsearch.index.RandomCreateIndexGenerator.randomMappingFields(builder, true);
         builder.endObject();
         return builder;
+    }
+
+    /**
+     * Sets random aliases to the provided {@link CreateIndexRequest}
+     */
+    public static void randomAliases(CreateIndexRequest request) {
+        int aliasesNo = randomIntBetween(0, 2);
+        for (int i = 0; i < aliasesNo; i++) {
+            request.alias(randomAlias());
+        }
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/rollover/RolloverRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/rollover/RolloverRequestTests.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.indices.rollover;
+
+import org.elasticsearch.action.admin.indices.rollover.Condition;
+import org.elasticsearch.action.admin.indices.rollover.MaxAgeCondition;
+import org.elasticsearch.action.admin.indices.rollover.MaxDocsCondition;
+import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+
+public class RolloverRequestTests extends ESTestCase {
+    public void testConstructorAndFieldAssignments() {
+        // test constructor
+        String alias = randomAlphaOfLength(5);
+        String newIndexName = null;
+        if (randomBoolean()) {
+            newIndexName = randomAlphaOfLength(8);
+        }
+        RolloverRequest rolloverRequest = new RolloverRequest(alias, newIndexName);
+        assertEquals(alias, rolloverRequest.getAlias());
+        assertEquals(newIndexName, rolloverRequest.getNewIndexName());
+
+        // test assignment of conditions
+        MaxAgeCondition maxAgeCondition = new MaxAgeCondition(new TimeValue(10));
+        MaxSizeCondition maxSizeCondition = new MaxSizeCondition(new ByteSizeValue(2000));
+        MaxDocsCondition maxDocsCondition = new MaxDocsCondition(10000L);
+        Condition<?>[] expectedConditions = new Condition<?>[] {maxAgeCondition, maxSizeCondition, maxDocsCondition};
+        rolloverRequest.addMaxIndexAgeCondition(maxAgeCondition.value());
+        rolloverRequest.addMaxIndexSizeCondition(maxSizeCondition.value());
+        rolloverRequest.addMaxIndexDocsCondition(maxDocsCondition.value());
+        List<Condition<?>> requestConditions = new ArrayList<>(rolloverRequest.getConditions().values());
+        assertThat(requestConditions, containsInAnyOrder(expectedConditions));
+    }
+
+    public void testValidation() {
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () ->
+            new RolloverRequest(null, null));
+        assertEquals("The index alias cannot be null!", exception.getMessage());
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/rollover/RolloverResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/rollover/RolloverResponseTests.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.indices.rollover;
+
+import org.elasticsearch.action.admin.indices.rollover.Condition;
+import org.elasticsearch.action.admin.indices.rollover.MaxAgeCondition;
+import org.elasticsearch.action.admin.indices.rollover.MaxDocsCondition;
+import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.common.xcontent.ToXContent.Params;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.Collections;
+
+import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
+
+public class RolloverResponseTests extends ESTestCase {
+
+    private static final List<Supplier<Condition<?>>> conditionSuppliers = new ArrayList<>();
+    static {
+        conditionSuppliers.add(() -> new MaxAgeCondition(new TimeValue(randomNonNegativeLong())));
+        conditionSuppliers.add(() -> new MaxSizeCondition(new ByteSizeValue(randomNonNegativeLong())));
+        conditionSuppliers.add(() -> new MaxDocsCondition(randomNonNegativeLong()));
+    }
+
+    public void testFromXContent() throws IOException {
+        xContentTester(
+            this::createParser,
+            RolloverResponseTests::createTestInstance,
+            RolloverResponseTests::toXContent,
+            RolloverResponse::fromXContent)
+            .supportsUnknownFields(true)
+            .randomFieldsExcludeFilter(getRandomFieldsExcludeFilter())
+            .test();
+    }
+
+    private static RolloverResponse createTestInstance() {
+        final String oldIndex = randomAlphaOfLength(8);
+        final String newIndex = randomAlphaOfLength(8);
+        final boolean dryRun = randomBoolean();
+        final boolean rolledOver = randomBoolean();
+        final boolean acknowledged = randomBoolean();
+        final boolean shardsAcknowledged = acknowledged && randomBoolean();
+
+        Map<String, Boolean> results = new HashMap<>();
+        int numResults = randomIntBetween(0, 3);
+        List<Supplier<Condition<?>>> conditions = randomSubsetOf(numResults, conditionSuppliers);
+        conditions.forEach(condition -> results.put(condition.get().name(), randomBoolean()));
+
+        return new RolloverResponse(oldIndex, newIndex, results, dryRun, rolledOver, acknowledged, shardsAcknowledged);
+    }
+
+    private Predicate<String> getRandomFieldsExcludeFilter() {
+        return field -> field.startsWith("conditions");
+    }
+
+    private static void toXContent(RolloverResponse response, XContentBuilder builder) throws IOException {
+        Params params = new ToXContent.MapParams(
+            Collections.singletonMap(BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER, "false"));
+        org.elasticsearch.action.admin.indices.rollover.RolloverResponse serverResponse =
+            new org.elasticsearch.action.admin.indices.rollover.RolloverResponse(
+                response.getOldIndex(),
+                response.getNewIndex(),
+                response.getConditionStatus(),
+                response.isDryRun(),
+                response.isRolledOver(),
+                response.isAcknowledged(),
+                response.isShardsAcknowledged()
+            );
+        serverResponse.toXContent(builder, params);
+    }
+}

--- a/docs/java-rest/high-level/indices/rollover.asciidoc
+++ b/docs/java-rest/high-level/indices/rollover.asciidoc
@@ -19,7 +19,8 @@ one or more conditions that determine when the index has to be rolled over:
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> The alias (first argument) that points to the index to rollover, and
-optionally the name of the new index in case the rollover operation is performed
+the name of the new index in case the rollover operation is performed.
+The new index argument is optional, and can be set to null
 <2> Condition on the age of the index
 <3> Condition on the number of documents in the index
 <4> Condition on the size of the index
@@ -39,24 +40,20 @@ include-tagged::{doc-tests-file}[{api}-request-timeout]
 --------------------------------------------------
 <1> Timeout to wait for the all the nodes to acknowledge the index is opened
 as a `TimeValue`
-<2> Timeout to wait for the all the nodes to acknowledge the index is opened
-as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request-masterTimeout]
 --------------------------------------------------
 <1> Timeout to connect to the master node as a `TimeValue`
-<2> Timeout to connect to the master node as a `String`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request-waitForActiveShards]
 --------------------------------------------------
-<1> The number of active shard copies to wait for before the rollover index API
-returns a response, as an `int`
-<2> The number of active shard copies to wait for before the rollover index API
-returns a response, as an `ActiveShardCount`
+<1> Sets the number of active shard copies to wait for before the rollover
+index API returns a response
+<2> Resets the number of active shard copies to wait for to the default value
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -98,5 +95,3 @@ each shard in the index before timing out
 <5> Whether the index has been rolled over
 <6> Whether the operation was performed or it was a dry run
 <7> The different conditions and whether they were matched or not
-
-

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
@@ -18,6 +18,10 @@
         }
       },
       "params": {
+        "include_type_name": {
+          "type" : "boolean",
+          "description" : "Whether a type should be included in the body of the mappings."
+        },
         "timeout": {
           "type" : "time",
           "description" : "Explicit operation timeout"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/40_mapping.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/40_mapping.yml
@@ -1,0 +1,47 @@
+---
+"Typeless mapping":
+  - skip:
+      version: " - 6.6.99"
+      reason: include_type_name was introduced in 6.7.0
+
+  - do:
+      indices.create:
+        include_type_name: false
+        index: logs-1
+        body:
+          aliases:
+            logs_search: {}
+
+  # index first document and wait for refresh
+  - do:
+      index:
+        index: logs-1
+        type: _doc
+        id:    "1"
+        body:  { "foo": "hello world" }
+        refresh: true
+
+  # index second document and wait for refresh
+  - do:
+      index:
+        index: logs-1
+        type: _doc
+        id:    "2"
+        body:  { "foo": "hello world" }
+        refresh: true
+
+  # perform alias rollover with new typeless mapping
+  - do:
+      indices.rollover:
+        include_type_name: false
+        alias: "logs_search"
+        body:
+          conditions:
+            max_docs: 2
+          mappings:
+            properties:
+              foo2:
+                type: keyword
+
+  - match: { conditions: { "[max_docs: 2]": true } }
+  - match: { rolled_over: true }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/41_mapping_with_types.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/41_mapping_with_types.yml
@@ -1,0 +1,47 @@
+---
+"Typeless mapping":
+  - skip:
+      version: " - 6.6.99"
+      reason: include_type_name was introduced in 6.7.0
+
+  - do:
+      indices.create:
+        index: logs-1
+        body:
+          aliases:
+            logs_search: {}
+
+  # index first document and wait for refresh
+  - do:
+      index:
+        index: logs-1
+        type:  _doc
+        id:    "1"
+        body:  { "foo": "hello world" }
+        refresh: true
+
+  # index second document and wait for refresh
+  - do:
+      index:
+        index: logs-1
+        type:  _doc
+        id:    "2"
+        body:  { "foo": "hello world" }
+        refresh: true
+
+  # perform alias rollover with new typeless mapping
+  - do:
+      indices.rollover:
+        include_type_name: true
+        alias: "logs_search"
+        body:
+          conditions:
+            max_docs: 2
+          mappings:
+            _doc:
+              properties:
+                foo2:
+                  type: keyword
+
+  - match: { conditions: { "[max_docs: 2]": true } }
+  - match: { rolled_over: true }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
@@ -75,6 +75,10 @@ public abstract class Condition<T> implements NamedWriteable, ToXContentFragment
         return value;
     }
 
+    public String name() {
+        return name;
+    }
+
     /**
      * Holder for index stats used to evaluate conditions
      */

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.MapperService;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -41,10 +42,13 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 /**
  * Request class to swap index under an alias upon satisfying conditions
+ *
+ * Note: there is a new class with the same name for the Java HLRC that uses a typeless format.
+ * Any changes done to this class should also go to that client class.
  */
 public class RolloverRequest extends AcknowledgedRequest<RolloverRequest> implements IndicesRequest, ToXContentObject {
 
-    private static final ObjectParser<RolloverRequest, Void> PARSER = new ObjectParser<>("rollover");
+    private static final ObjectParser<RolloverRequest, Boolean> PARSER = new ObjectParser<>("rollover");
     private static final ObjectParser<Map<String, Condition>, Void> CONDITION_PARSER = new ObjectParser<>("conditions");
 
     private static final ParseField CONDITIONS = new ParseField("conditions");
@@ -66,9 +70,14 @@ public class RolloverRequest extends AcknowledgedRequest<RolloverRequest> implem
             CONDITIONS, ObjectParser.ValueType.OBJECT);
         PARSER.declareField((parser, request, context) -> request.createIndexRequest.settings(parser.map()),
             CreateIndexRequest.SETTINGS, ObjectParser.ValueType.OBJECT);
-        PARSER.declareField((parser, request, context) -> {
-            for (Map.Entry<String, Object> mappingsEntry : parser.map().entrySet()) {
-                request.createIndexRequest.mapping(mappingsEntry.getKey(), (Map<String, Object>) mappingsEntry.getValue());
+        PARSER.declareField((parser, request, isTypeIncluded) -> {
+            if (isTypeIncluded) {
+                for (Map.Entry<String, Object> mappingsEntry : parser.map().entrySet()) {
+                    request.createIndexRequest.mapping(mappingsEntry.getKey(), (Map<String, Object>) mappingsEntry.getValue());
+                }
+            } else {
+                // a type is not included, add a dummy _doc type
+                request.createIndexRequest.mapping(MapperService.SINGLE_MAPPING_NAME, parser.map());
             }
         }, CreateIndexRequest.MAPPINGS, ObjectParser.ValueType.OBJECT);
         PARSER.declareField((parser, request, context) -> request.createIndexRequest.aliases(parser.map()),
@@ -230,7 +239,8 @@ public class RolloverRequest extends AcknowledgedRequest<RolloverRequest> implem
         return builder;
     }
 
-    public void fromXContent(XContentParser parser) throws IOException {
-        PARSER.parse(parser, this, null);
+    // param isTypeIncluded decides how mappings should be parsed from XContent
+    public void fromXContent(boolean isTypeIncluded, XContentParser parser) throws IOException {
+        PARSER.parse(parser, this, isTypeIncluded);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponse.java
@@ -37,6 +37,13 @@ import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 
+
+/**
+ * Response object for {@link RolloverRequest} API
+ *
+ * Note: there is a new class with the same name for the Java HLRC that uses a typeless format.
+ * Any changes done to this class should also go to that client class.
+ */
 public final class RolloverResponse extends ShardsAcknowledgedResponse implements ToXContentObject {
 
     private static final ParseField NEW_INDEX = new ParseField("new_index");

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestRolloverIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestRolloverIndexAction.java
@@ -19,9 +19,11 @@
 
 package org.elasticsearch.rest.action.admin.indices;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
@@ -31,6 +33,11 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 import java.io.IOException;
 
 public class RestRolloverIndexAction extends BaseRestHandler {
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
+        LogManager.getLogger(RestRolloverIndexAction.class));
+    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] The response format of rollover " +
+        "index requests will change in 7.0. Please start using the include_type_name parameter set to false " +
+        "to move to the new, typeless response format that will become the default.";    
     public RestRolloverIndexAction(Settings settings, RestController controller) {
         super(settings);
         controller.registerHandler(RestRequest.Method.POST, "/{index}/_rollover", this);
@@ -44,8 +51,12 @@ public class RestRolloverIndexAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        final boolean includeTypeName = request.paramAsBoolean(INCLUDE_TYPE_NAME_PARAMETER, DEFAULT_INCLUDE_TYPE_NAME_POLICY);
+        if (includeTypeName) {
+            deprecationLogger.deprecatedAndMaybeLog("index_rollover_with_types", TYPES_DEPRECATION_MESSAGE);
+        }
         RolloverRequest rolloverIndexRequest = new RolloverRequest(request.param("index"), request.param("new_index"));
-        request.applyContentParser(rolloverIndexRequest::fromXContent);
+        request.applyContentParser(parser -> rolloverIndexRequest.fromXContent(includeTypeName, parser));
         rolloverIndexRequest.dryRun(request.paramAsBoolean("dry_run", false));
         rolloverIndexRequest.timeout(request.paramAsTime("timeout", rolloverIndexRequest.timeout()));
         rolloverIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", rolloverIndexRequest.masterNodeTimeout()));

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
@@ -52,7 +52,6 @@ import static org.elasticsearch.common.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.hamcrest.Matchers.equalTo;
 
 public class RolloverRequestTests extends ESTestCase {
-
     private NamedWriteableRegistry writeableRegistry;
 
     @Override
@@ -72,7 +71,7 @@ public class RolloverRequestTests extends ESTestCase {
                     .field("max_size", "45gb")
                 .endObject()
             .endObject();
-        request.fromXContent(createParser(builder));
+        request.fromXContent(false, createParser(builder));
         Map<String, Condition> conditions = request.getConditions();
         assertThat(conditions.size(), equalTo(3));
         MaxAgeCondition maxAgeCondition = (MaxAgeCondition)conditions.get(MaxAgeCondition.NAME);
@@ -108,7 +107,7 @@ public class RolloverRequestTests extends ESTestCase {
                     .startObject("alias1").endObject()
                 .endObject()
             .endObject();
-        request.fromXContent(createParser(builder));
+        request.fromXContent(true, createParser(builder));
         Map<String, Condition> conditions = request.getConditions();
         assertThat(conditions.size(), equalTo(2));
         assertThat(request.getCreateIndexRequest().mappings().size(), equalTo(1));
@@ -147,7 +146,7 @@ public class RolloverRequestTests extends ESTestCase {
         BytesReference originalBytes = toShuffledXContent(rolloverRequest, xContentType, EMPTY_PARAMS, humanReadable);
 
         RolloverRequest parsedRolloverRequest = new RolloverRequest();
-        parsedRolloverRequest.fromXContent(createParser(xContentType.xContent(), originalBytes));
+        parsedRolloverRequest.fromXContent(true, createParser(xContentType.xContent(), originalBytes));
 
         CreateIndexRequest createIndexRequest = rolloverRequest.getCreateIndexRequest();
         CreateIndexRequest parsedCreateIndexRequest = parsedRolloverRequest.getCreateIndexRequest();
@@ -172,7 +171,7 @@ public class RolloverRequestTests extends ESTestCase {
         }
         builder.endObject();
         BytesReference mutated = XContentTestUtils.insertRandomFields(xContentType, BytesReference.bytes(builder), null, random());
-        expectThrows(XContentParseException.class, () -> request.fromXContent(createParser(xContentType.xContent(), mutated)));
+        expectThrows(XContentParseException.class, () -> request.fromXContent(false, createParser(xContentType.xContent(), mutated)));
     }
 
     public void testSameConditionCanOnlyBeAddedOnce() {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponseTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.indices.rollover;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractStreamableXContentTestCase;
@@ -57,7 +58,7 @@ public class RolloverResponseTests extends AbstractStreamableXContentTestCase<Ro
     private static final List<Supplier<Condition<?>>> conditionSuppliers = new ArrayList<>();
     static {
         conditionSuppliers.add(() -> new MaxAgeCondition(new TimeValue(randomNonNegativeLong())));
-        conditionSuppliers.add(() -> new MaxDocsCondition(randomNonNegativeLong()));
+        conditionSuppliers.add(() -> new MaxSizeCondition(new ByteSizeValue(randomNonNegativeLong())));
         conditionSuppliers.add(() -> new MaxDocsCondition(randomNonNegativeLong()));
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/RandomCreateIndexGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/RandomCreateIndexGenerator.java
@@ -126,7 +126,7 @@ public final class RandomCreateIndexGenerator {
         }
     }
 
-    private static Alias randomAlias() {
+    public static Alias randomAlias() {
         Alias alias = new Alias(randomAlphaOfLength(5));
 
         if (randomBoolean()) {


### PR DESCRIPTION
This PR is to put back #38389, after it has been reverted
#38445 has been created to fix warnings failures, so this time
this PR should not cause failures in 7.x

Backport for #38039

Relates to #35190


