### PR TITLE
Reduce garbage from allocations in deprecation logger (#38780)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -259,7 +259,11 @@ public class DeprecationLogger {
      * @return a warning value formatted according to RFC 7234
      */
     public static String formatWarning(final String s) {
-        return WARNING_PREFIX + " " + "\"" + escapeAndEncode(s) + "\"";
+        // Assume that the common scenario won't have a string to escape and encode.
+        int length = WARNING_PREFIX.length() + s.length() + 3;
+        final StringBuilder sb = new StringBuilder(length);
+        sb.append(WARNING_PREFIX).append(" \"").append(escapeAndEncode(s)).append("\"");
+        return sb.toString();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/logging/LoggerMessageFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LoggerMessageFormat.java
@@ -40,7 +40,7 @@ public class LoggerMessageFormat {
         if (messagePattern == null) {
             return null;
         }
-        if (argArray == null) {
+        if (argArray == null || argArray.length == 0) {
             if (prefix == null) {
                 return messagePattern;
             } else {


### PR DESCRIPTION
1. Setting length for formatWarning String to avoid AbstractStringBuilder.ensureCapacityInternal calls
2. Adding extra check for parameter array length == 0 to avoid unnecessarily creating StringBuilder in LoggerMessageFormat.format

Helps to narrow the performance gap in throughout for geonames benchmark (#37411) by 3%. For more details: https://github.com/elastic/elasticsearch/issues/37530#issuecomment-462758384 

Relates to #37530
Relates to #37411
Relates to #35754