### PR TITLE
Fix HistoryIntegrationTests timestamp comparsion BackPort#38505

### DIFF
--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
@@ -17,12 +17,15 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.xpack.core.watcher.actions.ActionStatus;
 import org.elasticsearch.xpack.core.watcher.client.WatchSourceBuilder;
 import org.elasticsearch.xpack.core.watcher.input.Input;
+import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
 import org.elasticsearch.xpack.core.watcher.support.xcontent.XContentSource;
 import org.elasticsearch.xpack.core.watcher.watch.WatchStatus;
 import org.elasticsearch.xpack.watcher.support.search.WatcherSearchTemplateRequest;
 import org.elasticsearch.xpack.watcher.test.AbstractWatcherIntegrationTestCase;
 import org.elasticsearch.xpack.watcher.trigger.schedule.IntervalSchedule;
+import org.hamcrest.Matcher;
 
+import java.time.ZonedDateTime;
 import java.util.Locale;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -172,10 +175,10 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
         assertThat(active, is(status.state().isActive()));
 
         String timestamp = source.getValue("status.state.timestamp");
-        assertThat(timestamp, is(status.state().getTimestamp().toString()));
+        assertThat(timestamp, isSameDate(status.state().getTimestamp()));
 
         String lastChecked = source.getValue("status.last_checked");
-        assertThat(lastChecked, is(status.lastChecked().toString()));
+        assertThat(lastChecked, isSameDate(status.lastChecked()));
 
         Integer version = source.getValue("status.version");
         int expectedVersion = (int) (status.version() - 1);
@@ -195,5 +198,15 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
         assertThat(mappingSource.getValue("doc.properties.status.enabled"), is(false));
         assertThat(mappingSource.getValue("doc.properties.status.properties.status"), is(nullValue()));
         assertThat(mappingSource.getValue("doc.properties.status.properties.status.properties.active"), is(nullValue()));
+    }
+
+
+    private Matcher<String> isSameDate(ZonedDateTime zonedDateTime) {
+        /*
+        When comparing timestamps returned from _search/.watcher-history* the same format of date has to be used
+        during serialisation to json on index time.
+        The toString of ZonedDateTime is omitting the millisecond part when is 0. This was not the case in joda.
+         */
+        return is(WatcherDateTimeUtils.formatDate(zonedDateTime));
     }
 }


### PR DESCRIPTION
When the millisecond part of a timestamp is 0 the toString
representation in java-time is omitting the millisecond part (joda was
not). The Search response is returning timestamps formatted with
WatcherDateTimeUtils, therefore comparisons of strings should be done
with the same formatter

relates #27330
BackPort#38505