### PR TITLE
Provide a clearer error message on keystore add

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/AddStringKeyStoreCommand.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AddStringKeyStoreCommand.java
@@ -91,8 +91,8 @@ class AddStringKeyStoreCommand extends EnvironmentAwareCommand {
 
         try {
             keystore.setString(setting, value);
-        } catch (IllegalArgumentException e) {
-            throw new UserException(ExitCodes.DATA_ERROR, "String value must contain only ASCII");
+        } catch (final IllegalArgumentException e) {
+            throw new UserException(ExitCodes.DATA_ERROR, e.getMessage());
         }
         keystore.save(env.configFile(), new char[0]);
     }

--- a/server/src/test/java/org/elasticsearch/common/settings/AddStringKeyStoreCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/AddStringKeyStoreCommandTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cli.UserException;
 import org.elasticsearch.env.Environment;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasToString;
 
 public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
     InputStream input;
@@ -137,6 +138,16 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
         UserException e = expectThrows(UserException.class, this::execute);
         assertEquals(ExitCodes.USAGE, e.exitCode);
         assertThat(e.getMessage(), containsString("The setting name can not be null"));
+    }
+
+    public void testUpperCaseInName() throws Exception {
+        createKeystore("");
+        terminal.addSecretInput("value");
+        final String key = randomAlphaOfLength(4) + randomAlphaOfLength(1).toUpperCase() + randomAlphaOfLength(4);
+        final UserException e = expectThrows(UserException.class, () -> execute(key));
+        assertThat(
+                e,
+                hasToString(containsString("Setting name [" + key + "] does not match the allowed setting name pattern [[a-z0-9_\\-.]+]")));
     }
 
     void setInput(String inputStr) {

--- a/server/src/test/java/org/elasticsearch/common/settings/AddStringKeyStoreCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/AddStringKeyStoreCommandTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.common.settings;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Map;
 
 import org.elasticsearch.cli.Command;
@@ -143,7 +144,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
     public void testUpperCaseInName() throws Exception {
         createKeystore("");
         terminal.addSecretInput("value");
-        final String key = randomAlphaOfLength(4) + randomAlphaOfLength(1).toUpperCase() + randomAlphaOfLength(4);
+        final String key = randomAlphaOfLength(4) + randomAlphaOfLength(1).toUpperCase(Locale.ROOT) + randomAlphaOfLength(4);
         final UserException e = expectThrows(UserException.class, () -> execute(key));
         assertThat(
                 e,


### PR DESCRIPTION
When trying to add a setting to the keystore with an upper case name, we reject with an unclear error message. This commit makes that error message much clearer.

Closes #39324