### PR TITLE
[Backport 7.x] Fix the OS sensing code in ClusterFormationTasks (#38457)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
@@ -20,6 +20,7 @@ package org.elasticsearch.gradle.doc
 
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
+import org.elasticsearch.gradle.test.ClusterFormationTasks
 import org.elasticsearch.gradle.test.RestTestPlugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -46,6 +47,7 @@ public class DocsTestPlugin extends RestTestPlugin {
             '\\{version_qualified\\}': VersionProperties.elasticsearch,
             '\\{lucene_version\\}' : VersionProperties.lucene.replaceAll('-snapshot-\\w+$', ''),
             '\\{build_flavor\\}' : project.integTestCluster.distribution,
+            '\\{build_type\\}' : ClusterFormationTasks.getOs().equals("windows") ? "zip" : "tar",
         ]
         Task listSnippets = project.tasks.create('listSnippets', SnippetsTask)
         listSnippets.group 'Docs'

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -274,7 +274,7 @@ class ClusterFormationTasks {
         }
         setup = configureCheckPreviousTask(taskName(prefix, node, 'checkPrevious'), project, setup, node)
         setup = configureStopTask(taskName(prefix, node, 'stopPrevious'), project, setup, node)
-        setup = configureExtractTask(taskName(prefix, node, 'extract'), project, setup, node, distribution)
+        setup = configureExtractTask(taskName(prefix, node, 'extract'), project, setup, node, distribution, config.distribution)
         setup = configureWriteConfigTask(taskName(prefix, node, 'configure'), project, setup, node, writeConfig)
         setup = configureCreateKeystoreTask(taskName(prefix, node, 'createKeystore'), project, setup, node)
         setup = configureAddKeystoreSettingTasks(prefix, project, setup, node)
@@ -343,14 +343,15 @@ class ClusterFormationTasks {
     }
 
     /** Adds a task to extract the elasticsearch distribution */
-    static Task configureExtractTask(String name, Project project, Task setup, NodeInfo node, Configuration configuration) {
+    static Task configureExtractTask(String name, Project project, Task setup, NodeInfo node,
+                                     Configuration configuration, String distribution) {
         List extractDependsOn = [configuration, setup]
         /* configuration.singleFile will be an external artifact if this is being run by a plugin not living in the
           elasticsearch source tree. If this is a plugin built in the elasticsearch source tree or this is a distro in
           the elasticsearch source tree then this should be the version of elasticsearch built by the source tree.
           If it isn't then Bad Things(TM) will happen. */
         Task extract = project.tasks.create(name: name, type: Copy, dependsOn: extractDependsOn) {
-            if (getOs().equals("windows")) {
+            if (getOs().equals("windows") || distribution.equals("integ-test-zip")) {
                 from {
                     project.zipTree(configuration.singleFile)
                 }
@@ -971,9 +972,9 @@ class ClusterFormationTasks {
     /** Find the current OS */
     static String getOs() {
         String os = "linux"
-        if (Os.FAMILY_WINDOWS) {
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
             os = "windows"
-        } else if (Os.FAMILY_MAC) {
+        } else if (Os.isFamily(Os.FAMILY_MAC)) {
             os = "darwin"
         }
         return os

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -351,7 +351,7 @@ class ClusterFormationTasks {
           the elasticsearch source tree then this should be the version of elasticsearch built by the source tree.
           If it isn't then Bad Things(TM) will happen. */
         Task extract = project.tasks.create(name: name, type: Copy, dependsOn: extractDependsOn) {
-            if (getOs().equals("windows") || distribution.equals("integ-test-zip")) {
+            if (getOs().equals("windows") || distribution.equals("integ-test-zip") || node.nodeVersion.before("7.0.0")) {
                 from {
                     project.zipTree(configuration.singleFile)
                 }

--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -6,6 +6,7 @@
 :jdk:                   1.8.0_131
 :jdk_major:             8
 :build_flavor:          default
+:build_type:            tar
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/docs/plugins/discovery-azure-classic.asciidoc
+++ b/docs/plugins/discovery-azure-classic.asciidoc
@@ -374,7 +374,7 @@ This command should give you a JSON result:
   "version" : {
     "number" : "{version_qualified}",
     "build_flavor" : "{build_flavor}",
-    "build_type" : "zip",
+    "build_type" : "{build_type}",
     "build_hash" : "f27399d",
     "build_date" : "2016-03-30T09:51:41.449Z",
     "build_snapshot" : false,

--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -143,7 +143,7 @@ The result will look similar to:
       "ip": "192.168.17",
       "version": "{version}",
       "build_flavor": "{build_flavor}",
-      "build_type": "zip",
+      "build_type": "{build_type}",
       "build_hash": "587409e",
       "roles": [
         "master",
@@ -224,7 +224,7 @@ The result will look similar to:
       "ip": "192.168.17",
       "version": "{version}",
       "build_flavor": "{build_flavor}",
-      "build_type": "zip",
+      "build_type": "{build_type}",
       "build_hash": "587409e",
       "roles": [],
       "attributes": {},

--- a/docs/reference/setup/install/check-running.asciidoc
+++ b/docs/reference/setup/install/check-running.asciidoc
@@ -20,7 +20,7 @@ which should give you a response something like this:
   "version" : {
     "number" : "{version_qualified}",
     "build_flavor" : "{build_flavor}",
-    "build_type" : "zip",
+    "build_type" : "{build_type}",
     "build_hash" : "f27399d",
     "build_date" : "2016-03-30T09:51:41.449Z",
     "build_snapshot" : false,


### PR DESCRIPTION
This fixes a bug in the sensing of the current OS family in the test cluster
formation code. Previously all builds would assume every environment 
was windows and would jump to using the windows zip build. This fixes 
the OS sensing code as well as updates some tests to account for 
different build flavors.

Backport of #38457 