### PR TITLE
SQL: fall back to using the field name for column label

### DIFF
--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcColumnInfo.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcColumnInfo.java
@@ -7,6 +7,8 @@ package org.elasticsearch.xpack.sql.jdbc;
 
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.sql.client.StringUtils.EMPTY;
+
 class JdbcColumnInfo {
     public final String catalog;
     public final String schema;
@@ -52,17 +54,17 @@ class JdbcColumnInfo {
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder();
-        if (false == "".equals(table)) {
+        if (false == EMPTY.equals(table)) {
             b.append(table).append('.');
         }
         b.append(name).append("<type=[").append(type).append(']');
-        if (false == "".equals(catalog)) {
+        if (false == EMPTY.equals(catalog)) {
             b.append(" catalog=[").append(catalog).append(']');
         }
-        if (false == "".equals(schema)) {
+        if (false == EMPTY.equals(schema)) {
             b.append(" schema=[").append(schema).append(']');
         }
-        if (false == "".equals(label)) {
+        if (false == EMPTY.equals(label)) {
             b.append(" label=[").append(label).append(']');
         }
         return b.append('>').toString();

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSetMetaData.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSetMetaData.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static java.lang.String.format;
+import static org.elasticsearch.xpack.sql.client.StringUtils.EMPTY;
 
 class JdbcResultSetMetaData implements ResultSetMetaData, JdbcWrapper {
 
@@ -70,7 +71,8 @@ class JdbcResultSetMetaData implements ResultSetMetaData, JdbcWrapper {
 
     @Override
     public String getColumnLabel(int column) throws SQLException {
-        return column(column).label;
+        JdbcColumnInfo info = column(column);
+        return true == EMPTY.equals(info.label) ? info.name : info.label;
     }
 
     @Override

--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSetMetaDataTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSetMetaDataTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.jdbc;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.elasticsearch.xpack.sql.client.StringUtils.EMPTY;
+
+public class JdbcResultSetMetaDataTests extends ESTestCase {
+    
+    private final List<JdbcColumnInfo> columns = Arrays.asList(
+                new JdbcColumnInfo("test_keyword", EsType.KEYWORD, EMPTY, EMPTY, EMPTY, EMPTY, 0),
+                new JdbcColumnInfo("test_integer", EsType.INTEGER, EMPTY, EMPTY, EMPTY, EMPTY, 11),
+                new JdbcColumnInfo("test_double", EsType.DOUBLE, EMPTY, EMPTY, EMPTY, EMPTY, 25)
+            );
+    private final JdbcResultSetMetaData metaData = new JdbcResultSetMetaData(null, columns);
+
+    public void testColumnsProperties() throws SQLException {
+        int maxColumnIndex = columns.size();
+        assertEquals(false, metaData.isAutoIncrement(randomIntBetween(1, maxColumnIndex)));
+        assertEquals(true, metaData.isCaseSensitive(randomIntBetween(1, maxColumnIndex)));
+        assertEquals(true, metaData.isSearchable(randomIntBetween(1, maxColumnIndex)));
+        assertEquals(false, metaData.isCurrency(randomIntBetween(1, maxColumnIndex)));
+        assertEquals(ResultSetMetaData.columnNullableUnknown, metaData.isNullable(randomIntBetween(1, maxColumnIndex)));
+        assertEquals(false, metaData.isSigned(1));
+        assertEquals(true, metaData.isSigned(2));
+        assertEquals(true, metaData.isSigned(3));
+    }
+    
+    public void testColumnNamesAndLabels() throws SQLException {
+        assertEquals("test_keyword", metaData.getColumnName(1));
+        assertEquals("test_integer", metaData.getColumnName(2));
+        assertEquals("test_double", metaData.getColumnName(3));
+        
+        assertEquals("test_keyword", metaData.getColumnLabel(1));
+        assertEquals("test_integer", metaData.getColumnLabel(2));
+        assertEquals("test_double", metaData.getColumnLabel(3));
+    }
+}

--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSetMetaDataTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSetMetaDataTests.java
@@ -20,7 +20,8 @@ public class JdbcResultSetMetaDataTests extends ESTestCase {
     private final List<JdbcColumnInfo> columns = Arrays.asList(
                 new JdbcColumnInfo("test_keyword", EsType.KEYWORD, EMPTY, EMPTY, EMPTY, EMPTY, 0),
                 new JdbcColumnInfo("test_integer", EsType.INTEGER, EMPTY, EMPTY, EMPTY, EMPTY, 11),
-                new JdbcColumnInfo("test_double", EsType.DOUBLE, EMPTY, EMPTY, EMPTY, EMPTY, 25)
+                new JdbcColumnInfo("test_double", EsType.DOUBLE, EMPTY, EMPTY, EMPTY, EMPTY, 25),
+                new JdbcColumnInfo("test_long", EsType.LONG, "test_table", "test", "schema", "custom_label", 20)
             );
     private final JdbcResultSetMetaData metaData = new JdbcResultSetMetaData(null, columns);
 
@@ -34,15 +35,18 @@ public class JdbcResultSetMetaDataTests extends ESTestCase {
         assertEquals(false, metaData.isSigned(1));
         assertEquals(true, metaData.isSigned(2));
         assertEquals(true, metaData.isSigned(3));
+        assertEquals(true, metaData.isSigned(4));
     }
     
     public void testColumnNamesAndLabels() throws SQLException {
         assertEquals("test_keyword", metaData.getColumnName(1));
         assertEquals("test_integer", metaData.getColumnName(2));
         assertEquals("test_double", metaData.getColumnName(3));
+        assertEquals("test_long", metaData.getColumnName(4));
         
         assertEquals("test_keyword", metaData.getColumnLabel(1));
         assertEquals("test_integer", metaData.getColumnLabel(2));
         assertEquals("test_double", metaData.getColumnLabel(3));
+        assertEquals("custom_label", metaData.getColumnLabel(4));
     }
 }

--- a/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcResultSetMetaDataIT.java
+++ b/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcResultSetMetaDataIT.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.qa.single_node;
+
+import org.elasticsearch.xpack.sql.qa.jdbc.ResultSetMetaDataTestCase;
+
+public class JdbcResultSetMetaDataIT extends ResultSetMetaDataTestCase {
+
+}

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetMetaDataTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetMetaDataTestCase.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.qa.jdbc;
+
+import org.elasticsearch.common.CheckedConsumer;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+public class ResultSetMetaDataTestCase extends JdbcIntegrationTestCase {
+    
+    private final String[] fieldsNames = new String[] {"test_byte", "test_integer", "test_long", "test_short",
+            "test_double", "test_float", "test_keyword", "test_boolean", "test_date"};
+    
+    public void testValidGetObjectCalls() throws Exception {
+        ResultSetTestCase.createIndex("test");
+        ResultSetTestCase.updateMapping("test", builder -> {
+            for(String field : fieldsNames) {
+                builder.startObject(field).field("type", field.substring(5)).endObject();
+            }
+        });
+        
+        String q = "SELECT test_byte, test_integer, test_long, test_short, test_double, test_float, test_keyword, "
+                + "test_boolean, test_date FROM test";
+        doWithQuery(q, (r) -> assertColumnNamesAndLabels(r.getMetaData(), fieldsNames));
+
+        q = "SELECT test_byte AS b, test_integer AS i, test_long AS l, test_short AS s, test_double AS d, test_float AS f, "
+                + "test_keyword AS k, test_boolean AS bool, test_date AS dt FROM test";
+        doWithQuery(q, (r) -> assertColumnNamesAndLabels(r.getMetaData(), new String[] {"b", "i", "l", "s", "d", "f", "k", "bool", "dt"}));
+    }
+    
+    private void doWithQuery(String query, CheckedConsumer<ResultSet, SQLException> consumer) throws SQLException {
+        try (Connection connection = esJdbc()) {
+            try (PreparedStatement statement = connection.prepareStatement(query)) {
+                try (ResultSet results = statement.executeQuery()) {
+                    assertEquals(fieldsNames.length, results.getMetaData().getColumnCount());
+                    consumer.accept(results);
+                }
+            }
+        }
+    }
+    
+    private void assertColumnNamesAndLabels(ResultSetMetaData metaData, String[] names) throws SQLException {
+        for(int i = 0; i < fieldsNames.length; i++) {
+            assertEquals(names[i], metaData.getColumnName(i + 1));
+            assertEquals(names[i], metaData.getColumnLabel(i + 1));
+        }
+    }
+}

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
@@ -1262,7 +1262,7 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
         }
     }
     
-    private void createIndex(String index) throws Exception {
+    protected static void createIndex(String index) throws Exception {
         Request request = new Request("PUT", "/" + index);
         XContentBuilder createIndex = JsonXContent.contentBuilder().startObject();
         createIndex.startObject("settings");
@@ -1282,7 +1282,7 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
         client().performRequest(request);
     }
 
-    private void updateMapping(String index, CheckedConsumer<XContentBuilder, IOException> body) throws Exception {
+    protected static void updateMapping(String index, CheckedConsumer<XContentBuilder, IOException> body) throws Exception {
         Request request = new Request("PUT", "/" + index + "/_mapping");
         XContentBuilder updateMapping = JsonXContent.contentBuilder().startObject();
         updateMapping.startObject("properties");
@@ -1460,7 +1460,7 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
         return map;
     }
 
-    private void updateMappingForNumericValuesTests(String indexName) throws Exception {
+    protected static void updateMappingForNumericValuesTests(String indexName) throws Exception {
         updateMapping(indexName, builder -> {
             for(String field : fieldsNames) {
                 builder.startObject(field).field("type", field.substring(5)).endObject();

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
@@ -1460,7 +1460,7 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
         return map;
     }
 
-    protected static void updateMappingForNumericValuesTests(String indexName) throws Exception {
+    private static void updateMappingForNumericValuesTests(String indexName) throws Exception {
         updateMapping(indexName, builder -> {
             for(String field : fieldsNames) {
                 builder.startObject(field).field("type", field.substring(5)).endObject();


### PR DESCRIPTION
This PR adds a simple fall back mechanism for the column label defined in [ResultSetMetaData](https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSetMetaData.html#getColumnLabel-int-) so that when asked for a column label we always return the field name. 
This PR does not provide the complete implementation of the column label definition; this will be addressed in a follow up issue since it involves more changes internally in ES-SQL (we do not keep around both the original value and the alias of a field so we can use both in JDBC).

This should fix issues with libraries (Ruby's Sequel used in the Logstash `jdbc` input plugin) that use the column label to discover the names to be used in the results.

Fixes https://github.com/elastic/elasticsearch/issues/38831.