### PR TITLE
Document 'max_size' parameter as shard size for rollover

### DIFF
--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -390,7 +390,7 @@ existing index meets one of the rollover conditions.
 [options="header"]
 |======
 | Name       | Required  | Default             | Description
-| `max_size` | no        | -                   | max index storage size.
+| `max_size` | no        | -                   | max primary shard index storage size.
                                                  See <<byte-units, Byte Units>>
                                                  for formatting
 | `max_docs` | no        | -                   | max number of documents an

--- a/docs/reference/ilm/using-policies-rollover.asciidoc
+++ b/docs/reference/ilm/using-policies-rollover.asciidoc
@@ -31,8 +31,8 @@ The rollover action takes the following parameters:
 .`rollover` Action Parameters
 |===
 |Name |Description
-|max_size |The maximum estimated size the index is allowed to grow
-to. Defaults to `null`. Optional.
+|max_size |The maximum estimated size the primary shard of the index is allowed
+to grow to. Defaults to `null`. Optional.
 |max_docs |The maximum number of document the index should
 contain. Defaults to `null`. Optional.
 |max_age |The maximum age of the index. Defaults to `null`. Optional.

--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -18,6 +18,15 @@ from the original (rolled-over) index.
 In this scenario, the write index will have its rollover alias' `is_write_index` set to `false`, while the newly created index
 will now have the rollover alias pointing to it as the write index with `is_write_index` as `true`.
 
+The available conditions are:
+
+.`conditions` parameters
+|===
+| Name     | Description
+| max_age  | The maximum age of the index
+| max_docs | The maximum number of documents the index should contain. This does not add documents multiple times for replicas
+| max_size | The maximum estimated size of the primary shard of the index
+|===
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
It was not clear that this is *primary* shard size, not the entire shard size.

Resolves #37981
