### PR TITLE
Deprecate the low-level REST client on JDK 7

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/bootstrap/JavaVersion.java
+++ b/client/rest/src/main/java/org/elasticsearch/bootstrap/JavaVersion.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.bootstrap;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+public class JavaVersion implements Comparable<JavaVersion> {
+
+    private final List<Integer> version;
+
+    public List<Integer> getVersion() {
+        return version;
+    }
+
+    private JavaVersion(List<Integer> version) {
+        if (version.size() >= 2 && version.get(0) == 1 && version.get(1) == 8) {
+            // for Java 8 there is ambiguity since both 1.8 and 8 are supported,
+            // so we rewrite the former to the latter
+            version = new ArrayList<>(version.subList(1, version.size()));
+        }
+        this.version = Collections.unmodifiableList(version);
+    }
+
+    public static JavaVersion parse(String value) {
+        Objects.requireNonNull(value);
+        if (!isValid(value)) {
+            throw new IllegalArgumentException("value");
+        }
+
+        List<Integer> version = new ArrayList<>();
+        String[] components = value.split("\\.");
+        for (String component : components) {
+            version.add(Integer.valueOf(component));
+        }
+
+        return new JavaVersion(version);
+    }
+
+    public static boolean isValid(String value) {
+        return value.matches("^0*[0-9]+(\\.[0-9]+)*$");
+    }
+
+    private static final JavaVersion CURRENT = parse(System.getProperty("java.specification.version"));
+
+    public static JavaVersion current() {
+        return CURRENT;
+    }
+
+    @Override
+    public int compareTo(JavaVersion o) {
+        int len = Math.max(version.size(), o.version.size());
+        for (int i = 0; i < len; i++) {
+            int d = (i < version.size() ? version.get(i) : 0);
+            int s = (i < o.version.size() ? o.version.get(i) : 0);
+            if (s < d)
+                return 1;
+            if (s > d)
+                return -1;
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || o.getClass() != getClass()) {
+            return false;
+        }
+        return compareTo((JavaVersion) o) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return version.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        final Iterator<Integer> it =  version.iterator();
+        sb.append(it.next());
+        while (it.hasNext()) {
+            sb.append(".").append(it.next());
+        }
+
+        return sb.toString();
+    }
+}

--- a/client/rest/src/main/java/org/elasticsearch/bootstrap/JavaVersion.java
+++ b/client/rest/src/main/java/org/elasticsearch/bootstrap/JavaVersion.java
@@ -97,7 +97,7 @@ public class JavaVersion implements Comparable<JavaVersion> {
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
-        final Iterator<Integer> it =  version.iterator();
+        final Iterator<Integer> it = version.iterator();
         sb.append(it.next());
         while (it.hasNext()) {
             sb.append(".").append(it.next());

--- a/client/rest/src/main/java/org/elasticsearch/client/JavaVersion.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/JavaVersion.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.bootstrap;
+package org.elasticsearch.client;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -46,6 +46,7 @@ import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.nio.client.methods.HttpAsyncMethods;
 import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
 import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
+import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.client.DeadHostState.TimeSupplier;
 
 import javax.net.ssl.SSLHandshakeException;
@@ -122,6 +123,9 @@ public class RestClient implements Closeable {
         this.nodeSelector = nodeSelector;
         this.warningsHandler = strictDeprecationMode ? WarningsHandler.STRICT : WarningsHandler.PERMISSIVE;
         setNodes(nodes);
+        if (JavaVersion.current().compareTo(JavaVersion.parse("1.8.0")) < 0) {
+            logger.warn("use of the low-level REST client on JDK 7 is deprecated and will be removed in version 7.0.0 of the client");
+        }
     }
 
     /**

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -46,7 +46,6 @@ import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.nio.client.methods.HttpAsyncMethods;
 import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
 import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
-import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.client.DeadHostState.TimeSupplier;
 
 import javax.net.ssl.SSLHandshakeException;

--- a/libs/core/src/test/java/org/elasticsearch/bootstrap/JarHellTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/bootstrap/JarHellTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.bootstrap;
 
+import org.elasticsearch.client.JavaVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.test.ESTestCase;

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.painless;
 
 import org.apache.lucene.util.Constants;
-import org.elasticsearch.bootstrap.JavaVersion;
+import org.elasticsearch.client.JavaVersion;
 import org.hamcrest.Matcher;
 
 import java.lang.invoke.MethodHandle;

--- a/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsTests.java
+++ b/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsTests.java
@@ -22,7 +22,7 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.bootstrap.JavaVersion;
+import org.elasticsearch.client.JavaVersion;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.Settings;

--- a/server/src/test/java/org/elasticsearch/bootstrap/JavaVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/JavaVersionTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.bootstrap;
 
+import org.elasticsearch.client.JavaVersion;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.List;

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.common.joda;
 
-import org.elasticsearch.bootstrap.JavaVersion;
+import org.elasticsearch.client.JavaVersion;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.test.ESTestCase;

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/JvmInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/JvmInfoTests.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.monitor.jvm;
 
 import org.apache.lucene.util.Constants;
-import org.elasticsearch.bootstrap.JavaVersion;
+import org.elasticsearch.client.JavaVersion;
 import org.elasticsearch.test.ESTestCase;
 
 public class JvmInfoTests extends ESTestCase {

--- a/server/src/test/java/org/elasticsearch/plugins/IndexStorePluginTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/IndexStorePluginTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.plugins;
 
-import org.elasticsearch.bootstrap.JavaVersion;
+import org.elasticsearch.client.JavaVersion;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NamedDateTimeProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NamedDateTimeProcessorTests.java
@@ -5,7 +5,7 @@
  */
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
-import org.elasticsearch.bootstrap.JavaVersion;
+import org.elasticsearch.client.JavaVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;


### PR DESCRIPTION
This commit deprecates the use of the low-level REST client in JDK 7. Support for the low-level REST client on JDK 7 will be removed in 7.0.0.

Relates #29607