### PR TITLE
[FEATURE][ML] User config appropriate permission checks on creating/running analytics

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalysisConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalysisConfig.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -27,14 +28,14 @@ public class DataFrameAnalysisConfig implements ToXContentObject, Writeable {
     private final Map<String, Object> config;
 
     public DataFrameAnalysisConfig(Map<String, Object> config) {
-        this.config = Objects.requireNonNull(config);
+        this.config = Collections.unmodifiableMap(Objects.requireNonNull(config));
         if (config.size() != 1) {
             throw ExceptionsHelper.badRequestException("A data frame analysis must specify exactly one analysis type");
         }
     }
 
     public DataFrameAnalysisConfig(DataFrameAnalysisConfig config) {
-        this.config = new HashMap<>(config.config);
+        this(new HashMap<>(config.config));
     }
 
     public DataFrameAnalysisConfig(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalysisConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalysisConfig.java
@@ -28,18 +28,14 @@ public class DataFrameAnalysisConfig implements ToXContentObject, Writeable {
     private final Map<String, Object> config;
 
     public DataFrameAnalysisConfig(Map<String, Object> config) {
-        this.config = Collections.unmodifiableMap(Objects.requireNonNull(config));
+        this.config = Collections.unmodifiableMap(new HashMap<>(Objects.requireNonNull(config)));
         if (config.size() != 1) {
             throw ExceptionsHelper.badRequestException("A data frame analysis must specify exactly one analysis type");
         }
     }
 
-    public DataFrameAnalysisConfig(DataFrameAnalysisConfig config) {
-        this(new HashMap<>(config.config));
-    }
-
     public DataFrameAnalysisConfig(StreamInput in) throws IOException {
-        config = in.readMap();
+        config = Collections.unmodifiableMap(in.readMap());
     }
 
     public Map<String, Object> asMap() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalysisConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalysisConfig.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -30,6 +31,10 @@ public class DataFrameAnalysisConfig implements ToXContentObject, Writeable {
         if (config.size() != 1) {
             throw ExceptionsHelper.badRequestException("A data frame analysis must specify exactly one analysis type");
         }
+    }
+
+    public DataFrameAnalysisConfig(DataFrameAnalysisConfig config) {
+        this.config = new HashMap<>(config.config);
     }
 
     public DataFrameAnalysisConfig(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -80,7 +80,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         parser.declareObject((builder, query) -> builder.setQuery(query, ignoreUnknownFields), (p, c) -> p.mapOrdered(), QUERY);
         if (ignoreUnknownFields) {
             // Headers are not parsed by the strict (config) parser, so headers supplied in the _body_ of a REST request will be rejected.
-            // (For config, headers are explicitly transferred from the auth headers by code in the put/update datafeed actions.)
+            // (For config, headers are explicitly transferred from the auth headers by code in the put data frame actions.)
             parser.declareObject(Builder::setHeaders, (p, c) -> p.mapStrings(), HEADERS);
         }
         return parser;
@@ -236,7 +236,10 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
             this.id = config.id;
             this.source = config.source;
             this.dest = config.dest;
-            this.analyses = new ArrayList<>(config.analyses);
+
+            List<DataFrameAnalysisConfig> configs = new ArrayList<>(config.analyses.size());
+            config.analyses.forEach(c -> configs.add(new DataFrameAnalysisConfig(c)));
+            this.analyses = configs;
             this.query = new LinkedHashMap<>(config.query);
             this.headers = new HashMap<>(config.headers);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -236,10 +236,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
             this.id = config.id;
             this.source = config.source;
             this.dest = config.dest;
-
-            List<DataFrameAnalysisConfig> configs = new ArrayList<>(config.analyses.size());
-            config.analyses.forEach(c -> configs.add(new DataFrameAnalysisConfig(c)));
-            this.analyses = configs;
+            this.analyses = new ArrayList<>(config.analyses);
             this.query = new LinkedHashMap<>(config.query);
             this.headers = new HashMap<>(config.headers);
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigTests.java
@@ -7,12 +7,16 @@ package org.elasticsearch.xpack.core.ml.dataframe;
 
 import com.carrotsearch.randomizedtesting.generators.CodepointSetGenerator;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -21,13 +25,18 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -61,6 +70,10 @@ public class DataFrameAnalyticsConfigTests extends AbstractSerializingTestCase<D
     }
 
     public static DataFrameAnalyticsConfig createRandom(String id) {
+        return createRandomBuilder(id).build();
+    }
+
+    public static DataFrameAnalyticsConfig.Builder createRandomBuilder(String id) {
         String source = randomAlphaOfLength(10);
         String dest = randomAlphaOfLength(10);
         List<DataFrameAnalysisConfig> analyses = Collections.singletonList(DataFrameAnalysisConfigTests.randomConfig());
@@ -74,7 +87,7 @@ public class DataFrameAnalyticsConfigTests extends AbstractSerializingTestCase<D
                 Collections.singletonMap(TermQueryBuilder.NAME,
                     Collections.singletonMap(randomAlphaOfLength(10), randomAlphaOfLength(10))), true);
         }
-        return builder.build();
+        return builder;
     }
 
     public static String randomValidId() {
@@ -140,6 +153,33 @@ public class DataFrameAnalyticsConfigTests extends AbstractSerializingTestCase<D
                 () -> DataFrameAnalyticsConfig.STRICT_PARSER.apply(parser, null).build());
             assertEquals("[6:64] [data_frame_analytics_config] failed to parse field [query]", e.getMessage());
         }
+    }
+
+    public void testToXContentForInternalStorage() throws IOException {
+        DataFrameAnalyticsConfig.Builder builder = createRandomBuilder("foo");
+
+        // headers are only persisted to cluster state
+        Map<String, String> headers = new HashMap<>();
+        headers.put("header-name", "header-value");
+        builder.setHeaders(headers);
+        DataFrameAnalyticsConfig config = builder.build();
+
+        ToXContent.MapParams params = new ToXContent.MapParams(Collections.singletonMap(ToXContentParams.FOR_INTERNAL_STORAGE, "true"));
+
+        BytesReference forClusterstateXContent = XContentHelper.toXContent(config, XContentType.JSON, params, false);
+        XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+            .createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, forClusterstateXContent.streamInput());
+
+        DataFrameAnalyticsConfig parsedConfig = DataFrameAnalyticsConfig.LENIENT_PARSER.apply(parser, null).build();
+        assertThat(parsedConfig.getHeaders(), hasEntry("header-name", "header-value"));
+
+        // headers are not written without the FOR_INTERNAL_STORAGE param
+        BytesReference nonClusterstateXContent = XContentHelper.toXContent(config, XContentType.JSON, ToXContent.EMPTY_PARAMS, false);
+        parser = XContentFactory.xContent(XContentType.JSON)
+            .createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, nonClusterstateXContent.streamInput());
+
+        parsedConfig = DataFrameAnalyticsConfig.LENIENT_PARSER.apply(parser, null).build();
+        assertThat(parsedConfig.getHeaders().entrySet(), hasSize(0));
     }
 
     public void testGetQueryDeprecations() {

--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -35,6 +35,7 @@ integTestRunner {
     'ml/datafeeds_crud/Test put datafeed with invalid query',
     'ml/datafeeds_crud/Test put datafeed with security headers in the body',
     'ml/datafeeds_crud/Test update datafeed with missing id',
+    'ml/data_frame_analytics_crud/Test put config with security headers in the body',
     'ml/data_frame_analytics_crud/Test put config with inconsistent body/param ids',
     'ml/data_frame_analytics_crud/Test put config with invalid id',
     'ml/data_frame_analytics_crud/Test put config with unknown top level field',

--- a/x-pack/plugin/ml/qa/ml-with-security/roles.yml
+++ b/x-pack/plugin/ml/qa/ml-with-security/roles.yml
@@ -11,7 +11,7 @@ minimal:
       privileges:
         - indices:admin/create
         - indices:admin/refresh
-        - indices:data/read/field_caps
-        - indices:data/read/search
+        - read
+        - index
         - indices:data/write/bulk
         - indices:data/write/index

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
@@ -6,8 +6,6 @@
 package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.index.IndexAction;
-import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.Client;
@@ -71,18 +69,16 @@ public class TransportPutDataFrameAnalyticsAction
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
             return;
         }
-        
         validateConfig(request.getConfig());
         if (licenseState.isAuthAllowed()) {
             final String username = securityContext.getUser().principal();
             RoleDescriptor.IndicesPrivileges sourceIndexPrivileges = RoleDescriptor.IndicesPrivileges.builder()
                 .indices(request.getConfig().getSource())
-                .privileges(SearchAction.NAME)
+                .privileges("read")
                 .build();
             RoleDescriptor.IndicesPrivileges destIndexPrivileges = RoleDescriptor.IndicesPrivileges.builder()
                 .indices(request.getConfig().getDest())
-                 // CreateIndexAction.NAME is more expansive than and create_index, in this instance we want at least create_index.
-                .privileges(SearchAction.NAME, IndexAction.NAME, "create_index")
+                .privileges("read", "index", "create_index")
                 .build();
 
             HasPrivilegesRequest privRequest = new HasPrivilegesRequest();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
 import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.support.ActionFilters;
@@ -82,7 +81,8 @@ public class TransportPutDataFrameAnalyticsAction
                 .build();
             RoleDescriptor.IndicesPrivileges destIndexPrivileges = RoleDescriptor.IndicesPrivileges.builder()
                 .indices(request.getConfig().getDest())
-                .privileges(SearchAction.NAME, IndexAction.NAME, CreateIndexAction.NAME)
+                 // CreateIndexAction.NAME is more expansive than and create_index, in this instance we want at least create_index.
+                .privileges(SearchAction.NAME, IndexAction.NAME, "create_index")
                 .build();
 
             HasPrivilegesRequest privRequest = new HasPrivilegesRequest();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
@@ -6,22 +6,40 @@
 package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
+import org.elasticsearch.action.index.IndexAction;
+import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ml.action.PutDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.ml.utils.MlStrings;
+import org.elasticsearch.xpack.core.security.SecurityContext;
+import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesAction;
+import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesRequest;
+import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.core.security.authz.permission.ResourcePrivileges;
+import org.elasticsearch.xpack.core.security.support.Exceptions;
 import org.elasticsearch.xpack.ml.dataframe.analyses.DataFrameAnalysesUtils;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
 
+import java.io.IOException;
 import java.util.function.Supplier;
 
 public class TransportPutDataFrameAnalyticsAction
@@ -29,14 +47,22 @@ public class TransportPutDataFrameAnalyticsAction
 
     private final XPackLicenseState licenseState;
     private final DataFrameAnalyticsConfigProvider configProvider;
+    private final ThreadPool threadPool;
+    private final SecurityContext securityContext;
+    private final Client client;
 
     @Inject
-    public TransportPutDataFrameAnalyticsAction(TransportService transportService, ActionFilters actionFilters,
-                                                XPackLicenseState licenseState, DataFrameAnalyticsConfigProvider configProvider) {
+    public TransportPutDataFrameAnalyticsAction(Settings settings, TransportService transportService, ActionFilters actionFilters,
+                                                XPackLicenseState licenseState, Client client, ThreadPool threadPool,
+                                                DataFrameAnalyticsConfigProvider configProvider) {
         super(PutDataFrameAnalyticsAction.NAME, transportService, actionFilters,
             (Supplier<PutDataFrameAnalyticsAction.Request>) PutDataFrameAnalyticsAction.Request::new);
         this.licenseState = licenseState;
         this.configProvider = configProvider;
+        this.threadPool = threadPool;
+        this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings) ?
+            new SecurityContext(settings, threadPool.getThreadContext()) : null;
+        this.client = client;
     }
 
     @Override
@@ -46,12 +72,59 @@ public class TransportPutDataFrameAnalyticsAction
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
             return;
         }
-
+        
         validateConfig(request.getConfig());
-        configProvider.put(request.getConfig(), ActionListener.wrap(
-            indexResponse -> listener.onResponse(new PutDataFrameAnalyticsAction.Response(request.getConfig())),
-            listener::onFailure
-        ));
+        if (licenseState.isAuthAllowed()) {
+            final String username = securityContext.getUser().principal();
+            RoleDescriptor.IndicesPrivileges sourceIndexPrivileges = RoleDescriptor.IndicesPrivileges.builder()
+                .indices(request.getConfig().getSource())
+                .privileges(SearchAction.NAME)
+                .build();
+            RoleDescriptor.IndicesPrivileges destIndexPrivileges = RoleDescriptor.IndicesPrivileges.builder()
+                .indices(request.getConfig().getDest())
+                .privileges(SearchAction.NAME, IndexAction.NAME, CreateIndexAction.NAME)
+                .build();
+
+            HasPrivilegesRequest privRequest = new HasPrivilegesRequest();
+            privRequest.applicationPrivileges(new RoleDescriptor.ApplicationResourcePrivileges[0]);
+            privRequest.username(username);
+            privRequest.clusterPrivileges(Strings.EMPTY_ARRAY);
+            privRequest.indexPrivileges(sourceIndexPrivileges, destIndexPrivileges);
+
+            ActionListener<HasPrivilegesResponse> privResponseListener = ActionListener.wrap(
+                r -> handlePrivsResponse(username, request, r, listener),
+                listener::onFailure);
+
+            client.execute(HasPrivilegesAction.INSTANCE, privRequest, privResponseListener);
+        } else {
+            configProvider.put(request.getConfig(), threadPool.getThreadContext().getHeaders(), ActionListener.wrap(
+                indexResponse -> listener.onResponse(new PutDataFrameAnalyticsAction.Response(request.getConfig())),
+                listener::onFailure
+            ));
+        }
+    }
+
+    private void handlePrivsResponse(String username, PutDataFrameAnalyticsAction.Request request,
+                                     HasPrivilegesResponse response,
+                                     ActionListener<PutDataFrameAnalyticsAction.Response> listener) throws IOException {
+        if (response.isCompleteMatch()) {
+            configProvider.put(request.getConfig(), threadPool.getThreadContext().getHeaders(), ActionListener.wrap(
+                indexResponse -> listener.onResponse(new PutDataFrameAnalyticsAction.Response(request.getConfig())),
+                listener::onFailure
+            ));
+        } else {
+            XContentBuilder builder = JsonXContent.contentBuilder();
+            builder.startObject();
+            for (ResourcePrivileges index : response.getIndexPrivileges()) {
+                builder.field(index.getResource());
+                builder.map(index.getPrivileges());
+            }
+            builder.endObject();
+
+            listener.onFailure(Exceptions.authorizationError("Cannot create data frame analytics [{}]" +
+                    " because user {} lacks permissions on the indices: {}",
+                request.getConfig().getId(), username, Strings.toString(builder)));
+        }
     }
 
     private void validateConfig(DataFrameAnalyticsConfig config) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -41,7 +41,6 @@ import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsManager;
 import org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractorFactory;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -131,7 +130,7 @@ public class TransportStartDataFrameAnalyticsAction
         // Validate config
         ActionListener<DataFrameAnalyticsConfig> configListener = ActionListener.wrap(
             config ->
-                DataFrameDataExtractorFactory.validateConfigAndSourceIndex(client, Collections.emptyMap(), config, validateListener),
+                DataFrameDataExtractorFactory.validateConfigAndSourceIndex(client, config, validateListener),
             listener::onFailure
         );
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -35,7 +35,6 @@ import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfig
 import org.elasticsearch.xpack.ml.dataframe.process.AnalyticsProcessManager;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -155,7 +154,7 @@ public class DataFrameAnalyticsManager {
         // TODO This could fail with errors. In that case we get stuck with the copied index.
         // We could delete the index in case of failure or we could try building the factory before reindexing
         // to catch the error early on.
-        DataFrameDataExtractorFactory.create(client, Collections.emptyMap(), config, dataExtractorFactoryListener);
+        DataFrameDataExtractorFactory.create(client, config, dataExtractorFactoryListener);
     }
 
     private void createDestinationIndex(String sourceIndex, String destinationIndex, Map<String, String> headers,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
@@ -27,7 +27,9 @@ import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsFields;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
@@ -57,6 +59,10 @@ public class DataFrameDataExtractor {
         this.context = Objects.requireNonNull(context);
         hasNext = true;
         searchHasShardFailure = false;
+    }
+
+    public Map<String, String> getHeaders() {
+        return Collections.unmodifiableMap(context.headers);
     }
 
     public boolean hasNext() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
@@ -58,12 +58,15 @@ public class DataFrameDataExtractorFactory {
     private final String analyticsId;
     private final String index;
     private final ExtractedFields extractedFields;
+    private final Map<String, String> headers;
 
-    private DataFrameDataExtractorFactory(Client client, String analyticsId, String index, ExtractedFields extractedFields) {
+    private DataFrameDataExtractorFactory(Client client, String analyticsId, String index, ExtractedFields extractedFields,
+                                          Map<String, String> headers) {
         this.client = Objects.requireNonNull(client);
         this.analyticsId = Objects.requireNonNull(analyticsId);
         this.index = Objects.requireNonNull(index);
         this.extractedFields = Objects.requireNonNull(extractedFields);
+        this.headers = headers;
     }
 
     public DataFrameDataExtractor newExtractor(boolean includeSource) {
@@ -73,7 +76,7 @@ public class DataFrameDataExtractorFactory {
                 Arrays.asList(index),
                 QueryBuilders.matchAllQuery(),
                 1000,
-                Collections.emptyMap(),
+                headers,
                 includeSource
             );
         return new DataFrameDataExtractor(client, context);
@@ -96,7 +99,7 @@ public class DataFrameDataExtractorFactory {
 
         validateIndexAndExtractFields(client, headers, config.getDest(), ActionListener.wrap(
             extractedFields -> listener.onResponse(
-                new DataFrameDataExtractorFactory(client, config.getId(), config.getDest(), extractedFields)),
+                new DataFrameDataExtractorFactory(client, config.getId(), config.getDest(), extractedFields, config.getHeaders())),
             listener::onFailure
         ));
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
@@ -88,16 +88,14 @@ public class DataFrameDataExtractorFactory {
      * The destination index must exist and contain at least 1 compatible field or validations will fail.
      *
      * @param client ES Client used to make calls against the cluster
-     * @param headers Headers to use
      * @param config The config from which to create the extractor factory
      * @param listener The listener to notify on creation or failure
      */
     public static void create(Client client,
-                              Map<String, String> headers,
                               DataFrameAnalyticsConfig config,
                               ActionListener<DataFrameDataExtractorFactory> listener) {
 
-        validateIndexAndExtractFields(client, headers, config.getDest(), ActionListener.wrap(
+        validateIndexAndExtractFields(client, config.getHeaders(), config.getDest(), ActionListener.wrap(
             extractedFields -> listener.onResponse(
                 new DataFrameDataExtractorFactory(client, config.getId(), config.getDest(), extractedFields, config.getHeaders())),
             listener::onFailure
@@ -108,15 +106,13 @@ public class DataFrameDataExtractorFactory {
      * Validates the source index and analytics config
      *
      * @param client ES Client to make calls
-     * @param headers Headers for auth
      * @param config Analytics config to validate
      * @param listener The listener to notify on failure or completion
      */
     public static void validateConfigAndSourceIndex(Client client,
-                                                    Map<String, String> headers,
                                                     DataFrameAnalyticsConfig config,
                                                     ActionListener<Boolean> listener) {
-        validateIndexAndExtractFields(client, headers, config.getSource(), ActionListener.wrap(
+        validateIndexAndExtractFields(client, config.getHeaders(), config.getSource(), ActionListener.wrap(
             fields -> {
                 config.getParsedQuery(); // validate query is acceptable
                 listener.onResponse(true);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractor;
 import org.elasticsearch.xpack.ml.dataframe.process.results.RowResults;
 
@@ -105,7 +106,11 @@ class DataFrameRowsJoiner {
             bulkRequest.add(indexRequest);
         }
         if (bulkRequest.numberOfActions() > 0) {
-            BulkResponse bulkResponse = client.execute(BulkAction.INSTANCE, bulkRequest).actionGet();
+            BulkResponse bulkResponse =
+                ClientHelper.executeWithHeaders(dataExtractor.getHeaders(),
+                    ClientHelper.ML_ORIGIN,
+                    client,
+                    () -> client.execute(BulkAction.INSTANCE, bulkRequest).actionGet());
             if (bulkResponse.hasFailures()) {
                 LOGGER.error("Failures while writing data frame");
                 // TODO Better error handling

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoinerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoinerTests.java
@@ -13,9 +13,12 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractor;
 import org.elasticsearch.xpack.ml.dataframe.process.results.RowResults;
 import org.junit.Before;
@@ -124,8 +127,12 @@ public class DataFrameRowsJoinerTests extends ESTestCase {
     }
 
     private void givenClientHasNoFailures() {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
         ActionFuture<BulkResponse> responseFuture = mock(ActionFuture.class);
         when(responseFuture.actionGet()).thenReturn(new BulkResponse(new BulkItemResponse[0], 0));
         when(client.execute(same(BulkAction.INSTANCE), bulkRequestCaptor.capture())).thenReturn(responseFuture);
+        when(client.threadPool()).thenReturn(threadPool);
     }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -45,6 +45,21 @@
   - match: { query: {"term" : { "user" : "Kimchy"} } }
 
 ---
+"Test put config with security headers in the body":
+  - do:
+      catch: /unknown field \[headers\], parser not found/
+      ml.put_data_frame_analytics:
+        id: "data_frame_with_header"
+        body:  >
+          {
+            "source": "source_index",
+            "dest": "dest_index",
+            "analyses": [{"outlier_detection":{}}],
+            "query": {"term" : { "user" : "Kimchy" }},
+            "headers":{ "a_security_header" : "secret" }
+          }
+
+---
 "Test put valid config with default outlier detection":
 
   - do:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -33,14 +33,14 @@
         id: "simple-outlier-detection-with-query"
         body: >
           {
-            "source": "source_index",
-            "dest": "dest_index",
+            "source": "index-source",
+            "dest": "index-dest",
             "analyses": [{"outlier_detection":{}}],
             "query": {"term" : { "user" : "Kimchy" }}
           }
   - match: { id: "simple-outlier-detection-with-query" }
-  - match: { source: "source_index" }
-  - match: { dest: "dest_index" }
+  - match: { source: "index-source" }
+  - match: { dest: "index-dest" }
   - match: { analyses: [{"outlier_detection":{}}] }
   - match: { query: {"term" : { "user" : "Kimchy"} } }
 
@@ -52,8 +52,8 @@
         id: "data_frame_with_header"
         body:  >
           {
-            "source": "source_index",
-            "dest": "dest_index",
+            "source": "index-source",
+            "dest": "index-dest",
             "analyses": [{"outlier_detection":{}}],
             "query": {"term" : { "user" : "Kimchy" }},
             "headers":{ "a_security_header" : "secret" }
@@ -67,13 +67,13 @@
         id: "simple-outlier-detection"
         body: >
           {
-            "source": "source_index",
-            "dest": "dest_index",
+            "source": "index-source",
+            "dest": "index-dest",
             "analyses": [{"outlier_detection":{}}]
           }
   - match: { id: "simple-outlier-detection" }
-  - match: { source: "source_index" }
-  - match: { dest: "dest_index" }
+  - match: { source: "index-source" }
+  - match: { dest: "index-dest" }
   - match: { analyses: [{"outlier_detection":{}}] }
   - match: { query: {"match_all" : {} } }
 
@@ -87,8 +87,8 @@
         body: >
           {
             "id": "body_id",
-            "source": "source_index",
-            "dest": "dest_index",
+            "source": "index-source",
+            "dest": "index-dest",
             "analyses": [{"outlier_detection":{}}]
           }
 
@@ -101,8 +101,8 @@
         id: "this id contains spaces"
         body: >
           {
-            "source": "source_index",
-            "dest": "dest_index",
+            "source": "index-source",
+            "dest": "index-dest",
             "analyses": [{"outlier_detection":{}}]
           }
 
@@ -115,8 +115,8 @@
         id: "unknown_field"
         body: >
           {
-            "source": "source_index",
-            "dest": "dest_index",
+            "source": "index-source",
+            "dest": "index-dest",
             "analyses": [{"outlier_detection":{}}],
             "unknown_field": 42
           }
@@ -130,8 +130,8 @@
         id: "unknown_field"
         body: >
           {
-            "source": "source_index",
-            "dest": "dest_index",
+            "source": "index-source",
+            "dest": "index-dest",
             "analyses": [{"outlier_detection":{"unknown_field": 42}}]
           }
 
@@ -144,7 +144,7 @@
         id: "simple-outlier-detection"
         body: >
           {
-            "dest": "dest_index",
+            "dest": "index-dest",
             "analyses": [{"outlier_detection":{}}]
           }
 
@@ -157,7 +157,7 @@
         id: "simple-outlier-detection"
         body: >
           {
-            "source": "source_index",
+            "source": "index-source",
             "analyses": [{"outlier_detection":{}}]
           }
 
@@ -170,8 +170,8 @@
         id: "simple-outlier-detection"
         body: >
           {
-            "source": "source_index",
-            "dest": "dest_index"
+            "source": "index-source",
+            "dest": "index-dest"
           }
 
 ---
@@ -183,8 +183,8 @@
         id: "simple-outlier-detection"
         body: >
           {
-            "source": "source_index",
-            "dest": "dest_index",
+            "source": "index-source",
+            "dest": "index-dest",
             "analyses": []
           }
 
@@ -197,8 +197,8 @@
         id: "simple-outlier-detection"
         body: >
           {
-            "source": "source_index",
-            "dest": "dest_index",
+            "source": "index-source",
+            "dest": "index-dest",
             "analyses": [{"outlier_detection":{}}, {"outlier_detection":{}}]
           }
 
@@ -210,8 +210,8 @@
         id: "foo-1"
         body: >
           {
-            "source": "foo-1_source",
-            "dest": "foo-1_dest",
+            "source": "index-foo-1_source",
+            "dest": "index-foo-1_dest",
             "analyses": [{"outlier_detection":{}}]
           }
 
@@ -220,8 +220,8 @@
         id: "foo-2"
         body: >
           {
-            "source": "foo-2_source",
-            "dest": "foo-2_dest",
+            "source": "index-foo-2_source",
+            "dest": "index-foo-2_dest",
             "analyses": [{"outlier_detection":{}}]
           }
   - match: { id: "foo-2" }
@@ -231,8 +231,8 @@
         id: "bar"
         body: >
           {
-            "source": "bar_source",
-            "dest": "bar_dest",
+            "source": "index-bar_source",
+            "dest": "index-bar_dest",
             "analyses": [{"outlier_detection":{}}]
           }
   - match: { id: "bar" }
@@ -295,8 +295,8 @@
         id: "foo-1"
         body: >
           {
-            "source": "foo-1_source",
-            "dest": "foo-1_dest",
+            "source": "index-foo-1_source",
+            "dest": "index-foo-1_dest",
             "analyses": [{"outlier_detection":{}}]
           }
 
@@ -305,8 +305,8 @@
         id: "foo-2"
         body: >
           {
-            "source": "foo-2_source",
-            "dest": "foo-2_dest",
+            "source": "index-foo-2_source",
+            "dest": "index-foo-2_dest",
             "analyses": [{"outlier_detection":{}}]
           }
   - match: { id: "foo-2" }
@@ -316,8 +316,8 @@
         id: "bar"
         body: >
           {
-            "source": "bar_source",
-            "dest": "bar_dest",
+            "source": "index-bar_source",
+            "dest": "index-bar_dest",
             "analyses": [{"outlier_detection":{}}]
           }
   - match: { id: "bar" }
@@ -381,8 +381,8 @@
         id: "foo"
         body: >
           {
-            "source": "source",
-            "dest": "dest",
+            "source": "index-source",
+            "dest": "index-dest",
             "analyses": [{"outlier_detection":{}}]
           }
 


### PR DESCRIPTION
This PR adds headers to the `DataFrameAnalyticsConfig` and utilizes those headers when running the analysis. 

NOTE: 
`CreateIndexAction.NAME` != `create_index` permission. Had a long chat with the security folks and apparently `CreateIndexAction.NAME` is treated as a prefix wildcard, where as `create_index` is that specific permission for that index pattern. 

When creating a role via the UI, the permission that auto-populates is `create_index`, and since that permission is enough (verified through testing), I opted to use it instead of the more expansive one.

There were many calls that were simply `client.execute` but these will all fail when security is turned on due to the default user not having any perms. I used the user's headers where I thought appropriate and changed the calls to be from the `ML_ORIGIN` 