### PR TITLE
Edits to text in Docs-Replication doc

### DIFF
--- a/docs/reference/docs/data-replication.asciidoc
+++ b/docs/reference/docs/data-replication.asciidoc
@@ -142,8 +142,8 @@ Dirty reads:: An isolated primary can expose writes that will not be acknowledge
 === The Tip of the Iceberg
 
 This document provides a high level overview of how Elasticsearch deals with data. Of course, there is much much more 
-going on under the hood. Things like primary terms, cluster state publishing and master election all play a role in 
+going on under the hood. Things like primary terms, cluster state publishing, and master election all play a role in 
 keeping this system behaving correctly. This document also doesn't cover known and important
 bugs (both closed and open). We recognize that https://github.com/elastic/elasticsearch/issues?q=label%3Aresiliency[GitHub is hard to keep up with].
-To help people stay on top of those and we maintain a dedicated https://www.elastic.co/guide/en/elasticsearch/resiliency/current/index.html[resiliency page]
+To help people stay on top of those, we maintain a dedicated https://www.elastic.co/guide/en/elasticsearch/resiliency/current/index.html[resiliency page]
 on our website. We strongly advise reading it.


### PR DESCRIPTION
Two minor edits (punctuation and an extraneous word) to “Reading and Writing documents” doc