### PR TITLE
[DOCS] Fix image warnings in CCR documentation

### DIFF
--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -156,7 +156,7 @@ Alternatively, you can manage remote clusters on the
 *Management / Elasticsearch / Remote Clusters* page in {kib}:
 
 [role="screenshot"]
-image::ml/images/remote-clusters.jpg["The Remote Clusters page in {kib}"]
+image::images/remote-clusters.jpg["The Remote Clusters page in {kib}"]
 
 
 [float]
@@ -335,4 +335,4 @@ Alternatively, you can manage auto-follow patterns on the
 *Management / Elasticsearch / Cross Cluster Replication* page in {kib}:
 
 [role="screenshot"]
-image::ml/images/auto-follow-patterns.jpg["The Auto-follow patterns page in {kib}"]
+image::images/auto-follow-patterns.jpg["The Auto-follow patterns page in {kib}"]


### PR DESCRIPTION
This PR fixes the following issues when building the Stack Overview with AsciiDoctor:

> INFO:build_docs:asciidoctor: WARNING: ../../../../elasticsearch/docs/reference/ccr/getting-started.asciidoc: line 159: can't read image at any of ["/doc/elasticsearch/docs/ml/images/remote-clusters.jpg"....]
> INFO:build_docs:asciidoctor: WARNING: ../../../../elasticsearch/docs/reference/ccr/getting-started.asciidoc: line 338: can't read image at any of ["/doc/elasticsearch/docs/ml/images/auto-follow-patterns.jpg"...]
