### PR TITLE
minor updates for user-agent ecs for 6.7

### DIFF
--- a/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
+++ b/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
@@ -150,7 +150,7 @@ public class UserAgentProcessor extends AbstractProcessor {
                 }
             }
         } else {
-            // Deprecated format, removed in 7.0
+            // Deprecated format, removed in 8.0
             for (Property property : this.properties) {
                 switch (property) {
                     case NAME:
@@ -316,7 +316,7 @@ public class UserAgentProcessor extends AbstractProcessor {
 
             if (useECS == false) {
                 deprecationLogger.deprecated("setting [ecs] to false for non-common schema " +
-                    "format is deprecated and will be removed in 7.0, set to true to use the non-deprecated format");
+                    "format is deprecated and will be removed in 8.0, set to true to use the non-deprecated format");
             }
 
             return new UserAgentProcessor(processorTag, field, targetField, parser, properties, ignoreMissing, useECS);
@@ -326,12 +326,12 @@ public class UserAgentProcessor extends AbstractProcessor {
     enum Property {
 
         NAME,
-        // Deprecated in 6.7 (superceded by VERSION), to be removed in 7.0
+        // Deprecated in 6.7 (superceded by VERSION), to be removed in 8.0
         @Deprecated MAJOR,
         @Deprecated MINOR,
         @Deprecated PATCH,
         OS,
-        // Deprecated in 6.7 (superceded by just using OS), to be removed in 7.0
+        // Deprecated in 6.7 (superceded by just using OS), to be removed in 8.0
         @Deprecated OS_NAME,
         @Deprecated OS_MAJOR,
         @Deprecated OS_MINOR,

--- a/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
+++ b/modules/ingest-user-agent/src/test/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
@@ -90,7 +90,7 @@
 
   - do:
       warnings:
-        - "setting [ecs] to false for non-common schema format is deprecated and will be removed in 7.0, set to true to use the non-deprecated format"
+        - "setting [ecs] to false for non-common schema format is deprecated and will be removed in 8.0, set to true to use the non-deprecated format"
         - "the [os_major] property is deprecated for the user-agent processor"
       ingest.put_pipeline:
         id: "my_pipeline"

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -78,8 +78,7 @@ public class ClusterDeprecationChecks {
                     .filter(Objects::nonNull)
                     .filter(processor -> processor.containsKey("user_agent"))
                     .map(processor -> processor.get("user_agent"))
-                    .anyMatch(processorConfig ->
-                        false == ConfigurationUtils.readBooleanProperty(null, null, processorConfig, "ecs", false));
+                    .anyMatch(processorConfig -> processorConfig.containsKey("ecs") == false);
             })
             .map(PipelineConfiguration::getId)
             .sorted() // Make the warning consistent for testing purposes

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -87,7 +87,7 @@ public class ClusterDeprecationChecks {
                 "User-Agent ingest plugin will use ECS-formatted output",
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                     "#ingest-user-agent-ecs-always",
-                "Ingest pipelines " + pipelinesWithDeprecatedEcsConfig + " will change to using ECS output format in 7.0");
+                "Ingest pipelines " + pipelinesWithDeprecatedEcsConfig + " will change to using ECS output format by default in 7.0");
         }
         return null;
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.ingest.ConfigurationUtils;
 import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -157,7 +157,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
             "User-Agent ingest plugin will use ECS-formatted output",
             "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                 "#ingest-user-agent-ecs-always",
-            "Ingest pipelines [ecs_false, ecs_null] will change to using ECS output format in 7.0");
+            "Ingest pipelines [ecs_null] will change to using ECS output format in 7.0");
         assertEquals(singletonList(expected), issues);
     }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -157,7 +157,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
             "User-Agent ingest plugin will use ECS-formatted output",
             "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
                 "#ingest-user-agent-ecs-always",
-            "Ingest pipelines [ecs_null] will change to using ECS output format in 7.0");
+            "Ingest pipelines [ecs_null] will change to using ECS output format by default in 7.0");
         assertEquals(singletonList(expected), issues);
     }
 }


### PR DESCRIPTION
PR #38757 changed 7.0 user-agent behavior for the ecs flag
to more closely resemble 6.7. This commit updates the forward
looking comments and deprecation notices to be more accurate
now that this flag will not be removed until 8.0

related #38757
