### PR TITLE
ilm.explain_lifecycle documents human again

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.explain_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.explain_lifecycle.json
@@ -11,13 +11,7 @@
           "description" : "The name of the index to explain"
         }
       },
-      "params": {
-        "human": {
-          "type" : "boolean",
-          "default" : "false",
-          "description" : "Return data such as dates in a human readable format"
-        }
-      }
+      "params": {}
     },
     "body": null
   }


### PR DESCRIPTION
This is already exposed as a `_common.json` global parameter.
