### PR TITLE
add missing `test2` index in alias example

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -280,7 +280,7 @@ POST /_aliases
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[s/^/PUT test\n/]
+// TEST[s/^/PUT test\nPUT test2\n/]
 
 In this example, we associate the alias `alias1` to both `test` and `test2`, where
 `test` will be the index chosen for writing to.

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -317,13 +317,13 @@ POST /_aliases
             "add" : {
                  "index" : "test",
                  "alias" : "alias1",
-                 "is_write_index" : true
+                 "is_write_index" : false
             }
         }, {
             "add" : {
                  "index" : "test2",
                  "alias" : "alias1",
-                 "is_write_index" : false
+                 "is_write_index" : true
             }
         }
     ]

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -269,6 +269,12 @@ POST /_aliases
                  "alias" : "alias1",
                  "is_write_index" : true
             }
+        },
+        {
+            "add" : {
+                 "index" : "test2",
+                 "alias" : "alias1"
+            }
         }
     ]
 }


### PR DESCRIPTION
from original PR:


>If I got the idea of aliases properly, I think that the index "test2" should have a reference in the 
>example above of the following sentence:
>
> " ... we associate the alias `alias1` to both `test` and `test2` ... "

this PR re-applies #39055. That PR was prematurely merged with a failing test.