### PR TITLE
Introduce a parameter suppress_types_warnings.

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -70,6 +70,16 @@ public abstract class BaseRestHandler implements RestHandler {
     public static final String INCLUDE_TYPE_NAME_PARAMETER = "include_type_name";
     public static final boolean DEFAULT_INCLUDE_TYPE_NAME_POLICY = false;
 
+    /**
+     * An undocumented parameter that when specified, causes types warnings to be skipped.
+     * It can be provided to put index template and create index requests, and defaults to false.
+     *
+     * This 'backdoor' parameter was introduced to prevent internal products from triggering
+     * types warnings, which makes the deprecation logs much less useful for others developing
+     * against elasticsearch. It will be removed as soon as possible.
+     */
+    public static final String SUPPRESS_TYPES_WARNINGS_PARAMETER = "suppress_types_warnings";
+
     protected BaseRestHandler(Settings settings) {
         // TODO drop settings from ctor
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
@@ -59,7 +59,8 @@ public class RestCreateIndexAction extends BaseRestHandler {
         final boolean includeTypeName = request.paramAsBoolean(INCLUDE_TYPE_NAME_PARAMETER,
             DEFAULT_INCLUDE_TYPE_NAME_POLICY);
 
-        if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER)) {
+        if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER)
+                && request.paramAsBoolean(SUPPRESS_TYPES_WARNINGS_PARAMETER, false) == false) {
             deprecationLogger.deprecatedAndMaybeLog("create_index_with_types", TYPES_DEPRECATION_MESSAGE);
         }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
@@ -60,7 +60,8 @@ public class RestPutIndexTemplateAction extends BaseRestHandler {
         boolean includeTypeName = request.paramAsBoolean(INCLUDE_TYPE_NAME_PARAMETER, DEFAULT_INCLUDE_TYPE_NAME_POLICY);
 
         PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest(request.param("name"));
-        if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER)) {
+        if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER)
+                && request.paramAsBoolean(SUPPRESS_TYPES_WARNINGS_PARAMETER, false) == false) {
             deprecationLogger.deprecatedAndMaybeLog("put_index_template_with_types", TYPES_DEPRECATION_MESSAGE);
         }
         if (request.hasParam("template")) {

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexActionTests.java
@@ -31,10 +31,12 @@ import org.elasticsearch.test.rest.RestActionTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
+import static org.elasticsearch.rest.BaseRestHandler.SUPPRESS_TYPES_WARNINGS_PARAMETER;
 import static org.mockito.Mockito.mock;
 
 public class RestCreateIndexActionTests extends RestActionTestCase {
@@ -62,6 +64,21 @@ public class RestCreateIndexActionTests extends RestActionTestCase {
             .withPath("/some_index")
             .build();
         action.prepareRequest(validRequest, mock(NodeClient.class));
+    }
+
+    public void testSuppressTypesWarnings() throws IOException {
+        for (String includeTypeNameValue :Arrays.asList("true", "false")){
+            Map<String, String> params = new HashMap<>();
+            params.put(INCLUDE_TYPE_NAME_PARAMETER, includeTypeNameValue);
+            params.put(SUPPRESS_TYPES_WARNINGS_PARAMETER, "true");
+
+            RestRequest deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
+                .withMethod(RestRequest.Method.PUT)
+                .withPath("/some_index")
+                .withParams(params)
+                .build();
+            action.prepareRequest(deprecatedRequest, mock(NodeClient.class));
+        }
     }
 
     public void testPrepareTypelessRequest() throws IOException {

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateActionTests.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
+import static org.elasticsearch.rest.BaseRestHandler.SUPPRESS_TYPES_WARNINGS_PARAMETER;
 import static org.mockito.Mockito.mock;
 
 public class RestPutIndexTemplateActionTests extends RestActionTestCase {
@@ -70,5 +71,31 @@ public class RestPutIndexTemplateActionTests extends RestActionTestCase {
                 .build();
         action.prepareRequest(request, mock(NodeClient.class));        
         assertWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE);
+    }
+
+    public void testSuppressTypesWarnings() throws IOException {
+       XContentBuilder content = XContentFactory.jsonBuilder().startObject()
+            .startObject("mappings")
+                .startObject("properties")
+                    .startObject("field1").field("type", "keyword").endObject()
+                    .startObject("field2").field("type", "text").endObject()
+                .endObject()
+            .endObject()
+            .startObject("aliases")
+                .startObject("read_alias").endObject()
+            .endObject()
+        .endObject();
+
+        Map<String, String> params = new HashMap<>();
+        params.put(INCLUDE_TYPE_NAME_PARAMETER, "false");
+        params.put(SUPPRESS_TYPES_WARNINGS_PARAMETER, "true");
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.PUT)
+            .withParams(params)
+            .withPath("/_template/_some_template")
+            .withContent(BytesReference.bytes(content), XContentType.JSON)
+            .build();
+
+        action.prepareRequest(request, mock(NodeClient.class));
     }
 }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResource.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResource.java
@@ -18,12 +18,14 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
+import static org.elasticsearch.rest.BaseRestHandler.SUPPRESS_TYPES_WARNINGS_PARAMETER;
 
 /**
  * {@code TemplateHttpResource}s allow the checking and uploading of templates to a remote cluster.
@@ -87,7 +89,10 @@ public class TemplateHttpResource extends PublishableHttpResource {
      */
     @Override
     protected void doPublish(final RestClient client, final ActionListener<Boolean> listener) {
-        Map<String, String> parameters = Collections.singletonMap(INCLUDE_TYPE_NAME_PARAMETER, "true");
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
+        parameters.put(SUPPRESS_TYPES_WARNINGS_PARAMETER, "true");
+
         putResource(client, listener, logger,
                     "/_template", templateName, parameters, this::templateToHttpEntity, "monitoring template",
                     resourceOwnerName, "monitoring cluster");

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/AbstractPublishableHttpResourceTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/AbstractPublishableHttpResourceTestCase.java
@@ -32,6 +32,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
+import static org.elasticsearch.rest.BaseRestHandler.SUPPRESS_TYPES_WARNINGS_PARAMETER;
 import static org.elasticsearch.xpack.monitoring.exporter.http.AsyncHttpResourceHelper.mockBooleanActionListener;
 import static org.elasticsearch.xpack.monitoring.exporter.http.AsyncHttpResourceHelper.whenPerformRequestAsyncWith;
 import static org.elasticsearch.xpack.monitoring.exporter.http.PublishableHttpResource.GET_DOES_NOT_EXIST;
@@ -225,6 +226,9 @@ public abstract class AbstractPublishableHttpResourceTestCase extends ESTestCase
 
         if (parameters.containsKey(INCLUDE_TYPE_NAME_PARAMETER)) {
             assertThat(parameters.remove(INCLUDE_TYPE_NAME_PARAMETER), is("true"));
+        }
+        if (parameters.containsKey(SUPPRESS_TYPES_WARNINGS_PARAMETER)) {
+            assertThat(parameters.remove(SUPPRESS_TYPES_WARNINGS_PARAMETER), is("true"));
         }
 
         assertThat(parameters.isEmpty(), is(true));

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
@@ -61,6 +61,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
+import static org.elasticsearch.rest.BaseRestHandler.SUPPRESS_TYPES_WARNINGS_PARAMETER;
 import static org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils.LAST_UPDATED_VERSION;
 import static org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils.TEMPLATE_VERSION;
 import static org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils.indexName;
@@ -288,8 +289,12 @@ public class HttpExporterIT extends MonitoringIntegTestCase {
                     recordedRequest = secondWebServer.takeRequest();
                     assertThat(recordedRequest.getMethod(), equalTo("PUT"));
                     assertThat(recordedRequest.getUri().getPath(), equalTo(resourcePrefix + template.v1()));
-                    final Map<String, String> parameters = Collections.singletonMap(INCLUDE_TYPE_NAME_PARAMETER, "true");
+
+                    Map<String, String> parameters = new HashMap<>();
+                    parameters.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
+                    parameters.put(SUPPRESS_TYPES_WARNINGS_PARAMETER, "true");
                     assertMonitorVersionQueryString(recordedRequest.getUri().getQuery(), parameters);
+
                     assertThat(recordedRequest.getBody(), equalTo(template.v2()));
                 }
             }
@@ -474,10 +479,14 @@ public class HttpExporterIT extends MonitoringIntegTestCase {
 
                 assertThat(putRequest.getMethod(), equalTo("PUT"));
                 assertThat(putRequest.getUri().getPath(), equalTo(pathPrefix + resourcePrefix + resource.v1()));
-                Map<String, String> parameters = resourcePrefix.startsWith("/_template")
-                    ? Collections.singletonMap(INCLUDE_TYPE_NAME_PARAMETER, "true")
-                    : Collections.emptyMap();
+
+                Map<String, String> parameters = new HashMap<>();
+                if (resourcePrefix.startsWith("/_template")) {
+                    parameters.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
+                    parameters.put(SUPPRESS_TYPES_WARNINGS_PARAMETER, "true");
+                }
                 assertMonitorVersionQueryString(putRequest.getUri().getQuery(), parameters);
+
                 assertThat(putRequest.getBody(), equalTo(resource.v2()));
                 assertHeaders(putRequest, customHeaders);
             }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResourceTests.java
@@ -13,11 +13,12 @@ import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
+import static org.elasticsearch.rest.BaseRestHandler.SUPPRESS_TYPES_WARNINGS_PARAMETER;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -80,12 +81,16 @@ public class TemplateHttpResourceTests extends AbstractPublishableHttpResourceTe
     }
 
     public void testDoPublishTrue() {
-        Map<String, String> parameters = Collections.singletonMap(INCLUDE_TYPE_NAME_PARAMETER, "true");
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
+        parameters.put(SUPPRESS_TYPES_WARNINGS_PARAMETER, "true");
         assertPublishSucceeds(resource, "/_template", templateName, parameters, StringEntity.class);
     }
 
     public void testDoPublishFalseWithException() {
-        Map<String, String> parameters = Collections.singletonMap(INCLUDE_TYPE_NAME_PARAMETER, "true");
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
+        parameters.put(SUPPRESS_TYPES_WARNINGS_PARAMETER, "true");
         assertPublishWithException(resource, "/_template", templateName, parameters, StringEntity.class);
     }
 


### PR DESCRIPTION
**Work in progress, putting this up for internal discussion.**

This undocumented parameter can be provided to 'put template' and 'create index'
requests, and will cause types warnings to be skipped even when
`include_type_name` has been specified.