### PR TITLE
Align docs etc with new discovery setting names

### DIFF
--- a/docs/plugins/discovery-azure-classic.asciidoc
+++ b/docs/plugins/discovery-azure-classic.asciidoc
@@ -15,7 +15,7 @@ include::install_remove.asciidoc[]
 [[discovery-azure-classic-usage]]
 ==== Azure Virtual Machine Discovery
 
-Azure VM discovery allows to use the azure APIs to perform automatic discovery.
+Azure VM discovery allows to use the Azure APIs to perform automatic discovery.
 Here is a simple sample configuration:
 
 [source,yaml]

--- a/docs/plugins/discovery-azure-classic.asciidoc
+++ b/docs/plugins/discovery-azure-classic.asciidoc
@@ -1,7 +1,8 @@
 [[discovery-azure-classic]]
 === Azure Classic Discovery Plugin
 
-The Azure Classic Discovery plugin uses the Azure Classic API for unicast discovery.
+The Azure Classic Discovery plugin uses the Azure Classic API to identify the
+addresses of seed hosts.
 
 // TODO: Link to ARM plugin when ready
 // See issue https://github.com/elastic/elasticsearch/issues/19146
@@ -14,8 +15,8 @@ include::install_remove.asciidoc[]
 [[discovery-azure-classic-usage]]
 ==== Azure Virtual Machine Discovery
 
-Azure VM discovery allows to use the azure APIs to perform automatic discovery (similar to multicast in non hostile
-multicast environments). Here is a simple sample configuration:
+Azure VM discovery allows to use the azure APIs to perform automatic discovery.
+Here is a simple sample configuration:
 
 [source,yaml]
 ----

--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -1,7 +1,8 @@
 [[discovery-ec2]]
 === EC2 Discovery Plugin
 
-The EC2 discovery plugin uses the https://github.com/aws/aws-sdk-java[AWS API] for unicast discovery.
+The EC2 discovery plugin uses the https://github.com/aws/aws-sdk-java[AWS API]
+to identify the addresses of seed hosts.
 
 *If you are looking for a hosted solution of Elasticsearch on AWS, please visit http://www.elastic.co/cloud.*
 
@@ -11,12 +12,12 @@ include::install_remove.asciidoc[]
 [[discovery-ec2-usage]]
 ==== Getting started with AWS
 
-The plugin provides a hosts provider for zen discovery named `ec2`. This hosts
-provider finds other Elasticsearch instances in EC2 through AWS metadata.
-Authentication is done using
+The plugin adds a seed hosts provider named `ec2`. This seed hosts provider
+finds other Elasticsearch instances in EC2 by querying the AWS metadata
+service.  Authentication is done using
 http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html[IAM
-Role] credentials by default. To enable the plugin, set the unicast host
-provider for Zen discovery to `ec2`:
+Role] credentials by default. To enable the plugin, configure {es} to use the
+`ec2` seed hosts provider:
 
 [source,yaml]
 ----
@@ -25,9 +26,9 @@ discovery.seed_providers: ec2
 
 ==== Settings
 
-EC2 host discovery supports a number of settings.  
-Some settings are sensitive and must be stored in the {ref}/secure-settings.html[elasticsearch keystore].
-For example, to use explicit AWS access keys:
+EC2 discovery supports a number of settings.  Some settings are sensitive and
+must be stored in the {ref}/secure-settings.html[elasticsearch keystore].  For
+example, to use explicit AWS access keys:
 
 [source,sh]
 ----
@@ -184,15 +185,18 @@ Management Console. It should look similar to this.
 [[discovery-ec2-filtering]]
 ===== Filtering by Tags
 
-The ec2 discovery can also filter machines to include in the cluster based on tags (and not just groups). The settings
-to use include the `discovery.ec2.tag.` prefix. For example, if you defined a tag `stage` in EC2 and set it to `dev`,
-setting `discovery.ec2.tag.stage` to `dev` will only filter instances with a tag key set to `stage`, and a value
-of `dev`. Adding multiple `discovery.ec2.tag` settings will require all of those tags to be set for the instance to be included.
+The ec2 discovery plugin can also filter machines to include in the cluster
+based on tags (and not just groups). The settings to use include the
+`discovery.ec2.tag.` prefix. For example, if you defined a tag `stage` in EC2
+and set it to `dev`, setting `discovery.ec2.tag.stage` to `dev` will only
+filter instances with a tag key set to `stage`, and a value of `dev`. Adding
+multiple `discovery.ec2.tag` settings will require all of those tags to be set
+for the instance to be included.
 
-One practical use for tag filtering is when an ec2 cluster contains many nodes that are not running Elasticsearch. In
-this case (particularly with high `discovery.zen.ping_timeout` values) there is a risk that a new node's discovery phase
-will end before it has found the cluster (which will result in it declaring itself master of a new cluster with the same
-name - highly undesirable). Tagging Elasticsearch ec2 nodes and then filtering by that tag will resolve this issue.
+One practical use for tag filtering is when an ec2 cluster contains many nodes
+that are not master-eligible {es} nodes. In this case, tagging the ec2
+instances that _are_ running the master-eligible {es} nodes, and then filtering
+by that tag, will help discovery to run more efficiently.
 
 [[discovery-ec2-attributes]]
 ===== Automatic Node Attributes
@@ -229,7 +233,6 @@ Prefer https://aws.amazon.com/amazon-linux-ami/[Amazon Linux AMIs] as since Elas
 
 ===== Networking
 * Networking throttling takes place on smaller instance types in both the form of https://lab.getbase.com/how-we-discovered-limitations-on-the-aws-tcp-stack/[bandwidth and number of connections]. Therefore if large number of connections are needed and networking is becoming a bottleneck, avoid https://aws.amazon.com/ec2/instance-types/[instance types] with networking labeled as `Moderate` or `Low`.
-* Multicast is not supported, even when in an VPC; the aws cloud plugin which joins by performing a security group lookup.
 * When running in multiple http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html[availability zones] be sure to leverage {ref}/allocation-awareness.html[shard allocation awareness] so that not all copies of shard data reside in the same availability zone.
 * Do not span a cluster across regions.  If necessary, use a cross cluster search.
 

--- a/docs/plugins/discovery-gce.asciidoc
+++ b/docs/plugins/discovery-gce.asciidoc
@@ -1,7 +1,8 @@
 [[discovery-gce]]
 === GCE Discovery Plugin
 
-The Google Compute Engine Discovery plugin uses the GCE API for unicast discovery.
+The Google Compute Engine Discovery plugin uses the GCE API to identify the
+addresses of seed hosts.
 
 :plugin_name: discovery-gce
 include::install_remove.asciidoc[]
@@ -9,8 +10,8 @@ include::install_remove.asciidoc[]
 [[discovery-gce-usage]]
 ==== GCE Virtual Machine Discovery
 
-Google Compute Engine VM discovery allows to use the google APIs to perform automatic discovery (similar to multicast
-in non hostile multicast environments). Here is a simple sample configuration:
+Google Compute Engine VM discovery allows to use the google APIs to perform
+automatic discovery of seed hosts. Here is a simple sample configuration:
 
 [source,yaml]
 --------------------------------------------------
@@ -358,11 +359,10 @@ The GCE discovery can also filter machines to include in the cluster based on ta
 For example, setting `discovery.gce.tags` to `dev` will only filter instances having a tag set to `dev`. Several tags
 set will require all of those tags to be set for the instance to be included.
 
-One practical use for tag filtering is when an GCE cluster contains many nodes that are not running
-Elasticsearch. In this case (particularly with high `discovery.zen.ping_timeout` values) there is a risk that a new
-node's discovery phase will end before it has found the cluster (which will result in it declaring itself master of a
-new cluster with the same name - highly undesirable). Adding tag on Elasticsearch GCE nodes and then filtering by that
-tag will resolve this issue.
+One practical use for tag filtering is when a GCE cluster contains many nodes
+that are not master-eligible {es} nodes. In this case, tagging the GCE
+instances that _are_ running the master-eligible {es} nodes, and then filtering
+by that tag, will help discovery to run more efficiently.
 
 Add your tag when building the new instance:
 

--- a/docs/plugins/discovery.asciidoc
+++ b/docs/plugins/discovery.asciidoc
@@ -1,8 +1,9 @@
 [[discovery]]
 == Discovery Plugins
 
-Discovery plugins extend Elasticsearch by adding new hosts providers that can be
-used to extend the {ref}/modules-discovery.html[cluster formation module].
+Discovery plugins extend Elasticsearch by adding new seed hosts providers that
+can be used to extend the {ref}/modules-discovery.html[cluster formation
+module].
 
 [float]
 ==== Core discovery plugins
@@ -12,22 +13,22 @@ The core discovery plugins are:
 <<discovery-ec2,EC2 discovery>>::
 
 The EC2 discovery plugin uses the https://github.com/aws/aws-sdk-java[AWS API]
-for unicast discovery.
+to identify the addresses of seed hosts.
 
 <<discovery-azure-classic,Azure Classic discovery>>::
 
-The Azure Classic discovery plugin uses the Azure Classic API for unicast
-discovery.
+The Azure Classic discovery plugin uses the Azure Classic API to identify the
+addresses of seed hosts.
 
 <<discovery-gce,GCE discovery>>::
 
-The Google Compute Engine discovery plugin uses the GCE API for unicast
-discovery.
+The Google Compute Engine discovery plugin uses the GCE API to identify the
+addresses of seed hosts.
 
 [float]
 ==== Community contributed discovery plugins
 
-A number of discovery plugins have been contributed by our community:
+The following discovery plugins have been contributed by our community:
 
 * https://github.com/fabric8io/elasticsearch-cloud-kubernetes[Kubernetes Discovery Plugin] (by Jimmi Dyson, http://fabric8.io[fabric8])
 

--- a/docs/reference/migration/migrate_7_0/plugins.asciidoc
+++ b/docs/reference/migration/migrate_7_0/plugins.asciidoc
@@ -41,7 +41,7 @@ renamed to `requiresAnalysisSettings`
 * This plugin has been removed since its functionality is now part of
 Elasticsearch and requires no plugin. The location of the hosts file has moved
 from `$ES_PATH_CONF/file-discovery/unicast_hosts.txt` to
-`$ES_PATH_CONF/unicast_hosts.txt`. See <<file-based-hosts-provider, the
+`$ES_PATH_CONF/unicast_hosts.txt`. See <<file-based-hosts-provider,the
 file-based hosts provider documentation>> for further information.
 
 [float]

--- a/docs/reference/modules/discovery/discovery-settings.asciidoc
+++ b/docs/reference/modules/discovery/discovery-settings.asciidoc
@@ -3,6 +3,73 @@
 
 Discovery and cluster formation are affected by the following settings:
 
+`discovery.seed_hosts`::
+
+    Provides a list of master-eligible nodes in the cluster. The list contains
+    either an array of hosts or a comma-delimited string. Each value has the
+    format `host:port` or `host`, where `port` defaults to the setting
+    `transport.profiles.default.port`. Note that IPv6 hosts must be bracketed.
+    The default value is `127.0.0.1, [::1]`. See <<unicast.hosts>>.
+    This setting was previously known as `discovery.zen.ping.unicast.hosts`.
+    Its old name is deprecated but continues to work in order to preserve
+    backwards compatibility. Support for the old name will be removed in a
+    future version.
+
+`discovery.seed_providers`::
+    Specifies which types of <<built-in-hosts-providers,seed hosts provider>>
+    to use to obtain the addresses of the seed nodes used to start the
+    discovery process. By default, it is the
+    <<settings-based-hosts-provider,settings-based seed hosts provider>>.
+    This setting was previously known as `discovery.zen.hosts_provider`. Its
+    old name is deprecated but continues to work in order to preserve backwards
+    compatibility. Support for the old name will be removed in a future
+    version.
+
+`discovery.cluster_formation_warning_timeout`::
+
+    Sets how long a node will try to form a cluster before logging a warning
+    that the cluster did not form. Defaults to `10s`. If a cluster has not
+    formed after `discovery.cluster_formation_warning_timeout` has elapsed then
+    the node will log a warning message that starts with the phrase `master not
+    discovered` which describes the current state of the discovery process.
+
+`discovery.find_peers_interval`::
+
+    Sets how long a node will wait before attempting another discovery round.
+    Defaults to `1s`.
+
+`discovery.probe.connect_timeout`::
+
+    Sets how long to wait when attempting to connect to each address. Defaults
+    to `3s`.
+
+`discovery.probe.handshake_timeout`::
+
+    Sets how long to wait when attempting to identify the remote node via a
+    handshake. Defaults to `1s`.
+
+`discovery.request_peers_timeout`::
+    Sets how long a node will wait after asking its peers again before
+    considering the request to have failed. Defaults to `3s`.
+
+`discovery.seed_resolver.max_concurrent_resolvers`::
+
+    Specifies how many concurrent DNS lookups to perform when resolving the
+    addresses of seed nodes. Defaults to `10`. This setting was previously
+    known as `discovery.zen.ping.unicast.concurrent_connects`. Its old name is
+    deprecated but continues to work in order to preserve backwards
+    compatibility. Support for the old name will be removed in a future
+    version.
+
+`discovery.seed_resolver.timeout`::
+
+    Specifies how long to wait for each DNS lookup performed when resolving the
+    addresses of seed nodes. Defaults to `5s`. This setting was previously
+    known as `discovery.zen.ping.unicast.hosts.resolve_timeout`. Its old name
+    is deprecated but continues to work in order to preserve backwards
+    compatibility. Support for the old name will be removed in a future
+    version.
+
 `cluster.auto_shrink_voting_configuration`::
 
     Controls whether the <<modules-discovery-voting,voting configuration>>
@@ -129,70 +196,3 @@ WARNING: This setting replaces the `discovery.zen.no_master_block` setting in
 earlier versions. The `discovery.zen.no_master_block` setting is ignored.
 
 --
-
-`discovery.seed_hosts`::
-
-    Provides a list of master-eligible nodes in the cluster. The list contains
-    either an array of hosts or a comma-delimited string. Each value has the
-    format `host:port` or `host`, where `port` defaults to the setting
-    `transport.profiles.default.port`. Note that IPv6 hosts must be bracketed.
-    The default value is `127.0.0.1, [::1]`. See <<unicast.hosts>>.
-    This setting was previously known as `discovery.zen.ping.unicast.hosts`.
-    Its old name is deprecated but continues to work in order to preserve
-    backwards compatibility. Support for the old name will be removed in a
-    future version.
-
-`discovery.seed_providers`::
-    Specifies which types of <<built-in-hosts-providers,seed hosts provider>>
-    to use to obtain the addresses of the seed nodes used to start the
-    discovery process. By default, it is the
-    <<settings-based-hosts-provider,settings-based seed hosts provider>>.
-    This setting was previously known as `discovery.zen.hosts_provider`. Its
-    old name is deprecated but continues to work in order to preserve backwards
-    compatibility. Support for the old name will be removed in a future
-    version.
-
-`discovery.cluster_formation_warning_timeout`::
-
-    Sets how long a node will try to form a cluster before logging a warning
-    that the cluster did not form. Defaults to `10s`. If a cluster has not
-    formed after `discovery.cluster_formation_warning_timeout` has elapsed then
-    the node will log a warning message that starts with the phrase `master not
-    discovered` which describes the current state of the discovery process.
-
-`discovery.find_peers_interval`::
-
-    Sets how long a node will wait before attempting another discovery round.
-    Defaults to `1s`.
-
-`discovery.probe.connect_timeout`::
-
-    Sets how long to wait when attempting to connect to each address. Defaults
-    to `3s`.
-
-`discovery.probe.handshake_timeout`::
-
-    Sets how long to wait when attempting to identify the remote node via a
-    handshake. Defaults to `1s`.
-
-`discovery.request_peers_timeout`::
-    Sets how long a node will wait after asking its peers again before
-    considering the request to have failed. Defaults to `3s`.
-
-`discovery.seed_resolver.max_concurrent_resolvers`::
-
-    Specifies how many concurrent DNS lookups to perform when resolving the
-    addresses of seed nodes. Defaults to `10`. This setting was previously
-    known as `discovery.zen.ping.unicast.concurrent_connects`. Its old name is
-    deprecated but continues to work in order to preserve backwards
-    compatibility. Support for the old name will be removed in a future
-    version.
-
-`discovery.seed_resolver.timeout`::
-
-    Specifies how long to wait for each DNS lookup performed when resolving the
-    addresses of seed nodes. Defaults to `5s`. This setting was previously
-    known as `discovery.zen.ping.unicast.hosts.resolve_timeout`. Its old name
-    is deprecated but continues to work in order to preserve backwards
-    compatibility. Support for the old name will be removed in a future
-    version.

--- a/docs/reference/modules/discovery/discovery-settings.asciidoc
+++ b/docs/reference/modules/discovery/discovery-settings.asciidoc
@@ -130,9 +130,30 @@ Discovery and cluster formation are affected by the following settings:
     considering the request to have failed. Defaults to `3s`.    
 
 `discovery.seed_providers`::
-    Specifies which types of <<built-in-hosts-providers,seed provider>> provide
-    the addresses of seed nodes. By default, it is the
-    <<settings-based-hosts-provider,settings-based hosts provider>>.
+    Specifies which types of <<built-in-hosts-providers,seed hosts provider>>
+    to use to obtain the addresses of the seed nodes used to start the
+    discovery process. By default, it is the
+    <<settings-based-hosts-provider,settings-based seed hosts provider>>.
+    This setting was previously known as `discovery.zen.hosts_provider`. Its
+    old name is deprecated but continues to work in order to preserve backwards
+    compatibility. Support for the old name will be removed in a future
+    version.
+
+`discovery.seed_resolver.max_concurrent_resolvers`::
+    Specifies how many concurrent DNS lookups to perform when resolving the
+    addresses of seed nodes. Defaults to `10`. This setting was previously
+    known as `discovery.zen.ping.unicast.concurrent_connects`. Its old name is
+    deprecated but continues to work in order to preserve backwards
+    compatibility. Support for the old name will be removed in a future
+    version.
+
+`discovery.seed_resolver.timeout`::
+    Specifies how long to wait for each DNS lookup performed when resolving the
+    addresses of seed nodes. Defaults to `5s`. This setting was previously
+    known as `discovery.zen.ping.unicast.hosts.resolve_timeout`. Its old name
+    is deprecated but continues to work in order to preserve backwards
+    compatibility. Support for the old name will be removed in a future
+    version.
 
 [[no-master-block]]`cluster.no_master_block`::
 Specifies which operations are rejected when there is no active master in a
@@ -169,6 +190,10 @@ earlier versions. The `discovery.zen.no_master_block` setting is ignored.
     format `host:port` or `host`, where `port` defaults to the setting
     `transport.profiles.default.port`. Note that IPv6 hosts must be bracketed.
     The default value is `127.0.0.1, [::1]`. See <<unicast.hosts>>.
+    This setting was previously known as `discovery.zen.ping.unicast.hosts`.
+    Its old name is deprecated but continues to work in order to preserve
+    backwards compatibility. Support for the old name will be removed in a
+    future version.
 
 `discovery.seed_resolver.timeout`::
 

--- a/docs/reference/modules/discovery/discovery-settings.asciidoc
+++ b/docs/reference/modules/discovery/discovery-settings.asciidoc
@@ -22,20 +22,20 @@ Discovery and cluster formation are affected by the following settings:
 
     Sets how long each election is allowed to take before a node considers it to
     have failed and schedules a retry. This defaults to `500ms`.
-    
+
 `cluster.election.initial_timeout`::
 
     Sets the upper bound on how long a node will wait initially, or after the
     elected master fails, before attempting its first election. This defaults
     to `100ms`.
 
-    
+
 `cluster.election.max_timeout`::
 
     Sets the maximum upper bound on how long a node will wait before attempting
     an first election, so that an network partition that lasts for a long time
     does not result in excessively sparse elections. This defaults to `10s`
-        
+
 [[fault-detection-settings]]`cluster.fault_detection.follower_check.interval`::
 
     Sets how long the elected master waits between follower checks to each
@@ -74,7 +74,7 @@ Discovery and cluster formation are affected by the following settings:
     state updates from lagging nodes. The default value is `90s`. If a node does
     not successfully apply the cluster state update within this period of time,
     it is considered to have failed and is removed from the cluster. See
-    <<cluster-state-publishing>>.  
+    <<cluster-state-publishing>>.
 
 `cluster.initial_master_nodes`::
 
@@ -88,19 +88,69 @@ Discovery and cluster formation are affected by the following settings:
     Sets how long a node will wait after sending a request to join a cluster
     before it considers the request to have failed and retries. Defaults to
     `60s`.
-    
+
 `cluster.max_voting_config_exclusions`::
 
     Sets a limit on the number of voting configuration exclusions at any one
     time. The default value is `10`. See
     <<modules-discovery-adding-removing-nodes>>.
-    
-`cluster.publish.timeout`:: 
-    
+
+`cluster.publish.timeout`::
+
     Sets how long the master node waits for each cluster state update to be
     completely published to all nodes. The default value is `30s`. If this
     period of time elapses, the cluster state change is rejected. See
-    <<cluster-state-publishing>>.   
+    <<cluster-state-publishing>>.
+
+[[no-master-block]]`cluster.no_master_block`::
+Specifies which operations are rejected when there is no active master in a
+cluster. This setting has two valid values:
++
+--
+`all`::: All operations on the node (both read and write operations) are rejected.
+This also applies for API cluster state read or write operations, like the get
+index settings, put mapping and cluster state API.
+
+`write`::: (default) Write operations are rejected. Read operations succeed,
+based on the last known cluster configuration. This situation may result in
+partial reads of stale data as this node may be isolated from the rest of the
+cluster.
+
+[NOTE]
+===============================
+* The `cluster.no_master_block` setting doesn't apply to nodes-based APIs
+(for example, cluster stats, node info, and node stats APIs). Requests to these
+APIs are not be blocked and can run on any available node.
+
+* For the cluster to be fully operational, it must have an active master.
+===============================
+
+WARNING: This setting replaces the `discovery.zen.no_master_block` setting in
+earlier versions. The `discovery.zen.no_master_block` setting is ignored.
+
+--
+
+`discovery.seed_hosts`::
+
+    Provides a list of master-eligible nodes in the cluster. The list contains
+    either an array of hosts or a comma-delimited string. Each value has the
+    format `host:port` or `host`, where `port` defaults to the setting
+    `transport.profiles.default.port`. Note that IPv6 hosts must be bracketed.
+    The default value is `127.0.0.1, [::1]`. See <<unicast.hosts>>.
+    This setting was previously known as `discovery.zen.ping.unicast.hosts`.
+    Its old name is deprecated but continues to work in order to preserve
+    backwards compatibility. Support for the old name will be removed in a
+    future version.
+
+`discovery.seed_providers`::
+    Specifies which types of <<built-in-hosts-providers,seed hosts provider>>
+    to use to obtain the addresses of the seed nodes used to start the
+    discovery process. By default, it is the
+    <<settings-based-hosts-provider,settings-based seed hosts provider>>.
+    This setting was previously known as `discovery.zen.hosts_provider`. Its
+    old name is deprecated but continues to work in order to preserve backwards
+    compatibility. Support for the old name will be removed in a future
+    version.
 
 `discovery.cluster_formation_warning_timeout`::
 
@@ -124,22 +174,13 @@ Discovery and cluster formation are affected by the following settings:
 
     Sets how long to wait when attempting to identify the remote node via a
     handshake. Defaults to `1s`.
-    
+
 `discovery.request_peers_timeout`::
     Sets how long a node will wait after asking its peers again before
-    considering the request to have failed. Defaults to `3s`.    
-
-`discovery.seed_providers`::
-    Specifies which types of <<built-in-hosts-providers,seed hosts provider>>
-    to use to obtain the addresses of the seed nodes used to start the
-    discovery process. By default, it is the
-    <<settings-based-hosts-provider,settings-based seed hosts provider>>.
-    This setting was previously known as `discovery.zen.hosts_provider`. Its
-    old name is deprecated but continues to work in order to preserve backwards
-    compatibility. Support for the old name will be removed in a future
-    version.
+    considering the request to have failed. Defaults to `3s`.
 
 `discovery.seed_resolver.max_concurrent_resolvers`::
+
     Specifies how many concurrent DNS lookups to perform when resolving the
     addresses of seed nodes. Defaults to `10`. This setting was previously
     known as `discovery.zen.ping.unicast.concurrent_connects`. Its old name is
@@ -148,59 +189,10 @@ Discovery and cluster formation are affected by the following settings:
     version.
 
 `discovery.seed_resolver.timeout`::
+
     Specifies how long to wait for each DNS lookup performed when resolving the
     addresses of seed nodes. Defaults to `5s`. This setting was previously
     known as `discovery.zen.ping.unicast.hosts.resolve_timeout`. Its old name
     is deprecated but continues to work in order to preserve backwards
     compatibility. Support for the old name will be removed in a future
     version.
-
-[[no-master-block]]`cluster.no_master_block`::
-Specifies which operations are rejected when there is no active master in a
-cluster. This setting has two valid values:
-+
---
-`all`::: All operations on the node (both read and write operations) are rejected.
-This also applies for API cluster state read or write operations, like the get
-index settings, put mapping and cluster state API.
-
-`write`::: (default) Write operations are rejected. Read operations succeed,
-based on the last known cluster configuration. This situation may result in
-partial reads of stale data as this node may be isolated from the rest of the
-cluster.
-
-[NOTE]
-===============================
-* The `cluster.no_master_block` setting doesn't apply to nodes-based APIs
-(for example, cluster stats, node info, and node stats APIs). Requests to these
-APIs are not be blocked and can run on any available node.
-  
-* For the cluster to be fully operational, it must have an active master.
-===============================
-
-WARNING: This setting replaces the `discovery.zen.no_master_block` setting in
-earlier versions. The `discovery.zen.no_master_block` setting is ignored.
-
---
-
-`discovery.seed_hosts`::
-
-    Provides a list of master-eligible nodes in the cluster. The list contains
-    either an array of hosts or a comma-delimited string. Each value has the
-    format `host:port` or `host`, where `port` defaults to the setting
-    `transport.profiles.default.port`. Note that IPv6 hosts must be bracketed.
-    The default value is `127.0.0.1, [::1]`. See <<unicast.hosts>>.
-    This setting was previously known as `discovery.zen.ping.unicast.hosts`.
-    Its old name is deprecated but continues to work in order to preserve
-    backwards compatibility. Support for the old name will be removed in a
-    future version.
-
-`discovery.seed_resolver.timeout`::
-
-    Sets the amount of time to wait for DNS lookups on each round of discovery.
-    This is specified as a <<time-units, time unit>> and defaults to `5s`.
-
-`discovery.seed_resolver.max_concurrent_resolvers`::
-
-    Sets the number of threads with which to perform DNS lookups for seed nodes.
-    This defaults to `10`.

--- a/docs/reference/modules/discovery/discovery-settings.asciidoc
+++ b/docs/reference/modules/discovery/discovery-settings.asciidoc
@@ -8,7 +8,7 @@ Discovery and cluster formation are affected by the following settings:
     Provides a list of master-eligible nodes in the cluster. Each value has the
     format `host:port` or `host`, where `port` defaults to the setting
     `transport.profiles.default.port`. Note that IPv6 hosts must be bracketed.
-    The default value is `127.0.0.1, [::1]`. See <<unicast.hosts>>. This
+    The default value is `["127.0.0.1", "[::1]"]`. See <<unicast.hosts>>. This
     setting was previously known as `discovery.zen.ping.unicast.hosts`. Its old
     name is deprecated but continues to work in order to preserve backwards
     compatibility. Support for the old name will be removed in a future

--- a/docs/reference/modules/discovery/discovery-settings.asciidoc
+++ b/docs/reference/modules/discovery/discovery-settings.asciidoc
@@ -5,23 +5,23 @@ Discovery and cluster formation are affected by the following settings:
 
 `discovery.seed_hosts`::
 
-    Provides a list of master-eligible nodes in the cluster. The list contains
-    either an array of hosts or a comma-delimited string. Each value has the
+    Provides a list of master-eligible nodes in the cluster. Each value has the
     format `host:port` or `host`, where `port` defaults to the setting
     `transport.profiles.default.port`. Note that IPv6 hosts must be bracketed.
-    The default value is `127.0.0.1, [::1]`. See <<unicast.hosts>>.
-    This setting was previously known as `discovery.zen.ping.unicast.hosts`.
-    Its old name is deprecated but continues to work in order to preserve
-    backwards compatibility. Support for the old name will be removed in a
-    future version.
+    The default value is `127.0.0.1, [::1]`. See <<unicast.hosts>>. This
+    setting was previously known as `discovery.zen.ping.unicast.hosts`. Its old
+    name is deprecated but continues to work in order to preserve backwards
+    compatibility. Support for the old name will be removed in a future
+    version.
 
 `discovery.seed_providers`::
+
     Specifies which types of <<built-in-hosts-providers,seed hosts provider>>
     to use to obtain the addresses of the seed nodes used to start the
     discovery process. By default, it is the
-    <<settings-based-hosts-provider,settings-based seed hosts provider>>.
-    This setting was previously known as `discovery.zen.hosts_provider`. Its
-    old name is deprecated but continues to work in order to preserve backwards
+    <<settings-based-hosts-provider,settings-based seed hosts provider>>.  This
+    setting was previously known as `discovery.zen.hosts_provider`. Its old
+    name is deprecated but continues to work in order to preserve backwards
     compatibility. Support for the old name will be removed in a future
     version.
 

--- a/docs/reference/modules/discovery/discovery.asciidoc
+++ b/docs/reference/modules/discovery/discovery.asciidoc
@@ -7,8 +7,8 @@ Elasticsearch node or when a node believes the master node failed and continues
 until the master node is found or a new master node is elected.
 
 This process starts with a list of _seed_ addresses from one or more
-<<built-in-hosts-providers,hosts providers>>, together with the addresses of
-any master-eligible nodes that were in the last known cluster. The process
+<<built-in-hosts-providers,seed hosts providers>>, together with the addresses
+of any master-eligible nodes that were in the last-known cluster. The process
 operates in two phases: First, each node probes the seed addresses by
 connecting to each address and attempting to identify the node to which it is
 connected. Secondly it shares with the remote node a list of all of its known
@@ -21,36 +21,48 @@ until it has discovered an elected master node. If no elected master is
 discovered then the node will retry after `discovery.find_peers_interval` which
 defaults to `1s`.
 
-If the node is master-eligible then it continues this discovery process until it
-has either discovered an elected master node or else it has discovered enough
-masterless master-eligible nodes to complete an election. If neither of these
-occur quickly enough then the node will retry after
+If the node is master-eligible then it continues this discovery process until
+it has either discovered an elected master node or else it has discovered
+enough masterless master-eligible nodes to complete an election. If neither of
+these occur quickly enough then the node will retry after
 `discovery.find_peers_interval` which defaults to `1s`.
 
 [[built-in-hosts-providers]]
-==== Hosts providers
+==== Seed hosts providers
 
-By default the cluster formation module offers two hosts providers to configure
-the list of seed nodes: a _settings_-based and a _file_-based hosts provider.
-It can be extended to support cloud environments and other forms of hosts
-providers via {plugins}/discovery.html[discovery plugins]. Hosts providers are
-configured using the `discovery.seed_providers` setting, which defaults to
-the _settings_-based hosts provider. Multiple hosts providers can be specified
-as a list.
+By default the cluster formation module offers two seed hosts providers to
+configure the list of seed nodes: a _settings_-based and a _file_-based seed
+hosts provider.  It can be extended to support cloud environments and other
+forms of seed hosts providers via {plugins}/discovery.html[discovery plugins].
+Seed hosts providers are configured using the `discovery.seed_providers`
+setting, which defaults to the _settings_-based hosts provider. This setting
+accepts a list of different providers, allowing you to make use of multiple
+ways to find the seed hosts for your cluster.
+
+Each seed hosts provider yields the IP addresses or hostnames of the seed
+nodes. If it returns any hostnames then these are resolved to IP addresses
+using a DNS lookup. If a hostname resolves to multiple IP addresses then {es}
+tries to find a seed node at all of these addresses. If the hosts provider does
+not explicitly give the TCP port of the node then by it will implicitly use the
+first port in the port range given by `transport.profiles.default.port`, or by
+`transport.port` if `transport.profiles.default.port` is not set. The number of
+concurrent lookups is controlled by
+`discovery.seed_resolver.max_concurrent_resolvers` which defaults to `10`, and
+the timeout for each lookup is controlled by `discovery.seed_resolver.timeout`
+which defaults to `5s`. Note that DNS lookups are subject to
+<<networkaddress-cache-ttl,JVM DNS caching>>.
 
 [float]
 [[settings-based-hosts-provider]]
-===== Settings-based hosts provider
+===== Settings-based seed hosts provider
 
-The settings-based hosts provider uses a node setting to configure a static list
-of hosts to use as seed nodes. These hosts can be specified as hostnames or IP
-addresses; hosts specified as hostnames are resolved to IP addresses during each
-round of discovery. Note that if you are in an environment where DNS resolutions
-vary with time, you might need to adjust your <<networkaddress-cache-ttl,JVM
-security settings>>.
+The settings-based seed hosts provider uses a node setting to configure a
+static list of the addresses of the seed nodes. These addresses can be given as
+hostnames or IP addresses; hosts specified as hostnames are resolved to IP
+addresses during each round of discovery.
 
-The list of hosts is set using the <<unicast.hosts,`discovery.seed_hosts`>> static
-setting.  For example:
+The list of hosts is set using the <<unicast.hosts,`discovery.seed_hosts`>>
+static setting. For example:
 
 [source,yaml]
 --------------------------------------------------
@@ -61,26 +73,19 @@ discovery.seed_hosts:
 --------------------------------------------------
 <1> The port will default to `transport.profiles.default.port` and fallback to
     `transport.port` if not specified.
-<2> A hostname that resolves to multiple IP addresses will try all resolved
-    addresses.
-
-Additionally, the `discovery.seed_resolver.timeout` configures the amount of
-time to wait for DNS lookups on each round of discovery. This is specified as a
-<<time-units, time unit>> and defaults to 5s.
-
-Unicast discovery uses the <<modules-transport,transport>> module to perform the
-discovery.
+<2> If a hostname resolves to multiple IP addresses, {es} will attempt to
+    connect to every resolved address.
 
 [float]
 [[file-based-hosts-provider]]
-===== File-based hosts provider
+===== File-based seed hosts provider
 
-The file-based hosts provider configures a list of hosts via an external file.
-Elasticsearch reloads this file when it changes, so that the list of seed nodes
+The file-based seed hosts provider configures a list of hosts via an external
+file.  {es} reloads this file when it changes, so that the list of seed nodes
 can change dynamically without needing to restart each node. For example, this
-gives a convenient mechanism for an Elasticsearch instance that is run in a
-Docker container to be dynamically supplied with a list of IP addresses to
-connect to when those IP addresses may not be known at node startup.
+gives a convenient mechanism for an {es} instance that is run in a Docker
+container to be dynamically supplied with a list of IP addresses to connect to
+when those IP addresses may not be known at node startup.
 
 To enable file-based discovery, configure the `file` hosts provider as follows
 in the `elasticsearch.yml` file:
@@ -91,27 +96,25 @@ discovery.seed_providers: file
 ----------------------------------------------------------------
 
 Then create a file at `$ES_PATH_CONF/unicast_hosts.txt` in the format described
-below. Any time a change is made to the `unicast_hosts.txt` file the new changes
-will be picked up by Elasticsearch and the new hosts list will be used.
+below. Any time a change is made to the `unicast_hosts.txt` file the new
+changes will be picked up by {es} and the new hosts list will be used.
 
 Note that the file-based discovery plugin augments the unicast hosts list in
-`elasticsearch.yml`. If there are valid seed addresses in
-`discovery.seed_hosts` then they are used in addition to those supplied in
-`unicast_hosts.txt`.
+`elasticsearch.yml`: if there are valid seed addresses in
+`discovery.seed_hosts` then {es} uses those addresses in addition to those
+supplied in `unicast_hosts.txt`.
 
-The `discovery.seed_resolver.timeout` setting also applies to DNS lookups for
-seed addresses given via file-based discovery. This is specified as a
-<<time-units, time unit>> and defaults to 5s.
-
-The format of the file is to specify one node entry per line.  Each node entry
+The `unicast_hosts.txt` file contains one node entry per line. Each node entry
 consists of the host (host name or IP address) and an optional transport port
-number.  If the port number is specified, is must come immediately after the
+number. If the port number is specified, is must come immediately after the
 host (on the same line) separated by a `:`.  If the port number is not
-specified, a default value of 9300 is used.
+specified, {es} will implicitly use the first port in the port range given by
+`transport.profiles.default.port`, or by `transport.port` if
+`transport.profiles.default.port` is not set.
 
 For example, this is an example of `unicast_hosts.txt` for a cluster with four
-nodes that participate in unicast discovery, some of which are not running on
-the default port:
+nodes that participate in discovery, some of which are not running on the
+default port:
 
 [source,txt]
 ----------------------------------------------------------------
@@ -122,13 +125,12 @@ the default port:
 [2001:0db8:85a3:0000:0000:8a2e:0370:7334]:9301
 ----------------------------------------------------------------
 
-Host names are allowed instead of IP addresses (similar to
-`discovery.seed_hosts`), and IPv6 addresses must be specified in
-brackets with the port coming after the brackets.
+Host names are allowed instead of IP addresses and are resolved by DNS as
+described above. IPv6 addresses must be given in brackets with the port, if
+needed, coming after the brackets.
 
-You can also add comments to this file. All comments must appear on
-their lines starting with `#` (i.e. comments cannot start in the middle of a
-line).
+You can also add comments to this file. All comments must appear on their lines
+starting with `#` (i.e. comments cannot start in the middle of a line).
 
 [float]
 [[ec2-hosts-provider]]

--- a/docs/reference/modules/discovery/publishing.asciidoc
+++ b/docs/reference/modules/discovery/publishing.asciidoc
@@ -34,9 +34,9 @@ which defaults to `90s`. If a node has still not successfully applied the
 cluster state update within this time then it is considered to have failed and
 is removed from the cluster.
 
-NOTE: Elasticsearch is a peer to peer based system, in which nodes communicate
-with one another directly. The high-throughput APIs (index, delete, search) do
-not normally interact with the master node. The responsibility of the master
-node is to maintain the global cluster state and reassign shards when nodes join or leave
-the cluster. Each time the cluster state is changed, the
-new state is published to all nodes in the cluster as described above.
+NOTE: {es} is a peer to peer based system, in which nodes communicate with one
+another directly. The high-throughput APIs (index, delete, search) do not
+normally interact with the master node. The responsibility of the master node
+is to maintain the global cluster state and reassign shards when nodes join or
+leave the cluster. Each time the cluster state is changed, the new state is
+published to all nodes in the cluster as described above.

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -19,12 +19,12 @@ Never expose an unprotected node to the public internet.
 
 `network.host`::
 
-The node will bind to this hostname or IP address and _publish_ (advertise) this
-host to other nodes in the cluster. Accepts an IP address, hostname, a
+The node will bind to this hostname or IP address and _publish_ (advertise)
+this host to other nodes in the cluster. Accepts an IP address, hostname, a
 <<network-interface-values,special value>>, or an array of any combination of
 these. Note that any values containing a `:` (e.g., an IPv6 address or
-containing one of the <<network-interface-values,special value>>) must be quoted
-because `:` is a special character in YAML.
+containing one of the <<network-interface-values,special values>>) must be
+quoted because `:` is a special character in YAML.
 +
 Defaults to `_local_`.
 
@@ -38,8 +38,10 @@ IP address will be used for discovery.
 https://en.wikipedia.org/wiki/Round-robin_DNS[Round robin DNS] -- returning a
 different IP from a list on each lookup -- can be used for discovery; non-
 existent IP addresses will throw exceptions and cause another DNS lookup on the
-next round of pinging (subject to JVM DNS caching).  + Defaults to
-`["127.0.0.1", "[::1]"]`.
+next round of pinging (subject to <<networkaddress-cache-ttl,JVM DNS
+caching>>).
++
+Defaults to `["127.0.0.1", "[::1]"]`.
 
 `http.port`::
 

--- a/docs/reference/setup/important-settings/discovery-settings.asciidoc
+++ b/docs/reference/setup/important-settings/discovery-settings.asciidoc
@@ -17,16 +17,17 @@ the available loopback addresses and will scan local ports 9300 to 9305 to try
 to connect to other nodes running on the same server. This provides an auto-
 clustering experience without having to do any configuration.
 
-When the moment comes to form a cluster with nodes on other servers, you must
-use the `discovery.seed_hosts` setting to provide a seed list of
-other nodes in the cluster that are master-eligible and likely to be live and
-contactable.  This setting should normally contain the addresses of all the
-master-eligible nodes in the cluster.
-This setting contains either an array of hosts or a comma-delimited string. Each
-value should be in the form of `host:port` or `host` (where `port` defaults to
-the setting `transport.profiles.default.port` falling back to `transport.port`
-if not set). Note that IPv6 hosts must be bracketed. The default for this
-setting is `127.0.0.1, [::1]`
+When you want to form a cluster with nodes on other hosts, you must use the
+`discovery.seed_hosts` setting to provide a list of other nodes in the cluster
+that are master-eligible and likely to be live and contactable in order to seed
+the <<modules-discovery-hosts-providers,discovery process>>. This setting
+should normally contain the addresses of all the master-eligible nodes in the
+cluster.  This setting contains either an array of hosts or a comma-delimited
+string. Each value should be in the form of `host:port` or `host` (where `port`
+defaults to the setting `transport.profiles.default.port` falling back to
+`transport.port` if not set). Note that IPv6 hosts must be bracketed. The
+default for this setting is `127.0.0.1, [::1]`.
+
 [float]
 [[initial_master_nodes]]
 ==== `cluster.initial_master_nodes`

--- a/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/cloud/azure/classic/management/AzureComputeService.java
+++ b/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/cloud/azure/classic/management/AzureComputeService.java
@@ -24,8 +24,8 @@ import com.microsoft.windowsazure.management.compute.models.HostedServiceGetDeta
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.discovery.azure.classic.AzureUnicastHostsProvider;
-import org.elasticsearch.discovery.azure.classic.AzureUnicastHostsProvider.Deployment;
+import org.elasticsearch.discovery.azure.classic.AzureSeedHostsProvider;
+import org.elasticsearch.discovery.azure.classic.AzureSeedHostsProvider.Deployment;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -63,9 +63,9 @@ public interface AzureComputeService {
     final class Discovery {
         public static final Setting<TimeValue> REFRESH_SETTING =
             Setting.positiveTimeSetting("discovery.azure.refresh_interval", TimeValue.timeValueSeconds(0), Property.NodeScope);
-        public static final Setting<AzureUnicastHostsProvider.HostType> HOST_TYPE_SETTING =
-            new Setting<>("discovery.azure.host.type", AzureUnicastHostsProvider.HostType.PRIVATE_IP.name(),
-                AzureUnicastHostsProvider.HostType::fromString, Property.NodeScope);
+        public static final Setting<AzureSeedHostsProvider.HostType> HOST_TYPE_SETTING =
+            new Setting<>("discovery.azure.host.type", AzureSeedHostsProvider.HostType.PRIVATE_IP.name(),
+                AzureSeedHostsProvider.HostType::fromString, Property.NodeScope);
         public static final Setting<String> ENDPOINT_NAME_SETTING = new Setting<>("discovery.azure.endpoint.name", "elasticsearch",
             Function.identity(), Property.NodeScope);
         public static final Setting<String> DEPLOYMENT_NAME_SETTING = Setting.simpleString("discovery.azure.deployment.name",

--- a/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/discovery/azure/classic/AzureSeedHostsProvider.java
+++ b/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/discovery/azure/classic/AzureSeedHostsProvider.java
@@ -38,7 +38,7 @@ import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.discovery.zen.UnicastHostsProvider;
+import org.elasticsearch.discovery.SeedHostsProvider;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
@@ -47,9 +47,9 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
-public class AzureUnicastHostsProvider implements UnicastHostsProvider {
+public class AzureSeedHostsProvider implements SeedHostsProvider {
     
-    private static final Logger logger = LogManager.getLogger(AzureUnicastHostsProvider.class);
+    private static final Logger logger = LogManager.getLogger(AzureSeedHostsProvider.class);
 
     public enum HostType {
         PRIVATE_IP("private_ip"),
@@ -110,8 +110,8 @@ public class AzureUnicastHostsProvider implements UnicastHostsProvider {
     private final String deploymentName;
     private final DeploymentSlot deploymentSlot;
 
-    public AzureUnicastHostsProvider(Settings settings, AzureComputeService azureComputeService,
-                                     TransportService transportService, NetworkService networkService) {
+    public AzureSeedHostsProvider(Settings settings, AzureComputeService azureComputeService,
+                                  TransportService transportService, NetworkService networkService) {
         this.settings = settings;
         this.azureComputeService = azureComputeService;
         this.transportService = transportService;
@@ -137,7 +137,7 @@ public class AzureUnicastHostsProvider implements UnicastHostsProvider {
      * Setting `cloud.azure.refresh_interval` to `0` will disable caching (default).
      */
     @Override
-    public List<TransportAddress> buildDynamicHosts(HostsResolver hostsResolver) {
+    public List<TransportAddress> getSeedAddresses(HostsResolver hostsResolver) {
         if (refreshInterval.millis() != 0) {
             if (dynamicHosts != null &&
                     (refreshInterval.millis() < 0 || (System.currentTimeMillis() - lastRefresh) < refreshInterval.millis())) {

--- a/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/plugin/discovery/azure/classic/AzureDiscoveryPlugin.java
+++ b/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/plugin/discovery/azure/classic/AzureDiscoveryPlugin.java
@@ -27,8 +27,8 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.discovery.azure.classic.AzureUnicastHostsProvider;
-import org.elasticsearch.discovery.zen.UnicastHostsProvider;
+import org.elasticsearch.discovery.SeedHostsProvider;
+import org.elasticsearch.discovery.azure.classic.AzureSeedHostsProvider;
 import org.elasticsearch.plugins.DiscoveryPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.transport.TransportService;
@@ -58,18 +58,18 @@ public class AzureDiscoveryPlugin extends Plugin implements DiscoveryPlugin {
     }
 
     @Override
-    public Map<String, Supplier<UnicastHostsProvider>> getZenHostsProviders(TransportService transportService,
-                                                                            NetworkService networkService) {
+    public Map<String, Supplier<SeedHostsProvider>> getSeedHostProviders(TransportService transportService,
+                                                                         NetworkService networkService) {
         return Collections.singletonMap(AZURE,
-            () -> createUnicastHostsProvider(settings, createComputeService(), transportService, networkService));
+            () -> createSeedHostsProvider(settings, createComputeService(), transportService, networkService));
     }
 
     // Used for testing
-    protected AzureUnicastHostsProvider createUnicastHostsProvider(final Settings settings,
-                                                                   final AzureComputeService azureComputeService,
-                                                                   final TransportService transportService,
-                                                                   final NetworkService networkService) {
-        return new AzureUnicastHostsProvider(settings, azureComputeService, transportService, networkService);
+    protected AzureSeedHostsProvider createSeedHostsProvider(final Settings settings,
+                                                             final AzureComputeService azureComputeService,
+                                                             final TransportService transportService,
+                                                             final NetworkService networkService) {
+        return new AzureSeedHostsProvider(settings, azureComputeService, transportService, networkService);
     }
 
     @Override

--- a/plugins/discovery-azure-classic/src/test/java/org/elasticsearch/cloud/azure/classic/AbstractAzureComputeServiceTestCase.java
+++ b/plugins/discovery-azure-classic/src/test/java/org/elasticsearch/cloud/azure/classic/AbstractAzureComputeServiceTestCase.java
@@ -34,7 +34,7 @@ import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.discovery.azure.classic.AzureUnicastHostsProvider;
+import org.elasticsearch.discovery.azure.classic.AzureSeedHostsProvider;
 import org.elasticsearch.plugin.discovery.azure.classic.AzureDiscoveryPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -152,15 +152,15 @@ public abstract class AbstractAzureComputeServiceTestCase extends ESIntegTestCas
         }
 
         /**
-         * Defines a {@link AzureUnicastHostsProvider} for testing purpose that is able to resolve
+         * Defines a {@link AzureSeedHostsProvider} for testing purpose that is able to resolve
          * network addresses for Azure instances running on the same host but different ports.
          */
         @Override
-        protected AzureUnicastHostsProvider createUnicastHostsProvider(final Settings settings,
-                                                                       final AzureComputeService azureComputeService,
-                                                                       final TransportService transportService,
-                                                                       final NetworkService networkService) {
-            return new AzureUnicastHostsProvider(settings, azureComputeService, transportService, networkService) {
+        protected AzureSeedHostsProvider createSeedHostsProvider(final Settings settings,
+                                                                 final AzureComputeService azureComputeService,
+                                                                 final TransportService transportService,
+                                                                 final NetworkService networkService) {
+            return new AzureSeedHostsProvider(settings, azureComputeService, transportService, networkService) {
                 @Override
                 protected String resolveInstanceAddress(final HostType hostType, final RoleInstance instance) {
                     if (hostType == HostType.PRIVATE_IP) {

--- a/plugins/discovery-azure-classic/src/test/java/org/elasticsearch/discovery/azure/classic/AzureDiscoveryClusterFormationTests.java
+++ b/plugins/discovery-azure-classic/src/test/java/org/elasticsearch/discovery/azure/classic/AzureDiscoveryClusterFormationTests.java
@@ -123,14 +123,14 @@ public class AzureDiscoveryClusterFormationTests extends ESIntegTestCase {
             .put(AzureComputeService.Management.ENDPOINT_SETTING.getKey(), "https://" + InetAddress.getLoopbackAddress().getHostAddress() +
                 ":" + httpsServer.getAddress().getPort())
             .put(AzureComputeService.Management.KEYSTORE_PATH_SETTING.getKey(), keyStoreFile.toAbsolutePath())
-            .put(AzureComputeService.Discovery.HOST_TYPE_SETTING.getKey(), AzureUnicastHostsProvider.HostType.PUBLIC_IP.name())
+            .put(AzureComputeService.Discovery.HOST_TYPE_SETTING.getKey(), AzureSeedHostsProvider.HostType.PUBLIC_IP.name())
             .put(AzureComputeService.Management.KEYSTORE_PASSWORD_SETTING.getKey(), "keypass")
             .put(AzureComputeService.Management.KEYSTORE_TYPE_SETTING.getKey(), "jks")
             .put(AzureComputeService.Management.SERVICE_NAME_SETTING.getKey(), "myservice")
             .put(AzureComputeService.Management.SUBSCRIPTION_ID_SETTING.getKey(), "subscription")
             .put(AzureComputeService.Discovery.DEPLOYMENT_NAME_SETTING.getKey(), "mydeployment")
             .put(AzureComputeService.Discovery.ENDPOINT_NAME_SETTING.getKey(), "myendpoint")
-            .put(AzureComputeService.Discovery.DEPLOYMENT_SLOT_SETTING.getKey(), AzureUnicastHostsProvider.Deployment.PRODUCTION.name())
+            .put(AzureComputeService.Discovery.DEPLOYMENT_SLOT_SETTING.getKey(), AzureSeedHostsProvider.Deployment.PRODUCTION.name())
             .build();
     }
 

--- a/plugins/discovery-azure-classic/src/test/java/org/elasticsearch/discovery/azure/classic/AzureTwoStartedNodesTests.java
+++ b/plugins/discovery-azure-classic/src/test/java/org/elasticsearch/discovery/azure/classic/AzureTwoStartedNodesTests.java
@@ -32,7 +32,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 public class AzureTwoStartedNodesTests extends AbstractAzureComputeServiceTestCase {
 
     public void testTwoNodesShouldRunUsingPrivateOrPublicIp() {
-        final String hostType = randomFrom(AzureUnicastHostsProvider.HostType.values()).getType();
+        final String hostType = randomFrom(AzureSeedHostsProvider.HostType.values()).getType();
         logger.info("--> using azure host type " + hostType);
 
         final Settings settings = Settings.builder()

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2SeedHostsProvider.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2SeedHostsProvider.java
@@ -36,7 +36,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.SingleObjectCache;
-import org.elasticsearch.discovery.zen.UnicastHostsProvider;
+import org.elasticsearch.discovery.SeedHostsProvider;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.ArrayList;
@@ -52,9 +52,9 @@ import static org.elasticsearch.discovery.ec2.AwsEc2Service.HostType.PUBLIC_DNS;
 import static org.elasticsearch.discovery.ec2.AwsEc2Service.HostType.PUBLIC_IP;
 import static org.elasticsearch.discovery.ec2.AwsEc2Service.HostType.TAG_PREFIX;
 
-class AwsEc2UnicastHostsProvider implements UnicastHostsProvider {
+class AwsEc2SeedHostsProvider implements SeedHostsProvider {
     
-    private static final Logger logger = LogManager.getLogger(AwsEc2UnicastHostsProvider.class);
+    private static final Logger logger = LogManager.getLogger(AwsEc2SeedHostsProvider.class);
 
     private final TransportService transportService;
 
@@ -72,7 +72,7 @@ class AwsEc2UnicastHostsProvider implements UnicastHostsProvider {
 
     private final TransportAddressesCache dynamicHosts;
 
-    AwsEc2UnicastHostsProvider(Settings settings, TransportService transportService, AwsEc2Service awsEc2Service) {
+    AwsEc2SeedHostsProvider(Settings settings, TransportService transportService, AwsEc2Service awsEc2Service) {
         this.transportService = transportService;
         this.awsEc2Service = awsEc2Service;
 
@@ -95,7 +95,7 @@ class AwsEc2UnicastHostsProvider implements UnicastHostsProvider {
     }
 
     @Override
-    public List<TransportAddress> buildDynamicHosts(HostsResolver hostsResolver) {
+    public List<TransportAddress> getSeedAddresses(HostsResolver hostsResolver) {
         return dynamicHosts.getOrRefresh();
     }
 
@@ -117,7 +117,7 @@ class AwsEc2UnicastHostsProvider implements UnicastHostsProvider {
             return dynamicHosts;
         }
 
-        logger.trace("building dynamic unicast discovery nodes...");
+        logger.trace("finding seed nodes...");
         for (final Reservation reservation : descInstances.getReservations()) {
             for (final Instance instance : reservation.getInstances()) {
                 // lets see if we can filter based on groups

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPlugin.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPlugin.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.discovery.zen.UnicastHostsProvider;
+import org.elasticsearch.discovery.SeedHostsProvider;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.DiscoveryPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -96,9 +96,9 @@ public class Ec2DiscoveryPlugin extends Plugin implements DiscoveryPlugin, Reloa
     }
 
     @Override
-    public Map<String, Supplier<UnicastHostsProvider>> getZenHostsProviders(TransportService transportService,
-                                                                            NetworkService networkService) {
-        return Collections.singletonMap(EC2, () -> new AwsEc2UnicastHostsProvider(settings, transportService, ec2Service));
+    public Map<String, Supplier<SeedHostsProvider>> getSeedHostProviders(TransportService transportService,
+                                                                         NetworkService networkService) {
+        return Collections.singletonMap(EC2, () -> new AwsEc2SeedHostsProvider(settings, transportService, ec2Service));
     }
 
     @Override

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryTests.java
@@ -92,8 +92,8 @@ public class Ec2DiscoveryTests extends ESTestCase {
 
     protected List<TransportAddress> buildDynamicHosts(Settings nodeSettings, int nodes, List<List<Tag>> tagsList) {
         try (Ec2DiscoveryPluginMock plugin = new Ec2DiscoveryPluginMock(Settings.EMPTY, nodes, tagsList)) {
-            AwsEc2UnicastHostsProvider provider = new AwsEc2UnicastHostsProvider(nodeSettings, transportService, plugin.ec2Service);
-            List<TransportAddress> dynamicHosts = provider.buildDynamicHosts(null);
+            AwsEc2SeedHostsProvider provider = new AwsEc2SeedHostsProvider(nodeSettings, transportService, plugin.ec2Service);
+            List<TransportAddress> dynamicHosts = provider.getSeedAddresses(null);
             logger.debug("--> addresses found: {}", dynamicHosts);
             return dynamicHosts;
         } catch (IOException e) {
@@ -257,7 +257,7 @@ public class Ec2DiscoveryTests extends ESTestCase {
         assertThat(dynamicHosts, hasSize(prodInstances));
     }
 
-    public void testReadHostFromTag() throws InterruptedException, UnknownHostException {
+    public void testReadHostFromTag() throws UnknownHostException {
         int nodes = randomIntBetween(5, 10);
 
         String[] addresses = new String[nodes];
@@ -290,16 +290,16 @@ public class Ec2DiscoveryTests extends ESTestCase {
     }
 
 
-    abstract class DummyEc2HostProvider extends AwsEc2UnicastHostsProvider {
+    abstract class DummyEc2SeedHostsProvider extends AwsEc2SeedHostsProvider {
         public int fetchCount = 0;
-        DummyEc2HostProvider(Settings settings, TransportService transportService, AwsEc2Service service) {
+        DummyEc2SeedHostsProvider(Settings settings, TransportService transportService, AwsEc2Service service) {
             super(settings, transportService, service);
         }
     }
 
-    public void testGetNodeListEmptyCache() throws Exception {
+    public void testGetNodeListEmptyCache() {
         AwsEc2Service awsEc2Service = new AwsEc2ServiceMock(1, null);
-        DummyEc2HostProvider provider = new DummyEc2HostProvider(Settings.EMPTY, transportService, awsEc2Service) {
+        DummyEc2SeedHostsProvider provider = new DummyEc2SeedHostsProvider(Settings.EMPTY, transportService, awsEc2Service) {
             @Override
             protected List<TransportAddress> fetchDynamicNodes() {
                 fetchCount++;
@@ -307,7 +307,7 @@ public class Ec2DiscoveryTests extends ESTestCase {
             }
         };
         for (int i=0; i<3; i++) {
-            provider.buildDynamicHosts(null);
+            provider.getSeedAddresses(null);
         }
         assertThat(provider.fetchCount, is(3));
     }
@@ -316,7 +316,7 @@ public class Ec2DiscoveryTests extends ESTestCase {
         Settings.Builder builder = Settings.builder()
                 .put(AwsEc2Service.NODE_CACHE_TIME_SETTING.getKey(), "500ms");
         try (Ec2DiscoveryPluginMock plugin = new Ec2DiscoveryPluginMock(Settings.EMPTY)) {
-            DummyEc2HostProvider provider = new DummyEc2HostProvider(builder.build(), transportService, plugin.ec2Service) {
+            DummyEc2SeedHostsProvider provider = new DummyEc2SeedHostsProvider(builder.build(), transportService, plugin.ec2Service) {
                 @Override
                 protected List<TransportAddress> fetchDynamicNodes() {
                     fetchCount++;
@@ -324,12 +324,12 @@ public class Ec2DiscoveryTests extends ESTestCase {
                 }
             };
             for (int i=0; i<3; i++) {
-                provider.buildDynamicHosts(null);
+                provider.getSeedAddresses(null);
             }
             assertThat(provider.fetchCount, is(1));
             Thread.sleep(1_000L); // wait for cache to expire
             for (int i=0; i<3; i++) {
-                provider.buildDynamicHosts(null);
+                provider.getSeedAddresses(null);
             }
             assertThat(provider.fetchCount, is(2));
         }

--- a/plugins/discovery-gce/src/main/java/org/elasticsearch/discovery/gce/GceSeedHostsProvider.java
+++ b/plugins/discovery-gce/src/main/java/org/elasticsearch/discovery/gce/GceSeedHostsProvider.java
@@ -36,7 +36,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.discovery.zen.UnicastHostsProvider;
+import org.elasticsearch.discovery.SeedHostsProvider;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
@@ -48,9 +48,9 @@ import java.util.function.Function;
 
 import static java.util.Collections.emptyList;
 
-public class GceUnicastHostsProvider implements UnicastHostsProvider {
+public class GceSeedHostsProvider implements SeedHostsProvider {
     
-    private static final Logger logger = LogManager.getLogger(GceUnicastHostsProvider.class);
+    private static final Logger logger = LogManager.getLogger(GceSeedHostsProvider.class);
 
     /**
      * discovery.gce.tags: The gce discovery can filter machines to include in the cluster based on tags.
@@ -75,9 +75,9 @@ public class GceUnicastHostsProvider implements UnicastHostsProvider {
     private long lastRefresh;
     private List<TransportAddress> cachedDynamicHosts;
 
-    public GceUnicastHostsProvider(Settings settings, GceInstancesService gceInstancesService,
-            TransportService transportService,
-            NetworkService networkService) {
+    public GceSeedHostsProvider(Settings settings, GceInstancesService gceInstancesService,
+                                TransportService transportService,
+                                NetworkService networkService) {
         this.settings = settings;
         this.gceInstancesService = gceInstancesService;
         this.transportService = transportService;
@@ -98,7 +98,7 @@ public class GceUnicastHostsProvider implements UnicastHostsProvider {
      * Information can be cached using `cloud.gce.refresh_interval` property if needed.
      */
     @Override
-    public List<TransportAddress> buildDynamicHosts(HostsResolver hostsResolver) {
+    public List<TransportAddress> getSeedAddresses(HostsResolver hostsResolver) {
         // We check that needed properties have been set
         if (this.project == null || this.project.isEmpty() || this.zones == null || this.zones.isEmpty()) {
             throw new IllegalArgumentException("one or more gce discovery settings are missing. " +

--- a/plugins/discovery-gce/src/main/java/org/elasticsearch/plugin/discovery/gce/GceDiscoveryPlugin.java
+++ b/plugins/discovery-gce/src/main/java/org/elasticsearch/plugin/discovery/gce/GceDiscoveryPlugin.java
@@ -34,8 +34,8 @@ import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.internal.io.IOUtils;
-import org.elasticsearch.discovery.gce.GceUnicastHostsProvider;
-import org.elasticsearch.discovery.zen.UnicastHostsProvider;
+import org.elasticsearch.discovery.SeedHostsProvider;
+import org.elasticsearch.discovery.gce.GceSeedHostsProvider;
 import org.elasticsearch.plugins.DiscoveryPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.transport.TransportService;
@@ -84,11 +84,11 @@ public class GceDiscoveryPlugin extends Plugin implements DiscoveryPlugin, Close
     }
 
     @Override
-    public Map<String, Supplier<UnicastHostsProvider>> getZenHostsProviders(TransportService transportService,
-                                                                            NetworkService networkService) {
+    public Map<String, Supplier<SeedHostsProvider>> getSeedHostProviders(TransportService transportService,
+                                                                         NetworkService networkService) {
         return Collections.singletonMap(GCE, () -> {
             gceInstancesService.set(createGceInstancesService());
-            return new GceUnicastHostsProvider(settings, gceInstancesService.get(), transportService, networkService);
+            return new GceSeedHostsProvider(settings, gceInstancesService.get(), transportService, networkService);
         });
     }
 
@@ -105,7 +105,7 @@ public class GceDiscoveryPlugin extends Plugin implements DiscoveryPlugin, Close
                 // Register GCE settings
                 GceInstancesService.PROJECT_SETTING,
                 GceInstancesService.ZONE_SETTING,
-                GceUnicastHostsProvider.TAGS_SETTING,
+                GceSeedHostsProvider.TAGS_SETTING,
                 GceInstancesService.REFRESH_SETTING,
                 GceInstancesService.RETRY_SETTING,
                 GceInstancesService.MAX_WAIT_SETTING)

--- a/plugins/discovery-gce/src/test/java/org/elasticsearch/discovery/gce/GceDiscoveryTests.java
+++ b/plugins/discovery-gce/src/test/java/org/elasticsearch/discovery/gce/GceDiscoveryTests.java
@@ -107,10 +107,10 @@ public class GceDiscoveryTests extends ESTestCase {
     }
 
     protected List<TransportAddress> buildDynamicNodes(GceInstancesServiceImpl gceInstancesService, Settings nodeSettings) {
-        GceUnicastHostsProvider provider = new GceUnicastHostsProvider(nodeSettings, gceInstancesService,
+        GceSeedHostsProvider provider = new GceSeedHostsProvider(nodeSettings, gceInstancesService,
             transportService, new NetworkService(Collections.emptyList()));
 
-        List<TransportAddress> dynamicHosts = provider.buildDynamicHosts(null);
+        List<TransportAddress> dynamicHosts = provider.getSeedAddresses(null);
         logger.info("--> addresses found: {}", dynamicHosts);
         return dynamicHosts;
     }
@@ -129,7 +129,7 @@ public class GceDiscoveryTests extends ESTestCase {
         Settings nodeSettings = Settings.builder()
                 .put(GceInstancesServiceImpl.PROJECT_SETTING.getKey(), projectName)
                 .put(GceInstancesServiceImpl.ZONE_SETTING.getKey(), "europe-west1-b")
-                .putList(GceUnicastHostsProvider.TAGS_SETTING.getKey(), "elasticsearch")
+                .putList(GceSeedHostsProvider.TAGS_SETTING.getKey(), "elasticsearch")
                 .build();
         mock = new GceInstancesServiceMock(nodeSettings);
         List<TransportAddress> dynamicHosts = buildDynamicNodes(mock, nodeSettings);
@@ -140,7 +140,7 @@ public class GceDiscoveryTests extends ESTestCase {
         Settings nodeSettings = Settings.builder()
                 .put(GceInstancesServiceImpl.PROJECT_SETTING.getKey(), projectName)
                 .put(GceInstancesServiceImpl.ZONE_SETTING.getKey(), "europe-west1-b")
-                .putList(GceUnicastHostsProvider.TAGS_SETTING.getKey(), "elasticsearch", "dev")
+                .putList(GceSeedHostsProvider.TAGS_SETTING.getKey(), "elasticsearch", "dev")
                 .build();
         mock = new GceInstancesServiceMock(nodeSettings);
         List<TransportAddress> dynamicHosts = buildDynamicNodes(mock, nodeSettings);
@@ -161,7 +161,7 @@ public class GceDiscoveryTests extends ESTestCase {
         Settings nodeSettings = Settings.builder()
                 .put(GceInstancesServiceImpl.PROJECT_SETTING.getKey(), projectName)
                 .put(GceInstancesServiceImpl.ZONE_SETTING.getKey(), "europe-west1-b")
-                .putList(GceUnicastHostsProvider.TAGS_SETTING.getKey(), "elasticsearch")
+                .putList(GceSeedHostsProvider.TAGS_SETTING.getKey(), "elasticsearch")
                 .build();
         mock = new GceInstancesServiceMock(nodeSettings);
         List<TransportAddress> dynamicHosts = buildDynamicNodes(mock, nodeSettings);
@@ -172,7 +172,7 @@ public class GceDiscoveryTests extends ESTestCase {
         Settings nodeSettings = Settings.builder()
                 .put(GceInstancesServiceImpl.PROJECT_SETTING.getKey(), projectName)
                 .put(GceInstancesServiceImpl.ZONE_SETTING.getKey(), "europe-west1-b")
-                .putList(GceUnicastHostsProvider.TAGS_SETTING.getKey(), "elasticsearch", "dev")
+                .putList(GceSeedHostsProvider.TAGS_SETTING.getKey(), "elasticsearch", "dev")
                 .build();
         mock = new GceInstancesServiceMock(nodeSettings);
         List<TransportAddress> dynamicHosts = buildDynamicNodes(mock, nodeSettings);

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
 
 import static org.elasticsearch.cluster.coordination.ClusterBootstrapService.INITIAL_MASTER_NODES_SETTING;
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
-import static org.elasticsearch.discovery.zen.SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 
 /**
  * We enforce bootstrap checks once a node has the transport protocol bound to a non-loopback interface or if the system property {@code

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
@@ -50,8 +50,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableSet;
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
 import static org.elasticsearch.discovery.DiscoveryModule.LEGACY_DISCOVERY_HOSTS_PROVIDER_SETTING;
-import static org.elasticsearch.discovery.zen.SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
-import static org.elasticsearch.discovery.zen.SettingsBasedHostsProvider.LEGACY_DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING;
+import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.LEGACY_DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING;
 
 public class ClusterBootstrapService {
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -61,9 +61,9 @@ import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoveryStats;
 import org.elasticsearch.discovery.HandshakingTransportAddressConnector;
 import org.elasticsearch.discovery.PeerFinder;
-import org.elasticsearch.discovery.UnicastConfiguredHostsResolver;
+import org.elasticsearch.discovery.SeedHostsResolver;
 import org.elasticsearch.discovery.zen.PendingClusterStateStats;
-import org.elasticsearch.discovery.zen.UnicastHostsProvider;
+import org.elasticsearch.discovery.SeedHostsProvider;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.TransportResponse.Empty;
 import org.elasticsearch.transport.TransportService;
@@ -113,7 +113,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     private final PreVoteCollector preVoteCollector;
     private final Random random;
     private final ElectionSchedulerFactory electionSchedulerFactory;
-    private final UnicastConfiguredHostsResolver configuredHostsResolver;
+    private final SeedHostsResolver configuredHostsResolver;
     private final TimeValue publishTimeout;
     private final PublicationTransportHandler publicationHandler;
     private final LeaderChecker leaderChecker;
@@ -139,7 +139,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
 
     public Coordinator(String nodeName, Settings settings, ClusterSettings clusterSettings, TransportService transportService,
                        NamedWriteableRegistry namedWriteableRegistry, AllocationService allocationService, MasterService masterService,
-                       Supplier<CoordinationState.PersistedState> persistedStateSupplier, UnicastHostsProvider unicastHostsProvider,
+                       Supplier<CoordinationState.PersistedState> persistedStateSupplier, SeedHostsProvider seedHostsProvider,
                        ClusterApplier clusterApplier, Collection<BiConsumer<DiscoveryNode, ClusterState>> onJoinValidators, Random random) {
         this.settings = settings;
         this.transportService = transportService;
@@ -156,7 +156,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         this.random = random;
         this.electionSchedulerFactory = new ElectionSchedulerFactory(settings, random, transportService.getThreadPool());
         this.preVoteCollector = new PreVoteCollector(transportService, this::startElection, this::updateMaxTermSeen);
-        configuredHostsResolver = new UnicastConfiguredHostsResolver(nodeName, settings, transportService, unicastHostsProvider);
+        configuredHostsResolver = new SeedHostsResolver(nodeName, settings, transportService, seedHostsProvider);
         this.peerFinder = new CoordinatorPeerFinder(settings, transportService,
             new HandshakingTransportAddressConnector(settings, transportService), configuredHostsResolver);
         this.publicationHandler = new PublicationTransportHandler(transportService, namedWriteableRegistry,

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -69,7 +69,7 @@ import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.PeerFinder;
 import org.elasticsearch.discovery.zen.ElectMasterService;
 import org.elasticsearch.discovery.zen.FaultDetection;
-import org.elasticsearch.discovery.zen.SettingsBasedHostsProvider;
+import org.elasticsearch.discovery.SettingsBasedSeedHostsProvider;
 import org.elasticsearch.discovery.zen.UnicastZenPing;
 import org.elasticsearch.discovery.zen.ZenDiscovery;
 import org.elasticsearch.env.Environment;
@@ -405,8 +405,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     ZenDiscovery.MASTER_ELECTION_WAIT_FOR_JOINS_TIMEOUT_SETTING,
                     ZenDiscovery.MASTER_ELECTION_IGNORE_NON_MASTER_PINGS_SETTING,
                     ZenDiscovery.MAX_PENDING_CLUSTER_STATES_SETTING,
-                    SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING,
-                    SettingsBasedHostsProvider.LEGACY_DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING,
+                    SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING,
+                    SettingsBasedSeedHostsProvider.LEGACY_DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING,
                     UnicastZenPing.DISCOVERY_SEED_RESOLVER_MAX_CONCURRENT_RESOLVERS_SETTING,
                     UnicastZenPing.DISCOVERY_SEED_RESOLVER_TIMEOUT_SETTING,
                     UnicastZenPing.LEGACY_DISCOVERY_ZEN_PING_UNICAST_CONCURRENT_CONNECTS_SETTING,

--- a/server/src/main/java/org/elasticsearch/discovery/FileBasedSeedHostsProvider.java
+++ b/server/src/main/java/org/elasticsearch/discovery/FileBasedSeedHostsProvider.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.discovery.zen;
+package org.elasticsearch.discovery;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,26 +33,27 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * An implementation of {@link UnicastHostsProvider} that reads hosts/ports
+ * An implementation of {@link SeedHostsProvider} that reads hosts/ports
  * from {@link #UNICAST_HOSTS_FILE}.
  *
- * Each unicast host/port that is part of the discovery process must be listed on
- * a separate line.  If the port is left off an entry, a default port of 9300 is
- * assumed.  An example unicast hosts file could read:
+ * Each host/port that is part of the discovery process must be listed on
+ * a separate line. If the port is left off an entry, we default to the
+ * first port in the {@code transport.port} range.
+ * An example unicast hosts file could read:
  *
  * 67.81.244.10
  * 67.81.244.11:9305
  * 67.81.244.15:9400
  */
-public class FileBasedUnicastHostsProvider implements UnicastHostsProvider {
+public class FileBasedSeedHostsProvider implements SeedHostsProvider {
 
-    private static final Logger logger = LogManager.getLogger(FileBasedUnicastHostsProvider.class);
+    private static final Logger logger = LogManager.getLogger(FileBasedSeedHostsProvider.class);
 
     public static final String UNICAST_HOSTS_FILE = "unicast_hosts.txt";
 
     private final Path unicastHostsFilePath;
 
-    public FileBasedUnicastHostsProvider(Path configFile) {
+    public FileBasedSeedHostsProvider(Path configFile) {
         this.unicastHostsFilePath = configFile.resolve(UNICAST_HOSTS_FILE);
     }
 
@@ -73,7 +74,7 @@ public class FileBasedUnicastHostsProvider implements UnicastHostsProvider {
     }
 
     @Override
-    public List<TransportAddress> buildDynamicHosts(HostsResolver hostsResolver) {
+    public List<TransportAddress> getSeedAddresses(HostsResolver hostsResolver) {
         final List<TransportAddress> transportAddresses = hostsResolver.resolveHosts(getHostsList(), 1);
         logger.debug("seed addresses: {}", transportAddresses);
         return transportAddresses;

--- a/server/src/main/java/org/elasticsearch/discovery/SeedHostsProvider.java
+++ b/server/src/main/java/org/elasticsearch/discovery/SeedHostsProvider.java
@@ -17,21 +17,22 @@
  * under the License.
  */
 
-package org.elasticsearch.discovery.zen;
+package org.elasticsearch.discovery;
 
 import org.elasticsearch.common.transport.TransportAddress;
 
 import java.util.List;
 
 /**
- * A pluggable provider of the list of unicast hosts to use for unicast discovery.
+ * A pluggable provider of the list of seed hosts to use for discovery.
  */
-public interface UnicastHostsProvider {
+public interface SeedHostsProvider {
 
     /**
-     * Builds the dynamic list of unicast hosts to be used for unicast discovery.
+     * Returns a list of seed hosts to use for discovery. Called repeatedly while discovery is active (i.e. while there is no master)
+     * so that this list may be dynamic.
      */
-    List<TransportAddress> buildDynamicHosts(HostsResolver hostsResolver);
+    List<TransportAddress> getSeedAddresses(HostsResolver hostsResolver);
 
     /**
      * Helper object that allows to resolve a list of hosts to a list of transport addresses.
@@ -41,5 +42,4 @@ public interface UnicastHostsProvider {
     interface HostsResolver {
         List<TransportAddress> resolveHosts(List<String> hosts, int limitPortCounts);
     }
-
 }

--- a/server/src/main/java/org/elasticsearch/discovery/SettingsBasedSeedHostsProvider.java
+++ b/server/src/main/java/org/elasticsearch/discovery/SettingsBasedSeedHostsProvider.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.discovery.zen;
+package org.elasticsearch.discovery;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,16 +33,16 @@ import java.util.function.Function;
 import static java.util.Collections.emptyList;
 
 /**
- * An implementation of {@link UnicastHostsProvider} that reads hosts/ports
+ * An implementation of {@link SeedHostsProvider} that reads hosts/ports
  * from the "discovery.seed_hosts" node setting. If the port is
- * left off an entry, a default port of 9300 is assumed.
+ * left off an entry, we default to the first port in the {@code transport.port} range.
  *
- * An example unicast hosts setting might look as follows:
+ * An example setting might look as follows:
  * [67.81.244.10, 67.81.244.11:9305, 67.81.244.15:9400]
  */
-public class SettingsBasedHostsProvider implements UnicastHostsProvider {
+public class SettingsBasedSeedHostsProvider implements SeedHostsProvider {
 
-    private static final Logger logger = LogManager.getLogger(SettingsBasedHostsProvider.class);
+    private static final Logger logger = LogManager.getLogger(SettingsBasedSeedHostsProvider.class);
 
     public static final Setting<List<String>> LEGACY_DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING =
         Setting.listSetting("discovery.zen.ping.unicast.hosts", emptyList(), Function.identity(), Property.NodeScope, Property.Deprecated);
@@ -57,7 +57,7 @@ public class SettingsBasedHostsProvider implements UnicastHostsProvider {
     private final List<String> configuredHosts;
     private final int limitPortCounts;
 
-    public SettingsBasedHostsProvider(Settings settings, TransportService transportService) {
+    public SettingsBasedSeedHostsProvider(Settings settings, TransportService transportService) {
         if (LEGACY_DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING.exists(settings)) {
             if (DISCOVERY_SEED_HOSTS_SETTING.exists(settings)) {
                 throw new IllegalArgumentException("it is forbidden to set both ["
@@ -81,7 +81,7 @@ public class SettingsBasedHostsProvider implements UnicastHostsProvider {
     }
 
     @Override
-    public List<TransportAddress> buildDynamicHosts(HostsResolver hostsResolver) {
+    public List<TransportAddress> getSeedAddresses(HostsResolver hostsResolver) {
         return hostsResolver.resolveHosts(configuredHosts, limitPortCounts);
     }
 }

--- a/server/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -59,6 +59,7 @@ import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.DiscoveryStats;
 import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
+import org.elasticsearch.discovery.SeedHostsProvider;
 import org.elasticsearch.discovery.zen.PublishClusterStateAction.IncomingClusterStateListener;
 import org.elasticsearch.gateway.GatewayMetaState;
 import org.elasticsearch.tasks.Task;
@@ -162,7 +163,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
 
     public ZenDiscovery(Settings settings, ThreadPool threadPool, TransportService transportService,
                         NamedWriteableRegistry namedWriteableRegistry, MasterService masterService, ClusterApplier clusterApplier,
-                        ClusterSettings clusterSettings, UnicastHostsProvider hostsProvider, AllocationService allocationService,
+                        ClusterSettings clusterSettings, SeedHostsProvider hostsProvider, AllocationService allocationService,
                         Collection<BiConsumer<DiscoveryNode, ClusterState>> onJoinValidators, GatewayMetaState gatewayMetaState) {
         this.onJoinValidators = JoinTaskExecutor.addBuiltInJoinValidators(onJoinValidators);
         this.masterService = masterService;
@@ -239,7 +240,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
 
     // protected to allow overriding in tests
     protected ZenPing newZenPing(Settings settings, ThreadPool threadPool, TransportService transportService,
-                                 UnicastHostsProvider hostsProvider) {
+                                 SeedHostsProvider hostsProvider) {
         return new UnicastZenPing(settings, threadPool, transportService, hostsProvider, this);
     }
 

--- a/server/src/main/java/org/elasticsearch/plugins/DiscoveryPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/DiscoveryPlugin.java
@@ -23,7 +23,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.discovery.zen.UnicastHostsProvider;
+import org.elasticsearch.discovery.SeedHostsProvider;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.Collections;
@@ -45,6 +45,7 @@ import java.util.function.Supplier;
  * }</pre>
  */
 public interface DiscoveryPlugin {
+
     /**
      * Override to add additional {@link NetworkService.CustomNameResolver}s.
      * This can be handy if you want to provide your own Network interface name like _mycard_
@@ -63,7 +64,7 @@ public interface DiscoveryPlugin {
     }
 
     /**
-     * Returns providers of unicast host lists for zen discovery.
+     * Returns providers of seed hosts for discovery.
      *
      * The key of the returned map is the name of the host provider
      * (see {@link org.elasticsearch.discovery.DiscoveryModule#DISCOVERY_SEED_PROVIDERS_SETTING}), and
@@ -73,8 +74,8 @@ public interface DiscoveryPlugin {
      *                         of a {@link org.elasticsearch.cluster.node.DiscoveryNode}
      * @param networkService Use to find the publish host address of the current node
      */
-    default Map<String, Supplier<UnicastHostsProvider>> getZenHostsProviders(TransportService transportService,
-                                                                             NetworkService networkService) {
+    default Map<String, Supplier<SeedHostsProvider>> getSeedHostProviders(TransportService transportService,
+                                                                          NetworkService networkService) {
         return Collections.emptyMap();
     }
 

--- a/server/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.discovery.DiscoveryModule;
-import org.elasticsearch.discovery.zen.SettingsBasedHostsProvider;
+import org.elasticsearch.discovery.SettingsBasedSeedHostsProvider;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
@@ -729,9 +729,9 @@ public class BootstrapChecksTests extends AbstractBootstrapCheckTestCase {
 
         ensureChecksPass.accept(Settings.builder().putList(ClusterBootstrapService.INITIAL_MASTER_NODES_SETTING.getKey()));
         ensureChecksPass.accept(Settings.builder().putList(DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING.getKey()));
-        ensureChecksPass.accept(Settings.builder().putList(SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING.getKey()));
+        ensureChecksPass.accept(Settings.builder().putList(SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING.getKey()));
         ensureChecksPass.accept(Settings.builder().putList(DiscoveryModule.LEGACY_DISCOVERY_HOSTS_PROVIDER_SETTING.getKey()));
-        ensureChecksPass.accept(Settings.builder().putList(SettingsBasedHostsProvider.LEGACY_DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING
+        ensureChecksPass.accept(Settings.builder().putList(SettingsBasedSeedHostsProvider.LEGACY_DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING
             .getKey()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
@@ -49,7 +49,7 @@ import static org.elasticsearch.cluster.coordination.ClusterBootstrapService.INI
 import static org.elasticsearch.cluster.coordination.ClusterBootstrapService.UNCONFIGURED_BOOTSTRAP_TIMEOUT_SETTING;
 import static org.elasticsearch.common.settings.Settings.builder;
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
-import static org.elasticsearch.discovery.zen.SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -128,7 +128,7 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
         testDoesNothingWithSettings(builder().putList(DISCOVERY_SEED_PROVIDERS_SETTING.getKey()));
     }
 
-    public void testDoesNothingByDefaultIfUnicastHostsConfigured() {
+    public void testDoesNothingByDefaultIfSeedHostsConfigured() {
         testDoesNothingWithSettings(builder().putList(DISCOVERY_SEED_HOSTS_SETTING.getKey()));
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -61,7 +61,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.discovery.zen.PublishClusterStateStats;
-import org.elasticsearch.discovery.zen.UnicastHostsProvider.HostsResolver;
+import org.elasticsearch.discovery.SeedHostsProvider.HostsResolver;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.gateway.MetaStateService;
 import org.elasticsearch.gateway.MockGatewayMetaState;
@@ -1070,7 +1070,7 @@ public class CoordinatorTests extends ESTestCase {
             logger.info("--> disconnecting {}", partitionedNode);
             partitionedNode.disconnect();
         }
-        cluster.setEmptyUnicastHostsList();
+        cluster.setEmptySeedHostsList();
         cluster.stabilise();
 
         partitionedNode.heal();
@@ -1145,7 +1145,7 @@ public class CoordinatorTests extends ESTestCase {
         private final Function<DiscoveryNode, MockPersistedState> defaultPersistedStateSupplier = MockPersistedState::new;
 
         @Nullable // null means construct a list from all the current nodes
-        private List<TransportAddress> unicastHostsList;
+        private List<TransportAddress> seedHostsList;
 
         Cluster(int initialNodeCount) {
             this(initialNodeCount, true);
@@ -1536,8 +1536,8 @@ public class CoordinatorTests extends ESTestCase {
             return getAnyNode();
         }
 
-        void setEmptyUnicastHostsList() {
-            unicastHostsList = emptyList();
+        void setEmptySeedHostsList() {
+            seedHostsList = emptyList();
         }
 
         class MockPersistedState implements PersistedState {
@@ -1702,7 +1702,7 @@ public class CoordinatorTests extends ESTestCase {
                     Collections.singletonList((dn, cs) -> extraJoinValidators.forEach(validator -> validator.accept(dn, cs)));
                 coordinator = new Coordinator("test_node", settings, clusterSettings, transportService, writableRegistry(),
                     ESAllocationTestCase.createAllocationService(Settings.EMPTY), masterService, this::getPersistedState,
-                    Cluster.this::provideUnicastHosts, clusterApplierService, onJoinValidators, Randomness.get());
+                    Cluster.this::provideSeedHosts, clusterApplierService, onJoinValidators, Randomness.get());
                 masterService.setClusterStatePublisher(coordinator);
 
                 logger.trace("starting up [{}]", localNode);
@@ -1903,8 +1903,8 @@ public class CoordinatorTests extends ESTestCase {
             }
         }
 
-        private List<TransportAddress> provideUnicastHosts(HostsResolver ignored) {
-            return unicastHostsList != null ? unicastHostsList
+        private List<TransportAddress> provideSeedHosts(HostsResolver ignored) {
+            return seedHostsList != null ? seedHostsList
                 : clusterNodes.stream().map(ClusterNode::getLocalNode).map(DiscoveryNode::getAddress).collect(Collectors.toList());
         }
     }

--- a/server/src/test/java/org/elasticsearch/discovery/MasterDisruptionIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/MasterDisruptionIT.java
@@ -78,7 +78,6 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
      */
     @TestLogging("_root:DEBUG,org.elasticsearch.cluster.service:TRACE,org.elasticsearch.test.disruption:TRACE")
     public void testStaleMasterNotHijackingMajority() throws Exception {
-        // 3 node cluster with unicast discovery:
         final List<String> nodes = startCluster(3);
 
         // Save the current master node as old master node, because that node will get frozen

--- a/server/src/test/java/org/elasticsearch/discovery/SeedHostsResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/SeedHostsResolverTests.java
@@ -39,10 +39,10 @@ import static org.hamcrest.core.IsNull.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class UnicastConfiguredHostsResolverTests extends ESTestCase {
+public class SeedHostsResolverTests extends ESTestCase {
 
     private List<TransportAddress> transportAddresses;
-    private UnicastConfiguredHostsResolver unicastConfiguredHostsResolver;
+    private SeedHostsResolver seedHostsResolver;
     private ThreadPool threadPool;
 
     @Before
@@ -53,14 +53,13 @@ public class UnicastConfiguredHostsResolverTests extends ESTestCase {
         TransportService transportService = mock(TransportService.class);
         when(transportService.getThreadPool()).thenReturn(threadPool);
 
-        unicastConfiguredHostsResolver
-            = new UnicastConfiguredHostsResolver("test_node", Settings.EMPTY, transportService, hostsResolver -> transportAddresses);
-        unicastConfiguredHostsResolver.start();
+        seedHostsResolver = new SeedHostsResolver("test_node", Settings.EMPTY, transportService, hostsResolver -> transportAddresses);
+        seedHostsResolver.start();
     }
 
     @After
     public void stopResolver() {
-        unicastConfiguredHostsResolver.stop();
+        seedHostsResolver.stop();
         threadPool.shutdown();
     }
 
@@ -74,7 +73,7 @@ public class UnicastConfiguredHostsResolverTests extends ESTestCase {
             transportAddresses.add(buildNewFakeTransportAddress());
         }
 
-        unicastConfiguredHostsResolver.resolveConfiguredHosts(resolvedAddresses -> {
+        seedHostsResolver.resolveConfiguredHosts(resolvedAddresses -> {
             try {
                 assertTrue(startLatch.await(30, TimeUnit.SECONDS));
             } catch (InterruptedException e) {
@@ -84,7 +83,7 @@ public class UnicastConfiguredHostsResolverTests extends ESTestCase {
             endLatch.countDown();
         });
 
-        unicastConfiguredHostsResolver.resolveConfiguredHosts(resolvedAddresses -> {
+        seedHostsResolver.resolveConfiguredHosts(resolvedAddresses -> {
             throw new AssertionError("unexpected concurrent resolution");
         });
 

--- a/server/src/test/java/org/elasticsearch/discovery/SettingsBasedSeedHostsProviderIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/SettingsBasedSeedHostsProviderIT.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.discovery.zen;
+package org.elasticsearch.discovery;
 
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
@@ -25,10 +25,10 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
-import static org.elasticsearch.discovery.zen.SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
-public class SettingsBasedHostsProviderIT extends ESIntegTestCase {
+public class SettingsBasedSeedHostsProviderIT extends ESIntegTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {

--- a/server/src/test/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
@@ -27,7 +27,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.discovery.zen.UnicastHostsProvider;
+import org.elasticsearch.discovery.SeedHostsProvider;
 import org.elasticsearch.discovery.zen.UnicastZenPing;
 import org.elasticsearch.discovery.zen.ZenPing;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -83,7 +83,7 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
             final TransportService nodeTransport =
                     internalCluster().getInstance(TransportService.class);
             // try to ping the single node directly
-            final UnicastHostsProvider provider =
+            final SeedHostsProvider provider =
                 hostsResolver -> Collections.singletonList(nodeTransport.getLocalNode().getAddress());
             final CountDownLatch latch = new CountDownLatch(1);
             final DiscoveryNodes nodes = DiscoveryNodes.builder()

--- a/server/src/test/java/org/elasticsearch/discovery/zen/UnicastZenPingTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/zen/UnicastZenPingTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.internal.io.IOUtils;
+import org.elasticsearch.discovery.SettingsBasedSeedHostsProvider;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
@@ -90,7 +91,7 @@ import java.util.stream.IntStream;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
-import static org.elasticsearch.discovery.zen.SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.elasticsearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -822,7 +823,7 @@ public class UnicastZenPingTests extends ESTestCase {
                            PingContextProvider contextProvider) {
             super(Settings.builder().put("node.name", networkHandle.node.getName()).put(settings).build(),
                 threadPool, networkHandle.transportService,
-                new SettingsBasedHostsProvider(settings, networkHandle.transportService), contextProvider);
+                new SettingsBasedSeedHostsProvider(settings, networkHandle.transportService), contextProvider);
         }
 
         volatile CountDownLatch allTasksCompleted;

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -195,7 +195,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.common.util.CollectionUtils.eagerPartition;
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
-import static org.elasticsearch.discovery.zen.SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.XContentTestUtils.convertToMap;
 import static org.elasticsearch.test.XContentTestUtils.differenceBetweenMapsIgnoringArrayOrder;

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -62,7 +62,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import static org.elasticsearch.cluster.coordination.ClusterBootstrapService.INITIAL_MASTER_NODES_SETTING;
-import static org.elasticsearch.discovery.zen.SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -154,7 +154,7 @@ import static org.elasticsearch.discovery.DiscoveryModule.ZEN2_DISCOVERY_TYPE;
 import static org.elasticsearch.discovery.DiscoveryModule.ZEN_DISCOVERY_TYPE;
 import static org.elasticsearch.discovery.DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING;
 import static org.elasticsearch.discovery.zen.ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING;
-import static org.elasticsearch.discovery.zen.FileBasedUnicastHostsProvider.UNICAST_HOSTS_FILE;
+import static org.elasticsearch.discovery.FileBasedSeedHostsProvider.UNICAST_HOSTS_FILE;
 import static org.elasticsearch.test.ESTestCase.assertBusy;
 import static org.elasticsearch.test.ESTestCase.awaitBusy;
 import static org.elasticsearch.test.ESTestCase.getTestTransportType;

--- a/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.discovery.DiscoverySettings;
-import org.elasticsearch.discovery.zen.SettingsBasedHostsProvider;
+import org.elasticsearch.discovery.SettingsBasedSeedHostsProvider;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESTestCase;
@@ -162,7 +162,7 @@ public class InternalTestClusterTests extends ESTestCase {
                         NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(),
                         2 * ((masterNodes ? InternalTestCluster.DEFAULT_HIGH_NUM_MASTER_NODES : 0) + maxNumDataNodes + numClientNodes))
                     .put(DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), "file")
-                    .putList(SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING.getKey())
+                    .putList(SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING.getKey())
                     .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType());
                 if (autoManageMinMasterNodes == false) {
                     assert minNumDataNodes == maxNumDataNodes;
@@ -239,7 +239,7 @@ public class InternalTestClusterTests extends ESTestCase {
                         2 + (masterNodes ? InternalTestCluster.DEFAULT_HIGH_NUM_MASTER_NODES : 0) + maxNumDataNodes + numClientNodes)
                     .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
                     .putList(DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), "file")
-                    .putList(SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING.getKey())
+                    .putList(SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING.getKey())
                     .build();
             }
 
@@ -337,7 +337,7 @@ public class InternalTestClusterTests extends ESTestCase {
                         .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
                         .put(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), 0)
                         .putList(DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), "file")
-                        .putList(SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING.getKey())
+                        .putList(SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING.getKey())
                         .build();
             }
 
@@ -420,7 +420,7 @@ public class InternalTestClusterTests extends ESTestCase {
                     .put(NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(), 2)
                     .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
                     .putList(DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), "file")
-                    .putList(SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING.getKey())
+                    .putList(SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING.getKey())
                     .build();
             }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
@@ -102,7 +102,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
-import static org.elasticsearch.discovery.zen.SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.empty;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/license/LicensingTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/license/LicensingTests.java
@@ -57,7 +57,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.discovery.zen.SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -275,7 +275,7 @@ public class LicensingTests extends SecurityIntegTestCase {
         enableLicensing(mode);
         ensureGreen();
 
-        final List<String> unicastHostsList = internalCluster().masterClient().admin().cluster().nodesInfo(new NodesInfoRequest()).get()
+        final List<String> seedHosts = internalCluster().masterClient().admin().cluster().nodesInfo(new NodesInfoRequest()).get()
             .getNodes().stream().map(n -> n.getTransport().getAddress().publishAddress().toString()).distinct()
             .collect(Collectors.toList());
 
@@ -289,7 +289,7 @@ public class LicensingTests extends SecurityIntegTestCase {
             .put("cluster.name", internalCluster().getClusterName())
             .put("path.home", home)
             .putList(DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING.getKey())
-            .putList(DISCOVERY_SEED_HOSTS_SETTING.getKey(), unicastHostsList);
+            .putList(DISCOVERY_SEED_HOSTS_SETTING.getKey(), seedHosts);
 
         Collection<Class<? extends Plugin>> mockPlugins = Arrays.asList(LocalStateSecurity.class, MockHttpTransport.TestPlugin.class);
         try (Node node = new MockNode(nodeSettings.build(), mockPlugins)) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ServerTransportFilterIntegrationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ServerTransportFilterIntegrationTests.java
@@ -42,7 +42,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 
-import static org.elasticsearch.discovery.zen.SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.elasticsearch.test.SecuritySettingsSource.addSSLSettingsForNodePEMFiles;
 import static org.elasticsearch.test.SecuritySettingsSource.addSSLSettingsForPEMFiles;
 import static org.elasticsearch.xpack.security.test.SecurityTestUtils.writeFile;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/IPHostnameVerificationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/IPHostnameVerificationTests.java
@@ -17,7 +17,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.elasticsearch.discovery.zen.SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.hamcrest.CoreMatchers.is;
 
 // TODO delete this test?

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/bench/WatcherExecutorServiceBenchmark.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/bench/WatcherExecutorServiceBenchmark.java
@@ -28,7 +28,7 @@ import java.time.Clock;
 import java.util.Arrays;
 
 import static java.util.Collections.emptyMap;
-import static org.elasticsearch.discovery.zen.SettingsBasedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.elasticsearch.xpack.watcher.actions.ActionBuilders.indexAction;
 import static org.elasticsearch.xpack.watcher.input.InputBuilders.httpInput;
 import static org.elasticsearch.xpack.watcher.input.InputBuilders.searchInput;


### PR DESCRIPTION
In #38333 and #38350 we moved away from the `discovery.zen` settings namespace
since these settings have an effect even though Zen Discovery itself is being
phased out. This change aligns the documentation and the names of related
classes and methods with the newly-introduced naming conventions.