### PR TITLE
Fix Deadlock from Thread.suspend in Test (#39261)

### DIFF
--- a/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
@@ -127,18 +127,18 @@ public class LongGCDisruptionTests extends ESTestCase {
         final LockedExecutor lockedExecutor = new LockedExecutor();
         final AtomicLong ops = new AtomicLong();
         final Thread[] threads = new Thread[5];
+        final Runnable yieldAndIncrement = () -> {
+            Thread.yield(); // give some chance to catch this stack trace
+            ops.incrementAndGet();
+        };
         try {
             for (int i = 0; i < threads.length; i++) {
                 threads[i] = new Thread(() -> {
                     for (int iter = 0; stop.get() == false; iter++) {
                         if (iter % 2 == 0) {
-                            lockedExecutor.executeLocked(() -> {
-                                Thread.yield(); // give some chance to catch this stack trace
-                                ops.incrementAndGet();
-                            });
+                            lockedExecutor.executeLocked(yieldAndIncrement);
                         } else {
-                            Thread.yield(); // give some chance to catch this stack trace
-                            ops.incrementAndGet();
+                            yieldAndIncrement.run();
                         }
                     }
                 });


### PR DESCRIPTION
* The lambda invoked by the `lockedExecutor` eventually gets JITed (which runs a static initializer that we will suspend in with a very tiny chance).
   * Fixed by creating the `Runnable` in the main test thread and using the same instance in all threads
* Closes #35686 
* Backport of #39261
