### PR TITLE
[FEATURE][ML] Add timeout to the start DF analytics request

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsRequestTests.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction.Request;
 
@@ -13,6 +14,10 @@ public class StartDataFrameAnalyticsRequestTests extends AbstractWireSerializing
 
     @Override
     protected Request createTestInstance() {
+        Request request = new Request(randomAlphaOfLength(20));
+        if (randomBoolean()) {
+            request.setTimeout(TimeValue.timeValueMillis(randomNonNegativeLong()));
+        }
         return new Request(randomAlphaOfLength(20));
     }
 

--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -99,6 +99,7 @@ integTestRunner {
     'ml/start_data_frame_analytics/Test start given missing config',
     'ml/start_data_frame_analytics/Test start given missing source index',
     'ml/start_data_frame_analytics/Test start given source index has no compatible fields',
+    'ml/start_data_frame_analytics/Test start with inconsistent body/param ids',
     'ml/start_stop_datafeed/Test start datafeed job, but not open',
     'ml/start_stop_datafeed/Test start non existing datafeed',
     'ml/start_stop_datafeed/Test stop non existing datafeed',

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -115,7 +115,7 @@ public class TransportStartDataFrameAnalyticsAction
             new ActionListener<PersistentTasksCustomMetaData.PersistentTask<StartDataFrameAnalyticsAction.TaskParams>>() {
                 @Override
                 public void onResponse(PersistentTasksCustomMetaData.PersistentTask<StartDataFrameAnalyticsAction.TaskParams> task) {
-                    waitForAnalyticsStarted(task, listener);
+                    waitForAnalyticsStarted(task, request.getTimeout(), listener);
                 }
 
                 @Override
@@ -147,10 +147,10 @@ public class TransportStartDataFrameAnalyticsAction
     }
 
     private void waitForAnalyticsStarted(PersistentTasksCustomMetaData.PersistentTask<StartDataFrameAnalyticsAction.TaskParams> task,
-                                         ActionListener<AcknowledgedResponse> listener) {
+                                         TimeValue timeout, ActionListener<AcknowledgedResponse> listener) {
         AnalyticsPredicate predicate = new AnalyticsPredicate();
-        // TODO Add timeout parameter to the start analytics request and use it here instead of hardcoded value
-        persistentTasksService.waitForPersistentTaskCondition(task.getId(), predicate, TimeValue.timeValueSeconds(10),
+        persistentTasksService.waitForPersistentTaskCondition(task.getId(), predicate, timeout,
+
             new PersistentTasksService.WaitForPersistentTaskListener<PersistentTaskParams>() {
 
                 @Override
@@ -280,6 +280,7 @@ public class TransportStartDataFrameAnalyticsAction
         @Override
         protected void nodeOperation(AllocatedPersistentTask task, StartDataFrameAnalyticsAction.TaskParams params,
                                      PersistentTaskState state) {
+            LOGGER.info("[{}] Starting data frame analytics", params.getId());
             DataFrameAnalyticsTaskState startedState = new DataFrameAnalyticsTaskState(DataFrameAnalyticsState.STARTED,
                 task.getAllocationId());
             task.updatePersistentTaskState(startedState, ActionListener.wrap(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestStartDataFrameAnalyticsAction.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.ml.rest.dataframe;
 
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -33,8 +34,17 @@ public class RestStartDataFrameAnalyticsAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         String id = restRequest.param(DataFrameAnalyticsConfig.ID.getPreferredName());
-        StartDataFrameAnalyticsAction.Request request = new StartDataFrameAnalyticsAction.Request(id);
-
+        StartDataFrameAnalyticsAction.Request request;
+        if (restRequest.hasContentOrSourceParam()) {
+            request = StartDataFrameAnalyticsAction.Request.parseRequest(id, restRequest.contentOrSourceParamParser());
+        } else {
+            request = new StartDataFrameAnalyticsAction.Request(id);
+            if (restRequest.hasParam(StartDataFrameAnalyticsAction.Request.TIMEOUT.getPreferredName())) {
+                TimeValue timeout = restRequest.paramAsTime(StartDataFrameAnalyticsAction.Request.TIMEOUT.getPreferredName(),
+                    request.getTimeout());
+                request.setTimeout(timeout);
+            }
+        }
         return channel -> client.execute(StartDataFrameAnalyticsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.start_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.start_data_frame_analytics.json
@@ -10,7 +10,17 @@
           "required": true,
           "description": "The ID of the data frame analytics to start"
         }
+      },
+      "params": {
+        "timeout": {
+          "type": "time",
+          "required": false,
+          "description": "Controls the time to wait until the task has started. Defaults to 20 seconds"
+        }
       }
+    },
+    "body": {
+      "description": "The start data frame analytics parameters"
     }
   }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_data_frame_analytics.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_data_frame_analytics.yml
@@ -44,3 +44,15 @@
       catch: /No compatible fields could be detected in index \[empty-index\]/
       ml.start_data_frame_analytics:
         id: "foo"
+
+---
+"Test start with inconsistent body/param ids":
+
+  - do:
+      catch: /Inconsistent id; 'body_id' specified in the body differs from 'url_id' specified as a URL argument/
+      ml.start_data_frame_analytics:
+        id: "url_id"
+        body: >
+          {
+            "id": "body_id"
+          }


### PR DESCRIPTION
Adds `timeout` to the start data frame analytics API. Also, this request can now read parameters from the URL or the body.