### PR TITLE
Use non-ILM template setting up watch history template & ILM disabled

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/WatcherIndexTemplateRegistryField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/WatcherIndexTemplateRegistryField.java
@@ -17,6 +17,7 @@ public final class WatcherIndexTemplateRegistryField {
     // Note: if you change this, also inform the kibana team around the watcher-ui
     public static final String INDEX_TEMPLATE_VERSION = "9";
     public static final String HISTORY_TEMPLATE_NAME = ".watch-history-" + INDEX_TEMPLATE_VERSION;
+    public static final String HISTORY_TEMPLATE_NAME_NO_ILM = ".watch-history-no-ilm-" + INDEX_TEMPLATE_VERSION;
     public static final String TRIGGERED_TEMPLATE_NAME = ".triggered_watches";
     public static final String WATCHES_TEMPLATE_NAME = ".watches";
     public static final String[] TEMPLATE_NAMES = new String[] {

--- a/x-pack/plugin/core/src/main/resources/watch-history-no-ilm.json
+++ b/x-pack/plugin/core/src/main/resources/watch-history-no-ilm.json
@@ -1,0 +1,615 @@
+{
+  "index_patterns": [ ".watcher-history-${xpack.watcher.template.version}*" ],
+  "order": 2147483646,
+  "settings": {
+    "index.number_of_shards": 1,
+    "index.number_of_replicas": 0,
+    "index.auto_expand_replicas": "0-1",
+    "index.format": 6
+  },
+  "mappings": {
+    "doc": {
+      "_meta": {
+        "watcher-history-version": "${xpack.watcher.template.version}"
+      },
+      "dynamic_templates": [
+        {
+          "disabled_payload_fields": {
+            "path_match": "result\\.(input(\\..+)*|(transform(\\..+)*)|(actions\\.transform(\\..+)*))\\.payload",
+            "match_pattern": "regex",
+            "mapping": {
+              "type": "object",
+              "enabled": false
+            }
+          }
+        },
+        {
+          "disabled_search_request_body_fields": {
+            "path_match": "result\\.(input(\\..+)*|(transform(\\..+)*)|(actions\\.transform(\\..+)*))\\.search\\.request\\.(body|template)",
+            "match_pattern": "regex",
+            "mapping": {
+              "type": "object",
+              "enabled": false
+            }
+          }
+        },
+        {
+          "disabled_exception_fields": {
+            "path_match": "result\\.(input(\\..+)*|(transform(\\..+)*)|(actions\\.transform(\\..+)*)|actions)\\.error",
+            "match_pattern": "regex",
+            "mapping": {
+              "type": "object",
+              "enabled": false
+            }
+          }
+        },
+        {
+          "disabled_jira_custom_fields": {
+            "path_match":   "result.actions.jira.fields.customfield_*",
+            "mapping": {
+              "type": "object",
+              "enabled": false
+            }
+          }
+        }
+      ],
+      "dynamic": false,
+      "properties": {
+        "watch_id": {
+          "type": "keyword"
+        },
+        "node": {
+          "type": "keyword"
+        },
+        "trigger_event": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "type" : {
+              "type" : "keyword"
+            },
+            "triggered_time": {
+              "type": "date"
+            },
+            "manual": {
+              "type": "object",
+              "dynamic": true,
+              "properties": {
+                "schedule": {
+                  "type": "object",
+                  "dynamic": true,
+                  "properties": {
+                    "scheduled_time": {
+                      "type": "date"
+                    }
+                  }
+                }
+              }
+            },
+            "schedule": {
+              "type": "object",
+              "dynamic": true,
+              "properties": {
+                "scheduled_time": {
+                  "type": "date"
+                }
+              }
+            }
+          }
+        },
+        "vars" : {
+          "type" : "object",
+          "enabled" : false
+        },
+        "input": {
+          "type": "object",
+          "enabled": false
+        },
+        "condition": {
+          "type": "object",
+          "enabled": false
+        },
+        "state": {
+          "type": "keyword"
+        },
+        "status": {
+          "type": "object",
+          "enabled" : false,
+          "dynamic" : true
+        },
+        "messages": {
+          "type": "text"
+        },
+        "user": {
+          "type": "text"
+        },
+        "exception" : {
+          "type" : "object",
+          "enabled" : false
+        },
+        "result": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "execution_time": {
+              "type": "date"
+            },
+            "execution_duration": {
+              "type": "long"
+            },
+            "input": {
+              "type": "object",
+              "dynamic": true,
+              "properties": {
+                "type" : {
+                  "type" : "keyword"
+                },
+                "status" : {
+                  "type" : "keyword"
+                },
+                "payload" : {
+                  "type" : "object",
+                  "enabled" : false
+                },
+                "search": {
+                  "type": "object",
+                  "dynamic": true,
+                  "properties": {
+                    "request": {
+                      "type": "object",
+                      "dynamic": true,
+                      "properties": {
+                        "search_type": {
+                          "type": "keyword"
+                        },
+                        "indices": {
+                          "type": "keyword"
+                        },
+                        "types": {
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  }
+                },
+                "http": {
+                  "type": "object",
+                  "dynamic": true,
+                  "properties": {
+                    "request": {
+                      "type": "object",
+                      "dynamic": true,
+                      "properties": {
+                        "path": {
+                          "type": "keyword"
+                        },
+                        "host": {
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "condition" : {
+              "type" : "object",
+              "dynamic" : true,
+              "properties" : {
+                "type" : {
+                  "type" : "keyword"
+                },
+                "status" : {
+                  "type" : "keyword"
+                },
+                "met" : {
+                  "type" : "boolean"
+                },
+                "compare" : {
+                  "type" : "object",
+                  "enabled" : false
+                },
+                "array_compare" : {
+                  "type" : "object",
+                  "enabled" : false
+                },
+                "script" : {
+                  "type" : "object",
+                  "enabled" : false
+                }
+              }
+            },
+            "transform" : {
+              "type" : "object",
+              "dynamic" : true,
+              "properties" : {
+                "type" : {
+                  "type" : "keyword"
+                },
+                "search" : {
+                  "type" : "object",
+                  "dynamic" : true,
+                  "properties" : {
+                    "request" : {
+                      "type" : "object",
+                      "dynamic" : true,
+                      "properties" : {
+                        "indices" : {
+                          "type" : "keyword"
+                        },
+                        "types" : {
+                          "type" : "keyword"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "actions": {
+              "type": "nested",
+              "include_in_parent": true,
+              "dynamic": true,
+              "properties": {
+                "id" : {
+                  "type" : "keyword"
+                },
+                "type" : {
+                  "type" : "keyword"
+                },
+                "status" : {
+                  "type" : "keyword"
+                },
+                "reason" : {
+                  "type" : "keyword"
+                },
+                "email": {
+                  "type": "object",
+                  "dynamic": true,
+                  "properties": {
+                    "message": {
+                      "type": "object",
+                      "dynamic": true,
+                      "properties": {
+                        "id": {
+                          "type": "keyword"
+                        },
+                        "from": {
+                          "type": "keyword"
+                        },
+                        "reply_to": {
+                          "type": "keyword"
+                        },
+                        "to": {
+                          "type": "keyword"
+                        },
+                        "cc": {
+                          "type": "keyword"
+                        },
+                        "bcc": {
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  }
+                },
+                "webhook": {
+                  "type": "object",
+                  "dynamic": true,
+                  "properties": {
+                    "request": {
+                      "type": "object",
+                      "dynamic": true,
+                      "properties": {
+                        "path": {
+                          "type": "keyword"
+                        },
+                        "host": {
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  }
+                },
+                "index": {
+                  "type": "object",
+                  "dynamic": true,
+                  "properties": {
+                    "response": {
+                      "type": "object",
+                      "dynamic": true,
+                      "properties": {
+                        "index": {
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "type": "keyword"
+                        },
+                        "id": {
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  }
+                },
+                "hipchat" : {
+                  "type": "object",
+                  "dynamic": true,
+                  "properties": {
+                    "account": {
+                      "type": "keyword"
+                    },
+                    "sent_messages": {
+                      "type": "nested",
+                      "include_in_parent": true,
+                      "dynamic": true,
+                      "properties": {
+                        "status": {
+                          "type": "keyword"
+                        },
+                        "reason": {
+                          "type": "text"
+                        },
+                        "request" : {
+                          "type" : "object",
+                          "enabled" : false
+                        },
+                        "response" : {
+                          "type" : "object",
+                          "enabled" : false
+                        },
+                        "room" : {
+                          "type": "keyword"
+                        },
+                        "user" : {
+                          "type": "keyword"
+                        },
+                        "message" : {
+                          "type" : "object",
+                          "dynamic" : true,
+                          "properties" : {
+                            "message_format" : {
+                              "type" : "keyword"
+                            },
+                            "color" : {
+                              "type" : "keyword"
+                            },
+                            "notify" : {
+                              "type" : "boolean"
+                            },
+                            "message" : {
+                              "type" : "text"
+                            },
+                            "from" : {
+                              "type" : "text"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "jira" : {
+                  "type": "object",
+                  "dynamic": true,
+                  "properties": {
+                    "account": {
+                      "type": "keyword"
+                    },
+                    "reason": {
+                      "type": "text"
+                    },
+                    "request" : {
+                      "type" : "object",
+                      "enabled" : false
+                    },
+                    "response" : {
+                      "type" : "object",
+                      "enabled" : false
+                    },
+                    "fields": {
+                      "type": "object",
+                      "dynamic": true,
+                      "properties": {
+                        "summary": {
+                          "type": "text"
+                        },
+                        "description": {
+                          "type": "text"
+                        },
+                        "labels" : {
+                          "type": "text"
+                        },
+                        "project" : {
+                          "type" : "object",
+                          "dynamic" : true,
+                          "properties" : {
+                            "key" : {
+                              "type" : "keyword"
+                            },
+                            "id" : {
+                              "type" : "keyword"
+                            }
+                          }
+                        },
+                        "issuetype" : {
+                          "type" : "object",
+                          "dynamic" : true,
+                          "properties" : {
+                            "name" : {
+                              "type": "keyword"
+                            },
+                            "id" : {
+                              "type" : "keyword"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "result": {
+                      "type": "object",
+                      "dynamic": true,
+                      "properties" : {
+                        "id" : {
+                          "type" : "keyword"
+                        },
+                        "key" : {
+                          "type" : "keyword"
+                        },
+                        "self" : {
+                          "type" : "keyword"
+                        }
+                      }
+                    }
+                  }
+                },
+                "slack" : {
+                  "type": "object",
+                  "dynamic": true,
+                  "properties": {
+                    "account": {
+                      "type": "keyword"
+                    },
+                    "sent_messages": {
+                      "type": "nested",
+                      "include_in_parent": true,
+                      "dynamic": true,
+                      "properties": {
+                        "status": {
+                          "type": "keyword"
+                        },
+                        "reason": {
+                          "type": "text"
+                        },
+                        "request" : {
+                          "type" : "object",
+                          "enabled" : false
+                        },
+                        "response" : {
+                          "type" : "object",
+                          "enabled" : false
+                        },
+                        "to" : {
+                          "type": "keyword"
+                        },
+                        "message" : {
+                          "type" : "object",
+                          "dynamic" : true,
+                          "properties" : {
+                            "from" : {
+                              "type" : "text"
+                            },
+                            "icon" : {
+                              "type" : "keyword"
+                            },
+                            "text" : {
+                              "type" : "text"
+                            },
+                            "attachments" : {
+                              "type" : "nested",
+                              "include_in_parent": true,
+                              "dynamic" : true,
+                              "properties" : {
+                                "color" : {
+                                  "type" : "keyword"
+                                },
+                                "fields" : {
+                                  "properties" : {
+                                    "value" : {
+                                      "type" : "text"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "pagerduty" : {
+                  "type": "object",
+                  "dynamic": true,
+                  "properties": {
+                    "account": {
+                      "type": "keyword"
+                    },
+                    "sent_event": {
+                      "type": "nested",
+                      "include_in_parent": true,
+                      "dynamic": true,
+                      "properties": {
+                        "reason": {
+                          "type": "text"
+                        },
+                        "request" : {
+                          "type" : "object",
+                          "enabled" : false
+                        },
+                        "response" : {
+                          "type" : "object",
+                          "enabled" : false
+                        },
+                        "event" : {
+                          "type" : "object",
+                          "dynamic" : true,
+                          "properties" : {
+                            "type" : {
+                              "type" : "keyword"
+                            },
+                            "client" : {
+                              "type" : "text"
+                            },
+                            "client_url" : {
+                              "type" : "keyword"
+                            },
+                            "account" : {
+                              "type" : "keyword"
+                            },
+                            "attach_payload" : {
+                              "type" : "boolean"
+                            },
+                            "incident_key" : {
+                              "type" : "keyword"
+                            },
+                            "description" : {
+                              "type" : "text"
+                            },
+                            "context" : {
+                              "type" : "nested",
+                              "include_in_parent": true,
+                              "dynamic" : true,
+                              "properties" : {
+                                "type" : {
+                                  "type" : "keyword"
+                                },
+                                "href" : {
+                                  "type" : "keyword"
+                                },
+                                "src" : {
+                                  "type" : "keyword"
+                                },
+                                "alt" : {
+                                  "type" : "text"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "metadata": {
+          "type": "object",
+          "dynamic": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
When ILM is disabled and Watcher is setting up the templates and policies for
the watch history indices, it will now use a template that does not have the
`index.lifecycle.name` setting, so that indices are not created with the
setting.

This also adds tests for the behavior, and changes the cluster state used in
these tests to be real instead of mocked.

Resolves #38805
