### PR TITLE
Make sure to reject mappings with type _doc when include_type_name is false.

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -313,15 +313,13 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             {
                 request = new CreateIndexRequest("twitter2");
                 //tag::create-index-mappings-map
-                Map<String, Object> jsonMap = new HashMap<>();
                 Map<String, Object> message = new HashMap<>();
                 message.put("type", "text");
                 Map<String, Object> properties = new HashMap<>();
                 properties.put("message", message);
                 Map<String, Object> mapping = new HashMap<>();
                 mapping.put("properties", properties);
-                jsonMap.put("_doc", mapping);
-                request.mapping(jsonMap); // <1>
+                request.mapping(mapping); // <1>
                 //end::create-index-mappings-map
                 CreateIndexResponse createIndexResponse = client.indices().create(request, RequestOptions.DEFAULT);
                 assertTrue(createIndexResponse.isAcknowledged());
@@ -332,15 +330,11 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                 XContentBuilder builder = XContentFactory.jsonBuilder();
                 builder.startObject();
                 {
-                    builder.startObject("_doc");
+                    builder.startObject("properties");
                     {
-                        builder.startObject("properties");
+                        builder.startObject("message");
                         {
-                            builder.startObject("message");
-                            {
-                                builder.field("type", "text");
-                            }
-                            builder.endObject();
+                            builder.field("type", "text");
                         }
                         builder.endObject();
                     }
@@ -381,10 +375,8 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                     "        \"number_of_replicas\" : 0\n" +
                     "    },\n" +
                     "    \"mappings\" : {\n" +
-                    "        \"_doc\" : {\n" +
-                    "            \"properties\" : {\n" +
-                    "                \"message\" : { \"type\" : \"text\" }\n" +
-                    "            }\n" +
+                    "        \"properties\" : {\n" +
+                    "            \"message\" : { \"type\" : \"text\" }\n" +
                     "        }\n" +
                     "    },\n" +
                     "    \"aliases\" : {\n" +

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/10_basic.yml
@@ -113,3 +113,23 @@
             properties:
               "":
                 type:     keyword
+
+---
+"Create index with explicit _doc type":
+  - skip:
+      version: " - 6.6.99"
+      reason: include_type_name was introduced in 6.7.0
+  - do:
+      catch: bad_request
+      indices.create:
+        include_type_name: false
+        index: test_index
+        body:
+          mappings:
+            _doc:
+              properties:
+                field:
+                  type: keyword
+
+  - match: { error.type: "illegal_argument_exception" }
+  - match: { error.reason: "The mapping definition cannot be nested under a type [_doc] unless include_type_name is set to true." }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/10_basic.yml
@@ -74,3 +74,28 @@
           properties:
             "":
               type:     keyword
+
+---
+"Put mappings with explicit _doc type":
+  - skip:
+      version: " - 6.6.99"
+      reason: include_type_name was introduced in 6.7.0
+
+  - do:
+      indices.create:
+        include_type_name: false
+        index: test_index
+
+  - do:
+      catch: bad_request
+      indices.put_mapping:
+        include_type_name: false
+        index: test_index
+        body:
+          _doc:
+            properties:
+              field:
+                type: keyword
+
+  - match: { error.type: "illegal_argument_exception" }
+  - match: { error.reason: "Types cannot be provided in put mapping requests, unless the include_type_name parameter is set to true." }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_template/10_basic.yml
@@ -260,3 +260,25 @@
       indices.put_template:
         name: test
         body: {}
+
+---
+"Put template with explicit _doc type":
+  - skip:
+      version: " - 6.6.99"
+      reason: include_type_name was introduced in 6.7.0
+
+  - do:
+      catch: bad_request
+      indices.put_template:
+        include_type_name: false
+        name: test
+        body:
+          index_patterns: test-*
+          mappings:
+            _doc:
+              properties:
+                field:
+                  type: keyword
+
+  - match: { error.type: "illegal_argument_exception" }
+  - match: { error.reason: "The mapping definition cannot be nested under a type [_doc] unless include_type_name is set to true." }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/40_mapping.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/40_mapping.yml
@@ -45,3 +45,33 @@
 
   - match: { conditions: { "[max_docs: 2]": true } }
   - match: { rolled_over: true }
+
+---
+"Mappings with explicit _doc type":
+  - skip:
+      version: " - 6.6.99"
+      reason: include_type_name was introduced in 6.7.0
+
+  - do:
+      indices.create:
+        index: logs-1
+        body:
+          aliases:
+            logs_search: {}
+
+  - do:
+      catch: bad_request
+      indices.rollover:
+        include_type_name: false
+        alias: "logs_search"
+        body:
+          conditions:
+            max_docs: 2
+          mappings:
+            _doc:
+              properties:
+                field:
+                  type: keyword
+
+  - match: { error.caused_by.type: "illegal_argument_exception" }
+  - match: { error.caused_by.reason: "The mapping definition cannot be nested under a type [_doc] unless include_type_name is set to true." }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.AbstractIndexComponent;
@@ -723,6 +724,19 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         }
         mapper = parse(type, null, true);
         return new DocumentMapperForType(mapper, mapper.mapping());
+    }
+
+    /**
+     * Returns {@code true} if the given {@code mappingSource} includes a type
+     * as a top-level object.
+     */
+    public static boolean isMappingSourceTyped(String type, Map<String, Object> mapping) {
+        return mapping.size() == 1 && mapping.keySet().iterator().next().equals(type);
+    }
+
+    public static boolean isMappingSourceTyped(String type, CompressedXContent mappingSource) {
+        Map<String, Object> root = XContentHelper.convertToMap(mappingSource.compressedReference(), true, XContentType.JSON).v2();
+        return isMappingSourceTyped(type, root);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -35,7 +34,6 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 public class RestPutIndexTemplateAction extends BaseRestHandler {
@@ -72,24 +70,14 @@ public class RestPutIndexTemplateAction extends BaseRestHandler {
         putRequest.cause(request.param("cause", ""));
 
         boolean includeTypeName = request.paramAsBoolean(INCLUDE_TYPE_NAME_PARAMETER, DEFAULT_INCLUDE_TYPE_NAME_POLICY);
-        Map<String, Object> sourceAsMap = prepareRequestSource(request, includeTypeName);
+        Map<String, Object> sourceAsMap = XContentHelper.convertToMap(request.requiredContent(), false,
+            request.getXContentType()).v2();
+        if (includeTypeName && sourceAsMap.containsKey("mappings")) {
+            DEPRECATION_LOGGER.deprecatedAndMaybeLog("put_index_template_with_types", TYPES_DEPRECATION_MESSAGE);
+        }
+        sourceAsMap = RestCreateIndexAction.prepareMappings(sourceAsMap, includeTypeName);
         putRequest.source(sourceAsMap);
 
         return channel -> client.admin().indices().putTemplate(putRequest, new RestToXContentListener<>(channel));
-    }
-
-    Map<String, Object> prepareRequestSource(RestRequest request, boolean includeTypeName) {
-        Map<String, Object> sourceAsMap = XContentHelper.convertToMap(request.requiredContent(), false,
-            request.getXContentType()).v2();
-        if (includeTypeName == false && sourceAsMap.containsKey("mappings")) {
-            Map<String, Object> newSourceAsMap = new HashMap<>(sourceAsMap);
-            newSourceAsMap.put("mappings", Collections.singletonMap(MapperService.SINGLE_MAPPING_NAME, sourceAsMap.get("mappings")));
-            return newSourceAsMap;
-        } else {
-            if(includeTypeName && sourceAsMap.containsKey("mappings") ) {
-                DEPRECATION_LOGGER.deprecatedAndMaybeLog("put_index_template_with_types", TYPES_DEPRECATION_MESSAGE);                
-            }
-            return sourceAsMap;
-        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
@@ -44,7 +44,7 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestPutMappingAction extends BaseRestHandler {
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
         LogManager.getLogger(RestPutMappingAction.class));
-    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in create index " +
+    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in put mapping " +
         "requests is deprecated. To be compatible with 7.0, the mapping definition should not be nested under " +
         "the type name, and the parameter include_type_name must be provided and set to false.";
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
@@ -33,8 +34,10 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.elasticsearch.client.Requests.putMappingRequest;
+import static org.elasticsearch.index.mapper.MapperService.isMappingSourceTyped;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
@@ -76,20 +79,24 @@ public class RestPutMappingAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        final boolean includeTypeName = request.paramAsBoolean(INCLUDE_TYPE_NAME_PARAMETER,
+        PutMappingRequest putMappingRequest = putMappingRequest(Strings.splitStringByCommaToArray(request.param("index")));
+
+        boolean includeTypeName = request.paramAsBoolean(INCLUDE_TYPE_NAME_PARAMETER,
             DEFAULT_INCLUDE_TYPE_NAME_POLICY);
-        final String type = request.param("type");
+        String type = request.param("type");
+        Map<String, Object> sourceAsMap = XContentHelper.convertToMap(request.requiredContent(), false,
+            request.getXContentType()).v2();
 
         if (includeTypeName) {
             deprecationLogger.deprecatedAndMaybeLog("put_mapping_with_types", TYPES_DEPRECATION_MESSAGE);
-        } else if (type != null) {
+        } else if (type != null || isMappingSourceTyped(MapperService.SINGLE_MAPPING_NAME, sourceAsMap)) {
             throw new IllegalArgumentException("Types cannot be provided in put mapping requests, unless " +
                 "the include_type_name parameter is set to true.");
         }
 
-        PutMappingRequest putMappingRequest = putMappingRequest(Strings.splitStringByCommaToArray(request.param("index")));
         putMappingRequest.type(includeTypeName ? type : MapperService.SINGLE_MAPPING_NAME);
-        putMappingRequest.source(request.requiredContent(), request.getXContentType());
+        putMappingRequest.source(sourceAsMap);
+
         if (request.hasParam("update_all_types")) {
             deprecationLogger.deprecated("[update_all_types] is deprecated since indices may not have more than one type anymore");
         }

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexActionTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.rest.FakeRestRequest;
@@ -70,5 +71,81 @@ public class RestCreateIndexActionTests extends RestActionTestCase {
             .build();
 
         action.prepareRequest(validRequest, mock(NodeClient.class));
+    }
+
+    public void testPrepareTypelessRequest() throws IOException {
+        XContentBuilder content = XContentFactory.jsonBuilder().startObject()
+            .startObject("mappings")
+                .startObject("properties")
+                    .startObject("field1").field("type", "keyword").endObject()
+                    .startObject("field2").field("type", "text").endObject()
+                .endObject()
+            .endObject()
+            .startObject("aliases")
+                .startObject("read_alias").endObject()
+            .endObject()
+        .endObject();
+
+         Map<String, Object> contentAsMap = XContentHelper.convertToMap(
+            BytesReference.bytes(content), true, content.contentType()).v2();
+        boolean includeTypeName = false;
+        Map<String, Object> source = RestCreateIndexAction.prepareMappings(contentAsMap, includeTypeName);
+
+         XContentBuilder expectedContent = XContentFactory.jsonBuilder().startObject()
+            .startObject("mappings")
+                .startObject("_doc")
+                    .startObject("properties")
+                        .startObject("field1").field("type", "keyword").endObject()
+                        .startObject("field2").field("type", "text").endObject()
+                    .endObject()
+                .endObject()
+            .endObject()
+            .startObject("aliases")
+                .startObject("read_alias").endObject()
+            .endObject()
+        .endObject();
+        Map<String, Object> expectedContentAsMap = XContentHelper.convertToMap(
+            BytesReference.bytes(expectedContent), true, expectedContent.contentType()).v2();
+
+         assertEquals(expectedContentAsMap, source);
+    }
+
+     public void testPrepareTypedRequest() throws IOException {
+        XContentBuilder content = XContentFactory.jsonBuilder().startObject()
+            .startObject("mappings")
+                .startObject("type")
+                    .startObject("properties")
+                        .startObject("field1").field("type", "keyword").endObject()
+                        .startObject("field2").field("type", "text").endObject()
+                    .endObject()
+                .endObject()
+            .endObject()
+            .startObject("aliases")
+                .startObject("read_alias").endObject()
+            .endObject()
+        .endObject();
+
+         Map<String, Object> contentAsMap = XContentHelper.convertToMap(
+            BytesReference.bytes(content), true, content.contentType()).v2();
+        boolean includeTypeName = true;
+        Map<String, Object> source = RestCreateIndexAction.prepareMappings(contentAsMap, includeTypeName);
+
+         assertEquals(contentAsMap, source);
+    }
+
+    public void testMalformedMappings() throws IOException {
+        XContentBuilder content = XContentFactory.jsonBuilder().startObject()
+            .field("mappings", "some string")
+            .startObject("aliases")
+                .startObject("read_alias").endObject()
+            .endObject()
+        .endObject();
+
+         Map<String, Object> contentAsMap = XContentHelper.convertToMap(
+            BytesReference.bytes(content), true, content.contentType()).v2();
+
+         boolean includeTypeName = false;
+        Map<String, Object> source = RestCreateIndexAction.prepareMappings(contentAsMap, includeTypeName);
+        assertEquals(contentAsMap, source);
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateActionTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.rest.FakeRestRequest;
@@ -32,10 +31,7 @@ import org.elasticsearch.test.rest.RestActionTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
-import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
 import static org.mockito.Mockito.mock;
 
 public class RestPutIndexTemplateActionTests extends RestActionTestCase {
@@ -44,54 +40,6 @@ public class RestPutIndexTemplateActionTests extends RestActionTestCase {
     @Before
     public void setUpAction() {
         action = new RestPutIndexTemplateAction(Settings.EMPTY, controller());
-    }
-
-    public void testPrepareTypelessRequest() throws IOException {
-        XContentBuilder content = XContentFactory.jsonBuilder().startObject()
-            .startObject("mappings")
-                .startObject("properties")
-                    .startObject("field1").field("type", "keyword").endObject()
-                    .startObject("field2").field("type", "text").endObject()
-                .endObject()
-            .endObject()
-            .startObject("aliases")
-                .startObject("read_alias").endObject()
-            .endObject()
-        .endObject();
-
-        Map<String, String> params = new HashMap<>();
-        params.put(INCLUDE_TYPE_NAME_PARAMETER, "false");
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
-            .withMethod(RestRequest.Method.PUT)
-            .withParams(params)
-            .withPath("/_template/_some_template")
-            .withContent(BytesReference.bytes(content), XContentType.JSON)
-            .build();
-        action.prepareRequest(request, mock(NodeClient.class));        
-        
-        // Internally the above prepareRequest method calls prepareRequestSource to inject a 
-        // default type into the mapping. Here we test that this does what is expected by
-        // explicitly calling that same helper function
-        boolean includeTypeName = false;
-        Map<String, Object> source = action.prepareRequestSource(request, includeTypeName);
-
-        XContentBuilder expectedContent = XContentFactory.jsonBuilder().startObject()
-            .startObject("mappings")
-                .startObject("_doc")
-                    .startObject("properties")
-                        .startObject("field1").field("type", "keyword").endObject()
-                        .startObject("field2").field("type", "text").endObject()
-                    .endObject()
-                .endObject()
-            .endObject()
-            .startObject("aliases")
-                .startObject("read_alias").endObject()
-            .endObject()
-        .endObject();
-        Map<String, Object> expectedContentAsMap = XContentHelper.convertToMap(
-            BytesReference.bytes(expectedContent), true, expectedContent.contentType()).v2();
-
-        assertEquals(expectedContentAsMap, source);
     }
 
     public void testIncludeTypeName() throws IOException {
@@ -116,26 +64,5 @@ public class RestPutIndexTemplateActionTests extends RestActionTestCase {
                 .build();
         action.prepareRequest(request, mock(NodeClient.class));        
         assertWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE);
-        boolean includeTypeName = true;
-        Map<String, Object> source = action.prepareRequestSource(request, includeTypeName);
-        assertWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE);
-
-        XContentBuilder expectedContent = XContentFactory.jsonBuilder().startObject()
-            .startObject("mappings")
-                .startObject("my_doc")
-                    .startObject("properties")
-                        .startObject("field1").field("type", "keyword").endObject()
-                        .startObject("field2").field("type", "text").endObject()
-                    .endObject()
-                .endObject()
-            .endObject()
-            .startObject("aliases")
-                .startObject("read_alias").endObject()
-            .endObject()
-        .endObject();
-        Map<String, Object> expectedContentAsMap = XContentHelper.convertToMap(
-            BytesReference.bytes(expectedContent), true, expectedContent.contentType()).v2();
-
-        assertEquals(expectedContentAsMap, source);        
     }    
 }


### PR DESCRIPTION
`CreateIndexRequest#source(Map<String, Object>, ... )`, which is used when
deserializing index creation requests, accidentally accepts mappings that are
nested twice under the type key (as described in the bug report #38266).

This in turn causes us to be too lenient in parsing typeless mappings. In
particular, we accept the following index creation request, even though it
should not contain the type key `_doc`:

```
PUT index?include_type_name=false
{
  "mappings": {
    "_doc": {
      "properties": { ... }
    }
  }
}
```

There is a similar issue for both 'put templates' and 'put mappings' requests
as well.

This PR makes the minimal changes to detect and reject these typed mappings in
requests. It does not address #38266 generally, or attempt a larger refactor
around types in these server-side requests, as I think this should be done at a
later time.

Backport of #38270.