### PR TITLE
Deprecate distance_type parameter in GeoDistanceQueryBuilder and aggregations

### DIFF
--- a/docs/reference/aggregations/bucket/geodistance-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/geodistance-aggregation.asciidoc
@@ -115,31 +115,7 @@ POST /museums/_search?size=0
 
 <1> The distances will be computed in kilometers
 
-There are two distance calculation modes: `arc` (the default), and `plane`. The `arc` calculation is the most accurate. The `plane` is the fastest but least accurate. Consider using `plane` when your search context is "narrow", and spans smaller geographical areas (~5km). `plane` will return higher error margins for searches across very large areas (e.g. cross continent search). The distance calculation type can be set using the `distance_type` parameter:
-
-[source,js]
---------------------------------------------------
-POST /museums/_search?size=0
-{
-    "aggs" : {
-        "rings" : {
-            "geo_distance" : {
-                "field" : "location",
-                "origin" : "52.3760, 4.894",
-                "unit" : "km",
-                "distance_type" : "plane",
-                "ranges" : [
-                    { "to" : 100 },
-                    { "from" : 100, "to" : 300 },
-                    { "from" : 300 }
-                ]
-            }
-        }
-    }
-}
---------------------------------------------------
-// CONSOLE
-// TEST[continued]
+deprecated[7.1.0] There are two distance calculation modes: `arc` (the default), and `plane`. The `arc` calculation is the most accurate. The `plane` is the fastest but least accurate. Consider using `plane` when your search context is "narrow", and spans smaller geographical areas (~5km). `plane` will return higher error margins for searches across very large areas (e.g. cross continent search). The distance calculation type can be set using the `distance_type` parameter:
 
 ==== Keyed Response
 

--- a/docs/reference/query-dsl/geo-distance-query.asciidoc
+++ b/docs/reference/query-dsl/geo-distance-query.asciidoc
@@ -189,7 +189,7 @@ The following are options allowed on the filter:
 
 `distance_type`::
 
-    How to compute the distance. Can either be `arc` (default), or `plane` (faster, but inaccurate on long distances and close to the poles).
+    deprectated[7.1.0] How to compute the distance. Can either be `arc` (default), or `plane` (faster, but inaccurate on long distances and close to the poles).
 
 `_name`::
 

--- a/docs/reference/search/request/sort.asciidoc
+++ b/docs/reference/search/request/sort.asciidoc
@@ -290,7 +290,6 @@ GET /_search
                 "order" : "asc",
                 "unit" : "km",
                 "mode" : "min",
-                "distance_type" : "arc",
                 "ignore_unmapped": true
             }
         }
@@ -306,7 +305,7 @@ GET /_search
 
 `distance_type`::
 
-    How to compute the distance. Can either be `arc` (default), or `plane` (faster, but inaccurate on long distances and close to the poles).
+    deprecated[7.1.0] How to compute the distance. Can either be `arc` (default), or `plane` (faster, but inaccurate on long distances and close to the poles).
 
 `mode`::
 

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoDistance.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoDistance.java
@@ -29,7 +29,9 @@ import java.util.Locale;
 
 /**
  * Geo distance calculation.
+ * @Deprecated geo_distance computation is handled internally to Lucene so this class is deprecated
  */
+@Deprecated
 public enum GeoDistance implements Writeable {
     PLANE, ARC;
 

--- a/server/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
@@ -52,6 +52,7 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
     /** Default for distance unit computation. */
     public static final DistanceUnit DEFAULT_DISTANCE_UNIT = DistanceUnit.DEFAULT;
     /** Default for geo distance computation. */
+    @Deprecated
     public static final GeoDistance DEFAULT_GEO_DISTANCE = GeoDistance.ARC;
 
     /**
@@ -60,7 +61,10 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
     public static final boolean DEFAULT_IGNORE_UNMAPPED = false;
 
     private static final ParseField VALIDATION_METHOD_FIELD = new ParseField("validation_method");
-    private static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type");
+    @Deprecated
+    private static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type")
+        .withAllDeprecated("no replacement: `distance_type` is handled internally and no longer supported. "
+            + "It will be removed in a future version.");
     private static final ParseField UNIT_FIELD = new ParseField("unit");
     private static final ParseField DISTANCE_FIELD = new ParseField("distance");
     private static final ParseField IGNORE_UNMAPPED_FIELD = new ParseField("ignore_unmapped");
@@ -71,6 +75,7 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
     /** Point to use as center. */
     private GeoPoint center = new GeoPoint(Double.NaN, Double.NaN);
     /** Algorithm to use for distance computation. */
+    @Deprecated
     private GeoDistance geoDistance = GeoDistance.ARC;
     /** How strict should geo coordinate validation be? */
     private GeoValidationMethod validationMethod = GeoValidationMethod.DEFAULT;
@@ -183,6 +188,7 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
     }
 
     /** Which type of geo distance calculation method to use. */
+    @Deprecated
     public GeoDistanceQueryBuilder geoDistance(GeoDistance geoDistance) {
         if (geoDistance == null) {
             throw new IllegalArgumentException("geoDistance must not be null");
@@ -192,6 +198,7 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
     }
 
     /** Returns geo distance calculation type to use. */
+    @Deprecated
     public GeoDistance geoDistance() {
         return this.geoDistance;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
@@ -55,7 +55,10 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
     public static final String NAME = "geo_distance";
     static final ParseField ORIGIN_FIELD = new ParseField("origin", "center", "point", "por");
     static final ParseField UNIT_FIELD = new ParseField("unit");
-    static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type");
+    @Deprecated
+    static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type")
+        .withAllDeprecated("no replacement: `distance_type` is handled internally and no longer supported. "
+            + "It will be removed in a future version.");
 
     private static final ObjectParser<GeoDistanceAggregationBuilder, Void> PARSER;
     static {

--- a/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -79,7 +79,10 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
     public static final GeoValidationMethod DEFAULT_VALIDATION = GeoValidationMethod.DEFAULT;
 
     private static final ParseField UNIT_FIELD = new ParseField("unit");
-    private static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type");
+    @Deprecated
+    private static final ParseField DISTANCE_TYPE_FIELD = new ParseField("distance_type")
+        .withAllDeprecated("no replacement: `distance_type` is handled internally and no longer supported. "
+            + "It will be removed in a future version.");
     private static final ParseField VALIDATION_METHOD_FIELD = new ParseField("validation_method");
     private static final ParseField SORTMODE_FIELD = new ParseField("mode", "sort_mode");
     private static final ParseField IGNORE_UNMAPPED = new ParseField("ignore_unmapped");
@@ -237,6 +240,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
     /**
      * The geo distance type used to compute the distance.
      */
+    @Deprecated
     public GeoDistanceSortBuilder geoDistance(GeoDistance geoDistance) {
         this.geoDistance = geoDistance;
         return this;
@@ -245,6 +249,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
     /**
      * Returns the geo distance type used to compute the distance.
      */
+    @Deprecated
     public GeoDistance geoDistance() {
         return this.geoDistance;
     }

--- a/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -25,7 +25,6 @@ import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.search.internal.SearchContext;
@@ -71,13 +70,30 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
         }
 
         if (randomBoolean()) {
-            qb.geoDistance(randomFrom(GeoDistance.values()));
-        }
-
-        if (randomBoolean()) {
             qb.ignoreUnmapped(randomBoolean());
         }
         return qb;
+    }
+
+    @Override
+    public void testFromXContent() throws IOException {
+        super.testFromXContent();
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
+            "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
+    }
+
+    @Override
+    public void testUnknownField() throws IOException {
+        super.testUnknownField();
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
+            "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
+    }
+
+    @Override
+    public void testValidOutput() throws IOException {
+        super.testValidOutput();
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
+            "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
     }
 
     public void testIllegalValues() {
@@ -110,9 +126,6 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
         assertEquals("geohash must not be null or empty", e.getMessage());
         e = expectThrows(IllegalArgumentException.class, () -> query.geohash(""));
         assertEquals("geohash must not be null or empty", e.getMessage());
-
-        e = expectThrows(IllegalArgumentException.class, () -> query.geoDistance(null));
-        assertEquals("geoDistance must not be null", e.getMessage());
     }
 
     /**
@@ -325,6 +338,8 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
         assertEquals(json, -70.0, parsed.point().getLon(), 0.0001);
         assertEquals(json, 40.0, parsed.point().getLat(), 0.0001);
         assertEquals(json, 12000.0, parsed.distance(), 0.0001);
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
+            "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
     }
 
     public void testIgnoreUnmapped() throws IOException {
@@ -356,5 +371,22 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "}";
         ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(json));
         assertEquals("[geo_distance] query doesn't support multiple fields, found [point1] and [point2]", e.getMessage());
+    }
+
+    public void testDistanceTypeIsDeprecated() throws IOException {
+        String json =
+            "{\n" +
+                "  \"geo_distance\" : {\n" +
+                "    \"pin.location\" : [ -70.0, 40.0 ],\n" +
+                "    \"distance\" : 12000.0,\n" +
+                "    \"distance_type\" : \"arc\",\n" +
+                "    \"validation_method\" : \"STRICT\",\n" +
+                "    \"ignore_unmapped\" : false,\n" +
+                "    \"boost\" : 1.0\n" +
+                "  }\n" +
+                "}";
+        parseQuery(json);
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
+            "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.bucket;
 
-import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParseException;
@@ -62,9 +61,6 @@ public class GeoDistanceRangeTests extends BaseAggregationTestCase<GeoDistanceAg
         }
         if (randomBoolean()) {
             factory.unit(randomFrom(DistanceUnit.values()));
-        }
-        if (randomBoolean()) {
-            factory.distanceType(randomFrom(GeoDistance.values()));
         }
         return factory;
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
@@ -81,6 +81,27 @@ public class GeoDistanceRangeTests extends BaseAggregationTestCase<GeoDistanceAg
         assertThat(ex.getCause().getMessage(), containsString("badField"));
     }
 
+    @Override
+    public void testFromXContent() throws IOException {
+        super.testFromXContent();
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
+            "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
+    }
+
+    @Override
+    public void testFromXContentMulti() throws IOException {
+        super.testFromXContentMulti();
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
+            "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
+    }
+
+    @Override
+    public void testToString() throws IOException {
+        super.testToString();
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
+            "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
+    }
+
     /**
      * We never render "null" values to xContent, but we should test that we can parse them (and they return correct defaults)
      */

--- a/server/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
@@ -229,7 +229,6 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
                 "    \"lon\" : -51.94128329747579\n" +
                 "  } ],\n" +
                 "  \"unit\" : \"m\",\n" +
-                "  \"distance_type\" : \"arc\",\n" +
                 "  \"mode\" : \"SUM\"\n" +
                 "}";
         try (XContentParser itemParser = createParser(JsonXContent.jsonXContent, json)) {
@@ -246,7 +245,6 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
                 "    \"VDcvDuFjE\" : [ \"7umzzv8eychg\", \"dmdgmt5z13uw\", " +
                 "    \"ezu09wxw6v4c\", \"kc7s3515p6k6\", \"jgeuvjwrmfzn\", \"kcpcfj7ruyf8\" ],\n" +
                 "    \"unit\" : \"m\",\n" +
-                "    \"distance_type\" : \"arc\",\n" +
                 "    \"mode\" : \"MAX\",\n" +
                 "    \"nested\" : {\n" +
                 "      \"filter\" : {\n" +
@@ -269,6 +267,24 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
                 + "-37.20467280596495, 38.71751043945551, "
                 + "-69.44606635719538, 84.25200328230858, "
                 + "-39.03717711567879, 44.74099852144718]", Arrays.toString(result.points()));
+        }
+    }
+
+    public void testDistanceTypeIsDeprecated() throws IOException {
+        String json = "{\n" +
+            "  \"testname\" : [ {\n" +
+            "    \"lat\" : -6.046997540714173,\n" +
+            "    \"lon\" : -51.94128329747579\n" +
+            "  } ],\n" +
+            "  \"unit\" : \"m\",\n" +
+            "  \"distance_type\" : \"arc\",\n" +
+            "  \"mode\" : \"MAX\"\n" +
+            "}";
+        try (XContentParser itemParser = createParser(JsonXContent.jsonXContent, json)) {
+            itemParser.nextToken();
+            GeoDistanceSortBuilder.fromXContent(itemParser, json);
+            assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
+                "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
         }
     }
 
@@ -396,6 +412,10 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
         }
         if (testItem.getNestedPath() != null) {
             expectedWarnings.add("[nested_path] has been deprecated in favour of the [nested] parameter");
+        }
+        if (testItem.geoDistance() != null) {
+            expectedWarnings.add("Deprecated field [distance_type] used, replaced by [no replacement: " +
+                "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
         }
         if (expectedWarnings.isEmpty() == false) {
             assertWarnings(expectedWarnings.toArray(new String[expectedWarnings.size()]));

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
@@ -65,8 +65,6 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
         assertNotSame(newAgg, testAgg);
         assertEquals(testAgg, newAgg);
         assertEquals(testAgg.hashCode(), newAgg.hashCode());
-        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
-            "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
     }
 
     /**
@@ -95,8 +93,6 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
         assertThat(parsed.getPipelineAggregatorFactories(), hasSize(0));
         assertEquals(factoriesBuilder, parsed);
         assertEquals(factoriesBuilder.hashCode(), parsed.hashCode());
-        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
-            "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
     }
 
     /**
@@ -135,8 +131,6 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
         assertNotSame(newAgg, testAgg);
         assertEquals(testAgg, newAgg);
         assertEquals(testAgg.hashCode(), newAgg.hashCode());
-        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
-            "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
     }
 
     protected AggregationBuilder parse(XContentParser parser) throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
@@ -65,6 +65,8 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
         assertNotSame(newAgg, testAgg);
         assertEquals(testAgg, newAgg);
         assertEquals(testAgg.hashCode(), newAgg.hashCode());
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
+            "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
     }
 
     /**
@@ -93,6 +95,8 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
         assertThat(parsed.getPipelineAggregatorFactories(), hasSize(0));
         assertEquals(factoriesBuilder, parsed);
         assertEquals(factoriesBuilder.hashCode(), parsed.hashCode());
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
+            "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
     }
 
     /**
@@ -131,6 +135,8 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
         assertNotSame(newAgg, testAgg);
         assertEquals(testAgg, newAgg);
         assertEquals(testAgg.hashCode(), newAgg.hashCode());
+        assertWarnings("Deprecated field [distance_type] used, replaced by [no replacement: " +
+            "`distance_type` is handled internally and no longer supported. It will be removed in a future version.]");
     }
 
     protected AggregationBuilder parse(XContentParser parser) throws IOException {


### PR DESCRIPTION
This is the deprecation portion of #22914. Since Lucene optimizes Sinnot's haversine distance computation, there is no need to carry optional distance calculations. Therefore the distance_type parameter and GeoDistance class is deprecated.

relates #23009