### PR TITLE
Fix size for alternate exists

### DIFF
--- a/docs/reference/search/exists.asciidoc
+++ b/docs/reference/search/exists.asciidoc
@@ -1,7 +1,7 @@
 [[search-exists]]
 == Search Exists API
 
-deprecated[2.1.0, use regular `_search` with `size` set to `0` and `terminate_after` set to `1` instead]
+deprecated[2.1.0, use regular `_search` with `size` set to `1` and `terminate_after` set to `1` instead]
 
 The exists API allows to easily determine if any
 matching documents exist for a provided query. It can be executed across one or more indices


### PR DESCRIPTION
With `size=0` result won't permit to check whether there are results or no.

This page doesn't exist anymore on master.