### PR TITLE
[DOCS] Updates 7.x Versions.asciidoc

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -1,8 +1,8 @@
-:version:               7.0.0-alpha2
+:version:               7.1.0
 :major-version:         7.x
 :lucene_version:        8.0.0
 :lucene_version_path:   8_0_0
-:branch:                master
+:branch:                7.x
 :jdk:                   1.8.0_131
 :jdk_major:             8
 :build_flavor:          default


### PR DESCRIPTION
This PR updates the version details in the Versions.asciidoc to match other repos (e.g. https://raw.githubusercontent.com/elastic/logstash/7.x/docs/index.asciidoc)
