### PR TITLE
[DOCS] Edits the remote clusters documentation

### DIFF
--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -2,25 +2,25 @@
 == Remote clusters
 
 ifndef::include-xpack[]
-The _remote clusters_ module allows establishing uni-directional connections to
-a remote cluster. This functionality is used in
+The _remote clusters_ module enables you to establish uni-directional
+connections to a remote cluster. This functionality is used in
 <<modules-cross-cluster-search,cross-cluster search>>.
 endif::[]
 ifdef::include-xpack[]
-The _remote clusters_ module allows establishing uni-directional connections to
-a remote cluster. This functionality is used in cross-cluster replication, and
+The _remote clusters_ module enables you to establish uni-directional
+connections to a remote cluster. This functionality is used in
+{stack-ov}/xpack-ccr.html[cross-cluster replication] and
 <<modules-cross-cluster-search,cross-cluster search>>.
 endif::[]
 
 Remote cluster connections work by configuring a remote cluster and connecting
 only to a limited number of nodes in the remote cluster. Each remote cluster is
-referenced by a name and a list of seed nodes.  When a remote cluster is
+referenced by a name and a list of seed nodes. When a remote cluster is
 registered, its cluster state is retrieved from one of the seed nodes so that by
 default up to three _gateway nodes_ are selected to be connected to as part of
 remote cluster requests.  Remote cluster connections consist of uni-directional
 connections from the coordinating node to the previously selected remote nodes
-only. It is possible to tag which nodes should be selected through node
-attributes (see <<remote-cluster-settings>>).
+only. You can tag which nodes should be selected by using node attributes (see <<remote-cluster-settings>>).
 
 Each node in a cluster that has remote clusters configured connects to one or
 more _gateway nodes_ and uses them to federate requests to the remote cluster.
@@ -173,6 +173,6 @@ PUT _cluster/settings
 [[retrieve-remote-clusters-info]]
 === Retrieving remote clusters info
 
-The <<cluster-remote-info, Remote Cluster Info API>> allows to retrieve
+You can use the <<cluster-remote-info, remote cluster info API>> to retrieve
 information about the configured remote clusters, as well as the remote nodes
 that the node is connected to.


### PR DESCRIPTION
This PR makes more small edits to the "Remote clusters" page in the Elasticsearch Reference (https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-remote-clusters.html) --above and beyond what was done in https://github.com/elastic/elasticsearch/pull/37678