### PR TITLE
Fix writing of SecurityFeatureSetUsage to pre-7.1

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
@@ -80,8 +80,10 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
         out.writeMap(realmsUsage);
         out.writeMap(rolesStoreUsage);
         out.writeMap(sslUsage);
-        out.writeMap(tokenServiceUsage);
-        out.writeMap(apiKeyServiceUsage);
+        if (out.getVersion().onOrAfter(Version.V_7_1_0)) {
+            out.writeMap(tokenServiceUsage);
+            out.writeMap(apiKeyServiceUsage);
+        }
         out.writeMap(auditUsage);
         out.writeMap(ipFilterUsage);
         if (out.getVersion().before(Version.V_6_0_0_beta1)) {


### PR DESCRIPTION
This change makes the writing of new usage data conditional based on
the version that is being written to. A test has also been added to
ensure serialization works as expected to an older version.

Relates #38687, #38917