### PR TITLE
Use accurate total hits in IndexPrimaryRelocationIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
@@ -100,8 +100,8 @@ public class IndexPrimaryRelocationIT extends ESIntegTestCase {
         finished.set(true);
         indexingThread.join();
         refresh("test");
-        ElasticsearchAssertions.assertHitCount(client().prepareSearch("test").get(), numAutoGenDocs.get());
-        ElasticsearchAssertions.assertHitCount(client().prepareSearch("test")// extra paranoia ;)
+        ElasticsearchAssertions.assertHitCount(client().prepareSearch("test").setTrackTotalHits(true).get(), numAutoGenDocs.get());
+        ElasticsearchAssertions.assertHitCount(client().prepareSearch("test").setTrackTotalHits(true)// extra paranoia ;)
             .setQuery(QueryBuilders.termQuery("auto", true)).get(), numAutoGenDocs.get());
     }
 


### PR DESCRIPTION
fix the test case that sometimes count may large then 10000, the case will fail,set track_total_hits=true to get the exact totalHits.
 
this is the failed case:
```
   1> [2019-02-22T18:30:29,438][INFO ][o.e.i.r.IndexPrimaryRelocationIT] [testPrimaryRelocationWhileIndexing] after test
FAILURE  122s J4 | IndexPrimaryRelocationIT.testPrimaryRelocationWhileIndexing <<< FAILURES!
   > Throwable #1: java.lang.AssertionError: Count is 10000+ hits but 11684 was expected.  Total shards: 1 Successful shards: 1 & 0 shard failures:
   >    at __randomizedtesting.SeedInfo.seed([F1177EA7F24A834A:AFB8E7F2A7BAFF31]:0)
   >    at org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount(ElasticsearchAssertions.java:256)
   >    at org.elasticsearch.indices.recovery.IndexPrimaryRelocationIT.testPrimaryRelocationWhileIndexing(IndexPrimaryRelocationIT.java:103)
   >    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
   >    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
   >    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
   >    at java.base/java.lang.reflect.Method.invoke(Method.java:566)
   >    at java.base/java.lang.Thread.run(Thread.java:834)
Completed [309/319] on J4 in 121.92s, 1 test, 1 failure <<< FAILURES!
```