### PR TITLE
Mute rolling upgrade watcher CRUD tests

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/60_watcher.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/60_watcher.yml
@@ -1,6 +1,10 @@
 ---
 "CRUD watch APIs":
 
+  - skip:
+      reason: https://github.com/elastic/elasticsearch/issues/33185
+      version: "6.7.0 - "
+
   # no need to put watch, exists already
   - do:
       watcher.get_watch:
@@ -69,6 +73,11 @@
 
 ---
 "Test watcher stats output":
+
+  - skip:
+      reason: https://github.com/elastic/elasticsearch/issues/33185
+      version: "6.7.0 - "
+
   - do:
       watcher.stats: {}
   - match: { "manually_stopped": false }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/60_watcher.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/60_watcher.yml
@@ -1,5 +1,8 @@
 ---
 "CRUD watch APIs":
+  - skip:
+      reason: https://github.com/elastic/elasticsearch/issues/33185
+      version: "6.7.0 - "
 
   - do:
       watcher.put_watch:
@@ -89,6 +92,11 @@
 
 ---
 "Test watcher stats output":
+
+  - skip:
+      reason: https://github.com/elastic/elasticsearch/issues/33185
+      version: "6.7.0 - "
+
   - do:
       watcher.stats: {}
   - match: { "manually_stopped": false }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/60_watcher.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/60_watcher.yml
@@ -1,6 +1,10 @@
 ---
 "CRUD watch APIs":
 
+  - skip:
+      reason: https://github.com/elastic/elasticsearch/issues/33185
+      version: "6.7.0 - "
+
   # no need to put watch, exists already
   - do:
       watcher.get_watch:
@@ -68,6 +72,11 @@
 
 ---
 "Test watcher stats output":
+
+  - skip:
+      reason: https://github.com/elastic/elasticsearch/issues/33185
+      version: "6.7.0 - "
+
   - do:
       watcher.stats: {}
   - match: { "manually_stopped": false }


### PR DESCRIPTION
This fails on old_cluster but mixed_cluster and upgraded_cluster
depend on watches set in old_cluster so that can't be muted on its
own. 

Opening a PR since this is not urgent( fails once every few days) and
to ensure muting doesn't add any regressions

Relates: #33185