### PR TITLE
Fix bat scripts to work with JAVA_HOME containing special characters

### DIFF
--- a/distribution/src/bin/elasticsearch-env.bat
+++ b/distribution/src/bin/elasticsearch-env.bat
@@ -58,5 +58,5 @@ set ES_DISTRIBUTION_FLAVOR=${es.distribution.flavor}
 set ES_DISTRIBUTION_TYPE=${es.distribution.type}
 
 if not defined ES_TMPDIR (
-  for /f "tokens=* usebackq" %%a in (`"%JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.TempDirectory""`) do set ES_TMPDIR=%%a
+  for /f "tokens=* usebackq" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.TempDirectory"`) do set  ES_TMPDIR=%%a
 )

--- a/distribution/src/bin/elasticsearch.bat
+++ b/distribution/src/bin/elasticsearch.bat
@@ -41,9 +41,10 @@ IF ERRORLEVEL 1 (
 	EXIT /B %ERRORLEVEL%
 )
 
-set "ES_JVM_OPTIONS=%ES_PATH_CONF%\jvm.options"
+set ES_JVM_OPTIONS=%ES_PATH_CONF%\jvm.options
 @setlocal
-for /F "usebackq delims=" %%a in (`"%JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.JvmOptionsParser" "!ES_JVM_OPTIONS!" || echo jvm_options_parser_failed"`) do set JVM_OPTIONS=%%a
+for /F "usebackq delims=" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.JvmOptionsParser" "!ES_JVM_OPTIONS!"
+^|^| echo jvm_options_parser_failed`) do set JVM_OPTIONS=%%a
 @endlocal & set "MAYBE_JVM_OPTIONS_PARSER_FAILED=%JVM_OPTIONS%" & set ES_JAVA_OPTS=%JVM_OPTIONS:${ES_TMPDIR}=!ES_TMPDIR!% %ES_JAVA_OPTS%
 
 if "%MAYBE_JVM_OPTIONS_PARSER_FAILED%" == "jvm_options_parser_failed" (


### PR DESCRIPTION
the `elasticsearch.bat` and `elasticsearch-env.bat` won't work if `JAVA` contains parentheses. This seems to be the limitation of `FOR /F IN (command) DO` syntax.  
The `JAVA` variable present in a command contains a path to a binary to start elasticsearch (with spaces & parans). We can workaround the problem of spaces and parentheses in this path by referring this variable with a `CALL` command.
Note that executing binaries with `CALL` is an undocumented behaviour (but works)

closes #38578
closes https://github.com/elastic/elasticsearch/pull/38624
closes https://github.com/elastic/elasticsearch/pull/33405
closes https://github.com/elastic/elasticsearch/issues/30606