### PR TITLE
SQL: fall back to using the field name for column label (#38842)

### DIFF
--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcResultSetMetaData.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcResultSetMetaData.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static java.lang.String.format;
+import static org.elasticsearch.xpack.sql.client.StringUtils.EMPTY;
 
 class JdbcResultSetMetaData implements ResultSetMetaData, JdbcWrapper {
 
@@ -72,7 +73,8 @@ class JdbcResultSetMetaData implements ResultSetMetaData, JdbcWrapper {
 
     @Override
     public String getColumnLabel(int column) throws SQLException {
-        return column(column).label;
+        ColumnInfo info = column(column);
+        return true == EMPTY.equals(info.label) ? info.name : info.label;
     }
 
     @Override

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/net/protocol/ColumnInfo.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/net/protocol/ColumnInfo.java
@@ -8,7 +8,10 @@ package org.elasticsearch.xpack.sql.jdbc.net.protocol;
 import java.sql.SQLType;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.sql.client.StringUtils.EMPTY;
+
 public class ColumnInfo {
+
     public final String catalog;
     public final String schema;
     public final String table;
@@ -53,17 +56,17 @@ public class ColumnInfo {
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder();
-        if (false == "".equals(table)) {
+        if (false == EMPTY.equals(table)) {
             b.append(table).append('.');
         }
         b.append(name).append("<type=[").append(type).append(']');
-        if (false == "".equals(catalog)) {
+        if (false == EMPTY.equals(catalog)) {
             b.append(" catalog=[").append(catalog).append(']');
         }
-        if (false == "".equals(schema)) {
+        if (false == EMPTY.equals(schema)) {
             b.append(" schema=[").append(schema).append(']');
         }
-        if (false == "".equals(label)) {
+        if (false == EMPTY.equals(label)) {
             b.append(" label=[").append(label).append(']');
         }
         return b.append('>').toString();

--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcResultSetMetaDataTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/jdbc/JdbcResultSetMetaDataTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.jdbc.jdbc;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.jdbc.net.protocol.ColumnInfo;
+
+import java.sql.JDBCType;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.elasticsearch.xpack.sql.client.StringUtils.EMPTY;
+
+public class JdbcResultSetMetaDataTests extends ESTestCase {
+    
+    private final List<ColumnInfo> columns = Arrays.asList(
+                new ColumnInfo("test_keyword", JDBCType.VARCHAR, EMPTY, EMPTY, EMPTY, EMPTY, 0),
+                new ColumnInfo("test_integer", JDBCType.INTEGER, EMPTY, EMPTY, EMPTY, EMPTY, 11),
+                new ColumnInfo("test_double", JDBCType.DOUBLE, EMPTY, EMPTY, EMPTY, EMPTY, 25),
+                new ColumnInfo("test_long", JDBCType.BIGINT, "test_table", "test", "schema", "custom_label", 20)
+            );
+    private final JdbcResultSetMetaData metaData = new JdbcResultSetMetaData(null, columns);
+
+    public void testColumnsProperties() throws SQLException {
+        int maxColumnIndex = columns.size();
+        assertEquals(false, metaData.isAutoIncrement(randomIntBetween(1, maxColumnIndex)));
+        assertEquals(true, metaData.isCaseSensitive(randomIntBetween(1, maxColumnIndex)));
+        assertEquals(true, metaData.isSearchable(randomIntBetween(1, maxColumnIndex)));
+        assertEquals(false, metaData.isCurrency(randomIntBetween(1, maxColumnIndex)));
+        assertEquals(ResultSetMetaData.columnNullableUnknown, metaData.isNullable(randomIntBetween(1, maxColumnIndex)));
+        assertEquals(false, metaData.isSigned(1));
+        assertEquals(true, metaData.isSigned(2));
+        assertEquals(true, metaData.isSigned(3));
+        assertEquals(true, metaData.isSigned(4));
+    }
+    
+    public void testColumnNamesAndLabels() throws SQLException {
+        assertEquals("test_keyword", metaData.getColumnName(1));
+        assertEquals("test_integer", metaData.getColumnName(2));
+        assertEquals("test_double", metaData.getColumnName(3));
+        assertEquals("test_long", metaData.getColumnName(4));
+        
+        assertEquals("test_keyword", metaData.getColumnLabel(1));
+        assertEquals("test_integer", metaData.getColumnLabel(2));
+        assertEquals("test_double", metaData.getColumnLabel(3));
+        assertEquals("custom_label", metaData.getColumnLabel(4));
+    }
+}

--- a/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcResultSetMetaDataIT.java
+++ b/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcResultSetMetaDataIT.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.qa.single_node;
+
+import org.elasticsearch.xpack.sql.qa.jdbc.ResultSetMetaDataTestCase;
+
+public class JdbcResultSetMetaDataIT extends ResultSetMetaDataTestCase {
+
+}

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetMetaDataTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetMetaDataTestCase.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.qa.jdbc;
+
+import org.elasticsearch.common.CheckedConsumer;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+public class ResultSetMetaDataTestCase extends JdbcIntegrationTestCase {
+    
+    private final String[] fieldsNames = new String[] {"test_byte", "test_integer", "test_long", "test_short",
+            "test_double", "test_float", "test_keyword", "test_boolean", "test_date"};
+    
+    public void testValidGetObjectCalls() throws Exception {
+        ResultSetTestCase.createIndex("test");
+        ResultSetTestCase.updateMapping("test", builder -> {
+            for(String field : fieldsNames) {
+                builder.startObject(field).field("type", field.substring(5)).endObject();
+            }
+        });
+        
+        String q = "SELECT test_byte, test_integer, test_long, test_short, test_double, test_float, test_keyword, "
+                + "test_boolean, test_date FROM test";
+        doWithQuery(q, (r) -> assertColumnNamesAndLabels(r.getMetaData(), fieldsNames));
+
+        q = "SELECT test_byte AS b, test_integer AS i, test_long AS l, test_short AS s, test_double AS d, test_float AS f, "
+                + "test_keyword AS k, test_boolean AS bool, test_date AS dt FROM test";
+        doWithQuery(q, (r) -> assertColumnNamesAndLabels(r.getMetaData(), new String[] {"b", "i", "l", "s", "d", "f", "k", "bool", "dt"}));
+    }
+    
+    private void doWithQuery(String query, CheckedConsumer<ResultSet, SQLException> consumer) throws SQLException {
+        try (Connection connection = esJdbc()) {
+            try (PreparedStatement statement = connection.prepareStatement(query)) {
+                try (ResultSet results = statement.executeQuery()) {
+                    assertEquals(fieldsNames.length, results.getMetaData().getColumnCount());
+                    consumer.accept(results);
+                }
+            }
+        }
+    }
+    
+    private void assertColumnNamesAndLabels(ResultSetMetaData metaData, String[] names) throws SQLException {
+        for(int i = 0; i < fieldsNames.length; i++) {
+            assertEquals(names[i], metaData.getColumnName(i + 1));
+            assertEquals(names[i], metaData.getColumnLabel(i + 1));
+        }
+    }
+}

--- a/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/ResultSetTestCase.java
+++ b/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/ResultSetTestCase.java
@@ -1261,7 +1261,7 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
         }
     }
     
-    private void createIndex(String index) throws Exception {
+    protected static void createIndex(String index) throws Exception {
         Request request = new Request("PUT", "/" + index);
         XContentBuilder createIndex = JsonXContent.contentBuilder().startObject();
         createIndex.startObject("settings");
@@ -1285,7 +1285,7 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
         client().performRequest(request);
     }
 
-    private void updateMapping(String index, CheckedConsumer<XContentBuilder, IOException> body) throws Exception {
+    protected static void updateMapping(String index, CheckedConsumer<XContentBuilder, IOException> body) throws Exception {
         Request request = new Request("PUT", "/" + index + "/_mapping/doc");
         XContentBuilder updateMapping = JsonXContent.contentBuilder().startObject();
         updateMapping.startObject("properties");
@@ -1463,7 +1463,7 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
         return map;
     }
 
-    private void updateMappingForNumericValuesTests(String indexName) throws Exception {
+    private static void updateMappingForNumericValuesTests(String indexName) throws Exception {
         updateMapping(indexName, builder -> {
             for(String field : fieldsNames) {
                 builder.startObject(field).field("type", field.substring(5)).endObject();


### PR DESCRIPTION
(cherry picked from commit 0567bf24957be477e7649cff94872b0e7dc4d284)

This is backport PR for 6.5 branch since there are significant changes between 6.5 and 6.6+, for the https://github.com/elastic/elasticsearch/pull/38842 PR:
- ColumnInfo has a different name and location in 6.6+
- EsType doesn't exist in 6.5
- there is one package name that is different