### PR TITLE
Specify include_type_name in HTTP monitoring.

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResource.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResource.java
@@ -17,8 +17,13 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
+
+import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
 
 /**
  * {@code TemplateHttpResource}s allow the checking and uploading of templates to a remote cluster.
@@ -30,6 +35,15 @@ import java.util.function.Supplier;
 public class TemplateHttpResource extends PublishableHttpResource {
 
     private static final Logger logger = LogManager.getLogger(TemplateHttpResource.class);
+
+    private static final Map<String, String> PARAMETERS;
+
+    static {
+        Map<String, String> parameters = new HashMap<>(
+            PublishableHttpResource.RESOURCE_VERSION_PARAMETERS);
+        parameters.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
+        PARAMETERS = Collections.unmodifiableMap(parameters);
+    }
 
     /**
      * The name of the template that is sent to the remote cluster.
@@ -50,7 +64,7 @@ public class TemplateHttpResource extends PublishableHttpResource {
      */
     public TemplateHttpResource(final String resourceOwnerName, @Nullable final TimeValue masterTimeout,
                                 final String templateName, final Supplier<String> template) {
-        super(resourceOwnerName, masterTimeout, PublishableHttpResource.RESOURCE_VERSION_PARAMETERS);
+        super(resourceOwnerName, masterTimeout, PARAMETERS);
 
         this.templateName = Objects.requireNonNull(templateName);
         this.template = Objects.requireNonNull(template);

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResource.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResource.java
@@ -13,12 +13,11 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -36,14 +35,10 @@ public class TemplateHttpResource extends PublishableHttpResource {
 
     private static final Logger logger = LogManager.getLogger(TemplateHttpResource.class);
 
-    private static final Map<String, String> PARAMETERS;
-
-    static {
-        Map<String, String> parameters = new HashMap<>(
-            PublishableHttpResource.RESOURCE_VERSION_PARAMETERS);
-        parameters.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
-        PARAMETERS = Collections.unmodifiableMap(parameters);
-    }
+    private static final Map<String, String> PARAMETERS = MapBuilder.<String, String>newMapBuilder()
+            .putAll(PublishableHttpResource.RESOURCE_VERSION_PARAMETERS)
+            .put(INCLUDE_TYPE_NAME_PARAMETER, "true")
+            .immutableMap();
 
     /**
      * The name of the template that is sent to the remote cluster.

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/AbstractPublishableHttpResourceTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/AbstractPublishableHttpResourceTestCase.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
 import static org.elasticsearch.xpack.monitoring.exporter.http.AsyncHttpResourceHelper.mockBooleanActionListener;
 import static org.elasticsearch.xpack.monitoring.exporter.http.AsyncHttpResourceHelper.whenPerformRequestAsyncWith;
 import static org.elasticsearch.xpack.monitoring.exporter.http.PublishableHttpResource.GET_DOES_NOT_EXIST;
@@ -212,6 +213,11 @@ public abstract class AbstractPublishableHttpResourceTestCase extends ESTestCase
         }
 
         assertThat(parameters.remove("filter_path"), is("*.version"));
+
+        if (parameters.containsKey(INCLUDE_TYPE_NAME_PARAMETER)) {
+            assertThat(parameters.remove(INCLUDE_TYPE_NAME_PARAMETER), is("true"));
+        }
+
         assertThat(parameters.isEmpty(), is(true));
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
@@ -58,6 +58,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
 import static org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils.LAST_UPDATED_VERSION;
 import static org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils.TEMPLATE_VERSION;
 import static org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils.indexName;
@@ -274,18 +275,19 @@ public class HttpExporterIT extends MonitoringIntegTestCase {
 
             assertMonitorVersion(secondWebServer);
 
+            String resourcePrefix = "/_template/";
             for (Tuple<String, String> template : monitoringTemplates(includeOldTemplates)) {
                 MockRequest recordedRequest = secondWebServer.takeRequest();
                 assertThat(recordedRequest.getMethod(), equalTo("GET"));
-                assertThat(recordedRequest.getUri().getPath(), equalTo("/_template/" + template.v1()));
-                assertThat(recordedRequest.getUri().getQuery(), equalTo(resourceVersionQueryString()));
+                assertThat(recordedRequest.getUri().getPath(), equalTo(resourcePrefix + template.v1()));
+                assertMonitorVersionQueryString(resourcePrefix, recordedRequest.getUri().getQuery());
 
                 if (missingTemplate.equals(template.v1())) {
                     recordedRequest = secondWebServer.takeRequest();
                     assertThat(recordedRequest.getMethod(), equalTo("PUT"));
                     assertThat(recordedRequest.getUri().getPath(), equalTo("/_template/" + template.v1()));
-                    assertThat(recordedRequest.getUri().getQuery(), equalTo(resourceVersionQueryString()));
-                    assertThat(recordedRequest.getBody(), equalTo(template.v2()));
+                    assertThat(recordedRequest.getUri().getPath(), equalTo(resourcePrefix + template.v1()));
+                    assertMonitorVersionQueryString(resourcePrefix, recordedRequest.getUri().getQuery());
                 }
             }
             assertMonitorPipelines(secondWebServer, !pipelineExistsAlready, null, null);
@@ -458,7 +460,7 @@ public class HttpExporterIT extends MonitoringIntegTestCase {
 
             assertThat(getRequest.getMethod(), equalTo("GET"));
             assertThat(getRequest.getUri().getPath(), equalTo(pathPrefix + resourcePrefix + resource.v1()));
-            assertThat(getRequest.getUri().getQuery(), equalTo(resourceVersionQueryString()));
+            assertMonitorVersionQueryString(resourcePrefix, getRequest.getUri().getQuery());
             assertHeaders(getRequest, customHeaders);
 
             if (alreadyExists == false) {
@@ -466,10 +468,18 @@ public class HttpExporterIT extends MonitoringIntegTestCase {
 
                 assertThat(putRequest.getMethod(), equalTo("PUT"));
                 assertThat(putRequest.getUri().getPath(), equalTo(pathPrefix + resourcePrefix + resource.v1()));
-                assertThat(putRequest.getUri().getQuery(), equalTo(resourceVersionQueryString()));
+                assertMonitorVersionQueryString(resourcePrefix, getRequest.getUri().getQuery());
                 assertThat(putRequest.getBody(), equalTo(resource.v2()));
                 assertHeaders(putRequest, customHeaders);
             }
+        }
+    }
+
+    private void assertMonitorVersionQueryString(String resourcePrefix, String query) {
+        if (resourcePrefix.startsWith("/_template")) {
+            assertThat(query, equalTo(INCLUDE_TYPE_NAME_PARAMETER + "=true&" + resourceVersionQueryString()));
+        } else {
+            assertThat(query, equalTo(resourceVersionQueryString()));
         }
     }
 


### PR DESCRIPTION
In 6.7, `include_type_name` must be specified in order to avoid deprecation
warnings. Here we make sure to use `include_type_name` when setting up templates
for the monitoring HTTP exporter.

Addresses #37442.