### PR TITLE
Reenable test in `indices.put_mapping/20_mix_typeless_typeful.yml`.

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/20_mix_typeless_typeful.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/20_mix_typeless_typeful.yml
@@ -55,8 +55,8 @@
 "PUT mapping with _doc on an index that has types":
 
  - skip:
-      version: "all"
-      reason: include_type_name is only supported as of 6.7 # AwaitsFix: https://github.com/elastic/elasticsearch/issues/38202
+      version: " - 6.6.99"
+      reason: include_type_name is only supported as of 6.7
 
 
  - do:


### PR DESCRIPTION
This test had been disabled because of test failures, but it only affected the
6.x branch. The fix for 6.x is at #39054. On master/7.x/7.0 we can reenable the
test as-is.