### PR TITLE
[DOCS] Fix inline callout in Watcher documentation

### DIFF
--- a/x-pack/docs/en/watcher/condition/array-compare.asciidoc
+++ b/x-pack/docs/en/watcher/condition/array-compare.asciidoc
@@ -25,7 +25,7 @@ than or equal to 25:
   "condition": {
     "array_compare": {
       "ctx.payload.aggregations.top_tweeters.buckets" : { <1>
-        "path": "doc_count" <2>,
+        "path": "doc_count", <2>
         "gte": { <3>
           "value": 25, <4>
         }


### PR DESCRIPTION
This PR fixes the following issue when building the Stack Overview with AsciiDoctor:

INFO:build_docs:asciidoctor: WARNING: ../../../../elasticsearch/x-pack/docs/en/watcher/condition/array-compare.asciidoc: line 40: no callout found for <2>

This is related to [elastic/docs#566](https://github.com/elastic/docs/pull/566)