### PR TITLE
Align generated release notes with doc standards

### DIFF
--- a/dev-tools/es_release_notes.pl
+++ b/dev-tools/es_release_notes.pl
@@ -87,11 +87,11 @@ sub dump_issues {
 :pull:  https://github.com/${User_Repo}pull/
 
 [[release-notes-$version]]
-== $version Release Notes
+== {es} version $version
 
 coming[$version]
 
-Also see <<breaking-changes-$branch>>.
+Also see <<breaking-changes-$branch,Breaking changes in $branch>>.
 
 ASCIIDOC
 


### PR DESCRIPTION
With this commit we change the script that generates the release notes
for Elasticsearch to align with the docs standards in the following
aspects:

* The release notes title changes to include the product name
* The link text to the breaking changes page is explicitly defined

Relates #39155