### PR TITLE
Remove Unused Parameter from Buffer Slice Method

### DIFF
--- a/libs/nio/src/main/java/org/elasticsearch/nio/InboundChannelBuffer.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/InboundChannelBuffer.java
@@ -194,15 +194,15 @@ public final class InboundChannelBuffer implements AutoCloseable {
     }
 
     /**
-     * This method will return an array of {@link ByteBuffer} representing the bytes from the index passed
+     * This method will return an array of {@link ByteBuffer} representing the bytes from the current index
      * through the end of this buffer. The buffers will be duplicates of the internal buffers, so any
      * modifications to the markers {@link ByteBuffer#position()}, {@link ByteBuffer#limit()}, etc will not
      * modify the this class.
      *
-     * @param from the index to slice from
      * @return the byte buffers
      */
-    public ByteBuffer[] sliceBuffersFrom(long from) {
+    public ByteBuffer[] sliceBuffers() {
+        final long from = internalIndex;
         if (from > capacity) {
             throw new IndexOutOfBoundsException("can't slice a channel buffer with capacity [" + capacity +
                 "], with slice parameters from [" + from + "]");

--- a/libs/nio/src/main/java/org/elasticsearch/nio/SocketChannelContext.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/SocketChannelContext.java
@@ -283,7 +283,7 @@ public abstract class SocketChannelContext extends ChannelContext<SocketChannel>
         } else {
             ioBuffer.flip();
             channelBuffer.ensureCapacity(channelBuffer.getIndex() + ioBuffer.remaining());
-            ByteBuffer[] buffers = channelBuffer.sliceBuffersFrom(channelBuffer.getIndex());
+            ByteBuffer[] buffers = channelBuffer.sliceBuffers();
             int j = 0;
             while (j < buffers.length && ioBuffer.remaining() > 0) {
                 ByteBuffer buffer = buffers[j++];

--- a/libs/nio/src/test/java/org/elasticsearch/nio/InboundChannelBufferTests.java
+++ b/libs/nio/src/test/java/org/elasticsearch/nio/InboundChannelBufferTests.java
@@ -227,7 +227,7 @@ public class InboundChannelBufferTests extends ESTestCase {
 
         long capacity = channelBuffer.getCapacity();
 
-        ByteBuffer[] postIndexBuffers = channelBuffer.sliceBuffersFrom(channelBuffer.getIndex());
+        ByteBuffer[] postIndexBuffers = channelBuffer.sliceBuffers();
         int i = 0;
         for (ByteBuffer buffer : postIndexBuffers) {
             while (buffer.hasRemaining()) {
@@ -241,7 +241,7 @@ public class InboundChannelBufferTests extends ESTestCase {
             assertEquals(indexIncremented - bytesReleased, channelBuffer.getIndex());
 
             long amountToInc = Math.min(randomInt(2000), channelBuffer.getRemaining());
-            ByteBuffer[] postIndexBuffers2 = channelBuffer.sliceBuffersFrom(channelBuffer.getIndex());
+            ByteBuffer[] postIndexBuffers2 = channelBuffer.sliceBuffers();
             assertEquals((byte) ((channelBuffer.getIndex() + bytesReleased) % 127), postIndexBuffers2[0].get());
             ByteBuffer[] preIndexBuffers = channelBuffer.sliceBuffersTo(channelBuffer.getIndex());
             if (preIndexBuffers.length > 0) {
@@ -257,6 +257,6 @@ public class InboundChannelBufferTests extends ESTestCase {
             indexIncremented += amountToInc;
         }
 
-        assertEquals(0, channelBuffer.sliceBuffersFrom(channelBuffer.getIndex()).length);
+        assertEquals(0, channelBuffer.sliceBuffers().length);
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/nio/SSLDriver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/nio/SSLDriver.java
@@ -175,7 +175,7 @@ public class SSLDriver implements AutoCloseable {
 
     private SSLEngineResult unwrap(InboundChannelBuffer buffer) throws SSLException {
         while (true) {
-            SSLEngineResult result = engine.unwrap(networkReadBuffer, buffer.sliceBuffersFrom(buffer.getIndex()));
+            SSLEngineResult result = engine.unwrap(networkReadBuffer, buffer.sliceBuffers());
             buffer.incrementIndex(result.bytesProduced());
             switch (result.getStatus()) {
                 case OK:

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SSLChannelContextTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SSLChannelContextTests.java
@@ -417,7 +417,7 @@ public class SSLChannelContextTests extends ESTestCase {
         return invocationOnMock -> {
             InboundChannelBuffer buffer = (InboundChannelBuffer) invocationOnMock.getArguments()[0];
             buffer.ensureCapacity(buffer.getIndex() + bytes.length);
-            ByteBuffer[] buffers = buffer.sliceBuffersFrom(buffer.getIndex());
+            ByteBuffer[] buffers = buffer.sliceBuffers();
             assert buffers[0].remaining() > bytes.length;
             buffers[0].put(bytes);
             buffer.incrementIndex(bytes.length);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SSLDriverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SSLDriverTests.java
@@ -112,8 +112,8 @@ public class SSLDriverTests extends ESTestCase {
         ByteBuffer[] buffers = {buffer};
         sendAppData(clientDriver, serverDriver, buffers);
         serverDriver.read(serverBuffer);
-        assertEquals(16384, serverBuffer.sliceBuffersFrom(0)[0].limit());
-        assertEquals(16384, serverBuffer.sliceBuffersFrom(0)[1].limit());
+        assertEquals(16384, serverBuffer.sliceBuffers()[0].limit());
+        assertEquals(16384, serverBuffer.sliceBuffers()[1].limit());
 
         ByteBuffer[] buffers2 = {ByteBuffer.wrap("pong".getBytes(StandardCharsets.UTF_8))};
         sendAppData(serverDriver, clientDriver, buffers2);


### PR DESCRIPTION
* We're always slicing from the current index in all callers of this method (the tests that pass `0` have index `0` set as well) => removed the parameter to make the logic a little easier to follow
