### PR TITLE
Set mappings when creating indices in SuggestSearchIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
@@ -83,7 +83,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
 
     // see #3196
     public void testSuggestAcrossMultipleIndices() throws IOException {
-        prepareCreate("test").addMapping("type1", "text", "type=text").get();
+        assertAcked(prepareCreate("test").addMapping("type1", "text", "type=text"));
         ensureGreen();
 
         index("test", "type1", "1", "text", "abcd");
@@ -97,7 +97,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
                 .text("abcd");
         logger.info("--> run suggestions with one index");
         searchSuggest("test", termSuggest);
-        prepareCreate("test_1").addMapping("type1", "text", "type=text").get();
+        assertAcked(prepareCreate("test_1").addMapping("type1", "text", "type=text"));
         ensureGreen();
 
         index("test_1", "type1", "1", "text", "ab cd");
@@ -302,7 +302,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
     }
 
     public void testSimple() throws Exception {
-        prepareCreate("test").addMapping("type1", "text", "type=text").get();
+        assertAcked(prepareCreate("test").addMapping("type1", "text", "type=text"));
         ensureGreen();
 
         index("test", "type1", "1", "text", "abcd");
@@ -327,7 +327,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
     }
 
     public void testEmpty() throws Exception {
-        prepareCreate("test").addMapping("type1", "text", "type=text").get();
+        assertAcked(prepareCreate("test").addMapping("type1", "text", "type=text"));
         ensureGreen();
 
         index("test", "type1", "1", "text", "bar");
@@ -346,7 +346,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
     }
 
     public void testWithMultipleCommands() throws Exception {
-        prepareCreate("test").addMapping("typ1", "field1", "type=text", "field2", "type=text").get();
+        assertAcked(prepareCreate("test").addMapping("typ1", "field1", "type=text", "field2", "type=text"));
         ensureGreen();
 
         index("test", "typ1", "1", "field1", "prefix_abcd", "field2", "prefix_efgh");

--- a/server/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
@@ -83,7 +83,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
 
     // see #3196
     public void testSuggestAcrossMultipleIndices() throws IOException {
-        createIndex("test");
+        prepareCreate("test").addMapping("type1", "text", "type=text").get();
         ensureGreen();
 
         index("test", "type1", "1", "text", "abcd");
@@ -97,7 +97,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
                 .text("abcd");
         logger.info("--> run suggestions with one index");
         searchSuggest("test", termSuggest);
-        createIndex("test_1");
+        prepareCreate("test_1").addMapping("type1", "text", "type=text").get();
         ensureGreen();
 
         index("test_1", "type1", "1", "text", "ab cd");
@@ -302,7 +302,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
     }
 
     public void testSimple() throws Exception {
-        createIndex("test");
+        prepareCreate("test").addMapping("type1", "text", "type=text").get();
         ensureGreen();
 
         index("test", "type1", "1", "text", "abcd");
@@ -327,7 +327,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
     }
 
     public void testEmpty() throws Exception {
-        createIndex("test");
+        prepareCreate("test").addMapping("type1", "text", "type=text").get();
         ensureGreen();
 
         index("test", "type1", "1", "text", "bar");
@@ -346,7 +346,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
     }
 
     public void testWithMultipleCommands() throws Exception {
-        createIndex("test");
+        prepareCreate("test").addMapping("typ1", "field1", "type=text", "field2", "type=text").get();
         ensureGreen();
 
         index("test", "typ1", "1", "field1", "prefix_abcd", "field2", "prefix_efgh");


### PR DESCRIPTION
These tests don't test dynamic mapping, so they can use preset mappings. This
removes the possibility they may fail due to the mapping not being available
since mapping updates are asynchronous.

Resolves #39315
