### PR TITLE
Adjust backwards-compatibility versions for interval filters

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
@@ -326,7 +326,7 @@ setup:
 ---
 "Test overlapping":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.0.99"
       reason: "Implemented in 7.1"
   - do:
       search:
@@ -349,7 +349,7 @@ setup:
 ---
 "Test before":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.0.99"
       reason: "Implemented in 7.1"
   - do:
       search:
@@ -369,7 +369,7 @@ setup:
 ---
 "Test after":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.0.99"
       reason: "Implemented in 7.1"
   - do:
       search:


### PR DESCRIPTION
Follow up to #38999, this commit re-enables backwards-compatibility REST tests 
for `before`, `after` and `overlapping` filters against versions 7.1 and up.