### PR TITLE
Extend nextDoc to delegate to the wrapped doc-value iterator for date_nanos

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericDVIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericDVIndexFieldData.java
@@ -177,6 +177,11 @@ public class SortedNumericDVIndexFieldData extends DocValuesIndexFieldData imple
                 public int docValueCount() {
                     return dv.docValueCount();
                 }
+
+                @Override
+                public int nextDoc() throws IOException {
+                    return dv.nextDoc();
+                }
             };
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexOptions;
@@ -26,6 +27,8 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.MultiReader;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
@@ -37,6 +40,9 @@ import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.fielddata.AtomicNumericFieldData;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.plain.SortedNumericDVIndexFieldData;
 import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType.Relation;
 import org.elasticsearch.index.mapper.ParseContext.Document;
@@ -213,5 +219,37 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> ft.rangeQuery(date1, date2, true, true, null, null, null, context));
         assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
+    }
+
+    public void testDateNanoDocValues() throws IOException {
+        // Create an index with some docValues
+        Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+        Document doc = new Document();
+        NumericDocValuesField docValuesField = new NumericDocValuesField("my_date", 1444608000000L);
+        doc.add(docValuesField);
+        w.addDocument(doc);
+        docValuesField.setLongValue(1459641600000L);
+        w.addDocument(doc);
+        w.flush();
+        // Create the doc values reader
+        Settings indexSettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1).build();
+        QueryShardContext context = new QueryShardContext(0,
+            new IndexSettings(IndexMetaData.builder("foo").settings(indexSettings).build(), indexSettings),
+            null, null, null, null, null, xContentRegistry(), writableRegistry(), null, null, () -> nowInMillis, null);
+        SortedNumericDVIndexFieldData fieldData = new SortedNumericDVIndexFieldData(context.index(), "my_date",
+            IndexNumericFieldData.NumericType.DATE_NANOSECONDS);
+        // Read index and check the doc values
+        DirectoryReader reader = DirectoryReader.open(w);
+        assertTrue(reader.leaves().size() > 0);
+        AtomicNumericFieldData a = fieldData.load(reader.leaves().get(0).reader().getContext());
+        SortedNumericDocValues docValues = a.getLongValues();
+        assertEquals(0, docValues.nextDoc());
+        assertEquals(1, docValues.nextDoc());
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, docValues.nextDoc());
+        reader.close();
+        w.close();
+        dir.close();
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
@@ -231,14 +231,11 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         w.addDocument(doc);
         docValuesField.setLongValue(1459641600000L);
         w.addDocument(doc);
-        w.flush();
         // Create the doc values reader
-        Settings indexSettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+        Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1).build();
-        QueryShardContext context = new QueryShardContext(0,
-            new IndexSettings(IndexMetaData.builder("foo").settings(indexSettings).build(), indexSettings),
-            null, null, null, null, null, xContentRegistry(), writableRegistry(), null, null, () -> nowInMillis, null);
-        SortedNumericDVIndexFieldData fieldData = new SortedNumericDVIndexFieldData(context.index(), "my_date",
+        IndexSettings indexSettings =  new IndexSettings(IndexMetaData.builder("foo").settings(settings).build(), settings);
+        SortedNumericDVIndexFieldData fieldData = new SortedNumericDVIndexFieldData(indexSettings.getIndex(), "my_date",
             IndexNumericFieldData.NumericType.DATE_NANOSECONDS);
         // Read index and check the doc values
         DirectoryReader reader = DirectoryReader.open(w);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
@@ -1561,4 +1561,45 @@ public class DateHistogramIT extends ESIntegTestCase {
     private ZonedDateTime key(Histogram.Bucket bucket) {
         return (ZonedDateTime) bucket.getKey();
     }
+
+    /**
+     * See https://github.com/elastic/elasticsearch/issues/39107. Make sure we handle properly different
+     * timeZones.
+     */
+    public void testDateNanosHistogram() throws Exception {
+        assertAcked(prepareCreate("nanos").addMapping("_doc", "date", "type=date_nanos").get());
+        indexRandom(true,
+            client().prepareIndex("nanos", "_doc", "1").setSource("date", "2000-01-01"));
+        indexRandom(true,
+            client().prepareIndex("nanos", "_doc", "2").setSource("date", "2000-01-02"));
+
+        //Search interval 24 hours
+        SearchResponse r = client().prepareSearch("nanos")
+            .addAggregation(dateHistogram("histo").field("date").interval(1000 * 60 * 60 * 24).timeZone(ZoneId.of("Europe/Berlin")))
+            .addDocValueField("date")
+            .get();
+        assertSearchResponse(r);
+
+        Histogram histogram = r.getAggregations().get("histo");
+        List<? extends Bucket> buckets = histogram.getBuckets();
+        assertEquals(2, buckets.size());
+        assertEquals(946681200000l,  ((ZonedDateTime)buckets.get(0).getKey()).toEpochSecond() * 1000);
+        assertEquals(1, buckets.get(0).getDocCount());
+        assertEquals(946767600000l, ((ZonedDateTime)buckets.get(1).getKey()).toEpochSecond() * 1000);
+        assertEquals(1, buckets.get(1).getDocCount());
+
+        r = client().prepareSearch("nanos")
+            .addAggregation(dateHistogram("histo").field("date").interval(1000 * 60 * 60 * 24).timeZone(ZoneId.of("UTC")))
+            .addDocValueField("date")
+            .get();
+        assertSearchResponse(r);
+
+        histogram = r.getAggregations().get("histo");
+        buckets = histogram.getBuckets();
+        assertEquals(2, buckets.size());
+        assertEquals(946684800000l,  ((ZonedDateTime)buckets.get(0).getKey()).toEpochSecond() * 1000);
+        assertEquals(1, buckets.get(0).getDocCount());
+        assertEquals(946771200000l, ((ZonedDateTime)buckets.get(1).getKey()).toEpochSecond() * 1000);
+        assertEquals(1, buckets.get(1).getDocCount());
+    }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
@@ -1575,7 +1575,8 @@ public class DateHistogramIT extends ESIntegTestCase {
 
         //Search interval 24 hours
         SearchResponse r = client().prepareSearch("nanos")
-            .addAggregation(dateHistogram("histo").field("date").interval(1000 * 60 * 60 * 24).timeZone(ZoneId.of("Europe/Berlin")))
+            .addAggregation(dateHistogram("histo").field("date").
+                interval(1000 * 60 * 60 * 24).timeZone(ZoneId.of("Europe/Berlin")))
             .addDocValueField("date")
             .get();
         assertSearchResponse(r);
@@ -1589,7 +1590,8 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertEquals(1, buckets.get(1).getDocCount());
 
         r = client().prepareSearch("nanos")
-            .addAggregation(dateHistogram("histo").field("date").interval(1000 * 60 * 60 * 24).timeZone(ZoneId.of("UTC")))
+            .addAggregation(dateHistogram("histo").field("date")
+                .interval(1000 * 60 * 60 * 24).timeZone(ZoneId.of("UTC")))
             .addDocValueField("date")
             .get();
         assertSearchResponse(r);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
@@ -1584,9 +1584,9 @@ public class DateHistogramIT extends ESIntegTestCase {
         Histogram histogram = r.getAggregations().get("histo");
         List<? extends Bucket> buckets = histogram.getBuckets();
         assertEquals(2, buckets.size());
-        assertEquals(946681200000l,  ((ZonedDateTime)buckets.get(0).getKey()).toEpochSecond() * 1000);
+        assertEquals(946681200000L,  ((ZonedDateTime)buckets.get(0).getKey()).toEpochSecond() * 1000);
         assertEquals(1, buckets.get(0).getDocCount());
-        assertEquals(946767600000l, ((ZonedDateTime)buckets.get(1).getKey()).toEpochSecond() * 1000);
+        assertEquals(946767600000L, ((ZonedDateTime)buckets.get(1).getKey()).toEpochSecond() * 1000);
         assertEquals(1, buckets.get(1).getDocCount());
 
         r = client().prepareSearch("nanos")
@@ -1599,9 +1599,9 @@ public class DateHistogramIT extends ESIntegTestCase {
         histogram = r.getAggregations().get("histo");
         buckets = histogram.getBuckets();
         assertEquals(2, buckets.size());
-        assertEquals(946684800000l,  ((ZonedDateTime)buckets.get(0).getKey()).toEpochSecond() * 1000);
+        assertEquals(946684800000L,  ((ZonedDateTime)buckets.get(0).getKey()).toEpochSecond() * 1000);
         assertEquals(1, buckets.get(0).getDocCount());
-        assertEquals(946771200000l, ((ZonedDateTime)buckets.get(1).getKey()).toEpochSecond() * 1000);
+        assertEquals(946771200000L, ((ZonedDateTime)buckets.get(1).getKey()).toEpochSecond() * 1000);
         assertEquals(1, buckets.get(1).getDocCount());
     }
 }


### PR DESCRIPTION
The type `date_nanos` does not direct doc-value iterators and it needs to extend `next_doc` in order to delegate the call to the wrapped iterator.

closes #39107