### PR TITLE
[Monitoring] Remove _type usages in _search requests

### DIFF
--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_cluster_status.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_cluster_status.json
@@ -47,19 +47,8 @@
                           }
                         },
                         {
-                          "bool": {
-                            "should": [
-                              {
-                                "term": {
-                                  "_type": "cluster_state"
-                                }
-                              },
-                              {
-                                "term": {
-                                  "type": "cluster_stats"
-                                }
-                              }
-                            ]
+                          "term": {
+                            "type": "cluster_stats"
                           }
                         },
                         {

--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_version_mismatch.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/elasticsearch_version_mismatch.json
@@ -40,19 +40,8 @@
                           }
                         },
                         {
-                          "bool": {
-                            "should": [
-                              {
-                                "term": {
-                                  "_type": "cluster_stats"
-                                }
-                              },
-                              {
-                                "term": {
-                                  "type": "cluster_stats"
-                                }
-                              }
-                            ]
+                          "term": {
+                            "type": "cluster_stats"
                           }
                         },
                         {

--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/kibana_version_mismatch.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/kibana_version_mismatch.json
@@ -44,19 +44,8 @@
                           }
                         },
                         {
-                          "bool": {
-                            "should": [
-                              {
-                                "term": {
-                                  "_type": "kibana_stats"
-                                }
-                              },
-                              {
-                                "term": {
-                                  "type": "kibana_stats"
-                                }
-                              }
-                            ]
+                          "term": {
+                            "type": "kibana_stats"
                           }
                         }
                       ]

--- a/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/logstash_version_mismatch.json
+++ b/x-pack/plugin/monitoring/src/main/resources/monitoring/watches/logstash_version_mismatch.json
@@ -44,19 +44,8 @@
                           }
                         },
                         {
-                          "bool": {
-                            "should": [
-                              {
-                                "term": {
-                                  "_type": "logstash_stats"
-                                }
-                              },
-                              {
-                                "term": {
-                                  "type": "logstash_stats"
-                                }
-                              }
-                            ]
+                          "term": {
+                            "type": "logstash_stats"
                           }
                         }
                       ]


### PR DESCRIPTION
This PR removes usages of the `_type` field in `_search` requests issued from Monitoring code.

Addresses #37442.