### PR TITLE
[DOCS] Unset machine learning upgrade mode

### DIFF
--- a/docs/reference/upgrade/close-ml.asciidoc
+++ b/docs/reference/upgrade/close-ml.asciidoc
@@ -25,18 +25,9 @@ prevent new jobs from opening, use the <<ml-set-upgrade-mode,set upgrade mode AP
 POST _ml/set_upgrade_mode?enabled=true
 --------------------------------------------------
 // CONSOLE
+// TEARDOWN
 
 This method does not persist the absolute latest model state, rather it uses the
 last model state that was automatically saved. By halting the tasks, you avoid
 incurring the cost of managing active jobs during the upgrade and it's quicker
 than stopping {dfeeds} and closing jobs. 
-
-//////////////////////////
-
-[source,js]
---------------------------------------------------
-POST /_ml/set_upgrade_mode?enabled=false
---------------------------------------------------
-// CONSOLE
-
-//////////////////////////

--- a/docs/reference/upgrade/close-ml.asciidoc
+++ b/docs/reference/upgrade/close-ml.asciidoc
@@ -1,5 +1,16 @@
 [testenv="platinum"]
 
+////////////
+Take us out of upgrade mode after running any snippets on this page.
+
+[source,js]
+--------------------------------------------------
+POST _ml/set_upgrade_mode?enabled=false
+--------------------------------------------------
+// CONSOLE
+// TEARDOWN
+////////////
+
 If your {ml} indices were created earlier than the previous major version, they
 must be reindexed. In those circumstances, there must be no machine learning
 jobs running during the upgrade. 
@@ -25,7 +36,6 @@ prevent new jobs from opening, use the <<ml-set-upgrade-mode,set upgrade mode AP
 POST _ml/set_upgrade_mode?enabled=true
 --------------------------------------------------
 // CONSOLE
-// TEARDOWN
 
 This method does not persist the absolute latest model state, rather it uses the
 last model state that was automatically saved. By halting the tasks, you avoid

--- a/docs/reference/upgrade/close-ml.asciidoc
+++ b/docs/reference/upgrade/close-ml.asciidoc
@@ -30,3 +30,13 @@ This method does not persist the absolute latest model state, rather it uses the
 last model state that was automatically saved. By halting the tasks, you avoid
 incurring the cost of managing active jobs during the upgrade and it's quicker
 than stopping {dfeeds} and closing jobs. 
+
+//////////////////////////
+
+[source,js]
+--------------------------------------------------
+POST /_ml/set_upgrade_mode?enabled=false
+--------------------------------------------------
+// CONSOLE
+
+//////////////////////////


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/38876 and https://github.com/elastic/elasticsearch/pull/38993

This PR makes the close-ml.asciidoc file set upgrade mode to false before it finishes. 
