### PR TITLE
Add overlapping, before, after filters to intervals query

### DIFF
--- a/docs/reference/query-dsl/intervals-query.asciidoc
+++ b/docs/reference/query-dsl/intervals-query.asciidoc
@@ -151,8 +151,14 @@ Produces intervals that are contained by an interval from the filter rule
 Produces intervals that do not contain an interval from the filter rule
 `not_contained_by`::
 Produces intervals that are not contained by an interval from the filter rule
+`overlapping`::
+Produces intervals that overlap with an interval from the filter rule
 `not_overlapping`::
 Produces intervals that do not overlap with an interval from the filter rule
+`before`::
+Produces intervals that appear before an interval from the filter role
+`after`::
+Produces intervals that appear after an interval from the filter role
 
 [[interval-script-filter]]
 ==== Script filters

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
@@ -322,3 +322,68 @@ setup:
                               query: "there"
                         ordered: false
   - match: { hits.total.value: 1 }
+
+---
+"Test overlapping":
+  - skip:
+      version: " - 7.9.99"
+      reason: "Implemented in 7.1"
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            intervals:
+              text:
+                match:
+                  query: "cold outside"
+                  ordered: true
+                  filter:
+                    overlapping:
+                      match:
+                        query: "baby there"
+                        ordered: false
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "3" }
+
+---
+"Test before":
+  - skip:
+      version: " - 7.9.99"
+      reason: "Implemented in 7.1"
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            intervals:
+              text:
+                match:
+                  query: "cold"
+                  filter:
+                    before:
+                      match:
+                        query: "outside"
+  - match: { hits.total.value: 2 }
+
+---
+"Test after":
+  - skip:
+      version: " - 7.9.99"
+      reason: "Implemented in 7.1"
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            intervals:
+              text:
+                match:
+                  query: "cold"
+                  filter:
+                    after:
+                      match:
+                        query: "outside"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "4" }
+

--- a/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
@@ -453,8 +453,14 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
                     return Intervals.notContaining(input, filterSource);
                 case "not_contained_by":
                     return Intervals.notContainedBy(input, filterSource);
+                case "overlapping":
+                    return Intervals.overlapping(input, filterSource);
                 case "not_overlapping":
                     return Intervals.nonOverlapping(input, filterSource);
+                case "before":
+                    return Intervals.before(input, filterSource);
+                case "after":
+                    return Intervals.after(input, filterSource);
                 default:
                     throw new IllegalArgumentException("Unknown filter type [" + type + "]");
             }

--- a/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
@@ -53,7 +53,8 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
     }
 
     private static final String[] filters = new String[]{
-        "containing", "contained_by", "not_containing", "not_contained_by", "not_overlapping"
+        "containing", "contained_by", "not_containing", "not_contained_by",
+        "overlapping", "not_overlapping", "before", "after"
     };
 
     private IntervalsSourceProvider.IntervalFilter createRandomFilter() {


### PR DESCRIPTION
Lucene recently added `overlapping`, `before` and `after` filters to the intervals package.  This
commit exposes them in elasticsearch.