### PR TITLE
unmute EvilLoggerTests#testDeprecatedSettings

### DIFF
--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -253,7 +253,6 @@ public class EvilLoggerTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/35990")
     public void testDeprecatedSettings() throws IOException, UserException {
         setupLogging("settings");
 


### PR DESCRIPTION
unmuting test to determine whether this is still an issue on
the current branch. If it is found that this test does
not fail in CI anymore, then this commit will remain and
test will stay tested.

related to #35990.