### PR TITLE
Add some logging related to retention lease syncing

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -2011,8 +2011,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         verifyNotClosed();
         final Tuple<Boolean, RetentionLeases> retentionLeases = getRetentionLeases(true);
         if (retentionLeases.v1()) {
-            retentionLeaseSyncer.sync(shardId, retentionLeases.v2(), ActionListener.wrap(() -> {}));
+            logger.trace("syncing retention leases [{}] after expiration check", retentionLeases.v2());
+            retentionLeaseSyncer.sync(
+                    shardId,
+                    retentionLeases.v2(),
+                    ActionListener.wrap(r -> {}, e -> logger.warn("failed to sync retention leases after expiration check", e)));
         } else {
+            logger.trace("background syncing retention leases [{}] after expiration check", retentionLeases.v2());
             retentionLeaseSyncer.backgroundSync(shardId, retentionLeases.v2());
         }
     }


### PR DESCRIPTION
When the background retention lease sync fires, we check an see if any retention leases are expired. If any did expire, we execute a full retention lease sync (write action). Since this is happening on a background thread, we do not block that thread waiting for success (it will simply try again when the timer elapses). However, we were swallowing exceptions that indicate failure. This commit addresses that by logging the failures. Additionally, we add some trace logging to the execution of syncing retention leases.

Relates #37165
Relates #38380