### PR TITLE
Update IndexTemplateMetaData to allow unknown fields (#38448)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/IndexTemplateMetaData.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/IndexTemplateMetaData.java
@@ -18,27 +18,66 @@
  */
 package org.elasticsearch.client.indices;
 
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MapperService;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 public class IndexTemplateMetaData  {
 
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<IndexTemplateMetaData, String> PARSER = new ConstructingObjectParser<>(
+        "IndexTemplateMetaData", true, (a, name) -> {
+        List<Map.Entry<String, AliasMetaData>> alias = (List<Map.Entry<String, AliasMetaData>>) a[5];
+        ImmutableOpenMap<String, AliasMetaData> aliasMap =
+            new ImmutableOpenMap.Builder<String, AliasMetaData>()
+                .putAll(alias.stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
+                .build();
+        return new IndexTemplateMetaData(
+            name,
+            (Integer) a[0],
+            (Integer) a[1],
+            (List<String>) a[2],
+            (Settings) a[3],
+            (MappingMetaData) a[4],
+            aliasMap);
+    });
+
+    static {
+        PARSER.declareInt(optionalConstructorArg(), new ParseField("order"));
+        PARSER.declareInt(optionalConstructorArg(), new ParseField("version"));
+        PARSER.declareStringArray(optionalConstructorArg(), new ParseField("index_patterns"));
+        PARSER.declareObject(optionalConstructorArg(), (p, c) -> {
+            Settings.Builder templateSettingsBuilder = Settings.builder();
+            templateSettingsBuilder.put(Settings.fromXContent(p));
+            templateSettingsBuilder.normalizePrefix(IndexMetaData.INDEX_SETTING_PREFIX);
+            return templateSettingsBuilder.build();
+        }, new ParseField("settings"));
+        PARSER.declareObject(optionalConstructorArg(), (p, c) -> {
+            Map<String, Object> mapping = p.map();
+            if (mapping.isEmpty()) {
+                return null;
+            }
+            return new MappingMetaData(MapperService.SINGLE_MAPPING_NAME, mapping);
+        }, new ParseField("mappings"));
+        PARSER.declareNamedObjects(optionalConstructorArg(),
+            (p, c, name) -> new AbstractMap.SimpleEntry<>(name, AliasMetaData.Builder.fromXContent(p)), new ParseField("aliases"));
+    }
 
     private final String name;
 
@@ -125,27 +164,22 @@ public class IndexTemplateMetaData  {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         IndexTemplateMetaData that = (IndexTemplateMetaData) o;
-
-        if (order != that.order) return false;
-        if (!Objects.equals(mappings, that.mappings)) return false;
-        if (!name.equals(that.name)) return false;
-        if (!settings.equals(that.settings)) return false;
-        if (!patterns.equals(that.patterns)) return false;
-
-        return Objects.equals(version, that.version);
+        return order == that.order &&
+            Objects.equals(name, that.name) &&
+            Objects.equals(version, that.version) &&
+            Objects.equals(patterns, that.patterns) &&
+            Objects.equals(settings, that.settings) &&
+            Objects.equals(mappings, that.mappings) &&
+            Objects.equals(aliases, that.aliases);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, order, version, patterns, settings, mappings);
+        return Objects.hash(name, order, version, patterns, settings, mappings, aliases);
     }
 
     public static class Builder {
-
-        private static final Set<String> VALID_FIELDS = Sets.newHashSet(
-            "template", "order", "mappings", "settings", "index_patterns", "aliases", "version");
 
         private String name;
 
@@ -193,7 +227,6 @@ public class IndexTemplateMetaData  {
             return this;
         }
 
-
         public Builder settings(Settings.Builder settings) {
             this.settings = settings.build();
             return this;
@@ -225,76 +258,7 @@ public class IndexTemplateMetaData  {
 
 
         public static IndexTemplateMetaData fromXContent(XContentParser parser, String templateName) throws IOException {
-            Builder builder = new Builder(templateName);
-
-            String currentFieldName = skipTemplateName(parser);
-            XContentParser.Token token;
-            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                if (token == XContentParser.Token.FIELD_NAME) {
-                    currentFieldName = parser.currentName();
-                } else if (token == XContentParser.Token.START_OBJECT) {
-                    if ("settings".equals(currentFieldName)) {
-                        Settings.Builder templateSettingsBuilder = Settings.builder();
-                        templateSettingsBuilder.put(Settings.fromXContent(parser));
-                        templateSettingsBuilder.normalizePrefix(IndexMetaData.INDEX_SETTING_PREFIX);
-                        builder.settings(templateSettingsBuilder.build());
-                    } else if ("mappings".equals(currentFieldName)) {
-                        Map<String, Object> mapping = parser.map();
-                        if (mapping.isEmpty() == false) {
-                            MappingMetaData md = new MappingMetaData(MapperService.SINGLE_MAPPING_NAME, mapping);
-                            builder.mapping(md);
-                        }
-                    } else if ("aliases".equals(currentFieldName)) {
-                        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                            builder.putAlias(AliasMetaData.Builder.fromXContent(parser));
-                        }
-                    } else {
-                        throw new ElasticsearchParseException("unknown key [{}] for index template", currentFieldName);
-                    }
-                } else if (token == XContentParser.Token.START_ARRAY) {
-                    if ("mappings".equals(currentFieldName)) {
-                        // The server-side IndexTemplateMetaData has toXContent impl that can return mappings
-                        // in an array but also a comment saying this never happens with typeless APIs.
-                        throw new ElasticsearchParseException("Invalid response format - "
-                                + "mappings are not expected to be returned in an array", currentFieldName);
-                    } else if ("index_patterns".equals(currentFieldName)) {
-                        List<String> index_patterns = new ArrayList<>();
-                        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                            index_patterns.add(parser.text());
-                        }
-                        builder.patterns(index_patterns);
-                    }
-                } else if (token.isValue()) {
-                    // Prior to 5.1.0, elasticsearch only supported a single index pattern called `template` (#21009)
-                    if("template".equals(currentFieldName)) {
-                        builder.patterns(Collections.singletonList(parser.text()));
-                    } else if ("order".equals(currentFieldName)) {
-                        builder.order(parser.intValue());
-                    } else if ("version".equals(currentFieldName)) {
-                        builder.version(parser.intValue());
-                    }
-                }
-            }
-            return builder.build();
-        }
-
-        private static String skipTemplateName(XContentParser parser) throws IOException {
-            XContentParser.Token token = parser.nextToken();
-            if (token == XContentParser.Token.START_OBJECT) {
-                token = parser.nextToken();
-                if (token == XContentParser.Token.FIELD_NAME) {
-                    String currentFieldName = parser.currentName();
-                    if (VALID_FIELDS.contains(currentFieldName)) {
-                        return currentFieldName;
-                    } else {
-                        // we just hit the template name, which should be ignored and we move on
-                        parser.nextToken();
-                    }
-                }
-            }
-
-            return null;
+            return PARSER.parse(parser, templateName);
         }
     }
-
 }


### PR DESCRIPTION
Updated IndexTemplateMetaData to use ObjectParser.

The IndexTemplateMetaData class used old parsing logic and was not
resiliant to new fields. This commit updates it to use the
ConstructingObjectParser and allow unknown fields.

Relates #36938