### PR TITLE
Fixed required fields and paths list (#39358)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.disable_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.disable_user.json
@@ -11,7 +11,7 @@
         "username": {
           "type" : "string",
           "description" : "The username of the user to disable",
-          "required" : false
+          "required" : true
         }
       },
       "params": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.enable_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.enable_user.json
@@ -11,7 +11,7 @@
         "username": {
           "type" : "string",
           "description" : "The username of the user to enable",
-          "required" : false
+          "required" : true
         }
       },
       "params": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_privileges.json
@@ -5,6 +5,8 @@
     "url": {
       "path": "/_security/privilege/{application}/{name}",
       "paths": [
+        "/_security/privilege",
+        "/_security/privilege/{application}",
         "/_security/privilege/{application}/{name}"
       ],
       "parts": {


### PR DESCRIPTION
Some small fix for the `x-pack` rest api spec.

* In both `security.enable_user.json` and `security.disable_user.json` the `username` parameter was `false` instead of `true` (the documentation is already correct).
* In `security.get_privileges.json` there were missing all the possible paths since the path parameters are not required. This fix aligns the document with the rest of the spec, where all the possible combinations are listed.
