### PR TITLE
Do not recommend installing vagrant-winrm

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -385,12 +385,6 @@ Unfortunately we're not able to provide boxes for them in open source use
 because of licensing issues. Any Virtualbox image that has WinRM and Powershell
 enabled for remote users should work.
 
-Testing on Windows requires the https://github.com/criteo/vagrant-winrm[vagrant-winrm] plugin.
-
-------------------------------------
-vagrant plugin install vagrant-winrm
-------------------------------------
-
 Specify the image IDs of the Windows boxes to gradle with the following project
 properties. They can be set in `~/.gradle/gradle.properties` like
 


### PR DESCRIPTION
I am getting a warning that vagrant winrm plugin is no longer required as it is shipped with vagrant. Removing the suggestion from TESTING.asciidoc to have it
```
WARNING: Vagrant has detected the `vagrant-winrm` plugin. Vagrant ships with
WinRM support builtin and no longer requires the `vagrant-winrm` plugin. To
prevent unexpected errors please uninstall the `vagrant-winrm` plugin using
the command shown below:

  vagrant plugin uninstall vagrant-winrm
```

my vagrant version
```
vagrant --version
Vagrant 2.1.4
```
plugins version I had
```
ninstalling the 'vagrant-winrm' plugin...
Successfully uninstalled vagrant-winrm-0.7.0
Successfully uninstalled minitar-0.8
```
