### PR TITLE
Revert "Mute failing test 20_mix_typless_typefull (#38781)" (#38912)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/20_mix_typeless_typeful.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/20_mix_typeless_typeful.yml
@@ -104,10 +104,8 @@
 "Implicitly create a typeless index while there is a typed template":
 
  - skip:
-    #version: " - 6.99.99"
-    #reason: needs typeless index operations to work on typed indices
-    version:  "all"
-    reason:   "muted, waiting for #38711"
+      version: " - 6.99.99"
+      reason: needs typeless index operations to work on typed indices
 
  - do:
       indices.put_template:


### PR DESCRIPTION
Backport of #38912

This reverts commit b91e0589fe1efdaa5061a75a3674a5cc8706b703.

This should be fixed by #38873

Resolves #38711
