### PR TITLE
Also mmap cfs files for hybridfs

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/store/FsDirectoryService.java
+++ b/server/src/main/java/org/elasticsearch/index/store/FsDirectoryService.java
@@ -144,6 +144,7 @@ public class FsDirectoryService extends DirectoryService {
                 case "nvd":
                 case "dvd":
                 case "tim":
+                case "cfs":
                     // we need to do these checks on the outer directory since the inner doesn't know about pending deletes
                     ensureOpen();
                     ensureCanRead(name);


### PR DESCRIPTION
With this commit we add the `.cfs` file extension to the list of file
types that are memory-mapped by hybridfs. `.cfs` files combine all files
of a Lucene segment into a single file in order to save file handles. As
this strategy is only used for "small" segments (less than 10% of the
shard size), it is benefical to memory-map them instead of accessing
them via NIO.

Relates #36668