### PR TITLE
missing 'test2' index example

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -271,6 +271,12 @@ POST /_aliases
                  "alias" : "alias1",
                  "is_write_index" : true
             }
+        },
+        {
+            "add" : {
+                 "index" : "test2",
+                 "alias" : "alias1"
+            }
         }
     ]
 }


### PR DESCRIPTION
If I got the idea of aliases properly, I think that the index "test2" should have a reference in the example above of the following sentence:

" ... we associate the alias `alias1` to both `test` and `test2` ... "
