### PR TITLE
Add an exception throw if waiting on transport port file fails (#37574)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
@@ -118,10 +118,15 @@ class ClusterConfiguration {
         if (seedNode == node) {
             return null
         }
-        ant.waitfor(maxwait: '40', maxwaitunit: 'second', checkevery: '500', checkeveryunit: 'millisecond') {
+        ant.waitfor(maxwait: '40', maxwaitunit: 'second', checkevery: '500', checkeveryunit: 'millisecond',
+                timeoutproperty: "failed.${seedNode.transportPortsFile.path}") {
             resourceexists {
                 file(file: seedNode.transportPortsFile.toString())
             }
+        }
+        if (ant.properties.containsKey("failed.${seedNode.transportPortsFile.path}".toString())) {
+            throw new GradleException("Failed to locate seed node transport file [${seedNode.transportPortsFile}]: " +
+                    "timed out waiting for it to be created after ${waitSeconds} seconds")
         }
         return seedNode.transportUri()
     }


### PR DESCRIPTION
In the ClusterConfiguration class of the build source, there is an Ant waitfor block 
that runs to ensure that the seed node's transport ports file is created before 
trying to read it. If the wait times out, the file read fails with not much helpful info. 
This just adds a timeout property to the waitfor block and throws a descriptive 
exception instead.

Backports #37574 