### PR TITLE
Fix the clock resolution to millis in ScheduledEventTests

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEventTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEventTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.core.ml.job.config.RuleCondition;
 
 import java.io.IOException;
 import java.time.Clock;
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.EnumSet;
@@ -28,7 +29,7 @@ import static org.hamcrest.Matchers.containsString;
 public class ScheduledEventTests extends AbstractSerializingTestCase<ScheduledEvent> {
 
     public static ScheduledEvent createScheduledEvent(String calendarId) {
-        ZonedDateTime start = Clock.systemUTC().instant().atZone(ZoneOffset.UTC);
+        ZonedDateTime start = nowWithMillisResolution();
         return new ScheduledEvent(randomAlphaOfLength(10), start, start.plusSeconds(randomIntBetween(1, 10000)),
                 calendarId, null);
     }
@@ -118,5 +119,9 @@ public class ScheduledEventTests extends AbstractSerializingTestCase<ScheduledEv
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
             ScheduledEvent.LENIENT_PARSER.apply(parser, null);
         }
+    }
+
+    private static ZonedDateTime nowWithMillisResolution() {
+        return Instant.ofEpochMilli(Clock.systemUTC().millis()).atZone(ZoneOffset.UTC);
     }
 }


### PR DESCRIPTION
The clock resolution changed from jdk8 to jdk10, hence the
test is passing in jdk8 but failing in jdk10.  Scheduled
events are serialised and deserialised with millisecond
precision, making test fail in jdk 10 and higher.

Fixes a problem introduced by #38415 and the fix is
identical to the one that was made in #38405.