### PR TITLE
Use pkill to shutdown elasticsearch using pid file

### DIFF
--- a/docs/reference/setup/install/zip-targz-daemon.asciidoc
+++ b/docs/reference/setup/install/zip-targz-daemon.asciidoc
@@ -14,7 +14,7 @@ To shut down Elasticsearch, kill the process ID recorded in the `pid` file:
 
 [source,sh]
 --------------------------------------------
-kill `cat pid`
+pkill -F pid
 --------------------------------------------
 
 NOTE: The startup scripts provided in the <<rpm,RPM>> and <<deb,Debian>>

--- a/docs/reference/setup/install/zip-targz-daemon.asciidoc
+++ b/docs/reference/setup/install/zip-targz-daemon.asciidoc
@@ -14,7 +14,7 @@ To shut down Elasticsearch, kill the process ID recorded in the `pid` file:
 
 [source,sh]
 --------------------------------------------
-pkill -F pid
+pkill -F pid 
 --------------------------------------------
 
 NOTE: The startup scripts provided in the <<rpm,RPM>> and <<deb,Debian>>


### PR DESCRIPTION
While running these commands from alias, facing issues using 
```
kill cat `pid`
```
possibly because it's being parsed using different rules.

, In some situations, the more compact:
```
pkill -F pid
```
is the way to go.

With this in place, I can simply use alias to start/stop elasticsearch

> alias elastic_run="cd /Users/neeraj/elasticsearch-6.6.0; ./bin/elasticsearch -d -p elastic_pid -Ecluster.name=neeraj_elasticsearch_cluster -Enode.name=neeraj_elastic_cluster_node"

> alias elastic_stop="cd /Users/neeraj/elasticsearch-6.6.0; pkill -F elastic_pid"


<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->