### PR TITLE
[DOC][SQL JDBC]change setup URL

### DIFF
--- a/docs/reference/sql/endpoints/jdbc.asciidoc
+++ b/docs/reference/sql/endpoints/jdbc.asciidoc
@@ -53,7 +53,7 @@ Once registered, the driver understands the following syntax as an URL:
 
 ["source","text",subs="attributes"]
 ----
-jdbc:es://<1>[http|https]?<2>[host[:port]]*<3>/[prefix]*<4>[?[option=value]&<5>]*
+jdbc:es://<1>[http|https]://<2>[host[:port]]*<3>/[prefix]*<4>[?[option=value]&<5>]*
 ----
 
 <1> `jdbc:es://` prefix. Mandatory.

--- a/docs/reference/sql/endpoints/jdbc.asciidoc
+++ b/docs/reference/sql/endpoints/jdbc.asciidoc
@@ -53,7 +53,7 @@ Once registered, the driver understands the following syntax as an URL:
 
 ["source","text",subs="attributes"]
 ----
-jdbc:es://[<1>[http|https]]://<2>[host[:port]]*<3>/[prefix]*<4>[?[option=value]&<5>]*
+jdbc:es://<1>[[http|https]://]<2>[host[:port]]*<3>/[prefix]*<4>[?[option=value]&<5>]*
 ----
 
 <1> `jdbc:es://` prefix. Mandatory.

--- a/docs/reference/sql/endpoints/jdbc.asciidoc
+++ b/docs/reference/sql/endpoints/jdbc.asciidoc
@@ -53,7 +53,7 @@ Once registered, the driver understands the following syntax as an URL:
 
 ["source","text",subs="attributes"]
 ----
-jdbc:es://<1>[http|https]://<2>[host[:port]]*<3>/[prefix]*<4>[?[option=value]&<5>]*
+jdbc:es://[<1>[http|https]]://<2>[host[:port]]*<3>/[prefix]*<4>[?[option=value]&<5>]*
 ----
 
 <1> `jdbc:es://` prefix. Mandatory.

--- a/docs/reference/sql/endpoints/jdbc.asciidoc
+++ b/docs/reference/sql/endpoints/jdbc.asciidoc
@@ -53,7 +53,7 @@ Once registered, the driver understands the following syntax as an URL:
 
 ["source","text",subs="attributes"]
 ----
-jdbc:es://<1>[[http|https]://]<2>[host[:port]]*<3>/[prefix]*<4>[?[option=value]&<5>]*
+jdbc:es://<1>[[http|https]://]*<2>[host[:port]]*<3>/[prefix]*<4>[?[option=value]&<5>]*
 ----
 
 <1> `jdbc:es://` prefix. Mandatory.


### PR DESCRIPTION
I read the following sources and thought that it was necessary to change the documentation of [SQL JDBC].
change setup URL「?」→「://」

https://github.com/elastic/elasticsearch/blob/6857d305270be3d987689fda37cc84b7bc18fbb3/x-pack/plugin/sql/qa/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/JdbcSecurityIT.java
