### PR TITLE
[DOCS] Adds placeholder for Go client documentation

### DIFF
--- a/docs/go/index.asciidoc
+++ b/docs/go/index.asciidoc
@@ -1,0 +1,8 @@
+= go-elasticsearch
+
+== Overview
+
+* https://github.com/elastic/go-elasticsearch
+* https://godoc.org/github.com/elastic/go-elasticsearch
+* https://github.com/elastic/go-elasticsearch/tree/master/_examples
+


### PR DESCRIPTION
This PR creates a placeholder for the documentation for the Go client, which will be added here: https://www.elastic.co/guide/en/elasticsearch/client/index.html