### PR TITLE
[DOCS] Removes problematic footer from Watcher docs

### DIFF
--- a/x-pack/docs/en/watcher/transform/script.asciidoc
+++ b/x-pack/docs/en/watcher/transform/script.asciidoc
@@ -39,25 +39,24 @@ The following table lists the possible settings that can be configured:
 
 [[transform-script-settings]]
 .Script Transform Settings
-[options="header,footer"]
+[options="header"]
 |======
 | Name      |Required | Default    | Description
 
-| `inline`  | yes*    | -          | When using an inline script, this field holds
+| `inline`  | yes    | -          | When using an inline script, this field holds
                                      the script itself.
 
-| `id`      | yes*    | -          | When referring to a stored script, this
+| `id`      | yes    | -          | When referring to a stored script, this
                                      field holds the id of the script.
 
 | `lang`    | no      | `painless` | The script language
 
 | `params`  | no      | -          | Additional parameters/variables that are
                                      accessible by the script
-
 |======
 
 When using the object notation of the script, one (and only one) of `inline`,
-or `id` fields must be defined
+or `id` fields must be defined.
 
 NOTE: In addition to the provided `params`, the scripts also have access to the
       <<watch-execution-context, Standard Watch Execution Context Parameters>>.

--- a/x-pack/docs/en/watcher/transform/script.asciidoc
+++ b/x-pack/docs/en/watcher/transform/script.asciidoc
@@ -43,10 +43,10 @@ The following table lists the possible settings that can be configured:
 |======
 | Name      |Required | Default    | Description
 
-| `inline`  | yes    | -          | When using an inline script, this field holds
+| `inline`  | yes     | -          | When using an inline script, this field holds
                                      the script itself.
 
-| `id`      | yes    | -          | When referring to a stored script, this
+| `id`      | yes     | -          | When referring to a stored script, this
                                      field holds the id of the script.
 
 | `lang`    | no      | `painless` | The script language


### PR DESCRIPTION
This PR fixes the following issues when building the Stack Overview with Asciidoctor:

> INFO:build_docs:Building HTML from /doc/stack-docs/docs/en/stack/index.asciidoc
INFO:build_docs:
INFO:build_docs:Error executing: xmllint --nonet --noout --valid /out/html_docs/index.xml
INFO:build_docs:
INFO:build_docs:---
INFO:build_docs:/out/html_docs/index.xml:11909: element tgroup: validity error : Element tgroup content does not follow the DTD, expecting (colspec* , spanspec* , thead? , tfoot? , tbody), got (colspec colspec colspec colspec thead tbody tfoot )
INFO:build_docs:</tgroup>

This problem relates to the table in https://www.elastic.co/guide/en/elastic-stack-overview/master/transform-script.html, which had a footer that wasn't properly cleaned up from earlier versions (e.g. https://www.elastic.co/guide/en/x-pack/5.0/transform-script.html)