### PR TITLE
remove ilm+ccr warning from docs

### DIFF
--- a/docs/reference/ilm/index.asciidoc
+++ b/docs/reference/ilm/index.asciidoc
@@ -6,10 +6,6 @@
 [partintro]
 --
 
-WARNING: {ilm-cap} is currently not supported by
-{stack-ov}/ccr-getting-started.html#ccr-getting-started-leader-index[leader indices] and
-{stack-ov}/ccr-getting-started.html#ccr-getting-started-follower-index[follower indices].
-
 The <<index-lifecycle-management-api, {ilm} ({ilm-init}) APIs>> enable you to
 automate how you want to manage your indices over time. Rather than simply
 performing management actions on your indices on a set schedule, you can base


### PR DESCRIPTION
This commit removes the ILM + CCR warning for 6.7.
