### PR TITLE
add geotile_grid ref to asciidoc

### DIFF
--- a/docs/reference/aggregations/bucket.asciidoc
+++ b/docs/reference/aggregations/bucket.asciidoc
@@ -39,6 +39,8 @@ include::bucket/geodistance-aggregation.asciidoc[]
 
 include::bucket/geohashgrid-aggregation.asciidoc[]
 
+include::bucket/geotilegrid-aggregation.asciidoc[]
+
 include::bucket/global-aggregation.asciidoc[]
 
 include::bucket/histogram-aggregation.asciidoc[]
@@ -62,4 +64,3 @@ include::bucket/significantterms-aggregation.asciidoc[]
 include::bucket/significanttext-aggregation.asciidoc[]
 
 include::bucket/terms-aggregation.asciidoc[]
-


### PR DESCRIPTION
Geotile_grid was added but not referenced from the TOC

| Backport Branch  | Backport PR |
|-----|-----|
| 7.x | #38639   |
| 7.0 | #38640  |