### PR TITLE
Fixing 503 Service Unavailable errors during fetch phase

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -85,8 +85,9 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
     @Override
     public RestStatus status() {
         if (shardFailures.length == 0) {
-            // if no successful shards, it means no active shards, so just return SERVICE_UNAVAILABLE
-            return RestStatus.SERVICE_UNAVAILABLE;
+            // if no successful shards, the failure could have happened even before the fetch phase started
+            // so try to get the status from the cause instead of returning SERVICE_UNAVAILABLE blindly
+            return ExceptionsHelper.status(this.getCause());
         }
         RestStatus status = shardFailures[0].status();
         if (shardFailures.length > 1) {

--- a/server/src/test/java/org/elasticsearch/action/search/SearchPhaseExecutionExceptionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchPhaseExecutionExceptionTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.TimestampParsingException;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -32,6 +33,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.shard.IndexShardClosedException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.InvalidIndexTemplateException;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.test.ESTestCase;
 
@@ -120,5 +122,32 @@ public class SearchPhaseExecutionExceptionTests extends ESTestCase {
         assertThat(parsedException.getMetadata("es.phase"), hasItem(phase));
         // SearchPhaseExecutionException has no cause field
         assertNull(parsedException.getCause());
+    }
+
+    public void testPhaseFailureWithoutSearchShardFailure() {
+        final ShardSearchFailure[] searchShardFailures = new ShardSearchFailure[0];
+        final String phase = randomFrom("fetch", "search", "other");
+        SearchPhaseExecutionException actual = new SearchPhaseExecutionException(phase, "unexpected failures", new EsRejectedExecutionException("ES rejected execution of fetch phase"), searchShardFailures);
+
+        assertEquals(actual.status(), RestStatus.TOO_MANY_REQUESTS);
+    }
+
+    public void testPhaseFailureWithSearchShardFailure() {
+        final ShardSearchFailure[] shardSearchFailures = new ShardSearchFailure[randomIntBetween(1, 5)];
+        for (int i = 0; i < shardSearchFailures.length; i++) {
+            Exception cause = randomFrom(
+                new ParsingException(1, 2, "foobar", null),
+                new InvalidIndexTemplateException("foo", "bar"),
+                new TimestampParsingException("foo", null),
+                new NullPointerException()
+            );
+            shardSearchFailures[i] = new ShardSearchFailure(cause, new SearchShardTarget("node_" + i,
+                new ShardId("test", "_na_", i), null, OriginalIndices.NONE));
+        }
+
+        final String phase = randomFrom("fetch", "search", "other");
+        SearchPhaseExecutionException actual = new SearchPhaseExecutionException(phase, "unexpected failures", new EsRejectedExecutionException("ES rejected execution of fetch phase"), shardSearchFailures);
+
+        assertNotEquals(actual.status(), RestStatus.TOO_MANY_REQUESTS);
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchPhaseExecutionExceptionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchPhaseExecutionExceptionTests.java
@@ -127,7 +127,8 @@ public class SearchPhaseExecutionExceptionTests extends ESTestCase {
     public void testPhaseFailureWithoutSearchShardFailure() {
         final ShardSearchFailure[] searchShardFailures = new ShardSearchFailure[0];
         final String phase = randomFrom("fetch", "search", "other");
-        SearchPhaseExecutionException actual = new SearchPhaseExecutionException(phase, "unexpected failures", new EsRejectedExecutionException("ES rejected execution of fetch phase"), searchShardFailures);
+        SearchPhaseExecutionException actual = new SearchPhaseExecutionException(phase, "unexpected failures",
+            new EsRejectedExecutionException("ES rejected execution of fetch phase"), searchShardFailures);
 
         assertEquals(actual.status(), RestStatus.TOO_MANY_REQUESTS);
     }
@@ -146,7 +147,8 @@ public class SearchPhaseExecutionExceptionTests extends ESTestCase {
         }
 
         final String phase = randomFrom("fetch", "search", "other");
-        SearchPhaseExecutionException actual = new SearchPhaseExecutionException(phase, "unexpected failures", new EsRejectedExecutionException("ES rejected execution of fetch phase"), shardSearchFailures);
+        SearchPhaseExecutionException actual = new SearchPhaseExecutionException(phase, "unexpected failures",
+            new EsRejectedExecutionException("ES rejected execution of fetch phase"), shardSearchFailures);
 
         assertNotEquals(actual.status(), RestStatus.TOO_MANY_REQUESTS);
     }


### PR DESCRIPTION
Closed elastic#38586

The bug occurs if onPhaseFailure gets called before onShardFailure in AbstractSearchAsyncAction. The exception is raised before the innerRun of [FetchSearchPhase](https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/action/search/FetchSearchPhase.java#L80) starts executing and resulting shardFailures is empty.
