### PR TITLE
Fix simple query string serialization conditional

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -174,7 +174,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
             in.readBoolean(); // lowercase_expanded_terms
         }
         settings.lenient(in.readBoolean());
-        if (in.getVersion().onOrAfter(Version.V_5_1_1)) {
+        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
             this.lenientSet = in.readBoolean();
         }
         settings.analyzeWildcard(in.readBoolean());
@@ -214,7 +214,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
             out.writeBoolean(true); // lowercase_expanded_terms
         }
         out.writeBoolean(settings.lenient());
-        if (out.getVersion().onOrAfter(Version.V_5_1_1)) {
+        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
             out.writeBoolean(lenientSet);
         }
         out.writeBoolean(settings.analyzeWildcard());


### PR DESCRIPTION
Looks like #21504 introduced a serialization conditional for lenientSet,
but the PR was never backported to 5.x hence whenever simple query
string is serialized between 6.x and 5.6, it can't be read/written properly causing errors on the transport layer.

This commit updates the conditional to only read/write the field against
6.0+ versions which are aware of it.

Closes #38889