### PR TITLE
[FEATURE][ML] Add query support for dataframe analytics config

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -6,29 +6,63 @@
 package org.elasticsearch.xpack.core.ml.dataframe;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.CachedSupplier;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParseException;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
+import org.elasticsearch.xpack.core.ml.utils.XContentObjectTransformer;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
 
     public static final String TYPE = "data_frame_analytics_config";
 
+    private static final XContentObjectTransformer<QueryBuilder> QUERY_TRANSFORMER = XContentObjectTransformer.queryBuilderTransformer();
+    static final TriFunction<Map<String, Object>, String, List<String>, QueryBuilder> lazyQueryParser =
+        (objectMap, id, warnings) -> {
+            try {
+                return QUERY_TRANSFORMER.fromMap(objectMap, warnings);
+            } catch (IOException | XContentParseException exception) {
+                // Certain thrown exceptions wrap up the real Illegal argument making it hard to determine cause for the user
+                if (exception.getCause() instanceof IllegalArgumentException) {
+                    throw ExceptionsHelper.badRequestException(
+                        Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_BAD_QUERY_FORMAT,
+                            id,
+                            exception.getCause().getMessage()),
+                        exception.getCause());
+                } else {
+                    throw ExceptionsHelper.badRequestException(
+                        Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_BAD_QUERY_FORMAT, exception, id),
+                        exception);
+                }
+            }
+        };
+
+
     public static final ParseField ID = new ParseField("id");
     public static final ParseField SOURCE = new ParseField("source");
     public static final ParseField DEST = new ParseField("dest");
     public static final ParseField ANALYSES = new ParseField("analyses");
     public static final ParseField CONFIG_TYPE = new ParseField("config_type");
+    public static final ParseField QUERY = new ParseField("query");
 
     public static final ObjectParser<Builder, Void> STRICT_PARSER = createParser(false);
     public static final ObjectParser<Builder, Void> LENIENT_PARSER = createParser(true);
@@ -41,6 +75,11 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         parser.declareString(Builder::setSource, SOURCE);
         parser.declareString(Builder::setDest, DEST);
         parser.declareObjectArray(Builder::setAnalyses, DataFrameAnalysisConfig.parser(), ANALYSES);
+        if (ignoreUnknownFields) {
+            parser.declareObject(Builder::setQuery, (p, c) -> p.mapOrdered(), QUERY);
+        } else {
+            parser.declareObject(Builder::setParsedQuery, (p, c) -> AbstractQueryBuilder.parseInnerQueryBuilder(p), QUERY);
+        }
         return parser;
     }
 
@@ -48,8 +87,11 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
     private final String source;
     private final String dest;
     private final List<DataFrameAnalysisConfig> analyses;
+    private final Map<String, Object> query;
+    private final CachedSupplier<QueryBuilder> querySupplier;
 
-    public DataFrameAnalyticsConfig(String id, String source, String dest, List<DataFrameAnalysisConfig> analyses) {
+    public DataFrameAnalyticsConfig(String id, String source, String dest, List<DataFrameAnalysisConfig> analyses,
+                                    Map<String, Object> query) {
         this.id = ExceptionsHelper.requireNonNull(id, ID);
         this.source = ExceptionsHelper.requireNonNull(source, SOURCE);
         this.dest = ExceptionsHelper.requireNonNull(dest, DEST);
@@ -61,6 +103,8 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         if (analyses.size() > 1) {
             throw new UnsupportedOperationException("Does not yet support multiple analyses");
         }
+        this.query = query == null ? null : Collections.unmodifiableMap(query);
+        this.querySupplier = new CachedSupplier<>(() -> lazyQueryParser.apply(query, id, new ArrayList<>()));
     }
 
     public DataFrameAnalyticsConfig(StreamInput in) throws IOException {
@@ -68,6 +112,12 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         source = in.readString();
         dest = in.readString();
         analyses = in.readList(DataFrameAnalysisConfig::new);
+        if (in.readBoolean()) {
+            this.query = in.readMap();
+        } else {
+            this.query = null;
+        }
+        this.querySupplier = new CachedSupplier<>(() -> lazyQueryParser.apply(query, id, new ArrayList<>()));
     }
 
     public String getId() {
@@ -86,6 +136,30 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         return analyses;
     }
 
+    @Nullable
+    public Map<String, Object> getQuery() {
+        return query;
+    }
+
+    @Nullable
+    public QueryBuilder getParsedQuery() {
+        return querySupplier.get();
+    }
+
+    /**
+     * Calls the lazy parser and returns any gathered deprecations
+     * @return The deprecations from parsing the query
+     */
+    public List<String> getQueryDeprecations() {
+        return getQueryDeprecations(lazyQueryParser);
+    }
+
+    List<String> getQueryDeprecations(TriFunction<Map<String, Object>, String, List<String>, QueryBuilder> parser) {
+        List<String> deprecations = new ArrayList<>();
+        parser.apply(query, id, deprecations);
+        return deprecations;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
@@ -95,6 +169,9 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         builder.field(ANALYSES.getPreferredName(), analyses);
         if (params.paramAsBoolean(ToXContentParams.INCLUDE_TYPE, false)) {
             builder.field(CONFIG_TYPE.getPreferredName(), TYPE);
+        }
+        if (query != null) {
+            builder.field(QUERY.getPreferredName(), query);
         }
         builder.endObject();
         return builder;
@@ -106,6 +183,10 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         out.writeString(source);
         out.writeString(dest);
         out.writeList(analyses);
+        out.writeBoolean(query != null);
+        if (query != null) {
+            out.writeMap(query);
+        }
     }
 
     @Override
@@ -117,12 +198,13 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         return Objects.equals(id, other.id)
             && Objects.equals(source, other.source)
             && Objects.equals(dest, other.dest)
-            && Objects.equals(analyses, other.analyses);
+            && Objects.equals(analyses, other.analyses)
+            && Objects.equals(query, other.query);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, source, dest, analyses);
+        return Objects.hash(id, source, dest, analyses, query);
     }
 
     public static String documentId(String id) {
@@ -135,29 +217,49 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         private String source;
         private String dest;
         private List<DataFrameAnalysisConfig> analyses;
+        private Map<String, Object> query;
 
         public String getId() {
             return id;
         }
 
-        public void setId(String id) {
+        public Builder setId(String id) {
             this.id = ExceptionsHelper.requireNonNull(id, ID);
+            return this;
         }
 
-        public void setSource(String source) {
+        public Builder setSource(String source) {
             this.source = ExceptionsHelper.requireNonNull(source, SOURCE);
+            return this;
         }
 
-        public void setDest(String dest) {
+        public Builder setDest(String dest) {
             this.dest = ExceptionsHelper.requireNonNull(dest, DEST);
+            return this;
         }
 
-        public void setAnalyses(List<DataFrameAnalysisConfig> analyses) {
+        public Builder setAnalyses(List<DataFrameAnalysisConfig> analyses) {
             this.analyses = ExceptionsHelper.requireNonNull(analyses, ANALYSES);
+            return this;
+        }
+
+        public Builder setParsedQuery(QueryBuilder query) {
+            try {
+                setQuery(QUERY_TRANSFORMER.toMap(query));
+                return this;
+            } catch (IOException exception) { // This exception should never really throw as we are simply transforming the object to a map
+                    throw ExceptionsHelper.badRequestException(
+                        Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_BAD_QUERY_FORMAT, id, exception.getMessage()), exception);
+            }
+        }
+
+        public Builder setQuery(Map<String, Object> query) {
+            this.query = query;
+            return this;
         }
 
         public DataFrameAnalyticsConfig build() {
-            return new DataFrameAnalyticsConfig(id, source, dest, analyses);
+            return new DataFrameAnalyticsConfig(id, source, dest, analyses, query);
         }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -229,16 +229,6 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
             return this;
         }
 
-        public Builder setParsedQuery(QueryBuilder query) {
-            try {
-                setQuery(QUERY_TRANSFORMER.toMap(ExceptionsHelper.requireNonNull(query, QUERY.getPreferredName())));
-                return this;
-            } catch (IOException exception) { // This exception should never really throw as we are simply transforming the object to a map
-                    throw ExceptionsHelper.badRequestException(
-                        Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_BAD_QUERY_FORMAT, id), exception);
-            }
-        }
-
         public Builder setQuery(Map<String, Object> query) {
             return setQuery(query, true);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -50,6 +50,8 @@ public final class Messages {
             "Datafeed frequency [{0}] must be a multiple of the aggregation interval [{1}]";
     public static final String DATAFEED_ID_ALREADY_TAKEN = "A datafeed with id [{0}] already exists";
 
+    public static final String DATA_FRAME_ANALYTICS_BAD_QUERY_FORMAT = "Data Frame Analytics config [{0}] query is not parsable: {1}";
+
     public static final String FILTER_CANNOT_DELETE = "Cannot delete filter [{0}] currently used by jobs {1}";
     public static final String FILTER_CONTAINS_TOO_MANY_ITEMS = "Filter [{0}] contains too many items; up to [{1}] items are allowed";
     public static final String FILTER_NOT_FOUND = "No filter with id [{0}] exists";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -50,7 +50,7 @@ public final class Messages {
             "Datafeed frequency [{0}] must be a multiple of the aggregation interval [{1}]";
     public static final String DATAFEED_ID_ALREADY_TAKEN = "A datafeed with id [{0}] already exists";
 
-    public static final String DATA_FRAME_ANALYTICS_BAD_QUERY_FORMAT = "Data Frame Analytics config [{0}] query is not parsable: {1}";
+    public static final String DATA_FRAME_ANALYTICS_BAD_QUERY_FORMAT = "Data Frame Analytics config [{0}] query is not parsable";
 
     public static final String FILTER_CANNOT_DELETE = "Cannot delete filter [{0}] currently used by jobs {1}";
     public static final String FILTER_CONTAINS_TOO_MANY_ITEMS = "Filter [{0}] contains too many items; up to [{1}] items are allowed";

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsActionRequestTests.java
@@ -5,11 +5,17 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractStreamableXContentTestCase;
 import org.elasticsearch.xpack.core.ml.action.PutDataFrameAnalyticsAction.Request;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfigTests;
 import org.junit.Before;
+
+import java.util.Collections;
 
 public class PutDataFrameAnalyticsActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
 
@@ -18,6 +24,18 @@ public class PutDataFrameAnalyticsActionRequestTests extends AbstractStreamableX
     @Before
     public void setUpId() {
         id = DataFrameAnalyticsConfigTests.randomValidId();
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, Collections.emptyList());
+        return new NamedWriteableRegistry(searchModule.getNamedWriteables());
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, Collections.emptyList());
+        return new NamedXContentRegistry(searchModule.getNamedXContents());
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractSerializingTestCase;
@@ -63,16 +62,15 @@ public class DataFrameAnalyticsConfigTests extends AbstractSerializingTestCase<D
         String source = randomAlphaOfLength(10);
         String dest = randomAlphaOfLength(10);
         List<DataFrameAnalysisConfig> analyses = Collections.singletonList(DataFrameAnalysisConfigTests.randomConfig());
-        QueryBuilder queryBuilder = randomBoolean() ?
-            QueryBuilders.termQuery(randomAlphaOfLength(10), randomAlphaOfLength(10)) :
-            null;
-        return new DataFrameAnalyticsConfig.Builder()
+        DataFrameAnalyticsConfig.Builder builder = new DataFrameAnalyticsConfig.Builder()
             .setId(id)
             .setAnalyses(analyses)
             .setSource(source)
-            .setDest(dest)
-            .setParsedQuery(queryBuilder)
-            .build();
+            .setDest(dest);
+        if (randomBoolean()) {
+            builder.setParsedQuery(QueryBuilders.termQuery(randomAlphaOfLength(10), randomAlphaOfLength(10)));
+        }
+        return builder.build();
     }
 
     public static String randomValidId() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigTests.java
@@ -6,19 +6,47 @@
 package org.elasticsearch.xpack.core.ml.dataframe;
 
 import com.carrotsearch.randomizedtesting.generators.CodepointSetGenerator;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.Matchers.hasItem;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
 public class DataFrameAnalyticsConfigTests extends AbstractSerializingTestCase<DataFrameAnalyticsConfig> {
 
     @Override
     protected DataFrameAnalyticsConfig doParseInstance(XContentParser parser) throws IOException {
         return DataFrameAnalyticsConfig.STRICT_PARSER.apply(parser, null).build();
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, Collections.emptyList());
+        return new NamedWriteableRegistry(searchModule.getNamedWriteables());
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, Collections.emptyList());
+        return new NamedXContentRegistry(searchModule.getNamedXContents());
     }
 
     @Override
@@ -35,11 +63,65 @@ public class DataFrameAnalyticsConfigTests extends AbstractSerializingTestCase<D
         String source = randomAlphaOfLength(10);
         String dest = randomAlphaOfLength(10);
         List<DataFrameAnalysisConfig> analyses = Collections.singletonList(DataFrameAnalysisConfigTests.randomConfig());
-        return new DataFrameAnalyticsConfig(id, source, dest, analyses);
+        QueryBuilder queryBuilder = randomBoolean() ?
+            QueryBuilders.termQuery(randomAlphaOfLength(10), randomAlphaOfLength(10)) :
+            null;
+        return new DataFrameAnalyticsConfig.Builder()
+            .setId(id)
+            .setAnalyses(analyses)
+            .setSource(source)
+            .setDest(dest)
+            .setParsedQuery(queryBuilder)
+            .build();
     }
 
     public static String randomValidId() {
-        CodepointSetGenerator generator =  new CodepointSetGenerator("abcdefghijklmnopqrstuvwxyz".toCharArray());
+        CodepointSetGenerator generator = new CodepointSetGenerator("abcdefghijklmnopqrstuvwxyz".toCharArray());
         return generator.ofCodePointsLength(random(), 10, 10);
+    }
+
+    private static final String ANACHRONISTIC_QUERY_DATA_FRAME_ANALYTICS = "{\n" +
+        "    \"id\": \"old-data-frame\",\n" +
+        "    \"source\": \"my-index\",\n" +
+        "    \"dest\": \"dest-index\",\n" +
+        "    \"analyses\": {\"outlier_detection\": {\"number_neighbours\": 10}},\n" +
+        //query:match:type stopped being supported in 6.x
+        "    \"query\": {\"match\" : {\"query\":\"fieldName\", \"type\": \"phrase\"}}\n" +
+        "}";
+
+    public void testPastQueryConfigParse() throws IOException {
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+            .createParser(NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                ANACHRONISTIC_QUERY_DATA_FRAME_ANALYTICS)) {
+
+            DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.LENIENT_PARSER.apply(parser, null).build();
+            ElasticsearchException e = expectThrows(ElasticsearchException.class, () -> config.getParsedQuery());
+            assertEquals("[match] query doesn't support multiple fields, found [query] and [type]", e.getMessage());
+        }
+
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+            .createParser(NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                ANACHRONISTIC_QUERY_DATA_FRAME_ANALYTICS)) {
+
+            XContentParseException e = expectThrows(XContentParseException.class,
+                () -> DataFrameAnalyticsConfig.STRICT_PARSER.apply(parser, null).build());
+            assertEquals("[6:25] [data_frame_analytics_config] failed to parse field [query]", e.getMessage());
+        }
+    }
+
+    public void testGetQueryDeprecations() {
+        DataFrameAnalyticsConfig dataFrame = createTestInstance();
+        String deprecationWarning = "Warning";
+        List<String> deprecations = dataFrame.getQueryDeprecations((map, id, deprecationlist) -> {
+            deprecationlist.add(deprecationWarning);
+            return new BoolQueryBuilder();
+        });
+        assertThat(deprecations, hasItem(deprecationWarning));
+
+        DataFrameAnalyticsConfig spiedConfig = spy(dataFrame);
+        spiedConfig.getQueryDeprecations();
+        verify(spiedConfig).getQueryDeprecations(DataFrameAnalyticsConfig.lazyQueryParser);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 
@@ -70,7 +70,9 @@ public class DataFrameAnalyticsConfigTests extends AbstractSerializingTestCase<D
             .setSource(source)
             .setDest(dest);
         if (randomBoolean()) {
-            builder.setParsedQuery(QueryBuilders.termQuery(randomAlphaOfLength(10), randomAlphaOfLength(10)));
+            builder.setQuery(
+                Collections.singletonMap(TermQueryBuilder.NAME,
+                    Collections.singletonMap(randomAlphaOfLength(10), randomAlphaOfLength(10))), true);
         }
         return builder.build();
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -130,7 +130,7 @@ public class TransportStartDataFrameAnalyticsAction
 
         // Validate config
         ActionListener<DataFrameAnalyticsConfig> configListener = ActionListener.wrap(
-            config -> DataFrameDataExtractorFactory.create(client, Collections.emptyMap(), config.getId(), config.getSource(),
+            config -> DataFrameDataExtractorFactory.create(client, Collections.emptyMap(), config,
                 ActionListener.wrap(dataExtractorFactory -> validatedConfigListener.onResponse(config), listener::onFailure)),
             listener::onFailure
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -145,7 +145,12 @@ public class DataFrameAnalyticsManager {
         // TODO This could fail with errors. In that case we get stuck with the copied index.
         // We could delete the index in case of failure or we could try building the factory before reindexing
         // to catch the error early on.
-        DataFrameDataExtractorFactory.create(client, Collections.emptyMap(), config, dataExtractorFactoryListener);
+        DataFrameDataExtractorFactory.create(client,
+            Collections.emptyMap(),
+            config.getId(),
+            config.getDest(),
+            config.getParsedQuery(),
+            dataExtractorFactoryListener);
     }
 
     private void createDestinationIndex(String sourceIndex, String destinationIndex, ActionListener<CreateIndexResponse> listener) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -145,12 +145,7 @@ public class DataFrameAnalyticsManager {
         // TODO This could fail with errors. In that case we get stuck with the copied index.
         // We could delete the index in case of failure or we could try building the factory before reindexing
         // to catch the error early on.
-        DataFrameDataExtractorFactory.create(client,
-            Collections.emptyMap(),
-            config.getId(),
-            config.getDest(),
-            config.getParsedQuery(),
-            dataExtractorFactoryListener);
+        DataFrameDataExtractorFactory.create(client, Collections.emptyMap(), config, dataExtractorFactoryListener);
     }
 
     private void createDestinationIndex(String sourceIndex, String destinationIndex, ActionListener<CreateIndexResponse> listener) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -108,6 +108,9 @@ public class DataFrameAnalyticsManager {
             createIndexResponse -> {
                 ReindexRequest reindexRequest = new ReindexRequest();
                 reindexRequest.setSourceIndices(config.getSource());
+                if (config.getParsedQuery() != null) {
+                    reindexRequest.setSourceQuery(config.getParsedQuery());
+                }
                 reindexRequest.setDestIndex(config.getDest());
                 reindexRequest.setScript(new Script("ctx._source." + DataFrameAnalyticsFields.ID + " = ctx._id"));
                 client.execute(ReindexAction.INSTANCE, reindexRequest, reindexCompletedListener);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -108,9 +108,8 @@ public class DataFrameAnalyticsManager {
             createIndexResponse -> {
                 ReindexRequest reindexRequest = new ReindexRequest();
                 reindexRequest.setSourceIndices(config.getSource());
-                if (config.getParsedQuery() != null) {
-                    reindexRequest.setSourceQuery(config.getParsedQuery());
-                }
+                // we default to match_all
+                reindexRequest.setSourceQuery(config.getParsedQuery());
                 reindexRequest.setDestIndex(config.getDest());
                 reindexRequest.setScript(new Script("ctx._source." + DataFrameAnalyticsFields.ID + " = ctx._id"));
                 client.execute(ReindexAction.INSTANCE, reindexRequest, reindexCompletedListener);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -142,8 +142,7 @@ public class DataFrameAnalyticsManager {
         // TODO This could fail with errors. In that case we get stuck with the copied index.
         // We could delete the index in case of failure or we could try building the factory before reindexing
         // to catch the error early on.
-        DataFrameDataExtractorFactory.create(client, Collections.emptyMap(), config.getId(), config.getDest(),
-                dataExtractorFactoryListener);
+        DataFrameDataExtractorFactory.create(client, Collections.emptyMap(), config, dataExtractorFactoryListener);
     }
 
     private void createDestinationIndex(String sourceIndex, String destinationIndex, ActionListener<CreateIndexResponse> listener) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
@@ -14,7 +14,7 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
-import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
@@ -58,15 +58,12 @@ public class DataFrameDataExtractorFactory {
     private final String analyticsId;
     private final String index;
     private final ExtractedFields extractedFields;
-    private final QueryBuilder query;
 
-    private DataFrameDataExtractorFactory(Client client, String analyticsId, String index, ExtractedFields extractedFields,
-                                          QueryBuilder query) {
+    private DataFrameDataExtractorFactory(Client client, String analyticsId, String index, ExtractedFields extractedFields) {
         this.client = Objects.requireNonNull(client);
         this.analyticsId = Objects.requireNonNull(analyticsId);
         this.index = Objects.requireNonNull(index);
         this.extractedFields = Objects.requireNonNull(extractedFields);
-        this.query = query;
     }
 
     public DataFrameDataExtractor newExtractor(boolean includeSource) {
@@ -74,7 +71,7 @@ public class DataFrameDataExtractorFactory {
                 analyticsId,
                 extractedFields,
                 Arrays.asList(index),
-                query,
+                QueryBuilders.matchAllQuery(),
                 1000,
                 Collections.emptyMap(),
                 includeSource
@@ -99,7 +96,7 @@ public class DataFrameDataExtractorFactory {
 
         validateIndexAndExtractFields(client, headers, config.getDest(), ActionListener.wrap(
             extractedFields -> listener.onResponse(
-                new DataFrameDataExtractorFactory(client, config.getId(), config.getDest(), extractedFields, config.getParsedQuery())),
+                new DataFrameDataExtractorFactory(client, config.getId(), config.getDest(), extractedFields)),
             listener::onFailure
         ));
     }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -26,6 +26,25 @@
   - match: { data_frame_analytics: [] }
 
 ---
+"Test put valid config with default outlier detection and query":
+
+  - do:
+      ml.put_data_frame_analytics:
+        id: "simple-outlier-detection-with-query"
+        body: >
+          {
+            "source": "source_index",
+            "dest": "dest_index",
+            "analyses": [{"outlier_detection":{}}],
+            "query": {"term" : { "user" : "Kimchy" }}
+          }
+  - match: { id: "simple-outlier-detection-with-query" }
+  - match: { source: "source_index" }
+  - match: { dest: "dest_index" }
+  - match: { analyses: [{"outlier_detection":{}}] }
+  - match: { query: {"term" : { "user" : "Kimchy"} } }
+
+---
 "Test put valid config with default outlier detection":
 
   - do:
@@ -35,14 +54,13 @@
           {
             "source": "source_index",
             "dest": "dest_index",
-            "analyses": [{"outlier_detection":{}}],
-            "query": {"term" : { "user" : "Kimchy" }}
+            "analyses": [{"outlier_detection":{}}]
           }
   - match: { id: "simple-outlier-detection" }
   - match: { source: "source_index" }
   - match: { dest: "dest_index" }
   - match: { analyses: [{"outlier_detection":{}}] }
-  - match: { query: {"term" : { "user" : { "value" : "Kimchy", "boost" : 1.0 }}}}
+  - match: { query: {"match_all" : {} } }
 
 ---
 "Test put config with inconsistent body/param ids":

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -35,12 +35,14 @@
           {
             "source": "source_index",
             "dest": "dest_index",
-            "analyses": [{"outlier_detection":{}}]
+            "analyses": [{"outlier_detection":{}}],
+            "query": {"term" : { "user" : "Kimchy" }}
           }
   - match: { id: "simple-outlier-detection" }
   - match: { source: "source_index" }
   - match: { dest: "dest_index" }
   - match: { analyses: [{"outlier_detection":{}}] }
+  - match: { query: {"term" : { "user" : { "value" : "Kimchy", "boost" : 1.0 }}}}
 
 ---
 "Test put config with inconsistent body/param ids":


### PR DESCRIPTION
Adds support for users to supply a query in DataFrameAnalyticsConfig.

This query support essentially mirrors how DatafeedConfig supports queries. 

From what I could tell, the query is supported already in search, and when paring up the results with the original docs. 