### PR TITLE
[FEATURE][ML] Wire in data frame analytics progress reporting

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -73,6 +73,7 @@ import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
 import org.elasticsearch.xpack.core.ml.action.DeleteCalendarAction;
 import org.elasticsearch.xpack.core.ml.action.DeleteCalendarEventAction;
+import org.elasticsearch.xpack.core.ml.action.DeleteDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.DeleteDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction;
 import org.elasticsearch.xpack.core.ml.action.DeleteFilterAction;
@@ -125,6 +126,7 @@ import org.elasticsearch.xpack.core.ml.action.UpdateProcessAction;
 import org.elasticsearch.xpack.core.ml.action.ValidateDetectorAction;
 import org.elasticsearch.xpack.core.ml.action.ValidateJobConfigAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
 import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
 import org.elasticsearch.xpack.core.monitoring.MonitoringFeatureSetUsage;
 import org.elasticsearch.xpack.core.rollup.RollupFeatureSetUsage;
@@ -304,6 +306,7 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                 PutDataFrameAnalyticsAction.INSTANCE,
                 GetDataFrameAnalyticsAction.INSTANCE,
                 GetDataFrameAnalyticsStatsAction.INSTANCE,
+                DeleteDataFrameAnalyticsAction.INSTANCE,
                 StartDataFrameAnalyticsAction.INSTANCE,
                 // security
                 ClearRealmCacheAction.INSTANCE,
@@ -388,9 +391,13 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                         StartDatafeedAction.DatafeedParams::new),
                 new NamedWriteableRegistry.Entry(PersistentTaskParams.class, MlTasks.JOB_TASK_NAME,
                         OpenJobAction.JobParams::new),
+                new NamedWriteableRegistry.Entry(PersistentTaskParams.class, MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
+                    StartDataFrameAnalyticsAction.TaskParams::new),
                 // ML - Task states
                 new NamedWriteableRegistry.Entry(PersistentTaskState.class, JobTaskState.NAME, JobTaskState::new),
                 new NamedWriteableRegistry.Entry(PersistentTaskState.class, DatafeedState.NAME, DatafeedState::fromStream),
+                new NamedWriteableRegistry.Entry(PersistentTaskState.class, DataFrameAnalyticsTaskState.NAME,
+                    DataFrameAnalyticsTaskState::new),
                 new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.MACHINE_LEARNING,
                         MachineLearningFeatureSetUsage::new),
                 // monitoring
@@ -467,6 +474,8 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                 // ML - Task states
                 new NamedXContentRegistry.Entry(PersistentTaskState.class, new ParseField(DatafeedState.NAME), DatafeedState::fromXContent),
                 new NamedXContentRegistry.Entry(PersistentTaskState.class, new ParseField(JobTaskState.NAME), JobTaskState::fromXContent),
+                new NamedXContentRegistry.Entry(PersistentTaskState.class, new ParseField(DataFrameAnalyticsTaskState.NAME),
+                    DataFrameAnalyticsTaskState::fromXContent),
                 // watcher
                 new NamedXContentRegistry.Entry(MetaData.Custom.class, new ParseField(WatcherMetaData.TYPE),
                         WatcherMetaData::fromXContent),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
@@ -29,7 +29,7 @@ public final class MlTasks {
 
     public static final String JOB_TASK_ID_PREFIX = "job-";
     public static final String DATAFEED_TASK_ID_PREFIX = "datafeed-";
-    private static final String DATA_FRAME_ANALYTICS_TASK_ID_PREFIX = "data_frame_analytics-";
+    public static final String DATA_FRAME_ANALYTICS_TASK_ID_PREFIX = "data_frame_analytics-";
 
     public static final PersistentTasksCustomMetaData.Assignment AWAITING_UPGRADE =
         new PersistentTasksCustomMetaData.Assignment(null,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/AbstractGetResourcesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/AbstractGetResourcesRequest.java
@@ -19,19 +19,19 @@ public abstract class AbstractGetResourcesRequest extends ActionRequest {
     private String resourceId;
     private PageParams pageParams = PageParams.defaultParams();
 
-    public void setResourceId(String resourceId) {
+    public final void setResourceId(String resourceId) {
         this.resourceId = resourceId;
     }
 
-    public String getResourceId() {
+    public final String getResourceId() {
         return resourceId;
     }
 
-    public void setPageParams(PageParams pageParams) {
+    public final void setPageParams(PageParams pageParams) {
         this.pageParams = pageParams;
     }
 
-    public PageParams getPageParams() {
+    public final PageParams getPageParams() {
         return pageParams;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsAction.java
@@ -34,6 +34,10 @@ public class GetDataFrameAnalyticsAction extends Action<GetDataFrameAnalyticsAct
 
         public Request() {}
 
+        public Request(String id) {
+            setResourceId(id);
+        }
+
         public Request(StreamInput in) throws IOException {
             readFrom(in);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -19,6 +20,7 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
@@ -160,6 +162,20 @@ public class StartDataFrameAnalyticsAction extends Action<AcknowledgedResponse> 
             builder.field(DataFrameAnalyticsConfig.ID.getPreferredName(), id);
             builder.endObject();
             return builder;
+        }
+    }
+
+    public interface TaskMatcher {
+
+        static boolean match(Task task, String expectedId) {
+            if (task instanceof TaskMatcher) {
+                if (MetaData.ALL.equals(expectedId)) {
+                    return true;
+                }
+                String expectedDescription = MlTasks.DATA_FRAME_ANALYTICS_TASK_ID_PREFIX + expectedId;
+                return expectedDescription.equals(task.getDescription());
+            }
+            return false;
         }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -226,13 +226,17 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         private Map<String, Object> query = Collections.singletonMap(MatchAllQueryBuilder.NAME, Collections.emptyMap());
         private Map<String, String> headers = Collections.emptyMap();
 
+        public Builder() {}
+
+        public Builder(String id) {
+            setId(id);
+        }
+
         public String getId() {
             return id;
         }
 
-        public Builder() {}
-
-        public Builder(DataFrameAnalyticsConfig config) {
+            public Builder(DataFrameAnalyticsConfig config) {
             this.id = config.id;
             this.source = config.source;
             this.dest = config.dest;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsTaskState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsTaskState.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.core.ml.dataframe;
 
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
@@ -20,6 +21,8 @@ import java.util.Objects;
 
 public class DataFrameAnalyticsTaskState implements PersistentTaskState {
 
+    public static final String NAME = MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME;
+
     private static ParseField STATE = new ParseField("state");
     private static ParseField ALLOCATION_ID = new ParseField("allocation_id");
 
@@ -27,7 +30,7 @@ public class DataFrameAnalyticsTaskState implements PersistentTaskState {
     private final long allocationId;
 
     private static final ConstructingObjectParser<DataFrameAnalyticsTaskState, Void> PARSER =
-            new ConstructingObjectParser<>(MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME, true,
+            new ConstructingObjectParser<>(NAME, true,
                 a -> new DataFrameAnalyticsTaskState((DataFrameAnalyticsState) a[0], (long) a[1]));
 
     static {
@@ -53,6 +56,11 @@ public class DataFrameAnalyticsTaskState implements PersistentTaskState {
         this.allocationId = allocationId;
     }
 
+    public DataFrameAnalyticsTaskState(StreamInput in) throws IOException {
+        this.state = DataFrameAnalyticsState.fromStream(in);
+        this.allocationId = in.readLong();
+    }
+
     public DataFrameAnalyticsState getState() {
         return state;
     }
@@ -63,7 +71,7 @@ public class DataFrameAnalyticsTaskState implements PersistentTaskState {
 
     @Override
     public String getWriteableName() {
-        return MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME;
+        return NAME;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsStatsActionResponseTests.java
@@ -22,8 +22,9 @@ public class GetDataFrameAnalyticsStatsActionResponseTests extends AbstractWireS
         int listSize = randomInt(10);
         List<Response.Stats> analytics = new ArrayList<>(listSize);
         for (int j = 0; j < listSize; j++) {
+            Integer progressPercentage = randomBoolean() ? null : randomIntBetween(0, 100);
             Response.Stats stats = new Response.Stats(DataFrameAnalyticsConfigTests.randomValidId(),
-                randomFrom(DataFrameAnalyticsState.values()), null, randomAlphaOfLength(20));
+                randomFrom(DataFrameAnalyticsState.values()), progressPercentage, null, randomAlphaOfLength(20));
             analytics.add(stats);
         }
         return new Response(new QueryPage<>(analytics, analytics.size(), GetDataFrameAnalyticsAction.Response.RESULTS_FIELD));

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.core.ml.action.DeleteDataFrameAnalyticsAction;
+import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsAction;
+import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.PutDataFrameAnalyticsAction;
+import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Base class of ML integration tests that use a native data_frame_analytics process
+ */
+abstract class MlNativeDataFrameAnalyticsIntegTestCase extends MlNativeIntegTestCase {
+
+    private List<DataFrameAnalyticsConfig> analytics = new ArrayList<>();
+
+    @Override
+    protected void cleanUpResources() {
+        cleanUpAnalytics();
+    }
+
+    private void cleanUpAnalytics() {
+        for (DataFrameAnalyticsConfig config : analytics) {
+            try {
+                deleteAnalytics(config.getId());
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+
+    protected void registerAnalytics(DataFrameAnalyticsConfig config) {
+        if (analytics.add(config) == false) {
+            throw new IllegalArgumentException("analytics config [" + config.getId() + "] is already registered");
+        }
+    }
+
+    protected PutDataFrameAnalyticsAction.Response putAnalytics(DataFrameAnalyticsConfig config) {
+        PutDataFrameAnalyticsAction.Request request = new PutDataFrameAnalyticsAction.Request(config);
+        return client().execute(PutDataFrameAnalyticsAction.INSTANCE, request).actionGet();
+    }
+
+    protected AcknowledgedResponse deleteAnalytics(String id) {
+        DeleteDataFrameAnalyticsAction.Request request = new DeleteDataFrameAnalyticsAction.Request(id);
+        return client().execute(DeleteDataFrameAnalyticsAction.INSTANCE, request).actionGet();
+    }
+
+    protected AcknowledgedResponse startAnalytics(String id) {
+        StartDataFrameAnalyticsAction.Request request = new StartDataFrameAnalyticsAction.Request(id);
+        return client().execute(StartDataFrameAnalyticsAction.INSTANCE, request).actionGet();
+    }
+
+    protected void waitUntilAnalyticsIsStopped(String id) throws Exception {
+        waitUntilAnalyticsIsStopped(id, TimeValue.timeValueSeconds(30));
+    }
+
+    protected void waitUntilAnalyticsIsStopped(String id, TimeValue waitTime) throws Exception {
+        assertBusy(() -> assertThat(getAnalyticsStats(id).get(0).getState(), equalTo(DataFrameAnalyticsState.STOPPED)),
+                waitTime.getMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    protected List<DataFrameAnalyticsConfig> getAnalytics(String id) {
+        GetDataFrameAnalyticsAction.Request request = new GetDataFrameAnalyticsAction.Request(id);
+        return client().execute(GetDataFrameAnalyticsAction.INSTANCE, request).actionGet().getResources().results();
+    }
+
+    protected List<GetDataFrameAnalyticsStatsAction.Response.Stats> getAnalyticsStats(String id) {
+        GetDataFrameAnalyticsStatsAction.Request request = new GetDataFrameAnalyticsStatsAction.Request(id);
+        GetDataFrameAnalyticsStatsAction.Response response = client().execute(GetDataFrameAnalyticsStatsAction.INSTANCE, request)
+            .actionGet();
+        return response.getResponse().results();
+    }
+
+    protected List<String> generateData(long timestamp, TimeValue bucketSpan, int bucketCount,
+                                      Function<Integer, Integer> timeToCountFunction) throws IOException {
+        List<String> data = new ArrayList<>();
+        long now = timestamp;
+        for (int bucketIndex = 0; bucketIndex < bucketCount; bucketIndex++) {
+            for (int count = 0; count < timeToCountFunction.apply(bucketIndex); count++) {
+                Map<String, Object> record = new HashMap<>();
+                record.put("time", now);
+                data.add(createJsonRecord(record));
+            }
+            now += bucketSpan.getMillis();
+        }
+        return data;
+    }
+
+    protected static String createJsonRecord(Map<String, Object> keyValueMap) throws IOException {
+        return Strings.toString(JsonXContent.contentBuilder().map(keyValueMap)) + "\n";
+    }
+}

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -29,8 +29,10 @@ import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
+import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
 import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
 import org.elasticsearch.xpack.core.security.SecurityField;
 import org.elasticsearch.xpack.core.security.authc.TokenMetaData;
@@ -112,10 +114,14 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
             entries.add(new NamedWriteableRegistry.Entry(MetaData.Custom.class, "ml", MlMetadata::new));
             entries.add(new NamedWriteableRegistry.Entry(PersistentTaskParams.class, MlTasks.DATAFEED_TASK_NAME,
                     StartDatafeedAction.DatafeedParams::new));
+            entries.add(new NamedWriteableRegistry.Entry(PersistentTaskParams.class, MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
+                StartDataFrameAnalyticsAction.TaskParams::new));
             entries.add(new NamedWriteableRegistry.Entry(PersistentTaskParams.class, MlTasks.JOB_TASK_NAME,
                     OpenJobAction.JobParams::new));
             entries.add(new NamedWriteableRegistry.Entry(PersistentTaskState.class, JobTaskState.NAME, JobTaskState::new));
             entries.add(new NamedWriteableRegistry.Entry(PersistentTaskState.class, DatafeedState.NAME, DatafeedState::fromStream));
+            entries.add(new NamedWriteableRegistry.Entry(PersistentTaskState.class, DataFrameAnalyticsTaskState.NAME,
+                DataFrameAnalyticsTaskState::new));
             entries.add(new NamedWriteableRegistry.Entry(ClusterState.Custom.class, TokenMetaData.TYPE, TokenMetaData::new));
             final NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(entries);
             ClusterState masterClusterState = client().admin().cluster().prepareState().all().get().getState();

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalysisConfig;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
+import org.junit.After;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTestCase {
+
+    @After
+    public void cleanup() {
+        cleanUp();
+    }
+
+    public void testOutlierDetectionWithFewDocuments() throws Exception {
+        String sourceIndex = "test-outlier-detection-with-few-docs";
+
+        client().admin().indices().prepareCreate(sourceIndex)
+            .addMapping("_doc", "numeric_1", "type=double", "numeric_2", "type=float", "categorical_1", "type=keyword")
+            .get();
+
+        BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
+        bulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        for (int i = 0; i < 5; i++) {
+            IndexRequest indexRequest = new IndexRequest(sourceIndex);
+
+            // We insert one odd value out of 5 for one feature
+            String docId = i == 0 ? "outlier" : "normal" + i;
+            indexRequest.id(docId);
+            indexRequest.source("numeric_1", i == 0 ? 100.0 : 1.0, "numeric_2", 1.0, "categorical_1", "foo_" + i);
+            bulkRequestBuilder.add(indexRequest);
+        }
+        BulkResponse bulkResponse = bulkRequestBuilder.get();
+        if (bulkResponse.hasFailures()) {
+            fail("Failed to index data: " + bulkResponse.buildFailureMessage());
+        }
+
+        String id = "test_outlier_detection_with_few_docs";
+        DataFrameAnalyticsConfig config = buildOutlierDetectionAnalytics(id, sourceIndex);
+        registerAnalytics(config);
+        putAnalytics(config);
+
+        assertState(id, DataFrameAnalyticsState.STOPPED);
+
+        startAnalytics(id);
+        waitUntilAnalyticsIsStopped(id);
+
+        SearchResponse sourceData = client().prepareSearch(sourceIndex).get();
+        double scoreOfOutlier = 0.0;
+        double scoreOfNonOutlier = -1.0;
+        for (SearchHit hit : sourceData.getHits()) {
+            GetResponse destDocGetResponse = client().prepareGet().setIndex(config.getDest()).setId(hit.getId()).get();
+            assertThat(destDocGetResponse.isExists(), is(true));
+            Map<String, Object> sourceDoc = hit.getSourceAsMap();
+            Map<String, Object> destDoc = destDocGetResponse.getSource();
+            for (String field : sourceDoc.keySet()) {
+                assertThat(destDoc.containsKey(field), is(true));
+                assertThat(destDoc.get(field), equalTo(sourceDoc.get(field)));
+            }
+            assertThat(destDoc.containsKey("outlier_score"), is(true));
+            double outlierScore = (double) destDoc.get("outlier_score");
+            assertThat(outlierScore, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(100.0)));
+            if (hit.getId().equals("outlier")) {
+                scoreOfOutlier = outlierScore;
+            } else {
+                if (scoreOfNonOutlier < 0) {
+                    scoreOfNonOutlier = outlierScore;
+                } else {
+                    assertThat(outlierScore, equalTo(scoreOfNonOutlier));
+                }
+            }
+        }
+        assertThat(scoreOfOutlier, is(greaterThan(scoreOfNonOutlier)));
+    }
+
+    public void testOutlierDetectionWithEnoughDocumentsToScroll() throws Exception {
+        String sourceIndex = "test-outlier-detection-with-enough-docs-to-scroll";
+
+        client().admin().indices().prepareCreate(sourceIndex)
+            .addMapping("_doc", "numeric_1", "type=double", "numeric_2", "type=float", "categorical_1", "type=keyword")
+            .get();
+
+        BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
+        bulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        int docCount = randomIntBetween(1024, 2048);
+        for (int i = 0; i < docCount; i++) {
+            IndexRequest indexRequest = new IndexRequest(sourceIndex);
+            indexRequest.source("numeric_1", randomDouble(), "numeric_2", randomFloat(), "categorical_1", randomAlphaOfLength(10));
+            bulkRequestBuilder.add(indexRequest);
+        }
+        BulkResponse bulkResponse = bulkRequestBuilder.get();
+        if (bulkResponse.hasFailures()) {
+            fail("Failed to index data: " + bulkResponse.buildFailureMessage());
+        }
+
+        String id = "test_outlier_detection_with_enough_docs_to_scroll";
+        DataFrameAnalyticsConfig config = buildOutlierDetectionAnalytics(id, sourceIndex);
+        registerAnalytics(config);
+        putAnalytics(config);
+
+        assertState(id, DataFrameAnalyticsState.STOPPED);
+
+        startAnalytics(id);
+        waitUntilAnalyticsIsStopped(id);
+
+        // Check we've got all docs
+        SearchResponse searchResponse = client().prepareSearch(config.getDest()).setTrackTotalHits(true).get();
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) docCount));
+
+        // Check they all have an outlier_score
+        searchResponse = client().prepareSearch(config.getDest()).setQuery(QueryBuilders.existsQuery("outlier_score")).get();
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) docCount));
+    }
+
+    private static DataFrameAnalyticsConfig buildOutlierDetectionAnalytics(String id, String sourceIndex) {
+        DataFrameAnalyticsConfig.Builder configBuilder = new DataFrameAnalyticsConfig.Builder(id);
+        configBuilder.setSource(sourceIndex);
+        configBuilder.setDest(sourceIndex + "-results");
+        Map<String, Object> analysisConfig = new HashMap<>();
+        analysisConfig.put("outlier_detection", Collections.emptyMap());
+        configBuilder.setAnalyses(Collections.singletonList(new DataFrameAnalysisConfig(analysisConfig)));
+        return configBuilder.build();
+    }
+
+    private void assertState(String id, DataFrameAnalyticsState state) {
+        List<GetDataFrameAnalyticsStatsAction.Response.Stats> stats = getAnalyticsStats(id);
+        assertThat(stats.size(), equalTo(1));
+        assertThat(stats.get(0).getId(), equalTo(id));
+        assertThat(stats.get(0).getState(), equalTo(state));
+    }
+}

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
@@ -136,7 +136,9 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) docCount));
 
         // Check they all have an outlier_score
-        searchResponse = client().prepareSearch(config.getDest()).setQuery(QueryBuilders.existsQuery("outlier_score")).get();
+        searchResponse = client().prepareSearch(config.getDest())
+            .setTrackTotalHits(true)
+            .setQuery(QueryBuilders.existsQuery("outlier_score")).get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) docCount));
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -13,6 +13,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -474,7 +475,8 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
         AnalyticsProcessManager analyticsProcessManager = new AnalyticsProcessManager(client, environment, threadPool,
             analyticsProcessFactory);
         DataFrameAnalyticsConfigProvider dataFrameAnalyticsConfigProvider = new DataFrameAnalyticsConfigProvider(client);
-        DataFrameAnalyticsManager dataFrameAnalyticsManager = new DataFrameAnalyticsManager(clusterService, client,
+        assert client instanceof NodeClient;
+        DataFrameAnalyticsManager dataFrameAnalyticsManager = new DataFrameAnalyticsManager(clusterService, (NodeClient) client,
             dataFrameAnalyticsConfigProvider, analyticsProcessManager);
         this.dataFrameAnalyticsManager.set(dataFrameAnalyticsManager);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
@@ -5,67 +5,143 @@
  */
 package org.elasticsearch.xpack.ml.action;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.TaskOperationFailure;
+import org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskRequest;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.block.ClusterBlockException;
-import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskResult;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction.Response.Stats;
 import org.elasticsearch.xpack.core.ml.action.util.QueryPage;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
+import org.elasticsearch.xpack.ml.action.TransportStartDataFrameAnalyticsAction.DataFrameAnalyticsTask;
+import org.elasticsearch.xpack.ml.dataframe.process.AnalyticsProcessManager;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
 public class TransportGetDataFrameAnalyticsStatsAction
-    extends TransportMasterNodeAction<GetDataFrameAnalyticsStatsAction.Request, GetDataFrameAnalyticsStatsAction.Response> {
+    extends TransportTasksAction<DataFrameAnalyticsTask, GetDataFrameAnalyticsStatsAction.Request,
+        GetDataFrameAnalyticsStatsAction.Response, QueryPage<Stats>> {
+
+    private static final Logger LOGGER = LogManager.getLogger(TransportGetDataFrameAnalyticsStatsAction.class);
 
     private final Client client;
+    private final AnalyticsProcessManager analyticsProcessManager;
 
     @Inject
     public TransportGetDataFrameAnalyticsStatsAction(TransportService transportService, ClusterService clusterService, Client client,
-                                                     ThreadPool threadPool, ActionFilters actionFilters,
-                                                     IndexNameExpressionResolver indexNameExpressionResolver) {
-        super(GetDataFrameAnalyticsStatsAction.NAME, transportService, clusterService, threadPool, actionFilters,
-            indexNameExpressionResolver, GetDataFrameAnalyticsStatsAction.Request::new);
+                                                     ActionFilters actionFilters, AnalyticsProcessManager analyticsProcessManager) {
+        super(GetDataFrameAnalyticsStatsAction.NAME, clusterService, transportService, actionFilters,
+            GetDataFrameAnalyticsStatsAction.Request::new, GetDataFrameAnalyticsStatsAction.Response::new,
+            in -> new QueryPage<>(in, GetDataFrameAnalyticsStatsAction.Response.Stats::new), ThreadPool.Names.MANAGEMENT);
         this.client = client;
+        this.analyticsProcessManager = analyticsProcessManager;
     }
 
     @Override
-    protected String executor() {
-        return ThreadPool.Names.SAME;
+    protected GetDataFrameAnalyticsStatsAction.Response newResponse(GetDataFrameAnalyticsStatsAction.Request request,
+                                                                    List<QueryPage<GetDataFrameAnalyticsStatsAction.Response.Stats>> tasks,
+                                                                    List<TaskOperationFailure> taskFailures,
+                                                                    List<FailedNodeException> nodeFailures) {
+        List<Stats> stats = new ArrayList<>();
+        for (QueryPage<Stats> task : tasks) {
+            stats.addAll(task.results());
+        }
+        Collections.sort(stats, Comparator.comparing(Stats::getId));
+        return new GetDataFrameAnalyticsStatsAction.Response(taskFailures, nodeFailures, new QueryPage<>(stats, stats.size(),
+            GetDataFrameAnalyticsAction.Response.RESULTS_FIELD));
     }
 
     @Override
-    protected GetDataFrameAnalyticsStatsAction.Response newResponse() {
-        return new GetDataFrameAnalyticsStatsAction.Response();
+    protected void taskOperation(GetDataFrameAnalyticsStatsAction.Request request, DataFrameAnalyticsTask task,
+                                 ActionListener<QueryPage<Stats>> listener) {
+        LOGGER.debug("Get stats for running task [{}]", task.getParams().getId());
+
+        ActionListener<Integer> progressListener = ActionListener.wrap(
+            progress -> {
+                Stats stats = buildStats(task.getParams().getId(), progress);
+                listener.onResponse(new QueryPage<>(Collections.singletonList(stats), 1,
+                    GetDataFrameAnalyticsAction.Response.RESULTS_FIELD));
+            }, listener::onFailure
+        );
+
+        ClusterState clusterState = clusterService.state();
+        PersistentTasksCustomMetaData tasks = clusterState.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
+        DataFrameAnalyticsState analyticsState = MlTasks.getDataFrameAnalyticsState(task.getParams().getId(), tasks);
+
+        // For a running task we report the progress associated with its current state
+        if (analyticsState == DataFrameAnalyticsState.REINDEXING) {
+            getReindexTaskProgress(task, progressListener);
+        } else {
+            progressListener.onResponse(analyticsProcessManager.getProgressPercent(task.getAllocationId()));
+        }
+    }
+
+    private void getReindexTaskProgress(DataFrameAnalyticsTask task, ActionListener<Integer> listener) {
+        TaskId reindexTaskId = new TaskId(clusterService.localNode().getId(), task.getReindexingTaskId());
+        GetTaskRequest getTaskRequest = new GetTaskRequest();
+        getTaskRequest.setTaskId(reindexTaskId);
+        client.admin().cluster().getTask(getTaskRequest, ActionListener.wrap(
+            taskResponse -> {
+                TaskResult taskResult = taskResponse.getTask();
+                BulkByScrollTask.Status taskStatus = (BulkByScrollTask.Status) taskResult.getTask().getStatus();
+                int progress =  taskStatus.getTotal() == 0 ? 100 : (int) (taskStatus.getCreated() * 100.0 / taskStatus.getTotal());
+                listener.onResponse(progress);
+            },
+            error -> {
+                if (error instanceof ResourceNotFoundException) {
+                    // The task has either not started yet or has finished, thus it is better to respond null and not show progress at all
+                    listener.onResponse(null);
+                } else {
+                    listener.onFailure(error);
+                }
+            }
+        ));
     }
 
     @Override
-    protected void masterOperation(GetDataFrameAnalyticsStatsAction.Request request, ClusterState state,
-                                   ActionListener<GetDataFrameAnalyticsStatsAction.Response> listener) throws Exception {
-        PersistentTasksCustomMetaData tasks = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
+    protected void doExecute(Task task, GetDataFrameAnalyticsStatsAction.Request request,
+                             ActionListener<GetDataFrameAnalyticsStatsAction.Response> listener) {
+        LOGGER.debug("Get stats for data frame analytics [{}]", request.getId());
 
         ActionListener<GetDataFrameAnalyticsAction.Response> getResponseListener = ActionListener.wrap(
             response -> {
-                List<GetDataFrameAnalyticsStatsAction.Response.Stats> stats = new ArrayList(response.getResources().results().size());
-                response.getResources().results().forEach(c -> stats.add(buildStats(c.getId(), tasks, state)));
-                listener.onResponse(new GetDataFrameAnalyticsStatsAction.Response(new QueryPage<>(stats, stats.size(),
-                    GetDataFrameAnalyticsAction.Response.RESULTS_FIELD)));
+                List<String> expandedIds = response.getResources().results().stream().map(DataFrameAnalyticsConfig::getId)
+                    .collect(Collectors.toList());
+                request.setExpandedIds(expandedIds);
+                ActionListener<GetDataFrameAnalyticsStatsAction.Response> runningTasksStatsListener = ActionListener.wrap(
+                    runningTasksStatsResponse -> gatherStatsForStoppedTasks(request.getExpandedIds(), runningTasksStatsResponse, listener),
+                    listener::onFailure
+                );
+                super.doExecute(task, request, runningTasksStatsListener);
             },
             listener::onFailure
         );
@@ -76,8 +152,29 @@ public class TransportGetDataFrameAnalyticsStatsAction
         executeAsyncWithOrigin(client, ML_ORIGIN, GetDataFrameAnalyticsAction.INSTANCE, getRequest, getResponseListener);
     }
 
-    private GetDataFrameAnalyticsStatsAction.Response.Stats buildStats(String concreteAnalyticsId, PersistentTasksCustomMetaData tasks,
-                                                                       ClusterState clusterState) {
+    void gatherStatsForStoppedTasks(List<String> expandedIds, GetDataFrameAnalyticsStatsAction.Response runningTasksResponse,
+                                    ActionListener<GetDataFrameAnalyticsStatsAction.Response> listener) {
+        List<String> stoppedTasksIds = determineStoppedTasksIds(expandedIds, runningTasksResponse.getResponse().results());
+        List<Stats> stoppedTasksStats = stoppedTasksIds.stream().map(this::buildStatsForStoppedTask).collect(Collectors.toList());
+        List<Stats> allTasksStats = new ArrayList<>(runningTasksResponse.getResponse().results());
+        allTasksStats.addAll(stoppedTasksStats);
+        Collections.sort(allTasksStats, Comparator.comparing(Stats::getId));
+        listener.onResponse(new GetDataFrameAnalyticsStatsAction.Response(new QueryPage<>(
+            allTasksStats, allTasksStats.size(), GetDataFrameAnalyticsAction.Response.RESULTS_FIELD)));
+    }
+
+    static List<String> determineStoppedTasksIds(List<String> expandedIds, List<Stats> runningTasksStats) {
+        Set<String> startedTasksIds = runningTasksStats.stream().map(Stats::getId).collect(Collectors.toSet());
+        return expandedIds.stream().filter(id -> startedTasksIds.contains(id) == false).collect(Collectors.toList());
+    }
+
+    private GetDataFrameAnalyticsStatsAction.Response.Stats buildStatsForStoppedTask(String concreteAnalyticsId) {
+        return buildStats(concreteAnalyticsId, null);
+    }
+
+    private GetDataFrameAnalyticsStatsAction.Response.Stats buildStats(String concreteAnalyticsId, @Nullable Integer progressPercent) {
+        ClusterState clusterState = clusterService.state();
+        PersistentTasksCustomMetaData tasks = clusterState.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
         PersistentTasksCustomMetaData.PersistentTask<?> analyticsTask = MlTasks.getDataFrameAnalyticsTask(concreteAnalyticsId, tasks);
         DataFrameAnalyticsState analyticsState = MlTasks.getDataFrameAnalyticsState(concreteAnalyticsId, tasks);
         DiscoveryNode node = null;
@@ -87,11 +184,6 @@ public class TransportGetDataFrameAnalyticsStatsAction
             assignmentExplanation = analyticsTask.getAssignment().getExplanation();
         }
         return new GetDataFrameAnalyticsStatsAction.Response.Stats(
-            concreteAnalyticsId, analyticsState, node, assignmentExplanation);
-    }
-
-    @Override
-    protected ClusterBlockException checkBlock(GetDataFrameAnalyticsStatsAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+            concreteAnalyticsId, analyticsState, progressPercent, node, assignmentExplanation);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResult.java
@@ -18,21 +18,30 @@ public class AnalyticsResult implements ToXContentObject {
 
     public static final ParseField TYPE = new ParseField("analytics_result");
 
+    public static final ParseField PROGRESS_PERCENT = new ParseField("progress_percent");
+
     static final ConstructingObjectParser<AnalyticsResult, Void> PARSER = new ConstructingObjectParser<>(TYPE.getPreferredName(),
-            a -> new AnalyticsResult((RowResults) a[0]));
+            a -> new AnalyticsResult((RowResults) a[0], (Integer) a[1]));
 
     static {
         PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), RowResults.PARSER, RowResults.TYPE);
+        PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), PROGRESS_PERCENT);
     }
 
     private final RowResults rowResults;
+    private final Integer progressPercent;
 
-    public AnalyticsResult(RowResults rowResults) {
+    public AnalyticsResult(RowResults rowResults, Integer progressPercent) {
         this.rowResults = rowResults;
+        this.progressPercent = progressPercent;
     }
 
     public RowResults getRowResults() {
         return rowResults;
+    }
+
+    public Integer getProgressPercent() {
+        return progressPercent;
     }
 
     @Override
@@ -40,6 +49,9 @@ public class AnalyticsResult implements ToXContentObject {
         builder.startObject();
         if (rowResults != null) {
             builder.field(RowResults.TYPE.getPreferredName(), rowResults);
+        }
+        if (progressPercent != null) {
+            builder.field(PROGRESS_PERCENT.getPreferredName(), progressPercent);
         }
         builder.endObject();
         return builder;
@@ -55,11 +67,11 @@ public class AnalyticsResult implements ToXContentObject {
         }
 
         AnalyticsResult that = (AnalyticsResult) other;
-        return Objects.equals(rowResults, that.rowResults);
+        return Objects.equals(rowResults, that.rowResults) && Objects.equals(progressPercent, that.progressPercent);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(rowResults);
+        return Objects.hash(rowResults, progressPercent);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessor.java
@@ -18,10 +18,12 @@ public class AnalyticsResultProcessor {
 
     private static final Logger LOGGER = LogManager.getLogger(AnalyticsResultProcessor.class);
 
+    private final AnalyticsProcessManager.ProcessContext processContext;
     private final DataFrameRowsJoiner dataFrameRowsJoiner;
     private final CountDownLatch completionLatch = new CountDownLatch(1);
 
-    public AnalyticsResultProcessor(DataFrameRowsJoiner dataFrameRowsJoiner) {
+    public AnalyticsResultProcessor(AnalyticsProcessManager.ProcessContext processContext, DataFrameRowsJoiner dataFrameRowsJoiner) {
+        this.processContext = Objects.requireNonNull(processContext);
         this.dataFrameRowsJoiner = Objects.requireNonNull(dataFrameRowsJoiner);
     }
 
@@ -56,6 +58,10 @@ public class AnalyticsResultProcessor {
         RowResults rowResults = result.getRowResults();
         if (rowResults != null) {
             dataFrameRowsJoiner.processRowResults(rowResults);
+        }
+        Integer progressPercent = result.getProgressPercent();
+        if (progressPercent != null) {
+            processContext.setProgressPercent(progressPercent);
         }
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessorTests.java
@@ -41,7 +41,7 @@ public class AnalyticsResultProcessorTests extends ESTestCase {
     }
 
     public void testProcess_GivenEmptyResults() {
-        givenProcessResults(Arrays.asList(new AnalyticsResult(null), new AnalyticsResult(null)));
+        givenProcessResults(Arrays.asList(new AnalyticsResult(null, null), new AnalyticsResult(null, null)));
         AnalyticsResultProcessor resultProcessor = createResultProcessor();
 
         resultProcessor.process(process);
@@ -53,7 +53,7 @@ public class AnalyticsResultProcessorTests extends ESTestCase {
     public void testProcess_GivenRowResults() {
         RowResults rowResults1 = mock(RowResults.class);
         RowResults rowResults2 = mock(RowResults.class);
-        givenProcessResults(Arrays.asList(new AnalyticsResult(rowResults1), new AnalyticsResult(rowResults2)));
+        givenProcessResults(Arrays.asList(new AnalyticsResult(rowResults1, null), new AnalyticsResult(rowResults2, null)));
         AnalyticsResultProcessor resultProcessor = createResultProcessor();
 
         resultProcessor.process(process);
@@ -69,6 +69,6 @@ public class AnalyticsResultProcessorTests extends ESTestCase {
     }
 
     private AnalyticsResultProcessor createResultProcessor() {
-        return new AnalyticsResultProcessor(dataFrameRowsJoiner);
+        return new AnalyticsResultProcessor(new AnalyticsProcessManager.ProcessContext(), dataFrameRowsJoiner);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultTests.java
@@ -17,10 +17,14 @@ public class AnalyticsResultTests extends AbstractXContentTestCase<AnalyticsResu
     @Override
     protected AnalyticsResult createTestInstance() {
         RowResults rowResults = null;
+        Integer progressPercent = null;
         if (randomBoolean()) {
             rowResults = RowResultsTests.createRandom();
         }
-        return new AnalyticsResult(rowResults);
+        if (randomBoolean()) {
+            progressPercent = randomIntBetween(0, 100);
+        }
+        return new AnalyticsResult(rowResults, progressPercent);
     }
 
     @Override


### PR DESCRIPTION
Adds progress reporting. Progress is reported per state.
In particular, this adds progress reporting for the
Reindexing state and the analyzing state.
    
For reindexing, we now store the reindex task id and we use
it to get the task info and calculate progress by taking into
consideration the number of docs created against the total docs.
    
For analyzing, we read the progress reported from the native process
and store it in memory. The get tasks action has been changed
to direct to the node running the process when possible. Then,
progress is reported additionally to the rest of stats for
running tasks.
    
This commit adds integration tests on the multi-node environment.
Those tests have revealed some issues which are also fixed here:
    
- Registering named content correctly
- Wait for task state to be `started` before responding in the start API