### PR TITLE
[DATA-FRAME-ANALYTICS] Add task recovery on node change 

### DIFF
--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     compileOnly project(path: xpackModule('core'), configuration: 'default')
     compileOnly "org.elasticsearch.plugin:elasticsearch-scripting-painless-spi:${versions.elasticsearch}"
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    testCompile project(':modules:lang-painless')
     // This should not be here
     testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
 
@@ -100,6 +101,7 @@ task internalClusterTest(type: RandomizedTestingTask,
                          dependsOn: unitTest.dependsOn) {
   include '**/*IT.class'
   systemProperty 'es.set.netty.runtime.available.processors', 'false'
+  systemProperties 'java.security.policy': file("src/main/plugin-metadata/plugin-security-test.policy").absolutePath
 }
 check.dependsOn internalClusterTest
 internalClusterTest.mustRunAfter test

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -100,8 +100,7 @@ public class DataFrameAnalyticsManager {
                         break;
                     // The task has fully reindexed the documents and we should continue on with our analyses
                     case ANALYZING:
-                        // TODO determine where to start analytics again???
-                        // For outlier detection, there is no saved model state, so it has to be rebuilt anyways
+                        // TODO apply previously stored model state if applicable
                         startAnalytics(task, config);
                         break;
                     // If we are already at REINDEXING, we are not 100% sure if we reindexed ALL the docs.
@@ -152,7 +151,7 @@ public class DataFrameAnalyticsManager {
                     RefreshAction.INSTANCE,
                     new RefreshRequest(config.getDest()),
                     refreshListener),
-            e -> task.markAsFailed(e)
+            task::markAsFailed
         );
 
         // Reindex
@@ -197,7 +196,7 @@ public class DataFrameAnalyticsManager {
                     task::markAsFailed
                 ));
             },
-            e -> task.markAsFailed(e)
+            task::markAsFailed
         );
 
         // TODO This could fail with errors. In that case we get stuck with the copied index.

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/analyses/DataFrameAnalysis.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/analyses/DataFrameAnalysis.java
@@ -10,6 +10,7 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 public interface DataFrameAnalysis extends ToXContentObject {
 
@@ -31,6 +32,13 @@ public interface DataFrameAnalysis extends ToXContentObject {
     }
 
     Type getType();
+
+    /**
+     * The fields that will contain the results of the analysis
+     *
+     * @return Set of Strings representing the result fields for the constructed analysis
+     */
+    Set<String> getResultFields();
 
     interface Factory {
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/analyses/OutlierDetection.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/analyses/OutlierDetection.java
@@ -5,9 +5,12 @@
  */
 package org.elasticsearch.xpack.ml.dataframe.analyses;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 public class OutlierDetection extends AbstractDataFrameAnalysis {
 
@@ -26,6 +29,13 @@ public class OutlierDetection extends AbstractDataFrameAnalysis {
 
     public static final String NUMBER_NEIGHBOURS = "number_neighbours";
     public static final String METHOD = "method";
+
+    private static final Set<String> RESULT_FIELDS;
+    static {
+        Set<String> set = new LinkedHashSet<>();
+        set.add("outlier_score");
+        RESULT_FIELDS = Collections.unmodifiableSet(set);
+    }
 
     private final Integer numberNeighbours;
     private final Method method;
@@ -50,6 +60,11 @@ public class OutlierDetection extends AbstractDataFrameAnalysis {
             params.put(METHOD, method);
         }
         return params;
+    }
+
+    @Override
+    public Set<String> getResultFields() {
+        return RESULT_FIELDS;
     }
 
     static class Factory implements DataFrameAnalysis.Factory {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
@@ -140,6 +140,7 @@ public class DataFrameDataExtractorFactory {
                                                  FieldCapabilitiesResponse fieldCapabilitiesResponse) {
         Set<String> fields = fieldCapabilitiesResponse.get().keySet();
         fields.removeAll(IGNORE_FIELDS);
+        // TODO a better solution may be to have some sort of known prefix and filtering that
         fields.removeAll(resultFields);
         removeFieldsWithIncompatibleTypes(fields, fieldCapabilitiesResponse);
         includeAndExcludeFields(fields, desiredFields, index);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
@@ -25,6 +25,8 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.ml.utils.NameResolver;
 import org.elasticsearch.xpack.ml.datafeed.extractor.fields.ExtractedField;
 import org.elasticsearch.xpack.ml.datafeed.extractor.fields.ExtractedFields;
+import org.elasticsearch.xpack.ml.dataframe.analyses.DataFrameAnalysesUtils;
+import org.elasticsearch.xpack.ml.dataframe.analyses.DataFrameAnalysis;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -99,10 +101,13 @@ public class DataFrameDataExtractorFactory {
     public static void create(Client client,
                               DataFrameAnalyticsConfig config,
                               ActionListener<DataFrameDataExtractorFactory> listener) {
-        validateIndexAndExtractFields(client, config.getHeaders(), config.getDest(), config.getAnalysesFields(), ActionListener.wrap(
-            extractedFields -> listener.onResponse(
-                new DataFrameDataExtractorFactory(client, config.getId(), config.getDest(), extractedFields, config.getHeaders())),
-            listener::onFailure
+        List<DataFrameAnalysis> analyses = DataFrameAnalysesUtils.readAnalyses(config.getAnalyses());
+        Set<String> resultFields = analyses.stream().flatMap(analysis -> analysis.getResultFields().stream()).collect(Collectors.toSet());
+        validateIndexAndExtractFields(client, config.getHeaders(), config.getDest(), config.getAnalysesFields(), resultFields,
+            ActionListener.wrap(
+                extractedFields -> listener.onResponse(
+                    new DataFrameDataExtractorFactory(client, config.getId(), config.getDest(), extractedFields, config.getHeaders())),
+                listener::onFailure
         ));
     }
 
@@ -116,21 +121,26 @@ public class DataFrameDataExtractorFactory {
     public static void validateConfigAndSourceIndex(Client client,
                                                     DataFrameAnalyticsConfig config,
                                                     ActionListener<Boolean> listener) {
-        validateIndexAndExtractFields(client, config.getHeaders(), config.getSource(), config.getAnalysesFields(), ActionListener.wrap(
-            fields -> {
-                config.getParsedQuery(); // validate query is acceptable
-                listener.onResponse(true);
-            },
-            listener::onFailure
+        List<DataFrameAnalysis> analyses = DataFrameAnalysesUtils.readAnalyses(config.getAnalyses());
+        Set<String> resultFields = analyses.stream().flatMap(analysis -> analysis.getResultFields().stream()).collect(Collectors.toSet());
+        validateIndexAndExtractFields(client, config.getHeaders(), config.getSource(), config.getAnalysesFields(), resultFields,
+            ActionListener.wrap(
+                fields -> {
+                    config.getParsedQuery(); // validate query is acceptable
+                    listener.onResponse(true);
+                },
+                listener::onFailure
         ));
     }
 
     // Visible for testing
     static ExtractedFields detectExtractedFields(String index,
                                                  FetchSourceContext desiredFields,
+                                                 Set<String> resultFields,
                                                  FieldCapabilitiesResponse fieldCapabilitiesResponse) {
         Set<String> fields = fieldCapabilitiesResponse.get().keySet();
         fields.removeAll(IGNORE_FIELDS);
+        fields.removeAll(resultFields);
         removeFieldsWithIncompatibleTypes(fields, fieldCapabilitiesResponse);
         includeAndExcludeFields(fields, desiredFields, index);
         List<String> sortedFields = new ArrayList<>(fields);
@@ -190,10 +200,12 @@ public class DataFrameDataExtractorFactory {
                                                       Map<String, String> headers,
                                                       String index,
                                                       FetchSourceContext desiredFields,
+                                                      Set<String> resultFields,
                                                       ActionListener<ExtractedFields> listener) {
         // Step 2. Extract fields (if possible) and notify listener
         ActionListener<FieldCapabilitiesResponse> fieldCapabilitiesHandler = ActionListener.wrap(
-            fieldCapabilitiesResponse -> listener.onResponse(detectExtractedFields(index, desiredFields, fieldCapabilitiesResponse)),
+            fieldCapabilitiesResponse -> listener.onResponse(
+                detectExtractedFields(index, desiredFields, resultFields, fieldCapabilitiesResponse)),
             e -> {
                 if (e instanceof IndexNotFoundException) {
                     listener.onFailure(new ResourceNotFoundException("cannot retrieve data because index "

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
@@ -101,8 +101,7 @@ public class DataFrameDataExtractorFactory {
     public static void create(Client client,
                               DataFrameAnalyticsConfig config,
                               ActionListener<DataFrameDataExtractorFactory> listener) {
-        List<DataFrameAnalysis> analyses = DataFrameAnalysesUtils.readAnalyses(config.getAnalyses());
-        Set<String> resultFields = analyses.stream().flatMap(analysis -> analysis.getResultFields().stream()).collect(Collectors.toSet());
+        Set<String> resultFields = resolveResultsFields(config);
         validateIndexAndExtractFields(client, config.getHeaders(), config.getDest(), config.getAnalysesFields(), resultFields,
             ActionListener.wrap(
                 extractedFields -> listener.onResponse(
@@ -121,8 +120,7 @@ public class DataFrameDataExtractorFactory {
     public static void validateConfigAndSourceIndex(Client client,
                                                     DataFrameAnalyticsConfig config,
                                                     ActionListener<Boolean> listener) {
-        List<DataFrameAnalysis> analyses = DataFrameAnalysesUtils.readAnalyses(config.getAnalyses());
-        Set<String> resultFields = analyses.stream().flatMap(analysis -> analysis.getResultFields().stream()).collect(Collectors.toSet());
+        Set<String> resultFields = resolveResultsFields(config);
         validateIndexAndExtractFields(client, config.getHeaders(), config.getSource(), config.getAnalysesFields(), resultFields,
             ActionListener.wrap(
                 fields -> {
@@ -226,5 +224,10 @@ public class DataFrameDataExtractorFactory {
             // This response gets discarded - the listener handles the real response
             return null;
         });
+    }
+
+    private static Set<String> resolveResultsFields(DataFrameAnalyticsConfig config) {
+        List<DataFrameAnalysis> analyses = DataFrameAnalysesUtils.readAnalyses(config.getAnalyses());
+        return analyses.stream().flatMap(analysis -> analysis.getResultFields().stream()).collect(Collectors.toSet());
     }
 }

--- a/x-pack/plugin/ml/src/main/plugin-metadata/plugin-security-test.policy
+++ b/x-pack/plugin/ml/src/main/plugin-metadata/plugin-security-test.policy
@@ -1,0 +1,5 @@
+// Needed for painless script to run
+grant {
+  // needed to create the classloader which allows plugins to extend other plugins
+  permission java.lang.RuntimePermission "createClassLoader";
+};

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsManagerIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsManagerIT.java
@@ -164,7 +164,7 @@ public class DataFrameAnalyticsManagerIT extends BaseMlIntegTestCase {
         String id = "test_outlier_detection_from_analyze_state";
         DataFrameAnalyticsConfig config = buildOutlierDetectionAnalytics(id, sourceIndex);
         putDataFrameAnalyticsConfig(config);
-        // Create the "results" index, as if we ran reindex already in the process, but did not transition from the state properly
+        // Create the "results" index to simulate running reindex already and having partially ran analysis
         createAnalysesResultsIndex(config.getDest(), true);
         List<AnalyticsResult> results = buildExpectedResults(sourceIndex);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsManagerIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsManagerIT.java
@@ -1,0 +1,410 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.analysis.common.CommonAnalysisPlugin;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.index.reindex.ReindexPlugin;
+import org.elasticsearch.painless.PainlessPlugin;
+import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.transport.Netty4Plugin;
+import org.elasticsearch.xpack.core.XPackClientPlugin;
+import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalysisConfig;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
+import org.elasticsearch.xpack.ml.LocalStateMachineLearning;
+import org.elasticsearch.xpack.ml.action.TransportStartDataFrameAnalyticsAction.DataFrameAnalyticsTask;
+import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsFields;
+import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsManager;
+import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
+import org.elasticsearch.xpack.ml.dataframe.process.AnalyticsProcess;
+import org.elasticsearch.xpack.ml.dataframe.process.AnalyticsProcessConfig;
+import org.elasticsearch.xpack.ml.dataframe.process.AnalyticsProcessFactory;
+import org.elasticsearch.xpack.ml.dataframe.process.AnalyticsProcessManager;
+import org.elasticsearch.xpack.ml.dataframe.process.AnalyticsResult;
+import org.elasticsearch.xpack.ml.dataframe.process.results.RowResults;
+import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
+import org.junit.Assert;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+
+public class DataFrameAnalyticsManagerIT extends BaseMlIntegTestCase {
+
+    private volatile boolean finished;
+    private DataFrameAnalyticsConfigProvider provider;
+    private static double EXPECTED_OUTLIER_SCORE = 42.0;
+    @Before
+    public void fieldSetup() {
+        provider = new DataFrameAnalyticsConfigProvider(client());
+        finished = false;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(LocalStateMachineLearning.class, CommonAnalysisPlugin.class,
+            ReindexPlugin.class, PainlessPlugin.class);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> transportClientPlugins() {
+        return Arrays.asList(XPackClientPlugin.class, Netty4Plugin.class, PainlessPlugin.class, ReindexPlugin.class);
+    }
+
+    public void testTaskContinuationFromReindexState() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(1);
+        ensureStableCluster(1);
+        String sourceIndex = "test-outlier-detection-from-reindex-state";
+        createIndexForAnalysis(sourceIndex);
+        String id = "test_outlier_detection_from_reindex_state";
+        DataFrameAnalyticsConfig config = buildOutlierDetectionAnalytics(id, sourceIndex);
+        putDataFrameAnalyticsConfig(config);
+        List<AnalyticsResult> results = buildExpectedResults(sourceIndex);
+
+        DataFrameAnalyticsManager manager = createManager(results);
+
+        DataFrameAnalyticsTask task = buildMockedTask(config.getId());
+        manager.execute(task, DataFrameAnalyticsState.REINDEXING);
+
+        // wait for markAsCompleted() or markAsFailed() to be called;
+        assertBusy(() -> assertTrue(isCompleted()), 120, TimeUnit.SECONDS);
+
+        // Check we've got all docs
+        SearchResponse searchResponse = client().prepareSearch(config.getDest()).setTrackTotalHits(true).get();
+        Assert.assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) 5));
+        for(SearchHit hit : searchResponse.getHits().getHits()) {
+            Map<String, Object> src = hit.getSourceAsMap();
+            assertNotNull(src.get("outlier_score"));
+            assertThat(src.get("outlier_score"), equalTo(EXPECTED_OUTLIER_SCORE));
+        }
+
+        verify(task, never()).markAsFailed(any(Exception.class));
+        verify(task, times(1)).markAsCompleted();
+    }
+
+    public void testTaskContinuationFromReindexStateWithPreviousResultsIndex() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(1);
+        ensureStableCluster(1);
+        String sourceIndex = "test-outlier-detection-from-reindex-state-with-results";
+        createIndexForAnalysis(sourceIndex);
+        String id = "test_outlier_detection_from_reindex_state_with_results";
+        DataFrameAnalyticsConfig config = buildOutlierDetectionAnalytics(id, sourceIndex);
+        putDataFrameAnalyticsConfig(config);
+
+        // Create the "results" index, as if we ran reindex already in the process, but did not transition from the state properly
+        createAnalysesResultsIndex(config.getDest(), false);
+        List<AnalyticsResult> results = buildExpectedResults(sourceIndex);
+
+        DataFrameAnalyticsManager manager = createManager(results);
+
+        DataFrameAnalyticsTask task = buildMockedTask(config.getId());
+        manager.execute(task, DataFrameAnalyticsState.REINDEXING);
+
+        // wait for markAsCompleted() or markAsFailed() to be called;
+        assertBusy(() -> assertTrue(isCompleted()), 120, TimeUnit.SECONDS);
+
+        // Check we've got all docs
+        SearchResponse searchResponse = client().prepareSearch(config.getDest()).setTrackTotalHits(true).get();
+        Assert.assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) 5));
+        for(SearchHit hit : searchResponse.getHits().getHits()) {
+            Map<String, Object> src = hit.getSourceAsMap();
+            assertNotNull(src.get("outlier_score"));
+            assertThat(src.get("outlier_score"), equalTo(EXPECTED_OUTLIER_SCORE));
+        }
+
+        verify(task, never()).markAsFailed(any(Exception.class));
+        verify(task, times(1)).markAsCompleted();
+    }
+
+    public void testTaskContinuationFromAnalyzeState() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(1);
+        ensureStableCluster(1);
+        String sourceIndex = "test-outlier-detection-from-analyze-state";
+        createIndexForAnalysis(sourceIndex);
+        String id = "test_outlier_detection_from_analyze_state";
+        DataFrameAnalyticsConfig config = buildOutlierDetectionAnalytics(id, sourceIndex);
+        putDataFrameAnalyticsConfig(config);
+        // Create the "results" index, as if we ran reindex already in the process, but did not transition from the state properly
+        createAnalysesResultsIndex(config.getDest(), true);
+        List<AnalyticsResult> results = buildExpectedResults(sourceIndex);
+
+        DataFrameAnalyticsManager manager = createManager(results);
+
+        DataFrameAnalyticsTask task = buildMockedTask(config.getId());
+        manager.execute(task, DataFrameAnalyticsState.ANALYZING);
+
+        // wait for markAsCompleted() or markAsFailed() to be called;
+        assertBusy(() -> assertTrue(isCompleted()), 120, TimeUnit.SECONDS);
+
+        // Check we've got all docs
+        SearchResponse searchResponse = client().prepareSearch(config.getDest()).setTrackTotalHits(true).get();
+        Assert.assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) 5));
+        for(SearchHit hit : searchResponse.getHits().getHits()) {
+            Map<String, Object> src = hit.getSourceAsMap();
+            assertNotNull(src.get("outlier_score"));
+            assertThat(src.get("outlier_score"), equalTo(EXPECTED_OUTLIER_SCORE));
+        }
+
+        verify(task, never()).markAsFailed(any(Exception.class));
+        verify(task, times(1)).markAsCompleted();
+        // Need to verify that we did not reindex again, as we already had the full destination index
+        verify(task, never()).setReindexingTaskId(anyLong());
+    }
+
+    private synchronized void completed() {
+        finished = true;
+    }
+
+    private synchronized boolean isCompleted() {
+        return finished;
+    }
+
+    private static DataFrameAnalyticsConfig buildOutlierDetectionAnalytics(String id, String sourceIndex) {
+        DataFrameAnalyticsConfig.Builder configBuilder = new DataFrameAnalyticsConfig.Builder(id);
+        configBuilder.setSource(sourceIndex);
+        configBuilder.setDest(sourceIndex + "-results");
+        Map<String, Object> analysisConfig = new HashMap<>();
+        analysisConfig.put("outlier_detection", Collections.emptyMap());
+        configBuilder.setAnalyses(Collections.singletonList(new DataFrameAnalysisConfig(analysisConfig)));
+        return configBuilder.build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void putDataFrameAnalyticsConfig(DataFrameAnalyticsConfig config) throws Exception {
+        PlainActionFuture future = new PlainActionFuture();
+        provider.put(config, Collections.emptyMap(), future);
+        future.get();
+    }
+
+    private void createIndexForAnalysis(String indexName) {
+        client().admin().indices().prepareCreate(indexName)
+            .addMapping("_doc", "numeric_1", "type=double", "numeric_2", "type=float", "categorical_1", "type=keyword")
+            .get();
+
+        BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
+        bulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        for (int i = 0; i < 5; i++) {
+            IndexRequest indexRequest = new IndexRequest(indexName);
+
+            // We insert one odd value out of 5 for one feature
+            String docId = i == 0 ? "outlier" : "normal" + i;
+            indexRequest.id(docId);
+            indexRequest.source("numeric_1", i == 0 ? 100.0 : 1.0, "numeric_2", 1.0, "categorical_1", "foo_" + i);
+            bulkRequestBuilder.add(indexRequest);
+        }
+        BulkResponse bulkResponse = bulkRequestBuilder.get();
+        if (bulkResponse.hasFailures()) {
+            Assert.fail("Failed to index data: " + bulkResponse.buildFailureMessage());
+        }
+    }
+
+    private void createAnalysesResultsIndex(String indexName, boolean includeOutlierScore) {
+        client().admin().indices().prepareCreate(indexName)
+            .addMapping("_doc",
+                "numeric_1", "type=double",
+                "numeric_2", "type=float",
+                "categorical_1", "type=keyword",
+                DataFrameAnalyticsFields.ID, "type=keyword")
+            .get();
+
+        BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
+        bulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        for (int i = 0; i < 5; i++) {
+            IndexRequest indexRequest = new IndexRequest(indexName);
+
+            // We insert one odd value out of 5 for one feature
+            String docId = i == 0 ? "outlier" : "normal" + i;
+            indexRequest.id(docId);
+            if (includeOutlierScore) {
+                indexRequest.source("numeric_1", i == 0 ? 100.0 : 1.0,
+                    "numeric_2", 1.0,
+                    "categorical_1", "foo_" + i,
+                    DataFrameAnalyticsFields.ID, docId,
+                    "outlier_score", 10.0); // simply needs to be a score different than expected
+            } else {
+                indexRequest.source("numeric_1", i == 0 ? 100.0 : 1.0,
+                    "numeric_2", 1.0,
+                    "categorical_1", "foo_" + i,
+                    DataFrameAnalyticsFields.ID, docId);
+            }
+            bulkRequestBuilder.add(indexRequest);
+        }
+        BulkResponse bulkResponse = bulkRequestBuilder.get();
+        if (bulkResponse.hasFailures()) {
+            Assert.fail("Failed to index data: " + bulkResponse.buildFailureMessage());
+        }
+    }
+
+    private List<AnalyticsResult> buildExpectedResults(String index) throws Exception {
+        SearchHit[] hits = client().search(new SearchRequest(index)).get().getHits().getHits();
+        Arrays.sort(hits, Comparator.comparing(SearchHit::getId));
+        List<AnalyticsResult> results = new ArrayList<>(hits.length);
+        for (SearchHit hit : hits) {
+            String[] fields = new String[2];
+            Map<String, Object> src = hit.getSourceAsMap();
+            fields[0] = src.get("numeric_1").toString();
+            fields[1] = src.get("numeric_2").toString();
+            results.add(new AnalyticsResult(new RowResults(Arrays.hashCode(fields),
+                Collections.singletonMap("outlier_score", EXPECTED_OUTLIER_SCORE)),null));
+        }
+        return results;
+    }
+
+    private DataFrameAnalyticsManager createManager(List<AnalyticsResult> expectedResults) {
+        AnalyticsProcessFactory factory = new MockedAnalyticsFactory(expectedResults);
+        AnalyticsProcessManager processManager = new AnalyticsProcessManager(client(),
+            TestEnvironment.newEnvironment(internalCluster().getDefaultSettings()),
+            client().threadPool(),
+            factory);
+        return new DataFrameAnalyticsManager(clusterService(), (NodeClient)internalCluster().dataNodeClient(), provider, processManager);
+    }
+
+    @SuppressWarnings("unchecked")
+    private DataFrameAnalyticsTask buildMockedTask(String id) {
+        StartDataFrameAnalyticsAction.TaskParams params = new StartDataFrameAnalyticsAction.TaskParams(id);
+        DataFrameAnalyticsTask task = mock(DataFrameAnalyticsTask.class);
+        when(task.getParams()).thenReturn(params);
+        when(task.getAllocationId()).thenReturn(1L);
+        doAnswer(invoked -> {
+            client().threadPool().executor("listener").execute(() -> {
+                ActionListener listener = (ActionListener) invoked.getArguments()[1];
+                final PersistentTasksCustomMetaData.PersistentTask<?> resp = new PersistentTasksCustomMetaData.PersistentTask<>(id,
+                    MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
+                    params,
+                    1,
+                    new PersistentTasksCustomMetaData.Assignment(null, "none"));
+                listener.onResponse(resp);
+            });
+            return null;
+        }).when(task).updatePersistentTaskState(any(DataFrameAnalyticsTaskState.class), any(ActionListener.class));
+        doNothing().when(task).setReindexingTaskId(anyLong());
+        doAnswer(invoked -> {
+            completed();
+            return null;
+        }).when(task).markAsCompleted();
+        doAnswer(invoked -> {
+            completed();
+            Exception e = (Exception)invoked.getArguments()[0];
+            fail(e.getMessage());
+            return null;
+        }).when(task).markAsFailed(any(Exception.class));
+        return task;
+    }
+
+    class MockedAnalyticsFactory implements AnalyticsProcessFactory {
+        final List<AnalyticsResult> results;
+
+        MockedAnalyticsFactory(List<AnalyticsResult> resultsToSupply) {
+            this.results = resultsToSupply;
+        }
+        @Override
+        public AnalyticsProcess createAnalyticsProcess(String jobId,
+                                                       AnalyticsProcessConfig analyticsProcessConfig,
+                                                       ExecutorService executorService) {
+            return new MockedAnalyticsProcess(results);
+        }
+    }
+
+    class MockedAnalyticsProcess implements AnalyticsProcess {
+
+        final List<AnalyticsResult> results;
+        final ZonedDateTime start;
+        MockedAnalyticsProcess(List<AnalyticsResult> resultsToSupply) {
+            results = resultsToSupply;
+            start = ZonedDateTime.now();
+        }
+
+        @Override
+        public void writeEndOfDataMessage() throws IOException { }
+
+        @Override
+        public Iterator<AnalyticsResult> readAnalyticsResults() {
+            return results.iterator();
+        }
+
+        @Override
+        public void consumeAndCloseOutputStream() { }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void writeRecord(String[] record) throws IOException { }
+
+        @Override
+        public void persistState() throws IOException { }
+
+        @Override
+        public void flushStream() throws IOException { }
+
+        @Override
+        public void kill() throws IOException { }
+
+        @Override
+        public ZonedDateTime getProcessStartTime() {
+            return start;
+        }
+
+        @Override
+        public boolean isProcessAlive() {
+            return true;
+        }
+
+        @Override
+        public boolean isProcessAliveAfterWaiting() {
+            return false;
+        }
+
+        @Override
+        public String readError() {
+            return null;
+        }
+
+        @Override
+        public void close() throws IOException { }
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
@@ -29,8 +29,11 @@ import org.elasticsearch.test.MockHttpTransport;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
 import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
+import org.elasticsearch.xpack.core.ml.action.DeleteDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.DeleteDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.DeleteJobAction;
+import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsAction;
+import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsAction;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetJobsAction;
@@ -40,6 +43,8 @@ import org.elasticsearch.xpack.core.ml.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.client.MachineLearningClient;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisLimits;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
@@ -206,6 +211,7 @@ public abstract class BaseMlIntegTestCase extends ESIntegTestCase {
         logger.info("[{}#{}]: Cleaning up datafeeds and jobs after test", getTestClass().getSimpleName(), getTestName());
         deleteAllDatafeeds(logger, client());
         deleteAllJobs(logger, client());
+        deleteAllDataFrameAnalytics(client());
         assertBusy(() -> {
             RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries()
                     .setActiveOnly(true)
@@ -346,6 +352,21 @@ public abstract class BaseMlIntegTestCase extends ESIntegTestCase {
             AcknowledgedResponse response =
                     client.execute(DeleteJobAction.INSTANCE, new DeleteJobAction.Request(job.getId())).get();
             assertTrue(response.isAcknowledged());
+        }
+    }
+
+    public static void deleteAllDataFrameAnalytics(Client client) throws Exception {
+        final QueryPage<DataFrameAnalyticsConfig> analytics =
+            client.execute(GetDataFrameAnalyticsAction.INSTANCE,
+                new GetDataFrameAnalyticsAction.Request("_all")).get().getResources();
+
+        assertBusy(() -> {
+            GetDataFrameAnalyticsStatsAction.Response statsResponse =
+                client().execute(GetDataFrameAnalyticsStatsAction.INSTANCE, new GetDataFrameAnalyticsStatsAction.Request("_all")).get();
+            assertTrue(statsResponse.getResponse().results().stream().allMatch(s -> s.getState().equals(DataFrameAnalyticsState.STOPPED)));
+        });
+        for (final DataFrameAnalyticsConfig config : analytics.results()) {
+            client.execute(DeleteDataFrameAnalyticsAction.INSTANCE, new DeleteDataFrameAnalyticsAction.Request(config.getId())).actionGet();
         }
     }
 


### PR DESCRIPTION
This change is fairly simple (for now) as we don't have any state to really recover. We simply need to check what the previous state was and take some simple actions ahead of time. 

