### PR TITLE
ensure no initializing shards during cluster cleanup

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -807,7 +807,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         request.addParameter("wait_for_no_initializing_shards", "true");
         request.addParameter("timeout", "70s");
         request.addParameter("level", "shards");
-        client().performRequest(request);
+        adminClient().performRequest(request);
     }
 
     protected static void createIndex(String name, Settings settings) throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -292,6 +292,7 @@ public abstract class ESRestTestCase extends ESTestCase {
     @After
     public final void cleanUpCluster() throws Exception {
         if (preserveClusterUponCompletion() == false) {
+            ensureNoInitializingShards();
             wipeCluster();
             waitForClusterStateUpdatesToFinish();
             logIfThereAreRunningTasks();


### PR DESCRIPTION
the illusive ShardLockObtainFailedException!

there are testing situations where newly created indices
are being wiped before they are fully initialized. This results
in an edge-case in the shard-locking strategy where an index
cannot be deleted.

This should fix these scenarios and reduce noise in the logs.

test examples with this occurring:

- https://github.com/elastic/elasticsearch/issues/30290#issuecomment-411064344
- https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+7.0+multijob-darwin-compatibility/21/console

I do not believe this to solve any test failures, since I believe these exceptions
in the logs are a side-effect of tests failing early right after a new index is created.

Plus, this exception is suppressed and logged. There is later cleanup by the cluster
to cleanly delete any pending deletes.