### PR TITLE
Fix possible assertion failure in IndicesQueryCache.close

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
@@ -206,7 +206,7 @@ public class IndicesQueryCache implements QueryCache, Closeable {
     }
 
     private static class StatsAndCount {
-        int count;
+        volatile int count;
         final Stats stats;
 
         StatsAndCount(Stats stats) {


### PR DESCRIPTION
The assertion that the stats2 map is empty in
IndicesQueryCache.close has been observed to
fail very occasionally in internal cluster tests.

The likely cause is a cross-thread visibility
problem for a count variable.  This change
makes that count volatile.

Relates #37117
Backport of #38714