### PR TITLE
[SearchRequest] Changing the constructor

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -125,7 +125,7 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
     /**
      * Constructs a new search request against the provided indices with the given search source.
      */
-    public SearchRequest(String[] indices, SearchSourceBuilder source) {
+    public SearchRequest(String... indices, SearchSourceBuilder source) {
         this();
         if (source == null) {
             throw new IllegalArgumentException("source must not be null");


### PR DESCRIPTION
When instantiating SearchRequest, you can not set String and SearchSourceBuilder as a set.
But I can set String only.
So I modified it.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
