### PR TITLE
Fix DissectParserTests expecting unique keys

### DIFF
--- a/libs/dissect/src/test/java/org/elasticsearch/dissect/DissectParserTests.java
+++ b/libs/dissect/src/test/java/org/elasticsearch/dissect/DissectParserTests.java
@@ -28,7 +28,6 @@ import org.mockito.internal.util.collections.Sets;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/libs/dissect/src/test/java/org/elasticsearch/dissect/DissectParserTests.java
+++ b/libs/dissect/src/test/java/org/elasticsearch/dissect/DissectParserTests.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
+import org.mockito.internal.util.collections.Sets;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -112,7 +113,7 @@ public class DissectParserTests extends ESTestCase {
         String delimiterFirstInput = "";
         String delimiterFirstPattern = "";
         //parallel arrays
-        List<String> expectedKeys = Arrays.asList(generateRandomStringArray(100, 10, false, false));
+        List<String> expectedKeys = new ArrayList<>(Sets.newSet(generateRandomStringArray(100, 10, false, false)));
         List<String> expectedValues = new ArrayList<>(expectedKeys.size());
         for (String key : expectedKeys) {
             String value = randomAsciiAlphanumOfLengthBetween(1, 100);
@@ -127,7 +128,6 @@ public class DissectParserTests extends ESTestCase {
         assertMatch(delimiterFirstPattern, delimiterFirstInput, expectedKeys, expectedValues);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/39244")
     public void testBasicMatchUnicode() {
         String valueFirstInput = "";
         String keyFirstPattern = "";
@@ -138,6 +138,9 @@ public class DissectParserTests extends ESTestCase {
         List<String> expectedValues = new ArrayList<>();
         for (int i = 0; i < randomIntBetween(1, 100); i++) {
             String key = randomAsciiAlphanumOfLengthBetween(1, 100);
+            while (expectedKeys.contains(key)) { // keys should be unique in this test
+                key = randomAsciiAlphanumOfLengthBetween(1, 100);
+            }
             String value = randomRealisticUnicodeOfCodepointLengthBetween(1, 100);
             String delimiter = Integer.toString(randomInt()); //int to ensures values and delimiters don't overlap, else validation can fail
             keyFirstPattern += "%{" + key + "}" + delimiter;
@@ -375,13 +378,11 @@ public class DissectParserTests extends ESTestCase {
 
     private void assertMatch(String pattern, String input, List<String> expectedKeys, List<String> expectedValues, String appendSeperator) {
         Map<String, String> results = new DissectParser(pattern, appendSeperator).parse(input);
-        List<String> foundKeys = new ArrayList<>(results.keySet());
-        List<String> foundValues = new ArrayList<>(results.values());
-        Collections.sort(foundKeys);
-        Collections.sort(foundValues);
-        Collections.sort(expectedKeys);
-        Collections.sort(expectedValues);
-        assertThat(foundKeys, Matchers.equalTo(expectedKeys));
-        assertThat(foundValues, Matchers.equalTo(expectedValues));
+        assertThat(results.size(), Matchers.equalTo(expectedKeys.size()));
+        assertThat(results.size(), Matchers.equalTo(expectedValues.size()));
+        for (int i = 0; i < results.size(); i++) {
+            final String key = expectedKeys.get(i);
+            assertThat(results.get(key), Matchers.equalTo(expectedValues.get(i)));
+        }
     }
 }


### PR DESCRIPTION
Fixes a bug in DissectParserTests where the tests expected dissect keys to be unique but were not.

Closes https://github.com/elastic/elasticsearch/issues/39244