### PR TITLE
Fix DateFormatters.parseMillis when no timezone is given

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/70_bwc_date.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/70_bwc_date.yml
@@ -1,6 +1,10 @@
 ---
 "Index java 8 date without timezone":
 
+ - skip:
+    version: " - 6.6.99"
+    reason: bwc formatters were introduced in Elasticsearch 6.7
+
  - do:
      indices.create:
          index: test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/70_bwc_date.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/70_bwc_date.yml
@@ -1,0 +1,35 @@
+---
+"Index java 8 date without timezone":
+
+ - do:
+     indices.create:
+         index: test_index
+         body:
+             settings:
+                 number_of_shards: 1
+             mappings:
+                 doc:
+                     properties:
+                         date_field:
+                             type: date
+                             format: "8yyyy-MM-dd HH:mm:ss"
+ - do:
+      bulk:
+          refresh: true
+          body:
+              - '{"index": {"_index": "test_index", "_type": "doc", "_id": "1"}}'
+              - '{"date_field": "2018-02-18 17:47:17"}'
+
+ - match: { errors: false }
+
+ - do:
+      get:
+          index:  test_index
+          type:   doc
+          id:     1
+
+ - match:   { _index:   test_index }
+ - match:   { _type:    doc }
+ - match:   { _id:      "1"}
+ - match:   { _version: 1}
+ - match:   { _source: { "date_field": "2018-02-18 17:47:17" }}

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
@@ -48,7 +48,7 @@ public interface DateFormatter {
      * Parse the given input into millis-since-epoch.
      */
     default long parseMillis(String input) {
-        return Instant.from(parse(input)).toEpochMilli();
+        return DateFormatters.from(parse(input)).toInstant().toEpochMilli();
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -616,6 +616,12 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2018-128", "year_month_day||ordinal_date", jodaFormatter, javaFormatter);
     }
 
+    public void testParsingMissingTimezone() {
+        long millisJava = DateFormatter.forPattern("8yyyy-MM-dd HH:mm:ss").parseMillis("2018-02-18 17:47:17");
+        long millisJoda = DateFormatter.forPattern("yyyy-MM-dd HH:mm:ss").parseMillis("2018-02-18 17:47:17");
+        assertThat(millisJava, is(millisJoda));
+    }
+
     private void assertSamePrinterOutput(String format, ZonedDateTime javaDate, DateTime jodaDate) {
         assertThat(jodaDate.getMillis(), is(javaDate.toInstant().toEpochMilli()));
         String javaTimeOut = DateFormatters.forPattern(format).format(javaDate);


### PR DESCRIPTION
The parseMillis method was able to work on formats without timezones by
falling back to UTC. The Java Date Formatter did not support this, as
the calling code was using the `Instant.from` java time API.

This switches over to an internal method which adds UTC as a timezone.

Closes #39067

This is a backport of #39100 with another REST test added