### PR TITLE
Remove unnecessary Dockerfile commands

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -23,8 +23,6 @@ RUN curl --retry 8 -s ${jdkUrl} | tar -C /opt -zxf -
 # REF: https://github.com/elastic/elasticsearch-docker/issues/171
 RUN ln -sf /etc/pki/ca-trust/extracted/java/cacerts /opt/jdk-${jdkVersion}/lib/security/cacerts
 
-RUN yum install -y unzip which
-
 RUN groupadd -g 1000 elasticsearch && \
     adduser -u 1000 -g 1000 -d /usr/share/elasticsearch elasticsearch
 
@@ -51,7 +49,7 @@ ENV JAVA_HOME /opt/jdk-${jdkVersion}
 COPY --from=builder /opt/jdk-${jdkVersion} /opt/jdk-${jdkVersion}
 
 RUN yum update -y && \
-    yum install -y nc unzip wget which && \
+    yum install -y nc && \
     yum clean all
 
 RUN groupadd -g 1000 elasticsearch && \

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -48,10 +48,9 @@ ENV JAVA_HOME /opt/jdk-${jdkVersion}
 
 COPY --from=builder /opt/jdk-${jdkVersion} /opt/jdk-${jdkVersion}
 
-RUN for iter in {1..10}; do yum update -y && \
+RUN yum update -y && \
     yum install -y nc && \
-    yum clean all && exit_code=0 && break || exit_code=$? && echo "yum error: retry $iter in 1s" && sleep 10; done; \
-    (exit $exit_code)
+    yum clean all
 
 RUN groupadd -g 1000 elasticsearch && \
     adduser -u 1000 -g 1000 -G 0 -d /usr/share/elasticsearch elasticsearch && \

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -48,9 +48,10 @@ ENV JAVA_HOME /opt/jdk-${jdkVersion}
 
 COPY --from=builder /opt/jdk-${jdkVersion} /opt/jdk-${jdkVersion}
 
-RUN yum update -y && \
+RUN for iter in {1..10}; do yum update -y && \
     yum install -y nc && \
-    yum clean all
+    yum clean all && exit_code=0 && break || exit_code=$? && echo "yum error: retry $iter in 1s" && sleep 10; done; \
+    (exit $exit_code)
 
 RUN groupadd -g 1000 elasticsearch && \
     adduser -u 1000 -g 1000 -G 0 -d /usr/share/elasticsearch elasticsearch && \


### PR DESCRIPTION
As the Dockerfile evolved we don't need anymore certain commands like
`unzip`, `which` and `wget` allowing us to slightly shrink the images
too.

Relates #38832
