### PR TITLE
[Data-Frame] stop tasks on failure

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transform/DataFrameTransformState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transform/DataFrameTransformState.java
@@ -1,149 +1,39 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
- */
-
 package org.elasticsearch.xpack.core.dataframe.transform;
 
-import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.elasticsearch.common.xcontent.ObjectParser;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.persistent.PersistentTaskState;
-import org.elasticsearch.tasks.Task;
-import org.elasticsearch.xpack.core.dataframe.DataFrameField;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.util.Locale;
 
-import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
-import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+public enum DataFrameTransformState implements Writeable {
+    STARTED, INDEXING, STOPPING, STOPPED, ABORTING, FAILED;
 
-public class DataFrameTransformState implements Task.Status, PersistentTaskState {
-    public static final String NAME = DataFrameField.TASK_NAME;
-
-    private final IndexerState state;
-    private final long generation;
-
-    @Nullable
-    private final SortedMap<String, Object> currentPosition;
-
-    private static final ParseField STATE = new ParseField("transform_state");
-    private static final ParseField CURRENT_POSITION = new ParseField("current_position");
-    private static final ParseField GENERATION = new ParseField("generation");
-
-    @SuppressWarnings("unchecked")
-    public static final ConstructingObjectParser<DataFrameTransformState, Void> PARSER = new ConstructingObjectParser<>(NAME,
-            args -> new DataFrameTransformState((IndexerState) args[0], (HashMap<String, Object>) args[1], (long) args[2]));
-
-    static {
-        PARSER.declareField(constructorArg(), p -> {
-            if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
-                return IndexerState.fromString(p.text());
-            }
-            throw new IllegalArgumentException("Unsupported token [" + p.currentToken() + "]");
-
-        }, STATE, ObjectParser.ValueType.STRING);
-        PARSER.declareField(optionalConstructorArg(), p -> {
-            if (p.currentToken() == XContentParser.Token.START_OBJECT) {
-                return p.map();
-            }
-            if (p.currentToken() == XContentParser.Token.VALUE_NULL) {
-                return null;
-            }
-            throw new IllegalArgumentException("Unsupported token [" + p.currentToken() + "]");
-        }, CURRENT_POSITION, ObjectParser.ValueType.VALUE_OBJECT_ARRAY);
-        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), GENERATION);
+    public static DataFrameTransformState fromString(String name) {
+        return valueOf(name.trim().toUpperCase(Locale.ROOT));
     }
 
-    public DataFrameTransformState(IndexerState state, @Nullable Map<String, Object> position, long generation) {
-        this.state = state;
-        this.currentPosition = position == null ? null : Collections.unmodifiableSortedMap(new TreeMap<>(position));
-        this.generation = generation;
+    public static DataFrameTransformState fromStream(StreamInput in) throws IOException {
+        return in.readEnum(DataFrameTransformState.class);
     }
 
-    public DataFrameTransformState(StreamInput in) throws IOException {
-        state = IndexerState.fromStream(in);
-        currentPosition = in.readBoolean() ? Collections.unmodifiableSortedMap(new TreeMap<>(in.readMap())) : null;
-        generation = in.readLong();
-    }
-
-    public IndexerState getIndexerState() {
-        return state;
-    }
-
-    public Map<String, Object> getPosition() {
-        return currentPosition;
-    }
-
-    public long getGeneration() {
-        return generation;
-    }
-
-    public static DataFrameTransformState fromXContent(XContentParser parser) {
-        try {
-            return PARSER.parse(parser, null);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
-        builder.field(STATE.getPreferredName(), state.value());
-        if (currentPosition != null) {
-            builder.field(CURRENT_POSITION.getPreferredName(), currentPosition);
-        }
-        builder.field(GENERATION.getPreferredName(), generation);
-        builder.endObject();
-        return builder;
-    }
-
-    @Override
-    public String getWriteableName() {
-        return NAME;
+    public static DataFrameTransformState fromIndexerState(IndexerState state) {
+        return fromString(state.toString());
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        state.writeTo(out);
-        out.writeBoolean(currentPosition != null);
-        if (currentPosition != null) {
-            out.writeMap(currentPosition);
-        }
-        out.writeLong(generation);
+        DataFrameTransformState state = this;
+        out.writeEnum(state);
     }
 
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-
-        DataFrameTransformState that = (DataFrameTransformState) other;
-
-        return Objects.equals(this.state, that.state) && Objects.equals(this.currentPosition, that.currentPosition)
-                && this.generation == that.generation;
+    public String value() {
+        return name().toLowerCase(Locale.ROOT);
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(state, currentPosition, generation);
+    public IndexerState toIndexerState() {
+        return this == FAILED ? IndexerState.STOPPED : IndexerState.fromString(this.toString());
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transform/DataFrameTransformState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transform/DataFrameTransformState.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
 package org.elasticsearch.xpack.core.dataframe.transform;
 
 import org.elasticsearch.common.io.stream.StreamInput;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transform/DataFrameTransformTaskState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transform/DataFrameTransformTaskState.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.dataframe.transform;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.persistent.PersistentTaskState;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
+import org.elasticsearch.xpack.core.indexing.IndexerState;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class DataFrameTransformTaskState implements Task.Status, PersistentTaskState {
+    public static final String NAME = DataFrameField.TASK_NAME;
+
+    private final DataFrameTransformState state;
+    private final long generation;
+    private final String reason;
+
+    @Nullable
+    private final SortedMap<String, Object> currentPosition;
+
+    private static final ParseField STATE = new ParseField("transform_state");
+    private static final ParseField CURRENT_POSITION = new ParseField("current_position");
+    private static final ParseField GENERATION = new ParseField("generation");
+    private static final ParseField REASON = new ParseField("reason");
+
+    @SuppressWarnings("unchecked")
+    public static final ConstructingObjectParser<DataFrameTransformTaskState, Void> PARSER = new ConstructingObjectParser<>(NAME,
+            args -> new DataFrameTransformTaskState((DataFrameTransformState) args[0],
+                (HashMap<String, Object>) args[1],
+                (long) args[2],
+                (String) args[3]));
+
+    static {
+        PARSER.declareField(constructorArg(), p -> {
+            if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
+                return DataFrameTransformState.fromString(p.text());
+            }
+            throw new IllegalArgumentException("Unsupported token [" + p.currentToken() + "]");
+
+        }, STATE, ObjectParser.ValueType.STRING);
+        PARSER.declareField(optionalConstructorArg(), p -> {
+            if (p.currentToken() == XContentParser.Token.START_OBJECT) {
+                return p.map();
+            }
+            if (p.currentToken() == XContentParser.Token.VALUE_NULL) {
+                return null;
+            }
+            throw new IllegalArgumentException("Unsupported token [" + p.currentToken() + "]");
+        }, CURRENT_POSITION, ObjectParser.ValueType.VALUE_OBJECT_ARRAY);
+        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), GENERATION);
+        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), REASON);
+    }
+
+    public DataFrameTransformTaskState(DataFrameTransformState state,
+                                       @Nullable Map<String, Object> position,
+                                       long generation,
+                                       @Nullable String reason) {
+        this.state = state;
+        this.currentPosition = position == null ? null : Collections.unmodifiableSortedMap(new TreeMap<>(position));
+        this.generation = generation;
+        this.reason = reason;
+    }
+
+    public DataFrameTransformTaskState(IndexerState state, @Nullable Map<String, Object> position, long generation) {
+        this.state = DataFrameTransformState.fromIndexerState(state);
+        this.currentPosition = position == null ? null : Collections.unmodifiableSortedMap(new TreeMap<>(position));
+        this.generation = generation;
+        this.reason = null;
+    }
+
+    public DataFrameTransformTaskState(StreamInput in) throws IOException {
+        state = DataFrameTransformState.fromStream(in);
+        currentPosition = in.readBoolean() ? Collections.unmodifiableSortedMap(new TreeMap<>(in.readMap())) : null;
+        generation = in.readLong();
+        reason = in.readOptionalString();
+    }
+
+    public DataFrameTransformState getState() {
+        return state;
+    }
+
+    public IndexerState getIndexerState() {
+        return state.toIndexerState();
+    }
+
+    public Map<String, Object> getPosition() {
+        return currentPosition;
+    }
+
+    public long getGeneration() {
+        return generation;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public static DataFrameTransformTaskState fromXContent(XContentParser parser) {
+        try {
+            return PARSER.parse(parser, null);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(STATE.getPreferredName(), state.value());
+        if (currentPosition != null) {
+            builder.field(CURRENT_POSITION.getPreferredName(), currentPosition);
+        }
+        if (reason != null) {
+            builder.field(REASON.getPreferredName(), reason);
+        }
+        builder.field(GENERATION.getPreferredName(), generation);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        state.writeTo(out);
+        out.writeBoolean(currentPosition != null);
+        if (currentPosition != null) {
+            out.writeMap(currentPosition);
+        }
+        out.writeLong(generation);
+        out.writeOptionalString(reason);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        DataFrameTransformTaskState that = (DataFrameTransformTaskState) other;
+
+        return Objects.equals(this.state, that.state) &&
+            Objects.equals(this.currentPosition, that.currentPosition) &&
+            this.generation == that.generation &&
+            Objects.equals(this.reason, that.reason);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(state, currentPosition, generation, reason);
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transform/DataFrameTransformTaskStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transform/DataFrameTransformTaskStateTests.java
@@ -9,32 +9,38 @@ package org.elasticsearch.xpack.core.dataframe.transform;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractSerializingTestCase;
-import org.elasticsearch.xpack.core.dataframe.transform.DataFrameTransformState;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class DataFrameTransformStateTests extends AbstractSerializingTestCase<DataFrameTransformState> {
+public class DataFrameTransformTaskStateTests extends AbstractSerializingTestCase<DataFrameTransformTaskState> {
 
-    public static DataFrameTransformState randomDataFrameTransformState() {
-        return new DataFrameTransformState(randomFrom(IndexerState.values()), randomPosition(), randomLongBetween(0,10));
+    public static DataFrameTransformTaskState randomDataFrameTransformState() {
+        if (randomBoolean()) {
+            return new DataFrameTransformTaskState(randomFrom(IndexerState.values()), randomPosition(), randomLongBetween(0,10));
+        } else {
+            return new DataFrameTransformTaskState(randomFrom(DataFrameTransformState.values()),
+                randomPosition(),
+                randomLongBetween(0,10),
+                randomAlphaOfLength(10));
+        }
     }
 
     @Override
-    protected DataFrameTransformState doParseInstance(XContentParser parser) throws IOException {
-        return DataFrameTransformState.fromXContent(parser);
+    protected DataFrameTransformTaskState doParseInstance(XContentParser parser) throws IOException {
+        return DataFrameTransformTaskState.fromXContent(parser);
     }
 
     @Override
-    protected DataFrameTransformState createTestInstance() {
+    protected DataFrameTransformTaskState createTestInstance() {
         return randomDataFrameTransformState();
     }
 
     @Override
-    protected Reader<DataFrameTransformState> instanceReader() {
-        return DataFrameTransformState::new;
+    protected Reader<DataFrameTransformTaskState> instanceReader() {
+        return DataFrameTransformTaskState::new;
     }
 
     private static Map<String, Object> randomPosition() {

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrame.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrame.java
@@ -45,7 +45,7 @@ import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
-import org.elasticsearch.xpack.core.dataframe.transform.DataFrameTransformState;
+import org.elasticsearch.xpack.core.dataframe.transform.DataFrameTransformTaskState;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.dataframe.action.DeleteDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.action.GetDataFrameTransformsAction;
@@ -217,10 +217,10 @@ public class DataFrame extends Plugin implements ActionPlugin, PersistentTaskPlu
         return  Arrays.asList(
                 new NamedXContentRegistry.Entry(PersistentTaskParams.class, new ParseField(DataFrameField.TASK_NAME),
                         DataFrameTransform::fromXContent),
-                new NamedXContentRegistry.Entry(Task.Status.class, new ParseField(DataFrameTransformState.NAME),
-                        DataFrameTransformState::fromXContent),
-                new NamedXContentRegistry.Entry(PersistentTaskState.class, new ParseField(DataFrameTransformState.NAME),
-                        DataFrameTransformState::fromXContent)
+                new NamedXContentRegistry.Entry(Task.Status.class, new ParseField(DataFrameTransformTaskState.NAME),
+                        DataFrameTransformTaskState::fromXContent),
+                new NamedXContentRegistry.Entry(PersistentTaskState.class, new ParseField(DataFrameTransformTaskState.NAME),
+                        DataFrameTransformTaskState::fromXContent)
                 );
     }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/DataFrameTransformStateAndStats.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/DataFrameTransformStateAndStats.java
@@ -15,7 +15,7 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.dataframe.transform.DataFrameIndexerTransformStats;
-import org.elasticsearch.xpack.core.dataframe.transform.DataFrameTransformState;
+import org.elasticsearch.xpack.core.dataframe.transform.DataFrameTransformTaskState;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -25,21 +25,21 @@ public class DataFrameTransformStateAndStats implements Writeable, ToXContentObj
     public static final ParseField STATE_FIELD = new ParseField("state");
 
     private final String id;
-    private final DataFrameTransformState transformState;
+    private final DataFrameTransformTaskState transformState;
     private final DataFrameIndexerTransformStats transformStats;
 
     public static final ConstructingObjectParser<DataFrameTransformStateAndStats, Void> PARSER = new ConstructingObjectParser<>(
             GetDataFrameTransformsAction.NAME,
-            a -> new DataFrameTransformStateAndStats((String) a[0], (DataFrameTransformState) a[1], (DataFrameIndexerTransformStats) a[2]));
+            a -> new DataFrameTransformStateAndStats((String) a[0], (DataFrameTransformTaskState) a[1], (DataFrameIndexerTransformStats) a[2]));
 
     static {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), DataFrameField.ID);
-        PARSER.declareObject(ConstructingObjectParser.constructorArg(), DataFrameTransformState.PARSER::apply, STATE_FIELD);
+        PARSER.declareObject(ConstructingObjectParser.constructorArg(), DataFrameTransformTaskState.PARSER::apply, STATE_FIELD);
         PARSER.declareObject(ConstructingObjectParser.constructorArg(), (p, c) -> DataFrameIndexerTransformStats.fromXContent(p),
                 DataFrameField.STATS_FIELD);
     }
 
-    public DataFrameTransformStateAndStats(String id, DataFrameTransformState state, DataFrameIndexerTransformStats stats) {
+    public DataFrameTransformStateAndStats(String id, DataFrameTransformTaskState state, DataFrameIndexerTransformStats stats) {
         this.id = Objects.requireNonNull(id);
         this.transformState = Objects.requireNonNull(state);
         this.transformStats = Objects.requireNonNull(stats);
@@ -47,7 +47,7 @@ public class DataFrameTransformStateAndStats implements Writeable, ToXContentObj
 
     public DataFrameTransformStateAndStats(StreamInput in) throws IOException {
         this.id = in.readString();
-        this.transformState = new DataFrameTransformState(in);
+        this.transformState = new DataFrameTransformTaskState(in);
         this.transformStats = new DataFrameIndexerTransformStats(in);
     }
 
@@ -97,7 +97,7 @@ public class DataFrameTransformStateAndStats implements Writeable, ToXContentObj
         return transformStats;
     }
 
-    public DataFrameTransformState getTransformState() {
+    public DataFrameTransformTaskState getTransformState() {
         return transformState;
     }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/DataFrameTransformStateAndStats.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/DataFrameTransformStateAndStats.java
@@ -30,7 +30,9 @@ public class DataFrameTransformStateAndStats implements Writeable, ToXContentObj
 
     public static final ConstructingObjectParser<DataFrameTransformStateAndStats, Void> PARSER = new ConstructingObjectParser<>(
             GetDataFrameTransformsAction.NAME,
-            a -> new DataFrameTransformStateAndStats((String) a[0], (DataFrameTransformTaskState) a[1], (DataFrameIndexerTransformStats) a[2]));
+            a -> new DataFrameTransformStateAndStats((String) a[0],
+                (DataFrameTransformTaskState) a[1],
+                (DataFrameIndexerTransformStats) a[2]));
 
     static {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), DataFrameField.ID);

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
@@ -75,6 +75,6 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
     protected AllocatedPersistentTask createTask(long id, String type, String action, TaskId parentTaskId,
             PersistentTasksCustomMetaData.PersistentTask<DataFrameTransform> persistentTask, Map<String, String> headers) {
         return new DataFrameTransformTask(id, type, action, parentTaskId, persistentTask.getParams(),
-                (DataFrameTransformTaskState) persistentTask.getState(), client, transformsConfigManager, schedulerEngine, threadPool, headers);
+            (DataFrameTransformTaskState) persistentTask.getState(), client, transformsConfigManager, schedulerEngine, threadPool, headers);
     }
 }

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/DataFrameFeatureSetTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/DataFrameFeatureSetTests.java
@@ -21,7 +21,7 @@ import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.XPackFeatureSet.Usage;
 import org.elasticsearch.xpack.core.dataframe.transform.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.dataframe.action.DataFrameTransformStateAndStats;
-import org.elasticsearch.xpack.dataframe.action.DataFrameTransformStateAndStatsTests;
+import org.elasticsearch.xpack.dataframe.action.DataFrameTransformTaskStateAndStatsTests;
 import org.elasticsearch.xpack.dataframe.action.GetDataFrameTransformsStatsAction;
 import org.elasticsearch.xpack.dataframe.action.GetDataFrameTransformsStatsAction.Response;
 import org.junit.Before;
@@ -77,7 +77,7 @@ public class DataFrameFeatureSetTests extends ESTestCase {
 
         List<DataFrameTransformStateAndStats> transformsStateAndStats = new ArrayList<>();
         for (int i = 0; i < randomIntBetween(0, 10); ++i) {
-            transformsStateAndStats.add(DataFrameTransformStateAndStatsTests.randomDataFrameTransformStateAndStats());
+            transformsStateAndStats.add(DataFrameTransformTaskStateAndStatsTests.randomDataFrameTransformStateAndStats());
         }
 
         GetDataFrameTransformsStatsAction.Response mockResponse = new GetDataFrameTransformsStatsAction.Response(transformsStateAndStats);

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/action/DataFrameTransformTaskStateAndStatsTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/action/DataFrameTransformTaskStateAndStatsTests.java
@@ -9,16 +9,16 @@ package org.elasticsearch.xpack.dataframe.action;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.dataframe.transform.DataFrameIndexerTransformStatsTests;
-import org.elasticsearch.xpack.core.dataframe.transform.DataFrameTransformStateTests;
+import org.elasticsearch.xpack.core.dataframe.transform.DataFrameTransformTaskStateTests;
 import org.elasticsearch.xpack.dataframe.transforms.AbstractSerializingDataFrameTestCase;
 
 import java.io.IOException;
 
-public class DataFrameTransformStateAndStatsTests extends AbstractSerializingDataFrameTestCase<DataFrameTransformStateAndStats> {
+public class DataFrameTransformTaskStateAndStatsTests extends AbstractSerializingDataFrameTestCase<DataFrameTransformStateAndStats> {
 
     public static DataFrameTransformStateAndStats randomDataFrameTransformStateAndStats() {
         return new DataFrameTransformStateAndStats(randomAlphaOfLengthBetween(1, 10),
-                DataFrameTransformStateTests.randomDataFrameTransformState(),
+                DataFrameTransformTaskStateTests.randomDataFrameTransformState(),
                 DataFrameIndexerTransformStatsTests.randomStats());
     }
 


### PR DESCRIPTION
This is an initial stab at decoupling the task state and the indexer state. Additionally, a new "FAILED" state has been included. 

There still seems to be lots of complication in the interaction between our task and the indexer...So this PR may be rejected whole-sale due to me not understanding the interactions. 
