### PR TITLE
[CI] Mute CcrRetentionLeaseIT.testRetentionLeaseIsRenewedDuringRecovery

### DIFF
--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
@@ -190,6 +190,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
 
     }
 
+    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/39268")
     public void testRetentionLeaseIsRenewedDuringRecovery() throws Exception {
         final String leaderIndex = "leader";
         final int numberOfShards = randomIntBetween(1, 3);


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch/issues/39268

