### PR TITLE
Fix build on Fips

### DIFF
--- a/x-pack/plugin/security/cli/build.gradle
+++ b/x-pack/plugin/security/cli/build.gradle
@@ -24,6 +24,7 @@ dependencyLicenses {
 
 if (project.inFipsJvm) {
     unitTest.enabled = false
+    testingConventions.enabled = false
     // Forbiden APIs non-portable checks fail because bouncy castle classes being used from the FIPS JDK since those are
     // not part of the Java specification - all of this is as designed, so we have to relax this check for FIPS.
     tasks.withType(CheckForbiddenApis) {
@@ -32,4 +33,5 @@ if (project.inFipsJvm) {
     // FIPS JVM includes many classes from bouncycastle which count as jar hell for the third party audit,
     // rather than provide a long list of exclusions, disable the check on FIPS.
     thirdPartyAudit.enabled = false
+
 }


### PR DESCRIPTION
testing convetions need to be disabled if the test task is for fips.

This is a cherry-pick of https://github.com/elastic/elasticsearch/commit/6a5f3f05f405095ef97c6e40eca4cbebcc4bb82f which fixed this on master. This was failing on 6.x and so now fails on 6.7

Closes #38322 and #37697