### PR TITLE
add missing `test2` index in alias example (#39212)

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -271,12 +271,18 @@ POST /_aliases
                  "alias" : "alias1",
                  "is_write_index" : true
             }
+        },
+        {
+            "add" : {
+                 "index" : "test2",
+                 "alias" : "alias1"
+            }
         }
     ]
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[s/^/PUT test\n/]
+// TEST[s/^/PUT test\nPUT test2\n/]
 
 In this example, we associate the alias `alias1` to both `test` and `test2`, where
 `test` will be the index chosen for writing to.
@@ -313,13 +319,13 @@ POST /_aliases
             "add" : {
                  "index" : "test",
                  "alias" : "alias1",
-                 "is_write_index" : true
+                 "is_write_index" : false
             }
         }, {
             "add" : {
                  "index" : "test2",
                  "alias" : "alias1",
-                 "is_write_index" : false
+                 "is_write_index" : true
             }
         }
     ]


### PR DESCRIPTION
* missing 'test2' index example (#39055)

If I got the idea of aliases properly, I think that the index "test2" 
should have a reference in the example above of the following sentence:

" ... we associate the alias `alias1` to both `test` and `test2` ... "

* add PUT test2

* Update aliases.asciidoc

swap which is write/read