### PR TITLE
Removed incorrect test

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -236,24 +236,6 @@
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             }
           }
-  - do:
-      catch: param
-      ml.put_job:
-        job_id: jobs-crud-id-already-taken
-        body:  >
-          {
-            "job_id":"jobs-crud-id-already-taken",
-            "description":"Analysis of response time by airline",
-            "analysis_config" : {
-                "bucket_span": "1h",
-                "detectors" :[{"function":"metric","field_name":"responsetime","by_field_name":"airline"}]
-            },
-            "data_description" : {
-                "field_delimiter":",",
-                "time_field":"time",
-                "time_format":"yyyy-MM-dd HH:mm:ssX"
-            }
-          }
 
 ---
 "Test update job":


### PR DESCRIPTION
There is no need for this test since the clients will only validate parameters, and not logic/state (eg, a client cannot know that the `job_id` is already taken).

cc @elastic/es-clients