### PR TITLE
Renew retention leases while following

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -540,12 +540,16 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             new SyncRetentionLeases(request, ReplicationGroup.this, wrappedListener).execute();
         }
 
-        public RetentionLease addRetentionLease(String id, long retainingSequenceNumber, String source,
+        public synchronized RetentionLease addRetentionLease(String id, long retainingSequenceNumber, String source,
                                                 ActionListener<ReplicationResponse> listener) {
             return getPrimary().addRetentionLease(id, retainingSequenceNumber, source, listener);
         }
 
-        public void removeRetentionLease(String id, ActionListener<ReplicationResponse> listener) {
+        public synchronized RetentionLease renewRetentionLease(String id, long retainingSequenceNumber, String source) {
+            return getPrimary().renewRetentionLease(id, retainingSequenceNumber, source);
+        }
+
+        public synchronized void removeRetentionLease(String id, ActionListener<ReplicationResponse> listener) {
             getPrimary().removeRetentionLease(id, listener);
         }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrRetentionLeases.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrRetentionLeases.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ccr;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.seqno.RetentionLeaseActions;
@@ -18,10 +19,17 @@ import org.elasticsearch.index.shard.ShardId;
 
 import java.util.Locale;
 import java.util.Optional;
-
-import static org.elasticsearch.index.seqno.RetentionLeaseActions.RETAIN_ALL;
+import java.util.concurrent.TimeUnit;
 
 public class CcrRetentionLeases {
+
+    // this setting is intentionally not registered, it is only used in tests
+    public static final Setting<TimeValue> RETENTION_LEASE_RENEW_INTERVAL_SETTING =
+            Setting.timeSetting(
+                    "index.ccr.retention_lease.renew_interval",
+                    new TimeValue(5, TimeUnit.MINUTES),
+                    new TimeValue(0, TimeUnit.MILLISECONDS),
+                    Setting.Property.NodeScope);
 
     /**
      * The retention lease ID used by followers.
@@ -52,20 +60,22 @@ public class CcrRetentionLeases {
      * Synchronously requests to add a retention lease with the specified retention lease ID on the specified leader shard using the given
      * remote client. Note that this method will block up to the specified timeout.
      *
-     * @param leaderShardId    the leader shard ID
-     * @param retentionLeaseId the retention lease ID
-     * @param remoteClient     the remote client on which to execute this request
-     * @param timeout          the timeout
+     * @param leaderShardId           the leader shard ID
+     * @param retentionLeaseId        the retention lease ID
+     * @param retainingSequenceNumber the retaining sequence number
+     * @param remoteClient            the remote client on which to execute this request
+     * @param timeout                 the timeout
      * @return an optional exception indicating whether or not the retention lease already exists
      */
     public static Optional<RetentionLeaseAlreadyExistsException> syncAddRetentionLease(
             final ShardId leaderShardId,
             final String retentionLeaseId,
+            final long retainingSequenceNumber,
             final Client remoteClient,
             final TimeValue timeout) {
         try {
             final PlainActionFuture<RetentionLeaseActions.Response> response = new PlainActionFuture<>();
-            asyncAddRetentionLease(leaderShardId, retentionLeaseId, remoteClient, response);
+            asyncAddRetentionLease(leaderShardId, retentionLeaseId, retainingSequenceNumber, remoteClient, response);
             response.actionGet(timeout);
             return Optional.empty();
         } catch (final RetentionLeaseAlreadyExistsException e) {
@@ -78,18 +88,20 @@ public class CcrRetentionLeases {
      * remote client. Note that this method will return immediately, with the specified listener callback invoked to indicate a response
      * or failure.
      *
-     * @param leaderShardId    the leader shard ID
-     * @param retentionLeaseId the retention lease ID
-     * @param remoteClient     the remote client on which to execute this request
-     * @param listener         the listener
+     * @param leaderShardId           the leader shard ID
+     * @param retentionLeaseId        the retention lease ID
+     * @param retainingSequenceNumber the retaining sequence number
+     * @param remoteClient            the remote client on which to execute this request
+     * @param listener                the listener
      */
     public static void asyncAddRetentionLease(
             final ShardId leaderShardId,
             final String retentionLeaseId,
+            final long retainingSequenceNumber,
             final Client remoteClient,
             final ActionListener<RetentionLeaseActions.Response> listener) {
         final RetentionLeaseActions.AddRequest request =
-                new RetentionLeaseActions.AddRequest(leaderShardId, retentionLeaseId, RETAIN_ALL, "ccr");
+                new RetentionLeaseActions.AddRequest(leaderShardId, retentionLeaseId, retainingSequenceNumber, "ccr");
         remoteClient.execute(RetentionLeaseActions.Add.INSTANCE, request, listener);
     }
 
@@ -97,20 +109,22 @@ public class CcrRetentionLeases {
      * Synchronously requests to renew a retention lease with the specified retention lease ID on the specified leader shard using the given
      * remote client. Note that this method will block up to the specified timeout.
      *
-     * @param leaderShardId    the leader shard ID
-     * @param retentionLeaseId the retention lease ID
-     * @param remoteClient     the remote client on which to execute this request
-     * @param timeout          the timeout
+     * @param leaderShardId           the leader shard ID
+     * @param retentionLeaseId        the retention lease ID
+     * @param retainingSequenceNumber the retaining sequence number
+     * @param remoteClient            the remote client on which to execute this request
+     * @param timeout                 the timeout
      * @return an optional exception indicating whether or not the retention lease already exists
      */
     public static Optional<RetentionLeaseNotFoundException> syncRenewRetentionLease(
             final ShardId leaderShardId,
             final String retentionLeaseId,
+            final long retainingSequenceNumber,
             final Client remoteClient,
             final TimeValue timeout) {
         try {
             final PlainActionFuture<RetentionLeaseActions.Response> response = new PlainActionFuture<>();
-            asyncRenewRetentionLease(leaderShardId, retentionLeaseId, remoteClient, response);
+            asyncRenewRetentionLease(leaderShardId, retentionLeaseId, retainingSequenceNumber, remoteClient, response);
             response.actionGet(timeout);
             return Optional.empty();
         } catch (final RetentionLeaseNotFoundException e) {
@@ -123,18 +137,20 @@ public class CcrRetentionLeases {
      * given remote client. Note that this method will return immediately, with the specified listener callback invoked to indicate a
      * response or failure.
      *
-     * @param leaderShardId    the leader shard ID
-     * @param retentionLeaseId the retention lease ID
-     * @param remoteClient     the remote client on which to execute this request
-     * @param listener         the listener
+     * @param leaderShardId           the leader shard ID
+     * @param retentionLeaseId        the retention lease ID
+     * @param retainingSequenceNumber the retaining sequence number
+     * @param remoteClient            the remote client on which to execute this request
+     * @param listener                the listener
      */
     public static void asyncRenewRetentionLease(
             final ShardId leaderShardId,
             final String retentionLeaseId,
+            final long retainingSequenceNumber,
             final Client remoteClient,
             final ActionListener<RetentionLeaseActions.Response> listener) {
         final RetentionLeaseActions.RenewRequest request =
-                new RetentionLeaseActions.RenewRequest(leaderShardId, retentionLeaseId, RETAIN_ALL, "ccr");
+                new RetentionLeaseActions.RenewRequest(leaderShardId, retentionLeaseId, retainingSequenceNumber, "ccr");
         remoteClient.execute(RetentionLeaseActions.Renew.INSTANCE, request, listener);
     }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
@@ -97,7 +97,7 @@ public abstract class ShardFollowNodeTask extends AllocatedPersistentTask {
 
     private Scheduler.Cancellable renewable;
 
-    Scheduler.Cancellable getRenewable() {
+    synchronized Scheduler.Cancellable getRenewable() {
         return renewable;
     }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -267,10 +267,9 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
 
                 /*
                  * We are going to attempt to renew the retention lease. If this fails it is either because the retention lease does not
-                 * lease does not exist, or something else happened. If the retention lease does not exist, we will attempt
-                 * to add the retention lease again. If that fails, it had better not be because the retention lease already
-                 * exists. Either way, we will attempt to renew again on the next scheduled execution. We will start by
-                 * creating listeners
+                 * exist, or something else happened. If the retention lease does not exist, we will attempt to add the retention lease
+                 * again. If that fails, it had better not be because the retention lease already exists. Either way, we will attempt to
+                 * renew again on the next scheduled execution.
                  */
                 final ActionListener<RetentionLeaseActions.Response> listener = ActionListener.wrap(
                         r -> {},

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -9,6 +9,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.store.AlreadyClosedException;
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -32,10 +34,14 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.engine.CommitStats;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.seqno.RetentionLeaseActions;
+import org.elasticsearch.index.seqno.RetentionLeaseAlreadyExistsException;
+import org.elasticsearch.index.seqno.RetentionLeaseNotFoundException;
 import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
@@ -45,9 +51,11 @@ import org.elasticsearch.persistent.PersistentTaskState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.persistent.PersistentTasksExecutor;
 import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.NoSuchRemoteClusterException;
 import org.elasticsearch.xpack.ccr.Ccr;
+import org.elasticsearch.xpack.ccr.CcrRetentionLeases;
 import org.elasticsearch.xpack.ccr.CcrSettings;
 import org.elasticsearch.xpack.ccr.action.bulk.BulkShardOperationsAction;
 import org.elasticsearch.xpack.ccr.action.bulk.BulkShardOperationsRequest;
@@ -60,6 +68,7 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.LongConsumer;
+import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.ccr.CcrLicenseChecker.wrapClient;
@@ -73,6 +82,7 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
     private final ThreadPool threadPool;
     private final ClusterService clusterService;
     private final IndexScopedSettings indexScopedSettings;
+    private final TimeValue retentionLeaseRenewInterval;
     private volatile TimeValue waitForMetadataTimeOut;
 
     public ShardFollowTasksExecutor(Client client,
@@ -84,6 +94,7 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
         this.threadPool = threadPool;
         this.clusterService = clusterService;
         this.indexScopedSettings = settingsModule.getIndexScopedSettings();
+        this.retentionLeaseRenewInterval = CcrRetentionLeases.RETENTION_LEASE_RENEW_INTERVAL_SETTING.get(settingsModule.getSettings());
         this.waitForMetadataTimeOut = CcrSettings.CCR_WAIT_FOR_METADATA_TIMEOUT.get(settingsModule.getSettings());
         clusterService.getClusterSettings().addSettingsUpdateConsumer(CcrSettings.CCR_WAIT_FOR_METADATA_TIMEOUT,
             newVal -> this.waitForMetadataTimeOut = newVal);
@@ -245,6 +256,88 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
                     errorHandler.accept(e);
                 }
             }
+
+            @Override
+            protected Scheduler.Cancellable scheduleBackgroundRetentionLeaseRenewal(final LongSupplier followerGlobalCheckpoint) {
+                final String retentionLeaseId = CcrRetentionLeases.retentionLeaseId(
+                        clusterService.getClusterName().value(),
+                        params.getFollowShardId().getIndex(),
+                        params.getRemoteCluster(),
+                        params.getLeaderShardId().getIndex());
+
+                /*
+                 * We are going to attempt to renew the retention lease. If this fails it is either because the retention lease does not
+                 * lease does not exist, or something else happened. If the retention lease does not exist, we will attempt
+                 * to add the retention lease again. If that fails, it had better not be because the retention lease already
+                 * exists. Either way, we will attempt to renew again on the next scheduled execution. We will start by
+                 * creating listeners
+                 */
+                final ActionListener<RetentionLeaseActions.Response> listener = ActionListener.wrap(
+                        r -> {},
+                        e -> {
+                            final Throwable cause = ExceptionsHelper.unwrapCause(e);
+                            logRetentionLeaseFailure(retentionLeaseId, cause);
+                            // noinspection StatementWithEmptyBody
+                            if (cause instanceof RetentionLeaseNotFoundException) {
+                                logger.trace(
+                                        "{} background adding retention lease [{}] while following",
+                                        params.getFollowShardId(),
+                                        retentionLeaseId);
+                                CcrRetentionLeases.asyncAddRetentionLease(
+                                        params.getLeaderShardId(),
+                                        retentionLeaseId,
+                                        followerGlobalCheckpoint.getAsLong(),
+                                        remoteClient(params),
+                                        ActionListener.wrap(
+                                                r -> {},
+                                                inner -> {
+                                                    /*
+                                                     * If this fails that the retention lease already exists, something highly unusual is
+                                                     * going on. Log it, and renew again after another renew interval has passed.
+                                                     */
+                                                    final Throwable innerCause = ExceptionsHelper.unwrapCause(inner);
+                                                    assert innerCause instanceof RetentionLeaseAlreadyExistsException == false;
+                                                    logRetentionLeaseFailure(retentionLeaseId, innerCause);
+                                                }));
+                            } else {
+                                /*
+                                 * If something else happened, we will attempt to renew again after another renew interval
+                                 * has passed.
+                                 */
+                            }
+                        });
+
+                return threadPool.scheduleWithFixedDelay(
+                        () -> {
+                            final ThreadContext threadContext = threadPool.getThreadContext();
+                            try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
+                                // we have to execute under the system context so that if security is enabled the management is authorized
+                                threadContext.markAsSystemContext();
+                                logger.trace(
+                                        "{} background renewing retention lease [{}] while following",
+                                        params.getFollowShardId(),
+                                        retentionLeaseId);
+                                CcrRetentionLeases.asyncRenewRetentionLease(
+                                        params.getLeaderShardId(),
+                                        retentionLeaseId,
+                                        followerGlobalCheckpoint.getAsLong(),
+                                        remoteClient(params),
+                                        listener);
+                            }
+                        },
+                        retentionLeaseRenewInterval,
+                        Ccr.CCR_THREAD_POOL_NAME);
+            }
+
+            private void logRetentionLeaseFailure(final String retentionLeaseId, final Throwable cause) {
+                assert cause instanceof ElasticsearchSecurityException == false : cause;
+                logger.warn(new ParameterizedMessage(
+                                "{} background management of retention lease [{}] failed while following",
+                                params.getFollowShardId(),
+                                retentionLeaseId),
+                        cause);
+            }
+
         };
     }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -289,6 +289,7 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
                             logRetentionLeaseFailure(retentionLeaseId, cause);
                             // noinspection StatementWithEmptyBody
                             if (cause instanceof RetentionLeaseNotFoundException) {
+                                // note that we do not need to mark as system context here as that is restored from the original renew
                                 logger.trace(
                                         "{} background adding retention lease [{}] while following",
                                         params.getFollowShardId(),

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -302,10 +302,7 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
                                                     logRetentionLeaseFailure(retentionLeaseId, innerCause);
                                                 }));
                             } else {
-                                /*
-                                 * If something else happened, we will attempt to renew again after another renew interval
-                                 * has passed.
-                                 */
+                                 // if something else happened, we will attempt to renew again after another renew interval has passed
                             }
                         });
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -275,6 +275,9 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
                 final ActionListener<RetentionLeaseActions.Response> listener = ActionListener.wrap(
                         r -> {},
                         e -> {
+                            if (isCancelled() || isCompleted()) {
+                                return;
+                            }
                             final Throwable cause = ExceptionsHelper.unwrapCause(e);
                             logRetentionLeaseFailure(retentionLeaseId, cause);
                             // noinspection StatementWithEmptyBody

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
@@ -373,6 +373,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
         final String leaderIndexSettings =
                 getIndexSettings(numberOfShards, 0, singletonMap(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), "true"));
         assertAcked(leaderClient().admin().indices().prepareCreate(leaderIndex).setSource(leaderIndexSettings, XContentType.JSON).get());
+        ensureLeaderYellow(leaderIndex);
         final PutFollowAction.Request followRequest = putFollow(leaderIndex, followerIndex);
         followerClient().execute(PutFollowAction.INSTANCE, followRequest).get();
 
@@ -464,6 +465,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
         final String leaderIndexSettings =
                 getIndexSettings(numberOfShards, 0, singletonMap(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), "true"));
         assertAcked(leaderClient().admin().indices().prepareCreate(leaderIndex).setSource(leaderIndexSettings, XContentType.JSON).get());
+        ensureLeaderYellow(leaderIndex);
         final PutFollowAction.Request followRequest = putFollow(leaderIndex, followerIndex);
         followerClient().execute(PutFollowAction.INSTANCE, followRequest).get();
 
@@ -538,6 +540,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                 TimeValue.timeValueMillis(200).getStringRep());
         final String leaderIndexSettings = getIndexSettings(numberOfShards, numberOfReplicas, additionalIndexSettings);
         assertAcked(leaderClient().admin().indices().prepareCreate(leaderIndex).setSource(leaderIndexSettings, XContentType.JSON).get());
+        ensureLeaderYellow(leaderIndex);
         final PutFollowAction.Request followRequest = putFollow(leaderIndex, followerIndex);
         followerClient().execute(PutFollowAction.INSTANCE, followRequest).get();
 
@@ -557,6 +560,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                 TimeValue.timeValueMillis(200).getStringRep());
         final String leaderIndexSettings = getIndexSettings(numberOfShards, numberOfReplicas, additionalIndexSettings);
         assertAcked(leaderClient().admin().indices().prepareCreate(leaderIndex).setSource(leaderIndexSettings, XContentType.JSON).get());
+        ensureLeaderYellow(leaderIndex);
         final PutFollowAction.Request followRequest = putFollow(leaderIndex, followerIndex);
         followerClient().execute(PutFollowAction.INSTANCE, followRequest).get();
 
@@ -618,6 +622,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                 TimeValue.timeValueMillis(200).getStringRep());
         final String leaderIndexSettings = getIndexSettings(numberOfShards, numberOfReplicas, additionalIndexSettings);
         assertAcked(leaderClient().admin().indices().prepareCreate(leaderIndex).setSource(leaderIndexSettings, XContentType.JSON).get());
+        ensureLeaderYellow(leaderIndex);
         final PutFollowAction.Request followRequest = putFollow(leaderIndex, followerIndex);
         followerClient().execute(PutFollowAction.INSTANCE, followRequest).get();
 
@@ -719,6 +724,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                 TimeValue.timeValueMillis(200).getStringRep());
         final String leaderIndexSettings = getIndexSettings(numberOfShards, numberOfReplicas, additionalIndexSettings);
         assertAcked(leaderClient().admin().indices().prepareCreate(leaderIndex).setSource(leaderIndexSettings, XContentType.JSON).get());
+        ensureLeaderYellow(leaderIndex);
         final PutFollowAction.Request followRequest = putFollow(leaderIndex, followerIndex);
         followerClient().execute(PutFollowAction.INSTANCE, followRequest).get();
 
@@ -745,6 +751,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                 TimeValue.timeValueMillis(200).getStringRep());
         final String leaderIndexSettings = getIndexSettings(numberOfShards, numberOfReplicas, additionalIndexSettings);
         assertAcked(leaderClient().admin().indices().prepareCreate(leaderIndex).setSource(leaderIndexSettings, XContentType.JSON).get());
+        ensureLeaderYellow(leaderIndex);
         final PutFollowAction.Request followRequest = putFollow(leaderIndex, followerIndex);
         followerClient().execute(PutFollowAction.INSTANCE, followRequest).get();
 
@@ -832,6 +839,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                 TimeValue.timeValueMillis(200).getStringRep());
         final String leaderIndexSettings = getIndexSettings(numberOfShards, numberOfReplicas, additionalIndexSettings);
         assertAcked(leaderClient().admin().indices().prepareCreate(leaderIndex).setSource(leaderIndexSettings, XContentType.JSON).get());
+        ensureLeaderYellow(leaderIndex);
         final PutFollowAction.Request followRequest = putFollow(leaderIndex, followerIndex);
         followerClient().execute(PutFollowAction.INSTANCE, followRequest).get();
 
@@ -865,6 +873,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                                             final RetentionLeaseNotFoundException e = new RetentionLeaseNotFoundException(retentionLeaseId);
                                             context.handler().handleException(new RemoteTransportException(e.getMessage(), e));
                                             responseLatch.countDown();
+                                            senderTransportService.transport().removeMessageListener(this);
                                         }
                                     }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
@@ -858,6 +858,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
 
                                 senderTransportService.transport().addMessageListener(new TransportMessageListener() {
 
+                                    @SuppressWarnings("rawtypes")
                                     @Override
                                     public void onResponseReceived(final long responseRequestId, final Transport.ResponseContext context) {
                                         if (requestId == responseRequestId) {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
@@ -804,7 +804,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
     /**
      * This test is fairly evil. This test is to ensure that we are protected against a race condition when unfollowing and a background
      * renewal fires. The action of unfollowing will remove retention leases from the leader. If a background renewal is firing at that
-     * times, it means that we will be met with a retention lease not found exception. That will in turn trigger behavior to attempt to
+     * time, it means that we will be met with a retention lease not found exception. That will in turn trigger behavior to attempt to
      * re-add the retention lease, which means we are left in a situation where we have unfollowed, but the retention lease still remains
      * on the leader. However, we have a guard against this in the callback after the retention lease not found exception is thrown, which
      * checks if the shard follow node task is cancelled or completed.

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskRandomTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskRandomTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.index.seqno.LocalCheckpointTracker;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.ccr.action.bulk.BulkShardOperationsResponse;
@@ -32,6 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.LongConsumer;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -175,6 +177,23 @@ public class ShardFollowNodeTaskRandomTests extends ESTestCase {
                     }
                 };
                 threadPool.generic().execute(task);
+            }
+
+            @Override
+            protected Scheduler.Cancellable scheduleBackgroundRetentionLeaseRenewal(final LongSupplier followerGlobalCheckpoint) {
+                return new Scheduler.Cancellable() {
+
+                    @Override
+                    public boolean cancel() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isCancelled() {
+                        return true;
+                    }
+
+                };
             }
 
             @Override

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskTests.java
@@ -8,13 +8,16 @@ package org.elasticsearch.xpack.ccr.action;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.xpack.ccr.action.bulk.BulkShardOperationsResponse;
 import org.elasticsearch.xpack.core.ccr.ShardFollowNodeTaskStatus;
 
@@ -27,12 +30,17 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.LongConsumer;
+import java.util.function.LongSupplier;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
@@ -52,6 +60,9 @@ public class ShardFollowNodeTaskTests extends ESTestCase {
     private BiConsumer<TimeValue, Runnable> scheduler = (delay, task) -> task.run();
 
     private Consumer<ShardFollowNodeTaskStatus> beforeSendShardChangesRequest = status -> {};
+
+    private AtomicBoolean scheduleRetentionLeaseRenewal = new AtomicBoolean();
+    private LongConsumer retentionLeaseRenewal = followerGlobalCheckpoint -> {};
 
     private AtomicBoolean simulateResponse = new AtomicBoolean();
 
@@ -936,6 +947,28 @@ public class ShardFollowNodeTaskTests extends ESTestCase {
         assertThat(ShardFollowNodeTask.computeDelay(1024, maxDelayInMillis), allOf(greaterThanOrEqualTo(0L), lessThanOrEqualTo(1000L)));
     }
 
+    public void testRetentionLeaseRenewal() throws InterruptedException {
+        scheduleRetentionLeaseRenewal.set(true);
+        final CountDownLatch latch = new CountDownLatch(1);
+        final long expectedFollowerGlobalChekcpoint = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
+        retentionLeaseRenewal = followerGlobalCheckpoint -> {
+            assertThat(followerGlobalCheckpoint, equalTo(expectedFollowerGlobalChekcpoint));
+            latch.countDown();
+        };
+
+        final ShardFollowTaskParams params = new ShardFollowTaskParams();
+        final ShardFollowNodeTask task = createShardFollowTask(params);
+
+        try {
+            startTask(task, randomLongBetween(expectedFollowerGlobalChekcpoint, Long.MAX_VALUE), expectedFollowerGlobalChekcpoint);
+            latch.await();
+        } finally {
+            task.onCancelled();
+            scheduleRetentionLeaseRenewal.set(false);
+        }
+    }
+
+
     static final class ShardFollowTaskParams {
         private String remoteCluster = null;
         private ShardId followShardId = new ShardId("follow_index", "", 0);
@@ -1060,6 +1093,47 @@ public class ShardFollowNodeTaskTests extends ESTestCase {
                         1L
                     );
                     handler.accept(response);
+                }
+            }
+
+            @Override
+            protected Scheduler.Cancellable scheduleBackgroundRetentionLeaseRenewal(final LongSupplier followerGlobalCheckpoint) {
+                if (scheduleRetentionLeaseRenewal.get()) {
+                    final ScheduledThreadPoolExecutor scheduler = Scheduler.initScheduler(Settings.EMPTY);
+                    final ScheduledFuture<?> future = scheduler.scheduleWithFixedDelay(
+                            () -> retentionLeaseRenewal.accept(followerGlobalCheckpoint.getAsLong()),
+                            0,
+                            TimeValue.timeValueMillis(200).millis(),
+                            TimeUnit.MILLISECONDS);
+                    return new Scheduler.Cancellable() {
+
+                        @Override
+                        public boolean cancel() {
+                            final boolean cancel = future.cancel(true);
+                            scheduler.shutdown();
+                            return cancel;
+                        }
+
+                        @Override
+                        public boolean isCancelled() {
+                            return future.isCancelled();
+                        }
+
+                    };
+                } else {
+                    return new Scheduler.Cancellable() {
+
+                        @Override
+                        public boolean cancel() {
+                            return true;
+                        }
+
+                        @Override
+                        public boolean isCancelled() {
+                            return true;
+                        }
+
+                    };
                 }
             }
 


### PR DESCRIPTION
This commit is the final piece of the integration of CCR with retention leases. Namely, we periodically renew retention leases and advance the retaining sequence number while following.

Relates #37165
Closes #38718
