### PR TITLE
Increase Timeout in UnicastZenPingTests (#38893)

### DIFF
--- a/server/src/test/java/org/elasticsearch/discovery/zen/UnicastZenPingTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/zen/UnicastZenPingTests.java
@@ -839,7 +839,7 @@ public class UnicastZenPingTests extends ESTestCase {
             markTaskAsStarted("send pings");
             markTaskAsStarted("send pings");
             final AtomicReference<PingCollection> response = new AtomicReference<>();
-            ping(response::set, TimeValue.timeValueMillis(1), TimeValue.timeValueSeconds(1));
+            ping(response::set, TimeValue.timeValueMillis(1), TimeValue.timeValueSeconds(30));
             pingingRoundClosed.await();
             final PingCollection result = response.get();
             assertNotNull("pinging didn't complete",  result);


### PR DESCRIPTION
* Just like #37268 removing another 1s timeout, those are dangerous since they're easily exceeded by an untimely gc pause
* Closes #26701
