### PR TITLE
[ML] Improve DeleteExpiredDataIT failure message (#39298)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
@@ -248,9 +248,18 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
         // Assert at least one state doc for each job
         assertThat(stateDocsResponse.getHits().getTotalHits().value, greaterThanOrEqualTo(5L));
 
+        int nonExistingJobDocsCount = 0;
+        List<String> nonExistingJobExampleIds = new ArrayList<>();
         for (SearchHit hit : stateDocsResponse.getHits().getHits()) {
-            assertThat(hit.getId().startsWith("non_existing_job"), is(false));
+            if (hit.getId().startsWith("non_existing_job")) {
+                nonExistingJobDocsCount++;
+                if (nonExistingJobExampleIds.size() < 10) {
+                    nonExistingJobExampleIds.add(hit.getId());
+                }
+            }
         }
+        assertThat("Documents for non_existing_job are still around; examples: " + nonExistingJobExampleIds,
+            nonExistingJobDocsCount, equalTo(0));
     }
 
     private static Job.Builder newJobBuilder(String id) {


### PR DESCRIPTION
This test failed once in a very long time with the assertion
that there is no document for the `non_existing_job` in the
state index. I could not see how that is possible and I cannot
reproduce. With this commit the failure message will reveal
some examples of the left behind docs which might shed a light
about what could go wrong.

