### PR TITLE
Don't do BWC packaing tests if disabled

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -191,26 +191,32 @@ class VagrantTestPlugin implements Plugin<Project> {
             dependencies.add(project.dependencies.project(path: ":distribution:${it}", configuration: 'default'))
         }
 
-        // The version of elasticsearch that we upgrade *from*
-        VersionCollection.UnreleasedVersionInfo unreleasedInfo = project.bwcVersions.unreleasedInfo(upgradeFromVersion)
-        if (unreleasedInfo != null) {
-            // handle snapshots pointing to bwc build
-            UPGRADE_FROM_ARCHIVES.each {
-                dependencies.add(project.dependencies.project(
-                        path: ":distribution:bwc:${unreleasedInfo.gradleProjectName}", configuration: it))
-                if (upgradeFromVersion.onOrAfter('6.3.0')) {
+        if (project.ext.bwc_tests_enabled) {
+            // The version of elasticsearch that we upgrade *from*
+            // we only add them as dependencies if the bwc tests are enabled, so we don't trigger builds otherwise
+            VersionCollection.UnreleasedVersionInfo unreleasedInfo = project.bwcVersions.unreleasedInfo(upgradeFromVersion)
+            if (unreleasedInfo != null) {
+                // handle snapshots pointing to bwc build
+                UPGRADE_FROM_ARCHIVES.each {
                     dependencies.add(project.dependencies.project(
-                            path: ":distribution:bwc:${unreleasedInfo.gradleProjectName}", configuration: "oss-${it}"))
+                            path: ":distribution:bwc:${unreleasedInfo.gradleProjectName}", configuration: it))
+                    if (upgradeFromVersion.onOrAfter('6.3.0')) {
+                        dependencies.add(project.dependencies.project(
+                                path: ":distribution:bwc:${unreleasedInfo.gradleProjectName}", configuration: "oss-${it}"))
+                    }
+                }
+            } else {
+                UPGRADE_FROM_ARCHIVES.each {
+                    // The version of elasticsearch that we upgrade *from*
+                    dependencies.add("downloads.${it}:elasticsearch:${upgradeFromVersion}@${it}")
+                    if (upgradeFromVersion.onOrAfter('6.3.0')) {
+                        dependencies.add("downloads.${it}:elasticsearch-oss:${upgradeFromVersion}@${it}")
+                    }
                 }
             }
         } else {
-            UPGRADE_FROM_ARCHIVES.each {
-                // The version of elasticsearch that we upgrade *from*
-                dependencies.add("downloads.${it}:elasticsearch:${upgradeFromVersion}@${it}")
-                if (upgradeFromVersion.onOrAfter('6.3.0')) {
-                    dependencies.add("downloads.${it}:elasticsearch-oss:${upgradeFromVersion}@${it}")
-                }
-            }
+            // Upgrade tests will go from current to current when the BWC tests are disabled to skip real BWC tests.
+            upgradeFromVersion = Version.fromString(project.version)
         }
 
         for (Object dependency : dependencies) {


### PR DESCRIPTION
Packaging tests did not honor bwc tests being off.
We run bwc versions if there's any dependency on them, so this is the 
reason for which we were building  the BWC versions
even if the tests are tured off, so this also closes #35347.

The upgrade tests already know how to deal with the "from version" being current.


