### PR TITLE
Docs: Fix some deprecation links

### DIFF
--- a/docs/reference/migration/apis/deprecation.asciidoc
+++ b/docs/reference/migration/apis/deprecation.asciidoc
@@ -54,7 +54,7 @@ Example response:
     {
       "level" : "critical",
       "message" : "Cluster name cannot contain ':'",
-      "url" : "{ref}/breaking-changes-7.0.html#_literal_literal_is_no_longer_allowed_in_cluster_name",
+      "url" : "{ref-70}/breaking-changes-7.0.html#_literal_literal_is_no_longer_allowed_in_cluster_name",
       "details" : "This cluster is named [mycompany:logging], which contains the illegal character ':'."
     }
   ],
@@ -64,7 +64,7 @@ Example response:
       {
         "level" : "warning",
         "message" : "Index name cannot contain ':'",
-        "url" : "{ref}/breaking-changes-7.0.html#_literal_literal_is_no_longer_allowed_in_index_name",
+        "url" : "{ref-70}/breaking-changes-7.0.html#_literal_literal_is_no_longer_allowed_in_index_name",
         "details" : "This index is named [logs:apache], which contains the illegal character ':'."
       }
     ]


### PR DESCRIPTION
`{ref}` no longer refers to the 7.0 branch so the
`breaking-changes-7.0.html` file won't be built there.
