### PR TITLE
Fix NPE on Stale Index in IndicesService

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -874,6 +874,9 @@ public class IndicesService extends AbstractLifecycleComponent
             final IndexMetaData metaData;
             try {
                 metaData = metaStateService.loadIndexState(index);
+                if (metaData == null) {
+                    throw new IllegalStateException("Index state does not exist.");
+                }
             } catch (Exception e) {
                 logger.warn(() -> new ParameterizedMessage("[{}] failed to load state file from a stale deleted index, " +
                     "folders will be left on disk", index), e);

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -875,7 +875,7 @@ public class IndicesService extends AbstractLifecycleComponent
             try {
                 metaData = metaStateService.loadIndexState(index);
                 if (metaData == null) {
-                    throw new IllegalStateException("Index state does not exist.");
+                    return null;
                 }
             } catch (Exception e) {
                 logger.warn(() -> new ParameterizedMessage("[{}] failed to load state file from a stale deleted index, " +


### PR DESCRIPTION
* We should treat a `null` return for the metadata as equal to an error and break out 
  * Added the check at this level even though it required nested `throw` because adding it further downstream would impact other functionality
* We should probably still try and find a cleaner solution that doesn't cause us to have to retry file deletions when deleting eventually, but this should stabilize things for now (was able to reproduce and confirm the fix for #38845 manually) 
* Closes #38845

