### PR TITLE
mute Failing tests related to logging and joda-java migration

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
@@ -47,6 +47,7 @@ public class JsonThrowablePatternConverterTests extends ESTestCase {
         assertThat(jsonLogLine.stacktrace(), Matchers.nullValue());
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/38705")
     public void testStacktraceWithJson() throws IOException {
         LogManager.getLogger().info("asdf");
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherIndexingListenerTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherIndexingListenerTests.java
@@ -126,6 +126,7 @@ public class WatcherIndexingListenerTests extends ESTestCase {
         verifyZeroInteractions(parser);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/38581")
     public void testPreIndex() throws Exception {
         when(operation.type()).thenReturn(Watch.DOC_TYPE);
         when(operation.id()).thenReturn(randomAlphaOfLength(10));

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/index/IndexActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/index/IndexActionTests.java
@@ -277,6 +277,7 @@ public class IndexActionTests extends ESTestCase {
                 fieldName + "] or [ctx.payload._doc." + fieldName + "]"));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/38581")
     public void testIndexActionExecuteSingleDoc() throws Exception {
         boolean customId = randomBoolean();
         boolean docIdAsParam = customId && randomBoolean();

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
@@ -152,6 +152,7 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/38693")
     public void testThatHistoryContainsStatus() throws Exception {
         watcherClient().preparePutWatch("test_watch")
                 .setSource(watchBuilder()


### PR DESCRIPTION
The test is failing due to wrong format when comparing - awaits fix from 
https://github.com/elastic/elasticsearch/issues/38693
and https://github.com/elastic/elasticsearch/issues/38705
and https://github.com/elastic/elasticsearch/issues/38581