### PR TITLE
Update the gcs chunk_size documentation.

### DIFF
--- a/docs/plugins/repository-gcs.asciidoc
+++ b/docs/plugins/repository-gcs.asciidoc
@@ -233,7 +233,7 @@ The following settings are supported:
 
     Big files can be broken down into chunks during snapshotting if needed.
     The chunk size can be specified in bytes or by using size value notation,
-    i.e. `1g`, `10m`, `5k`. Defaults to `100m`.
+    e.g. , `10m` or `5k`. Defaults to `100m`, which is the maximum permitted.
 
 `compress`::
 


### PR DESCRIPTION
Remove `1g` from the examples, as the GCS repository chunk_size can be at most 100m. As illustrated by the error message when trying to set it to `1g`:

```
$ curl -H 'Content-type: application/json' -u user:pass -XPUT http://127.0.0.1:9200/_snapshot/backup -d '{
  "type": "gcs",
  "settings": {
    "bucket": "elk-backup",
    "client": "backups",
    "chunk_size": "1g"
  }
}'
{"error":{"root_cause":[{"type":"repository_exception","reason":"[backup] failed to create repository"}],"type":"repository_exception","reason":"[backup] failed to create repository","caused_by":{"type":"illegal_argument_exception","reason":"failed to parse value [1g] for setting [chunk_size], must be <= [100mb]"}},"status":500}
```