### PR TITLE
Move testToUtc test to DateFormattersTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -22,7 +22,6 @@ package org.elasticsearch.common.time;
 import org.elasticsearch.test.ESTestCase;
 
 import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -30,7 +29,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
-import java.time.temporal.TemporalField;
 import java.util.Locale;
 
 import static org.hamcrest.Matchers.containsString;

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -21,12 +21,16 @@ package org.elasticsearch.common.time;
 
 import org.elasticsearch.test.ESTestCase;
 
+import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalField;
 import java.util.Locale;
 
 import static org.hamcrest.Matchers.containsString;
@@ -95,6 +99,8 @@ public class DateFormattersTests extends ESTestCase {
         e = expectThrows(IllegalArgumentException.class, () -> formatter.parse("1234.1234567890"));
         assertThat(e.getMessage(), is("failed to parse date field [1234.1234567890] with format [epoch_second]"));
     }
+
+
 
     public void testEpochMilliParsersWithDifferentFormatters() {
         DateFormatter formatter = DateFormatter.forPattern("strict_date_optional_time||epoch_millis");
@@ -247,5 +253,16 @@ public class DateFormattersTests extends ESTestCase {
         DateTimeFormatter roundupParser = formatter.getRoundupParser();
         assertThat(roundupParser.getLocale(), is(locale));
         assertThat(formatter.locale(), is(locale));
+    }
+
+    public void test0MillisAreFormatted() {
+        DateFormatter formatter = DateFormatter.forPattern("strict_date_time");
+
+        Clock clock = Clock.fixed(ZonedDateTime.of(2019,02,8,11,43,00,0,
+            ZoneOffset.UTC).toInstant(),ZoneOffset.UTC);
+
+        String formatted = formatter.formatMillis(clock.millis());
+
+        assertThat(formatted, is("2019-02-08T11:43:00.000Z"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -255,12 +255,9 @@ public class DateFormattersTests extends ESTestCase {
 
     public void test0MillisAreFormatted() {
         DateFormatter formatter = DateFormatter.forPattern("strict_date_time");
-
-        Clock clock = Clock.fixed(ZonedDateTime.of(2019,02,8,11,43,00,0,
-            ZoneOffset.UTC).toInstant(),ZoneOffset.UTC);
-
+        Clock clock = Clock.fixed(ZonedDateTime.of(2019, 02, 8, 11, 43, 00, 0,
+            ZoneOffset.UTC).toInstant(), ZoneOffset.UTC);
         String formatted = formatter.formatMillis(clock.millis());
-
         assertThat(formatted, is("2019-02-08T11:43:00.000Z"));
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringDoc.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringDoc.java
@@ -16,9 +16,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.monitoring.MonitoredSystem;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.Objects;
 
 /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringDoc.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringDoc.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  */
 public abstract class MonitoringDoc implements ToXContentObject {
 
-    private static final DateFormatter dateTimeFormatter = DateFormatter.forPattern("strict_date_time");
+    private static final DateFormatter dateTimeFormatter = DateFormatter.forPattern("strict_date_time").withZone(ZoneOffset.UTC);
     private final String cluster;
     private final long timestamp;
     private final long intervalMillis;
@@ -126,9 +126,7 @@ public abstract class MonitoringDoc implements ToXContentObject {
      * @return a string representing the timestamp
      */
     public static String toUTC(final long timestamp) {
-        ZonedDateTime zonedDateTime = Instant.ofEpochMilli(timestamp).atZone(ZoneOffset.UTC);
-        return dateTimeFormatter.format(zonedDateTime);
-
+        return dateTimeFormatter.formatMillis(timestamp);
     }
 
     /**

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BaseMonitoringDocTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BaseMonitoringDocTestCase.java
@@ -26,10 +26,6 @@ import org.elasticsearch.xpack.monitoring.collector.shards.ShardMonitoringDoc;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BaseMonitoringDocTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BaseMonitoringDocTestCase.java
@@ -26,8 +26,10 @@ import org.elasticsearch.xpack.monitoring.collector.shards.ShardMonitoringDoc;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -164,13 +166,6 @@ public abstract class BaseMonitoringDocTestCase<T extends MonitoringDoc> extends
                 assertThat(sourceNode.get("timestamp"), equalTo(MonitoringDoc.toUTC(node.getTimestamp())));
             }
         }
-    }
-
-    public void testToUTC() {
-        final long timestamp = System.currentTimeMillis();
-        final String expected = Instant.ofEpochMilli(timestamp).atZone(ZoneOffset.UTC).toString();
-
-        assertEquals(expected, MonitoringDoc.toUTC(timestamp));
     }
 
     public void testMonitoringNodeConstructor() {


### PR DESCRIPTION
The test was relying on toString in ZonedDateTime which is different to
what is formatted by strict_date_time when milliseconds are 0
The method is just delegating to dateFormatter, so that scenario should
be covered there.

closes #38359