### PR TITLE
Fix Deadlock from Thread.suspend in Test

### DIFF
--- a/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
@@ -127,18 +127,18 @@ public class LongGCDisruptionTests extends ESTestCase {
         final LockedExecutor lockedExecutor = new LockedExecutor();
         final AtomicLong ops = new AtomicLong();
         final Thread[] threads = new Thread[5];
+        final Runnable yieldAndIncrement = () -> {
+            Thread.yield(); // give some chance to catch this stack trace
+            ops.incrementAndGet();
+        };
         try {
             for (int i = 0; i < threads.length; i++) {
                 threads[i] = new Thread(() -> {
                     for (int iter = 0; stop.get() == false; iter++) {
                         if (iter % 2 == 0) {
-                            lockedExecutor.executeLocked(() -> {
-                                Thread.yield(); // give some chance to catch this stack trace
-                                ops.incrementAndGet();
-                            });
+                            lockedExecutor.executeLocked(yieldAndIncrement);
                         } else {
-                            Thread.yield(); // give some chance to catch this stack trace
-                            ops.incrementAndGet();
+                            yieldAndIncrement.run();
                         }
                     }
                 });


### PR DESCRIPTION
* The lambda invoked by the `lockedExecutor` eventually gets JITed (which runs a static initializer that we will suspend in with a very tiny chance).
   * Fixed by creating the `Runnable` in the main test thread and using the same instance in all threads
* Closes #35686

-----------------------------------------------------

See stacktraces from failed run, that deadlocked:

```java
  1>  [test_node][1]
  1> ----
  1> java.lang.Thread.yield(Native Method)
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests.lambda$testNotBlockingUnsafeStackTraces$2(LongGCDisruptionTests.java:136)
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests$$Lambda$1750/1219702866.run(Unknown Source)
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests$LockedExecutor.executeLocked(LongGCDisruptionTests.java:47)
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests.lambda$testNotBlockingUnsafeStackTraces$3(LongGCDisruptionTests.java:135)
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests$$Lambda$1749/1018511683.run(Unknown Source)
  1> java.lang.Thread.run(Thread.java:748)
  1> [test_node][3]
  1> ----
  1> java.lang.Thread.yield(Native Method)
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests.lambda$testNotBlockingUnsafeStackTraces$3(LongGCDisruptionTests.java:140)
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests$$Lambda$1749/1018511683.run(Unknown Source)
  1> java.lang.Thread.run(Thread.java:748)
  1> [test_node][0]
  1> ----
  1> java.lang.Thread.yield(Native Method)
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests.lambda$testNotBlockingUnsafeStackTraces$3(LongGCDisruptionTests.java:140)
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests$$Lambda$1749/1018511683.run(Unknown Source)
  1> java.lang.Thread.run(Thread.java:748)
  1> [test_node][2]
  1> ----
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests$$Lambda$1750/1219702866.<init>(Unknown Source)
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests$$Lambda$1750/1219702866.get$Lambda(Unknown Source)
  1> java.lang.invoke.LambdaForm$DMH/1525416409.invokeStatic_L_L(LambdaForm$DMH)
  1> java.lang.invoke.LambdaForm$MH/1692675110.linkToTargetMethod(LambdaForm$MH)
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests.lambda$testNotBlockingUnsafeStackTraces$3(LongGCDisruptionTests.java:135)
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests$$Lambda$1749/1018511683.run(Unknown Source)
  1> java.lang.Thread.run(Thread.java:748)
  1> [test_node][4]
  1> ----
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests$$Lambda$1750/1219702866.get$Lambda(Unknown Source)
  1> java.lang.invoke.LambdaForm$DMH/1525416409.invokeStatic_L_L(LambdaForm$DMH)
  1> java.lang.invoke.LambdaForm$MH/1692675110.linkToTargetMethod(LambdaForm$MH)
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests.lambda$testNotBlockingUnsafeStackTraces$3(LongGCDisruptionTests.java:135)
  1> org.elasticsearch.test.disruption.LongGCDisruptionTests$$Lambda$1749/1018511683.run(Unknown Source)
  1> java.lang.Thread.run(Thread.java:748)
  1> [2019-02-21T05:37:30,979][INFO ][o.e.t.d.LongGCDisruptionTests] [testNotBlockingUnsafeStackTraces] after test
ERROR   31.9s J4 | LongGCDisruptionTests.testNotBlockingUnsafeStackTraces <<< FAILURES!
   > Throwable #1: java.lang.RuntimeException: suspending node threads took too long
   > 	at __randomizedtesting.SeedInfo.seed([6AB1F3531F128FA:4B8578A15DF9093]:0)
   > 	at org.elasticsearch.test.disruption.LongGCDisruption.startDisrupting(LongGCDisruption.java:124)
   > 	at org.elasticsearch.test.disruption.LongGCDisruptionTests.testNotBlockingUnsafeStackTraces(LongGCDisruptionTests.java:149)
   > 	at java.lang.Thread.run(Thread.java:748)
Completed [37/37] on J4 in 32.12s, 3 tests, 1 error <<< FAILURES!
```