### PR TITLE
SQL: Reintroduce column-based Page utility

### DIFF
--- a/x-pack/plugin/sql/sql-proto/build.gradle
+++ b/x-pack/plugin/sql/sql-proto/build.gradle
@@ -7,6 +7,45 @@ apply plugin: 'elasticsearch.build'
 description = 'Request and response objects shared by the cli, jdbc ' +
         'and the Elasticsearch plugin'
 
+// we want to keep the JDKs in our IDEs set to JDK 8 until minimum JDK is bumped to 9 so we do not include this source set in our IDEs
+if (!isEclipse && !isIdea) {
+  sourceSets {
+    java9 {
+      java {
+        srcDirs = ['src/main/java9']
+      }
+    }
+  }
+  
+  configurations {
+    java9Compile.extendsFrom(compile)
+  }
+  
+  dependencies {
+    java9Compile sourceSets.main.output
+  }
+
+  compileJava9Java {
+    sourceCompatibility = 9
+    targetCompatibility = 9
+  }
+
+  forbiddenApisJava9 {
+    if (project.runtimeJavaVersion < JavaVersion.VERSION_1_9) {
+      targetCompatibility = JavaVersion.VERSION_1_9.getMajorVersion()
+    }
+  }
+
+  jar {
+    metaInf {
+      into 'versions/9'
+      from sourceSets.java9.output
+    }
+    manifest.attributes('Multi-Release': 'true')
+  }
+}
+
+
 dependencies {
     compile (project(':libs:core')) {
         transitive = false
@@ -16,6 +55,11 @@ dependencies {
     }
     compile "joda-time:joda-time:${versions.joda}"
     runtime "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+    
+    if (!isEclipse && !isIdea) {
+      java9Compile sourceSets.main.output
+    }
+
 
     testCompile "org.elasticsearch.test:framework:${version}"
 }

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/Page.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/Page.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.proto;
+
+import java.lang.reflect.Array;
+import java.util.List;
+
+// Stores a page of data in a columnar-format since:
+// * the structure does not change
+// * array allocation can be quite efficient
+// * array can be reallocated (as the pages have the same size)
+
+// c1 c1 c1
+// c2 c2 c2 ...
+public class Page {
+
+    private static final Page EMPTY = new Page(0, new Object[0][0]);
+    // logical limit
+    private int rows;
+
+    private final Object[][] data;
+
+    private Page(int rows, Object[][] data) {
+        this.rows = rows;
+        this.data = data;
+    }
+
+    void resize(int newLength) {
+        if (data.length < 1) {
+            return;
+        }
+
+        // resize only when needed
+        // the array is kept around so check its length not the logical limit
+        if (newLength > data[0].length) {
+            for (int i = 0; i < data.length; i++) {
+                data[i] = (Object[]) Array.newInstance(data[i].getClass().getComponentType(), newLength);
+            }
+        }
+        rows = newLength;
+    }
+
+    public int rows() {
+        return rows;
+    }
+
+    Object[] column(int index) {
+        Utils.checkIndex(index, data.length);
+        return data[index];
+    }
+
+    public Object entry(int row, int column) {
+        Utils.checkIndex(row, rows);
+        return column(column)[row];
+    }
+
+    static Page of(List<Class<?>> types, int dataSize) {
+        if (types == null || types.isEmpty()) {
+            return EMPTY;
+        }
+
+        Object[][] data = new Object[types.size()][];
+
+        for (int i = 0; i < types.size(); i++) {
+            data[i] = (Object[]) Array.newInstance(types.get(i), dataSize);
+        }
+
+        return new Page(dataSize, data);
+    }
+}

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/Utils.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/Utils.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.proto;
+
+import java.util.Locale;
+
+import static java.lang.String.format;
+
+class Utils {
+
+    static void checkIndex(int index, int length) {
+        if (index < 0 || index >= length) {
+            throw new IndexOutOfBoundsException(format(Locale.ROOT, "Index out of range:  %d (max is %d)", index, length - 1));
+        }
+    }
+}

--- a/x-pack/plugin/sql/sql-proto/src/main/java9/org/elasticsearch/xpack/sql/proto/Utils.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java9/org/elasticsearch/xpack/sql/proto/Utils.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.proto;
+
+import java.util.Objects;
+
+class Utils {
+
+    static void checkIndex(int index, int length) {
+        return Objects.checkIndex(index, length);
+    }
+}


### PR DESCRIPTION
Send the data internally in columnar format (which maps to arrays)
instead of a row based approach to save on data compaction especially
when dealing with primitives

Close #37998

However having a columnar format might make sense for the internal serialization as well which needs to be backwards compatible. Hence why this issue is currently WIP.