### PR TITLE
Ensure global test seed is used for all random testing tasks

### DIFF
--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingPlugin.groovy
@@ -8,7 +8,7 @@ import org.gradle.api.tasks.TaskContainer
 class RandomizedTestingPlugin implements Plugin<Project> {
 
     void apply(Project project) {
-        def seed = setupSeed(project)
+        String seed = setupSeed(project)
         createUnitTestTask(project.tasks)
         configureAnt(project.ant, seed)
     }

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingPlugin.groovy
@@ -3,15 +3,14 @@ package com.carrotsearch.gradle.junit4
 import com.carrotsearch.ant.tasks.junit4.JUnit4
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.tasks.TaskContainer
 
 class RandomizedTestingPlugin implements Plugin<Project> {
 
     void apply(Project project) {
-        setupSeed(project)
+        def seed = setupSeed(project)
         createUnitTestTask(project.tasks)
-        configureAnt(project.ant)
+        configureAnt(project.ant, seed)
     }
 
     /**
@@ -21,12 +20,12 @@ class RandomizedTestingPlugin implements Plugin<Project> {
      * outcome of subsequent runs. Pinning the seed up front like this makes
      * the reproduction line from one run be useful on another run.
      */
-    static void setupSeed(Project project) {
+    static String setupSeed(Project project) {
         if (project.rootProject.ext.has('testSeed')) {
             /* Skip this if we've already pinned the testSeed. It is important
              * that this checks the rootProject so that we know we've only ever
              * initialized one time. */
-            return
+            return project.rootProject.ext.testSeed
         }
         String testSeed = System.getProperty('tests.seed')
         if (testSeed == null) {
@@ -39,6 +38,8 @@ class RandomizedTestingPlugin implements Plugin<Project> {
         project.rootProject.subprojects {
             project.ext.testSeed = testSeed
         }
+
+        return testSeed
     }
 
     static void createUnitTestTask(TaskContainer tasks) {
@@ -52,7 +53,8 @@ class RandomizedTestingPlugin implements Plugin<Project> {
         }
     }
 
-    static void configureAnt(AntBuilder ant) {
+    static void configureAnt(AntBuilder ant, String seed) {
         ant.project.addTaskDefinition('junit4:junit4', JUnit4.class)
+        ant.properties.put('tests.seed', seed)
     }
 }


### PR DESCRIPTION
Recently it was noticed that the global generated test seed reported at the beginning of every Gradle build was not always used for subsequent test tasks. For example:

```
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 5.2.1
  OS Info               : Mac OS X 10.14.3 (x86_64)
  JDK Version           : 11 (Oracle Corporation 11.0.2 [OpenJDK 64-Bit Server VM 11.0.2+9])
  JAVA_HOME             : /Users/mark/.sdkman/candidates/java/11.0.2-open
  Random Testing Seed   : DA01B1B09A1CDA37
=======================================

> Task :server:integTest
==> Test Info: seed=4804DC280933D0C4; jvms=6; suites=319
```

As you can see, the global seed `DA01B1B09A1CDA37` is not the same as the seed `4804DC280933D0C4` used by the `:server:integTest` Task.

It turns out the reason for this is an implementation detail in how the Ant `junit4` task works.

```
// Initialize random if not already provided.
    if (random == null) {
      this.random = MoreObjects.firstNonNull( 
          Strings.emptyToNull(getProject().getProperty(SYSPROP_RANDOM_SEED())),
          SeedUtils.formatSeed(new Random().nextLong()));
    }
```

In this case it looks for an Ant _project_ property, and if not defined, falls back to generating a new seed.

We currently rely on explicitly setting the `test.seed` system property on the test task [here](https://github.com/elastic/elasticsearch/blob/c031322c18496883d45d48d9ef15bec277632122/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingTask.groovy#L273) but this actually gets ignored when the forked test VMs are created and the randomly generated seed (created above) is used instead.

```
// Pass the random seed property.
    createJvmarg().setValue("-D" + SYSPROP_PREFIX() + "=" + CURRENT_PREFIX());
    createJvmarg().setValue("-D" + SYSPROP_RANDOM_SEED() + "=" + random);
```

While investigating it was noticed that invoking the build with an explicit seed (ex: `./gradlew -Dtest.seed=foo`) *does* result in the behavior we want, which is that all random test tasks in the build use the global seed. The reason for this is that all build system properties are inherited by Ant as project properties.

This PR simply unifies these behaviors such that when the global seed is generated as part of the build (not specified on the commandline) we explicitly set the appropriate Ant project property to ensure this propagates to any and all Ant tasks.