### PR TITLE
Conditionally build BWC projects in parallel

### DIFF
--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -207,6 +207,9 @@ bwcVersions.forPreviousUnreleased { VersionCollection.UnreleasedVersionInfo unre
             } else if (showStacktraceName.equals("ALWAYS_FULL")) {
                 args "--full-stacktrace"
             }
+            if (gradle.getStartParameter().isParallelProjectExecutionEnabled()) {
+                args "--parallel"
+            }
             standardOutput = new IndentingOutputStream(System.out, bwcVersion)
             errorOutput = new IndentingOutputStream(System.err, bwcVersion)
             configure extraConfig


### PR DESCRIPTION
This commit sets the BWC projects to build in parallel if Gradle was invoked with parallal project execution enabled. This substantially speeds up the time of building the BWC projects since there are many dependent projects needed to build a BWC version.
