### PR TITLE
[DOCS] Fixes broken migration links

### DIFF
--- a/docs/reference/migration/apis/deprecation.asciidoc
+++ b/docs/reference/migration/apis/deprecation.asciidoc
@@ -54,7 +54,7 @@ Example response:
     {
       "level" : "critical",
       "message" : "Cluster name cannot contain ':'",
-      "url" : "{ref}/breaking-changes-7.0.html#_literal_literal_is_no_longer_allowed_in_cluster_name",
+      "url" : "{ref-70}/breaking-changes-7.0.html#_literal_literal_is_no_longer_allowed_in_cluster_name",
       "details" : "This cluster is named [mycompany:logging], which contains the illegal character ':'."
     }
   ],
@@ -64,7 +64,7 @@ Example response:
       {
         "level" : "warning",
         "message" : "Index name cannot contain ':'",
-        "url" : "{ref}/breaking-changes-7.0.html#_literal_literal_is_no_longer_allowed_in_index_name",
+        "url" : "{ref-70}/breaking-changes-7.0.html#_literal_literal_is_no_longer_allowed_in_index_name",
         "details" : "This index is named [logs:apache], which contains the illegal character ':'."
       }
     ]


### PR DESCRIPTION
This PR addresses the following broken links:

>16:11:27 Bad cross-document links:
>16:11:27   /var/lib/jenkins/workspace/elastic+docs+master+build/.repos/.temp/target_repo/html/en/elasticsearch/reference/6.6/migration-api-deprecation.html:
16:11:27    - en/elasticsearch/reference/master/breaking-changes-7.0.html
16

These links are broken because "master" is no longer associated with 7.0 documentation.