### PR TITLE
Avoid creating a green index in RetentionLeaseIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
@@ -551,7 +551,7 @@ public class RetentionLeaseIT extends ESIntegTestCase  {
         final int numDataNodes = internalCluster().numDataNodes();
         final Settings settings = Settings.builder()
                 .put("index.number_of_shards", 1)
-                .put("index.number_of_replicas", numDataNodes == 1 ? 0 : numDataNodes - 1)
+                .put("index.number_of_replicas", numDataNodes)
                 .put(IndexService.RETENTION_LEASE_SYNC_INTERVAL_SETTING.getKey(), TimeValue.timeValueSeconds(1))
                 .build();
         assertAcked(prepareCreate("index").setSettings(settings));
@@ -570,7 +570,7 @@ public class RetentionLeaseIT extends ESIntegTestCase  {
         primary.addRetentionLease(idForInitialRetentionLease, initialRetainingSequenceNumber, source, listener);
         latch.await();
 
-        final String waitForActiveValue = randomBoolean() ? "all" : Integer.toString(numDataNodes);
+        final String waitForActiveValue = randomBoolean() ? "all" : Integer.toString(numDataNodes + 1);
 
         client()
                 .admin()


### PR DESCRIPTION
In #39224 we made shard history retention lease syncing ignore the
`index.write.wait_for_active_shards` setting on the index, and added a test
that showed that it was ignored. However the test as merged actually creates a
green index, so the `wait_for_active_shards` setting has no effect. This change
adjusts the test to create a yellow index to verify that
`wait_for_active_shards` really is ignored.