### PR TITLE
fix SettingsFilterTests#testFiltering in FIPS

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SettingsFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SettingsFilterTests.java
@@ -146,9 +146,32 @@ public class SettingsFilterTests extends ESTestCase {
         if (useLegacyLdapBindPassword) {
             deprecatedSettings.add(PoolingSessionFactorySettings.LEGACY_BIND_PASSWORD);
         }
-        assertSettingDeprecationsAndWarnings(deprecatedSettings.toArray(new Setting<?>[0]), "SSL configuration [xpack.http.ssl] relies " +
-            "upon fallback to another configuration for [key configuration, trust configuration, supported protocols], " +
-            "which is deprecated.");
+        if (inFipsJvm()) {
+            assertSettingDeprecationsAndWarnings(deprecatedSettings.toArray(new Setting<?>[0]),
+                "[xpack.ssl.truststore.secure_password] " +
+                    "setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes " +
+                    "documentation for the next major version.",
+                "SSL configuration [xpack.http.ssl] relies upon fallback to another configuration for [supported protocols], " +
+                    "which is deprecated.",
+                "[xpack.ssl.supported_protocols] setting was deprecated in Elasticsearch and will be removed in a future release! See " +
+                    "the breaking changes documentation for the next major version.",
+                "[bind_password] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking " +
+                    "changes documentation for the next major version.",
+                "[xpack.ssl.keystore.secure_password] setting was deprecated in Elasticsearch and will be removed in a future release! " +
+                    "See the breaking changes documentation for the next major version.",
+                "[xpack.ssl.keystore.algorithm] setting was deprecated in Elasticsearch and will be removed in a future release! " +
+                    "See the breaking changes documentation for the next major version.",
+                "[xpack.ssl.keystore.secure_key_password] setting was deprecated in Elasticsearch and will be removed in a " +
+                    "future release! See the breaking changes documentation for the next major version.",
+                "[xpack.ssl.cipher_suites] setting was deprecated in Elasticsearch and will be removed in a future release! See the " +
+                    "breaking changes documentation for the next major version.",
+                "[xpack.ssl.truststore.algorithm] setting was deprecated in Elasticsearch and will be removed in a future release! " +
+                    "See the breaking changes documentation for the next major version.");
+        } else {
+            assertSettingDeprecationsAndWarnings(deprecatedSettings.toArray(new Setting<?>[0]), "SSL configuration [xpack.http.ssl] " +
+                "relies upon fallback to another configuration for [key configuration, trust configuration, supported protocols], " +
+                "which is deprecated.");
+        }
     }
 
     private void configureUnfilteredSetting(String settingName, String value) {


### PR DESCRIPTION
It seems that when this test is run in FIPS mode,
more deprecated settings are used. This introduces
a separate assertion when in FIPS mode.

CI failures with assertion errors:

- https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+6.7+matrix-java-periodic/ES_BUILD_JAVA=java11,ES_RUNTIME_JAVA=java8fips,nodes=immutable&&linux&&docker/17/console
- https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+6.7+matrix-java-periodic/ES_BUILD_JAVA=java11,ES_RUNTIME_JAVA=java8fips,nodes=immutable&&linux&&docker/18/console

assertion error in fips:

```
java.lang.AssertionError: 
Expected: a collection containing "SSL configuration [xpack.http.ssl] relies upon fallback to another configuration for [key configuration, trust configuration, supported protocols], which is deprecated."
     but: was "[xpack.ssl.truststore.secure_password] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.", was "SSL configuration [xpack.http.ssl] relies upon fallback to another configuration for [supported protocols], which is deprecated.", was "[xpack.ssl.supported_protocols] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.", was "[bind_password] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.", was "[xpack.ssl.keystore.secure_password] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.", was "[xpack.ssl.keystore.algorithm] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.", was "[xpack.ssl.keystore.secure_key_password] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.", was "[xpack.ssl.cipher_suites] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.", was "[xpack.ssl.truststore.algorithm] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version."
	at __randomizedtesting.SeedInfo.seed([435DB5484B2D250:4670BA27F0CF8E22]:0)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:956)
	at org.junit.Assert.assertThat(Assert.java:923)
	at org.elasticsearch.test.ESTestCase.assertWarnings(ESTestCase.java:415)
	at org.elasticsearch.test.ESTestCase.assertSettingDeprecationsAndWarnings(ESTestCase.java:395)
	at org.elasticsearch.test.ESTestCase.assertSettingDeprecationsAndWarnings(ESTestCase.java:391)
	at org.elasticsearch.test.SettingsFilterTests.testFiltering(SettingsFilterTests.java:149)
```
