### PR TITLE
Unmute CoordinatorTests.testDiscoveryUsesNodesFromLastClusterState()

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1060,7 +1060,6 @@ public class CoordinatorTests extends ESTestCase {
         cluster1.stabilise();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/39437")
     public void testDiscoveryUsesNodesFromLastClusterState() {
         final Cluster cluster = new Cluster(randomIntBetween(3, 5));
         cluster.runRandomly();
@@ -1443,7 +1442,8 @@ public class CoordinatorTests extends ESTestCase {
                 leader.improveConfiguration(lastAcceptedState), sameInstance(lastAcceptedState));
 
             logger.info("checking linearizability of history with size {}: {}", history.size(), history);
-            assertTrue("history not linearizable: " + history, linearizabilityChecker.isLinearizable(spec, history, i -> null));
+            // See https://github.com/elastic/elasticsearch/issues/39437
+            //assertTrue("history not linearizable: " + history, linearizabilityChecker.isLinearizable(spec, history, i -> null));
             logger.info("linearizability check completed");
         }
 


### PR DESCRIPTION
This commit unmutes the test and comments out the offending call to `linearizabilityChecker.isLinearizable()` as suggested in https://github.com/elastic/elasticsearch/issues/39437#issuecomment-467833038
