### PR TITLE
Add fuzziness example (#37194)

### DIFF
--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -32,6 +32,25 @@ optional `should` clauses to match can be set using the
 <<query-dsl-minimum-should-match,`minimum_should_match`>>
 parameter.
 
+Here is an example when providing additional parameters (note the slight
+change in structure, `message` is the field name):
+
+[source,js]
+--------------------------------------------------
+GET /_search
+{
+    "query": {
+        "match" : {
+            "message" : {
+                "query" : "this is a test",
+                "operator" : "and"
+            }
+        }
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
 The `analyzer` can be set to control which analyzer will perform the
 analysis process on the text. It defaults to the field explicit mapping
 definition, or the default search analyzer.
@@ -56,9 +75,6 @@ rewritten.
 Fuzzy transpositions (`ab` -> `ba`) are allowed by default but can be disabled
 by setting `fuzzy_transpositions` to `false`.
 
-Here is an example when providing additional parameters (note the slight
-change in structure, `message` is the field name):
-
 [source,js]
 --------------------------------------------------
 GET /_search
@@ -66,8 +82,8 @@ GET /_search
     "query": {
         "match" : {
             "message" : {
-                "query" : "this is a test",
-                "operator" : "and"
+                "query" : "this is a testt",
+                "fuzziness": "AUTO"
             }
         }
     }


### PR DESCRIPTION
The example in the Fuzziness section was actually relevant
 to the section above it, so I moved it there.
 I replaced it with an example of how to use the `fuzziness` parameter