### PR TITLE
Fix anaylze NullPointerException when AnalyzeTokenList tokens is null

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/DetailAnalyzeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/DetailAnalyzeResponse.java
@@ -296,8 +296,10 @@ public class DetailAnalyzeResponse implements Streamable, ToXContentFragment {
         XContentBuilder toXContentWithoutObject(XContentBuilder builder, Params params) throws IOException {
             builder.field(Fields.NAME, this.name);
             builder.startArray(AnalyzeResponse.Fields.TOKENS);
-            for (AnalyzeResponse.AnalyzeToken token : tokens) {
-                token.toXContent(builder, params);
+            if (tokens != null) {
+                for (AnalyzeResponse.AnalyzeToken token : tokens) {
+                    token.toXContent(builder, params);
+                }
             }
             builder.endArray();
             return builder;


### PR DESCRIPTION

GET test_analyze/_analyze api maybe return NullPointerException when AnalyzeTokenList tokens is null.
It appears when get AnalyzeResponse from other es node. because it will cause new AnalyzeResponse from readFrom method.
the NullPointerException case can appear as follow(more then two nodes):

first:
```
PUT test_analyze
{
  "settings": {
    "index": {
      "analysis": {
        "filter": {
          "stopwords_filter": {
            "type": "stop",
            "stopwords": ["the", "over"]
          }
        },
        "analyzer": {
          "standard_syno": {
            "filter": [
              "stopwords_filter"
            ],
            "type": "custom",
            "tokenizer": "standard"
          }
        }
      }
    }
  }
}
```

then:
```
GET test_analyze/_analyze
{
  "text":"the",
  "analyzer":"standard_syno",
  "explain":true
}
```

it sometimes appear(when transport action execute on the other node):
```
{
  "error": {
    "root_cause": [
      {
        "type": "null_pointer_exception",
        "reason": null
      }
    ],
    "type": "null_pointer_exception",
    "reason": null
  },
  "status": 500
}
```

I fixed this bug in the commit.
I also find that when charfilters field is null, the xcontent result is different when execute on local node and on the other node. because this is my fisrt commit, I made this pr simple.