### PR TITLE
[BACKPORT 6.6] Disable BWC mode in TokenService by default 

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -652,6 +652,7 @@ public class Security extends Plugin implements ActionPlugin, IngestPlugin, Netw
         settingsList.add(TokenService.TOKEN_PASSPHRASE);
         settingsList.add(TokenService.DELETE_INTERVAL);
         settingsList.add(TokenService.DELETE_TIMEOUT);
+        settingsList.add(TokenService.BWC_ENABLED);
         settingsList.add(SecurityServerTransportInterceptor.TRANSPORT_TYPE_PROFILE_SETTING);
         settingsList.addAll(SSLConfigurationSettings.getProfileSettings());
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -165,6 +165,8 @@ public final class TokenService extends AbstractComponent {
             TimeValue.timeValueMinutes(30L), Property.NodeScope);
     public static final Setting<TimeValue> DELETE_TIMEOUT = Setting.timeSetting("xpack.security.authc.token.delete.timeout",
             TimeValue.MINUS_ONE, Property.NodeScope);
+    public static final Setting<Boolean> BWC_ENABLED = Setting.boolSetting("xpack.security.authc.token.compat.enabled",
+            false, Property.NodeScope, Property.Deprecated);
 
     static final String INVALIDATED_TOKEN_DOC_TYPE = "invalidated-token";
     static final int MINIMUM_BYTES = VERSION_BYTES + SALT_BYTES + IV_BYTES + 1;
@@ -181,6 +183,7 @@ public final class TokenService extends AbstractComponent {
     private final SecurityIndexManager securityIndex;
     private final ExpiredTokenRemover expiredTokenRemover;
     private final boolean enabled;
+    private final boolean bwcEnabled;
     private volatile TokenKeys keyCache;
     private volatile long lastExpirationRunMs;
     private final AtomicLong createdTimeStamps = new AtomicLong(-1);
@@ -213,6 +216,7 @@ public final class TokenService extends AbstractComponent {
         this.lastExpirationRunMs = client.threadPool().relativeTimeInMillis();
         this.deleteInterval = DELETE_INTERVAL.get(settings);
         this.enabled = isTokenServiceEnabled(settings);
+        this.bwcEnabled = BWC_ENABLED.get(settings);
         this.expiredTokenRemover = new ExpiredTokenRemover(settings, client);
         ensureEncryptionCiphersSupported();
         KeyAndCache keyAndCache = new KeyAndCache(new KeyAndTimestamp(tokenPassphrase, createdTimeStamps.incrementAndGet()),
@@ -431,8 +435,12 @@ public final class TokenService extends AbstractComponent {
                                                 }), client::get);
                                         });
                                 }}, listener::onFailure));
-                        } else {
+                        } else if (bwcEnabled) {
                             decryptToken(in, cipher, version, listener);
+                        } else {
+                            logger.debug("Found [{}] version token, but old token compatibility is disabled", version);
+                            listener.onFailure(
+                                new IllegalArgumentException("Cannot authenticate using token from version [" + version + "]"));
                         }
                     } catch (GeneralSecurityException e) {
                         // could happen with a token that is not ours
@@ -633,6 +641,8 @@ public final class TokenService extends AbstractComponent {
             logger.warn("Failed to invalidate [{}] tokens after [{}] attempts", tokenIds.size(),
                 attemptCount.get());
             listener.onFailure(invalidGrantException("failed to invalidate tokens"));
+        } else if (bwcEnabled == false) {
+            indexInvalidation(tokenIds, listener, attemptCount, "access_token", previousResult);
         } else {
             BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
             for (String tokenId : tokenIds) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -983,6 +983,9 @@ public class AuthenticationServiceTests extends ESTestCase {
                 } else if (e instanceof NegativeArraySizeException) {
                     assertThat(e.getMessage(), containsString("array size must be positive but was: "));
                     latch.countDown();
+                } else if (e instanceof IllegalArgumentException) {
+                    assertThat(e.getMessage(), containsString("Cannot authenticate using token from version"));
+                    latch.countDown();
                 } else {
                     logger.error("unexpected exception", e);
                     latch.countDown();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -30,10 +30,11 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.settings.MockSecureSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -63,6 +64,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
+import javax.crypto.SecretKey;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.Clock;
@@ -75,8 +77,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
-
-import javax.crypto.SecretKey;
 
 import static java.time.Clock.systemUTC;
 import static org.elasticsearch.repositories.ESBlobStoreTestCase.randomBytes;
@@ -100,8 +100,7 @@ public class TokenServiceTests extends ESTestCase {
     private SecurityIndexManager securityIndex;
     private ClusterService clusterService;
     private boolean mixedCluster;
-    private Settings tokenServiceEnabledSettings = Settings.builder()
-        .put(XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.getKey(), true).build();
+    private Settings tokenServiceEnabledSettings;
 
     @Before
     public void setupClient() {
@@ -169,6 +168,10 @@ public class TokenServiceTests extends ESTestCase {
                 .build();
             ClusterServiceUtils.setState(clusterService, updatedState);
         }
+        tokenServiceEnabledSettings = Settings.builder()
+            .put(XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.getKey(), true)
+            .put(TokenService.BWC_ENABLED.getKey(), mixedCluster)
+            .build();
     }
 
     @After
@@ -221,6 +224,8 @@ public class TokenServiceTests extends ESTestCase {
             UserToken fromOtherService = future.get();
             assertAuthenticationEquals(authentication, fromOtherService.getAuthentication());
         }
+
+        assertSettingDeprecationsAndWarnings(new Setting[] { TokenService.BWC_ENABLED });
     }
 
     public void testInvalidAuthorizationHeader() throws Exception {
@@ -236,6 +241,8 @@ public class TokenServiceTests extends ESTestCase {
             UserToken serialized = future.get();
             assertThat(serialized, nullValue());
         }
+
+        assertSettingDeprecationsAndWarnings(new Setting[] { TokenService.BWC_ENABLED });
     }
 
     public void testRotateKey() throws Exception {
@@ -283,6 +290,8 @@ public class TokenServiceTests extends ESTestCase {
             UserToken serialized = future.get();
             assertEquals(authentication, serialized.getAuthentication());
         }
+
+        assertSettingDeprecationsAndWarnings(new Setting[] { TokenService.BWC_ENABLED });
     }
 
     private void rotateKeys(TokenService tokenService) {
@@ -329,6 +338,8 @@ public class TokenServiceTests extends ESTestCase {
             UserToken serialized = future.get();
             assertAuthenticationEquals(authentication, serialized.getAuthentication());
         }
+
+        assertSettingDeprecationsAndWarnings(new Setting[] { TokenService.BWC_ENABLED });
     }
 
     public void testPruneKeys() throws Exception {
@@ -392,6 +403,7 @@ public class TokenServiceTests extends ESTestCase {
             assertAuthenticationEquals(authentication, serialized.getAuthentication());
         }
 
+        assertSettingDeprecationsAndWarnings(new Setting[] { TokenService.BWC_ENABLED });
     }
 
     public void testPassphraseWorks() throws Exception {
@@ -424,8 +436,8 @@ public class TokenServiceTests extends ESTestCase {
             anotherService.getAndValidateToken(requestContext, future);
             assertNull(future.get());
         }
-        assertWarnings("[xpack.security.authc.token.passphrase] setting was deprecated in Elasticsearch and will be removed in a future" +
-                " release! See the breaking changes documentation for the next major version.");
+
+        assertSettingDeprecationsAndWarnings(new Setting[] { TokenService.BWC_ENABLED, TokenService.TOKEN_PASSPHRASE });
     }
 
     public void testGetTokenWhenKeyCacheHasExpired() throws Exception {
@@ -439,6 +451,8 @@ public class TokenServiceTests extends ESTestCase {
 
         tokenService.clearActiveKeyCache();
         assertThat(tokenService.getUserTokenString(token), notNullValue());
+
+        assertSettingDeprecationsAndWarnings(new Setting[] { TokenService.BWC_ENABLED });
     }
 
     public void testInvalidatedToken() throws Exception {
@@ -486,6 +500,8 @@ public class TokenServiceTests extends ESTestCase {
             assertThat(headerValue, containsString("Bearer realm="));
             assertThat(headerValue, containsString("expired"));
         }
+
+        assertSettingDeprecationsAndWarnings(new Setting[] { TokenService.BWC_ENABLED });
     }
 
     public void testComputeSecretKeyIsConsistent() throws Exception {
@@ -545,6 +561,8 @@ public class TokenServiceTests extends ESTestCase {
             assertThat(headerValue, containsString("Bearer realm="));
             assertThat(headerValue, containsString("expired"));
         }
+
+        assertSettingDeprecationsAndWarnings(new Setting[] { TokenService.BWC_ENABLED });
     }
 
     public void testTokenServiceDisabled() throws Exception {
@@ -653,6 +671,8 @@ public class TokenServiceTests extends ESTestCase {
             tokenService.getAndValidateToken(requestContext, future);
             assertEquals(token.getAuthentication(), future.get().getAuthentication());
         }
+
+        assertSettingDeprecationsAndWarnings(new Setting[] { TokenService.BWC_ENABLED });
     }
 
     public void testDecodePre6xToken() throws GeneralSecurityException, ExecutionException, InterruptedException, IOException {
@@ -660,7 +680,10 @@ public class TokenServiceTests extends ESTestCase {
                 "J1fxg/JZNQDPufePg1GxV/RAQm2Gr8mYAelijEVlWIdYaQ3R76U+P/w6Q1v90dGVZQn6DKMOfgmkfwAFNY";
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString(TokenService.TOKEN_PASSPHRASE.getKey(), "xpack_token_passpharse");
-        Settings settings = Settings.builder().put(XPackSettings.HTTP_SSL_ENABLED.getKey(), true).setSecureSettings(secureSettings).build();
+        Settings settings = Settings.builder()
+            .put(XPackSettings.HTTP_SSL_ENABLED.getKey(), true)
+            .put(TokenService.BWC_ENABLED.getKey(), true)
+            .setSecureSettings(secureSettings).build();
         TokenService tokenService = new TokenService(settings, systemUTC(), client, securityIndex, clusterService);
         ThreadContext requestContext = new ThreadContext(Settings.EMPTY);
         requestContext.putHeader("Authorization", "Bearer " + token);
@@ -674,8 +697,30 @@ public class TokenServiceTests extends ESTestCase {
             assertEquals(Version.V_5_6_0, serialized.getAuthentication().getVersion());
             assertArrayEquals(new String[]{"admin"}, serialized.getAuthentication().getUser().roles());
         }
+
+        assertSettingDeprecationsAndWarnings(new Setting[] { TokenService.BWC_ENABLED, TokenService.TOKEN_PASSPHRASE });
+    }
+
+    public void testV5TokensAreNotAcceptedByDefault() throws Exception {
+        String token = "g+y0AiDWsbLNzUGTywPa3VCz053RUPW7wAx4xTAonlcqjOmO1AzMhQDTUku/+ZtdtMgDobKqIrNdNvchvFMX0pvZLY6i4nAG2OhkApSstPfQQP" +
+            "J1fxg/JZNQDPufePg1GxV/RAQm2Gr8mYAelijEVlWIdYaQ3R76U+P/w6Q1v90dGVZQn6DKMOfgmkfwAFNY";
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString(TokenService.TOKEN_PASSPHRASE.getKey(), "xpack_token_passpharse");
+        Settings settings = Settings.builder()
+            .put(XPackSettings.HTTP_SSL_ENABLED.getKey(), true)
+            .setSecureSettings(secureSettings).build();
+        TokenService tokenService = new TokenService(settings, systemUTC(), client, securityIndex, clusterService);
+        ThreadContext requestContext = new ThreadContext(Settings.EMPTY);
+        requestContext.putHeader("Authorization", "Bearer " + token);
+
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+            PlainActionFuture<UserToken> future = new PlainActionFuture<>();
+            tokenService.decodeToken(tokenService.getFromHeader(requestContext), future);
+            final IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, future::actionGet);
+            assertThat(iae.getMessage(), containsString("Cannot authenticate using token from version [5.6.0]"));
+        }
         assertWarnings("[xpack.security.authc.token.passphrase] setting was deprecated in Elasticsearch and will be removed in a future" +
-                " release! See the breaking changes documentation for the next major version.");
+            " release! See the breaking changes documentation for the next major version.");
     }
 
     public void testGetAuthenticationWorksWithExpiredToken() throws Exception {
@@ -689,6 +734,8 @@ public class TokenServiceTests extends ESTestCase {
         tokenService.getAuthenticationAndMetaData(userTokenString, authFuture);
         Authentication retrievedAuth = authFuture.actionGet().v1();
         assertAuthenticationEquals(authentication, retrievedAuth);
+
+        assertSettingDeprecationsAndWarnings(new Setting[] { TokenService.BWC_ENABLED });
     }
 
     private void mockGetTokenFromId(UserToken userToken) {

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -219,6 +219,7 @@ subprojects {
         }
         setting 'node.attr.upgraded', 'true'
         setting 'xpack.security.authc.token.enabled', 'true'
+        setting 'xpack.security.authc.token.compat.enabled', 'true'
         setting 'xpack.security.audit.enabled', 'true'
         setting 'xpack.security.audit.outputs', 'index'
         setting 'node.name', "upgraded-node-${stopNode}"


### PR DESCRIPTION
The token service has backwards compatibility code that allows it to
accept and generate tokens that are compatible with older versions of
Elasticsearch.

This compatibility code has been removed from 7.x and is only needed
in 6.x if running in a mixed version cluster with very old versions,
or for the lifetime of a token that was generated in an older version
(the default lifetime is 20 minutes).

Maintaining the old style invalidation documents and accepting old
style token strings adds complexity and overhead to the token service
which is typically not needed, and is a source of instability.

This compatibility code is now disabled unless the
`xpack.security.authc.token.compat.enabled` setting is set to true.

Backport of: #38881