### PR TITLE
ML allow aliased .ml-anomalies* index on PUT Job (#38821)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -38,6 +38,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -252,7 +253,25 @@ public class JobResultsProvider {
 
         String readAliasName = AnomalyDetectorsIndex.jobResultsAliasedName(job.getId());
         String writeAliasName = AnomalyDetectorsIndex.resultsWriteAlias(job.getId());
-        String indexName = job.getInitialResultsIndexName();
+        String tempIndexName = job.getInitialResultsIndexName();
+
+        // Our read/write aliases should point to the concrete index
+        // If the initial index is NOT an alias, either it is already a concrete index, or it does not exist yet
+        if (state.getMetaData().hasAlias(tempIndexName)) {
+            IndexNameExpressionResolver resolver = new IndexNameExpressionResolver();
+            String[] concreteIndices = resolver.concreteIndexNames(state, IndicesOptions.lenientExpandOpen(), tempIndexName);
+
+            // SHOULD NOT be closed as in typical call flow checkForLeftOverDocuments already verified this
+            // if it is closed, we bailout and return an error
+            if (concreteIndices.length == 0) {
+                finalListener.onFailure(
+                    ExceptionsHelper.badRequestException("Cannot create job [{}] as it requires closed index {}", job.getId(),
+                        tempIndexName));
+                return;
+            }
+            tempIndexName = concreteIndices[0];
+        }
+        final String indexName = tempIndexName;
 
         final ActionListener<Boolean> createAliasListener = ActionListener.wrap(success -> {
             final IndicesAliasesRequest request = client.admin().indices().prepareAliases()


### PR DESCRIPTION
Manually tested in the following manner:

* Created and opened A job
* Created a new index with the same mappings, aliases and properties as the `.ml-anomalies-shared` index
* Reindexed `.ml-anomalies-shared` into new index
* DELETE `.ml-anomalies-shared`
* Created alias for `.ml-anomalies-shared` to point to new concrete index.
* Created and opened a new job that needs the shared index.

After the test

```
GET _cat/aliases?v
```

```
alias                     index                           filter routing.index routing.search
.ml-annotations-read      .ml-annotations-6               -      -             -
.ml-annotations-write     .ml-annotations-6               -      -             -
.kibana                   .kibana_1                       -      -             -
.ml-anomalies-.write-jb2  .reindex-6-.ml-anomalies-shared -      -             -
.ml-anomalies-.write-job1 .reindex-6-.ml-anomalies-shared -      -             -
.ml-anomalies-jb2         .reindex-6-.ml-anomalies-shared *      -             -
.ml-anomalies-job1        .reindex-6-.ml-anomalies-shared *      -             -
.ml-anomalies-shared      .reindex-6-.ml-anomalies-shared -      -             -
.ml-state-write           .ml-state                       -      -             -
```

closes #38773

backport #38821