### PR TITLE
#29652 fix split API issue

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -1475,7 +1475,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
         // this is important to special case here since we use this to validate this in various places in the code but allow to split form
         // 1 to N but we never modify the sourceIndexMetadata to accommodate for that
         int routingNumShards = numSourceShards == 1 ? numTargetShards : sourceIndexMetadata.getRoutingNumShards();
-        if (routingNumShards % numTargetShards != 0) {
+        if (numTargetShards % routingNumShards != 0) {
             throw new IllegalStateException("the number of routing shards ["
                 + routingNumShards + "] must be a multiple of the target shards [" + numTargetShards + "]");
         }


### PR DESCRIPTION
Solving calculation errors caused by dividing small numbers(routingNumShards) by large numbers(numTargetShards)

Resolved by modification of formula.