### PR TITLE
Handle UTF-8 values in the keystore

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
@@ -532,7 +532,7 @@ public class KeyStoreWrapper implements SecureSettings {
         }
         ByteBuffer byteBuffer = ByteBuffer.wrap(entry.bytes);
         CharBuffer charBuffer = StandardCharsets.UTF_8.decode(byteBuffer);
-        return new SecureString(charBuffer.array());
+        return new SecureString(Arrays.copyOfRange(charBuffer.array(), charBuffer.position(), charBuffer.limit()));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/common/settings/AddStringKeyStoreCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/AddStringKeyStoreCommandTests.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Random;
 
 import org.elasticsearch.cli.Command;
 import org.elasticsearch.cli.ExitCodes;
@@ -131,6 +132,16 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
         setInput("secret value 2");
         execute("--stdin", "foo");
         assertSecureString("foo", "secret value 2");
+    }
+
+    public void testAddUtf8String() throws Exception {
+        KeyStoreWrapper.create().save(env.configFile(), new char[0]);
+        byte[] bytes = new byte[randomIntBetween(8, 16)];
+        new Random().nextBytes(bytes);
+        String secretValue = new String(bytes, StandardCharsets.UTF_8);
+        setInput(secretValue);
+        execute("-x", "foo");
+        assertSecureString("foo", secretValue);
     }
 
     public void testMissingSettingName() throws Exception {


### PR DESCRIPTION
Our current implementation uses CharBuffer#array to get the chars
that were decoded from the UTF-8 bytes. The backing array of
CharBuffer is created in CharsetDecoder#decode and gets an initial
length that is the same as the length of the ByteBuffer it decodes,
hence the number of UTF-8 bytes.
This works fine for the first 128 characters where each one needs
one byte, but for the next UTF-8 characters (other latin alphabets
Greek, Cyrillic etc.) where we need 2 to 4 bytes per character, this
backing char array has a larger size than the number of the actual
chars this CharBuffer contains. Calling `array()` on it will return
a char array that can potentially have extra null chars so the
SecureString we get from the KeystoreWrapper, is not the same as the
one we entered.

This commit changes the behavior to use Arrays#copyOfRange to get
the necessary chars from the CharBuffer and adds a test with
random ( maybe not printable ) UTF-8 strings