### PR TITLE
fix UpdateSettingsRequestStreamableTests.mutateInstance

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequestStreamableTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequestStreamableTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.settings.put;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.Settings.Builder;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.test.AbstractStreamableTestCase;
 import org.elasticsearch.test.ESTestCase;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.function.Supplier;
 
 public class UpdateSettingsRequestStreamableTests extends AbstractStreamableTestCase<UpdateSettingsRequest> {
 
@@ -39,9 +41,10 @@ public class UpdateSettingsRequestStreamableTests extends AbstractStreamableTest
     protected UpdateSettingsRequest mutateInstance(UpdateSettingsRequest request) {
         UpdateSettingsRequest mutation = copyRequest(request);
         List<Runnable> mutators = new ArrayList<>();
+        Supplier<TimeValue> timeValueSupplier = () -> TimeValue.parseTimeValue(ESTestCase.randomTimeValue(), "_setting");
         mutators.add(() -> mutation
-                .masterNodeTimeout(randomValueOtherThan(request.masterNodeTimeout().getStringRep(), ESTestCase::randomTimeValue)));
-        mutators.add(() -> mutation.timeout(randomValueOtherThan(request.timeout().getStringRep(), ESTestCase::randomTimeValue)));
+                .masterNodeTimeout(randomValueOtherThan(request.masterNodeTimeout(), timeValueSupplier)));
+        mutators.add(() -> mutation.timeout(randomValueOtherThan(request.timeout(), timeValueSupplier)));
         mutators.add(() -> mutation.settings(mutateSettings(request.settings())));
         mutators.add(() -> mutation.indices(mutateIndices(request.indices())));
         mutators.add(() -> mutation.indicesOptions(randomValueOtherThan(request.indicesOptions(),


### PR DESCRIPTION
Mutations of the timeout values were using string-representations.

This resulted in very rare cases where the original timeout value was
represented as something like "0ms" and the new random time-value generated
was "0s". Although their string representations differ, their underlying
TimeValue does not. This resulted in `-Dtests.seed=7F4C034C43C22B1B` to
fail.

Now, new TimeValue objects are being supplied and tested in the randomization equality check.

CI failure:

link: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+intake/2222

reproduction: 

```./gradlew :server:unitTest -Dtests.seed=7F4C034C43C22B1B -Dtests.class=org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequestStreamableTests -Dtests.method="testEqualsAndHashcode" -Dtests.security.manager=true -Dtests.locale=no-NO -Dtests.timezone=Asia/Beirut -Dcompiler.java=11 -Druntime.java=8```

error message:

```
04:03:35 FAILURE 0.02s J5 | UpdateSettingsRequestStreamableTests.testEqualsAndHashcode <<< FAILURES!
04:03:35    > Throwable #1: java.lang.AssertionError: UpdateSettingsRequest mutation should not be equal to original
04:03:35    > Expected: not <indices : [index-wtwix, index-rga],{}>
04:03:35    >      but: was <indices : [index-wtwix, index-rga],{}>
04:03:35    > 	at __randomizedtesting.SeedInfo.seed([7F4C034C43C22B1B:E437B818C256234]:0)
04:03:35    > 	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
04:03:35    > 	at org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode(EqualsHashCodeTestUtils.java:82)
04:03:35    > 	at org.elasticsearch.test.AbstractWireTestCase.testEqualsAndHashcode(AbstractWireTestCase.java:61)
```