### PR TITLE
Set update mappings mater node timeout to 30 min

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -318,7 +318,8 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
                 leaderIndexMetadata.getMappings().size() + "]";
             MappingMetaData mappingMetaData = leaderIndexMetadata.getMappings().iterator().next().value;
             if (mappingMetaData != null) {
-                final PutMappingRequest putMappingRequest = CcrRequests.putMappingRequest(followerIndex.getName(), mappingMetaData);
+                final PutMappingRequest putMappingRequest = CcrRequests.putMappingRequest(followerIndex.getName(), mappingMetaData)
+                    .masterNodeTimeout(TimeValue.timeValueMinutes(30));
                 followerClient.admin().indices().putMapping(putMappingRequest).actionGet(ccrSettings.getRecoveryActionTimeout());
             }
         }


### PR DESCRIPTION
This is related to #35975. We do not want a slow master to fail a
recovery from remote process due to a slow put mappings call. This
commit increases the master node timeout on this call to 30 mins.