### PR TITLE
Fix skip versions of `indices.put_mapping/20_mix_typeless_typeful.yml`.

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/20_mix_typeless_typeful.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/20_mix_typeless_typeful.yml
@@ -57,8 +57,8 @@
 "PUT mapping with _doc on an index that has types":
 
  - skip:
-      version: "all"
-      reason: 5.x indices can have types that start with an `_` # AwaitsFix: https://github.com/elastic/elasticsearch/issues/38202
+      version: " - 6.1.99"
+      reason: _doc as a type name was only allowed as of 6.2
 
 
  - do:


### PR DESCRIPTION
The test assumed that it could run against all 6.x indices but it actually
requires 6.2+ since 6.2 is the first version that allowed `_doc` as a type
name (#27816).

Closes #38202