### PR TITLE
Fix line separators in JSON logging tests backport #38771

### DIFF
--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
@@ -46,6 +46,7 @@ import java.util.stream.Stream;
  * It has to be in a <code>org.elasticsearch.common.logging</code> package to use <code>PrefixLogger</code>
  */
 public class JsonLoggerTests extends ESTestCase {
+    private static final String LINE_SEPARATOR = System.lineSeparator();
 
     @BeforeClass
     public static void initNodeName() {
@@ -109,15 +110,15 @@ public class JsonLoggerTests extends ESTestCase {
 
     public void testJsonInMessage() throws IOException {
         final Logger testLogger = LogManager.getLogger("test");
-        String json = "{\n" +
-            "  \"terms\" : {\n" +
-            "    \"user\" : [\n" +
-            "      \"u1\",\n" +
-            "      \"u2\",\n" +
-            "      \"u3\"\n" +
-            "    ],\n" +
-            "    \"boost\" : 1.0\n" +
-            "  }\n" +
+        String json = "{" + LINE_SEPARATOR +
+            "  \"terms\" : {" + LINE_SEPARATOR +
+            "    \"user\" : [" + LINE_SEPARATOR +
+            "      \"u1\"," + LINE_SEPARATOR +
+            "      \"u2\"," + LINE_SEPARATOR +
+            "      \"u3\"" + LINE_SEPARATOR +
+            "    ]," + LINE_SEPARATOR +
+            "    \"boost\" : 1.0" + LINE_SEPARATOR +
+            "  }" + LINE_SEPARATOR +
             "}";
 
         testLogger.info(json);
@@ -151,15 +152,15 @@ public class JsonLoggerTests extends ESTestCase {
     public void testJsonInStacktraceMessageIsSplitted() throws IOException {
         final Logger testLogger = LogManager.getLogger("test");
 
-        String json = "{\n" +
-            "  \"terms\" : {\n" +
-            "    \"user\" : [\n" +
-            "      \"u1\",\n" +
-            "      \"u2\",\n" +
-            "      \"u3\"\n" +
-            "    ],\n" +
-            "    \"boost\" : 1.0\n" +
-            "  }\n" +
+        String json = "{" + LINE_SEPARATOR +
+            "  \"terms\" : {" + LINE_SEPARATOR +
+            "    \"user\" : [" + LINE_SEPARATOR +
+            "      \"u1\"," + LINE_SEPARATOR +
+            "      \"u2\"," + LINE_SEPARATOR +
+            "      \"u3\"" + LINE_SEPARATOR +
+            "    ]," + LINE_SEPARATOR +
+            "    \"boost\" : 1.0" + LINE_SEPARATOR +
+            "  }" + LINE_SEPARATOR +
             "}";
         testLogger.error("error message " + json, new Exception(json));
 

--- a/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
@@ -48,7 +48,6 @@ public class JsonThrowablePatternConverterTests extends ESTestCase {
         assertThat(jsonLogLine.stacktrace(), Matchers.nullValue());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/38705")
     public void testStacktraceWithJson() throws IOException {
         LogManager.getLogger().info("asdf");
 

--- a/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/JsonThrowablePatternConverterTests.java
@@ -33,7 +33,8 @@ import java.io.StringReader;
 import static org.hamcrest.Matchers.equalTo;
 
 public class JsonThrowablePatternConverterTests extends ESTestCase {
-    JsonThrowablePatternConverter converter = JsonThrowablePatternConverter.newInstance(null, null);
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+    private JsonThrowablePatternConverter converter = JsonThrowablePatternConverter.newInstance(null, null);
 
     public void testNoStacktrace() throws IOException {
         LogEvent event = Log4jLogEvent.newBuilder()
@@ -51,15 +52,15 @@ public class JsonThrowablePatternConverterTests extends ESTestCase {
     public void testStacktraceWithJson() throws IOException {
         LogManager.getLogger().info("asdf");
 
-        String json = "{\n" +
-            "  \"terms\" : {\n" +
-            "    \"user\" : [\n" +
-            "      \"u1\",\n" +
-            "      \"u2\",\n" +
-            "      \"u3\"\n" +
-            "    ],\n" +
-            "    \"boost\" : 1.0\n" +
-            "  }\n" +
+        String json = "{" + LINE_SEPARATOR +
+            "  \"terms\" : {" + LINE_SEPARATOR +
+            "    \"user\" : [" + LINE_SEPARATOR +
+            "      \"u1\"," + LINE_SEPARATOR +
+            "      \"u2\"," + LINE_SEPARATOR +
+            "      \"u3\"" + LINE_SEPARATOR +
+            "    ]," + LINE_SEPARATOR +
+            "    \"boost\" : 1.0" + LINE_SEPARATOR +
+            "  }" + LINE_SEPARATOR +
             "}";
         Exception thrown = new Exception(json);
         LogEvent event = Log4jLogEvent.newBuilder()
@@ -75,7 +76,7 @@ public class JsonThrowablePatternConverterTests extends ESTestCase {
                                                 .findFirst()
                                                 .orElseThrow(() -> new AssertionError("no logs parsed"));
 
-        int jsonLength = json.split("\n").length;
+        int jsonLength = json.split(LINE_SEPARATOR).length;
         int stacktraceLength = thrown.getStackTrace().length;
         assertThat("stacktrace should formatted in multiple lines",
             jsonLogLine.stacktrace().size(), equalTo(jsonLength + stacktraceLength));


### PR DESCRIPTION
The hardcoded '\n' in string will not work in Windows where there is a
different line separator. A System.lineSeparator should be used to make
it work on all platforms
closes #38705
