### PR TITLE
[DOCS] Add warning about bypassing ML PUT APIs

### DIFF
--- a/docs/reference/ml/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/apis/put-datafeed.asciidoc
@@ -19,6 +19,11 @@ Instantiates a {dfeed}.
 You must create a job before you create a {dfeed}.  You can associate only one
 {dfeed} to each job.
 
+IMPORTANT:  Putting a {dfeed} must be done via this API only. Do not put a {dfeed}
+            directly to the `.ml-config` index using the Elasticsearch Index API.
+            If {es} {security-features} are enabled, make sure no `write`
+            privileges are granted to anyone over the `.ml-config` index.
+
 
 ==== Path Parameters
 

--- a/docs/reference/ml/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/apis/put-datafeed.asciidoc
@@ -19,10 +19,10 @@ Instantiates a {dfeed}.
 You must create a job before you create a {dfeed}.  You can associate only one
 {dfeed} to each job.
 
-IMPORTANT:  Putting a {dfeed} must be done via this API only. Do not put a {dfeed}
-            directly to the `.ml-config` index using the Elasticsearch Index API.
-            If {es} {security-features} are enabled, make sure no `write`
-            privileges are granted to anyone over the `.ml-config` index.
+IMPORTANT:  You must use {kib} or this API to create a {dfeed}. Do not put a {dfeed}
+            directly to the `.ml-config` index using the Elasticsearch index API.
+            If {es} {security-features} are enabled, do not give users `write`
+            privileges on the `.ml-config` index.
 
 
 ==== Path Parameters

--- a/docs/reference/ml/apis/put-job.asciidoc
+++ b/docs/reference/ml/apis/put-job.asciidoc
@@ -12,7 +12,13 @@ Instantiates a job.
 
 `PUT _ml/anomaly_detectors/<job_id>`
 
-//===== Description
+===== Description
+
+IMPORTANT:  Putting a job must be done via this API only. Do not put a job
+            directly to the `.ml-config` index using the Elasticsearch Index API.
+            If {es} {security-features} are enabled, make sure no `write`
+            privileges are granted to anyone over the `.ml-config` index.
+
 
 ==== Path Parameters
 

--- a/docs/reference/ml/apis/put-job.asciidoc
+++ b/docs/reference/ml/apis/put-job.asciidoc
@@ -14,10 +14,10 @@ Instantiates a job.
 
 ===== Description
 
-IMPORTANT:  Putting a job must be done via this API only. Do not put a job
-            directly to the `.ml-config` index using the Elasticsearch Index API.
-            If {es} {security-features} are enabled, make sure no `write`
-            privileges are granted to anyone over the `.ml-config` index.
+IMPORTANT: You must use {kib} or this API to create a {ml} job. Do not put a job
+            directly to the `.ml-config` index using the Elasticsearch index API.
+            If {es} {security-features} are enabled, do not give users `write`
+            privileges on the `.ml-config` index.
 
 
 ==== Path Parameters


### PR DESCRIPTION
Now that ML configurations are stored in the .ml-config
index rather than in cluster state there is a possibility
that some users may try to add configurations directly to
the index.  Allowing this creates a variety of problems
including possible data exflitration attacks (depending on
how security is set up), so this commit adds warnings
against allowing writes to the .ml-config index other than
via the ML APIs.