### PR TITLE
relax ML Info Docs expected response

### DIFF
--- a/docs/reference/ml/apis/get-ml-info.asciidoc
+++ b/docs/reference/ml/apis/get-ml-info.asciidoc
@@ -58,4 +58,4 @@ This is a possible response:
   "limits" : { }
 }
 ----
-// TESTRESPONSE
+// TESTRESPONSE[s/"upgrade_mode": false/"upgrade_mode": $body.upgrade_mode/]


### PR DESCRIPTION
the get-ml-info API documentation tested that the
response show that ML's `upgrade_mode` was false.
For reasons that may be true due to other tests running in
parallel or not cleaning themselves up, this may not be
guaranteed. Since the actual value here is not of importance,
this commit relaxes the requirement that upgrade_mode be
static.

from the CI failure stacktrace

```
FAILURE 0.07s | DocsClientYamlTestSuiteIT.test {yaml=reference/ml/apis/get-ml-info/line_37} <<< FAILURES!
   > Throwable #1: java.lang.AssertionError: Failure at [reference/ml/apis/get-ml-info:15]: $body didn't match expected value:
   >                          $body: 
   >                         defaults: 
   >                  anomaly_detectors: 
   >        categorization_examples_limit: same [4]
   >                   model_memory_limit: same [1gb]
   >        model_snapshot_retention_days: same [1]
   >                          datafeeds: 
   >                          scroll_size: same [1000]
   >                           limits: same [empty map]
   >                     upgrade_mode: expected [false] but was [true]
   > 	at __randomizedtesting.SeedInfo.seed([3BBDE8E41A5C59B9:B3E9D73EB4A03441]:0)
```

there may be another doc that changes the upgrade_mode, but that should not be a concern.
The other option is to fix the leakage, but I think this change is valid on its own.

CI links to failures:

- https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+7.x+release-tests/36/console
- https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+7.0+multijob-unix-compatibility/os=centos-6/19/console
- https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+6.7+intake/114/console