### PR TITLE
Mute CoordinatorTests.testDiscoveryUsesNodesFromLastClusterState()

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1060,6 +1060,7 @@ public class CoordinatorTests extends ESTestCase {
         cluster1.stabilise();
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/39437")
     public void testDiscoveryUsesNodesFromLastClusterState() {
         final Cluster cluster = new Cluster(randomIntBetween(3, 5));
         cluster.runRandomly();


### PR DESCRIPTION
Relates to #39437

