### PR TITLE
Enable JsonThrowablePatternConverterTests with more debug

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.common.logging;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.SimpleMessage;
@@ -47,9 +46,7 @@ public class JsonThrowablePatternConverterTests extends ESTestCase {
         assertThat(jsonLogLine.stacktrace(), Matchers.nullValue());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/38705")
     public void testStacktraceWithJson() throws IOException {
-        LogManager.getLogger().info("asdf");
 
         String json = "{\n" +
             "  \"terms\" : {\n" +
@@ -67,6 +64,7 @@ public class JsonThrowablePatternConverterTests extends ESTestCase {
                                       .setThrown(thrown)
                                       .build();
 
+
         String result = format(event);
 
         //confirms exception is correctly parsed
@@ -77,7 +75,7 @@ public class JsonThrowablePatternConverterTests extends ESTestCase {
 
         int jsonLength = json.split("\n").length;
         int stacktraceLength = thrown.getStackTrace().length;
-        assertThat("stacktrace should formatted in multiple lines",
+        assertThat("stacktrace should formatted in multiple lines. JsonLogLine= " + jsonLogLine+" result= "+result,
             jsonLogLine.stacktrace().size(), equalTo(jsonLength + stacktraceLength));
     }
 


### PR DESCRIPTION
reenable the test with more debugging info
relates https://github.com/elastic/elasticsearch/issues/38705