### PR TITLE
correct key is "clientip", not only "ip"

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1810,7 +1810,7 @@ Named skip key modifier example
 | *Pattern* | `%{clientip} %{?ident} %{?auth} [%{@timestamp}]`
 | *Input*   | 1.2.3.4 - - [30/Apr/1998:22:00:52 +0000]
 | *Result*  a|
-* ip = 1.2.3.4
+* clientip = 1.2.3.4
 * @timestamp = 30/Apr/1998:22:00:52 +0000
 |======
 


### PR DESCRIPTION
If I understood well, whatever name you point to be used, it will be "key' name exported ...