### PR TITLE
Update Lucene snapshot repo for 7.0.0-beta1

### DIFF
--- a/docs/java-rest/high-level/getting-started.asciidoc
+++ b/docs/java-rest/high-level/getting-started.asciidoc
@@ -83,7 +83,7 @@ dependencies {
 The very first releases of any major version (like a beta), might have been built on top of a Lucene Snapshot version.
 In such a case you will be unable to resolve the Lucene dependencies of the client.
 
-For example, if you want to use the `7.0.0-alpha2` version which depends on Lucene `8.0.0-snapshot-774e9aefbc`, you must
+For example, if you want to use the `7.0.0-beta1` version which depends on Lucene `8.0.0-snapshot-83f9835`, you must
 define the following repository.
 
 For Maven:
@@ -93,7 +93,7 @@ For Maven:
 <repository>
     <id>elastic-lucene-snapshots</id>
     <name>Elastic Lucene Snapshots</name>
-    <url>http://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/774e9aefbc</url>
+    <url>http://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/83f9835</url>
     <releases><enabled>true</enabled></releases>
     <snapshots><enabled>false</enabled></snapshots>
 </repository>
@@ -104,7 +104,7 @@ For Gradle:
 ["source","groovy",subs="attributes"]
 --------------------------------------------------
 maven {
-    url 'http://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/774e9aefbc'
+    url 'http://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/83f9835'
 }
 --------------------------------------------------
 


### PR DESCRIPTION
The Lucene snapshot repo changed. We can update the documentation to help our users.

This can be also applied to 8.0.0 I guess? Which means `master`, `7.x` and `7.0` branch.
