### PR TITLE
Fix the test failure in dense and sparse vectors

### DIFF
--- a/modules/mapper-extras/src/test/resources/rest-api-spec/test/dense-vector/20_special_cases.yml
+++ b/modules/mapper-extras/src/test/resources/rest-api-spec/test/dense-vector/20_special_cases.yml
@@ -11,6 +11,8 @@ setup:
         body:
           settings:
             number_of_replicas: 0
+            # we need to have 1 shard to get request failure in test "Dense vectors should error with sparse vector functions"
+            number_of_shards: 1
           mappings:
             properties:
               my_dense_vector:
@@ -124,10 +126,6 @@ setup:
 
 ---
 "Dense vectors should error with sparse vector functions":
-
-- skip:
-    version: "all"
-    reason: "awaits fix in #39218"
 
 - do:
     index:

--- a/modules/mapper-extras/src/test/resources/rest-api-spec/test/sparse-vector/20_special_cases.yml
+++ b/modules/mapper-extras/src/test/resources/rest-api-spec/test/sparse-vector/20_special_cases.yml
@@ -11,6 +11,8 @@ setup:
         body:
           settings:
             number_of_replicas: 0
+            # we need to have 1 shard to get request failure in test "Sparse vectors should error with dense vector functions"
+            number_of_shards: 1
           mappings:
             properties:
               my_sparse_vector:
@@ -175,10 +177,6 @@ setup:
 
 ---
 "Sparse vectors should error with dense vector functions":
-
-- skip:
-    version: "all"
-    reason: "awaits fix in #39218"
 
 - do:
     index:


### PR DESCRIPTION
Create index with only 1 shard to ensure an expected request failure

Closes #39218