### PR TITLE
[ML] Reenable ml rolling upgrade tests

### DIFF
--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -198,11 +198,6 @@ subprojects {
       if (version.before('5.6.9') || (version.onOrAfter('6.0.0') && version.before('6.2.4'))) {
         jvmArgs '-da:org.elasticsearch.xpack.monitoring.exporter.http.HttpExportBulk'
       }
-
-      systemProperty 'tests.rest.blacklist', [
-              'old_cluster/30_ml_jobs_crud/*',
-              'old_cluster/40_ml_datafeed_crud/*',
-      ].join(',')
     }
 
     Task oldClusterTestRunner = tasks.getByName("${baseName}#oldClusterTestRunner")
@@ -244,11 +239,6 @@ subprojects {
         if (version.before('6.0.0')) {
           keystoreSetting 'xpack.security.authc.token.passphrase', 'token passphrase'
         }
-
-        systemProperty 'tests.rest.blacklist', [
-                'mixed_cluster/30_ml_jobs_crud/*',
-                'mixed_cluster/40_ml_datafeed_crud/*',
-        ].join(',')
       }
     }
 
@@ -265,8 +255,8 @@ subprojects {
       // We only need to run these tests once so we may as well do it when we're two thirds upgraded
       systemProperty 'tests.rest.blacklist', [
           'mixed_cluster/10_basic/Start scroll in mixed cluster on upgraded node that we will continue after upgrade',
-          'mixed_cluster/30_ml_jobs_crud/*',
-          'mixed_cluster/40_ml_datafeed_crud/*',
+          'mixed_cluster/30_ml_jobs_crud/Create a job in the mixed cluster and write some data',
+          'mixed_cluster/40_ml_datafeed_crud/Put job and datafeed in mixed cluster',
         ].join(',')
       finalizedBy "${baseName}#oldClusterTestCluster#node1.stop"
     }
@@ -282,11 +272,6 @@ subprojects {
       systemProperty 'tests.rest.suite', 'mixed_cluster'
       systemProperty 'tests.first_round', 'false'
       finalizedBy "${baseName}#oldClusterTestCluster#node2.stop"
-
-      systemProperty 'tests.rest.blacklist', [
-              'mixed_cluster/30_ml_jobs_crud/*',
-              'mixed_cluster/40_ml_datafeed_crud/*',
-      ].join(',')
     }
 
     Task upgradedClusterTest = tasks.create(name: "${baseName}#upgradedClusterTest", type: RestIntegTestTask)
@@ -316,11 +301,6 @@ subprojects {
               systemProperty 'tests.rest.blacklist', '/20_security/Verify default password migration results in upgraded cluster'
           }
       }
-
-      systemProperty 'tests.rest.blacklist', [
-              'upgraded_cluster/30_ml_jobs_crud/*',
-              'upgraded_cluster/40_ml_datafeed_crud/*',
-      ].join(',')
     }
 
     Task versionBwcTest = tasks.create(name: "${baseName}#bwcTest") {

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
@@ -78,27 +78,6 @@ setup:
   - is_true: ''
 
 ---
-"Test job with no model memory limit has established model memory after reopening":
-  - do:
-      ml.open_job:
-        job_id: no-model-memory-limit-job
-
-  - do:
-      ml.get_jobs:
-        job_id: no-model-memory-limit-job
-  - is_true: jobs.0.established_model_memory
-  - lt: { jobs.0.established_model_memory: 100000 }
-
-  - do:
-      ml.close_job:
-        job_id: no-model-memory-limit-job
-
-  - do:
-      ml.delete_job:
-        job_id: no-model-memory-limit-job
-  - match: { acknowledged: true }
-
----
 "Test job with pre 6.4 rules":
 
   - do:


### PR DESCRIPTION
I believe these tests were accidentally muted during the config migration project.