### PR TITLE
Mute Bulk indexing of monitoring data

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
@@ -1,6 +1,10 @@
 ---
 "Bulk indexing of monitoring data":
 
+  - skip:
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/30101"
+
   - do:
       monitoring.bulk:
         system_id:          "kibana"


### PR DESCRIPTION
Opened a PR to verify that the muted tests do not affect any other rest tests, since this fails rarely and will hopefully not impact anyone else's dev workflow until it's muted.

Relates: https://github.com/elastic/elasticsearch/issues/30101