### PR TITLE
Fix synchronization in LocalCheckpointTracker#contains

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointTracker.java
@@ -157,11 +157,11 @@ public class LocalCheckpointTracker {
             return true;
         }
         final long bitSetKey = getBitSetKey(seqNo);
-        final CountedBitSet bitSet;
+        final int bitSetOffset = seqNoToBitSetOffset(seqNo);
         synchronized (this) {
-            bitSet = processedSeqNo.get(bitSetKey);
+            final CountedBitSet bitSet = processedSeqNo.get(bitSetKey);
+            return bitSet != null && bitSet.get(bitSetOffset);
         }
-        return bitSet != null && bitSet.get(seqNoToBitSetOffset(seqNo));
     }
 
     /**


### PR DESCRIPTION
While investigating #38633, I realize that we are accessing a `CountedBitSet` in `LocalCheckpointTracker#contains` without proper synchronization.

Relates #33871