### PR TITLE
Obsolete pre 7.0 noarch package in rpm (#39472)

### DIFF
--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -18,6 +18,7 @@
 
 import org.elasticsearch.gradle.LoggedExec
 import org.elasticsearch.gradle.MavenFilteringHack
+import org.redline_rpm.header.Flags
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -329,6 +330,8 @@ Closure commonRpmConfig(boolean oss) {
 
     packageGroup 'Application/Internet'
     requires '/bin/bash'
+
+    obsoletes packageName, '7.0.0', Flags.LESS
 
     prefix '/usr'
     packager 'Elasticsearch'


### PR DESCRIPTION
This commit makes the rpm metadata indicate the pre 7.0 noarch packages
are obsoleted by this package. This fixes an issue where upgrading with
yum would cause an error thinking there was nothing to upgrade.

closes #39414
