### PR TITLE
Add ILM plugin for MonitoringIT tests

### DIFF
--- a/x-pack/plugin/monitoring/build.gradle
+++ b/x-pack/plugin/monitoring/build.gradle
@@ -22,6 +22,8 @@ dependencies {
 
     // baz - this goes away after we separate out the actions #27759
     testCompile "org.elasticsearch.plugin:x-pack-watcher:${version}"
+
+    testCompile "org.elasticsearch.plugin:x-pack-ilm:${version}"
 }
 
 compileJava.options.compilerArgs << "-Xlint:-deprecation,-rawtypes,-serial,-try,-unchecked"

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/LocalStateMonitoring.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/LocalStateMonitoring.java
@@ -10,6 +10,7 @@ import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.elasticsearch.xpack.indexlifecycle.IndexLifecycle;
 import org.elasticsearch.xpack.watcher.Watcher;
 
 import java.nio.file.Path;
@@ -47,5 +48,6 @@ public class LocalStateMonitoring extends LocalStateCompositeXPackPlugin {
                 return thisVar.getLicenseState();
             }
         });
+        plugins.add(new IndexLifecycle(settings));
     }
 }


### PR DESCRIPTION
Without this, when creating the watch history indices they complain about there
being no such setting as `index.lifecycle.name`.

Relates to #38805
