### PR TITLE
Add Checks for Closed Channel in Selector Loop (#39096)

### DIFF
--- a/libs/nio/src/main/java/org/elasticsearch/nio/NioSelector.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/NioSelector.java
@@ -238,12 +238,13 @@ public class NioSelector implements Closeable {
             }
 
             if (channelContext.isConnectComplete()) {
-                if ((ops & SelectionKey.OP_WRITE) != 0) {
-                    handleWrite(channelContext);
-                }
-
-                if ((ops & SelectionKey.OP_READ) != 0) {
-                    handleRead(channelContext);
+                if (channelContext.selectorShouldClose() == false) {
+                    if ((ops & SelectionKey.OP_WRITE) != 0) {
+                        handleWrite(channelContext);
+                    }
+                    if (channelContext.selectorShouldClose() == false && (ops & SelectionKey.OP_READ) != 0) {
+                        handleRead(channelContext);
+                    }
                 }
             }
             eventHandler.postHandling(channelContext);
@@ -336,7 +337,9 @@ public class NioSelector implements Closeable {
         }
 
         if (shouldFlushAfterQueuing) {
-            handleWrite(context);
+            if (context.selectorShouldClose() == false) {
+                handleWrite(context);
+            }
             eventHandler.postHandling(context);
         }
     }

--- a/libs/nio/src/main/java/org/elasticsearch/nio/SocketChannelContext.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/SocketChannelContext.java
@@ -209,7 +209,7 @@ public abstract class SocketChannelContext extends ChannelContext<SocketChannel>
 
     protected void handleReadBytes() throws IOException {
         int bytesConsumed = Integer.MAX_VALUE;
-        while (bytesConsumed > 0 && channelBuffer.getIndex() > 0) {
+        while (isOpen() && bytesConsumed > 0 && channelBuffer.getIndex() > 0) {
             bytesConsumed = readWriteHandler.consumeReads(channelBuffer);
             channelBuffer.release(bytesConsumed);
         }

--- a/libs/nio/src/test/java/org/elasticsearch/nio/SocketChannelContextTests.java
+++ b/libs/nio/src/test/java/org/elasticsearch/nio/SocketChannelContextTests.java
@@ -476,7 +476,7 @@ public class SocketChannelContextTests extends ESTestCase {
 
         @Override
         public boolean selectorShouldClose() {
-            return false;
+            return isClosing.get();
         }
 
         @Override


### PR DESCRIPTION
* A few warnings could be observed in test logs about `NoSuchElementException` being thrown in `InboundChannelBuffer#sliceBuffersTo`.
These were the result of calls to this method after the relevant channel and hence the buffer was closed already as a result of a failed IO operation.
  * Fixed by adding the necessary guard statements to break out in these cases. I don't think there is a need here to do any additional error handling since `eventHandler.postHandling(channelContext);` at the end of the `processKey`
call in the main selection loop handles closing channels and invoking callbacks for writes that failed to go through already.
