### PR TITLE
Fix DateFormatters.parseMillis when no timezone is given

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
@@ -47,7 +47,7 @@ public interface DateFormatter {
      * Parse the given input into millis-since-epoch.
      */
     default long parseMillis(String input) {
-        return Instant.from(parse(input)).toEpochMilli();
+        return DateFormatters.from(parse(input)).toInstant().toEpochMilli();
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -683,6 +683,12 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2018-10-10T10:11:12,123Z", format, jodaFormatter, javaFormatter);
     }
 
+    public void testParsingMissingTimezone() {
+        long millisJava = DateFormatter.forPattern("8yyyy-MM-dd HH:mm:ss").parseMillis("2018-02-18 17:47:17");
+        long millisJoda = DateFormatter.forPattern("yyyy-MM-dd HH:mm:ss").parseMillis("2018-02-18 17:47:17");
+        assertThat(millisJava, is(millisJoda));
+    }
+
     private void assertSamePrinterOutput(String format, ZonedDateTime javaDate, DateTime jodaDate) {
         assertThat(jodaDate.getMillis(), is(javaDate.toInstant().toEpochMilli()));
         String javaTimeOut = DateFormatter.forPattern(format).format(javaDate);


### PR DESCRIPTION
The parseMillis method was able to work on formats without timezones by
falling back to UTC. The Java Date Formatter did not support this, as
the calling code was using the `Instant.from` java time API.

This switches over to an internal method which adds UTC as a timezone.

Closes #39067
