### PR TITLE
Don't Ping on Handshake Connection (#39076)

### DIFF
--- a/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
+++ b/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
@@ -80,7 +80,8 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
 
                 logger.trace("[{}] opening probe connection", this);
                 final Connection connection = transportService.openConnection(targetNode,
-                    ConnectionProfile.buildSingleChannelProfile(Type.REG, probeConnectTimeout, probeHandshakeTimeout));
+                    ConnectionProfile.buildSingleChannelProfile(Type.REG, probeConnectTimeout, probeHandshakeTimeout,
+                        TimeValue.MINUS_ONE, null));
                 logger.trace("[{}] opened probe connection", this);
 
                 final DiscoveryNode remoteNode;

--- a/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
@@ -293,7 +293,8 @@ public class UnicastZenPing implements ZenPing {
         }
 
         final ConnectionProfile connectionProfile =
-            ConnectionProfile.buildSingleChannelProfile(TransportRequestOptions.Type.REG, requestDuration, requestDuration);
+            ConnectionProfile.buildSingleChannelProfile(TransportRequestOptions.Type.REG, requestDuration, requestDuration,
+                TimeValue.MINUS_ONE, null);
         final PingingRound pingingRound = new PingingRound(pingingRoundIdGenerator.incrementAndGet(), seedAddresses, resultsConsumer,
             nodes.getLocalNode(), connectionProfile);
         activePingingRounds.put(pingingRound.id(), pingingRound);

--- a/server/src/main/java/org/elasticsearch/transport/ConnectionProfile.java
+++ b/server/src/main/java/org/elasticsearch/transport/ConnectionProfile.java
@@ -102,23 +102,6 @@ public final class ConnectionProfile {
     }
 
     /**
-     * Builds a connection profile that is dedicated to a single channel type. Allows passing compression
-     * settings.
-     */
-    public static ConnectionProfile buildSingleChannelProfile(TransportRequestOptions.Type channelType, boolean compressionEnabled) {
-        return buildSingleChannelProfile(channelType, null, null, null, compressionEnabled);
-    }
-
-    /**
-     * Builds a connection profile that is dedicated to a single channel type. Allows passing connection and
-     * handshake timeouts.
-     */
-    public static ConnectionProfile buildSingleChannelProfile(TransportRequestOptions.Type channelType, @Nullable TimeValue connectTimeout,
-                                                              @Nullable TimeValue handshakeTimeout) {
-        return buildSingleChannelProfile(channelType, connectTimeout, handshakeTimeout, null, null);
-    }
-
-    /**
      * Builds a connection profile that is dedicated to a single channel type. Allows passing connection and
      * handshake timeouts and compression settings.
      */


### PR DESCRIPTION
* Don't Ping on Handshake Connection
* It does not make sense to run pings on the handshake connection
   * Set the ping interval to `-1` to deactivate pings on it
