### PR TITLE
SQL: Use underlying exact field for LIKE/RLIKE

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/resources/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/docs.csv-spec
@@ -2353,6 +2353,7 @@ SELECT * FROM (SELECT first_name, last_name FROM emp WHERE last_name NOT LIKE '%
   first_name   |   last_name
 ---------------+---------------
 Anneke         |Preusig
+Alejandro      |McAlpine
 Anoosh         |Peyn
 Arumugam       |Ossenbruggen
 // end::limitationSubSelect
@@ -2365,6 +2366,7 @@ SELECT first_name, last_name FROM emp WHERE last_name NOT LIKE '%a%' AND first_n
   first_name   |   last_name
 ---------------+---------------
 Anneke         |Preusig
+Alejandro      |McAlpine
 Anoosh         |Peyn
 Arumugam       |Ossenbruggen
 ;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
@@ -483,7 +483,7 @@ final class QueryTranslator {
             if (e.field() instanceof FieldAttribute) {
                 FieldAttribute fa = (FieldAttribute) e.field();
                 inexact = fa.isInexact();
-                target = nameOf(inexact ? fa : fa.exactAttribute());
+                target = nameOf(inexact ? fa.exactAttribute() : fa);
             } else {
                 throw new SqlIllegalArgumentException("Scalar function ({}) not allowed (yet) as arguments for LIKE",
                         Expressions.name(e.field()));


### PR DESCRIPTION
Previously, if a text field had an underlying keyword field
the latter was not used instead of the text leading to wrong
results returned by queries filtering with LIKE/RLIKE.

Fixes: #39442
