### PR TITLE
Adjust BWC version for token/API key service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,8 +160,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/38687" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
@@ -80,8 +80,10 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
         out.writeMap(realmsUsage);
         out.writeMap(rolesStoreUsage);
         out.writeMap(sslUsage);
-        out.writeMap(tokenServiceUsage);
-        out.writeMap(apiKeyServiceUsage);
+        if (out.getVersion().onOrAfter(Version.V_7_1_0)) {
+            out.writeMap(tokenServiceUsage);
+            out.writeMap(apiKeyServiceUsage);
+        }
         out.writeMap(auditUsage);
         out.writeMap(ipFilterUsage);
         if (out.getVersion().before(Version.V_6_0_0_beta1)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
@@ -43,7 +43,7 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
         realmsUsage = in.readMap();
         rolesStoreUsage = in.readMap();
         sslUsage = in.readMap();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO change the version to V_7_1_0 on backporting
+        if (in.getVersion().onOrAfter(Version.V_7_1_0)) {
             tokenServiceUsage = in.readMap();
             apiKeyServiceUsage = in.readMap();
         }


### PR DESCRIPTION
This commit adjusts the BWC version for the token/API key service enabled status flag that was added to security feature set usage.

Relates #38687
