### PR TITLE
Refactoring scheduled event to store instant instead of zoned tme zone

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEvent.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEvent.java
@@ -27,8 +27,6 @@ import org.elasticsearch.xpack.core.ml.utils.time.TimeUtils;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEvent.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEvent.java
@@ -55,18 +55,18 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         parser.declareString(ScheduledEvent.Builder::description, DESCRIPTION);
         parser.declareField(ScheduledEvent.Builder::startTime, p -> {
             if (p.currentToken() == XContentParser.Token.VALUE_NUMBER) {
-                return ZonedDateTime.ofInstant(Instant.ofEpochMilli(p.longValue()), ZoneOffset.UTC);
+                return Instant.ofEpochMilli(p.longValue());
             } else if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
-                return ZonedDateTime.ofInstant(Instant.ofEpochMilli(TimeUtils.dateStringToEpoch(p.text())), ZoneOffset.UTC);
+                return Instant.ofEpochMilli(TimeUtils.dateStringToEpoch(p.text()));
             }
             throw new IllegalArgumentException(
                     "unexpected token [" + p.currentToken() + "] for [" + START_TIME.getPreferredName() + "]");
         }, START_TIME, ObjectParser.ValueType.VALUE);
         parser.declareField(ScheduledEvent.Builder::endTime, p -> {
             if (p.currentToken() == XContentParser.Token.VALUE_NUMBER) {
-                return ZonedDateTime.ofInstant(Instant.ofEpochMilli(p.longValue()), ZoneOffset.UTC);
+                return Instant.ofEpochMilli(p.longValue());
             } else if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
-                return ZonedDateTime.ofInstant(Instant.ofEpochMilli(TimeUtils.dateStringToEpoch(p.text())), ZoneOffset.UTC);
+                return Instant.ofEpochMilli(TimeUtils.dateStringToEpoch(p.text()));
             }
             throw new IllegalArgumentException(
                     "unexpected token [" + p.currentToken() + "] for [" + END_TIME.getPreferredName() + "]");
@@ -83,12 +83,12 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
     }
 
     private final String description;
-    private final ZonedDateTime startTime;
-    private final ZonedDateTime endTime;
+    private final Instant startTime;
+    private final Instant endTime;
     private final String calendarId;
     private final String eventId;
 
-    ScheduledEvent(String description, ZonedDateTime startTime, ZonedDateTime endTime, String calendarId, @Nullable String eventId) {
+    ScheduledEvent(String description, Instant startTime, Instant endTime, String calendarId, @Nullable String eventId) {
         this.description = Objects.requireNonNull(description);
         this.startTime = Objects.requireNonNull(startTime);
         this.endTime = Objects.requireNonNull(endTime);
@@ -98,8 +98,8 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
 
     public ScheduledEvent(StreamInput in) throws IOException {
         description = in.readString();
-        startTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(in.readVLong()), ZoneOffset.UTC);
-        endTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(in.readVLong()), ZoneOffset.UTC);
+        startTime = Instant.ofEpochMilli(in.readVLong());
+        endTime = Instant.ofEpochMilli(in.readVLong());
         calendarId = in.readString();
         eventId = in.readOptionalString();
     }
@@ -108,11 +108,11 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         return description;
     }
 
-    public ZonedDateTime getStartTime() {
+    public Instant getStartTime() {
         return startTime;
     }
 
-    public ZonedDateTime getEndTime() {
+    public Instant getEndTime() {
         return endTime;
     }
 
@@ -141,9 +141,9 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
 
         long bucketSpanSecs = bucketSpan.getSeconds();
 
-        long bucketStartTime = Intervals.alignToFloor(getStartTime().toEpochSecond(), bucketSpanSecs);
+        long bucketStartTime = Intervals.alignToFloor(getStartTime().getEpochSecond(), bucketSpanSecs);
         conditions.add(RuleCondition.createTime(Operator.GTE, bucketStartTime));
-        long bucketEndTime = Intervals.alignToCeil(getEndTime().toEpochSecond(), bucketSpanSecs);
+        long bucketEndTime = Intervals.alignToCeil(getEndTime().getEpochSecond(), bucketSpanSecs);
         conditions.add(RuleCondition.createTime(Operator.LT, bucketEndTime));
 
         DetectionRule.Builder builder = new DetectionRule.Builder(conditions);
@@ -154,8 +154,8 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(description);
-        out.writeVLong(startTime.toInstant().toEpochMilli());
-        out.writeVLong(endTime.toInstant().toEpochMilli());
+        out.writeVLong(startTime.toEpochMilli());
+        out.writeVLong(endTime.toEpochMilli());
         out.writeString(calendarId);
         out.writeOptionalString(eventId);
     }
@@ -164,8 +164,8 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(DESCRIPTION.getPreferredName(), description);
-        builder.timeField(START_TIME.getPreferredName(), START_TIME.getPreferredName() + "_string", startTime.toInstant().toEpochMilli());
-        builder.timeField(END_TIME.getPreferredName(), END_TIME.getPreferredName() + "_string", endTime.toInstant().toEpochMilli());
+        builder.timeField(START_TIME.getPreferredName(), START_TIME.getPreferredName() + "_string", startTime.toEpochMilli());
+        builder.timeField(END_TIME.getPreferredName(), END_TIME.getPreferredName() + "_string", endTime.toEpochMilli());
         builder.field(Calendar.ID.getPreferredName(), calendarId);
         if (eventId != null) {
             builder.field(EVENT_ID.getPreferredName(), eventId);
@@ -197,8 +197,8 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         // Note ZonedDataTime.equals() fails because the time zone and date-time must be the same
         // which isn't the case in tests where the time zone is randomised.
         return description.equals(other.description)
-                && Objects.equals(startTime.toInstant().getEpochSecond(), other.startTime.toInstant().getEpochSecond())
-                && Objects.equals(endTime.toInstant().getEpochSecond(), other.endTime.toInstant().getEpochSecond())
+                && Objects.equals(startTime.getEpochSecond(), other.startTime.getEpochSecond())
+                && Objects.equals(endTime.getEpochSecond(), other.endTime.getEpochSecond())
                 && calendarId.equals(other.calendarId);
     }
 
@@ -209,8 +209,8 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
 
     public static class Builder {
         private String description;
-        private ZonedDateTime startTime;
-        private ZonedDateTime endTime;
+        private Instant startTime;
+        private Instant endTime;
         private String calendarId;
         private String eventId;
 
@@ -219,12 +219,12 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
             return this;
         }
 
-        public Builder startTime(ZonedDateTime startTime) {
+        public Builder startTime(Instant startTime) {
             this.startTime = startTime;
             return this;
         }
 
-        public Builder endTime(ZonedDateTime endTime) {
+        public Builder endTime(Instant endTime) {
             this.endTime = endTime;
             return this;
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEventTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEventTests.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.core.ml.calendars;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -18,7 +17,7 @@ import org.elasticsearch.xpack.core.ml.job.config.RuleAction;
 import org.elasticsearch.xpack.core.ml.job.config.RuleCondition;
 
 import java.io.IOException;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -27,7 +26,7 @@ import static org.hamcrest.Matchers.containsString;
 public class ScheduledEventTests extends AbstractSerializingTestCase<ScheduledEvent> {
 
     public static ScheduledEvent createScheduledEvent(String calendarId) {
-        ZonedDateTime start = DateUtils.nowWithMillisResolution();
+        Instant start = Instant.ofEpochSecond(Instant.now().toEpochMilli());
         return new ScheduledEvent(randomAlphaOfLength(10), start, start.plusSeconds(randomIntBetween(1, 10000)),
                 calendarId, null);
     }
@@ -70,7 +69,7 @@ public class ScheduledEventTests extends AbstractSerializingTestCase<ScheduledEv
         long conditionEndTime = (long) conditions.get(1).getValue();
         assertEquals(0, conditionEndTime % bucketSpanSecs);
 
-        long eventTime = event.getEndTime().toEpochSecond() - conditionStartTime;
+        long eventTime = event.getEndTime().getEpochSecond() - conditionStartTime;
         long numbBucketsInEvent = (eventTime + bucketSpanSecs -1) / bucketSpanSecs;
         assertEquals(bucketSpanSecs * (bucketCount + numbBucketsInEvent), conditionEndTime);
     }
@@ -83,11 +82,11 @@ public class ScheduledEventTests extends AbstractSerializingTestCase<ScheduledEv
         builder.description("foo");
         e = expectThrows(ElasticsearchStatusException.class, builder::build);
         assertEquals("Field [start_time] cannot be null", e.getMessage());
-        ZonedDateTime now = ZonedDateTime.now();
+        Instant now = Instant.now();
         builder.startTime(now);
         e = expectThrows(ElasticsearchStatusException.class, builder::build);
         assertEquals("Field [end_time] cannot be null", e.getMessage());
-        builder.endTime(now.plusHours(1));
+        builder.endTime(now.plusSeconds(1*60*60));
         e = expectThrows(ElasticsearchStatusException.class, builder::build);
         assertEquals("Field [calendar_id] cannot be null", e.getMessage());
         builder.calendarId("foo");
@@ -96,7 +95,7 @@ public class ScheduledEventTests extends AbstractSerializingTestCase<ScheduledEv
 
         builder = new ScheduledEvent.Builder().description("f").calendarId("c");
         builder.startTime(now);
-        builder.endTime(now.minusHours(2));
+        builder.endTime(now.minusSeconds(2*60*60));
 
         e = expectThrows(ElasticsearchStatusException.class, builder::build);
         assertThat(e.getMessage(), containsString("must come before end time"));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEventTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEventTests.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.containsString;
 public class ScheduledEventTests extends AbstractSerializingTestCase<ScheduledEvent> {
 
     public static ScheduledEvent createScheduledEvent(String calendarId) {
-        Instant start = Instant.ofEpochSecond(Instant.now().toEpochMilli());
+        Instant start = Instant.ofEpochMilli(Instant.now().toEpochMilli());
         return new ScheduledEvent(randomAlphaOfLength(10), start, start.plusSeconds(randomIntBetween(1, 10000)),
                 calendarId, null);
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
@@ -14,7 +14,11 @@ import org.elasticsearch.xpack.core.ml.action.GetBucketsAction;
 import org.elasticsearch.xpack.core.ml.action.GetRecordsAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateJobAction;
 import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
-import org.elasticsearch.xpack.core.ml.job.config.*;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
+import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
+import org.elasticsearch.xpack.core.ml.job.config.Detector;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.config.JobUpdate;
 import org.elasticsearch.xpack.core.ml.job.results.AnomalyRecord;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.junit.After;
@@ -26,7 +30,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
@@ -14,27 +14,19 @@ import org.elasticsearch.xpack.core.ml.action.GetBucketsAction;
 import org.elasticsearch.xpack.core.ml.action.GetRecordsAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateJobAction;
 import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
-import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
-import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
-import org.elasticsearch.xpack.core.ml.job.config.Detector;
-import org.elasticsearch.xpack.core.ml.job.config.Job;
-import org.elasticsearch.xpack.core.ml.job.config.JobUpdate;
+import org.elasticsearch.xpack.core.ml.job.config.*;
 import org.elasticsearch.xpack.core.ml.job.results.AnomalyRecord;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.junit.After;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
 
@@ -56,21 +48,21 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
         long firstEventStartTime = 1514937600000L;
         long firstEventEndTime = firstEventStartTime + 2 * 60 * 60 * 1000;
         events.add(new ScheduledEvent.Builder().description("1st event (2hr)")
-                .startTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(firstEventStartTime), ZoneOffset.UTC))
-                .endTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(firstEventEndTime), ZoneOffset.UTC))
+                .startTime(Instant.ofEpochMilli(firstEventStartTime))
+                .endTime(Instant.ofEpochMilli(firstEventEndTime))
                 .calendarId(calendarId).build());
         // add 10 min event smaller than the bucket
         long secondEventStartTime = 1515067200000L;
         long secondEventEndTime = secondEventStartTime + 10 * 60 * 1000;
         events.add(new ScheduledEvent.Builder().description("2nd event with period smaller than bucketspan")
-                .startTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(secondEventStartTime), ZoneOffset.UTC))
-                .endTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(secondEventEndTime), ZoneOffset.UTC))
+                .startTime(Instant.ofEpochMilli(secondEventStartTime))
+                .endTime(Instant.ofEpochMilli(secondEventEndTime))
                 .calendarId(calendarId).build());
         long thirdEventStartTime = 1515088800000L;
         long thirdEventEndTime = thirdEventStartTime + 3 * 60 * 60 * 1000;
         events.add(new ScheduledEvent.Builder().description("3rd event 3hr")
-                .startTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(thirdEventStartTime), ZoneOffset.UTC))
-                .endTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(thirdEventEndTime), ZoneOffset.UTC))
+                .startTime(Instant.ofEpochMilli(thirdEventStartTime))
+                .endTime(Instant.ofEpochMilli(thirdEventEndTime))
                 .calendarId(calendarId).build());
 
         postScheduledEvents(calendarId, events);
@@ -168,8 +160,8 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
         long firstEventStartTime = startTime + bucketSpan.millis() * bucketCount;
         long firstEventEndTime = firstEventStartTime + bucketSpan.millis() * 2;
         events.add(new ScheduledEvent.Builder().description("1st event 2hr")
-                .startTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(firstEventStartTime), ZoneOffset.UTC))
-                .endTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(firstEventEndTime), ZoneOffset.UTC))
+                .startTime(Instant.ofEpochMilli(firstEventStartTime))
+                .endTime((Instant.ofEpochMilli(firstEventEndTime)))
                 .calendarId(calendarId).build());
         postScheduledEvents(calendarId, events);
 
@@ -217,8 +209,8 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
         long eventStartTime = startTime + (bucketCount + 1) * bucketSpan.millis();
         long eventEndTime = eventStartTime + (long)(1.5 * bucketSpan.millis());
         events.add(new ScheduledEvent.Builder().description("Some Event")
-                .startTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(eventStartTime), ZoneOffset.UTC))
-                .endTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(eventEndTime), ZoneOffset.UTC))
+                .startTime((Instant.ofEpochMilli(eventStartTime)))
+                .endTime((Instant.ofEpochMilli(eventEndTime)))
                 .calendarId(calendarId).build());
 
         postScheduledEvents(calendarId, events);
@@ -287,8 +279,8 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
         long eventStartTime = startTime + (bucketCount + 1) * bucketSpan.millis();
         long eventEndTime = eventStartTime + (long)(1.5 * bucketSpan.millis());
         events.add(new ScheduledEvent.Builder().description("Some Event")
-                .startTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(eventStartTime), ZoneOffset.UTC))
-                .endTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(eventEndTime), ZoneOffset.UTC))
+                .startTime((Instant.ofEpochMilli(eventStartTime)))
+                .endTime((Instant.ofEpochMilli(eventEndTime)))
                 .calendarId(calendarId).build());
 
         postScheduledEvents(calendarId, events);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
@@ -23,46 +23,22 @@ import org.elasticsearch.xpack.core.ml.action.PutJobAction;
 import org.elasticsearch.xpack.core.ml.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.calendars.Calendar;
 import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
-import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
-import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
-import org.elasticsearch.xpack.core.ml.job.config.DetectionRule;
-import org.elasticsearch.xpack.core.ml.job.config.Detector;
-import org.elasticsearch.xpack.core.ml.job.config.Job;
-import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
-import org.elasticsearch.xpack.core.ml.job.config.RuleAction;
-import org.elasticsearch.xpack.core.ml.job.config.RuleScope;
+import org.elasticsearch.xpack.core.ml.job.config.*;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
-import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
-import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCountsTests;
-import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
-import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
-import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.Quantiles;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.*;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
-import org.elasticsearch.xpack.ml.job.persistence.CalendarQueryBuilder;
-import org.elasticsearch.xpack.ml.job.persistence.JobDataCountsPersister;
-import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
-import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
-import org.elasticsearch.xpack.ml.job.persistence.ScheduledEventsQueryBuilder;
+import org.elasticsearch.xpack.ml.job.persistence.*;
 import org.elasticsearch.xpack.ml.job.process.autodetect.params.AutodetectParams;
 import org.junit.Before;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.isIn;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.Is.is;
 
@@ -335,7 +311,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
     }
 
     private ScheduledEvent buildScheduledEvent(String description, ZonedDateTime start, ZonedDateTime end, String calendarId) {
-        return new ScheduledEvent.Builder().description(description).startTime(start).endTime(end).calendarId(calendarId).build();
+        return new ScheduledEvent.Builder().description(description).startTime(start.toInstant()).endTime(end.toInstant()).calendarId(calendarId).build();
     }
 
     public void testGetAutodetectParams() throws Exception {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
@@ -23,22 +23,46 @@ import org.elasticsearch.xpack.core.ml.action.PutJobAction;
 import org.elasticsearch.xpack.core.ml.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.calendars.Calendar;
 import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
-import org.elasticsearch.xpack.core.ml.job.config.*;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
+import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
+import org.elasticsearch.xpack.core.ml.job.config.DetectionRule;
+import org.elasticsearch.xpack.core.ml.job.config.Detector;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
+import org.elasticsearch.xpack.core.ml.job.config.RuleAction;
+import org.elasticsearch.xpack.core.ml.job.config.RuleScope;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
-import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.*;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCountsTests;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.Quantiles;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
-import org.elasticsearch.xpack.ml.job.persistence.*;
+import org.elasticsearch.xpack.ml.job.persistence.CalendarQueryBuilder;
+import org.elasticsearch.xpack.ml.job.persistence.JobDataCountsPersister;
+import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
+import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
+import org.elasticsearch.xpack.ml.job.persistence.ScheduledEventsQueryBuilder;
 import org.elasticsearch.xpack.ml.job.process.autodetect.params.AutodetectParams;
 import org.junit.Before;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.Is.is;
 
@@ -311,7 +335,12 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
     }
 
     private ScheduledEvent buildScheduledEvent(String description, ZonedDateTime start, ZonedDateTime end, String calendarId) {
-        return new ScheduledEvent.Builder().description(description).startTime(start.toInstant()).endTime(end.toInstant()).calendarId(calendarId).build();
+        return new ScheduledEvent.Builder()
+            .description(description)
+            .startTime(start.toInstant())
+            .endTime(end.toInstant())
+            .calendarId(calendarId)
+            .build();
     }
 
     public void testGetAutodetectParams() throws Exception {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/AutodetectControlMsgWriterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/AutodetectControlMsgWriterTests.java
@@ -8,7 +8,11 @@ package org.elasticsearch.xpack.ml.job.process.autodetect.writer;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
-import org.elasticsearch.xpack.core.ml.job.config.*;
+import org.elasticsearch.xpack.core.ml.job.config.DetectionRule;
+import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
+import org.elasticsearch.xpack.core.ml.job.config.ModelPlotConfig;
+import org.elasticsearch.xpack.core.ml.job.config.Operator;
+import org.elasticsearch.xpack.core.ml.job.config.RuleCondition;
 import org.elasticsearch.xpack.ml.job.process.autodetect.params.DataLoadParams;
 import org.elasticsearch.xpack.ml.job.process.autodetect.params.FlushJobParams;
 import org.elasticsearch.xpack.ml.job.process.autodetect.params.TimeRange;
@@ -27,7 +31,9 @@ import java.util.Optional;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class AutodetectControlMsgWriterTests extends ESTestCase {
     private LengthEncodedWriter lengthEncodedWriter;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/AutodetectControlMsgWriterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/AutodetectControlMsgWriterTests.java
@@ -8,11 +8,7 @@ package org.elasticsearch.xpack.ml.job.process.autodetect.writer;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
-import org.elasticsearch.xpack.core.ml.job.config.DetectionRule;
-import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
-import org.elasticsearch.xpack.core.ml.job.config.ModelPlotConfig;
-import org.elasticsearch.xpack.core.ml.job.config.Operator;
-import org.elasticsearch.xpack.core.ml.job.config.RuleCondition;
+import org.elasticsearch.xpack.core.ml.job.config.*;
 import org.elasticsearch.xpack.ml.job.process.autodetect.params.DataLoadParams;
 import org.elasticsearch.xpack.ml.job.process.autodetect.params.FlushJobParams;
 import org.elasticsearch.xpack.ml.job.process.autodetect.params.TimeRange;
@@ -31,9 +27,7 @@ import java.util.Optional;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.*;
 
 public class AutodetectControlMsgWriterTests extends ESTestCase {
     private LengthEncodedWriter lengthEncodedWriter;
@@ -226,14 +220,14 @@ public class AutodetectControlMsgWriterTests extends ESTestCase {
         ScheduledEvent.Builder event1 = new ScheduledEvent.Builder();
         event1.calendarId("moon");
         event1.description("new year");
-        event1.startTime(ZonedDateTime.parse("2018-01-01T00:00:00Z"));
-        event1.endTime(ZonedDateTime.parse("2018-01-02T00:00:00Z"));
+        event1.startTime(ZonedDateTime.parse("2018-01-01T00:00:00Z").toInstant());
+        event1.endTime(ZonedDateTime.parse("2018-01-02T00:00:00Z").toInstant());
 
         ScheduledEvent.Builder event2 = new ScheduledEvent.Builder();
         event2.calendarId("moon");
         event2.description("Jan maintenance day");
-        event2.startTime(ZonedDateTime.parse("2018-01-06T00:00:00Z"));
-        event2.endTime(ZonedDateTime.parse("2018-01-07T00:00:00Z"));
+        event2.startTime(ZonedDateTime.parse("2018-01-06T00:00:00Z").toInstant());
+        event2.endTime(ZonedDateTime.parse("2018-01-07T00:00:00Z").toInstant());
 
         writer.writeUpdateScheduledEventsMessage(Arrays.asList(event1.build(), event2.build()), TimeValue.timeValueHours(1));
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/FieldConfigWriterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/FieldConfigWriterTests.java
@@ -11,12 +11,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
-import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
-import org.elasticsearch.xpack.core.ml.job.config.DetectionRule;
-import org.elasticsearch.xpack.core.ml.job.config.Detector;
-import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
-import org.elasticsearch.xpack.core.ml.job.config.Operator;
-import org.elasticsearch.xpack.core.ml.job.config.RuleCondition;
+import org.elasticsearch.xpack.core.ml.job.config.*;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.ini4j.Config;
 import org.ini4j.Ini;
@@ -30,18 +25,9 @@ import java.io.OutputStreamWriter;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.*;
 
 
 public class FieldConfigWriterTests extends ESTestCase {
@@ -239,12 +225,12 @@ public class FieldConfigWriterTests extends ESTestCase {
         analysisConfig = builder.build();
 
         scheduledEvents.add(new ScheduledEvent.Builder().description("The Ashes")
-                .startTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(1511395200000L), ZoneOffset.UTC))
-                .endTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(1515369600000L), ZoneOffset.UTC))
+                .startTime(Instant.ofEpochMilli(1511395200000L))
+                .endTime(Instant.ofEpochMilli(1515369600000L))
                 .calendarId("calendar_id").build());
         scheduledEvents.add(new ScheduledEvent.Builder().description("elasticon")
-                .startTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(1519603200000L), ZoneOffset.UTC))
-                .endTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(1519862400000L), ZoneOffset.UTC))
+                .startTime(Instant.ofEpochMilli(1519603200000L))
+                .endTime(Instant.ofEpochMilli(1519862400000L))
                 .calendarId("calendar_id").build());
 
         writer = mock(OutputStreamWriter.class);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/FieldConfigWriterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/FieldConfigWriterTests.java
@@ -11,7 +11,12 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
-import org.elasticsearch.xpack.core.ml.job.config.*;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
+import org.elasticsearch.xpack.core.ml.job.config.DetectionRule;
+import org.elasticsearch.xpack.core.ml.job.config.Detector;
+import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
+import org.elasticsearch.xpack.core.ml.job.config.Operator;
+import org.elasticsearch.xpack.core.ml.job.config.RuleCondition;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.ini4j.Config;
 import org.ini4j.Ini;
@@ -25,9 +30,16 @@ import java.io.OutputStreamWriter;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 
 public class FieldConfigWriterTests extends ESTestCase {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/ScheduledEventsWriterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/ScheduledEventsWriterTests.java
@@ -11,8 +11,6 @@ import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -32,12 +30,12 @@ public class ScheduledEventsWriterTests extends ESTestCase {
     public void testWrite() throws IOException {
         List<ScheduledEvent> events = new ArrayList<>();
         events.add(new ScheduledEvent.Builder().description("Black Friday")
-                .startTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(1511395200000L), ZoneOffset.UTC))
-                .endTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(1515369600000L), ZoneOffset.UTC))
+                .startTime(Instant.ofEpochMilli(1511395200000L))
+                .endTime(Instant.ofEpochMilli(1515369600000L))
                 .calendarId("calendar_id").build());
         events.add(new ScheduledEvent.Builder().description("Blue Monday")
-                .startTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(1519603200000L), ZoneOffset.UTC))
-                .endTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(1519862400000L), ZoneOffset.UTC))
+                .startTime(Instant.ofEpochMilli(1519603200000L))
+                .endTime(Instant.ofEpochMilli(1519862400000L))
                 .calendarId("calendar_id").build());
 
         StringBuilder buffer = new StringBuilder();


### PR DESCRIPTION
The ScheduledEvent class has never preserved the time
zone so it makes more sense for it to store the start and
end time using Instant rather than ZonedDateTime.

Closes #38620