### PR TITLE
6.x backport: Fix _host based require filters

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -147,16 +147,7 @@ public class DiscoveryNodeFilters {
                 }
             } else if ("_host".equals(attr)) {
                 for (String value : values) {
-                    if (Regex.simpleMatch(value, node.getHostName())) {
-                        if (opType == OpType.OR) {
-                            return true;
-                        }
-                    } else {
-                        if (opType == OpType.AND) {
-                            return false;
-                        }
-                    }
-                    if (Regex.simpleMatch(value, node.getHostAddress())) {
+                    if (Regex.simpleMatch(value, node.getHostName()) || Regex.simpleMatch(value, node.getHostAddress())) {
                         if (opType == OpType.OR) {
                             return true;
                         }

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
@@ -235,6 +235,26 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
         assertThat(filters.match(node), equalTo(true));
     }
 
+    public void testHostNameFilteringMatchingAnd() {
+        Settings settings = shuffleSettings(Settings.builder()
+            .put("xxx._host", "A")
+            .build());
+        DiscoveryNodeFilters filters = buildFromSettings(AND, "xxx.", settings);
+
+        DiscoveryNode node = new DiscoveryNode("", "", "", "A", "192.1.1.54", localAddress, emptyMap(), emptySet(), null);
+        assertThat(filters.match(node), equalTo(true));
+    }
+
+    public void testHostAddressFilteringMatchingAnd() {
+        Settings settings = shuffleSettings(Settings.builder()
+            .put("xxx._host", "192.1.1.54")
+            .build());
+        DiscoveryNodeFilters filters = buildFromSettings(AND, "xxx.", settings);
+
+        DiscoveryNode node = new DiscoveryNode("", "", "", "A", "192.1.1.54", localAddress, emptyMap(), emptySet(), null);
+        assertThat(filters.match(node), equalTo(true));
+    }
+
     public void testIpPublishFilteringNotMatchingOr() {
         Settings settings = shuffleSettings(Settings.builder()
                 .put("xxx.tag", "A")


### PR DESCRIPTION
Using index.routing.allocation.require._host does not correctly work because the boolean logic in
filter matching is broken (DiscoveryNodeFilters.match(...) will return false) when
opType ==OpType.AND