### PR TITLE
fix #38578 env bat quoting issue

### DIFF
--- a/distribution/src/bin/elasticsearch-env.bat
+++ b/distribution/src/bin/elasticsearch-env.bat
@@ -57,5 +57,5 @@ set ES_DISTRIBUTION_FLAVOR=${es.distribution.flavor}
 set ES_DISTRIBUTION_TYPE=${es.distribution.type}
 
 if not defined ES_TMPDIR (
-  for /f "tokens=* usebackq" %%a in (`"%JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.TempDirectory""`) do set ES_TMPDIR=%%a
+  for /f "tokens=* usebackq" %%a in ('%JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.TempDirectory"') do set ES_TMPDIR=%%a
 )


### PR DESCRIPTION
When `%JAVA%` gets inferred from` %PATH%` trying to resolve `%ES_TMPDIR%` failed.

If `%JAVA_HOME%` was set explicitly this did not cause an error.
