### PR TITLE
Add Docker build type

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -31,6 +31,7 @@ WORKDIR /usr/share/elasticsearch
 ${source_elasticsearch}
 
 RUN tar zxf /opt/${elasticsearch} --strip-components=1
+RUN sed -ie 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' /usr/share/elasticsearch/bin/elasticsearch-env
 RUN mkdir -p config data logs
 RUN chmod 0775 config data logs
 COPY config/elasticsearch.yml config/log4j2.properties config/

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -31,7 +31,8 @@ WORKDIR /usr/share/elasticsearch
 ${source_elasticsearch}
 
 RUN tar zxf /opt/${elasticsearch} --strip-components=1
-RUN sed -ie 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' /usr/share/elasticsearch/bin/elasticsearch-env
+RUN grep ES_DISTRIBUTION_TYPE=far /usr/share/elasticsearch/bin/elasticsearch-env \
+    && sed -ie 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' /usr/share/elasticsearch/bin/elasticsearch-env
 RUN mkdir -p config data logs
 RUN chmod 0775 config data logs
 COPY config/elasticsearch.yml config/log4j2.properties config/

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /usr/share/elasticsearch
 ${source_elasticsearch}
 
 RUN tar zxf /opt/${elasticsearch} --strip-components=1
-RUN grep ES_DISTRIBUTION_TYPE=far /usr/share/elasticsearch/bin/elasticsearch-env \
+RUN grep ES_DISTRIBUTION_TYPE=tar /usr/share/elasticsearch/bin/elasticsearch-env \
     && sed -ie 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' /usr/share/elasticsearch/bin/elasticsearch-env
 RUN mkdir -p config data logs
 RUN chmod 0775 config data logs

--- a/server/src/main/java/org/elasticsearch/Build.java
+++ b/server/src/main/java/org/elasticsearch/Build.java
@@ -75,6 +75,7 @@ public class Build {
     public enum Type {
 
         DEB("deb"),
+        DOCKER("docker"),
         RPM("rpm"),
         TAR("tar"),
         ZIP("zip"),
@@ -94,6 +95,8 @@ public class Build {
             switch (displayName) {
                 case "deb":
                     return Type.DEB;
+                case "docker":
+                    return Type.DOCKER;
                 case "rpm":
                     return Type.RPM;
                 case "tar":


### PR DESCRIPTION
This commit adds a new build type (together with deb/rpm/tar/zip) to represent the official Docker images. This build type will be displayed in APIs such as the main and nodes info APIs.
