### PR TITLE
SQL: Generate a random zone by comparing the offsets for CurrentDate tests

### DIFF
--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/TestUtils.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/TestUtils.java
@@ -6,10 +6,20 @@
 
 package org.elasticsearch.xpack.sql;
 
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.xpack.sql.proto.Mode;
 import org.elasticsearch.xpack.sql.proto.Protocol;
 import org.elasticsearch.xpack.sql.session.Configuration;
 import org.elasticsearch.xpack.sql.util.DateUtils;
+
+import java.time.ZoneId;
+
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
+import static org.elasticsearch.test.ESTestCase.randomFrom;
+import static org.elasticsearch.test.ESTestCase.randomIntBetween;
+import static org.elasticsearch.test.ESTestCase.randomNonNegativeLong;
+import static org.elasticsearch.test.ESTestCase.randomZone;
+
 
 public class TestUtils {
 
@@ -18,5 +28,29 @@ public class TestUtils {
     public static final Configuration TEST_CFG = new Configuration(DateUtils.UTC, Protocol.FETCH_SIZE,
             Protocol.REQUEST_TIMEOUT, Protocol.PAGE_TIMEOUT, null, Mode.PLAIN,
             null, null, null);
+
+    public static Configuration randomConfiguration() {
+        return new Configuration(randomZone(),
+                randomIntBetween(0,  1000),
+                new TimeValue(randomNonNegativeLong()),
+                new TimeValue(randomNonNegativeLong()),
+                null,
+                randomFrom(Mode.values()),
+                randomAlphaOfLength(10),
+                randomAlphaOfLength(10),
+                randomAlphaOfLength(10));
+    }
+
+    public static Configuration randomConfiguration(ZoneId providedZoneId) {
+        return new Configuration(providedZoneId,
+                randomIntBetween(0,  1000),
+                new TimeValue(randomNonNegativeLong()),
+                new TimeValue(randomNonNegativeLong()),
+                null,
+                randomFrom(Mode.values()),
+                randomAlphaOfLength(10),
+                randomAlphaOfLength(10),
+                randomAlphaOfLength(10));
+    }
 
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/FunctionRegistryTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/FunctionRegistryTests.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.sql.expression.function;
 
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 import org.elasticsearch.xpack.sql.expression.Expression;
@@ -13,7 +12,6 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.sql.expression.gen.pipeline.Pipe;
 import org.elasticsearch.xpack.sql.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.sql.parser.ParsingException;
-import org.elasticsearch.xpack.sql.proto.Mode;
 import org.elasticsearch.xpack.sql.session.Configuration;
 import org.elasticsearch.xpack.sql.tree.NodeInfo;
 import org.elasticsearch.xpack.sql.tree.Source;
@@ -25,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
+import static org.elasticsearch.xpack.sql.TestUtils.randomConfiguration;
 import static org.elasticsearch.xpack.sql.expression.function.FunctionRegistry.def;
 import static org.elasticsearch.xpack.sql.expression.function.UnresolvedFunction.ResolutionType.DISTINCT;
 import static org.elasticsearch.xpack.sql.expression.function.UnresolvedFunction.ResolutionType.EXTRACT;
@@ -231,30 +230,6 @@ public class FunctionRegistryTests extends ESTestCase {
         return new UnresolvedFunction(SourceTests.randomSource(), "DUMMY_FUNCTION", resolutionType, Arrays.asList(children));
     }
     
-    private Configuration randomConfiguration() {
-        return new Configuration(randomZone(),
-                randomIntBetween(0,  1000),
-                new TimeValue(randomNonNegativeLong()),
-                new TimeValue(randomNonNegativeLong()),
-                null,
-                randomFrom(Mode.values()),
-                randomAlphaOfLength(10),
-                randomAlphaOfLength(10),
-                randomAlphaOfLength(10));
-    }
-    
-    private Configuration randomConfiguration(ZoneId providedZoneId) {
-        return new Configuration(providedZoneId,
-                randomIntBetween(0,  1000),
-                new TimeValue(randomNonNegativeLong()),
-                new TimeValue(randomNonNegativeLong()),
-                null,
-                randomFrom(Mode.values()),
-                randomAlphaOfLength(10),
-                randomAlphaOfLength(10),
-                randomAlphaOfLength(10));
-    }
-
     public static class DummyFunction extends ScalarFunction {
         public DummyFunction(Source source) {
             super(source, emptyList());

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentDateTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentDateTests.java
@@ -6,18 +6,19 @@
 
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.expression.Expression;
-import org.elasticsearch.xpack.sql.proto.Mode;
-import org.elasticsearch.xpack.sql.proto.Protocol;
-import org.elasticsearch.xpack.sql.session.Configuration;
 import org.elasticsearch.xpack.sql.tree.AbstractNodeTestCase;
 import org.elasticsearch.xpack.sql.tree.Source;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Objects;
 
 public class CurrentDateTests extends AbstractNodeTestCase<CurrentDate, Expression> {
 
     public static CurrentDate randomCurrentDate() {
-        return new CurrentDate(Source.EMPTY, new Configuration(randomZone(), Protocol.FETCH_SIZE,
-            Protocol.REQUEST_TIMEOUT, Protocol.PAGE_TIMEOUT, null, Mode.PLAIN, null, null, null));
+        return new CurrentDate(Source.EMPTY, TestUtils.randomConfiguration());
     }
 
     @Override
@@ -32,8 +33,10 @@ public class CurrentDateTests extends AbstractNodeTestCase<CurrentDate, Expressi
 
     @Override
     protected CurrentDate mutate(CurrentDate instance) {
-        return new CurrentDate(instance.source(), new Configuration(randomZone(), Protocol.FETCH_SIZE,
-            Protocol.REQUEST_TIMEOUT, Protocol.PAGE_TIMEOUT, null, Mode.PLAIN, null, null, null));
+        ZonedDateTime now = instance.configuration().now();
+        ZoneId mutatedZoneId = randomValueOtherThanMany(o -> Objects.equals(now.getOffset(), o.getRules().getOffset(now.toInstant())),
+                () -> randomZone());
+        return new CurrentDate(instance.source(), TestUtils.randomConfiguration(mutatedZoneId));
     }
 
     @Override


### PR DESCRIPTION
This PR changes the way a ZoneId is randomized for CurrentDateTests by comparing the offsets of the existent zone and the new randomized one, so that a new CurrentDate will truly be different from an existent one. Otherwise, two ZoneId will be equal if their ID is equal, but two different ZoneIds can have equal offsets which will generate the same value for current date and equals and hashCode tests will fail.

Fixes https://github.com/elastic/elasticsearch/issues/38666.