### PR TITLE
[ML] Transition to typeless (mapping) APIs

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetaIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetaIndex.java
@@ -21,32 +21,28 @@ public final class MlMetaIndex {
      */
     public static final String INDEX_NAME = ".ml-meta";
 
-    public static final String TYPE = "doc";
-
     private MlMetaIndex() {}
 
     public static XContentBuilder docMapping() throws IOException {
         XContentBuilder builder = jsonBuilder();
         builder.startObject();
-            builder.startObject(TYPE);
-                ElasticsearchMappings.addMetaInformation(builder);
-                ElasticsearchMappings.addDefaultMapping(builder);
-                builder.startObject(ElasticsearchMappings.PROPERTIES)
-                    .startObject(Calendar.ID.getPreferredName())
-                        .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.KEYWORD)
-                    .endObject()
-                    .startObject(Calendar.JOB_IDS.getPreferredName())
-                        .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.KEYWORD)
-                    .endObject()
-                    .startObject(Calendar.DESCRIPTION.getPreferredName())
-                        .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.KEYWORD)
-                    .endObject()
-                    .startObject(ScheduledEvent.START_TIME.getPreferredName())
-                        .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.DATE)
-                    .endObject()
-                    .startObject(ScheduledEvent.END_TIME.getPreferredName())
-                        .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.DATE)
-                    .endObject()
+            ElasticsearchMappings.addMetaInformation(builder);
+            ElasticsearchMappings.addDefaultMapping(builder);
+            builder.startObject(ElasticsearchMappings.PROPERTIES)
+                .startObject(Calendar.ID.getPreferredName())
+                    .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.KEYWORD)
+                .endObject()
+                .startObject(Calendar.JOB_IDS.getPreferredName())
+                    .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.KEYWORD)
+                .endObject()
+                .startObject(Calendar.DESCRIPTION.getPreferredName())
+                    .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.KEYWORD)
+                .endObject()
+                .startObject(ScheduledEvent.START_TIME.getPreferredName())
+                    .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.DATE)
+                .endObject()
+                .startObject(ScheduledEvent.END_TIME.getPreferredName())
+                    .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.DATE)
                 .endObject()
             .endObject()
         .endObject();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetaIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetaIndex.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import java.io.IOException;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 
 public final class MlMetaIndex {
     /**
@@ -26,23 +27,25 @@ public final class MlMetaIndex {
     public static XContentBuilder docMapping() throws IOException {
         XContentBuilder builder = jsonBuilder();
         builder.startObject();
-            ElasticsearchMappings.addMetaInformation(builder);
-            ElasticsearchMappings.addDefaultMapping(builder);
-            builder.startObject(ElasticsearchMappings.PROPERTIES)
-                .startObject(Calendar.ID.getPreferredName())
-                    .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.KEYWORD)
-                .endObject()
-                .startObject(Calendar.JOB_IDS.getPreferredName())
-                    .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.KEYWORD)
-                .endObject()
-                .startObject(Calendar.DESCRIPTION.getPreferredName())
-                    .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.KEYWORD)
-                .endObject()
-                .startObject(ScheduledEvent.START_TIME.getPreferredName())
-                    .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.DATE)
-                .endObject()
-                .startObject(ScheduledEvent.END_TIME.getPreferredName())
-                    .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.DATE)
+            builder.startObject(SINGLE_MAPPING_NAME);
+                ElasticsearchMappings.addMetaInformation(builder);
+                ElasticsearchMappings.addDefaultMapping(builder);
+                builder.startObject(ElasticsearchMappings.PROPERTIES)
+                    .startObject(Calendar.ID.getPreferredName())
+                        .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.KEYWORD)
+                    .endObject()
+                    .startObject(Calendar.JOB_IDS.getPreferredName())
+                        .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.KEYWORD)
+                    .endObject()
+                    .startObject(Calendar.DESCRIPTION.getPreferredName())
+                        .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.KEYWORD)
+                    .endObject()
+                    .startObject(ScheduledEvent.START_TIME.getPreferredName())
+                        .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.DATE)
+                    .endObject()
+                    .startObject(ScheduledEvent.END_TIME.getPreferredName())
+                        .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.DATE)
+                    .endObject()
                 .endObject()
             .endObject()
         .endObject();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationIndex.java
@@ -111,7 +111,8 @@ public class AnnotationIndex {
 
     public static XContentBuilder annotationsMapping() throws IOException {
         XContentBuilder builder = jsonBuilder()
-            .startObject();
+            .startObject()
+                .startObject(SINGLE_MAPPING_NAME);
         ElasticsearchMappings.addMetaInformation(builder);
         builder.startObject(ElasticsearchMappings.PROPERTIES)
                         .startObject(Annotation.ANNOTATION.getPreferredName())
@@ -142,7 +143,8 @@ public class AnnotationIndex {
                             .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.KEYWORD)
                         .endObject()
                     .endObject()
-                .endObject();
+                .endObject()
+            .endObject();
         return builder;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationIndex.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.SortedMap;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
@@ -71,7 +72,7 @@ public class AnnotationIndex {
 
                 CreateIndexRequest createIndexRequest = new CreateIndexRequest(INDEX_NAME);
                 try (XContentBuilder annotationsMapping = AnnotationIndex.annotationsMapping()) {
-                    createIndexRequest.mapping("_doc", annotationsMapping);
+                    createIndexRequest.mapping(SINGLE_MAPPING_NAME, annotationsMapping);
                     createIndexRequest.settings(Settings.builder()
                         .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
                         .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, "1")

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationIndex.java
@@ -71,7 +71,7 @@ public class AnnotationIndex {
 
                 CreateIndexRequest createIndexRequest = new CreateIndexRequest(INDEX_NAME);
                 try (XContentBuilder annotationsMapping = AnnotationIndex.annotationsMapping()) {
-                    createIndexRequest.mapping(ElasticsearchMappings.DOC_TYPE, annotationsMapping);
+                    createIndexRequest.mapping("_doc", annotationsMapping);
                     createIndexRequest.settings(Settings.builder()
                         .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
                         .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, "1")
@@ -110,8 +110,7 @@ public class AnnotationIndex {
 
     public static XContentBuilder annotationsMapping() throws IOException {
         XContentBuilder builder = jsonBuilder()
-            .startObject()
-                .startObject(ElasticsearchMappings.DOC_TYPE);
+            .startObject();
         ElasticsearchMappings.addMetaInformation(builder);
         builder.startObject(ElasticsearchMappings.PROPERTIES)
                         .startObject(Annotation.ANNOTATION.getPreferredName())
@@ -142,8 +141,7 @@ public class AnnotationIndex {
                             .field(ElasticsearchMappings.TYPE, ElasticsearchMappings.KEYWORD)
                         .endObject()
                     .endObject()
-                .endObject()
-            .endObject();
+                .endObject();
         return builder;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -569,6 +569,17 @@ public class ElasticsearchMappings {
         addModelSizeStatsFieldsToMapping(builder);
     }
 
+    /**
+     * Generate a keyword mapping for {@code termFields} for the default type
+     * {@link org.elasticsearch.index.mapper.MapperService#SINGLE_MAPPING_NAME}
+     *
+     * If the returned mapping is used in index creation and the new index has a matching template
+     * then the mapping type ({@link org.elasticsearch.index.mapper.MapperService#SINGLE_MAPPING_NAME})
+     * must match the mapping type of the template otherwise the mappings will not be merged correctly.
+     *
+     * @param termFields Fields to generate mapping for
+     * @return The mapping
+     */
     public static XContentBuilder termFieldsMapping(Collection<String> termFields) {
         try {
             XContentBuilder builder = jsonBuilder().startObject();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -1057,8 +1057,13 @@ public class ElasticsearchMappings {
         }
 
         if (indicesThatRequireAnUpdate.length > 0) {
+            // Use the mapping type of the first index in the update
+            IndexMetaData indexMetaData = state.metaData().index(indicesThatRequireAnUpdate[0]);
+            String mappingType = indexMetaData.mapping().type();
+
             try (XContentBuilder mapping = mappingSupplier.get()) {
                 PutMappingRequest putMappingRequest = new PutMappingRequest(indicesThatRequireAnUpdate);
+                putMappingRequest.type(mappingType);
                 putMappingRequest.source(mapping);
                 executeAsyncWithOrigin(client, ML_ORIGIN, PutMappingAction.INSTANCE, putMappingRequest,
                     ActionListener.wrap(response -> {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -571,8 +571,10 @@ public class ElasticsearchMappings {
     public static XContentBuilder termFieldsMapping(Collection<String> termFields) {
         try {
             XContentBuilder builder = jsonBuilder().startObject();
+            builder.startObject("_doc");
             builder.startObject(PROPERTIES);
             addTermFields(builder, termFields);
+            builder.endObject();
             builder.endObject();
             return builder.endObject();
         } catch (IOException e) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
@@ -571,7 +572,7 @@ public class ElasticsearchMappings {
     public static XContentBuilder termFieldsMapping(Collection<String> termFields) {
         try {
             XContentBuilder builder = jsonBuilder().startObject();
-            builder.startObject("_doc");
+            builder.startObject(SINGLE_MAPPING_NAME);
             builder.startObject(PROPERTIES);
             addTermFields(builder, termFields);
             builder.endObject();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -136,6 +136,7 @@ public class ElasticsearchMappings {
     public static XContentBuilder configMapping() throws IOException {
         XContentBuilder builder = jsonBuilder();
         builder.startObject();
+        builder.startObject(SINGLE_MAPPING_NAME);
         addMetaInformation(builder);
         addDefaultMapping(builder);
         builder.startObject(PROPERTIES);
@@ -144,6 +145,7 @@ public class ElasticsearchMappings {
         addDatafeedConfigFields(builder);
 
         builder.endObject()
+               .endObject()
                .endObject();
         return builder;
     }
@@ -424,6 +426,7 @@ public class ElasticsearchMappings {
     public static XContentBuilder resultsMapping(Collection<String> extraTermFields) throws IOException {
         XContentBuilder builder = jsonBuilder();
         builder.startObject();
+        builder.startObject(SINGLE_MAPPING_NAME);
         addMetaInformation(builder);
         addDefaultMapping(builder);
         builder.startObject(PROPERTIES);
@@ -452,8 +455,11 @@ public class ElasticsearchMappings {
 
         // end properties
         builder.endObject();
+        // end type
+        builder.endObject();
         // end mapping
         builder.endObject();
+
 
         return builder;
     }
@@ -873,8 +879,10 @@ public class ElasticsearchMappings {
     public static XContentBuilder stateMapping() throws IOException {
         XContentBuilder builder = jsonBuilder();
         builder.startObject();
+        builder.startObject(SINGLE_MAPPING_NAME);
         addMetaInformation(builder);
         builder.field(ENABLED, false);
+        builder.endObject();
         builder.endObject();
 
         return builder;
@@ -960,6 +968,7 @@ public class ElasticsearchMappings {
 
     public static XContentBuilder auditMessageMapping() throws IOException {
         XContentBuilder builder = jsonBuilder().startObject();
+        builder.startObject(SINGLE_MAPPING_NAME);
         addMetaInformation(builder);
         builder.startObject(PROPERTIES)
                 .startObject(Job.ID.getPreferredName())
@@ -982,8 +991,10 @@ public class ElasticsearchMappings {
                 .startObject(AuditMessage.NODE_NAME.getPreferredName())
                     .field(TYPE, KEYWORD)
                 .endObject()
-            .endObject()
+        .endObject()
+        .endObject()
         .endObject();
+
         return builder;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -959,33 +959,31 @@ public class ElasticsearchMappings {
     }
 
     public static XContentBuilder auditMessageMapping() throws IOException {
-        XContentBuilder builder = jsonBuilder().startObject()
-            .startObject(AuditMessage.TYPE.getPreferredName());
+        XContentBuilder builder = jsonBuilder().startObject();
         addMetaInformation(builder);
         builder.startObject(PROPERTIES)
-                            .startObject(Job.ID.getPreferredName())
-                                .field(TYPE, KEYWORD)
-                            .endObject()
-                            .startObject(AuditMessage.LEVEL.getPreferredName())
-                               .field(TYPE, KEYWORD)
-                            .endObject()
-                            .startObject(AuditMessage.MESSAGE.getPreferredName())
-                                .field(TYPE, TEXT)
-                                .startObject(FIELDS)
-                                    .startObject(RAW)
-                                        .field(TYPE, KEYWORD)
-                                    .endObject()
-                                .endObject()
-                            .endObject()
-                            .startObject(AuditMessage.TIMESTAMP.getPreferredName())
-                                .field(TYPE, DATE)
-                            .endObject()
-                            .startObject(AuditMessage.NODE_NAME.getPreferredName())
-                                .field(TYPE, KEYWORD)
-                            .endObject()
+                .startObject(Job.ID.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(AuditMessage.LEVEL.getPreferredName())
+                   .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(AuditMessage.MESSAGE.getPreferredName())
+                    .field(TYPE, TEXT)
+                    .startObject(FIELDS)
+                        .startObject(RAW)
+                            .field(TYPE, KEYWORD)
                         .endObject()
                     .endObject()
-                .endObject();
+                .endObject()
+                .startObject(AuditMessage.TIMESTAMP.getPreferredName())
+                    .field(TYPE, DATE)
+                .endObject()
+                .startObject(AuditMessage.NODE_NAME.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+            .endObject()
+        .endObject();
         return builder;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/AuditMessage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/AuditMessage.java
@@ -22,7 +22,7 @@ import java.util.Date;
 import java.util.Objects;
 
 public class AuditMessage implements ToXContentObject, Writeable {
-    public static final ParseField TYPE = new ParseField("audit_message");
+    private static final ParseField TYPE = new ParseField("audit_message");
 
     public static final ParseField MESSAGE = new ParseField("message");
     public static final ParseField LEVEL = new ParseField("level");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
@@ -117,7 +117,7 @@ public class ElasticsearchMappingsTests extends ESTestCase {
     @SuppressWarnings("unchecked")
     public void testTermFieldMapping() throws IOException {
 
-        XContentBuilder builder = ElasticsearchMappings.termFieldsMapping(null, Arrays.asList("apple", "strawberry",
+        XContentBuilder builder = ElasticsearchMappings.termFieldsMapping(Arrays.asList("apple", "strawberry",
                 AnomalyRecord.BUCKET_SPAN.getPreferredName()));
 
         XContentParser parser = createParser(builder);
@@ -217,7 +217,7 @@ public class ElasticsearchMappingsTests extends ESTestCase {
             }
             mapping.put("_meta", meta);
 
-            indexMetaData.putMapping(new MappingMetaData(ElasticsearchMappings.DOC_TYPE, mapping));
+            indexMetaData.putMapping(new MappingMetaData("_doc", mapping));
 
             metaDataBuilder.put(indexMetaData);
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
@@ -45,6 +45,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
+
 
 public class ElasticsearchMappingsTests extends ESTestCase {
 
@@ -121,7 +123,8 @@ public class ElasticsearchMappingsTests extends ESTestCase {
                 AnomalyRecord.BUCKET_SPAN.getPreferredName()));
 
         XContentParser parser = createParser(builder);
-        Map<String, Object> properties = (Map<String, Object>) parser.map().get(ElasticsearchMappings.PROPERTIES);
+        Map<String, Object> mapping = (Map<String, Object>) parser.map().get(SINGLE_MAPPING_NAME);
+        Map<String, Object> properties = (Map<String, Object>) mapping.get(ElasticsearchMappings.PROPERTIES);
 
         Map<String, Object> instanceMapping = (Map<String, Object>) properties.get("apple");
         assertNotNull(instanceMapping);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
@@ -233,7 +233,7 @@ public class ElasticsearchMappingsTests extends ESTestCase {
 
     private Set<String> collectResultsDocFieldNames() throws IOException {
         // Only the mappings for the results index should be added below.  Do NOT add mappings for other indexes here.
-        return collectFieldNames(ElasticsearchMappings.resultsMapping());
+        return collectFieldNames(ElasticsearchMappings.resultsMapping("_doc"));
     }
 
     private Set<String> collectConfigDocFieldNames() throws IOException {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
@@ -126,7 +126,7 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
 
             // Update snapshot timestamp to force it out of snapshot retention window
             String snapshotUpdate = "{ \"timestamp\": " + oneDayAgo + "}";
-            UpdateRequest updateSnapshotRequest = new UpdateRequest(".ml-anomalies-" + job.getId(), "doc", snapshotDocId);
+            UpdateRequest updateSnapshotRequest = new UpdateRequest(".ml-anomalies-" + job.getId(), snapshotDocId);
             updateSnapshotRequest.doc(snapshotUpdate.getBytes(StandardCharsets.UTF_8), XContentType.JSON);
             client().execute(UpdateAction.INSTANCE, updateSnapshotRequest).get();
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -694,7 +694,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                                 .put(IndexSettings.MAX_RESULT_WINDOW_SETTING.getKey(),
                                         AnomalyDetectorsIndex.CONFIG_INDEX_MAX_RESULTS_WINDOW))
                         .version(Version.CURRENT.id)
-                        .putMapping(ElasticsearchMappings.DOC_TYPE, Strings.toString(configMapping))
+                        .putMapping("_doc", Strings.toString(configMapping))
                         .build();
                 templates.put(AnomalyDetectorsIndex.configIndexName(), configTemplate);
             } catch (IOException e) {
@@ -708,9 +708,10 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                         .settings(Settings.builder()
                                 .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
                                 .put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), delayedNodeTimeOutSetting))
-                        .putMapping(ElasticsearchMappings.DOC_TYPE, Strings.toString(stateMapping))
+                        .putMapping("_doc", Strings.toString(stateMapping))
                         .version(Version.CURRENT.id)
                         .build();
+
                 templates.put(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX, stateTemplate);
             } catch (IOException e) {
                 logger.error("Error loading the template for the " + AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + " index", e);
@@ -728,7 +729,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                                 .put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), "async")
                                 // set the default all search field
                                 .put(IndexSettings.DEFAULT_FIELD_SETTING.getKey(), ElasticsearchMappings.ALL_FIELD_VALUES))
-                        .putMapping(ElasticsearchMappings.DOC_TYPE, Strings.toString(docMapping))
+                        .putMapping("_doc", Strings.toString(docMapping))
                         .version(Version.CURRENT.id)
                         .build();
                 templates.put(AnomalyDetectorsIndex.jobResultsIndexPrefix(), jobResultsTemplate);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -717,7 +717,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 logger.error("Error loading the template for the " + AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + " index", e);
             }
 
-            try (XContentBuilder docMapping = ElasticsearchMappings.resultsMapping()) {
+            try (XContentBuilder docMapping = ElasticsearchMappings.resultsMapping(SINGLE_MAPPING_NAME)) {
                 IndexTemplateMetaData jobResultsTemplate = IndexTemplateMetaData.builder(AnomalyDetectorsIndex.jobResultsIndexPrefix())
                         .patterns(Collections.singletonList(AnomalyDetectorsIndex.jobResultsIndexPrefix() + "*"))
                         .settings(Settings.builder()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -111,7 +111,6 @@ import org.elasticsearch.xpack.core.ml.action.ValidateJobConfigAction;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields;
 import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
-import org.elasticsearch.xpack.core.ml.notifications.AuditMessage;
 import org.elasticsearch.xpack.core.ml.notifications.AuditorField;
 import org.elasticsearch.xpack.core.template.TemplateUtils;
 import org.elasticsearch.xpack.ml.action.TransportCloseJobAction;
@@ -651,7 +650,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
 
             try (XContentBuilder auditMapping = ElasticsearchMappings.auditMessageMapping()) {
                 IndexTemplateMetaData notificationMessageTemplate = IndexTemplateMetaData.builder(AuditorField.NOTIFICATIONS_INDEX)
-                        .putMapping(AuditMessage.TYPE.getPreferredName(), Strings.toString(auditMapping))
+                        .putMapping(SINGLE_MAPPING_NAME, Strings.toString(auditMapping))
                         .patterns(Collections.singletonList(AuditorField.NOTIFICATIONS_INDEX))
                         .version(Version.CURRENT.id)
                         .settings(Settings.builder()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -676,7 +676,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                                 .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
                                 .put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), delayedNodeTimeOutSetting))
                         .version(Version.CURRENT.id)
-                        .putMapping(MlMetaIndex.TYPE, Strings.toString(docMapping))
+                        .putMapping(SINGLE_MAPPING_NAME, Strings.toString(docMapping))
                         .build();
                 templates.put(MlMetaIndex.INDEX_NAME, metaTemplate);
             } catch (IOException e) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -250,6 +250,7 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import static java.util.Collections.emptyList;
+import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 
 public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlugin, PersistentTaskPlugin {
     public static final String NAME = "ml";
@@ -694,7 +695,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                                 .put(IndexSettings.MAX_RESULT_WINDOW_SETTING.getKey(),
                                         AnomalyDetectorsIndex.CONFIG_INDEX_MAX_RESULTS_WINDOW))
                         .version(Version.CURRENT.id)
-                        .putMapping("_doc", Strings.toString(configMapping))
+                        .putMapping(SINGLE_MAPPING_NAME, Strings.toString(configMapping))
                         .build();
                 templates.put(AnomalyDetectorsIndex.configIndexName(), configTemplate);
             } catch (IOException e) {
@@ -708,7 +709,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                         .settings(Settings.builder()
                                 .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
                                 .put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), delayedNodeTimeOutSetting))
-                        .putMapping("_doc", Strings.toString(stateMapping))
+                        .putMapping(SINGLE_MAPPING_NAME, Strings.toString(stateMapping))
                         .version(Version.CURRENT.id)
                         .build();
 
@@ -729,7 +730,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                                 .put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), "async")
                                 // set the default all search field
                                 .put(IndexSettings.DEFAULT_FIELD_SETTING.getKey(), ElasticsearchMappings.ALL_FIELD_VALUES))
-                        .putMapping("_doc", Strings.toString(docMapping))
+                        .putMapping(SINGLE_MAPPING_NAME, Strings.toString(docMapping))
                         .version(Version.CURRENT.id)
                         .build();
                 templates.put(AnomalyDetectorsIndex.jobResultsIndexPrefix(), jobResultsTemplate);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
@@ -414,7 +413,7 @@ public class MlConfigMigrator {
     }
 
     private IndexRequest indexRequest(ToXContentObject source, String documentId, ToXContent.Params params) {
-        IndexRequest indexRequest = new IndexRequest(AnomalyDetectorsIndex.configIndexName(), ElasticsearchMappings.DOC_TYPE, documentId);
+        IndexRequest indexRequest = new IndexRequest(AnomalyDetectorsIndex.configIndexName()).id(documentId);
 
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             indexRequest.source(source.toXContent(builder, params));
@@ -439,9 +438,9 @@ public class MlConfigMigrator {
 
         logger.debug("taking a snapshot of ml_metadata");
         String documentId = "ml-config";
-        IndexRequestBuilder indexRequest = client.prepareIndex(AnomalyDetectorsIndex.jobStateIndexWriteAlias(),
-                ElasticsearchMappings.DOC_TYPE, documentId)
-                .setOpType(DocWriteRequest.OpType.CREATE);
+        IndexRequest indexRequest = new IndexRequest(AnomalyDetectorsIndex.jobStateIndexWriteAlias())
+                .id(documentId)
+                .opType(DocWriteRequest.OpType.CREATE);
 
         ToXContent.MapParams params = new ToXContent.MapParams(Collections.singletonMap(ToXContentParams.FOR_INTERNAL_STORAGE, "true"));
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
@@ -449,7 +448,7 @@ public class MlConfigMigrator {
             mlMetadata.toXContent(builder, params);
             builder.endObject();
 
-            indexRequest.setSource(builder);
+            indexRequest.source(builder);
         } catch (IOException e) {
             logger.error("failed to serialise ml_metadata", e);
             listener.onFailure(e);
@@ -458,7 +457,7 @@ public class MlConfigMigrator {
 
         AnomalyDetectorsIndex.createStateIndexAndAliasIfNecessary(client, clusterService.state(), ActionListener.wrap(
             r -> {
-                executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, indexRequest.request(),
+                executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, indexRequest,
                     ActionListener.<IndexResponse>wrap(
                         indexResponse -> {
                             listener.onResponse(indexResponse.getResult() == DocWriteResponse.Result.CREATED);
@@ -489,7 +488,7 @@ public class MlConfigMigrator {
                             .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
                             .put(IndexSettings.MAX_RESULT_WINDOW_SETTING.getKey(), AnomalyDetectorsIndex.CONFIG_INDEX_MAX_RESULTS_WINDOW)
             );
-            createIndexRequest.mapping(ElasticsearchMappings.DOC_TYPE, ElasticsearchMappings.configMapping());
+            createIndexRequest.mapping("_all", ElasticsearchMappings.configMapping());
         } catch (Exception e) {
             logger.error("error writing the .ml-config mappings", e);
             listener.onFailure(e);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
@@ -65,6 +65,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
@@ -488,7 +489,7 @@ public class MlConfigMigrator {
                             .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
                             .put(IndexSettings.MAX_RESULT_WINDOW_SETTING.getKey(), AnomalyDetectorsIndex.CONFIG_INDEX_MAX_RESULTS_WINDOW)
             );
-            createIndexRequest.mapping("_all", ElasticsearchMappings.configMapping());
+            createIndexRequest.mapping(SINGLE_MAPPING_NAME, ElasticsearchMappings.configMapping());
         } catch (Exception e) {
             logger.error("error writing the .ml-config mappings", e);
             listener.onFailure(e);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteCalendarEventAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteCalendarEventAction.java
@@ -55,7 +55,7 @@ public class TransportDeleteCalendarEventAction extends HandledTransportAction<D
 
         ActionListener<Calendar> calendarListener = ActionListener.wrap(
                 calendar -> {
-                    GetRequest getRequest = new GetRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, eventId);
+                    GetRequest getRequest = new GetRequest(MlMetaIndex.INDEX_NAME, eventId);
                     executeAsyncWithOrigin(client, ML_ORIGIN, GetAction.INSTANCE, getRequest, ActionListener.wrap(
                             getResponse -> {
                                 if (getResponse.isExists() == false) {
@@ -89,7 +89,7 @@ public class TransportDeleteCalendarEventAction extends HandledTransportAction<D
     }
 
     private void deleteEvent(String eventId, Calendar calendar, ActionListener<AcknowledgedResponse> listener) {
-        DeleteRequest deleteRequest = new DeleteRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, eventId);
+        DeleteRequest deleteRequest = new DeleteRequest(MlMetaIndex.INDEX_NAME, eventId);
         deleteRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
         executeAsyncWithOrigin(client, ML_ORIGIN, DeleteAction.INSTANCE, deleteRequest,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteFilterAction.java
@@ -84,8 +84,7 @@ public class TransportDeleteFilterAction extends HandledTransportAction<DeleteFi
     }
 
     private void deleteFilter(String filterId, ActionListener<AcknowledgedResponse> listener) {
-        DeleteRequest deleteRequest = new DeleteRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE,
-            MlFilter.documentId(filterId));
+        DeleteRequest deleteRequest = new DeleteRequest(MlMetaIndex.INDEX_NAME, MlFilter.documentId(filterId));
         BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
         bulkRequestBuilder.add(deleteRequest);
         bulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.FinalizeJobExecutionAction;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
-import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.utils.VoidChainTaskExecutor;
 
@@ -71,8 +70,7 @@ public class TransportFinalizeJobExecutionAction extends TransportMasterNodeActi
         Map<String, Object> update = Collections.singletonMap(Job.FINISHED_TIME.getPreferredName(), new Date());
 
         for (String jobId: request.getJobIds()) {
-            UpdateRequest updateRequest = new UpdateRequest(AnomalyDetectorsIndex.configIndexName(),
-                    ElasticsearchMappings.DOC_TYPE, Job.documentId(jobId));
+            UpdateRequest updateRequest = new UpdateRequest(AnomalyDetectorsIndex.configIndexName(), Job.documentId(jobId));
             updateRequest.retryOnConflict(3);
             updateRequest.doc(update);
             updateRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetFiltersAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetFiltersAction.java
@@ -68,7 +68,7 @@ public class TransportGetFiltersAction extends HandledTransportAction<GetFilters
     }
 
     private void getFilter(String filterId, ActionListener<GetFiltersAction.Response> listener) {
-        GetRequest getRequest = new GetRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, MlFilter.documentId(filterId));
+        GetRequest getRequest = new GetRequest(MlMetaIndex.INDEX_NAME, MlFilter.documentId(filterId));
         executeAsyncWithOrigin(client, ML_ORIGIN, GetAction.INSTANCE, getRequest, new ActionListener<GetResponse>() {
             @Override
             public void onResponse(GetResponse getDocResponse) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPostCalendarEventsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPostCalendarEventsAction.java
@@ -62,7 +62,7 @@ public class TransportPostCalendarEventsAction extends HandledTransportAction<Po
                     BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
 
                     for (ScheduledEvent event: events) {
-                        IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE);
+                        IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME);
                         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
                             indexRequest.source(event.toXContent(builder,
                                     new ToXContent.MapParams(Collections.singletonMap(ToXContentParams.INCLUDE_TYPE,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutCalendarAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutCalendarAction.java
@@ -49,7 +49,7 @@ public class TransportPutCalendarAction extends HandledTransportAction<PutCalend
     protected void doExecute(Task task, PutCalendarAction.Request request, ActionListener<PutCalendarAction.Response> listener) {
         Calendar calendar = request.getCalendar();
 
-        IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, calendar.documentId());
+        IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME).id(calendar.documentId());
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             indexRequest.source(calendar.toXContent(builder,
                     new ToXContent.MapParams(Collections.singletonMap(ToXContentParams.INCLUDE_TYPE, "true"))));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutFilterAction.java
@@ -48,7 +48,7 @@ public class TransportPutFilterAction extends HandledTransportAction<PutFilterAc
     @Override
     protected void doExecute(Task task, PutFilterAction.Request request, ActionListener<PutFilterAction.Response> listener) {
         MlFilter filter = request.getFilter();
-        IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, filter.documentId());
+        IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME).id(filter.documentId());
         indexRequest.opType(DocWriteRequest.OpType.CREATE);
         indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateFilterAction.java
@@ -103,7 +103,7 @@ public class TransportUpdateFilterAction extends HandledTransportAction<UpdateFi
     private void indexUpdatedFilter(MlFilter filter, final long seqNo, final long primaryTerm,
                                     UpdateFilterAction.Request request,
                                     ActionListener<PutFilterAction.Response> listener) {
-        IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, filter.documentId());
+        IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME).id(filter.documentId());
         indexRequest.setIfSeqNo(seqNo);
         indexRequest.setIfPrimaryTerm(primaryTerm);
         indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
@@ -139,7 +139,7 @@ public class TransportUpdateFilterAction extends HandledTransportAction<UpdateFi
     }
 
     private void getFilterWithVersion(String filterId, ActionListener<FilterWithSeqNo> listener) {
-        GetRequest getRequest = new GetRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, MlFilter.documentId(filterId));
+        GetRequest getRequest = new GetRequest(MlMetaIndex.INDEX_NAME, MlFilter.documentId(filterId));
         executeAsyncWithOrigin(client, ML_ORIGIN, GetAction.INSTANCE, getRequest, new ActionListener<GetResponse>() {
             @Override
             public void onResponse(GetResponse getDocResponse) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateModelSnapshotAction.java
@@ -23,7 +23,6 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.UpdateModelSnapshotAction;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
-import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
@@ -80,8 +79,7 @@ public class TransportUpdateModelSnapshotAction extends HandledTransportAction<U
     }
 
     private void indexModelSnapshot(Result<ModelSnapshot> modelSnapshot, Consumer<Boolean> handler, Consumer<Exception> errorHandler) {
-        IndexRequest indexRequest = new IndexRequest(modelSnapshot.index, ElasticsearchMappings.DOC_TYPE,
-                ModelSnapshot.documentId(modelSnapshot.result));
+        IndexRequest indexRequest = new IndexRequest(modelSnapshot.index).id(ModelSnapshot.documentId(modelSnapshot.result));
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             modelSnapshot.result.toXContent(builder, ToXContent.EMPTY_PARAMS);
             indexRequest.source(builder);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
@@ -21,7 +21,6 @@ import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -62,7 +61,6 @@ import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobUpdate;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
-import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 
@@ -120,12 +118,11 @@ public class JobConfigProvider {
     public void putJob(Job job, ActionListener<IndexResponse> listener) {
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             XContentBuilder source = job.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
-            IndexRequest indexRequest =  client.prepareIndex(AnomalyDetectorsIndex.configIndexName(),
-                    ElasticsearchMappings.DOC_TYPE, Job.documentId(job.getId()))
-                    .setSource(source)
-                    .setOpType(DocWriteRequest.OpType.CREATE)
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                    .request();
+            IndexRequest indexRequest =  new IndexRequest(AnomalyDetectorsIndex.configIndexName())
+                    .id(Job.documentId(job.getId()))
+                    .source(source)
+                    .opType(DocWriteRequest.OpType.CREATE)
+                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
             executeAsyncWithOrigin(client, ML_ORIGIN, IndexAction.INSTANCE, indexRequest, ActionListener.wrap(
                     listener::onResponse,
@@ -155,8 +152,7 @@ public class JobConfigProvider {
      * @param jobListener Job listener
      */
     public void getJob(String jobId, ActionListener<Job.Builder> jobListener) {
-        GetRequest getRequest = new GetRequest(AnomalyDetectorsIndex.configIndexName(),
-                ElasticsearchMappings.DOC_TYPE, Job.documentId(jobId));
+        GetRequest getRequest = new GetRequest(AnomalyDetectorsIndex.configIndexName(), Job.documentId(jobId));
 
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, getRequest, new ActionListener<GetResponse>() {
             @Override
@@ -193,8 +189,7 @@ public class JobConfigProvider {
      * @param actionListener Deleted job listener
      */
     public void deleteJob(String jobId, boolean errorIfMissing, ActionListener<DeleteResponse> actionListener) {
-        DeleteRequest request = new DeleteRequest(AnomalyDetectorsIndex.configIndexName(),
-                ElasticsearchMappings.DOC_TYPE, Job.documentId(jobId));
+        DeleteRequest request = new DeleteRequest(AnomalyDetectorsIndex.configIndexName(), Job.documentId(jobId));
         request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
         executeAsyncWithOrigin(client, ML_ORIGIN, DeleteAction.INSTANCE, request, new ActionListener<DeleteResponse>() {
@@ -230,8 +225,7 @@ public class JobConfigProvider {
      */
     public void updateJob(String jobId, JobUpdate update, ByteSizeValue maxModelMemoryLimit,
                           ActionListener<Job> updatedJobListener) {
-        GetRequest getRequest = new GetRequest(AnomalyDetectorsIndex.configIndexName(),
-                ElasticsearchMappings.DOC_TYPE, Job.documentId(jobId));
+        GetRequest getRequest = new GetRequest(AnomalyDetectorsIndex.configIndexName(), Job.documentId(jobId));
 
         executeAsyncWithOrigin(client, ML_ORIGIN, GetAction.INSTANCE, getRequest, new ActionListener<GetResponse>() {
             @Override
@@ -295,8 +289,7 @@ public class JobConfigProvider {
      */
     public void updateJobWithValidation(String jobId, JobUpdate update, ByteSizeValue maxModelMemoryLimit,
                                         UpdateValidator validator, ActionListener<Job> updatedJobListener) {
-        GetRequest getRequest = new GetRequest(AnomalyDetectorsIndex.configIndexName(),
-                ElasticsearchMappings.DOC_TYPE, Job.documentId(jobId));
+        GetRequest getRequest = new GetRequest(AnomalyDetectorsIndex.configIndexName(), Job.documentId(jobId));
 
         executeAsyncWithOrigin(client, ML_ORIGIN, GetAction.INSTANCE, getRequest, new ActionListener<GetResponse>() {
             @Override
@@ -347,14 +340,14 @@ public class JobConfigProvider {
                                  ActionListener<Job> updatedJobListener) {
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             XContentBuilder updatedSource = updatedJob.toXContent(builder, ToXContent.EMPTY_PARAMS);
-            IndexRequestBuilder indexRequest = client.prepareIndex(AnomalyDetectorsIndex.configIndexName(),
-                    ElasticsearchMappings.DOC_TYPE, Job.documentId(updatedJob.getId()))
-                    .setSource(updatedSource)
+            IndexRequest indexRequest = new IndexRequest(AnomalyDetectorsIndex.configIndexName())
+                    .id(Job.documentId(updatedJob.getId()))
+                    .source(updatedSource)
                     .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             indexRequest.setIfSeqNo(seqNo);
             indexRequest.setIfPrimaryTerm(primaryTerm);
 
-            executeAsyncWithOrigin(client, ML_ORIGIN, IndexAction.INSTANCE, indexRequest.request(), ActionListener.wrap(
+            executeAsyncWithOrigin(client, ML_ORIGIN, IndexAction.INSTANCE, indexRequest, ActionListener.wrap(
                     indexResponse -> {
                         assert indexResponse.getResult() == DocWriteResponse.Result.UPDATED;
                         updatedJobListener.onResponse(updatedJob);
@@ -383,8 +376,7 @@ public class JobConfigProvider {
      * @param listener          Exists listener
      */
     public void jobExists(String jobId, boolean errorIfMissing, ActionListener<Boolean> listener) {
-        GetRequest getRequest = new GetRequest(AnomalyDetectorsIndex.configIndexName(),
-                ElasticsearchMappings.DOC_TYPE, Job.documentId(jobId));
+        GetRequest getRequest = new GetRequest(AnomalyDetectorsIndex.configIndexName(), Job.documentId(jobId));
         getRequest.fetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE);
 
         executeAsyncWithOrigin(client, ML_ORIGIN, GetAction.INSTANCE, getRequest, new ActionListener<GetResponse>() {
@@ -458,8 +450,7 @@ public class JobConfigProvider {
      * @param listener  Responds with true if successful else an error
      */
     public void markJobAsDeleting(String jobId, ActionListener<Boolean> listener) {
-        UpdateRequest updateRequest = new UpdateRequest(AnomalyDetectorsIndex.configIndexName(),
-                ElasticsearchMappings.DOC_TYPE, Job.documentId(jobId));
+        UpdateRequest updateRequest = new UpdateRequest(AnomalyDetectorsIndex.configIndexName(), Job.documentId(jobId));
         updateRequest.retryOnConflict(3);
         updateRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         updateRequest.doc(Collections.singletonMap(Job.DELETING.getPreferredName(), Boolean.TRUE));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataCountsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataCountsPersister.java
@@ -17,7 +17,6 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
-import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 
 import java.io.IOException;
@@ -54,10 +53,9 @@ public class JobDataCountsPersister {
      */
     public void persistDataCounts(String jobId, DataCounts counts, ActionListener<Boolean> listener) {
         try (XContentBuilder content = serialiseCounts(counts)) {
-            final IndexRequest request = client.prepareIndex(AnomalyDetectorsIndex.resultsWriteAlias(jobId), ElasticsearchMappings.DOC_TYPE,
-                    DataCounts.documentId(jobId))
-                    .setSource(content)
-                    .request();
+            final IndexRequest request = new IndexRequest(AnomalyDetectorsIndex.resultsWriteAlias(jobId))
+                    .id(DataCounts.documentId(jobId))
+                    .source(content);
             executeAsyncWithOrigin(client, ML_ORIGIN, IndexAction.INSTANCE, request, new ActionListener<IndexResponse>() {
                 @Override
                 public void onResponse(IndexResponse indexResponse) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobRenormalizedResultsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobRenormalizedResultsPersister.java
@@ -26,7 +26,6 @@ import java.util.List;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.stashWithOrigin;
-import static org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings.DOC_TYPE;
 
 
 /**
@@ -78,7 +77,7 @@ public class JobRenormalizedResultsPersister {
 
     public void updateResult(String id, String index, ToXContent resultDoc) {
         try (XContentBuilder content = toXContentBuilder(resultDoc)) {
-            bulkRequest.add(new IndexRequest(index, DOC_TYPE, id).source(content));
+            bulkRequest.add(new IndexRequest(index).id(id).source(content));
         } catch (IOException e) {
             logger.error(new ParameterizedMessage("[{}] Error serialising result", jobId), e);
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
@@ -46,7 +46,6 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 import static org.elasticsearch.xpack.core.ClientHelper.stashWithOrigin;
-import static org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings.DOC_TYPE;
 
 /**
  * Persists result types, Quantiles etc to Elasticsearch<br>
@@ -175,7 +174,7 @@ public class JobResultsPersister {
 
         private void indexResult(String id, ToXContent resultDoc, String resultType) {
             try (XContentBuilder content = toXContentBuilder(resultDoc)) {
-                bulkRequest.add(new IndexRequest(indexName, DOC_TYPE, id).source(content));
+                bulkRequest.add(new IndexRequest(indexName).id(id).source(content));
             } catch (IOException e) {
                 logger.error(new ParameterizedMessage("[{}] Error serialising {}", jobId, resultType), e);
             }
@@ -349,7 +348,7 @@ public class JobResultsPersister {
             logCall(indexName);
 
             try (XContentBuilder content = toXContentBuilder(object)) {
-                IndexRequest indexRequest = new IndexRequest(indexName, DOC_TYPE, id).source(content).setRefreshPolicy(refreshPolicy);
+                IndexRequest indexRequest = new IndexRequest(indexName).id(id).source(content).setRefreshPolicy(refreshPolicy);
                 executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, indexRequest, listener, client::index);
             } catch (IOException e) {
                 logger.error(new ParameterizedMessage("[{}] Error writing [{}]", jobId, (id == null) ? "auto-generated ID" : id), e);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -353,7 +353,7 @@ public class JobResultsProvider {
     private void updateIndexMappingWithTermFields(String indexName, String mappingType, Collection<String> termFields,
                                                   ActionListener<Boolean> listener) {
         // Put the whole mapping, not just the term fields, otherwise we'll wipe the _meta section of the mapping
-        try (XContentBuilder termFieldsMapping = ElasticsearchMappings.resultsMapping(termFields)) {
+        try (XContentBuilder termFieldsMapping = ElasticsearchMappings.resultsMapping(mappingType, termFields)) {
             final PutMappingRequest request = client.admin().indices().preparePutMapping(indexName)
                     .setType(mappingType)
                     .setSource(termFieldsMapping).request();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -124,6 +124,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.clientWithOrigin;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
@@ -290,7 +291,7 @@ public class JobResultsProvider {
             // This assumes the requested mapping will be merged with mappings from the template,
             // and may need to be revisited if template merging is ever refactored
             try (XContentBuilder termFieldsMapping = ElasticsearchMappings.termFieldsMapping(termFields)) {
-                createIndexRequest.mapping("_doc", termFieldsMapping);
+                createIndexRequest.mapping(SINGLE_MAPPING_NAME, termFieldsMapping);
             }
             executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, createIndexRequest,
                     ActionListener.<CreateIndexResponse>wrap(
@@ -354,10 +355,10 @@ public class JobResultsProvider {
     }
 
     private void updateIndexMappingWithTermFields(String indexName, Collection<String> termFields, ActionListener<Boolean> listener) {
-        // Put the whole "doc" mapping, not just the term fields, otherwise we'll wipe the _meta section of the mapping
+        // Put the whole mapping, not just the term fields, otherwise we'll wipe the _meta section of the mapping
         try (XContentBuilder termFieldsMapping = ElasticsearchMappings.resultsMapping(termFields)) {
             final PutMappingRequest request = client.admin().indices().preparePutMapping(indexName)
-                    .setType("_doc")
+                    .setType(SINGLE_MAPPING_NAME)   // TODO check current mapping name
                     .setSource(termFieldsMapping).request();
             executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, request, new ActionListener<AcknowledgedResponse>() {
                 @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -503,7 +503,7 @@ public class JobResultsProvider {
                      .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
             return objectParser.apply(parser, null);
         } catch (IOException e) {
-            errorHandler.accept(new ElasticsearchParseException("failed to parse " + hit.getType(), e));
+            errorHandler.accept(new ElasticsearchParseException("failed to parse " + hit.getId(), e));
             return null;
         }
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -1186,7 +1186,7 @@ public class JobResultsProvider {
                     currentJobs.removeAll(jobIdsToRemove);
                     Calendar updatedCalendar = new Calendar(calendar.getId(), new ArrayList<>(currentJobs), calendar.getDescription());
 
-                    UpdateRequest updateRequest = new UpdateRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, updatedCalendar.documentId());
+                    UpdateRequest updateRequest = new UpdateRequest(MlMetaIndex.INDEX_NAME, updatedCalendar.documentId());
                     updateRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
                     try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
@@ -1254,8 +1254,7 @@ public class JobResultsProvider {
                                 ids.remove(jobId);
                                 return new Calendar(c.getId(), new ArrayList<>(ids), c.getDescription());
                             }).forEach(c -> {
-                                UpdateRequest updateRequest = new UpdateRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE,
-                                        c.documentId());
+                                UpdateRequest updateRequest = new UpdateRequest(MlMetaIndex.INDEX_NAME, c.documentId());
                                 try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
                                     updateRequest.doc(c.toXContent(builder, ToXContent.EMPTY_PARAMS));
                                 } catch (IOException e) {
@@ -1278,7 +1277,7 @@ public class JobResultsProvider {
     }
 
     public void calendar(String calendarId, ActionListener<Calendar> listener) {
-        GetRequest getRequest = new GetRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, Calendar.documentId(calendarId));
+        GetRequest getRequest = new GetRequest(MlMetaIndex.INDEX_NAME, Calendar.documentId(calendarId));
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, getRequest, new ActionListener<GetResponse>() {
             @Override
             public void onResponse(GetResponse getDocResponse) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -289,8 +289,8 @@ public class JobResultsProvider {
             CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName);
             // This assumes the requested mapping will be merged with mappings from the template,
             // and may need to be revisited if template merging is ever refactored
-            try (XContentBuilder termFieldsMapping = ElasticsearchMappings.termFieldsMapping(ElasticsearchMappings.DOC_TYPE, termFields)) {
-                createIndexRequest.mapping(ElasticsearchMappings.DOC_TYPE, termFieldsMapping);
+            try (XContentBuilder termFieldsMapping = ElasticsearchMappings.termFieldsMapping(termFields)) {
+                createIndexRequest.mapping("_doc", termFieldsMapping);
             }
             executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, createIndexRequest,
                     ActionListener.<CreateIndexResponse>wrap(
@@ -356,7 +356,8 @@ public class JobResultsProvider {
     private void updateIndexMappingWithTermFields(String indexName, Collection<String> termFields, ActionListener<Boolean> listener) {
         // Put the whole "doc" mapping, not just the term fields, otherwise we'll wipe the _meta section of the mapping
         try (XContentBuilder termFieldsMapping = ElasticsearchMappings.resultsMapping(termFields)) {
-            final PutMappingRequest request = client.admin().indices().preparePutMapping(indexName).setType(ElasticsearchMappings.DOC_TYPE)
+            final PutMappingRequest request = client.admin().indices().preparePutMapping(indexName)
+                    .setType("_doc")
                     .setSource(termFieldsMapping).request();
             executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, request, new ActionListener<AcknowledgedResponse>() {
                 @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/StateStreamer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/StateStreamer.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
-import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.CategorizerState;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 
@@ -75,7 +74,6 @@ public class StateStreamer {
 
             try (ThreadContext.StoredContext ignore = stashWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN)) {
                 SearchResponse stateResponse = client.prepareSearch(indexName)
-                    .setTypes(ElasticsearchMappings.DOC_TYPE)
                     .setSize(1)
                     .setQuery(QueryBuilders.idsQuery().addIds(stateDocId)).get();
                 if (stateResponse.getHits().getHits().length == 0) {
@@ -102,7 +100,6 @@ public class StateStreamer {
 
             try (ThreadContext.StoredContext ignore = stashWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN)) {
                 SearchResponse stateResponse = client.prepareSearch(indexName)
-                    .setTypes(ElasticsearchMappings.DOC_TYPE)
                     .setSize(1)
                     .setQuery(QueryBuilders.idsQuery().addIds(docId)).get();
                 if (stateResponse.getHits().getHits().length == 0) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectStateProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectStateProcessor.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
-import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.ml.process.StateProcessor;
 
 import java.io.IOException;
@@ -98,7 +97,7 @@ public class AutodetectStateProcessor implements StateProcessor {
 
     void persist(BytesReference bytes) throws IOException {
         BulkRequest bulkRequest = new BulkRequest();
-        bulkRequest.add(bytes, AnomalyDetectorsIndex.jobStateIndexWriteAlias(), ElasticsearchMappings.DOC_TYPE, XContentType.JSON);
+        bulkRequest.add(bytes, AnomalyDetectorsIndex.jobStateIndexWriteAlias(), XContentType.JSON);
         if (bulkRequest.numberOfActions() > 0) {
             LOGGER.trace("[{}] Persisting job state document", jobId);
             try (ThreadContext.StoredContext ignore = stashWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN)) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/UnusedStateRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/UnusedStateRemover.java
@@ -18,7 +18,6 @@ import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
-import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.CategorizerState;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelState;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.Quantiles;
@@ -105,7 +104,6 @@ public class UnusedStateRemover implements MlDataRemover {
         LOGGER.info("Found [{}] unused state documents; attempting to delete",
                 unusedDocIds.size());
         DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(AnomalyDetectorsIndex.jobStateIndexPattern())
-            .types(ElasticsearchMappings.DOC_TYPE)
             .setIndicesOptions(IndicesOptions.lenientExpandOpen())
             .setQuery(QueryBuilders.idsQuery().addIds(unusedDocIds.toArray(new String[0])));
         client.execute(DeleteByQueryAction.INSTANCE, deleteByQueryRequest, ActionListener.wrap(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/notifications/Auditor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/notifications/Auditor.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.ml.notifications;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
@@ -38,30 +37,30 @@ public class Auditor {
     }
 
     public void info(String jobId, String message) {
-        indexDoc(AuditMessage.TYPE.getPreferredName(), AuditMessage.newInfo(jobId, message, nodeName));
+        indexDoc(AuditMessage.newInfo(jobId, message, nodeName));
     }
 
     public void warning(String jobId, String message) {
-        indexDoc(AuditMessage.TYPE.getPreferredName(), AuditMessage.newWarning(jobId, message, nodeName));
+        indexDoc(AuditMessage.newWarning(jobId, message, nodeName));
     }
 
     public void error(String jobId, String message) {
-        indexDoc(AuditMessage.TYPE.getPreferredName(), AuditMessage.newError(jobId, message, nodeName));
+        indexDoc(AuditMessage.newError(jobId, message, nodeName));
     }
 
-    private void indexDoc(String type, ToXContent toXContent) {
-        IndexRequest indexRequest = new IndexRequest(AuditorField.NOTIFICATIONS_INDEX, type);
+    private void indexDoc(ToXContent toXContent) {
+        IndexRequest indexRequest = new IndexRequest(AuditorField.NOTIFICATIONS_INDEX);
         indexRequest.source(toXContentBuilder(toXContent));
         indexRequest.timeout(TimeValue.timeValueSeconds(5));
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, indexRequest, new ActionListener<IndexResponse>() {
             @Override
             public void onResponse(IndexResponse indexResponse) {
-                LOGGER.trace("Successfully persisted {}", type);
+                LOGGER.trace("Successfully persisted audit message");
             }
 
             @Override
             public void onFailure(Exception e) {
-                LOGGER.debug(new ParameterizedMessage("Error writing {}", new Object[]{type}, e));
+                LOGGER.debug("Error writing audit message", e);
             }
         }, client::index);
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManagerTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData.PersistentTask;
 import org.elasticsearch.test.ESTestCase;
@@ -34,12 +33,9 @@ import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
-import org.elasticsearch.xpack.core.ml.notifications.AuditMessage;
-import org.elasticsearch.xpack.core.ml.notifications.AuditorField;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.action.TransportStartDatafeedAction.DatafeedTask;
 import org.elasticsearch.xpack.ml.action.TransportStartDatafeedActionTests;
-import org.elasticsearch.xpack.ml.job.persistence.MockClientBuilder;
 import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager;
 import org.elasticsearch.xpack.ml.notifications.Auditor;
 import org.junit.Before;
@@ -98,12 +94,6 @@ public class DatafeedManagerTests extends ESTestCase {
         clusterService = mock(ClusterService.class);
         when(clusterService.state()).thenReturn(cs.build());
 
-
-        ArgumentCaptor<XContentBuilder> argumentCaptor = ArgumentCaptor.forClass(XContentBuilder.class);
-        Client client = new MockClientBuilder("foo")
-                .prepareIndex(AuditorField.NOTIFICATIONS_INDEX, AuditMessage.TYPE.getPreferredName(), "responseId", argumentCaptor)
-                .build();
-
         DiscoveryNode dNode = mock(DiscoveryNode.class);
         when(dNode.getName()).thenReturn("this_node_has_a_name");
         when(clusterService.localNode()).thenReturn(dNode);
@@ -136,8 +126,8 @@ public class DatafeedManagerTests extends ESTestCase {
         AutodetectProcessManager autodetectProcessManager = mock(AutodetectProcessManager.class);
         doAnswer(invocation -> hasOpenAutodetectCommunicator.get()).when(autodetectProcessManager).hasOpenAutodetectCommunicator(anyLong());
 
-        datafeedManager = new DatafeedManager(threadPool, client, clusterService, datafeedJobBuilder, () -> currentTime, auditor,
-            autodetectProcessManager);
+        datafeedManager = new DatafeedManager(threadPool, mock(Client.class), clusterService, datafeedJobBuilder,
+                () -> currentTime, auditor, autodetectProcessManager);
 
         verify(clusterService).addListener(capturedClusterStateListener.capture());
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
@@ -504,7 +504,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
         for (ScheduledEvent event : events) {
-            IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE);
+            IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME);
             try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
                 ToXContent.MapParams params = new ToXContent.MapParams(Collections.singletonMap(ToXContentParams.INCLUDE_TYPE, "true"));
                 indexRequest.source(event.toXContent(builder, params));
@@ -547,7 +547,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
         for (MlFilter filter : filters) {
-            IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, filter.documentId());
+            IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME).id(filter.documentId());
             try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
                 ToXContent.MapParams params = new ToXContent.MapParams(Collections.singletonMap(ToXContentParams.INCLUDE_TYPE, "true"));
                 indexRequest.source(filter.toXContent(builder, params));
@@ -577,7 +577,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
         for (Calendar calendar: calendars) {
-            IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, calendar.documentId());
+            IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME).id(calendar.documentId());
             try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
                 ToXContent.MapParams params = new ToXContent.MapParams(Collections.singletonMap(ToXContentParams.INCLUDE_TYPE, "true"));
                 indexRequest.source(calendar.toXContent(builder, params));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/MlConfigMigratorIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/MlConfigMigratorIT.java
@@ -7,7 +7,7 @@ package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.DocWriteRequest;
-import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -39,7 +39,6 @@ import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
-import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.ml.MlConfigMigrationEligibilityCheck;
 import org.elasticsearch.xpack.ml.MlConfigMigrator;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
@@ -213,13 +212,11 @@ public class MlConfigMigratorIT extends MlSingleNodeTestCase {
         AnomalyDetectorsIndex.createStateIndexAndAliasIfNecessary(client(), clusterService.state(), future);
         future.actionGet();
 
-        IndexRequestBuilder indexRequest = client().prepareIndex(AnomalyDetectorsIndex.jobStateIndexWriteAlias(),
-                ElasticsearchMappings.DOC_TYPE, "ml-config")
-                .setSource(Collections.singletonMap("a_field", "a_value"))
-                .setOpType(DocWriteRequest.OpType.CREATE)
+        IndexRequest indexRequest = new IndexRequest(AnomalyDetectorsIndex.jobStateIndexWriteAlias()).id("ml-config")
+                .opType(DocWriteRequest.OpType.CREATE)
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
-        indexRequest.execute().actionGet();
+        client().index(indexRequest).actionGet();
 
         doAnswer(invocation -> {
             ClusterStateUpdateTask listener = (ClusterStateUpdateTask) invocation.getArguments()[1];
@@ -386,7 +383,6 @@ public class MlConfigMigratorIT extends MlSingleNodeTestCase {
         client().admin().indices().prepareRefresh(AnomalyDetectorsIndex.jobStateIndexPattern()).get();
         SearchResponse searchResponse = client()
             .prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern())
-            .setTypes(ElasticsearchMappings.DOC_TYPE)
             .setSize(1)
             .setQuery(QueryBuilders.idsQuery().addIds("ml-config"))
             .get();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/MlConfigMigratorIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/MlConfigMigratorIT.java
@@ -213,6 +213,7 @@ public class MlConfigMigratorIT extends MlSingleNodeTestCase {
         future.actionGet();
 
         IndexRequest indexRequest = new IndexRequest(AnomalyDetectorsIndex.jobStateIndexWriteAlias()).id("ml-config")
+                .source(Collections.singletonMap("a_field", "a_value"))
                 .opType(DocWriteRequest.OpType.CREATE)
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
@@ -770,39 +770,38 @@ public class JobResultsProviderTests extends ESTestCase {
 
     public void testViolatedFieldCountLimit() throws Exception {
         Map<String, Object> mapping = new HashMap<>();
-        for (int i = 0; i < 10; i++) {
+
+        int i = 0;
+        for (; i < 10; i++) {
             mapping.put("field" + i, Collections.singletonMap("type", "string"));
         }
 
-        IndexMetaData.Builder indexMetaData1 = new IndexMetaData.Builder("index1")
-                .settings(Settings.builder()
-                        .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
-                        .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
-                        .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0))
-                .putMapping(new MappingMetaData("type1", Collections.singletonMap("properties", mapping)));
-        MetaData metaData = MetaData.builder()
-                .put(indexMetaData1)
-                .build();
-        boolean result = JobResultsProvider.violatedFieldCountLimit("index1", 0, 10,
-                ClusterState.builder(new ClusterName("_name")).metaData(metaData).build());
-        assertFalse(result);
-
-        result = JobResultsProvider.violatedFieldCountLimit("index1", 1, 10,
-                ClusterState.builder(new ClusterName("_name")).metaData(metaData).build());
-        assertTrue(result);
-
-        IndexMetaData.Builder indexMetaData2 = new IndexMetaData.Builder("index1")
+        IndexMetaData indexMetaData1 = new IndexMetaData.Builder("index1")
                 .settings(Settings.builder()
                         .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                         .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                         .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0))
                 .putMapping(new MappingMetaData("type1", Collections.singletonMap("properties", mapping)))
-                .putMapping(new MappingMetaData("type2", Collections.singletonMap("properties", mapping)));
-        metaData = MetaData.builder()
-                .put(indexMetaData2)
                 .build();
-        result = JobResultsProvider.violatedFieldCountLimit("index1", 0, 19,
-                ClusterState.builder(new ClusterName("_name")).metaData(metaData).build());
+        boolean result = JobResultsProvider.violatedFieldCountLimit(0, 10, indexMetaData1);
+        assertFalse(result);
+
+        result = JobResultsProvider.violatedFieldCountLimit(1, 10, indexMetaData1);
+        assertTrue(result);
+
+        for (; i < 20; i++) {
+            mapping.put("field" + i, Collections.singletonMap("type", "string"));
+        }
+
+        IndexMetaData indexMetaData2 = new IndexMetaData.Builder("index1")
+                .settings(Settings.builder()
+                        .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                        .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0))
+                .putMapping(new MappingMetaData("type1", Collections.singletonMap("properties", mapping)))
+                .build();
+
+        result = JobResultsProvider.violatedFieldCountLimit(0, 19, indexMetaData2);
         assertTrue(result);
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockClientBuilder.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockClientBuilder.java
@@ -28,14 +28,11 @@ import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.get.GetRequestBuilder;
 import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequestBuilder;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.AdminClient;
 import org.elasticsearch.client.Client;
@@ -352,39 +349,6 @@ public class MockClientBuilder {
             }
         }).when(client).search(eq(request), any());
 
-        return this;
-    }
-
-    public MockClientBuilder prepareSearchAnySize(String index, String type, SearchResponse response, ArgumentCaptor<QueryBuilder> filter) {
-        SearchRequestBuilder builder = mock(SearchRequestBuilder.class);
-        when(builder.setTypes(eq(type))).thenReturn(builder);
-        when(builder.addSort(any(SortBuilder.class))).thenReturn(builder);
-        when(builder.setQuery(filter.capture())).thenReturn(builder);
-        when(builder.setPostFilter(filter.capture())).thenReturn(builder);
-        when(builder.setFrom(any(Integer.class))).thenReturn(builder);
-        when(builder.setSize(any(Integer.class))).thenReturn(builder);
-        when(builder.setFetchSource(eq(true))).thenReturn(builder);
-        when(builder.addDocValueField(any(String.class))).thenReturn(builder);
-        when(builder.addDocValueField(any(String.class), any(String.class))).thenReturn(builder);
-        when(builder.addSort(any(String.class), any(SortOrder.class))).thenReturn(builder);
-        when(builder.get()).thenReturn(response);
-        when(client.prepareSearch(eq(index))).thenReturn(builder);
-        return this;
-    }
-
-    @SuppressWarnings("unchecked")
-    public MockClientBuilder prepareIndex(String index, String type, String responseId, ArgumentCaptor<XContentBuilder> getSource) {
-        IndexRequestBuilder builder = mock(IndexRequestBuilder.class);
-        PlainActionFuture<IndexResponse> actionFuture = mock(PlainActionFuture.class);
-        IndexResponse response = mock(IndexResponse.class);
-        when(response.getId()).thenReturn(responseId);
-
-        when(client.prepareIndex(eq(index), eq(type))).thenReturn(builder);
-        when(client.prepareIndex(eq(index), eq(type), any(String.class))).thenReturn(builder);
-        when(builder.setSource(getSource.capture())).thenReturn(builder);
-        when(builder.setRefreshPolicy(eq(RefreshPolicy.IMMEDIATE))).thenReturn(builder);
-        when(builder.execute()).thenReturn(actionFuture);
-        when(actionFuture.actionGet()).thenReturn(response);
         return this;
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/notifications/AuditorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/notifications/AuditorTests.java
@@ -51,7 +51,6 @@ public class AuditorTests extends ESTestCase {
         verify(client).index(indexRequestCaptor.capture(), any());
         IndexRequest indexRequest = indexRequestCaptor.getValue();
         assertArrayEquals(new String[] {".ml-notifications"}, indexRequest.indices());
-        assertEquals("audit_message", indexRequest.type());
         assertEquals(TimeValue.timeValueSeconds(5), indexRequest.timeout());
         AuditMessage auditMessage = parseAuditMessage(indexRequest.source());
         assertEquals("foo", auditMessage.getJobId());
@@ -66,7 +65,6 @@ public class AuditorTests extends ESTestCase {
         verify(client).index(indexRequestCaptor.capture(), any());
         IndexRequest indexRequest = indexRequestCaptor.getValue();
         assertArrayEquals(new String[] {".ml-notifications"}, indexRequest.indices());
-        assertEquals("audit_message", indexRequest.type());
         assertEquals(TimeValue.timeValueSeconds(5), indexRequest.timeout());
         AuditMessage auditMessage = parseAuditMessage(indexRequest.source());
         assertEquals("bar", auditMessage.getJobId());
@@ -81,7 +79,6 @@ public class AuditorTests extends ESTestCase {
         verify(client).index(indexRequestCaptor.capture(), any());
         IndexRequest indexRequest = indexRequestCaptor.getValue();
         assertArrayEquals(new String[] {".ml-notifications"}, indexRequest.indices());
-        assertEquals("audit_message", indexRequest.type());
         assertEquals(TimeValue.timeValueSeconds(5), indexRequest.timeout());
         AuditMessage auditMessage = parseAuditMessage(indexRequest.source());
         assertEquals("foobar", auditMessage.getJobId());

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/custom_all_field.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/custom_all_field.yml
@@ -35,7 +35,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-custom-all-test-1
-        type:   doc
         id:     custom_all_1464739200000_1_1
         body:
           {
@@ -62,7 +61,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-custom-all-test-2
-        type:   doc
         id:     custom_all_1464739200000_1_2
         body:
           {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_forecast.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_forecast.yml
@@ -34,7 +34,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
-        type:   doc
         id:     "delete-forecast-job_model_forecast_someforecastid_1486591200000_1800_0_961_0"
         body:
           {
@@ -56,7 +55,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
-        type:   doc
         id:     "delete-forecast-job_model_forecast_someforecastid_1486591300000_1800_0_961_0"
         body:
           {
@@ -78,7 +76,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
-        type:   doc
         id:     "delete-forecast-job_model_forecast_request_stats_someforecastid"
         body:
           {
@@ -112,19 +109,16 @@ setup:
       get:
         id: delete-forecast-job_model_forecast_request_stats_someforecastid
         index: .ml-anomalies-shared
-        type: doc
   - do:
       catch: missing
       get:
         id: delete-forecast-job_model_forecast_someforecastid_1486591300000_1800_0_961_0
         index: .ml-anomalies-shared
-        type: doc
   - do:
       catch: missing
       get:
         id: delete-forecast-job_model_forecast_someforecastid_1486591200000_1800_0_961_0
         index: .ml-anomalies-shared
-        type: doc
 
 ---
 "Test delete on _all forecasts not allow no forecasts":

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_model_snapshot.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_model_snapshot.yml
@@ -39,7 +39,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-delete-model-snapshot
-        type:   doc
         id:     "delete-model-snapshot_model_snapshot_inactive-snapshot"
         body: >
           {
@@ -57,7 +56,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index:  .ml-state
-        type:   doc
         id:     "delete-model-snapshot_model_state_inactive-snapshot#1"
         body: >
           {
@@ -69,7 +67,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index:  .ml-state
-        type:   doc
         id:     "delete-model-snapshot_model_state_inactive-snapshot#2"
         body: >
           {
@@ -82,7 +79,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-delete-model-snapshot
-        type:   doc
         id:     "delete-model-snapshot_model_snapshot_active-snapshot"
         body: >
           {
@@ -158,7 +154,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       count:
         index: .ml-state
-        type: doc
 
   - match: { count: 3 }
 
@@ -191,7 +186,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       count:
         index: .ml-state
-        type: doc
 
   - match: { count: 1 }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/filter_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/filter_crud.yml
@@ -8,7 +8,6 @@ setup:
         Content-Type: application/json
       index:
         index: .ml-meta
-        type: doc
         id: filter_imposter-filter
         body: >
           {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_model_snapshots.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_model_snapshots.yml
@@ -23,7 +23,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-get-model-snapshots
-        type:   doc
         id:     "get-model-snapshots-1"
         body:  >
           {
@@ -39,7 +38,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-state
-        type:   doc
         id:     "get-model-snapshots_model_state_1#1"
         body:  >
           {
@@ -51,7 +49,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-get-model-snapshots
-        type:   doc
         id:     "get-model-snapshots-2"
         body:  >
           {
@@ -66,7 +63,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index:  .ml-state
-        type:   doc
         id:     "get-model-snapshots_model_state_2#1"
         body:  >
           {
@@ -77,7 +73,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index:  .ml-state
-        type:   doc
         id:     "get-model-snapshots_model_state_2#2"
         body:  >
           {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/index_layout.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/index_layout.yml
@@ -186,7 +186,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index: .ml-state
-        type: doc
         id: index-layout-job2_categorizer_state#1
         body:
           key: value
@@ -196,7 +195,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index: .ml-state
-        type: doc
         id: index-layout-job2_categorizer_state#2
         body:
           key: value
@@ -299,7 +297,6 @@ setup:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       count:
-        type: doc
         index: .ml-state
   - match: {count: 0}
 
@@ -307,7 +304,6 @@ setup:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       count:
-        type: doc
         index: .ml-state
   - match: {count: 0}
 
@@ -315,7 +311,6 @@ setup:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       count:
-        type: doc
         index: .ml-state
   - match: {count: 0}
 
@@ -387,7 +382,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index: foo
-        type: doc
         body:
           key: value
 
@@ -396,7 +390,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index: .ml-anomalies-foo
-        type: doc
         body:
           key: value
 
@@ -405,7 +398,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index: .ml-anomalies-foo
-        type: doc
         body:
           key: value
           job_id: foo
@@ -512,7 +504,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index: .ml-state
-        type: doc
         id: index-layout-quantiles-job_quantiles
         body:
           state: quantile-state
@@ -563,7 +554,6 @@ setup:
 
       index:
         index:  .ml-anomalies-shared
-        type:   doc
         id:     "index-layout-state-job_model_snapshot_123"
         body: >
           {
@@ -579,7 +569,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index: .ml-state
-        type: doc
         id: index-layout-state-job_model_state_123#1
         body:
           state: new-model-state
@@ -589,7 +578,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index: .ml-state
-        type: doc
         id: index-layout-state-job_model_state_123#2
         body:
           state: more-new-model-state
@@ -599,7 +587,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index: .ml-state
-        type: doc
         id: index-layout-state-job_categorizer_state#1
         body:
           state: new-categorizer-state
@@ -609,7 +596,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index: .ml-state
-        type: doc
         id: index-layout-state-job_categorizer_state#2
         body:
           state: more-new-categorizer-state

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_buckets.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_buckets.yml
@@ -23,7 +23,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-jobs-get-result-buckets
-        type:   doc
         id:     "jobs-get-result-buckets_1464739200000_1"
         body:
           {
@@ -40,7 +39,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-jobs-get-result-buckets
-        type:   doc
         id:     "jobs-get-result-buckets_1470009600000_2"
         body:
           {
@@ -57,7 +55,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-jobs-get-result-buckets
-        type:   doc
         id:     "jobs-get-result-buckets_1470096000000_3"
         body:
           {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_categories.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_categories.yml
@@ -23,7 +23,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-jobs-get-result-categories
-        type:   doc
         id:     jobs-get-result-categories-1
         body:   { "job_id": "jobs-get-result-categories", "category_id": 1 }
   - do:
@@ -32,7 +31,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-jobs-get-result-categories
-        type:   doc
         id:     jobs-get-result-categories-2
         body:   { "job_id": "jobs-get-result-categories", "category_id": 2 }
   - do:
@@ -41,7 +39,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-unrelated
-        type:   doc
         id:     jobs-get-result-categories-3
         body:   { "job_id": "unrelated", "category_id": 1 }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_influencers.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_influencers.yml
@@ -23,7 +23,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-get-influencers-test
-        type:   doc
         id:     get-influencers-test_1464739200000_1_1
         body:
           {
@@ -42,7 +41,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-get-influencers-test
-        type:   doc
         id:     get-influencers-test_1464825600000_1_2
         body:
           {
@@ -62,7 +60,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-get-influencers-test
-        type:   doc
         id:     get-influencers-test_1464912000000_1_3
         body:
           {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_overall_buckets.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_overall_buckets.yml
@@ -64,7 +64,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
-        type:   doc
         id:     "jobs-get-result-overall-buckets-60_1"
         body:
           {
@@ -81,7 +80,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
-        type:   doc
         id:     "jobs-get-result-overall-buckets-60_2"
         body:
           {
@@ -98,7 +96,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
-        type:   doc
         id:     "jobs-get-result-overall-buckets-60_3"
         body:
           {
@@ -114,7 +111,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index:  .ml-anomalies-shared
-        type:   doc
         id:     "jobs-get-result-overall-buckets-30_1"
         body:
           {
@@ -131,7 +127,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
-        type:   doc
         id:     "jobs-get-result-overall-buckets-30_2"
         body:
           {
@@ -148,7 +143,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
-        type:   doc
         id:     "jobs-get-result-overall-buckets-30_3"
         body:
           {
@@ -165,7 +159,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
-        type:   doc
         id:     "jobs-get-result-overall-buckets-17_1"
         body:
           {
@@ -182,7 +175,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
-        type:   doc
         id:     "jobs-get-result-overall-buckets-17_2"
         body:
           {
@@ -199,7 +191,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
-        type:   doc
         id:     "jobs-get-result-overall-buckets-17_3"
         body:
           {
@@ -216,7 +207,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
-        type:   doc
         id:     "jobs-get-result-overall-buckets-17_4"
         body:
           {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_records.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_records.yml
@@ -23,7 +23,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-jobs-get-result-records
-        type:   doc
         id:     jobs-get-result-records_1464739200000_1_1
         body:
           {
@@ -40,7 +39,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-jobs-get-result-records
-        type:   doc
         id:     jobs-get-result-records_1464825600000_1_2
         body:
           {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_stats.yml
@@ -234,7 +234,6 @@ setup:
         Content-Type: application/json
       index:
         index: .ml-anomalies-shared
-        type: doc
         id: job-stats-v54-bwc-test-data-counts
         body:
           {
@@ -259,7 +258,6 @@ setup:
         Content-Type: application/json
       index:
         index: .ml-anomalies-shared
-        type: doc
         id: job-stats-v54-bwc-test-model_size_stats
         body:
           {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/ml_anomalies_default_mappings.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/ml_anomalies_default_mappings.yml
@@ -25,7 +25,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
-        type:   doc
         id:     "new_doc"
         body: >
           {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/post_data.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/post_data.yml
@@ -89,7 +89,6 @@ setup:
   - do:
       get:
         index: .ml-anomalies-post-data-job
-        type: doc
         id: post-data-job_data_counts
 
   - match: { _source.processed_record_count: 2 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/revert_model_snapshot.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/revert_model_snapshot.yml
@@ -39,7 +39,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
-        type:   doc
         id:     "revert-model-snapshot_model_snapshot_first"
         body: >
           {
@@ -67,7 +66,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
-        type:   doc
         id:     "revert-model-snapshot_model_snapshot_second"
         body: >
           {
@@ -95,7 +93,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
-        type:   doc
         id:     "revert-model-snapshot_1464825600000_1"
         body: >
           {
@@ -111,7 +108,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
-        type:   doc
         id:     "revert-model-snapshot_1464782400000_1"
         body: >
           {
@@ -127,7 +123,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
-        type:   doc
         id:     "revert-model-snapshot_1462060800000_1"
         body: >
           {
@@ -143,7 +138,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
-        type:   doc
         id:     "revert-model-snapshot_1464825600000_1_1"
         body: >
           {
@@ -159,7 +153,6 @@ setup:
         Content-Type: application/json
       index:
          index:  .ml-anomalies-revert-model-snapshot
-         type:   doc
          id:     "revert-model-snapshot_1462060800000_1_2"
          body: >
            {
@@ -175,7 +168,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
-        type:   doc
         id:     "revert-model-snapshot_1464825600000_1_3"
         body:   {
                   "job_id": "revert-model-snapshot",
@@ -193,7 +185,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
-        type:   doc
         id:     "revert-model-snapshot_1462060800000_1_4"
         body:
            {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/update_model_snapshot.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/update_model_snapshot.yml
@@ -23,7 +23,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-update-model-snapshot
-        type:   doc
         id:     "update-model-snapshot_model_snapshot_snapshot-1"
         body: >
           {
@@ -39,7 +38,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index:  .ml-state
-        type:   doc
         id:     "update-model-snapshot_model_state_1#1"
         body:  >
           {
@@ -50,7 +48,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index:  .ml-state
-        type:   doc
         id:     "update-model-snapshot_model_state_1#2"
         body:  >
           {
@@ -61,7 +58,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index:  .ml-state
-        type:   doc
         id:     "update-model-snapshot_model_state_1#3"
         body:  >
           {
@@ -73,7 +69,6 @@ setup:
         Content-Type: application/json
       index:
         index:  .ml-anomalies-update-model-snapshot
-        type:   doc
         id:     "update-model-snapshot_model_snapshot_snapshot-2"
         body: >
           {
@@ -90,7 +85,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index:  .ml-state
-        type:   doc
         id:     "update-model-snapshot_model_state_2#1"
         body:  >
           {
@@ -101,7 +95,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:
         index:  .ml-state
-        type:   doc
         id:     "update-model-snapshot_model_state_2#2"
         body:  >
           {


### PR DESCRIPTION
Removes deprecated usage of types in the APIs and resolves a reindex issue with the upgrade assistant in 7 to wit:

- ml indices use `doc` as the single mapping type by convention
- 7.0 has an upgrade assistant which advises to reindex the ml indices from the previous version 
- after reindex the mapping type of the destination index is `_doc` unless a target type is specified
- ml may update the mapping of the results index when a new job is created
- if ml continues to use the `doc` type after reindex a mapping conflict occurs as the index would have 2 types `doc` and `_doc`. This is the cause of #38796

Depending on whether or not the upgrade assistant has been run the single mapping type of the ml indices may be `doc` or `_doc`, moving to the typeless APIs largely covers this situation however, there is the case of updating the results index mapping on job creation in which case the new mapping must have the same type as the old otherwise the index will have 2 types of mappings

~~WIP in progress as testing is required, depends on #39243~~