### PR TITLE
bad formatted JSON object (#38515)

### DIFF
--- a/docs/reference/ingest/processors/foreach.asciidoc
+++ b/docs/reference/ingest/processors/foreach.asciidoc
@@ -141,8 +141,8 @@ block to send the document to the 'failure_index' index for later inspection:
         "on_failure" : [
           {
             "set" : {
-              "field", "_index",
-              "value", "failure_index"
+              "field": "_index",
+              "value": "failure_index"
             }
           }
         ]


### PR DESCRIPTION
It just need to replace the wrong " , " to " : "

Backport of #38515