### PR TITLE
Deprecation message is different on FIPS JVM

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SettingsFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SettingsFilterTests.java
@@ -146,9 +146,10 @@ public class SettingsFilterTests extends ESTestCase {
         if (useLegacyLdapBindPassword) {
             deprecatedSettings.add(PoolingSessionFactorySettings.LEGACY_BIND_PASSWORD);
         }
+
+        String fallbackProperties = inFipsJvm() ? "supported protocols" : "key configuration, trust configuration, supported protocols";
         assertSettingDeprecationsAndWarnings(deprecatedSettings.toArray(new Setting<?>[0]), "SSL configuration [xpack.http.ssl] relies " +
-            "upon fallback to another configuration for [key configuration, trust configuration, supported protocols], " +
-            "which is deprecated.");
+            "upon fallback to another configuration for [" + fallbackProperties + "], which is deprecated.");
     }
 
     private void configureUnfilteredSetting(String settingName, String value) {


### PR DESCRIPTION
Due to certain settings not be allowed on a FIPS JVM, this test
generates a slightly different deprecation message when run in FIPS
mode.

This change makes the message conditional on the JVM mode.