### PR TITLE
[DOCS] Adds 6.7.0 release notes

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the changes in each release.
 
+* <<release-notes-6.7.0>>
 * <<release-notes-6.6.1>>
 * <<release-notes-6.6.0>>
 * <<release-notes-6.5.4>>
@@ -41,6 +42,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/6.7.asciidoc[]
 include::release-notes/6.6.asciidoc[]
 include::release-notes/6.5.asciidoc[]
 include::release-notes/6.4.asciidoc[]

--- a/docs/reference/release-notes/6.7.asciidoc
+++ b/docs/reference/release-notes/6.7.asciidoc
@@ -1,9 +1,9 @@
 [[release-notes-6.7.0]]
-== 6.7.0 Release Notes
+== {es} version 6.7.0
 
 coming[6.7.0]
 
-Also see <<breaking-changes-6.7>>.
+Also see <<breaking-changes-6.7,Breaking changes in 6.7>>.
 
 [[breaking-6.7.0]]
 [float]


### PR DESCRIPTION
This PR adds the 6.7.0 Elasticsearch Release Notes (which were created in  https://github.com/elastic/elasticsearch/pull/38840) to the Elasticsearch Reference.

It also edits the file name and page title to align with the other pages.
