### PR TITLE
Make pullFixture a task dependency of resolveAllDependencies

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -21,4 +21,4 @@ export JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA}
 export JAVA8_HOME="${HOME}"/.java/java8
 export JAVA11_HOME="${HOME}"/.java/java11
 export JAVA12_HOME="${HOME}"/.java/java12
-./gradlew --parallel  clean  --scan -Porg.elasticsearch.acceptScanTOS=true -s resolveAllDependencies
+./gradlew --parallel clean --scan -Porg.elasticsearch.acceptScanTOS=true -s resolveAllDependencies

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -21,4 +21,4 @@ export JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA}
 export JAVA8_HOME="${HOME}"/.java/java8
 export JAVA11_HOME="${HOME}"/.java/java11
 export JAVA12_HOME="${HOME}"/.java/java12
-./gradlew --parallel  clean pullFixture  --scan -Porg.elasticsearch.acceptScanTOS=true -s resolveAllDependencies
+./gradlew --parallel  clean  --scan -Porg.elasticsearch.acceptScanTOS=true -s resolveAllDependencies

--- a/build.gradle
+++ b/build.gradle
@@ -616,9 +616,10 @@ if (System.properties.get("build.compare") != null) {
 
 allprojects {
   task resolveAllDependencies {
-    doLast {
-      configurations.findAll { it.isCanBeResolved() }.each { it.resolve() }
-    }
+      dependsOn tasks.matching { it.name == "pullFixture"}
+      doLast {
+        configurations.findAll { it.isCanBeResolved() }.each { it.resolve() }
+      }
   }
 }
 


### PR DESCRIPTION
With this change we will pull the docker test fixtures ( and thus cache
the images ) for older versions too as the `resolveAllDependencies` is
already being called on the bwc checkouts too.

Closes #38832 