### PR TITLE
Fixed required fields and paths list (#39358)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.security.disable_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.security.disable_user.json
@@ -9,7 +9,7 @@
         "username": {
           "type" : "string",
           "description" : "The username of the user to disable",
-          "required" : false
+          "required" : true
         }
       },
       "params": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.security.enable_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.security.enable_user.json
@@ -9,7 +9,7 @@
         "username": {
           "type" : "string",
           "description" : "The username of the user to enable",
-          "required" : false
+          "required" : true
         }
       },
       "params": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.security.get_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.security.get_privileges.json
@@ -4,7 +4,11 @@
     "methods": [ "GET" ],
     "url": {
       "path": "/_xpack/security/privilege/{application}/{name}",
-      "paths": [ "/_xpack/security/privilege/{application}/{name}" ],
+      "paths": [
+        "/_xpack/security/privilege",
+        "/_xpack/security/privilege/{application}",
+        "/_xpack/security/privilege/{application}/{name}"
+      ],
       "parts": {
         "application": {
           "type" : "string",


### PR DESCRIPTION
Some small fix for the `x-pack` rest api spec.

* In both `security.enable_user.json` and `security.disable_user.json`
  the `username` parameter was `false` instead of `true`
  (the documentation is already correct).
* In `security.get_privileges.json` there were missing all the
  possible paths since the path parameters are not required.
  This fix aligns the document with the rest of the spec,
  where all the possible combinations are listed.
