### PR TITLE
[Monitoring] Remove `include_type_name` parameter from GET _template request 

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/ClusterAlertHttpResource.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/ClusterAlertHttpResource.java
@@ -105,7 +105,7 @@ public class ClusterAlertHttpResource extends PublishableHttpResource {
     @Override
     protected void doPublish(final RestClient client, final ActionListener<Boolean> listener) {
         putResource(client, listener, logger,
-                    "/_watcher/watch", watchId.get(), this::watchToHttpEntity, "monitoring cluster alert",
+                    "/_watcher/watch", watchId.get(), Collections.emptyMap(), this::watchToHttpEntity, "monitoring cluster alert",
                     resourceOwnerName, "monitoring cluster");
     }
 

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/PipelineHttpResource.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/PipelineHttpResource.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils;
 
+import java.util.Collections;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -72,7 +73,7 @@ public class PipelineHttpResource extends PublishableHttpResource {
     @Override
     protected void doPublish(final RestClient client, final ActionListener<Boolean> listener) {
         putResource(client, listener, logger,
-                    "/_ingest/pipeline", pipelineName, this::pipelineToHttpEntity, "monitoring pipeline",
+                    "/_ingest/pipeline", pipelineName, Collections.emptyMap(), this::pipelineToHttpEntity, "monitoring pipeline",
                     resourceOwnerName, "monitoring cluster");
     }
 

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResource.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResource.java
@@ -70,7 +70,7 @@ public abstract class PublishableHttpResource extends HttpResource {
     /**
      * The default parameters to use for any request.
      */
-    protected final Map<String, String> parameters;
+    protected final Map<String, String> defaultParameters;
 
     /**
      * Create a new {@link PublishableHttpResource} that {@linkplain #isDirty() is dirty}.
@@ -102,9 +102,9 @@ public abstract class PublishableHttpResource extends HttpResource {
             parameters.putAll(baseParameters);
             parameters.put("master_timeout", masterTimeout.toString());
 
-            this.parameters = Collections.unmodifiableMap(parameters);
+            this.defaultParameters = Collections.unmodifiableMap(parameters);
         } else {
-            this.parameters = baseParameters;
+            this.defaultParameters = baseParameters;
         }
     }
 
@@ -113,8 +113,8 @@ public abstract class PublishableHttpResource extends HttpResource {
      *
      * @return Never {@code null}.
      */
-    public Map<String, String> getParameters() {
-        return parameters;
+    public Map<String, String> getDefaultParameters() {
+        return defaultParameters;
     }
 
     /**
@@ -221,7 +221,8 @@ public abstract class PublishableHttpResource extends HttpResource {
         logger.trace("checking if {} [{}] exists on the [{}] {}", resourceType, resourceName, resourceOwnerName, resourceOwnerType);
 
         final Request request = new Request("GET", resourceBasePath + "/" + resourceName);
-        addParameters(request);
+        addDefaultParameters(request);
+
         // avoid exists and DNE parameters from being an exception by default
         final Set<Integer> expectedResponseCodes = Sets.union(exists, doesNotExist);
         request.addParameter("ignore", expectedResponseCodes.stream().map(i -> i.toString()).collect(Collectors.joining(",")));
@@ -299,6 +300,7 @@ public abstract class PublishableHttpResource extends HttpResource {
      * @param logger The logger to use for status messages.
      * @param resourceBasePath The base path/endpoint to check for the resource (e.g., "/_template").
      * @param resourceName The name of the resource (e.g., "template123").
+     * @param parameters Map of query string parameters, if any.
      * @param body The {@link HttpEntity} that makes up the body of the request.
      * @param resourceType The type of resource (e.g., "monitoring template").
      * @param resourceOwnerName The user-recognizeable resource owner.
@@ -309,6 +311,7 @@ public abstract class PublishableHttpResource extends HttpResource {
                                final Logger logger,
                                final String resourceBasePath,
                                final String resourceName,
+                               final Map<String, String> parameters,
                                final java.util.function.Supplier<HttpEntity> body,
                                final String resourceType,
                                final String resourceOwnerName,
@@ -317,7 +320,8 @@ public abstract class PublishableHttpResource extends HttpResource {
 
 
         final Request request = new Request("PUT", resourceBasePath + "/" + resourceName);
-        addParameters(request);
+        addDefaultParameters(request);
+        addParameters(request, parameters);
         request.setEntity(body.get());
 
         client.performRequestAsync(request, new ResponseListener() {
@@ -376,9 +380,9 @@ public abstract class PublishableHttpResource extends HttpResource {
         logger.trace("deleting {} [{}] from the [{}] {}", resourceType, resourceName, resourceOwnerName, resourceOwnerType);
 
         final Request request = new Request("DELETE", resourceBasePath + "/" + resourceName);
-        addParameters(request);
+        addDefaultParameters(request);
 
-        if (false == parameters.containsKey("ignore")) {
+        if (false == defaultParameters.containsKey("ignore")) {
             // avoid 404 being an exception by default
             request.addParameter("ignore", Integer.toString(RestStatus.NOT_FOUND.getStatus()));
         }
@@ -463,7 +467,11 @@ public abstract class PublishableHttpResource extends HttpResource {
         return true;
     }
 
-    private void addParameters(final Request request) {
+    private void addDefaultParameters(final Request request) {
+        this.addParameters(request, defaultParameters);
+    }
+
+    private void addParameters(final Request request, final Map<String, String> parameters) {
         for (final Map.Entry<String, String> param : parameters.entrySet()) {
             request.addParameter(param.getKey(), param.getValue());
         }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResource.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResource.java
@@ -41,7 +41,6 @@ public class TemplateHttpResource extends PublishableHttpResource {
     static {
         Map<String, String> parameters = new TreeMap<>();
         parameters.put("filter_path", FILTER_PATH_RESOURCE_VERSION);
-        parameters.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
         PARAMETERS = Collections.unmodifiableMap(parameters);
     }
 
@@ -88,8 +87,9 @@ public class TemplateHttpResource extends PublishableHttpResource {
      */
     @Override
     protected void doPublish(final RestClient client, final ActionListener<Boolean> listener) {
+        Map<String, String> parameters = Collections.singletonMap(INCLUDE_TYPE_NAME_PARAMETER, "true");
         putResource(client, listener, logger,
-                    "/_template", templateName, this::templateToHttpEntity, "monitoring template",
+                    "/_template", templateName, parameters, this::templateToHttpEntity, "monitoring template",
                     resourceOwnerName, "monitoring cluster");
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/AbstractPublishableHttpResourceTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/AbstractPublishableHttpResourceTestCase.java
@@ -27,6 +27,7 @@ import org.mockito.ArgumentCaptor;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -81,7 +82,7 @@ public abstract class AbstractPublishableHttpResourceTestCase extends ESTestCase
      */
     protected void assertCheckWithException(final PublishableHttpResource resource,
                                             final String resourceBasePath, final String resourceName) {
-        assertCheckWithException(resource, getParameters(resource.getParameters()), resourceBasePath, resourceName);
+        assertCheckWithException(resource, getParameters(resource.getDefaultParameters()), resourceBasePath, resourceName);
     }
 
     /**
@@ -140,7 +141,7 @@ public abstract class AbstractPublishableHttpResourceTestCase extends ESTestCase
         final Exception e = randomFrom(new IOException("expected"), new RuntimeException("expected"), responseException);
 
         final Request request = new Request("DELETE", endpoint);
-        addParameters(request, deleteParameters(resource.getParameters()));
+        addParameters(request, deleteParameters(resource.getDefaultParameters()));
         whenPerformRequestAsyncWith(client, request, e);
 
         resource.doCheck(client, listener);
@@ -155,11 +156,13 @@ public abstract class AbstractPublishableHttpResourceTestCase extends ESTestCase
      * @param resource The resource to execute.
      * @param resourceBasePath The base endpoint (e.g., "/_template")
      * @param resourceName The resource name (e.g., the template or pipeline name).
+     * @param parameters Map of query string parameters, if any.
      * @param bodyType The request body provider's type.
      */
     protected void assertPublishSucceeds(final PublishableHttpResource resource, final String resourceBasePath, final String resourceName,
+                                         Map<String, String> parameters,
                                          final Class<? extends HttpEntity> bodyType) {
-        doPublishWithStatusCode(resource, resourceBasePath, resourceName, bodyType, successfulPublishStatus(), true);
+        doPublishWithStatusCode(resource, resourceBasePath, resourceName, parameters, bodyType, successfulPublishStatus(), true);
     }
 
     /**
@@ -168,10 +171,12 @@ public abstract class AbstractPublishableHttpResourceTestCase extends ESTestCase
      *
      * @param resource The resource to execute.
      * @param resourceBasePath The base endpoint (e.g., "/_template")
+     * @param parameters Map of query string parameters, if any.
      * @param resourceName The resource name (e.g., the template or pipeline name).
      */
     protected void assertPublishWithException(final PublishableHttpResource resource,
                                               final String resourceBasePath, final String resourceName,
+                                              Map<String, String> parameters,
                                               final Class<? extends HttpEntity> bodyType) {
         final String endpoint = concatenateEndpoint(resourceBasePath, resourceName);
         final Exception e = randomFrom(new IOException("expected"), new RuntimeException("expected"));
@@ -182,16 +187,20 @@ public abstract class AbstractPublishableHttpResourceTestCase extends ESTestCase
 
         verifyListener(null);
 
+        Map <String, String> allParameters = new HashMap<>();
+        allParameters.putAll(resource.getDefaultParameters());
+        allParameters.putAll(parameters);
+
         final ArgumentCaptor<Request> request = ArgumentCaptor.forClass(Request.class);
         verify(client).performRequestAsync(request.capture(), any(ResponseListener.class));
         assertThat(request.getValue().getMethod(), is("PUT"));
         assertThat(request.getValue().getEndpoint(), is(endpoint));
-        assertThat(request.getValue().getParameters(), is(resource.getParameters()));
+        assertThat(request.getValue().getParameters(), is(allParameters));
         assertThat(request.getValue().getEntity(), instanceOf(bodyType));
     }
 
     protected void assertParameters(final PublishableHttpResource resource) {
-        final Map<String, String> parameters = new HashMap<>(resource.getParameters());
+        final Map<String, String> parameters = new HashMap<>(resource.getDefaultParameters());
 
         if (masterTimeout != null && TimeValue.MINUS_ONE.equals(masterTimeout) == false) {
             assertThat(parameters.remove("master_timeout"), is(masterTimeout.toString()));
@@ -204,7 +213,7 @@ public abstract class AbstractPublishableHttpResourceTestCase extends ESTestCase
     }
 
     protected void assertVersionParameters(final PublishableHttpResource resource) {
-        final Map<String, String> parameters = new HashMap<>(resource.getParameters());
+        final Map<String, String> parameters = new HashMap<>(resource.getDefaultParameters());
 
         if (masterTimeout != null && TimeValue.MINUS_ONE.equals(masterTimeout) == false) {
             assertThat(parameters.remove("master_timeout"), is(masterTimeout.toString()));
@@ -244,7 +253,7 @@ public abstract class AbstractPublishableHttpResourceTestCase extends ESTestCase
         final String endpoint = concatenateEndpoint(resourceBasePath, resourceName);
         final Response response = response("GET", endpoint, status, entity);
 
-        doCheckWithStatusCode(resource, getParameters(resource.getParameters(), exists, doesNotExist), endpoint, expected, response);
+        doCheckWithStatusCode(resource, getParameters(resource.getDefaultParameters(), exists, doesNotExist), endpoint, expected, response);
     }
 
     protected void doCheckWithStatusCode(final PublishableHttpResource resource, final Map<String, String> expectedParameters,
@@ -262,6 +271,7 @@ public abstract class AbstractPublishableHttpResourceTestCase extends ESTestCase
     }
 
     private void doPublishWithStatusCode(final PublishableHttpResource resource, final String resourceBasePath, final String resourceName,
+                                         Map<String, String> parameters,
                                          final Class<? extends HttpEntity> bodyType,
                                          final RestStatus status,
                                          final boolean errorFree) {
@@ -277,9 +287,13 @@ public abstract class AbstractPublishableHttpResourceTestCase extends ESTestCase
         final ArgumentCaptor<Request> request = ArgumentCaptor.forClass(Request.class);
         verify(client).performRequestAsync(request.capture(), any(ResponseListener.class));
 
+        Map <String, String> allParameters = new HashMap<>();
+        allParameters.putAll(resource.getDefaultParameters());
+        allParameters.putAll(parameters);
+
         assertThat(request.getValue().getMethod(), is("PUT"));
         assertThat(request.getValue().getEndpoint(), is(endpoint));
-        assertThat(request.getValue().getParameters(), is(resource.getParameters()));
+        assertThat(request.getValue().getParameters(), is(allParameters));
         assertThat(request.getValue().getEntity(), instanceOf(bodyType));
     }
 
@@ -297,7 +311,7 @@ public abstract class AbstractPublishableHttpResourceTestCase extends ESTestCase
                                                  final String endpoint, final Boolean expected,
                                                  final Response response) {
         final Request request = new Request("DELETE", endpoint);
-        addParameters(request, deleteParameters(resource.getParameters()));
+        addParameters(request, deleteParameters(resource.getDefaultParameters()));
         whenPerformRequestAsyncWith(client, request, response);
 
         resource.doCheck(client, listener);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/ClusterAlertHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/ClusterAlertHttpResourceTests.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.monitoring.exporter.http;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.http.HttpEntity;
@@ -127,11 +128,11 @@ public class ClusterAlertHttpResourceTests extends AbstractPublishableHttpResour
     }
 
     public void testDoPublishTrue() throws IOException {
-        assertPublishSucceeds(resource, "/_watcher/watch", watchId, StringEntity.class);
+        assertPublishSucceeds(resource, "/_watcher/watch", watchId, Collections.emptyMap(), StringEntity.class);
     }
 
     public void testDoPublishFalseWithException() throws IOException {
-        assertPublishWithException(resource, "/_watcher/watch", watchId, StringEntity.class);
+        assertPublishWithException(resource, "/_watcher/watch", watchId, Collections.emptyMap(), StringEntity.class);
     }
 
     public void testShouldReplaceClusterAlertRethrowsIOException() throws IOException {
@@ -181,7 +182,7 @@ public class ClusterAlertHttpResourceTests extends AbstractPublishableHttpResour
     }
 
     public void testParameters() {
-        final Map<String, String> parameters = new HashMap<>(resource.getParameters());
+        final Map<String, String> parameters = new HashMap<>(resource.getDefaultParameters());
 
         assertThat(parameters.remove("filter_path"), is("metadata.xpack.version_created"));
         assertThat(parameters.isEmpty(), is(true));

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.rest.RestUtils;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.http.MockRequest;
@@ -281,13 +282,14 @@ public class HttpExporterIT extends MonitoringIntegTestCase {
                 MockRequest recordedRequest = secondWebServer.takeRequest();
                 assertThat(recordedRequest.getMethod(), equalTo("GET"));
                 assertThat(recordedRequest.getUri().getPath(), equalTo(resourcePrefix + template.v1()));
-                assertMonitorVersionQueryString(resourcePrefix, recordedRequest.getUri().getQuery());
+                assertMonitorVersionQueryString(recordedRequest.getUri().getQuery(), Collections.emptyMap());
 
                 if (missingTemplate.equals(template.v1())) {
                     recordedRequest = secondWebServer.takeRequest();
                     assertThat(recordedRequest.getMethod(), equalTo("PUT"));
                     assertThat(recordedRequest.getUri().getPath(), equalTo(resourcePrefix + template.v1()));
-                    assertMonitorVersionQueryString(resourcePrefix, recordedRequest.getUri().getQuery());
+                    final Map<String, String> parameters = Collections.singletonMap(INCLUDE_TYPE_NAME_PARAMETER, "true");
+                    assertMonitorVersionQueryString(recordedRequest.getUri().getQuery(), parameters);
                     assertThat(recordedRequest.getBody(), equalTo(template.v2()));
                 }
             }
@@ -464,7 +466,7 @@ public class HttpExporterIT extends MonitoringIntegTestCase {
 
             assertThat(getRequest.getMethod(), equalTo("GET"));
             assertThat(getRequest.getUri().getPath(), equalTo(pathPrefix + resourcePrefix + resource.v1()));
-            assertMonitorVersionQueryString(resourcePrefix, getRequest.getUri().getQuery());
+            assertMonitorVersionQueryString(getRequest.getUri().getQuery(), Collections.emptyMap());
             assertHeaders(getRequest, customHeaders);
 
             if (alreadyExists == false) {
@@ -472,19 +474,28 @@ public class HttpExporterIT extends MonitoringIntegTestCase {
 
                 assertThat(putRequest.getMethod(), equalTo("PUT"));
                 assertThat(putRequest.getUri().getPath(), equalTo(pathPrefix + resourcePrefix + resource.v1()));
-                assertMonitorVersionQueryString(resourcePrefix, getRequest.getUri().getQuery());
+                Map<String, String> parameters = resourcePrefix.startsWith("/_template")
+                    ? Collections.singletonMap(INCLUDE_TYPE_NAME_PARAMETER, "true")
+                    : Collections.emptyMap();
+                assertMonitorVersionQueryString(putRequest.getUri().getQuery(), parameters);
                 assertThat(putRequest.getBody(), equalTo(resource.v2()));
                 assertHeaders(putRequest, customHeaders);
             }
         }
     }
 
-    private void assertMonitorVersionQueryString(String resourcePrefix, String query) {
-        if (resourcePrefix.startsWith("/_template")) {
-            assertThat(query, equalTo(INCLUDE_TYPE_NAME_PARAMETER + "=true&" + resourceVersionQueryString()));
-        } else {
-            assertThat(query, equalTo(resourceVersionQueryString()));
-        }
+    private void assertMonitorVersionQueryString(String query, final Map<String, String> parameters) {
+        Map<String, String> expectedQueryStringMap = new HashMap<>();
+        RestUtils.decodeQueryString(query, 0, expectedQueryStringMap);
+
+        Map<String, String> resourceVersionQueryStringMap = new HashMap<>();
+        RestUtils.decodeQueryString(resourceVersionQueryString(), 0, resourceVersionQueryStringMap);
+
+        Map<String, String> actualQueryStringMap = new HashMap<>();
+        actualQueryStringMap.putAll(resourceVersionQueryStringMap);
+        actualQueryStringMap.putAll(parameters);
+
+        assertEquals(expectedQueryStringMap, actualQueryStringMap);
     }
 
     private void assertMonitorWatches(final MockWebServer webServer,

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
@@ -545,7 +545,7 @@ public class HttpExporterTests extends ESTestCase {
         if (timeout != null) {
             for (final HttpResource resource : resources) {
                 if (resource instanceof PublishableHttpResource) {
-                    assertEquals(timeout.getStringRep(), ((PublishableHttpResource) resource).getParameters().get("master_timeout"));
+                    assertEquals(timeout.getStringRep(), ((PublishableHttpResource) resource).getDefaultParameters().get("master_timeout"));
                 }
             }
         }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/PipelineHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/PipelineHttpResourceTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.is;
@@ -77,11 +78,11 @@ public class PipelineHttpResourceTests extends AbstractPublishableHttpResourceTe
     }
 
     public void testDoPublishTrue() {
-        assertPublishSucceeds(resource, "/_ingest/pipeline", pipelineName, ByteArrayEntity.class);
+        assertPublishSucceeds(resource, "/_ingest/pipeline", pipelineName, Collections.emptyMap(), ByteArrayEntity.class);
     }
 
     public void testDoPublishFalseWithException() {
-        assertPublishWithException(resource, "/_ingest/pipeline", pipelineName, ByteArrayEntity.class);
+        assertPublishWithException(resource, "/_ingest/pipeline", pipelineName, Collections.emptyMap(), ByteArrayEntity.class);
     }
 
     public void testParameters() {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResourceTests.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.monitoring.exporter.http;
 
+import java.util.Collections;
 import java.util.Map;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
@@ -66,7 +67,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
         final RestStatus failedStatus = failedCheckStatus();
         final Response response = response("GET", endpoint, failedStatus);
         final Request request = new Request("GET", endpoint);
-        addParameters(request, getParameters(resource.getParameters()));
+        addParameters(request, getParameters(resource.getDefaultParameters()));
 
         whenPerformRequestAsyncWith(client, request, response);
 
@@ -102,7 +103,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
         final XContent xContent = mock(XContent.class);
         final int minimumVersion = randomInt();
         final Request request = new Request("GET", endpoint);
-        addParameters(request, getParameters(resource.getParameters()));
+        addParameters(request, getParameters(resource.getDefaultParameters()));
 
         whenPerformRequestAsyncWith(client, request, response);
 
@@ -126,7 +127,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
         final Response response = response("GET", endpoint, okStatus, entity);
         final XContent xContent = mock(XContent.class);
         final Request request = new Request("GET", endpoint);
-        addParameters(request, getParameters(resource.getParameters()));
+        addParameters(request, getParameters(resource.getDefaultParameters()));
 
         whenPerformRequestAsyncWith(client, request, response);
 
@@ -151,7 +152,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
         final Response response = e == responseException ? responseException.getResponse() : null;
 
         final Request request = new Request("GET", endpoint);
-        addParameters(request, getParameters(resource.getParameters()));
+        addParameters(request, getParameters(resource.getDefaultParameters()));
 
         whenPerformRequestAsyncWith(client, request, e);
 
@@ -176,12 +177,13 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
         final String endpoint = concatenateEndpoint(resourceBasePath, resourceName);
         final Exception e = randomFrom(new IOException("expected"), new RuntimeException("expected"));
         final Request request = new Request("PUT", endpoint);
-        addParameters(request, resource.getParameters());
+        addParameters(request, resource.getDefaultParameters());
         request.setEntity(entity);
 
         whenPerformRequestAsyncWith(client, request, e);
 
-        resource.putResource(client, listener, logger, resourceBasePath, resourceName, body, resourceType, owner, ownerType);
+        final Map<String, String> parameters = Collections.emptyMap();
+        resource.putResource(client, listener, logger, resourceBasePath, resourceName, parameters, body, resourceType, owner, ownerType);
 
         verifyListener(null);
 
@@ -207,7 +209,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
         final RestStatus failedStatus = failedCheckStatus();
         final ResponseException responseException = responseException("DELETE", endpoint, failedStatus);
         final Exception e = randomFrom(new IOException("expected"), new RuntimeException("expected"), responseException);
-        final Map<String, String> deleteParameters = deleteParameters(resource.getParameters());
+        final Map<String, String> deleteParameters = deleteParameters(resource.getDefaultParameters());
         final Request request = new Request("DELETE", endpoint);
         addParameters(request, deleteParameters);
 
@@ -304,7 +306,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
         final String endpoint = concatenateEndpoint(resourceBasePath, resourceName);
         final Response response = response("GET", endpoint, status);
         final Request request = new Request("GET", endpoint);
-        addParameters(request, getParameters(resource.getParameters()));
+        addParameters(request, getParameters(resource.getDefaultParameters()));
 
         whenPerformRequestAsyncWith(client, request, response);
 
@@ -337,7 +339,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
         final Response response = response("GET", endpoint, status, entity);
         final XContent xContent = XContentType.JSON.xContent();
         final Request request = new Request("GET", endpoint);
-        addParameters(request, getParameters(resource.getParameters()));
+        addParameters(request, getParameters(resource.getDefaultParameters()));
 
         whenPerformRequestAsyncWith(client, request, response);
 
@@ -370,12 +372,13 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
         final String endpoint = concatenateEndpoint(resourceBasePath, resourceName);
         final Response response = response("PUT", endpoint, status);
         final Request request = new Request("PUT", endpoint);
-        addParameters(request, resource.getParameters());
+        addParameters(request, resource.getDefaultParameters());
         request.setEntity(entity);
 
         whenPerformRequestAsyncWith(client, request, response);
 
-        resource.putResource(client, listener, logger, resourceBasePath, resourceName, body, resourceType, owner, ownerType);
+        final Map<String, String> parameters = Collections.emptyMap();
+        resource.putResource(client, listener, logger, resourceBasePath, resourceName, parameters, body, resourceType, owner, ownerType);
 
         verifyListener(errorFree ? true : null);
         verify(client).performRequestAsync(eq(request), any(ResponseListener.class));
@@ -431,7 +434,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
     private void assertDeleteResource(final RestStatus status, final boolean expected) {
         final String endpoint = concatenateEndpoint(resourceBasePath, resourceName);
         final Response response = response("DELETE", endpoint, status);
-        final Map<String, String> deleteParameters = deleteParameters(resource.getParameters());
+        final Map<String, String> deleteParameters = deleteParameters(resource.getDefaultParameters());
         final Request request = new Request("DELETE", endpoint);
         addParameters(request, deleteParameters);
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResourceTests.java
@@ -13,8 +13,11 @@ import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -77,11 +80,13 @@ public class TemplateHttpResourceTests extends AbstractPublishableHttpResourceTe
     }
 
     public void testDoPublishTrue() {
-        assertPublishSucceeds(resource, "/_template", templateName, StringEntity.class);
+        Map<String, String> parameters = Collections.singletonMap(INCLUDE_TYPE_NAME_PARAMETER, "true");
+        assertPublishSucceeds(resource, "/_template", templateName, parameters, StringEntity.class);
     }
 
     public void testDoPublishFalseWithException() {
-        assertPublishWithException(resource, "/_template", templateName, StringEntity.class);
+        Map<String, String> parameters = Collections.singletonMap(INCLUDE_TYPE_NAME_PARAMETER, "true");
+        assertPublishWithException(resource, "/_template", templateName, parameters, StringEntity.class);
     }
 
     public void testParameters() {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/WatcherExistsHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/WatcherExistsHttpResourceTests.java
@@ -35,7 +35,7 @@ public class WatcherExistsHttpResourceTests extends AbstractPublishableHttpResou
     private final MultiHttpResource watches = mock(MultiHttpResource.class);
 
     private final WatcherExistsHttpResource resource = new WatcherExistsHttpResource(owner, clusterService, watches);
-    private final Map<String, String> expectedParameters = getParameters(resource.getParameters(), GET_EXISTS, XPACK_DOES_NOT_EXIST);
+    private final Map<String, String> expectedParameters = getParameters(resource.getDefaultParameters(), GET_EXISTS, XPACK_DOES_NOT_EXIST);
 
     public void testDoCheckIgnoresClientWhenNotElectedMaster() {
         whenNotElectedMaster();
@@ -175,7 +175,7 @@ public class WatcherExistsHttpResourceTests extends AbstractPublishableHttpResou
     }
 
     public void testParameters() {
-        final Map<String, String> parameters = resource.getParameters();
+        final Map<String, String> parameters = resource.getDefaultParameters();
 
         assertThat(parameters.get("filter_path"), is(WatcherExistsHttpResource.WATCHER_CHECK_PARAMETERS.get("filter_path")));
 


### PR DESCRIPTION
Backport of #38818 to `7.0`. Original description:

The HTTP exporter code in the Monitoring plugin makes `GET _template` requests to check for existence of templates. These requests don't need to pass the `include_type_name` query parameter so this PR removes it from the request. This should remove the following deprecation log entries on the Monitoring cluster in 7.0.0 onwards:

```
[types removal] Specifying include_type_name in get index template requests is deprecated.
```