### PR TITLE
Terms aggregations doc added note about fielddata

### DIFF
--- a/docs/reference/aggregations/bucket/terms-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/terms-aggregation.asciidoc
@@ -59,13 +59,15 @@ GET /_search
 {
     "aggs" : {
         "genres" : {
-            "terms" : { "field" : "genre" }
+            "terms" : { "field" : "genre" } <1>
         }
     }
 }
 --------------------------------------------------
 // CONSOLE
 // TEST[s/_search/_search\?filter_path=aggregations/]
+<1> `terms` aggregation needs a field of type `keyword` or any other data type suitable for bucket aggregations. In order to use it with `text` you will need to enable 
+<<fielddata>>.
 
 Response:
 

--- a/docs/reference/aggregations/bucket/terms-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/terms-aggregation.asciidoc
@@ -67,7 +67,7 @@ GET /_search
 // CONSOLE
 // TEST[s/_search/_search\?filter_path=aggregations/]
 <1> `terms` aggregation needs a field of type `keyword` or any other data type suitable for bucket aggregations. In order to use it with `text` you will need to enable 
-<<fielddata>>.
+<<fielddata, fielddata>>.
 
 Response:
 


### PR DESCRIPTION
Added a note in the first example of a terms aggregation briefly explaining the need to enable fielddata for text fields.

Closes #31592 