### PR TITLE
Move testToUtc test to DateFormattersTests Backport #38610

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -21,8 +21,10 @@ package org.elasticsearch.common.time;
 
 import org.elasticsearch.test.ESTestCase;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
@@ -95,6 +97,8 @@ public class DateFormattersTests extends ESTestCase {
         e = expectThrows(IllegalArgumentException.class, () -> formatter.parse("1234.1234567890"));
         assertThat(e.getMessage(), is("failed to parse date field [1234.1234567890] with format [epoch_second]"));
     }
+
+
 
     public void testEpochMilliParsersWithDifferentFormatters() {
         DateFormatter formatter = DateFormatter.forPattern("strict_date_optional_time||epoch_millis");
@@ -247,5 +251,13 @@ public class DateFormattersTests extends ESTestCase {
         DateTimeFormatter roundupParser = formatter.getRoundupParser();
         assertThat(roundupParser.getLocale(), is(locale));
         assertThat(formatter.locale(), is(locale));
+    }
+
+    public void test0MillisAreFormatted() {
+        DateFormatter formatter = DateFormatter.forPattern("strict_date_time");
+        Clock clock = Clock.fixed(ZonedDateTime.of(2019, 02, 8, 11, 43, 00, 0,
+            ZoneOffset.UTC).toInstant(), ZoneOffset.UTC);
+        String formatted = formatter.formatMillis(clock.millis());
+        assertThat(formatted, is("2019-02-08T11:43:00.000Z"));
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringDoc.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringDoc.java
@@ -16,9 +16,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.monitoring.MonitoredSystem;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.Objects;
 
 /**
@@ -26,7 +24,7 @@ import java.util.Objects;
  */
 public abstract class MonitoringDoc implements ToXContentObject {
 
-    private static final DateFormatter dateTimeFormatter = DateFormatter.forPattern("strict_date_time");
+    private static final DateFormatter dateTimeFormatter = DateFormatter.forPattern("strict_date_time").withZone(ZoneOffset.UTC);
     private final String cluster;
     private final long timestamp;
     private final long intervalMillis;
@@ -126,9 +124,7 @@ public abstract class MonitoringDoc implements ToXContentObject {
      * @return a string representing the timestamp
      */
     public static String toUTC(final long timestamp) {
-        ZonedDateTime zonedDateTime = Instant.ofEpochMilli(timestamp).atZone(ZoneOffset.UTC);
-        return dateTimeFormatter.format(zonedDateTime);
-
+        return dateTimeFormatter.formatMillis(timestamp);
     }
 
     /**

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BaseMonitoringDocTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BaseMonitoringDocTestCase.java
@@ -26,8 +26,6 @@ import org.elasticsearch.xpack.monitoring.collector.shards.ShardMonitoringDoc;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -164,13 +162,6 @@ public abstract class BaseMonitoringDocTestCase<T extends MonitoringDoc> extends
                 assertThat(sourceNode.get("timestamp"), equalTo(MonitoringDoc.toUTC(node.getTimestamp())));
             }
         }
-    }
-
-    public void testToUTC() {
-        final long timestamp = System.currentTimeMillis();
-        final String expected = Instant.ofEpochMilli(timestamp).atZone(ZoneOffset.UTC).toString();
-
-        assertEquals(expected, MonitoringDoc.toUTC(timestamp));
     }
 
     public void testMonitoringNodeConstructor() {


### PR DESCRIPTION
The test was relying on toString in ZonedDateTime which is different to
what is formatted by strict_date_time when milliseconds are 0
The method is just delegating to dateFormatter, so that scenario should
be covered there.

closes #38359
Backport #38610
