### PR TITLE
6.7 backport:Added unit test for FollowParameters class

### DIFF
--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/FollowInfoResponseTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/FollowInfoResponseTests.java
@@ -6,10 +6,7 @@
 package org.elasticsearch.xpack.ccr.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.ccr.action.FollowInfoAction;
@@ -26,7 +23,6 @@ import static org.elasticsearch.xpack.core.ccr.action.FollowInfoAction.Response.
 
 public class FollowInfoResponseTests extends AbstractSerializingTestCase<FollowInfoAction.Response> {
 
-    static final ObjectParser<FollowParameters, Void> PARAMETERS_PARSER = new ObjectParser<>("parameters_parser", FollowParameters::new);
     static final ConstructingObjectParser<FollowerInfo, Void> INFO_PARSER = new ConstructingObjectParser<>(
         "info_parser",
         args -> {
@@ -40,13 +36,12 @@ public class FollowInfoResponseTests extends AbstractSerializingTestCase<FollowI
         });
 
     static {
-        FollowParameters.initParser(PARAMETERS_PARSER);
-
         INFO_PARSER.declareString(ConstructingObjectParser.constructorArg(), FollowerInfo.FOLLOWER_INDEX_FIELD);
         INFO_PARSER.declareString(ConstructingObjectParser.constructorArg(), FollowerInfo.REMOTE_CLUSTER_FIELD);
         INFO_PARSER.declareString(ConstructingObjectParser.constructorArg(), FollowerInfo.LEADER_INDEX_FIELD);
         INFO_PARSER.declareString(ConstructingObjectParser.constructorArg(), FollowerInfo.STATUS_FIELD);
-        INFO_PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), PARAMETERS_PARSER, FollowerInfo.PARAMETERS_FIELD);
+        INFO_PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), FollowParametersTests.PARSER,
+            FollowerInfo.PARAMETERS_FIELD);
     }
 
     @SuppressWarnings("unchecked")
@@ -79,17 +74,7 @@ public class FollowInfoResponseTests extends AbstractSerializingTestCase<FollowI
         for (int i = 0; i < numInfos; i++) {
             FollowParameters followParameters = null;
             if (randomBoolean()) {
-                followParameters = new FollowParameters();
-                followParameters.setMaxOutstandingReadRequests(randomIntBetween(0, Integer.MAX_VALUE));
-                followParameters.setMaxOutstandingWriteRequests(randomIntBetween(0, Integer.MAX_VALUE));
-                followParameters.setMaxReadRequestOperationCount(randomIntBetween(0, Integer.MAX_VALUE));
-                followParameters.setMaxWriteRequestOperationCount(randomIntBetween(0, Integer.MAX_VALUE));
-                followParameters.setMaxReadRequestSize(new ByteSizeValue(randomNonNegativeLong()));
-                followParameters.setMaxWriteRequestSize(new ByteSizeValue(randomNonNegativeLong()));
-                followParameters.setMaxWriteBufferCount(randomIntBetween(0, Integer.MAX_VALUE));
-                followParameters.setMaxWriteBufferSize(new ByteSizeValue(randomNonNegativeLong()));
-                followParameters.setMaxRetryDelay(new TimeValue(randomNonNegativeLong()));
-                followParameters.setReadPollTimeout(new TimeValue(randomNonNegativeLong()));
+                followParameters = FollowParametersTests.randomInstance();
             }
 
             infos.add(new FollowerInfo(randomAlphaOfLength(4), randomAlphaOfLength(4), randomAlphaOfLength(4),

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/FollowParametersTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/FollowParametersTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ccr.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xpack.core.ccr.action.FollowParameters;
+
+import java.io.IOException;
+
+public class FollowParametersTests extends AbstractSerializingTestCase<FollowParameters> {
+
+    static final ObjectParser<FollowParameters, Void> PARSER = new ObjectParser<>("test_parser", FollowParameters::new);
+    static {
+        FollowParameters.initParser(PARSER);
+    }
+
+    @Override
+    protected FollowParameters doParseInstance(XContentParser parser) throws IOException {
+        return PARSER.apply(parser, null);
+    }
+
+    @Override
+    protected FollowParameters createTestInstance() {
+        return randomInstance();
+    }
+
+    @Override
+    protected Writeable.Reader<FollowParameters> instanceReader() {
+        return FollowParameters::new;
+    }
+
+    static FollowParameters randomInstance() {
+        FollowParameters followParameters = new FollowParameters();
+        followParameters.setMaxOutstandingReadRequests(randomIntBetween(0, Integer.MAX_VALUE));
+        followParameters.setMaxOutstandingWriteRequests(randomIntBetween(0, Integer.MAX_VALUE));
+        followParameters.setMaxReadRequestOperationCount(randomIntBetween(0, Integer.MAX_VALUE));
+        followParameters.setMaxWriteRequestOperationCount(randomIntBetween(0, Integer.MAX_VALUE));
+        followParameters.setMaxReadRequestSize(new ByteSizeValue(randomNonNegativeLong()));
+        followParameters.setMaxWriteRequestSize(new ByteSizeValue(randomNonNegativeLong()));
+        followParameters.setMaxWriteBufferCount(randomIntBetween(0, Integer.MAX_VALUE));
+        followParameters.setMaxWriteBufferSize(new ByteSizeValue(randomNonNegativeLong()));
+        followParameters.setMaxRetryDelay(new TimeValue(randomNonNegativeLong()));
+        followParameters.setReadPollTimeout(new TimeValue(randomNonNegativeLong()));
+        return followParameters;
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowInfoAction.java
@@ -191,7 +191,7 @@ public class FollowInfoAction extends Action<FollowInfoAction.Request, FollowInf
                 remoteCluster = in.readString();
                 leaderIndex = in.readString();
                 status = Status.fromString(in.readString());
-                parameters = in.readOptionalWriteable(innerIn -> new FollowParameters(in));
+                parameters = in.readOptionalWriteable(FollowParameters::new);
             }
 
             @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowParameters.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowParameters.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.AbstractObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.ccr.AutoFollowMetadata;
 
@@ -22,7 +23,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class FollowParameters implements Writeable {
+public class FollowParameters implements Writeable, ToXContentObject {
 
     static final TimeValue RETRY_DELAY_MAX = TimeValue.timeValueMinutes(5);
 
@@ -185,7 +186,7 @@ public class FollowParameters implements Writeable {
         return e;
     }
 
-    FollowParameters(StreamInput in) throws IOException {
+    public FollowParameters(StreamInput in) throws IOException {
         fromStreamInput(in);
     }
 
@@ -214,6 +215,14 @@ public class FollowParameters implements Writeable {
         maxWriteBufferSize = in.readOptionalWriteable(ByteSizeValue::new);
         maxRetryDelay = in.readOptionalTimeValue();
         readPollTimeout = in.readOptionalTimeValue();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        toXContentFragment(builder);
+        builder.endObject();
+        return builder;
     }
 
     XContentBuilder toXContentFragment(final XContentBuilder builder) throws IOException {


### PR DESCRIPTION
A unit test that tests FollowParameters directly was missing.

Backport of #38500
