### PR TITLE
[DOCS] Fixes table and code block separators in Watcher documentation

### DIFF
--- a/x-pack/docs/en/watcher/actions/email.asciidoc
+++ b/x-pack/docs/en/watcher/actions/email.asciidoc
@@ -117,11 +117,11 @@ killed by firewalls or load balancers in-between.
                     specify the `url` attribute to configure the host and path to
                     the service endpoint. See <<webhook-action-attributes>> for
                     the full list of HTTP request attributes. Required.
-|======
+|=====
 
 .`data` attachment type attributes
 [options="header"]
-|=====
+|======
 | Name        | Description
 | `format`    | Attaches the watch data, equivalent to specifying `attach_data`
                 in the watch configuration. Possible values are `json` or `yaml`.
@@ -131,7 +131,7 @@ killed by firewalls or load balancers in-between.
 
 .`reporting` attachment type attributes
 [options="header"]
-|=====
+|======
 | Name            | Description
 | `url`           | The URL to trigger the dashboard creation
 | `inline`        | Configures as an attachment to sent with disposition `inline`. This

--- a/x-pack/docs/en/watcher/example-watches/example-watch-meetupdata.asciidoc
+++ b/x-pack/docs/en/watcher/example-watches/example-watch-meetupdata.asciidoc
@@ -50,7 +50,7 @@ output { <2>
 [source,shell]
 ----------------------------------------------------------
 curl http://stream.meetup.com/2/rsvps | bin/logstash -f livestream.conf
----------------------------------------------------------
+----------------------------------------------------------
 // NOTCONSOLE
 -- 
 
@@ -143,7 +143,7 @@ To set up the watch:
       }
     }
   },
---------------------------------------------------
+-------------------------------------------------
 // NOTCONSOLE
 <1> Elasticsearch Date math is used to select the Logstash indices that contain the meetup data. The second pattern is needed in case the previous hour crosses days.
 <2> Find all of the RSVPs with `Open Source` as a topic.
@@ -167,7 +167,7 @@ To set up the watch:
 +
 --
 [source,js]
---------------------------------------------------
+---------------------------------------------------
 "actions": {
     "email_me": {
       "throttle_period": "10m",


### PR DESCRIPTION
This PR fixes the following issues when building the Stack Overview with AsciiDoctor:

> INFO:build_docs:asciidoctor: ERROR: ../../../../elasticsearch/x-pack/docs/en/watcher/actions/email.asciidoc: line 132: table missing leading separator; recovering automatically
> INFO:build_docs:asciidoctor: WARNING: ../../../../elasticsearch/x-pack/docs/en/watcher/example-watches/example-watch-meetupdata.asciidoc: line 53: code block end doesn't match start
> INFO:build_docs:asciidoctor: WARNING: ../../../../elasticsearch/x-pack/docs/en/watcher/example-watches/example-watch-meetupdata.asciidoc: line 146: code block end doesn't match start
> INFO:build_docs:asciidoctor: WARNING: ../../../../elasticsearch/x-pack/docs/en/watcher/example-watches/example-watch-meetupdata.asciidoc: line 187: code block end doesn't match start


