### PR TITLE
Specialize pre-closing checks for engine implementations

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
@@ -108,13 +108,7 @@ public class TransportVerifyShardBeforeCloseAction extends TransportReplicationA
         if (clusterBlocks.hasIndexBlock(shardId.getIndexName(), request.clusterBlock()) == false) {
             throw new IllegalStateException("Index shard " + shardId + " must be blocked by " + request.clusterBlock() + " before closing");
         }
-
-        final long maxSeqNo = indexShard.seqNoStats().getMaxSeqNo();
-        if (indexShard.getGlobalCheckpoint() != maxSeqNo) {
-            throw new IllegalStateException("Global checkpoint [" + indexShard.getGlobalCheckpoint()
-                + "] mismatches maximum sequence number [" + maxSeqNo + "] on index shard " + shardId);
-        }
-
+        indexShard.checkIndexBeforeClose();
         indexShard.flush(new FlushRequest().force(true));
         logger.trace("{} shard is ready for closing", shardId);
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
@@ -108,7 +108,7 @@ public class TransportVerifyShardBeforeCloseAction extends TransportReplicationA
         if (clusterBlocks.hasIndexBlock(shardId.getIndexName(), request.clusterBlock()) == false) {
             throw new IllegalStateException("Index shard " + shardId + " must be blocked by " + request.clusterBlock() + " before closing");
         }
-        indexShard.checkIndexBeforeClose();
+        indexShard.verifyShardBeforeIndexClosing();
         indexShard.flush(new FlushRequest().force(true));
         logger.trace("{} shard is ready for closing", shardId);
     }

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -266,11 +266,18 @@ public abstract class Engine implements Closeable {
     }
 
     /**
-     * Check the consistency of the given global checkpoint with the engine before closing it
+     * Performs the pre-closing checks on the {@link Engine}.
      *
-     * @param globalCheckpoint the value of the global checkpoint
+     * @throws IllegalStateException if the sanity checks failed
      */
-    public abstract void checkGlobalCheckpointBeforeClose(long globalCheckpoint);
+    public void verifyEngineBeforeIndexClosing() throws IllegalStateException {
+        final long globalCheckpoint = engineConfig.getGlobalCheckpointSupplier().getAsLong();
+        final long maxSeqNo = getSeqNoStats(globalCheckpoint).getMaxSeqNo();
+        if (globalCheckpoint != maxSeqNo) {
+            throw new IllegalStateException("Global checkpoint [" + globalCheckpoint
+                + "] mismatches maximum sequence number [" + maxSeqNo + "] on index shard " + shardId);
+        }
+    }
 
     /**
      * A throttling class that can be activated, causing the

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -266,6 +266,13 @@ public abstract class Engine implements Closeable {
     }
 
     /**
+     * Check the consistency of the given global checkpoint with the engine before closing it
+     *
+     * @param globalCheckpoint the value of the global checkpoint
+     */
+    public abstract void checkGlobalCheckpointBeforeClose(long globalCheckpoint);
+
+    /**
      * A throttling class that can be activated, causing the
      * {@code acquireThrottle} method to block on a lock when throttling
      * is enabled

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -2460,15 +2460,6 @@ public class InternalEngine extends Engine {
         return localCheckpointTracker.getStats(globalCheckpoint);
     }
 
-    @Override
-    public void checkGlobalCheckpointBeforeClose(final long globalCheckpoint) {
-        final long maxSeqNo = getSeqNoStats(globalCheckpoint).getMaxSeqNo();
-        if (globalCheckpoint != maxSeqNo) {
-            throw new IllegalStateException("Global checkpoint [" + globalCheckpoint
-                + "] mismatches maximum sequence number [" + maxSeqNo + "] on index shard " + shardId);
-        }
-    }
-
     /**
      * Returns the number of times a version was looked up either from the index.
      * Note this is only available if assertions are enabled

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -2460,6 +2460,15 @@ public class InternalEngine extends Engine {
         return localCheckpointTracker.getStats(globalCheckpoint);
     }
 
+    @Override
+    public void checkGlobalCheckpointBeforeClose(final long globalCheckpoint) {
+        final long maxSeqNo = getSeqNoStats(globalCheckpoint).getMaxSeqNo();
+        if (globalCheckpoint != maxSeqNo) {
+            throw new IllegalStateException("Global checkpoint [" + globalCheckpoint
+                + "] mismatches maximum sequence number [" + maxSeqNo + "] on index shard " + shardId);
+        }
+    }
+
     /**
      * Returns the number of times a version was looked up either from the index.
      * Note this is only available if assertions are enabled

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -143,7 +143,7 @@ public class ReadOnlyEngine extends Engine {
     }
 
     @Override
-    public void checkGlobalCheckpointBeforeClose(final long globalCheckpoint) {
+    public void verifyEngineBeforeIndexClosing() throws IllegalStateException {
         // the value of the global checkpoint is verified when the read-only engine is opened,
         // and it is not expected to change during the lifecycle of the engine. We could also
         // check this value before closing the read-only engine but if something went wrong

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -142,6 +142,16 @@ public class ReadOnlyEngine extends Engine {
         }
     }
 
+    @Override
+    public void checkGlobalCheckpointBeforeClose(final long globalCheckpoint) {
+        // the value of the global checkpoint is verified when the read-only engine is opened,
+        // and it is not expected to change during the lifecycle of the engine. We could also
+        // check this value before closing the read-only engine but if something went wrong
+        // and the global checkpoint is not in-sync with the max. sequence number anymore,
+        // checking the value here again would prevent the read-only engine to be closed and
+        // reopened as an internal engine, which would be the path to fix the issue.
+    }
+
     protected final DirectoryReader wrapReader(DirectoryReader reader,
                                                     Function<DirectoryReader, DirectoryReader> readerWrapperFunction) throws IOException {
         reader = ElasticsearchDirectoryReader.wrap(reader, engineConfig.getShardId());

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3098,7 +3098,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      *
      * @throws IllegalStateException if the sanity checks failed
      */
-    public void checkIndexBeforeClose() throws IllegalStateException {
-        getEngine().checkGlobalCheckpointBeforeClose(replicationTracker.getGlobalCheckpoint());
+    public void verifyShardBeforeIndexClosing() throws IllegalStateException {
+        getEngine().verifyEngineBeforeIndexClosing();
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3092,4 +3092,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         getEngine().advanceMaxSeqNoOfUpdatesOrDeletes(seqNo);
         assert seqNo <= getMaxSeqNoOfUpdatesOrDeletes() : getMaxSeqNoOfUpdatesOrDeletes() + " < " + seqNo;
     }
+
+    /**
+     * Performs the pre-closing checks on the {@link IndexShard}.
+     *
+     * @throws IllegalStateException if the sanity checks failed
+     */
+    public void checkIndexBeforeClose() throws IllegalStateException {
+        getEngine().checkGlobalCheckpointBeforeClose(replicationTracker.getGlobalCheckpoint());
+    }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
@@ -171,16 +171,16 @@ public class TransportVerifyShardBeforeCloseActionTests extends ESTestCase {
         verify(indexShard, times(0)).flush(any(FlushRequest.class));
     }
 
-    public void testCheckIndexBeforeClose() throws Exception {
+    public void testVerifyShardBeforeIndexClosing() throws Exception {
         executeOnPrimaryOrReplica();
-        verify(indexShard, times(1)).checkIndexBeforeClose();
+        verify(indexShard, times(1)).verifyShardBeforeIndexClosing();
         verify(indexShard, times(1)).flush(any(FlushRequest.class));
     }
 
-    public void testCheckIndexBeforeCloseFailed() {
-        doThrow(new IllegalStateException("test")).when(indexShard).checkIndexBeforeClose();
+    public void testVerifyShardBeforeIndexClosingFailed() {
+        doThrow(new IllegalStateException("test")).when(indexShard).verifyShardBeforeIndexClosing();
         expectThrows(IllegalStateException.class, this::executeOnPrimaryOrReplica);
-        verify(indexShard, times(1)).checkIndexBeforeClose();
+        verify(indexShard, times(1)).verifyShardBeforeIndexClosing();
         verify(indexShard, times(0)).flush(any(FlushRequest.class));
     }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngine.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngine.java
@@ -197,7 +197,7 @@ public final class FollowingEngine extends InternalEngine {
     }
 
     @Override
-    public void checkGlobalCheckpointBeforeClose(final long globalCheckpoint) {
+    public void verifyEngineBeforeIndexClosing() throws IllegalStateException {
         // the value of the global checkpoint is not verified when the following engine is closed,
         // allowing it to be closed even in the case where all operations have not been fetched and
         // processed from the leader and the operations history has gaps. This way the following

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngine.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngine.java
@@ -195,4 +195,12 @@ public final class FollowingEngine extends InternalEngine {
     public long getNumberOfOptimizedIndexing() {
         return numOfOptimizedIndexing.count();
     }
+
+    @Override
+    public void checkGlobalCheckpointBeforeClose(final long globalCheckpoint) {
+        // the value of the global checkpoint is not verified when the following engine is closed,
+        // allowing it to be closed even in the case where all operations have not been fetched and
+        // processed from the leader and the operations history has gaps. This way the following
+        // engine can be closed and reopened in order to bootstrap the follower index again.
+    }
 }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CloseFollowerIndexIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CloseFollowerIndexIT.java
@@ -81,6 +81,7 @@ public class CloseFollowerIndexIT extends CcrIntegTestCase {
         leaderSearchRequest.source().trackTotalHits(true);
         long leaderIndexDocs = leaderClient().search(leaderSearchRequest).actionGet().getHits().getTotalHits().value;
         assertBusy(() -> {
+            refresh(followerClient(), "index2");
             SearchRequest followerSearchRequest = new SearchRequest("index2");
             followerSearchRequest.source().trackTotalHits(true);
             long followerIndexDocs = followerClient().search(followerSearchRequest).actionGet().getHits().getTotalHits().value;

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CloseFollowerIndexIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CloseFollowerIndexIT.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ccr;
+
+import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
+import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.metadata.MetaDataIndexStateService;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.xpack.CcrIntegTestCase;
+import org.elasticsearch.xpack.core.ccr.action.PutFollowAction;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Collections.singletonMap;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class CloseFollowerIndexIT extends CcrIntegTestCase {
+
+    public void testCloseAndReopenFollowerIndex() throws Exception {
+        final String leaderIndexSettings = getIndexSettings(1, 1, singletonMap(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), "true"));
+        assertAcked(leaderClient().admin().indices().prepareCreate("index1").setSource(leaderIndexSettings, XContentType.JSON));
+        ensureLeaderYellow("index1");
+
+        PutFollowAction.Request followRequest = new PutFollowAction.Request();
+        followRequest.setRemoteCluster("leader_cluster");
+        followRequest.setLeaderIndex("index1");
+        followRequest.setFollowerIndex("index2");
+        followRequest.getParameters().setMaxRetryDelay(TimeValue.timeValueMillis(10));
+        followRequest.getParameters().setReadPollTimeout(TimeValue.timeValueMillis(10));
+        followRequest.getParameters().setMaxReadRequestSize(new ByteSizeValue(1));
+        followRequest.getParameters().setMaxOutstandingReadRequests(128);
+        followRequest.waitForActiveShards(ActiveShardCount.DEFAULT);
+
+        followerClient().execute(PutFollowAction.INSTANCE, followRequest).get();
+        ensureFollowerGreen("index2");
+
+        AtomicBoolean isRunning = new AtomicBoolean(true);
+        int numThreads = 4;
+        Thread[] threads = new Thread[numThreads];
+        for (int i = 0; i < numThreads; i++) {
+            threads[i] = new Thread(() -> {
+                while (isRunning.get()) {
+                    leaderClient().prepareIndex("index1", "doc").setSource("{}", XContentType.JSON).get();
+                }
+            });
+            threads[i].start();
+        }
+
+        atLeastDocsIndexed(followerClient(), "index2", 32);
+        AcknowledgedResponse response = followerClient().admin().indices().close(new CloseIndexRequest("index2")).get();
+        assertThat(response.isAcknowledged(), is(true));
+
+        ClusterState clusterState = followerClient().admin().cluster().prepareState().get().getState();
+        List<ClusterBlock> blocks = new ArrayList<>(clusterState.getBlocks().indices().get("index2"));
+        assertThat(blocks.size(), equalTo(1));
+        assertThat(blocks.get(0).id(), equalTo(MetaDataIndexStateService.INDEX_CLOSED_BLOCK_ID));
+
+        isRunning.set(false);
+        for (Thread thread : threads) {
+            thread.join();
+        }
+        assertAcked(followerClient().admin().indices().open(new OpenIndexRequest("index2")).get());
+
+        refresh(leaderClient(), "index1");
+        SearchRequest leaderSearchRequest = new SearchRequest("index1");
+        leaderSearchRequest.source().trackTotalHits(true);
+        long leaderIndexDocs = leaderClient().search(leaderSearchRequest).actionGet().getHits().getTotalHits().value;
+        assertBusy(() -> {
+            SearchRequest followerSearchRequest = new SearchRequest("index2");
+            followerSearchRequest.source().trackTotalHits(true);
+            long followerIndexDocs = followerClient().search(followerSearchRequest).actionGet().getHits().getTotalHits().value;
+            assertThat(followerIndexDocs, equalTo(leaderIndexDocs));
+        });
+    }
+}

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
@@ -642,20 +642,20 @@ public class FollowingEngineTests extends ESTestCase {
     }
 
     /**
-     * Test that {@link FollowingEngine#checkGlobalCheckpointBeforeClose(long)} never fails
+     * Test that {@link FollowingEngine#verifyEngineBeforeIndexClosing()} never fails
      * whatever the value of the global checkpoint to check is.
      */
-    public void testCheckGlobalCheckpointBeforeCloseIsNoOp() throws IOException {
+    public void testVerifyShardBeforeIndexClosingIsNoOp() throws IOException {
         final long seqNo = randomIntBetween(0, Integer.MAX_VALUE);
         runIndexTest(
             seqNo,
             Engine.Operation.Origin.PRIMARY,
             (followingEngine, index) -> {
-                final long globalCheckpoint = randomNonNegativeLong();
+                globalCheckpoint.set(randomNonNegativeLong());
                 try {
-                    followingEngine.checkGlobalCheckpointBeforeClose(globalCheckpoint);
+                    followingEngine.verifyEngineBeforeIndexClosing();
                 } catch (final IllegalStateException e) {
-                    fail("Following engine failed when checking the global checkpoint value [" + globalCheckpoint + "] before close");
+                    fail("Following engine pre-closing verifications failed");
                 }
             });
     }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
@@ -640,4 +640,23 @@ public class FollowingEngineTests extends ESTestCase {
             }
         }
     }
+
+    /**
+     * Test that {@link FollowingEngine#checkGlobalCheckpointBeforeClose(long)} never fails
+     * whatever the value of the global checkpoint to check is.
+     */
+    public void testCheckGlobalCheckpointBeforeCloseIsNoOp() throws IOException {
+        final long seqNo = randomIntBetween(0, Integer.MAX_VALUE);
+        runIndexTest(
+            seqNo,
+            Engine.Operation.Origin.PRIMARY,
+            (followingEngine, index) -> {
+                final long globalCheckpoint = randomNonNegativeLong();
+                try {
+                    followingEngine.checkGlobalCheckpointBeforeClose(globalCheckpoint);
+                } catch (final IllegalStateException e) {
+                    fail("Following engine failed when checking the global checkpoint value [" + globalCheckpoint + "] before close");
+                }
+            });
+    }
 }


### PR DESCRIPTION
This pull request allows engine implementations to perform specialized sanity checks during the closing of index shards. 

Co-authored-by: Martijn van Groningen <martijn.v.groningen@**.com>