### PR TITLE
[ML-DataFrame] default to match_all if query is not given

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
 import org.elasticsearch.xpack.core.dataframe.transform.DataFrameIndexerTransformStats;
@@ -46,8 +45,7 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
 
     @Override
     protected void onStartJob(long now) {
-        QueryConfig queryConfig = getConfig().getQueryConfig();
-        QueryBuilder queryBuilder = queryConfig != null ? queryConfig.getQuery() : new MatchAllQueryBuilder();
+        QueryBuilder queryBuilder = getConfig().getQueryConfig().getQuery();
 
         pivot = new Pivot(getConfig().getSource(), queryBuilder, getConfig().getPivotConfig());
     }

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/QueryConfigTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/QueryConfigTests.java
@@ -101,6 +101,36 @@ public class QueryConfigTests extends AbstractSerializingDataFrameTestCase<Query
         }
     }
 
+    public void testFailOnEmptyQuery() throws IOException {
+        String source = "";
+
+        // lenient, passes but reports invalid
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
+            QueryConfig query = QueryConfig.fromXContent(parser, true);
+            assertFalse(query.isValid());
+        }
+
+        // strict throws
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
+            expectThrows(IllegalArgumentException.class, () -> QueryConfig.fromXContent(parser, false));
+        }
+    }
+
+    public void testFailOnEmptyQueryClause() throws IOException {
+        String source = "{}";
+
+        // lenient, passes but reports invalid
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
+            QueryConfig query = QueryConfig.fromXContent(parser, true);
+            assertFalse(query.isValid());
+        }
+
+        // strict throws
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
+            expectThrows(IllegalArgumentException.class, () -> QueryConfig.fromXContent(parser, false));
+        }
+    }
+
     public void testDeprecation() throws IOException {
         String source = "{\"" + MockDeprecatedQueryBuilder.NAME + "\" : {}}";
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {


### PR DESCRIPTION
this adds a default "match_all" query to make query support more visible