### PR TITLE
add debug logging to SimpleClusterStateIT#testIndicesOptions

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -51,6 +51,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.hamcrest.CollectionAssertions;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.junit.Before;
@@ -253,13 +254,14 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
         }
     }
 
+    @TestLogging("org.elasticsearch.action.admin.indices.close:DEBUG,org.elasticsearch.cluster.metadata:DEBUG")
     public void testIndicesOptions() throws Exception {
         ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().clear().setMetaData(true).setIndices("f*")
                 .get();
         assertThat(clusterStateResponse.getState().metaData().indices().size(), is(2));
 
         // close one index
-        client().admin().indices().close(Requests.closeIndexRequest("fuu")).get();
+        assertAcked(client().admin().indices().close(Requests.closeIndexRequest("fuu")).get());
         clusterStateResponse = client().admin().cluster().prepareState().clear().setMetaData(true).setIndices("f*").get();
         assertThat(clusterStateResponse.getState().metaData().indices().size(), is(1));
         assertThat(clusterStateResponse.getState().metaData().index("foo").getState(), equalTo(IndexMetaData.State.OPEN));


### PR DESCRIPTION
testIndicesOptions fails sometimes because not all indices
are closed in time before the next cluster-state assertion.
This change adds debug logging to the close action, as well
as its calls out to the MetaDataIndexStateService. This should
help understand why things failed, next time they do.

relates to #38745.