### PR TITLE
Correctly disable tests for FIPS JVMs Port to 6.7

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexRestClientSslTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexRestClientSslTests.java
@@ -144,7 +144,7 @@ public class ReindexRestClientSslTests extends ESTestCase {
     }
 
     public void testClientSucceedsWithVerificationDisabled() throws IOException {
-        assertFalse("Cannot disable verification in FIPS JVM", inFipsJvm());
+        assumeFalse("Cannot disable verification in FIPS JVM", inFipsJvm());
         final List<Thread> threads = new ArrayList<>();
         final Settings settings = Settings.builder()
             .put("path.home", createTempDir())


### PR DESCRIPTION
Replace assertFalse with assumeFalse

resolves #38212.

backport of #38214.