### PR TITLE
[DATA-FRAME] Sort `GET` transforms and stats by ID (#39365)

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportGetDataFrameTransformsAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportGetDataFrameTransformsAction.java
@@ -28,8 +28,8 @@ import org.elasticsearch.xpack.dataframe.persistence.DataFrameTransformsConfigMa
 import org.elasticsearch.xpack.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.xpack.dataframe.transforms.DataFrameTransformTask;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -52,8 +52,10 @@ public class TransportGetDataFrameTransformsAction extends
     @Override
     protected Response newResponse(Request request, List<Response> tasks, List<TaskOperationFailure> taskOperationFailures,
             List<FailedNodeException> failedNodeExceptions) {
-        List<DataFrameTransformConfig> configs = tasks.stream().map(GetDataFrameTransformsAction.Response::getTransformConfigurations)
-                .flatMap(Collection::stream).collect(Collectors.toList());
+        List<DataFrameTransformConfig> configs = tasks.stream()
+            .flatMap(r -> r.getTransformConfigurations().stream())
+            .sorted(Comparator.comparing(DataFrameTransformConfig::getId))
+            .collect(Collectors.toList());
         return new Response(configs, taskOperationFailures, failedNodeExceptions);
     }
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportGetDataFrameTransformsStatsAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportGetDataFrameTransformsStatsAction.java
@@ -26,8 +26,8 @@ import org.elasticsearch.xpack.dataframe.action.GetDataFrameTransformsStatsActio
 import org.elasticsearch.xpack.dataframe.persistence.DataFramePersistentTaskUtils;
 import org.elasticsearch.xpack.dataframe.transforms.DataFrameTransformTask;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -48,8 +48,9 @@ public class TransportGetDataFrameTransformsStatsAction extends
     protected Response newResponse(Request request, List<Response> tasks, List<TaskOperationFailure> taskOperationFailures,
             List<FailedNodeException> failedNodeExceptions) {
         List<DataFrameTransformStateAndStats> responses = tasks.stream()
-                .map(GetDataFrameTransformsStatsAction.Response::getTransformsStateAndStats).flatMap(Collection::stream)
-                .collect(Collectors.toList());
+            .flatMap(r -> r.getTransformsStateAndStats().stream())
+            .sorted(Comparator.comparing(DataFrameTransformStateAndStats::getId))
+            .collect(Collectors.toList());
         return new Response(responses, taskOperationFailures, failedNodeExceptions);
     }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_crud.yml
@@ -89,11 +89,15 @@ setup:
       data_frame.get_data_frame_transform:
         transform_id: "*"
   - match: { count: 2 }
+  - match: { transforms.0.id: "airline-transform" }
+  - match: { transforms.1.id: "airline-transform-dos" }
 
   - do:
       data_frame.get_data_frame_transform:
         transform_id: "_all"
   - match: { count: 2 }
+  - match: { transforms.0.id: "airline-transform" }
+  - match: { transforms.1.id: "airline-transform-dos" }
 
   - do:
       data_frame.delete_data_frame_transform:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_stats.yml
@@ -78,11 +78,15 @@ teardown:
       data_frame.get_data_frame_transform_stats:
         transform_id: "*"
   - match: { count: 2 }
+  - match: { transforms.0.id: "airline-transform-stats" }
+  - match: { transforms.1.id: "airline-transform-stats-dos" }
 
   - do:
       data_frame.get_data_frame_transform_stats:
         transform_id: "_all"
   - match: { count: 2 }
+  - match: { transforms.0.id: "airline-transform-stats" }
+  - match: { transforms.1.id: "airline-transform-stats-dos" }
 
   - do:
       data_frame.delete_data_frame_transform:


### PR DESCRIPTION
Sorts the output of `GET transforms` and `GET transforms/_stats` to sort by ID.

Adds check to yaml test accordingly.