### PR TITLE
Allow indices to be closed without executing sanity checks

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
@@ -34,6 +34,10 @@
             "options" : ["open","closed","none","all"],
             "default" : "open",
             "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+        },
+        "force": {
+          "type" : "boolean",
+          "description" : "Whether closing the index should be forced"
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
@@ -58,8 +58,14 @@
 
   - match: { acknowledged: true }
   - match: { shards_acknowledged: true }
+
 ---
 "Close index with force flag":
+  - skip:
+      version: " - 7.99.99"
+      reason: force parameter was added in 8.0.0
+      features: "warnings"
+
   - do:
       indices.create:
         index: test_index
@@ -75,3 +81,5 @@
       indices.close:
         index: test_index
         force: true
+      warnings:
+        - "parameter [force] is deprecated but was [true]"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
@@ -58,3 +58,20 @@
 
   - match: { acknowledged: true }
   - match: { shards_acknowledged: true }
+---
+"Close index with force flag":
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            number_of_replicas: 0
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+  - do:
+      indices.close:
+        index: test_index
+        force: true

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexClusterStateUpdateRequest.java
@@ -26,12 +26,22 @@ import org.elasticsearch.cluster.ack.IndicesClusterStateUpdateRequest;
 public class CloseIndexClusterStateUpdateRequest extends IndicesClusterStateUpdateRequest<CloseIndexClusterStateUpdateRequest> {
 
     private final long taskId;
+    private final boolean force;
 
     public CloseIndexClusterStateUpdateRequest(final long taskId) {
+        this(taskId, false);
+    }
+
+    public CloseIndexClusterStateUpdateRequest(final long taskId, final boolean force) {
         this.taskId = taskId;
+        this.force = force;
     }
 
     public long taskId() {
         return taskId;
+    }
+
+    public boolean force() {
+        return force;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.close;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -38,6 +39,7 @@ public class CloseIndexRequest extends AcknowledgedRequest<CloseIndexRequest> im
 
     private String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private boolean force = false;
 
     public CloseIndexRequest() {
     }
@@ -101,11 +103,29 @@ public class CloseIndexRequest extends AcknowledgedRequest<CloseIndexRequest> im
         return this;
     }
 
+    /**
+     * Force the closing of indices without executing the pre-close sanity checks
+     */
+    public boolean force() {
+        return force;
+    }
+
+    /**
+     * Force the closing of indices without executing the pre-close sanity checks
+     */
+    public CloseIndexRequest force(final boolean force) {
+        this.force = force;
+        return this;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            force = in.readBoolean();
+        }
     }
 
     @Override
@@ -113,5 +133,8 @@ public class CloseIndexRequest extends AcknowledgedRequest<CloseIndexRequest> im
         super.writeTo(out);
         out.writeStringArray(indices);
         indicesOptions.writeIndicesOptions(out);
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeBoolean(force);
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequestBuilder.java
@@ -60,4 +60,9 @@ public class CloseIndexRequestBuilder
         request.indicesOptions(indicesOptions);
         return this;
     }
+
+    public CloseIndexRequestBuilder setForce(final boolean force) {
+        request.force(force);
+        return this;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
@@ -111,7 +111,7 @@ public class TransportCloseIndexAction extends TransportMasterNodeAction<CloseIn
             return;
         }
 
-        final CloseIndexClusterStateUpdateRequest closeRequest = new CloseIndexClusterStateUpdateRequest(task.getId())
+        final CloseIndexClusterStateUpdateRequest closeRequest = new CloseIndexClusterStateUpdateRequest(task.getId(), request.force())
             .ackTimeout(request.timeout())
             .masterNodeTimeout(request.masterNodeTimeout())
             .indices(concreteIndices);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCloseIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCloseIndexAction.java
@@ -49,6 +49,7 @@ public class RestCloseIndexAction extends BaseRestHandler {
         closeIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", closeIndexRequest.masterNodeTimeout()));
         closeIndexRequest.timeout(request.paramAsTime("timeout", closeIndexRequest.timeout()));
         closeIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, closeIndexRequest.indicesOptions()));
+        closeIndexRequest.force(request.paramAsBoolean("force", closeIndexRequest.force()));
         return channel -> client.admin().indices().close(closeIndexRequest, new RestToXContentListener<>(channel));
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexStateServiceUtils.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexStateServiceUtils.java
@@ -31,11 +31,14 @@ public class MetaDataIndexStateServiceUtils {
     }
 
     /**
-     * Allows to call {@link MetaDataIndexStateService#addIndexClosedBlocks(Index[], Map, ClusterState)} which is a protected method.
+     * Allows to call {@link MetaDataIndexStateService#addIndexClosedBlocks(Index[], Map, ClusterState, boolean)}
+     * which is a protected method.
      */
-    public static ClusterState addIndexClosedBlocks(final Index[] indices, final Map<Index, ClusterBlock> blockedIndices,
-                                                    final ClusterState state) {
-        return MetaDataIndexStateService.addIndexClosedBlocks(indices, blockedIndices, state);
+    public static ClusterState addIndexClosedBlocks(final Index[] indices,
+                                                    final Map<Index, ClusterBlock> blockedIndices,
+                                                    final ClusterState state,
+                                                    final boolean forced) {
+        return MetaDataIndexStateService.addIndexClosedBlocks(indices, blockedIndices, state, forced);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -103,6 +103,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.getRandom;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.rarely;
 import static org.elasticsearch.env.Environment.PATH_HOME_SETTING;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -225,7 +226,7 @@ public class ClusterStateChanges {
             .map(index -> state.metaData().index(index).getIndex()).toArray(Index[]::new);
 
         final Map<Index, ClusterBlock> blockedIndices = new HashMap<>();
-        ClusterState newState = MetaDataIndexStateServiceUtils.addIndexClosedBlocks(concreteIndices, blockedIndices, state);
+        ClusterState newState = MetaDataIndexStateServiceUtils.addIndexClosedBlocks(concreteIndices, blockedIndices, state, rarely());
 
         newState = MetaDataIndexStateServiceUtils.closeRoutingTable(newState, blockedIndices, blockedIndices.keySet().stream()
             .collect(Collectors.toMap(Function.identity(), index -> new AcknowledgedResponse(true))));

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestCloseIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestCloseIndexActionTests.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.indices;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+
+public class RestCloseIndexActionTests extends ESTestCase {
+
+    public void testForceParameterDeprecationWarnings() throws Exception {
+        final String forceParameter = randomFrom("true", "false");
+        final FakeRestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+                .withParams(Collections.singletonMap("force", forceParameter))
+                .withPath("index/_close")
+                .build();
+
+        final RestCloseIndexAction handler = new RestCloseIndexAction(Settings.EMPTY, mock(RestController.class));
+        handler.prepareRequest(request, mock(NodeClient.class));
+        assertWarnings("parameter [force] is deprecated but was [" + forceParameter + "]");
+    }
+}


### PR DESCRIPTION
This pull request adds a new `force` parameter to the Close Index API that allows to close indices without executing the sanity checks added in #36249. The purpose of this parameter is to bring back the previous  (< 6.7.0) behavior in the case where something went wrong and the verification executed when closing an index are certain to never succeed.

We intend to deprecate this parameter in 7.0+ and backport this change to 6.7.0.

We decided to not document this parameter for now (but we can revisit this decision).