### PR TITLE
Ensure that maxConcurrentShardRequests is never defaulted to 0

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -341,7 +341,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         final DiscoveryNodes nodes = clusterState.nodes();
         BiFunction<String, String, Transport.Connection> connectionLookup = buildConnectionLookup(searchRequest.getLocalClusterAlias(),
             nodes::get, remoteConnections, searchTransportService::getConnection);
-        assert nodeCount > 0 || shardIterators.size() == 0;
+        assert nodeCount > 0 || shardIterators.size() == 0 : "non empty search iterators but node count is 0";
         setMaxConcurrentShardRequests(searchRequest, nodeCount);
         boolean preFilterSearchShards = shouldPreFilterSearchShards(searchRequest, shardIterators);
         searchAsyncAction(task, searchRequest, shardIterators, timeProvider, connectionLookup, clusterState.version(),
@@ -350,11 +350,10 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
 
     static void setMaxConcurrentShardRequests(SearchRequest searchRequest, int nodeCount) {
         if (searchRequest.isMaxConcurrentShardRequestsSet() == false) {
-            // we try to set a default of max concurrent shard requests based on
-            // the node count but upper-bound it by 256 by default to keep it sane. A single
-            // search request that fans out lots of shards should hit a cluster too hard while 256 is already a lot.
-            // we multiply it by the default number of shards such that a single request in a cluster of 1 would hit all shards of a
-            // default index.
+            // we try to set a default of max concurrent shard requests based on the node count but upper-bound it by 256 by default to
+            // keep it sane. A single search request that fans out to lots of shards should hit a cluster too hard while 256 is already
+            // a lot. we multiply it by the default number of shards such that a single request in a cluster of 1 would hit all shards of
+            // a default index. We take into account that we may be in a cluster with no data nodes searching against no shards.
             searchRequest.setMaxConcurrentShardRequests(Math.min(256, Math.max(nodeCount, 1)
                 * IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getDefault(Settings.EMPTY)));
         }

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -341,4 +341,25 @@ public class TransportSearchActionTests extends ESTestCase {
         return new OriginalIndices(localIndices, IndicesOptions.fromOptions(randomBoolean(),
                 randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
     }
+
+    public void testSetMaxConcurrentShardRequests() {
+        {
+            SearchRequest searchRequest = new SearchRequest();
+            int value = randomIntBetween(1, Integer.MAX_VALUE);
+            searchRequest.setMaxConcurrentShardRequests(value);
+            TransportSearchAction.setMaxConcurrentShardRequests(searchRequest, randomIntBetween(0, Integer.MAX_VALUE));
+            assertEquals(value, searchRequest.getMaxConcurrentShardRequests());
+        }
+        {
+            SearchRequest searchRequest = new SearchRequest();
+            int nodeCount = randomIntBetween(1, 1000000);
+            TransportSearchAction.setMaxConcurrentShardRequests(searchRequest, nodeCount);
+            assertEquals(Math.min(256, nodeCount * 5), searchRequest.getMaxConcurrentShardRequests());
+        }
+        {
+            SearchRequest searchRequest = new SearchRequest();
+            TransportSearchAction.setMaxConcurrentShardRequests(searchRequest, 0);
+            assertEquals(5, searchRequest.getMaxConcurrentShardRequests());
+        }
+    }
 }


### PR DESCRIPTION
It may happen that a search request is run in a cluster where there are
no data nodes, for instance when running a search against an empty cluster.

In that case we end up defaulting
`maxConcurrentShardRequests` to `0` when not set, which causes a
confusing error returned back to the user as `SearchRequest` does not
allow a value that's lower than `1`. We should rather make sure that `1`
is used instead, whenever the node count is `0`.

Note that this is only relevant in 6.7 or previous versions as from 7.0 we throttle 
search requests per node rather than globally.