### PR TITLE
Don't fail init script if `/proc/.../max_map_count` absent (#35933)

### DIFF
--- a/distribution/packages/src/deb/init.d/elasticsearch
+++ b/distribution/packages/src/deb/init.d/elasticsearch
@@ -122,7 +122,7 @@ case "$1" in
 		ulimit -l $MAX_LOCKED_MEMORY
 	fi
 
-	if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count -a "$MAX_MAP_COUNT" -gt $(cat /proc/sys/vm/max_map_count) ]; then
+	if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ] && [ "$MAX_MAP_COUNT" -gt $(cat /proc/sys/vm/max_map_count) ]; then
 		sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
 	fi
 

--- a/distribution/packages/src/rpm/init.d/elasticsearch
+++ b/distribution/packages/src/rpm/init.d/elasticsearch
@@ -90,7 +90,7 @@ start() {
     if [ -n "$MAX_LOCKED_MEMORY" ]; then
         ulimit -l $MAX_LOCKED_MEMORY
     fi
-    if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count -a "$MAX_MAP_COUNT" -gt $(cat /proc/sys/vm/max_map_count) ]; then
+    if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ] && [ "$MAX_MAP_COUNT" -gt $(cat /proc/sys/vm/max_map_count) ]; then
         sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
     fi
 


### PR DESCRIPTION
Currently init scripts fail when `/proc/sys/vm/max_map_count` is not present
with `-bash: [: too many arguments`.

Fix conditional logic to avoid trying to set the `max_map_count` sysctl if not
present.

Relates #27236