### PR TITLE
re-enable SmokeTestWatcherWithSecurityIT

### DIFF
--- a/x-pack/qa/smoke-test-watcher-with-security/src/test/java/org/elasticsearch/smoketest/SmokeTestWatcherWithSecurityIT.java
+++ b/x-pack/qa/smoke-test-watcher-with-security/src/test/java/org/elasticsearch/smoketest/SmokeTestWatcherWithSecurityIT.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.smoketest;
 
 import org.apache.http.util.EntityUtils;
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.Strings;
@@ -32,7 +31,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/35361")
 public class SmokeTestWatcherWithSecurityIT extends ESRestTestCase {
 
     private static final String TEST_ADMIN_USERNAME = "test_admin";
@@ -198,7 +196,6 @@ public class SmokeTestWatcherWithSecurityIT extends ESRestTestCase {
                     .endObject().endObject().endObject();
             builder.startObject("actions").startObject("index").startObject("index")
                     .field("index", "my_test_index")
-                    .field("doc_type", "doc")
                     .field("doc_id", "my-id")
                     .endObject().endObject().endObject();
             builder.endObject();
@@ -229,7 +226,6 @@ public class SmokeTestWatcherWithSecurityIT extends ESRestTestCase {
                     .endObject().endObject().endObject();
             builder.startObject("actions").startObject("index").startObject("index")
                     .field("index", "my_test_index")
-                    .field("doc_type", "doc")
                     .field("doc_id", "some-id")
                     .endObject().endObject().endObject();
             builder.endObject();
@@ -250,7 +246,6 @@ public class SmokeTestWatcherWithSecurityIT extends ESRestTestCase {
             builder.startObject("input").startObject("simple").field("spam", "eggs").endObject().endObject();
             builder.startObject("actions").startObject("index").startObject("index")
                     .field("index", "my_test_index")
-                    .field("doc_type", "doc")
                     .field("doc_id", "my-id")
                     .endObject().endObject().endObject();
             builder.endObject();
@@ -274,7 +269,6 @@ public class SmokeTestWatcherWithSecurityIT extends ESRestTestCase {
             builder.startObject("input").startObject("simple").field("spam", "eggs").endObject().endObject();
             builder.startObject("actions").startObject("index").startObject("index")
                     .field("index", "index_not_allowed_to_read")
-                    .field("doc_type", "doc")
                     .field("doc_id", "my-id")
                     .endObject().endObject().endObject();
             builder.endObject();


### PR DESCRIPTION
opening this PR to run this on CI a handful of times before deciding if these tests 
really do need to be refactored to be less flaky.

relates to #30777, #35361, #29877.
