### PR TITLE
Make 7.0 like 6.7 user agent ecs

### DIFF
--- a/docs/reference/ingest/processors/user-agent.asciidoc
+++ b/docs/reference/ingest/processors/user-agent.asciidoc
@@ -69,7 +69,9 @@ Which returns
         "version": "10.10.5",
         "full": "Mac OS X 10.10.5"
       },
-      "device": "Other"
+      "device" : {
+        "name" : "Other"
+      },
     }
   }
 }

--- a/docs/reference/ingest/processors/user-agent.asciidoc
+++ b/docs/reference/ingest/processors/user-agent.asciidoc
@@ -19,6 +19,7 @@ The ingest-user-agent module ships by default with the regexes.yaml made availab
 | `regex_file`           | no        | -                                                                                               | The name of the file in the `config/ingest-user-agent` directory containing the regular expressions for parsing the user agent string. Both the directory and the file have to be created before starting Elasticsearch. If not specified, ingest-user-agent will use the regexes.yaml from uap-core it ships with (see below).
 | `properties`           | no        | [`name`, `major`, `minor`, `patch`, `build`, `os`, `os_name`, `os_major`, `os_minor`, `device`] | Controls what properties are added to `target_field`.
 | `ignore_missing`       | no        | `false`                                                                                         | If `true` and `field` does not exist, the processor quietly exits without modifying the document
+| `ecs`                  | no        | `false`                                                                                         | Whether to return the output in Elastic Common Schema format. NOTE: ECS format will be the default in Elasticsearch 7.0 and non-ECS format is deprecated.
 |======
 
 Here is an example that adds the user agent details to the `user_agent` field based on the `agent` field:
@@ -31,7 +32,8 @@ PUT _ingest/pipeline/user_agent
   "processors" : [
     {
       "user_agent" : {
-        "field" : "agent"
+        "field" : "agent",
+        "ecs" : true
       }
     }
   ]
@@ -60,13 +62,13 @@ Which returns
     "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
     "user_agent": {
       "name": "Chrome",
-      "major": "51",
-      "minor": "0",
-      "patch": "2704",
-      "os_name": "Mac OS X",
-      "os": "Mac OS X 10.10.5",
-      "os_major": "10",
-      "os_minor": "10",
+      "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
+      "version": "51.0.2704",
+      "os": {
+        "name": "Mac OS X",
+        "version": "10.10.5",
+        "full": "Mac OS X 10.10.5"
+      },
       "device": "Other"
     }
   }

--- a/docs/reference/ingest/processors/user-agent.asciidoc
+++ b/docs/reference/ingest/processors/user-agent.asciidoc
@@ -19,7 +19,7 @@ The ingest-user-agent module ships by default with the regexes.yaml made availab
 | `regex_file`           | no        | -                                                                                               | The name of the file in the `config/ingest-user-agent` directory containing the regular expressions for parsing the user agent string. Both the directory and the file have to be created before starting Elasticsearch. If not specified, ingest-user-agent will use the regexes.yaml from uap-core it ships with (see below).
 | `properties`           | no        | [`name`, `major`, `minor`, `patch`, `build`, `os`, `os_name`, `os_major`, `os_minor`, `device`] | Controls what properties are added to `target_field`.
 | `ignore_missing`       | no        | `false`                                                                                         | If `true` and `field` does not exist, the processor quietly exits without modifying the document
-| `ecs`                  | no        | `false`                                                                                         | Whether to return the output in Elastic Common Schema format. NOTE: ECS format will be the default in Elasticsearch 7.0 and non-ECS format is deprecated.
+| `ecs`                  | no        | `true`                                                                                         | Whether to return the output in Elastic Common Schema format. NOTE: This setting is deprecated and will be removed in a future version.
 |======
 
 Here is an example that adds the user agent details to the `user_agent` field based on the `agent` field:
@@ -32,8 +32,7 @@ PUT _ingest/pipeline/user_agent
   "processors" : [
     {
       "user_agent" : {
-        "field" : "agent",
-        "ecs" : true
+        "field" : "agent"
       }
     }
   ]

--- a/docs/reference/ingest/processors/user-agent.asciidoc
+++ b/docs/reference/ingest/processors/user-agent.asciidoc
@@ -60,13 +60,13 @@ Which returns
     "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
     "user_agent": {
       "name": "Chrome",
-      "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
-      "version": "51.0.2704",
-      "os": {
-        "name": "Mac OS X",
-        "version": "10.10.5",
-        "full": "Mac OS X 10.10.5"
-      },
+      "major": "51",
+      "minor": "0",
+      "patch": "2704",
+      "os_name": "Mac OS X",
+      "os": "Mac OS X 10.10.5",
+      "os_major": "10",
+      "os_minor": "10",
       "device": "Other"
     }
   }

--- a/docs/reference/ingest/processors/user-agent.asciidoc
+++ b/docs/reference/ingest/processors/user-agent.asciidoc
@@ -67,9 +67,7 @@ Which returns
         "version": "10.10.5",
         "full": "Mac OS X 10.10.5"
       },
-      "device" : {
-        "name" : "Other"
-      },
+      "device": "Other"
     }
   }
 }

--- a/docs/reference/migration/migrate_7_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/settings.asciidoc
@@ -198,9 +198,3 @@ could have lead to dropping audit events while the operations on the system
 were allowed to continue as usual. The recommended replacement is the
 use of the `logfile` audit output type and using other components from the
 Elastic Stack to handle the indexing part.
-
-[float]
-[[ingest-user-agent-ecs-always]]
-==== Ingest User Agent processor always uses `ecs` output format
-The deprecated `ecs` setting for the user agent ingest processor has been
-removed. https://github.com/elastic/ecs[ECS] format is now the default.

--- a/docs/reference/migration/migrate_7_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/settings.asciidoc
@@ -198,3 +198,9 @@ could have lead to dropping audit events while the operations on the system
 were allowed to continue as usual. The recommended replacement is the
 use of the `logfile` audit output type and using other components from the
 Elastic Stack to handle the indexing part.
+
+[float]
+[[ingest-user-agent-ecs-always]]
+==== Ingest User Agent processor defaults uses `ecs` output format
+https://github.com/elastic/ecs[ECS] format is now the default.
+The `ecs` setting for the user agent ingest processor now defaults to true.

--- a/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
+++ b/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
@@ -19,15 +19,19 @@
 
 package org.elasticsearch.ingest.useragent;
 
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.useragent.UserAgentParser.Details;
 import org.elasticsearch.ingest.useragent.UserAgentParser.VersionedName;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -40,6 +44,8 @@ import static org.elasticsearch.ingest.ConfigurationUtils.readStringProperty;
 
 public class UserAgentProcessor extends AbstractProcessor {
 
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(UserAgentProcessor.class));
+
     public static final String TYPE = "user_agent";
 
     private final String field;
@@ -47,15 +53,17 @@ public class UserAgentProcessor extends AbstractProcessor {
     private final Set<Property> properties;
     private final UserAgentParser parser;
     private final boolean ignoreMissing;
+    private final boolean useECS;
 
     public UserAgentProcessor(String tag, String field, String targetField, UserAgentParser parser, Set<Property> properties,
-                              boolean ignoreMissing) {
+                              boolean ignoreMissing, boolean useECS) {
         super(tag);
         this.field = field;
         this.targetField = targetField;
         this.parser = parser;
         this.properties = properties;
         this.ignoreMissing = ignoreMissing;
+        this.useECS = useECS;
     }
 
     boolean isIgnoreMissing() {
@@ -63,7 +71,7 @@ public class UserAgentProcessor extends AbstractProcessor {
     }
 
     @Override
-    public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
+    public IngestDocument execute(IngestDocument ingestDocument) {
         String userAgent = ingestDocument.getFieldValue(field, String.class, ignoreMissing);
 
         if (userAgent == null && ignoreMissing) {
@@ -75,71 +83,134 @@ public class UserAgentProcessor extends AbstractProcessor {
         Details uaClient = parser.parse(userAgent);
 
         Map<String, Object> uaDetails = new HashMap<>();
-        for (Property property : this.properties) {
-            switch (property) {
-                case NAME:
-                    if (uaClient.userAgent != null && uaClient.userAgent.name != null) {
-                        uaDetails.put("name", uaClient.userAgent.name);
-                    }
-                    else {
-                        uaDetails.put("name", "Other");
-                    }
-                    break;
-                case MAJOR:
-                    if (uaClient.userAgent != null && uaClient.userAgent.major != null) {
-                        uaDetails.put("major", uaClient.userAgent.major);
-                    }
-                    break;
-                case MINOR:
-                    if (uaClient.userAgent != null && uaClient.userAgent.minor != null) {
-                        uaDetails.put("minor", uaClient.userAgent.minor);
-                    }
-                    break;
-                case PATCH:
-                    if (uaClient.userAgent != null && uaClient.userAgent.patch != null) {
-                        uaDetails.put("patch", uaClient.userAgent.patch);
-                    }
-                    break;
-                case BUILD:
-                    if (uaClient.userAgent != null && uaClient.userAgent.build != null) {
-                        uaDetails.put("build", uaClient.userAgent.build);
-                    }
-                    break;
-                case OS:
-                    if (uaClient.operatingSystem != null) {
-                        uaDetails.put("os", buildFullOSName(uaClient.operatingSystem));
-                    }
-                    else {
-                        uaDetails.put("os", "Other");
-                    }
 
-                    break;
-                case OS_NAME:
-                    if (uaClient.operatingSystem != null && uaClient.operatingSystem.name != null) {
-                        uaDetails.put("os_name", uaClient.operatingSystem.name);
-                    }
-                    else {
-                        uaDetails.put("os_name", "Other");
-                    }
-                    break;
-                case OS_MAJOR:
-                    if (uaClient.operatingSystem != null && uaClient.operatingSystem.major != null) {
-                        uaDetails.put("os_major", uaClient.operatingSystem.major);
-                    }
-                    break;
-                case OS_MINOR:
-                    if (uaClient.operatingSystem != null && uaClient.operatingSystem.minor != null) {
-                        uaDetails.put("os_minor", uaClient.operatingSystem.minor);
-                    }
-                    break;
-                case DEVICE:
-                    if (uaClient.device != null && uaClient.device.name != null) {
-                        uaDetails.put("device", uaClient.device.name);
-                    }
-                    else {
-                        uaDetails.put("device", "Other");
-                    }
-                    break;
+        if (useECS) {
+            // Parse the user agent in the ECS (Elastic Common Schema) format
+            for (Property property : this.properties) {
+                switch (property) {
+                    case ORIGINAL:
+                        uaDetails.put("original", userAgent);
+                        break;
+                    case NAME:
+                        if (uaClient.userAgent != null && uaClient.userAgent.name != null) {
+                            uaDetails.put("name", uaClient.userAgent.name);
+                        } else {
+                            uaDetails.put("name", "Other");
+                        }
+                        break;
+                    case VERSION:
+                        StringBuilder version = new StringBuilder();
+                        if (uaClient.userAgent != null && uaClient.userAgent.major != null) {
+                            version.append(uaClient.userAgent.major);
+                            if (uaClient.userAgent.minor != null) {
+                                version.append(".").append(uaClient.userAgent.minor);
+                                if (uaClient.userAgent.patch != null) {
+                                    version.append(".").append(uaClient.userAgent.patch);
+                                    if (uaClient.userAgent.build != null) {
+                                        version.append(".").append(uaClient.userAgent.build);
+                                    }
+                                }
+                            }
+                            uaDetails.put("version", version.toString());
+                        }
+                        break;
+                    case OS:
+                        if (uaClient.operatingSystem != null) {
+                            Map<String, String> osDetails = new HashMap<>(3);
+                            if (uaClient.operatingSystem.name != null) {
+                                osDetails.put("name", uaClient.operatingSystem.name);
+                                StringBuilder sb = new StringBuilder();
+                                if (uaClient.operatingSystem.major != null) {
+                                    sb.append(uaClient.operatingSystem.major);
+                                    if (uaClient.operatingSystem.minor != null) {
+                                        sb.append(".").append(uaClient.operatingSystem.minor);
+                                        if (uaClient.operatingSystem.patch != null) {
+                                            sb.append(".").append(uaClient.operatingSystem.patch);
+                                            if (uaClient.operatingSystem.build != null) {
+                                                sb.append(".").append(uaClient.operatingSystem.build);
+                                            }
+                                        }
+                                    }
+                                    osDetails.put("version", sb.toString());
+                                    osDetails.put("full", uaClient.operatingSystem.name + " " + sb.toString());
+                                }
+                                uaDetails.put("os", osDetails);
+                            }
+                        }
+                        break;
+                    case DEVICE:
+                        if (uaClient.device != null && uaClient.device.name != null) {
+                            uaDetails.put("device", uaClient.device.name);
+                        } else {
+                            uaDetails.put("device", "Other");
+                        }
+                        break;
+                }
+            }
+        } else {
+            // Deprecated format, removed in 7.0
+            for (Property property : this.properties) {
+                switch (property) {
+                    case NAME:
+                        if (uaClient.userAgent != null && uaClient.userAgent.name != null) {
+                            uaDetails.put("name", uaClient.userAgent.name);
+                        } else {
+                            uaDetails.put("name", "Other");
+                        }
+                        break;
+                    case MAJOR:
+                        if (uaClient.userAgent != null && uaClient.userAgent.major != null) {
+                            uaDetails.put("major", uaClient.userAgent.major);
+                        }
+                        break;
+                    case MINOR:
+                        if (uaClient.userAgent != null && uaClient.userAgent.minor != null) {
+                            uaDetails.put("minor", uaClient.userAgent.minor);
+                        }
+                        break;
+                    case PATCH:
+                        if (uaClient.userAgent != null && uaClient.userAgent.patch != null) {
+                            uaDetails.put("patch", uaClient.userAgent.patch);
+                        }
+                        break;
+                    case BUILD:
+                        if (uaClient.userAgent != null && uaClient.userAgent.build != null) {
+                            uaDetails.put("build", uaClient.userAgent.build);
+                        }
+                        break;
+                    case OS:
+                        if (uaClient.operatingSystem != null) {
+                            uaDetails.put("os", buildFullOSName(uaClient.operatingSystem));
+                        } else {
+                            uaDetails.put("os", "Other");
+                        }
+
+                        break;
+                    case OS_NAME:
+                        if (uaClient.operatingSystem != null && uaClient.operatingSystem.name != null) {
+                            uaDetails.put("os_name", uaClient.operatingSystem.name);
+                        } else {
+                            uaDetails.put("os_name", "Other");
+                        }
+                        break;
+                    case OS_MAJOR:
+                        if (uaClient.operatingSystem != null && uaClient.operatingSystem.major != null) {
+                            uaDetails.put("os_major", uaClient.operatingSystem.major);
+                        }
+                        break;
+                    case OS_MINOR:
+                        if (uaClient.operatingSystem != null && uaClient.operatingSystem.minor != null) {
+                            uaDetails.put("os_minor", uaClient.operatingSystem.minor);
+                        }
+                        break;
+                    case DEVICE:
+                        if (uaClient.device != null && uaClient.device.name != null) {
+                            uaDetails.put("device", uaClient.device.name);
+                        } else {
+                            uaDetails.put("device", "Other");
+                        }
+                        break;
+                }
             }
         }
 
@@ -199,6 +270,10 @@ public class UserAgentProcessor extends AbstractProcessor {
         return parser;
     }
 
+    public boolean isUseECS() {
+        return useECS;
+    }
+
     public static final class Factory implements Processor.Factory {
 
         private final Map<String, UserAgentParser> userAgentParsers;
@@ -215,6 +290,7 @@ public class UserAgentProcessor extends AbstractProcessor {
             String regexFilename = readStringProperty(TYPE, processorTag, config, "regex_file", IngestUserAgentPlugin.DEFAULT_PARSER_NAME);
             List<String> propertyNames = readOptionalList(TYPE, processorTag, config, "properties");
             boolean ignoreMissing = readBooleanProperty(TYPE, processorTag, config, "ignore_missing", false);
+            boolean useECS = readBooleanProperty(TYPE, processorTag, config, "ecs", false);
 
             UserAgentParser parser = userAgentParsers.get(regexFilename);
             if (parser == null) {
@@ -236,17 +312,51 @@ public class UserAgentProcessor extends AbstractProcessor {
                 properties = EnumSet.allOf(Property.class);
             }
 
-            return new UserAgentProcessor(processorTag, field, targetField, parser, properties, ignoreMissing);
+            if (useECS == false) {
+                deprecationLogger.deprecated("setting [ecs] to false for non-common schema " +
+                    "format is deprecated and will be removed in 7.0, set to true to use the non-deprecated format");
+            }
+
+            return new UserAgentProcessor(processorTag, field, targetField, parser, properties, ignoreMissing, useECS);
         }
     }
 
     enum Property {
 
-        NAME, MAJOR, MINOR, PATCH, OS, OS_NAME, OS_MAJOR, OS_MINOR, DEVICE, BUILD;
+        NAME,
+        // Deprecated in 6.7 (superceded by VERSION), to be removed in 7.0
+        @Deprecated MAJOR,
+        @Deprecated MINOR,
+        @Deprecated PATCH,
+        OS,
+        // Deprecated in 6.7 (superceded by just using OS), to be removed in 7.0
+        @Deprecated OS_NAME,
+        @Deprecated OS_MAJOR,
+        @Deprecated OS_MINOR,
+        DEVICE,
+        @Deprecated BUILD, // Same deprecated as OS_* above
+        ORIGINAL,
+        VERSION;
+
+        private static Set<Property> DEPRECATED_PROPERTIES;
+
+        static {
+            Set<Property> deprecated = new HashSet<>();
+            for (Field field : Property.class.getFields()) {
+                if (field.isEnumConstant() && field.isAnnotationPresent(Deprecated.class)) {
+                    deprecated.add(valueOf(field.getName()));
+                }
+            }
+            DEPRECATED_PROPERTIES = deprecated;
+        }
 
         public static Property parseProperty(String propertyName) {
             try {
-                return valueOf(propertyName.toUpperCase(Locale.ROOT));
+                Property value = valueOf(propertyName.toUpperCase(Locale.ROOT));
+                if (DEPRECATED_PROPERTIES.contains(value)) {
+                    deprecationLogger.deprecated("the [{}] property is deprecated for the user-agent processor", propertyName);
+                }
+                return value;
             }
             catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException("illegal property value [" + propertyName + "]. valid values are " +

--- a/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
+++ b/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
@@ -139,11 +139,13 @@ public class UserAgentProcessor extends AbstractProcessor {
                         }
                         break;
                     case DEVICE:
+                        Map<String, String> deviceDetails = new HashMap<>(1);
                         if (uaClient.device != null && uaClient.device.name != null) {
-                            uaDetails.put("device", uaClient.device.name);
+                            deviceDetails.put("name", uaClient.device.name);
                         } else {
-                            uaDetails.put("device", "Other");
+                            deviceDetails.put("name", "Other");
                         }
+                        uaDetails.put("device", deviceDetails);
                         break;
                 }
             }

--- a/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
+++ b/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
@@ -134,13 +134,11 @@ public class UserAgentProcessor extends AbstractProcessor {
                     }
                     break;
                 case DEVICE:
-                    Map<String, String> deviceDetails = new HashMap<>(1);
                     if (uaClient.device != null && uaClient.device.name != null) {
-                        deviceDetails.put("name", uaClient.device.name);
+                        uaDetails.put("device", uaClient.device.name);
                     } else {
-                        deviceDetails.put("name", "Other");
+                        uaDetails.put("device", "Other");
                     }
-                    uaDetails.put("device", deviceDetails);
                     break;
             }
         }

--- a/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
+++ b/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
@@ -150,7 +150,7 @@ public class UserAgentProcessor extends AbstractProcessor {
                 }
             }
         } else {
-            // Deprecated format, removed in 7.0
+            // Deprecated format, removed in 8.0
             for (Property property : this.properties) {
                 switch (property) {
                     case NAME:
@@ -292,7 +292,7 @@ public class UserAgentProcessor extends AbstractProcessor {
             String regexFilename = readStringProperty(TYPE, processorTag, config, "regex_file", IngestUserAgentPlugin.DEFAULT_PARSER_NAME);
             List<String> propertyNames = readOptionalList(TYPE, processorTag, config, "properties");
             boolean ignoreMissing = readBooleanProperty(TYPE, processorTag, config, "ignore_missing", false);
-            boolean useECS = readBooleanProperty(TYPE, processorTag, config, "ecs", false);
+            boolean useECS = readBooleanProperty(TYPE, processorTag, config, "ecs", true);
 
             UserAgentParser parser = userAgentParsers.get(regexFilename);
             if (parser == null) {
@@ -316,7 +316,7 @@ public class UserAgentProcessor extends AbstractProcessor {
 
             if (useECS == false) {
                 deprecationLogger.deprecated("setting [ecs] to false for non-common schema " +
-                    "format is deprecated and will be removed in 7.0, set to true to use the non-deprecated format");
+                    "format is deprecated and will be removed in 8.0, set to true or remove to use the non-deprecated format");
             }
 
             return new UserAgentProcessor(processorTag, field, targetField, parser, properties, ignoreMissing, useECS);
@@ -326,12 +326,12 @@ public class UserAgentProcessor extends AbstractProcessor {
     enum Property {
 
         NAME,
-        // Deprecated in 6.7 (superceded by VERSION), to be removed in 7.0
+        // Deprecated in 6.7 (superceded by VERSION), to be removed in 8.0
         @Deprecated MAJOR,
         @Deprecated MINOR,
         @Deprecated PATCH,
         OS,
-        // Deprecated in 6.7 (superceded by just using OS), to be removed in 7.0
+        // Deprecated in 6.7 (superceded by just using OS), to be removed in 8.0
         @Deprecated OS_NAME,
         @Deprecated OS_MAJOR,
         @Deprecated OS_MINOR,

--- a/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorFactoryTests.java
+++ b/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorFactoryTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.ingest.useragent;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.BeforeClass;
 
@@ -27,17 +28,21 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -78,6 +83,7 @@ public class UserAgentProcessorFactoryTests extends ESTestCase {
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
+        config.put("ecs", true);
 
         String processorTag = randomAlphaOfLength(10);
 
@@ -90,6 +96,7 @@ public class UserAgentProcessorFactoryTests extends ESTestCase {
         assertThat(processor.getUaParser().getDevicePatterns().size(), greaterThan(0));
         assertThat(processor.getProperties(), equalTo(EnumSet.allOf(UserAgentProcessor.Property.class)));
         assertFalse(processor.isIgnoreMissing());
+        assertTrue(processor.isUseECS());
     }
 
     public void testBuildWithIgnoreMissing() throws Exception {
@@ -98,6 +105,7 @@ public class UserAgentProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("ignore_missing", true);
+        config.put("ecs", true);
 
         String processorTag = randomAlphaOfLength(10);
 
@@ -118,6 +126,7 @@ public class UserAgentProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("target_field", "_target_field");
+        config.put("ecs", true);
 
         UserAgentProcessor processor = factory.create(null, null, config);
         assertThat(processor.getField(), equalTo("_field"));
@@ -130,6 +139,7 @@ public class UserAgentProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("regex_file", regexWithoutDevicesFilename);
+        config.put("ecs", true);
 
         UserAgentProcessor processor = factory.create(null, null, config);
         assertThat(processor.getField(), equalTo("_field"));
@@ -155,8 +165,17 @@ public class UserAgentProcessorFactoryTests extends ESTestCase {
         Set<UserAgentProcessor.Property> properties = EnumSet.noneOf(UserAgentProcessor.Property.class);
         List<String> fieldNames = new ArrayList<>();
         int numFields = scaledRandomIntBetween(1, UserAgentProcessor.Property.values().length);
+        Set<String> warnings = new HashSet<>();
+        Set<UserAgentProcessor.Property> deprecated = Arrays.stream(UserAgentProcessor.Property.class.getFields())
+            .filter(Field::isEnumConstant)
+            .filter(field -> field.isAnnotationPresent(Deprecated.class))
+            .map(field -> UserAgentProcessor.Property.valueOf(field.getName()))
+            .collect(Collectors.toSet());
         for (int i = 0; i < numFields; i++) {
             UserAgentProcessor.Property property = UserAgentProcessor.Property.values()[i];
+            if (deprecated.contains(property)) {
+                warnings.add("the [" + property.name().toLowerCase(Locale.ROOT) + "] property is deprecated for the user-agent processor");
+            }
             properties.add(property);
             fieldNames.add(property.name().toLowerCase(Locale.ROOT));
         }
@@ -164,10 +183,14 @@ public class UserAgentProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("properties", fieldNames);
+        config.put("ecs", true);
 
         UserAgentProcessor processor = factory.create(null, null, config);
         assertThat(processor.getField(), equalTo("_field"));
         assertThat(processor.getProperties(), equalTo(properties));
+        if (warnings.size() > 0) {
+            assertWarnings(warnings.toArray(Strings.EMPTY_ARRAY));
+        }
     }
 
     public void testInvalidProperty() throws Exception {
@@ -179,7 +202,7 @@ public class UserAgentProcessorFactoryTests extends ESTestCase {
 
         ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () -> factory.create(null, null, config));
         assertThat(e.getMessage(), equalTo("[properties] illegal property value [invalid]. valid values are [NAME, MAJOR, MINOR, "
-                + "PATCH, OS, OS_NAME, OS_MAJOR, OS_MINOR, DEVICE, BUILD]"));
+                + "PATCH, OS, OS_NAME, OS_MAJOR, OS_MINOR, DEVICE, BUILD, ORIGINAL, VERSION]"));
     }
 
     public void testInvalidPropertiesType() throws Exception {

--- a/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorFactoryTests.java
+++ b/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorFactoryTests.java
@@ -178,8 +178,8 @@ public class UserAgentProcessorFactoryTests extends ESTestCase {
         config.put("properties", Collections.singletonList("invalid"));
 
         ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () -> factory.create(null, null, config));
-        assertThat(e.getMessage(), equalTo("[properties] illegal property value [invalid]. valid values are [NAME, OS, DEVICE, " +
-            "ORIGINAL, VERSION]"));
+        assertThat(e.getMessage(), equalTo("[properties] illegal property value [invalid]. valid values are [NAME, MAJOR, MINOR, "
+                + "PATCH, OS, OS_NAME, OS_MAJOR, OS_MINOR, DEVICE, BUILD]"));
     }
 
     public void testInvalidPropertiesType() throws Exception {

--- a/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorFactoryTests.java
+++ b/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorFactoryTests.java
@@ -83,14 +83,12 @@ public class UserAgentProcessorFactoryTests extends ESTestCase {
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
-        config.put("ecs", true);
 
         String processorTag = randomAlphaOfLength(10);
 
         UserAgentProcessor processor = factory.create(null, processorTag, config);
         assertThat(processor.getTag(), equalTo(processorTag));
         assertThat(processor.getField(), equalTo("_field"));
-        assertThat(processor.getTargetField(), equalTo("user_agent"));
         assertThat(processor.getUaParser().getUaPatterns().size(), greaterThan(0));
         assertThat(processor.getUaParser().getOsPatterns().size(), greaterThan(0));
         assertThat(processor.getUaParser().getDevicePatterns().size(), greaterThan(0));

--- a/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
+++ b/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
@@ -48,12 +48,12 @@ public class UserAgentProcessorTests extends ESTestCase {
         UserAgentParser parser = new UserAgentParser(randomAlphaOfLength(10), regexStream, new UserAgentCache(1000));
 
         processor = new UserAgentProcessor(randomAlphaOfLength(10), "source_field", "target_field", parser,
-                EnumSet.allOf(UserAgentProcessor.Property.class), false);
+                EnumSet.allOf(UserAgentProcessor.Property.class), false, true);
     }
 
     public void testNullValueWithIgnoreMissing() throws Exception {
         UserAgentProcessor processor = new UserAgentProcessor(randomAlphaOfLength(10), "source_field", "target_field", null,
-            EnumSet.allOf(UserAgentProcessor.Property.class), true);
+            EnumSet.allOf(UserAgentProcessor.Property.class), true, true);
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(),
             Collections.singletonMap("source_field", null));
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
@@ -63,7 +63,7 @@ public class UserAgentProcessorTests extends ESTestCase {
 
     public void testNonExistentWithIgnoreMissing() throws Exception {
         UserAgentProcessor processor = new UserAgentProcessor(randomAlphaOfLength(10), "source_field", "target_field", null,
-            EnumSet.allOf(UserAgentProcessor.Property.class), true);
+            EnumSet.allOf(UserAgentProcessor.Property.class), true, true);
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
         processor.execute(ingestDocument);
@@ -72,7 +72,7 @@ public class UserAgentProcessorTests extends ESTestCase {
 
     public void testNullWithoutIgnoreMissing() throws Exception {
         UserAgentProcessor processor = new UserAgentProcessor(randomAlphaOfLength(10), "source_field", "target_field", null,
-            EnumSet.allOf(UserAgentProcessor.Property.class), false);
+            EnumSet.allOf(UserAgentProcessor.Property.class), false, true);
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(),
             Collections.singletonMap("source_field", null));
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
@@ -82,7 +82,7 @@ public class UserAgentProcessorTests extends ESTestCase {
 
     public void testNonExistentWithoutIgnoreMissing() throws Exception {
         UserAgentProcessor processor = new UserAgentProcessor(randomAlphaOfLength(10), "source_field", "target_field", null,
-            EnumSet.allOf(UserAgentProcessor.Property.class), false);
+            EnumSet.allOf(UserAgentProcessor.Property.class), false, true);
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
         Exception exception = expectThrows(Exception.class, () -> processor.execute(ingestDocument));
@@ -103,16 +103,13 @@ public class UserAgentProcessorTests extends ESTestCase {
         Map<String, Object> target = (Map<String, Object>) data.get("target_field");
 
         assertThat(target.get("name"), is("Chrome"));
-        assertThat(target.get("major"), is("33"));
-        assertThat(target.get("minor"), is("0"));
-        assertThat(target.get("patch"), is("1750"));
-        assertNull(target.get("build"));
+        assertThat(target.get("version"), is("33.0.1750"));
 
-        assertThat(target.get("os"), is("Mac OS X 10.9.2"));
-        assertThat(target.get("os_name"), is("Mac OS X"));
-        assertThat(target.get("os_major"), is("10"));
-        assertThat(target.get("os_minor"), is("9"));
-
+        Map<String, String> os = new HashMap<>();
+        os.put("name", "Mac OS X");
+        os.put("version", "10.9.2");
+        os.put("full", "Mac OS X 10.9.2");
+        assertThat(target.get("os"), is(os));
         assertThat(target.get("device"), is("Other"));
     }
 
@@ -131,15 +128,13 @@ public class UserAgentProcessorTests extends ESTestCase {
         Map<String, Object> target = (Map<String, Object>) data.get("target_field");
 
         assertThat(target.get("name"), is("Android"));
-        assertThat(target.get("major"), is("3"));
-        assertThat(target.get("minor"), is("0"));
-        assertNull(target.get("patch"));
-        assertNull(target.get("build"));
+        assertThat(target.get("version"), is("3.0"));
 
-        assertThat(target.get("os"), is("Android 3.0"));
-        assertThat(target.get("os_name"), is("Android"));
-        assertThat(target.get("os_major"), is("3"));
-        assertThat(target.get("os_minor"), is("0"));
+        Map<String, String> os = new HashMap<>();
+        os.put("name", "Android");
+        os.put("version", "3.0");
+        os.put("full", "Android 3.0");
+        assertThat(target.get("os"), is(os));
 
         assertThat(target.get("device"), is("Motorola Xoom"));
     }
@@ -158,15 +153,9 @@ public class UserAgentProcessorTests extends ESTestCase {
         Map<String, Object> target = (Map<String, Object>) data.get("target_field");
 
         assertThat(target.get("name"), is("EasouSpider"));
-        assertNull(target.get("major"));
-        assertNull(target.get("minor"));
-        assertNull(target.get("patch"));
-        assertNull(target.get("build"));
 
-        assertThat(target.get("os"), is("Other"));
-        assertThat(target.get("os_name"), is("Other"));
-        assertNull(target.get("os_major"));
-        assertNull(target.get("os_minor"));
+        assertNull(target.get("version"));
+        assertNull(target.get("os"));
 
         assertThat(target.get("device"), is("Spider"));
     }
@@ -190,10 +179,7 @@ public class UserAgentProcessorTests extends ESTestCase {
         assertNull(target.get("patch"));
         assertNull(target.get("build"));
 
-        assertThat(target.get("os"), is("Other"));
-        assertThat(target.get("os_name"), is("Other"));
-        assertNull(target.get("os_major"));
-        assertNull(target.get("os_minor"));
+        assertNull(target.get("os"));
 
         assertThat(target.get("device"), is("Other"));
     }

--- a/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
+++ b/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
@@ -110,7 +110,9 @@ public class UserAgentProcessorTests extends ESTestCase {
         os.put("version", "10.9.2");
         os.put("full", "Mac OS X 10.9.2");
         assertThat(target.get("os"), is(os));
-        assertThat(target.get("device"), is("Other"));
+        Map<String, String> device = new HashMap<>();
+        device.put("name", "Other");
+        assertThat(target.get("device"), is(device));
     }
 
     @SuppressWarnings("unchecked")
@@ -136,7 +138,9 @@ public class UserAgentProcessorTests extends ESTestCase {
         os.put("full", "Android 3.0");
         assertThat(target.get("os"), is(os));
 
-        assertThat(target.get("device"), is("Motorola Xoom"));
+        Map<String, String> device = new HashMap<>();
+        device.put("name", "Motorola Xoom");
+        assertThat(target.get("device"), is(device));
     }
 
     @SuppressWarnings("unchecked")
@@ -157,7 +161,9 @@ public class UserAgentProcessorTests extends ESTestCase {
         assertNull(target.get("version"));
         assertNull(target.get("os"));
 
-        assertThat(target.get("device"), is("Spider"));
+        Map<String, String> device = new HashMap<>();
+        device.put("name", "Spider");
+        assertThat(target.get("device"), is(device));
     }
 
     @SuppressWarnings("unchecked")
@@ -181,6 +187,8 @@ public class UserAgentProcessorTests extends ESTestCase {
 
         assertNull(target.get("os"));
 
-        assertThat(target.get("device"), is("Other"));
+        Map<String, String> device = new HashMap<>();
+        device.put("name", "Other");
+        assertThat(target.get("device"), is(device));
     }
 }

--- a/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
+++ b/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
@@ -103,13 +103,16 @@ public class UserAgentProcessorTests extends ESTestCase {
         Map<String, Object> target = (Map<String, Object>) data.get("target_field");
 
         assertThat(target.get("name"), is("Chrome"));
-        assertThat(target.get("version"), is("33.0.1750"));
+        assertThat(target.get("major"), is("33"));
+        assertThat(target.get("minor"), is("0"));
+        assertThat(target.get("patch"), is("1750"));
+        assertNull(target.get("build"));
 
-        Map<String, String> os = new HashMap<>();
-        os.put("name", "Mac OS X");
-        os.put("version", "10.9.2");
-        os.put("full", "Mac OS X 10.9.2");
-        assertThat(target.get("os"), is(os));
+        assertThat(target.get("os"), is("Mac OS X 10.9.2"));
+        assertThat(target.get("os_name"), is("Mac OS X"));
+        assertThat(target.get("os_major"), is("10"));
+        assertThat(target.get("os_minor"), is("9"));
+
         assertThat(target.get("device"), is("Other"));
     }
 
@@ -128,13 +131,15 @@ public class UserAgentProcessorTests extends ESTestCase {
         Map<String, Object> target = (Map<String, Object>) data.get("target_field");
 
         assertThat(target.get("name"), is("Android"));
-        assertThat(target.get("version"), is("3.0"));
+        assertThat(target.get("major"), is("3"));
+        assertThat(target.get("minor"), is("0"));
+        assertNull(target.get("patch"));
+        assertNull(target.get("build"));
 
-        Map<String, String> os = new HashMap<>();
-        os.put("name", "Android");
-        os.put("version", "3.0");
-        os.put("full", "Android 3.0");
-        assertThat(target.get("os"), is(os));
+        assertThat(target.get("os"), is("Android 3.0"));
+        assertThat(target.get("os_name"), is("Android"));
+        assertThat(target.get("os_major"), is("3"));
+        assertThat(target.get("os_minor"), is("0"));
 
         assertThat(target.get("device"), is("Motorola Xoom"));
     }
@@ -153,9 +158,15 @@ public class UserAgentProcessorTests extends ESTestCase {
         Map<String, Object> target = (Map<String, Object>) data.get("target_field");
 
         assertThat(target.get("name"), is("EasouSpider"));
+        assertNull(target.get("major"));
+        assertNull(target.get("minor"));
+        assertNull(target.get("patch"));
+        assertNull(target.get("build"));
 
-        assertNull(target.get("version"));
-        assertNull(target.get("os"));
+        assertThat(target.get("os"), is("Other"));
+        assertThat(target.get("os_name"), is("Other"));
+        assertNull(target.get("os_major"));
+        assertNull(target.get("os_minor"));
 
         assertThat(target.get("device"), is("Spider"));
     }
@@ -179,7 +190,10 @@ public class UserAgentProcessorTests extends ESTestCase {
         assertNull(target.get("patch"));
         assertNull(target.get("build"));
 
-        assertNull(target.get("os"));
+        assertThat(target.get("os"), is("Other"));
+        assertThat(target.get("os_name"), is("Other"));
+        assertNull(target.get("os_major"));
+        assertNull(target.get("os_minor"));
 
         assertThat(target.get("device"), is("Other"));
     }

--- a/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
+++ b/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
@@ -110,9 +110,7 @@ public class UserAgentProcessorTests extends ESTestCase {
         os.put("version", "10.9.2");
         os.put("full", "Mac OS X 10.9.2");
         assertThat(target.get("os"), is(os));
-        Map<String, String> device = new HashMap<>();
-        device.put("name", "Other");
-        assertThat(target.get("device"), is(device));
+        assertThat(target.get("device"), is("Other"));
     }
 
     @SuppressWarnings("unchecked")
@@ -138,9 +136,7 @@ public class UserAgentProcessorTests extends ESTestCase {
         os.put("full", "Android 3.0");
         assertThat(target.get("os"), is(os));
 
-        Map<String, String> device = new HashMap<>();
-        device.put("name", "Motorola Xoom");
-        assertThat(target.get("device"), is(device));
+        assertThat(target.get("device"), is("Motorola Xoom"));
     }
 
     @SuppressWarnings("unchecked")
@@ -161,9 +157,7 @@ public class UserAgentProcessorTests extends ESTestCase {
         assertNull(target.get("version"));
         assertNull(target.get("os"));
 
-        Map<String, String> device = new HashMap<>();
-        device.put("name", "Spider");
-        assertThat(target.get("device"), is(device));
+        assertThat(target.get("device"), is("Spider"));
     }
 
     @SuppressWarnings("unchecked")
@@ -186,8 +180,7 @@ public class UserAgentProcessorTests extends ESTestCase {
         assertNull(target.get("build"));
 
         assertNull(target.get("os"));
-        Map<String, String> device = new HashMap<>();
-        device.put("name", "Other");
-        assertThat(target.get("device"), is(device));
+
+        assertThat(target.get("device"), is("Other"));
     }
 }

--- a/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
+++ b/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
@@ -9,7 +9,8 @@
             "processors": [
               {
                 "user_agent" : {
-                  "field" : "field1"
+                  "field" : "field1",
+                  "ecs": true
                 }
               }
             ]
@@ -29,13 +30,9 @@
         id: 1
   - match: { _source.field1: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36" }
   - match: { _source.user_agent.name: "Chrome" }
-  - match: { _source.user_agent.os: "Mac OS X 10.9.2" }
-  - match: { _source.user_agent.os_name: "Mac OS X" }
-  - match: { _source.user_agent.os_major: "10" }
-  - match: { _source.user_agent.os_minor: "9" }
-  - match: { _source.user_agent.major: "33" }
-  - match: { _source.user_agent.minor: "0" }
-  - match: { _source.user_agent.patch: "1750" }
+  - match: { _source.user_agent.original: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36" }
+  - match: { _source.user_agent.os: {"name":"Mac OS X", "version":"10.9.2", "full":"Mac OS X 10.9.2"} }
+  - match: { _source.user_agent.version: "33.0.1750" }
   - match: { _source.user_agent.device: "Other" }
 
 ---
@@ -50,6 +47,7 @@
               {
                 "user_agent" : {
                   "field" : "field1",
+                  "ecs": true,
                   "target_field": "field2",
                   "properties": ["os"]
                 }
@@ -70,11 +68,62 @@
         index: test
         id: 1
   - match: { _source.field1: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36" }
-  - match: { _source.field2.os: "Mac OS X 10.9.2" }
+  - match: { _source.field2.os.full: "Mac OS X 10.9.2" }
   - is_false: _source.user_agent
   - is_false: _source.field2.name
   - is_false: _source.field2.os_name
   - is_false: _source.field2.os_major
+  - is_false: _source.field2.os_minor
+  - is_false: _source.field2.major
+  - is_false: _source.field2.minor
+  - is_false: _source.field2.patch
+  - is_false: _source.field2.device
+
+---
+"Test user agent processor with non-ECS schema":
+  - skip:
+      features: warnings
+
+  - do:
+      warnings:
+        - "setting [ecs] to false for non-common schema format is deprecated and will be removed in 7.0, set to true to use the non-deprecated format"
+        - "the [os_major] property is deprecated for the user-agent processor"
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "user_agent" : {
+                  "field" : "field1",
+                  "target_field": "field2",
+                  "properties": ["os", "os_major"]
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        type: test
+        id: 1
+        pipeline: "my_pipeline"
+        body: {field1: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36"}
+
+  - do:
+      get:
+        index: test
+        type: test
+        id: 1
+  - match: { _source.field1: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36" }
+  - match: { _source.field2.os: "Mac OS X 10.9.2" }
+  - match: { _source.field2.os_major: "10" }
+  - is_false: _source.user_agent
+  - is_false: _source.field2.name
+  - is_false: _source.field2.os_name
   - is_false: _source.field2.os_minor
   - is_false: _source.field2.major
   - is_false: _source.field2.minor

--- a/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
+++ b/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
@@ -33,7 +33,7 @@
   - match: { _source.user_agent.original: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36" }
   - match: { _source.user_agent.os: {"name":"Mac OS X", "version":"10.9.2", "full":"Mac OS X 10.9.2"} }
   - match: { _source.user_agent.version: "33.0.1750" }
-  - match: { _source.user_agent.device: "Other" }
+  - match: { _source.user_agent.device: {"name": "Other" }}
 
 ---
 "Test user agent processor with parameters":

--- a/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
+++ b/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
@@ -29,9 +29,13 @@
         id: 1
   - match: { _source.field1: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36" }
   - match: { _source.user_agent.name: "Chrome" }
-  - match: { _source.user_agent.original: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36" }
-  - match: { _source.user_agent.os: {"name":"Mac OS X", "version":"10.9.2", "full":"Mac OS X 10.9.2"} }
-  - match: { _source.user_agent.version: "33.0.1750" }
+  - match: { _source.user_agent.os: "Mac OS X 10.9.2" }
+  - match: { _source.user_agent.os_name: "Mac OS X" }
+  - match: { _source.user_agent.os_major: "10" }
+  - match: { _source.user_agent.os_minor: "9" }
+  - match: { _source.user_agent.major: "33" }
+  - match: { _source.user_agent.minor: "0" }
+  - match: { _source.user_agent.patch: "1750" }
   - match: { _source.user_agent.device: "Other" }
 
 ---
@@ -66,8 +70,13 @@
         index: test
         id: 1
   - match: { _source.field1: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36" }
-  - match: { _source.field2.os.full: "Mac OS X 10.9.2" }
+  - match: { _source.field2.os: "Mac OS X 10.9.2" }
   - is_false: _source.user_agent
   - is_false: _source.field2.name
+  - is_false: _source.field2.os_name
+  - is_false: _source.field2.os_major
+  - is_false: _source.field2.os_minor
+  - is_false: _source.field2.major
+  - is_false: _source.field2.minor
+  - is_false: _source.field2.patch
   - is_false: _source.field2.device
-  - is_false: _source.field2.original

--- a/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
+++ b/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
@@ -32,7 +32,7 @@
   - match: { _source.user_agent.original: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36" }
   - match: { _source.user_agent.os: {"name":"Mac OS X", "version":"10.9.2", "full":"Mac OS X 10.9.2"} }
   - match: { _source.user_agent.version: "33.0.1750" }
-  - match: { _source.user_agent.device: {"name": "Other" }}
+  - match: { _source.user_agent.device: "Other" }
 
 ---
 "Test user agent processor with parameters":

--- a/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
+++ b/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
@@ -9,8 +9,7 @@
             "processors": [
               {
                 "user_agent" : {
-                  "field" : "field1",
-                  "ecs": true
+                  "field" : "field1"
                 }
               }
             ]
@@ -86,7 +85,7 @@
 
   - do:
       warnings:
-        - "setting [ecs] to false for non-common schema format is deprecated and will be removed in 7.0, set to true to use the non-deprecated format"
+        - "setting [ecs] to false for non-common schema format is deprecated and will be removed in 8.0, set to true or remove to use the non-deprecated format"
         - "the [os_major] property is deprecated for the user-agent processor"
       ingest.put_pipeline:
         id: "my_pipeline"
@@ -97,6 +96,7 @@
               {
                 "user_agent" : {
                   "field" : "field1",
+                  "ecs": false,
                   "target_field": "field2",
                   "properties": ["os", "os_major"]
                 }

--- a/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/30_custom_regex.yml
+++ b/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/30_custom_regex.yml
@@ -31,6 +31,6 @@
         id: 1
   - match: { _source.field1: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36" }
   - match: { _source.user_agent.name: "Test" }
-  - match: { _source.user_agent.device: "Other" }
+  - match: { _source.user_agent.device: {"name": "Other" }}
   - is_false: _source.user_agent.os
   - is_false: _source.user_agent.version

--- a/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/30_custom_regex.yml
+++ b/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/30_custom_regex.yml
@@ -10,6 +10,7 @@
               {
                 "user_agent" : {
                   "field": "field1",
+                  "ecs": true,
                   "regex_file": "test-regexes.yml"
                 }
               }
@@ -30,11 +31,6 @@
         id: 1
   - match: { _source.field1: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36" }
   - match: { _source.user_agent.name: "Test" }
-  - match: { _source.user_agent.os: "Other" }
-  - match: { _source.user_agent.os_name: "Other" }
   - match: { _source.user_agent.device: "Other" }
-  - is_false: _source.user_agent.os_major
-  - is_false: _source.user_agent.os_minor
-  - is_false: _source.user_agent.major
-  - is_false: _source.user_agent.minor
-  - is_false: _source.user_agent.patch
+  - is_false: _source.user_agent.os
+  - is_false: _source.user_agent.version

--- a/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/30_custom_regex.yml
+++ b/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/30_custom_regex.yml
@@ -30,6 +30,11 @@
         id: 1
   - match: { _source.field1: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36" }
   - match: { _source.user_agent.name: "Test" }
+  - match: { _source.user_agent.os: "Other" }
+  - match: { _source.user_agent.os_name: "Other" }
   - match: { _source.user_agent.device: "Other" }
-  - is_false: _source.user_agent.os
-  - is_false: _source.user_agent.version
+  - is_false: _source.user_agent.os_major
+  - is_false: _source.user_agent.os_minor
+  - is_false: _source.user_agent.major
+  - is_false: _source.user_agent.minor
+  - is_false: _source.user_agent.patch

--- a/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/30_custom_regex.yml
+++ b/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/30_custom_regex.yml
@@ -30,6 +30,6 @@
         id: 1
   - match: { _source.field1: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.149 Safari/537.36" }
   - match: { _source.user_agent.name: "Test" }
-  - match: { _source.user_agent.device: {"name": "Other" }}
+  - match: { _source.user_agent.device: "Other" }
   - is_false: _source.user_agent.os
   - is_false: _source.user_agent.version

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -343,7 +343,7 @@ public class IngestService implements ClusterStateApplier {
         return new Pipeline(id, description, null, new CompoundProcessor(failureProcessor));
     }
 
-    static ClusterState innerPut(PutPipelineRequest request, ClusterState currentState) {
+    public static ClusterState innerPut(PutPipelineRequest request, ClusterState currentState) {
         IngestMetadata currentIngestMetadata = currentState.metaData().custom(IngestMetadata.TYPE);
         Map<String, PipelineConfiguration> pipelines;
         if (currentIngestMetadata != null) {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.deprecation;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.ingest.ConfigurationUtils;
+import org.elasticsearch.ingest.IngestService;
+import org.elasticsearch.ingest.PipelineConfiguration;
+import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class ClusterDeprecationChecks {
+
+    @SuppressWarnings("unchecked")
+    static DeprecationIssue checkUserAgentPipelines(ClusterState state) {
+        List<PipelineConfiguration> pipelines = IngestService.getPipelines(state);
+
+        List<String> pipelinesWithDeprecatedEcsConfig = pipelines.stream()
+            .filter(Objects::nonNull)
+            .filter(pipeline -> {
+                Map<String, Object> pipelineConfig = pipeline.getConfigAsMap();
+
+                List<Map<String, Map<String, Object>>> processors =
+                    (List<Map<String, Map<String, Object>>>) pipelineConfig.get("processors");
+                return processors.stream()
+                    .filter(Objects::nonNull)
+                    .filter(processor -> processor.containsKey("user_agent"))
+                    .map(processor -> processor.get("user_agent"))
+                    .anyMatch(processorConfig ->
+                        false == ConfigurationUtils.readBooleanProperty(null, null, processorConfig, "ecs", false));
+            })
+            .map(PipelineConfiguration::getId)
+            .sorted() // Make the warning consistent for testing purposes
+            .collect(Collectors.toList());
+        if (pipelinesWithDeprecatedEcsConfig.isEmpty() == false) {
+            return new DeprecationIssue(DeprecationIssue.Level.WARNING,
+                "User-Agent ingest plugin will use ECS-formatted output",
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                    "#ingest-user-agent-ecs-always",
+                "Ingest pipelines " + pipelinesWithDeprecatedEcsConfig + " will change to using ECS output format in 7.0");
+        }
+        return null;
+
+    }
+}

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.ingest.ConfigurationUtils;
 import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
@@ -34,18 +33,17 @@ public class ClusterDeprecationChecks {
                     .filter(Objects::nonNull)
                     .filter(processor -> processor.containsKey("user_agent"))
                     .map(processor -> processor.get("user_agent"))
-                    .anyMatch(processorConfig ->
-                        false == ConfigurationUtils.readBooleanProperty(null, null, processorConfig, "ecs", false));
+                    .anyMatch(processorConfig -> processorConfig.containsKey("ecs"));
             })
             .map(PipelineConfiguration::getId)
             .sorted() // Make the warning consistent for testing purposes
             .collect(Collectors.toList());
         if (pipelinesWithDeprecatedEcsConfig.isEmpty() == false) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
-                "User-Agent ingest plugin will use ECS-formatted output",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                "User-Agent ingest plugin will always use ECS-formatted output",
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html" +
                     "#ingest-user-agent-ecs-always",
-                "Ingest pipelines " + pipelinesWithDeprecatedEcsConfig + " will change to using ECS output format in 7.0");
+                "Ingest pipelines " + pipelinesWithDeprecatedEcsConfig + " uses the [ecs] option which needs to be removed to work in 8.0");
         }
         return null;
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -31,7 +31,10 @@ public class DeprecationChecks {
     }
 
     static List<Function<ClusterState, DeprecationIssue>> CLUSTER_SETTINGS_CHECKS =
-        Collections.emptyList();
+        Collections.unmodifiableList(Arrays.asList(
+            ClusterDeprecationChecks::checkUserAgentPipelines
+        ));
+
 
     static List<BiFunction<Settings, PluginsAndModules, DeprecationIssue>> NODE_SETTINGS_CHECKS =
         Collections.unmodifiableList(Arrays.asList(

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -67,10 +67,10 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(CLUSTER_SETTINGS_CHECKS, c -> c.apply(finalState));
 
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
-            "User-Agent ingest plugin will use ECS-formatted output",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+            "User-Agent ingest plugin will always use ECS-formatted output",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html" +
                 "#ingest-user-agent-ecs-always",
-            "Ingest pipelines [ecs_false, ecs_null] will change to using ECS output format in 7.0");
+            "Ingest pipelines [ecs_false, ecs_true] uses the [ecs] option which needs to be removed to work in 8.0");
         assertEquals(singletonList(expected), issues);
     }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.deprecation;
+
+import org.elasticsearch.action.ingest.PutPipelineRequest;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.ingest.IngestService;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.elasticsearch.xpack.deprecation.DeprecationChecks.CLUSTER_SETTINGS_CHECKS;
+
+public class ClusterDeprecationChecksTests extends ESTestCase {
+
+    public void testUserAgentEcsCheck() {
+        PutPipelineRequest ecsFalseRequest = new PutPipelineRequest("ecs_false",
+            new BytesArray("{\n" +
+                "  \"description\" : \"This has ecs set to false\",\n" +
+                "  \"processors\" : [\n" +
+                "    {\n" +
+                "      \"user_agent\" : {\n" +
+                "        \"field\" : \"agent\",\n" +
+                "        \"ecs\" : false\n" +
+                "      }\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}"), XContentType.JSON);
+        PutPipelineRequest ecsNullRequest = new PutPipelineRequest("ecs_null",
+            new BytesArray("{\n" +
+                "  \"description\" : \"This has ecs set to false\",\n" +
+                "  \"processors\" : [\n" +
+                "    {\n" +
+                "      \"user_agent\" : {\n" +
+                "        \"field\" : \"agent\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}"), XContentType.JSON);
+        PutPipelineRequest ecsTrueRequest = new PutPipelineRequest("ecs_true",
+            new BytesArray("{\n" +
+                "  \"description\" : \"This has ecs set to false\",\n" +
+                "  \"processors\" : [\n" +
+                "    {\n" +
+                "      \"user_agent\" : {\n" +
+                "        \"field\" : \"agent\",\n" +
+                "        \"ecs\" : true\n" +
+                "      }\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}"), XContentType.JSON);
+
+        ClusterState state = ClusterState.builder(new ClusterName("test")).build();
+        state = IngestService.innerPut(ecsTrueRequest, state);
+        state = IngestService.innerPut(ecsFalseRequest, state);
+        state = IngestService.innerPut(ecsNullRequest, state);
+
+        final ClusterState finalState = state;
+        List<DeprecationIssue> issues = DeprecationChecks.filterChecks(CLUSTER_SETTINGS_CHECKS, c -> c.apply(finalState));
+
+        DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
+            "User-Agent ingest plugin will use ECS-formatted output",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
+                "#ingest-user-agent-ecs-always",
+            "Ingest pipelines [ecs_false, ecs_null] will change to using ECS output format in 7.0");
+        assertEquals(singletonList(expected), issues);
+    }
+}


### PR DESCRIPTION
This PR moves the user_agent processor to share a code base with 6.7 as discovered in https://github.com/elastic/beats/issues/10650 is required for Beats migration to 7.0. This re-introduces the `ecs` option and the optional legacy behavior. 

This change is largely a set of revert's and cherry-picks, of which only the the most recent commits (ones without a #number) is net new code. This change is intended to be merged to 7.0.0 and then 7.x to allow the `ecs` option to live during the 7.x timeframe. 

Additionally, this changes the default from `false` to `true` for the `ecs` option.

6.7: `ecs` : default `false`
7.x: `ecs` : default `true`
8.0: no option, but behaves as `true`

The first 5 commits here:
git revert 5b008a34aa3c07e37b12b415d3c22a44da491329 (Lee's initial 7.x implementation of user_agent ecs)
git revert cac6b8e06f051d68919faf6081f1c87fa5b6757d  (Jake's minor change applied to 7.x)
git cherry-pick 5dfe1935345da3799931fd4a3ebe0b6aa9c17f57 (Lee's initial 6.x implementation of user_agent ecs)
git cherry-pick ec8ddc890a34853ee8db6af66f608b0ad0cd1099 (Jake's minor change applied to the 6.x )   
git cherry-pick f63cbdb9b426ba24ee4d987ca767ca05a22f2fbb (Gordon's 6.x deprecation info API, with manual merge fixes)
