### PR TITLE
[DOCS] Edits warning in put watch API

### DIFF
--- a/x-pack/docs/en/rest-api/watcher/put-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/put-watch.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Put watch</titleabbrev>
 ++++
 
-The PUT watch API either registers a new watch in {watcher} or update an
+The PUT watch API either registers a new watch in {watcher} or updates an
 existing one.
 
 [float]
@@ -21,13 +21,13 @@ the `.watches` index and its trigger is immediately registered with the relevant
 trigger engine. Typically for the `schedule` trigger, the scheduler is the
 trigger engine.
 
-IMPORTANT:  Putting a watch must be done via this API only. Do not put a watch
-            directly to the `.watches` index using the Elasticsearch Index API.
-            If {es} {security-features} are enabled, make sure no `write`
-            privileges are granted to anyone over the `.watches` index.
+IMPORTANT:  You must use {kib} or this API to create a watch. Do not put a watch
+            directly to the `.watches` index using the Elasticsearch index API.
+            If {es} {security-features} are enabled, do not give users `write`
+            privileges on the `.watches` index.
 
 When adding a watch you can also define its initial
-{xpack-ref}/how-watcher-works.html#watch-active-state[active state]. You do that
+{stack-ov}/how-watcher-works.html#watch-active-state[active state]. You do that
 by setting the `active` parameter.
 
 [float]
@@ -52,16 +52,16 @@ A watch has the following fields:
 |======
 | Name              | Description
 
-| `trigger`         | The {xpack-ref}/trigger.html[trigger] that defines when
+| `trigger`         | The {stack-ov}/trigger.html[trigger] that defines when
                       the watch should run.
 
-| `input`           | The {xpack-ref}/input.html[input] that defines the input
+| `input`           | The {stack-ov}/input.html[input] that defines the input
                       that loads the data for the watch.
 
-| `condition`       | The {xpack-ref}/condition.html[condition] that defines if
+| `condition`       | The {stack-ov}/condition.html[condition] that defines if
                       the actions should be run.
 
-| `actions`         | The list of {xpack-ref}/actions.html[actions] that will be
+| `actions`         | The list of {stack-ov}/actions.html[actions] that will be
                       run if the condition matches
 
 | `metadata`        | Metadata json that will be copied into the history entries.
@@ -75,7 +75,7 @@ A watch has the following fields:
 ==== Authorization
 
 You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {xpack-ref}/security-privileges.html[Security Privileges].
+information, see {stack-ov}/security-privileges.html[Security Privileges].
 
 [float]
 ==== Security Integration
@@ -148,7 +148,7 @@ PUT _watcher/watch/my-watch
 // CONSOLE
 
 When you add a watch you can also define its initial
-{xpack-ref}/how-watcher-works.html#watch-active-state[active state]. You do that
+{stack-ov}/how-watcher-works.html#watch-active-state[active state]. You do that
 by setting the `active` parameter. The following command adds a watch and sets
 it to be inactive by default:
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/38509#issuecomment-461361885

This PR updates a warning in the put watch API reference to clearly indicate that either Kibana or the API can be used.  It also replaces some out-dated URL attributes. 