### PR TITLE
Generate mvn pom for ssl-config library

### DIFF
--- a/libs/ssl-config/build.gradle
+++ b/libs/ssl-config/build.gradle
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+apply plugin: 'nebula.maven-base-publish'
+apply plugin: 'nebula.maven-scm'
+
 dependencies {
     compile "org.elasticsearch:elasticsearch-core:${version}"
 


### PR DESCRIPTION
This is used by the reindex-client library which is published to maven

Relates: #37287, #37527
Backport of: #39019