### PR TITLE
Mute RetentionLeastIT.testRetentionLeasesSyncOnRecovery on 7x

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
@@ -260,6 +260,7 @@ public class RetentionLeaseIT extends ESIntegTestCase  {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/38588")
     public void testRetentionLeasesSyncOnRecovery() throws Exception {
         final int numberOfReplicas = 2 - scaledRandomIntBetween(0, 2);
         internalCluster().ensureAtLeastNumDataNodes(1 + numberOfReplicas);


### PR DESCRIPTION
Backporting muting of RetentionLeaseIT.testRetentionLeasesSyncOnRecovery on 7x.

Relates #38588.