### PR TITLE
Add enabled status for token and api key service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,8 +159,8 @@ task verifyVersions {
  * the enabled state of every bwc task. It should be set back to true
  * after the backport of the backcompat code is complete.
  */
-final boolean bwc_tests_enabled = true
-final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+final boolean bwc_tests_enabled = false
+final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/38687" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
@@ -22,6 +22,8 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
     private static final String ROLES_XFIELD = "roles";
     private static final String ROLE_MAPPING_XFIELD = "role_mapping";
     private static final String SSL_XFIELD = "ssl";
+    private static final String TOKEN_SERVICE_XFIELD = "token_service";
+    private static final String API_KEY_SERVICE_XFIELD = "api_key_service";
     private static final String AUDIT_XFIELD = "audit";
     private static final String IP_FILTER_XFIELD = "ipfilter";
     private static final String ANONYMOUS_XFIELD = "anonymous";
@@ -29,6 +31,8 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
     private Map<String, Object> realmsUsage;
     private Map<String, Object> rolesStoreUsage;
     private Map<String, Object> sslUsage;
+    private Map<String, Object> tokenServiceUsage;
+    private Map<String, Object> apiKeyServiceUsage;
     private Map<String, Object> auditUsage;
     private Map<String, Object> ipFilterUsage;
     private Map<String, Object> anonymousUsage;
@@ -39,6 +43,10 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
         realmsUsage = in.readMap();
         rolesStoreUsage = in.readMap();
         sslUsage = in.readMap();
+        if (in.getVersion().onOrAfter(Version.V_7_1_0)) {
+            tokenServiceUsage = in.readMap();
+            apiKeyServiceUsage = in.readMap();
+        }
         auditUsage = in.readMap();
         ipFilterUsage = in.readMap();
         if (in.getVersion().before(Version.V_6_0_0_beta1)) {
@@ -52,12 +60,15 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
     public SecurityFeatureSetUsage(boolean available, boolean enabled, Map<String, Object> realmsUsage,
                                    Map<String, Object> rolesStoreUsage, Map<String, Object> roleMappingStoreUsage,
                                    Map<String, Object> sslUsage, Map<String, Object> auditUsage,
-                                   Map<String, Object> ipFilterUsage, Map<String, Object> anonymousUsage) {
+                                   Map<String, Object> ipFilterUsage, Map<String, Object> anonymousUsage,
+                                   Map<String, Object> tokenServiceUsage, Map<String, Object> apiKeyServiceUsage) {
         super(XPackField.SECURITY, available, enabled);
         this.realmsUsage = realmsUsage;
         this.rolesStoreUsage = rolesStoreUsage;
         this.roleMappingStoreUsage = roleMappingStoreUsage;
         this.sslUsage = sslUsage;
+        this.tokenServiceUsage = tokenServiceUsage;
+        this.apiKeyServiceUsage = apiKeyServiceUsage;
         this.auditUsage = auditUsage;
         this.ipFilterUsage = ipFilterUsage;
         this.anonymousUsage = anonymousUsage;
@@ -69,6 +80,8 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
         out.writeMap(realmsUsage);
         out.writeMap(rolesStoreUsage);
         out.writeMap(sslUsage);
+        out.writeMap(tokenServiceUsage);
+        out.writeMap(apiKeyServiceUsage);
         out.writeMap(auditUsage);
         out.writeMap(ipFilterUsage);
         if (out.getVersion().before(Version.V_6_0_0_beta1)) {
@@ -87,6 +100,8 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
             builder.field(ROLES_XFIELD, rolesStoreUsage);
             builder.field(ROLE_MAPPING_XFIELD, roleMappingStoreUsage);
             builder.field(SSL_XFIELD, sslUsage);
+            builder.field(TOKEN_SERVICE_XFIELD, tokenServiceUsage);
+            builder.field(API_KEY_SERVICE_XFIELD, apiKeyServiceUsage);
             builder.field(AUDIT_XFIELD, auditUsage);
             builder.field(IP_FILTER_XFIELD, ipFilterUsage);
             builder.field(ANONYMOUS_XFIELD, anonymousUsage);
@@ -96,4 +111,5 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
     public Map<String, Object> getRealmsUsage() {
         return Collections.unmodifiableMap(realmsUsage);
     }
+
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
@@ -43,7 +43,7 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
         realmsUsage = in.readMap();
         rolesStoreUsage = in.readMap();
         sslUsage = in.readMap();
-        if (in.getVersion().onOrAfter(Version.V_7_1_0)) {
+        if (in.getVersion().onOrAfter(Version.CURRENT)) { // TODO change the version to V_7_1_0 on backporting
             tokenServiceUsage = in.readMap();
             apiKeyServiceUsage = in.readMap();
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
@@ -43,7 +43,7 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
         realmsUsage = in.readMap();
         rolesStoreUsage = in.readMap();
         sslUsage = in.readMap();
-        if (in.getVersion().onOrAfter(Version.CURRENT)) { // TODO change the version to V_7_1_0 on backporting
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO change the version to V_7_1_0 on backporting
             tokenServiceUsage = in.readMap();
             apiKeyServiceUsage = in.readMap();
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatureSet.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatureSet.java
@@ -29,7 +29,9 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.singletonMap;
+import static org.elasticsearch.xpack.core.XPackSettings.API_KEY_SERVICE_ENABLED_SETTING;
 import static org.elasticsearch.xpack.core.XPackSettings.HTTP_SSL_ENABLED;
+import static org.elasticsearch.xpack.core.XPackSettings.TOKEN_SERVICE_ENABLED_SETTING;
 import static org.elasticsearch.xpack.core.XPackSettings.TRANSPORT_SSL_ENABLED;
 
 /**
@@ -93,6 +95,8 @@ public class SecurityFeatureSet implements XPackFeatureSet {
     @Override
     public void usage(ActionListener<XPackFeatureSet.Usage> listener) {
         Map<String, Object> sslUsage = sslUsage(settings);
+        Map<String, Object> tokenServiceUsage = tokenServiceUsage(settings);
+        Map<String, Object> apiKeyServiceUsage = apiKeyServiceUsage(settings);
         Map<String, Object> auditUsage = auditUsage(settings);
         Map<String, Object> ipFilterUsage = ipFilterUsage(ipFilter);
         Map<String, Object> anonymousUsage = singletonMap("enabled", AnonymousUser.isAnonymousEnabled(settings));
@@ -103,9 +107,9 @@ public class SecurityFeatureSet implements XPackFeatureSet {
         final CountDown countDown = new CountDown(3);
         final Runnable doCountDown = () -> {
             if (countDown.countDown()) {
-                listener.onResponse(new SecurityFeatureSetUsage(available(), enabled(), realmsUsageRef.get(),
-                        rolesUsageRef.get(), roleMappingUsageRef.get(),
-                        sslUsage, auditUsage, ipFilterUsage, anonymousUsage));
+                listener.onResponse(new SecurityFeatureSetUsage(available(), enabled(), realmsUsageRef.get(), rolesUsageRef.get(),
+                        roleMappingUsageRef.get(), sslUsage, auditUsage, ipFilterUsage, anonymousUsage, tokenServiceUsage,
+                        apiKeyServiceUsage));
             }
         };
 
@@ -150,6 +154,14 @@ public class SecurityFeatureSet implements XPackFeatureSet {
         map.put("http", singletonMap("enabled", HTTP_SSL_ENABLED.get(settings)));
         map.put("transport", singletonMap("enabled", TRANSPORT_SSL_ENABLED.get(settings)));
         return map;
+    }
+
+    static Map<String, Object> tokenServiceUsage(Settings settings) {
+        return singletonMap("enabled", TOKEN_SERVICE_ENABLED_SETTING.get(settings));
+    }
+
+    static Map<String, Object> apiKeyServiceUsage(Settings settings) {
+        return singletonMap("enabled", API_KEY_SERVICE_ENABLED_SETTING.get(settings));
     }
 
     static Map<String, Object> auditUsage(Settings settings) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityFeatureSetTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityFeatureSetTests.java
@@ -96,6 +96,20 @@ public class SecurityFeatureSetTests extends ESTestCase {
         settings.put("xpack.security.http.ssl.enabled", httpSSLEnabled);
         final boolean transportSSLEnabled = randomBoolean();
         settings.put("xpack.security.transport.ssl.enabled", transportSSLEnabled);
+
+        boolean configureEnabledFlagForTokenAndApiKeyServices = randomBoolean();
+        final boolean tokenServiceEnabled;
+        final boolean apiKeyServiceEnabled;
+        if (configureEnabledFlagForTokenAndApiKeyServices) {
+            tokenServiceEnabled = randomBoolean();
+            settings.put("xpack.security.authc.token.enabled", tokenServiceEnabled);
+            apiKeyServiceEnabled = randomBoolean();
+            settings.put("xpack.security.authc.api_key.enabled", apiKeyServiceEnabled);
+        } else {
+            tokenServiceEnabled = httpSSLEnabled;
+            apiKeyServiceEnabled = httpSSLEnabled;
+        }
+
         final boolean auditingEnabled = randomBoolean();
         settings.put(XPackSettings.AUDIT_ENABLED.getKey(), auditingEnabled);
         final boolean httpIpFilterEnabled = randomBoolean();
@@ -185,6 +199,12 @@ public class SecurityFeatureSetTests extends ESTestCase {
                 assertThat(source.getValue("ssl.http.enabled"), is(httpSSLEnabled));
                 assertThat(source.getValue("ssl.transport.enabled"), is(transportSSLEnabled));
 
+                // check Token service
+                assertThat(source.getValue("token_service.enabled"), is(tokenServiceEnabled));
+
+                // check API Key service
+                assertThat(source.getValue("api_key_service.enabled"), is(apiKeyServiceEnabled));
+
                 // auditing
                 assertThat(source.getValue("audit.enabled"), is(auditingEnabled));
                 if (auditingEnabled) {
@@ -218,6 +238,8 @@ public class SecurityFeatureSetTests extends ESTestCase {
             } else {
                 assertThat(source.getValue("realms"), is(nullValue()));
                 assertThat(source.getValue("ssl"), is(nullValue()));
+                assertThat(source.getValue("token_service"), is(nullValue()));
+                assertThat(source.getValue("api_key_service"), is(nullValue()));
                 assertThat(source.getValue("audit"), is(nullValue()));
                 assertThat(source.getValue("anonymous"), is(nullValue()));
                 assertThat(source.getValue("ipfilter"), is(nullValue()));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityFeatureSetTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityFeatureSetTests.java
@@ -97,16 +97,20 @@ public class SecurityFeatureSetTests extends ESTestCase {
         final boolean transportSSLEnabled = randomBoolean();
         settings.put("xpack.security.transport.ssl.enabled", transportSSLEnabled);
 
-        boolean configureEnabledFlagForTokenAndApiKeyServices = randomBoolean();
+        boolean configureEnabledFlagForTokenService = randomBoolean();
         final boolean tokenServiceEnabled;
-        final boolean apiKeyServiceEnabled;
-        if (configureEnabledFlagForTokenAndApiKeyServices) {
+        if (configureEnabledFlagForTokenService) {
             tokenServiceEnabled = randomBoolean();
             settings.put("xpack.security.authc.token.enabled", tokenServiceEnabled);
+        } else {
+            tokenServiceEnabled = httpSSLEnabled;
+        }
+        boolean configureEnabledFlagForApiKeyService = randomBoolean();
+        final boolean apiKeyServiceEnabled;
+        if (configureEnabledFlagForApiKeyService) {
             apiKeyServiceEnabled = randomBoolean();
             settings.put("xpack.security.authc.api_key.enabled", apiKeyServiceEnabled);
         } else {
-            tokenServiceEnabled = httpSSLEnabled;
             apiKeyServiceEnabled = httpSSLEnabled;
         }
 


### PR DESCRIPTION
Right now there is no way to determine whether the
token service or API key service is enabled or not.
This commit adds support for the enabled status of
token and API key service to security feature set
usage API `/_xpack/usage`.

Closes #38535