### PR TITLE
Adapt the Cluster Health and Cat Indices APIs to closed indices

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
@@ -12,6 +12,12 @@
         }
       },
       "params": {
+        "expand_wildcards": {
+          "type" : "enum",
+          "options" : ["open","closed","none","all"],
+          "default" : "all",
+          "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+        },
         "level": {
           "type" : "enum",
           "options" : ["cluster","indices","shards"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
@@ -1,5 +1,5 @@
 ---
-"Test cat indices output":
+"Test cat indices output (no indices)":
 
   - do:
       cat.indices: {}
@@ -7,6 +7,8 @@
   - match:
       $body: |
                /^$/
+---
+"Test cat indices output":
 
   - do:
       indices.create:
@@ -47,29 +49,88 @@
                   (\d\d\d\d\-\d\d\-\d\dT\d\d:\d\d:\d\d.\d\d\dZ) \s*
                 )
                 $/
+---
+"Test cat indices output for closed index (pre 8.0.0)":
+  - skip:
+      version: "8.0.0 - "
+      reason:  "closed indices are replicated starting version 8.0"
+
+  - do:
+      indices.create:
+        index: index-2
+        body:
+          settings:
+            number_of_shards: 3
+            number_of_replicas: 0
+
   - do:
       indices.close:
-        index: index1
+        index: index-2
+  - is_true: acknowledged
+
+  - do:
+      cluster.health:
+        wait_for_status: green
 
   - do:
       cat.indices:
-        index: index*
+        index: index-*
 
   - match:
       $body: |
-               /^(       \s+
-                  close  \s+
-                  index1 \s+
+               /^(        \s+
+                  close   \s+
+                  index-2 \s+
                   ([a-zA-Z0-9=/_+]|[\\\-]){22} \s+
-                         \s+
-                         \s+
-                         \s+
-                         \s+
-                         \s+
-                         \s*
+                          \s+
+                          \s+
+                          \s+
+                          \s+
+                          \s+
+                          \s*
                 )
                 $/
+---
+"Test cat indices output for closed index":
+  - skip:
+      version: " - 7.99.99"
+      reason:  "closed indices are replicated starting version 8.0"
 
+  - do:
+      indices.create:
+        index: index-2
+        body:
+          settings:
+            number_of_shards: 3
+            number_of_replicas: 0
+
+  - do:
+      indices.close:
+        index: index-2
+  - is_true: acknowledged
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+  - do:
+      cat.indices:
+        index: index-*
+
+  - match:
+      $body: |
+        /^(green  \s+
+           close   \s+
+           index-2 \s+
+           ([a-zA-Z0-9=/_+]|[\\\-]){22} \s+
+           3       \s+
+           0       \s+
+                   \s+
+                   \s+
+                   \s+
+                   \s*
+         )
+         $/
 ---
 "Test cat indices using health status":
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yml
@@ -132,4 +132,150 @@
   - is_true: indices
   - is_true: indices.test_index.shards
 
+---
+"cluster health with closed index (pre 8.0)":
+  - skip:
+      version: "8.0.0 - "
+      reason:  "closed indices are replicated starting version 8.0"
 
+  - do:
+      indices.create:
+        index: index-1
+        body:
+          settings:
+            index:
+              number_of_replicas: 0
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+  - match:     { status:     green }
+
+  - do:
+      indices.create:
+        index: index-2
+        body:
+          settings:
+            index:
+              number_of_replicas: 50
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+        wait_for_no_relocating_shards: true
+  - match:     { status:     yellow }
+
+  - do:
+      cluster.health:
+        index: index-*
+  - match:     { status:     yellow }
+
+  - do:
+      cluster.health:
+        index: index-1
+  - match:     { status:     green }
+
+  - do:
+      cluster.health:
+        index: index-2
+  - match:     { status:     yellow }
+
+  - do:
+      indices.close:
+        index: index-2
+  - is_true: acknowledged
+
+  # closing the index-2 turns the cluster health back to green
+  - do:
+      cluster.health:
+        wait_for_status: green
+  - match:     { status:     green }
+
+  - do:
+      cluster.health:
+        index: index-*
+  - match:     { status:     green }
+
+  - do:
+      cluster.health:
+        index: index-1
+  - match:     { status:     green }
+
+  - do:
+      cluster.health:
+        index: index-2
+  - match:     { status:     green }
+
+---
+"cluster health with closed index":
+  - skip:
+      version: " - 7.99.99"
+      reason:  "closed indices are replicated starting version 8.0"
+
+  - do:
+      indices.create:
+        index: index-1
+        body:
+          settings:
+            index:
+              number_of_replicas: 0
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+  - match:     { status:     green }
+
+  - do:
+      indices.create:
+        index: index-2
+        body:
+          settings:
+            index:
+              number_of_replicas: 50
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+        wait_for_no_relocating_shards: true
+  - match:     { status:     yellow }
+
+  - do:
+      cluster.health:
+        index: index-*
+  - match:     { status:     yellow }
+
+  - do:
+      cluster.health:
+        index: index-1
+  - match:     { status:     green }
+
+  - do:
+      cluster.health:
+        index: index-2
+  - match:     { status:     yellow }
+
+  # closing the index-2 does not change the cluster health with replicated closed indices
+  - do:
+      indices.close:
+        index: index-2
+  - is_true: acknowledged
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+  - match:     { status:     yellow }
+
+  - do:
+      cluster.health:
+        index: index-*
+  - match:     { status:     yellow }
+
+  - do:
+      cluster.health:
+        index: index-1
+  - match:     { status:     green }
+
+  - do:
+      cluster.health:
+        index: index-2
+  - match:     { status:     yellow }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/30_indices_options.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/30_indices_options.yml
@@ -1,0 +1,79 @@
+setup:
+
+  - do:
+      indices.create:
+        index: index-1
+        body:
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 0
+
+  - do:
+      indices.create:
+        index: index-2
+        body:
+          settings:
+            number_of_shards:   2
+            number_of_replicas: 0
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+  - do:
+      indices.close:
+        index: index-2
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+---
+"cluster health with expand_wildcards":
+  - skip:
+      version: " - 7.99.99"
+      reason:  "indices options has been introduced in cluster health request starting version 8.0"
+
+  - do:
+      cluster.health:
+        index: "index-*"
+        level: indices
+        expand_wildcards: open
+  - match:     { status:                          green }
+  - match:     { active_shards:                   1     }
+  - match:     { indices.index-1.status:          green }
+  - match:     { indices.index-1.active_shards:   1     }
+  - is_false:  indices.index-2
+
+  - do:
+      cluster.health:
+        index: "index-*"
+        level: indices
+        expand_wildcards: closed
+  - match:     { status:                          green }
+  - match:     { active_shards:                   2     }
+  - is_false:  indices.index-1
+  - match:     { indices.index-2.status:          green }
+  - match:     { indices.index-2.active_shards:   2     }
+
+  - do:
+      cluster.health:
+        index: "index-*"
+        level: indices
+        expand_wildcards: all
+  - match:     { status:                          green }
+  - match:     { active_shards:                   3     }
+  - match:     { indices.index-1.status:          green }
+  - match:     { indices.index-1.active_shards:   1     }
+  - match:     { indices.index-2.status:          green }
+  - match:     { indices.index-2.active_shards:   2     }
+
+  - do:
+      cluster.health:
+        index: "index-*"
+        level: indices
+        expand_wildcards: none
+  - match:     { status:                          green }
+  - match:     { active_shards:                   0     }
+  - is_false:  indices.index-1
+  - is_false:  indices.index-2

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.cluster.health;
 
 import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
@@ -35,6 +36,11 @@ public class ClusterHealthRequestBuilder
 
     public ClusterHealthRequestBuilder setIndices(String... indices) {
         request.indices(indices);
+        return this;
+    }
+
+    public ClusterHealthRequestBuilder setIndicesOptions(final IndicesOptions indicesOptions) {
+        request.indicesOptions(indicesOptions);
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -90,7 +90,11 @@ public class IndicesOptions implements ToXContentFragment {
     public static final IndicesOptions STRICT_EXPAND_OPEN =
         new IndicesOptions(EnumSet.of(Option.ALLOW_NO_INDICES), EnumSet.of(WildcardStates.OPEN));
     public static final IndicesOptions LENIENT_EXPAND_OPEN =
-        new IndicesOptions(EnumSet.of(Option.ALLOW_NO_INDICES, Option.IGNORE_UNAVAILABLE), EnumSet.of(WildcardStates.OPEN));
+        new IndicesOptions(EnumSet.of(Option.ALLOW_NO_INDICES, Option.IGNORE_UNAVAILABLE),
+            EnumSet.of(WildcardStates.OPEN));
+    public static final IndicesOptions LENIENT_EXPAND_OPEN_CLOSED =
+        new IndicesOptions(EnumSet.of(Option.ALLOW_NO_INDICES, Option.IGNORE_UNAVAILABLE),
+            EnumSet.of(WildcardStates.OPEN, WildcardStates.CLOSED));
     public static final IndicesOptions STRICT_EXPAND_OPEN_CLOSED =
         new IndicesOptions(EnumSet.of(Option.ALLOW_NO_INDICES), EnumSet.of(WildcardStates.OPEN, WildcardStates.CLOSED));
     public static final IndicesOptions STRICT_EXPAND_OPEN_FORBID_CLOSED =
@@ -438,6 +442,14 @@ public class IndicesOptions implements ToXContentFragment {
      */
     public static IndicesOptions lenientExpandOpen() {
         return LENIENT_EXPAND_OPEN;
+    }
+
+    /**
+     * @return indices options that ignores unavailable indices,  expands wildcards to both open and closed
+     * indices and allows that no indices are resolved from wildcard expressions (not returning an error).
+     */
+    public static IndicesOptions lenientExpand() {
+        return LENIENT_EXPAND_OPEN_CLOSED;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterHealthAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.rest.action.admin.cluster;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.common.Priority;
@@ -39,9 +40,9 @@ import java.util.Set;
 import static org.elasticsearch.client.Requests.clusterHealthRequest;
 
 public class RestClusterHealthAction extends BaseRestHandler {
+
     public RestClusterHealthAction(Settings settings, RestController controller) {
         super(settings);
-
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/health", this);
         controller.registerHandler(RestRequest.Method.GET, "/_cluster/health/{index}", this);
     }
@@ -53,7 +54,8 @@ public class RestClusterHealthAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        ClusterHealthRequest clusterHealthRequest = clusterHealthRequest(Strings.splitStringByCommaToArray(request.param("index")));
+        final ClusterHealthRequest clusterHealthRequest = clusterHealthRequest(Strings.splitStringByCommaToArray(request.param("index")));
+        clusterHealthRequest.indicesOptions(IndicesOptions.fromRequest(request, clusterHealthRequest.indicesOptions()));
         clusterHealthRequest.local(request.paramAsBoolean("local", clusterHealthRequest.local()));
         clusterHealthRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterHealthRequest.masterNodeTimeout()));
         clusterHealthRequest.timeout(request.paramAsTime("timeout", clusterHealthRequest.timeout()));

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestTests.java
@@ -19,15 +19,23 @@
 
 package org.elasticsearch.action.admin.cluster.health;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.Locale;
+
+import static org.elasticsearch.test.VersionUtils.getPreviousVersion;
+import static org.elasticsearch.test.VersionUtils.randomVersionBetween;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class ClusterHealthRequestTests extends ESTestCase {
+
     public void testSerialize() throws Exception {
         final ClusterHealthRequest originalRequest = randomRequest();
         final ClusterHealthRequest cloneRequest;
@@ -43,9 +51,89 @@ public class ClusterHealthRequestTests extends ESTestCase {
         assertThat(cloneRequest.waitForNoRelocatingShards(), equalTo(originalRequest.waitForNoRelocatingShards()));
         assertThat(cloneRequest.waitForActiveShards(), equalTo(originalRequest.waitForActiveShards()));
         assertThat(cloneRequest.waitForEvents(), equalTo(originalRequest.waitForEvents()));
+        assertIndicesEquals(cloneRequest.indices(), originalRequest.indices());
+        assertThat(cloneRequest.indicesOptions(), equalTo(originalRequest.indicesOptions()));
     }
 
-    ClusterHealthRequest randomRequest() {
+    public void testBwcSerialization() throws Exception {
+        for (int runs = 0; runs < randomIntBetween(5, 20); runs++) {
+            // Generate a random cluster health request in version < 8.0.0 and serializes it
+            final BytesStreamOutput out = new BytesStreamOutput();
+            out.setVersion(randomVersionBetween(random(), Version.V_6_3_0, getPreviousVersion(Version.V_8_0_0)));
+
+            final ClusterHealthRequest expected = randomRequest();
+            {
+                expected.getParentTask().writeTo(out);
+                out.writeTimeValue(expected.masterNodeTimeout());
+                out.writeBoolean(expected.local());
+                if (expected.indices() == null) {
+                    out.writeVInt(0);
+                } else {
+                    out.writeVInt(expected.indices().length);
+                    for (String index : expected.indices()) {
+                        out.writeString(index);
+                    }
+                }
+                out.writeTimeValue(expected.timeout());
+                if (expected.waitForStatus() == null) {
+                    out.writeBoolean(false);
+                } else {
+                    out.writeBoolean(true);
+                    out.writeByte(expected.waitForStatus().value());
+                }
+                out.writeBoolean(expected.waitForNoRelocatingShards());
+                expected.waitForActiveShards().writeTo(out);
+                out.writeString(expected.waitForNodes());
+                if (expected.waitForEvents() == null) {
+                    out.writeBoolean(false);
+                } else {
+                    out.writeBoolean(true);
+                    Priority.writeTo(expected.waitForEvents(), out);
+                }
+                out.writeBoolean(expected.waitForNoInitializingShards());
+            }
+
+            // Deserialize and check the cluster health request
+            final StreamInput in = out.bytes().streamInput();
+            in.setVersion(out.getVersion());
+            final ClusterHealthRequest actual = new ClusterHealthRequest(in);
+
+            assertThat(actual.waitForStatus(), equalTo(expected.waitForStatus()));
+            assertThat(actual.waitForNodes(), equalTo(expected.waitForNodes()));
+            assertThat(actual.waitForNoInitializingShards(), equalTo(expected.waitForNoInitializingShards()));
+            assertThat(actual.waitForNoRelocatingShards(), equalTo(expected.waitForNoRelocatingShards()));
+            assertThat(actual.waitForActiveShards(), equalTo(expected.waitForActiveShards()));
+            assertThat(actual.waitForEvents(), equalTo(expected.waitForEvents()));
+            assertIndicesEquals(actual.indices(), expected.indices());
+            assertThat(actual.indicesOptions(), equalTo(IndicesOptions.lenientExpandOpen()));
+        }
+
+        for (int runs = 0; runs < randomIntBetween(5, 20); runs++) {
+            // Generate a random cluster health request in current version
+            final ClusterHealthRequest expected = randomRequest();
+
+            // Serialize to node in version < 8.0.0
+            final BytesStreamOutput out = new BytesStreamOutput();
+            out.setVersion(randomVersionBetween(random(), Version.V_6_3_0, getPreviousVersion(Version.V_8_0_0)));
+            expected.writeTo(out);
+
+            // Deserialize and check the cluster health request
+            final StreamInput in = out.bytes().streamInput();
+            in.setVersion(out.getVersion());
+            final ClusterHealthRequest actual = new ClusterHealthRequest(in);
+
+            assertThat(actual.waitForStatus(), equalTo(expected.waitForStatus()));
+            assertThat(actual.waitForNodes(), equalTo(expected.waitForNodes()));
+            assertThat(actual.waitForNoInitializingShards(), equalTo(expected.waitForNoInitializingShards()));
+            assertThat(actual.waitForNoRelocatingShards(), equalTo(expected.waitForNoRelocatingShards()));
+            assertThat(actual.waitForActiveShards(), equalTo(expected.waitForActiveShards()));
+            assertThat(actual.waitForEvents(), equalTo(expected.waitForEvents()));
+            assertIndicesEquals(actual.indices(), expected.indices());
+            assertThat(actual.indicesOptions(), equalTo(IndicesOptions.lenientExpandOpen()));
+        }
+    }
+
+    private ClusterHealthRequest randomRequest() {
         ClusterHealthRequest request = new ClusterHealthRequest();
         request.waitForStatus(randomFrom(ClusterHealthStatus.values()));
         request.waitForNodes(randomFrom("", "<", "<=", ">", ">=") + between(0, 1000));
@@ -53,7 +141,21 @@ public class ClusterHealthRequestTests extends ESTestCase {
         request.waitForNoRelocatingShards(randomBoolean());
         request.waitForActiveShards(randomIntBetween(0, 10));
         request.waitForEvents(randomFrom(Priority.values()));
+        if (randomBoolean()) {
+            final String[] indices = new String[randomIntBetween(1, 10)];
+            for (int i = 0; i < indices.length; i++) {
+                indices[i] = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+            }
+            request.indices(indices);
+        }
+        if (randomBoolean()) {
+            request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
+        }
         return request;
     }
 
+    private static void assertIndicesEquals(final String[] actual, final String[] expected) {
+        // null indices in ClusterHealthRequest is deserialized as empty string array
+        assertArrayEquals(expected != null ? expected : Strings.EMPTY_ARRAY, actual);
+    }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -155,8 +155,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 .put(indexBuilder("foofoo").putAlias(AliasMetaData.builder("barbaz")));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
 
-        IndicesOptions lenientExpand = IndicesOptions.fromOptions(true, true, true, true);
-        IndicesOptions[] indicesOptions = new IndicesOptions[]{ IndicesOptions.lenientExpandOpen(), lenientExpand};
+        IndicesOptions[] indicesOptions = new IndicesOptions[]{IndicesOptions.lenientExpandOpen(), IndicesOptions.lenientExpand()};
         for (IndicesOptions options : indicesOptions) {
             IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, options);
             String[] results = indexNameExpressionResolver.concreteIndexNames(context, "foo");
@@ -199,7 +198,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         String[] results = indexNameExpressionResolver.concreteIndexNames(context, Strings.EMPTY_ARRAY);
         assertEquals(3, results.length);
 
-        context = new IndexNameExpressionResolver.Context(state, lenientExpand);
+        context = new IndexNameExpressionResolver.Context(state, IndicesOptions.lenientExpand());
         results = indexNameExpressionResolver.concreteIndexNames(context, Strings.EMPTY_ARRAY);
         assertEquals(Arrays.toString(results), 4, results.length);
 
@@ -208,7 +207,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertEquals(3, results.length);
         assertThat(results, arrayContainingInAnyOrder("foo", "foobar", "foofoo"));
 
-        context = new IndexNameExpressionResolver.Context(state, lenientExpand);
+        context = new IndexNameExpressionResolver.Context(state, IndicesOptions.lenientExpand());
         results = indexNameExpressionResolver.concreteIndexNames(context, "foofoo*");
         assertEquals(4, results.length);
         assertThat(results, arrayContainingInAnyOrder("foo", "foobar", "foofoo", "foofoo-closed"));


### PR DESCRIPTION
Note: this PR will be merged in the `replicated-closed-indices` feature branch

This pull request adapts the Cluster Health API to support replicated closed indices. In order to do that, this pull request removes the hard coded indices options from the `ClusterHealthRequest` and replaces it with a new `IndicesOptions.lenientExpand()` option. This option will be used by the master node (once it is upgraded to 8.0) to compute the global cluster health using both opened and closed indices information by default. The `expand_wildcards` REST parameter is also documented and tests where added to ensure that a specific expansion type can be used to monitoring the health of a only opened or only closed indices.

Since the Cat Indices relies on the Cluster Health API, it has been adapted to report information about closed indices too. Note that the health and number of shards/replicas is only printed out for closed indices that have an index routing table. Closed indices without routing table have the same output as before.

Related to #33888 

