### PR TITLE
[ML-DataFrame] set minimum supported version

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransform.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransform.java
@@ -49,8 +49,7 @@ public class DataFrameTransform extends AbstractDiffable<DataFrameTransform> imp
 
     @Override
     public Version getMinimalSupportedVersion() {
-        // TODO: to be changed once target version has been defined
-        return Version.CURRENT;
+        return Version.V_7_1_0;
     }
 
     @Override


### PR DESCRIPTION
change the minimum supported version of data frame transform

depends: https://github.com/elastic/elasticsearch/pull/39029
