### PR TITLE
Change the min supported version to 6.7.0 for API keys

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -60,7 +60,7 @@ public class Authentication implements ToXContentObject {
             this.lookedUpBy = null;
         }
         this.version = in.getVersion();
-        if (in.getVersion().onOrAfter(Version.V_7_0_0)) { // TODO change to V6_6 after backport
+        if (in.getVersion().onOrAfter(Version.V_6_7_0)) {
             type = AuthenticationType.values()[in.readVInt()];
             metadata = in.readMap();
         } else {
@@ -165,7 +165,7 @@ public class Authentication implements ToXContentObject {
         } else {
             out.writeBoolean(false);
         }
-        if (out.getVersion().onOrAfter(Version.V_7_0_0)) { // TODO change to V6_6 after backport
+        if (out.getVersion().onOrAfter(Version.V_6_7_0)) {
             out.writeVInt(type.ordinal());
             out.writeMap(metadata);
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -167,11 +167,11 @@ public class ApiKeyService {
                     final Instant expiration = getApiKeyExpiration(created, request);
                     final SecureString apiKey = UUIDs.randomBase64UUIDSecureString();
                     final Version version = clusterService.state().nodes().getMinNodeVersion();
-                    if (version.before(Version.V_7_0_0)) { // TODO(jaymode) change to V6_6_0 on backport!
+                    if (version.before(Version.V_6_7_0)) {
                         logger.warn(
                                 "nodes prior to the minimum supported version for api keys {} exist in the cluster;"
                                         + " these nodes will not be able to use api keys",
-                                Version.V_7_0_0);
+                                Version.V_6_7_0);
                     }
 
                     final char[] keyHash = hasher.hash(apiKey);


### PR DESCRIPTION
This commit changes the minimum supported version to 6.7.0
for API keys, the change for the API keys has been backported
to 6.7.0 version #38399 