### PR TITLE
Correct rebuilding of Persian analyzer

### DIFF
--- a/docs/reference/analysis/analyzers/lang-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/lang-analyzer.asciidoc
@@ -1358,7 +1358,7 @@ PUT /persian_example
       "char_filter": {
         "zero_width_spaces": {
             "type":       "mapping",
-            "mappings": [ "\\u200C=> "] <1>
+            "mappings": [ "\\u200C=>\\u0020"] <1>
         }
       },
       "filter": {


### PR DESCRIPTION
Make substitution of \u200C with a space explicit

The problem with this symbol `\u200C` in a test string, that **SHOULD** be substituted with space in the rebuilt Persian analyzer, but it is not.

Correcting this line `"mappings": [ "\\u200C=> "] <1>` to `"mappings": [ "\\u200C=>\\u0020"] <1>` in
[lang-analyzer](https://github.com/elastic/elasticsearch/blob/master/docs/reference/analysis/analyzers/lang-analyzer.asciidoc) solves the problem.
This change explicitly says to substitute ZWNJ with a space.

Closes #38188