### PR TITLE
Add some missing toString() implementations

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionListenerResponseHandler.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListenerResponseHandler.java
@@ -68,4 +68,9 @@ public class ActionListenerResponseHandler<Response extends TransportResponse> i
     public Response read(StreamInput in) throws IOException {
         return reader.read(in);
     }
+
+    @Override
+    public String toString() {
+        return super.toString() + "/" + listener;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -196,6 +196,11 @@ public class ReplicationOperation<
                     replicaException, ReplicationOperation.this::decPendingAndFinishIfNeeded,
                     ReplicationOperation.this::onPrimaryDemoted, throwable -> decPendingAndFinishIfNeeded());
             }
+
+            @Override
+            public String toString() {
+                return "[" + replicaRequest + "][" + shard + "]";
+            }
         });
     }
 


### PR DESCRIPTION
Sometimes we turn objects into strings for logging or debugging using
`toString()`, but the default implementation is often unhelpful. This change
improves on this in two places I ran into recently.