### PR TITLE
[DOCS] Corrected API path for /_security/api_key

### DIFF
--- a/x-pack/docs/en/rest-api/security/get-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-api-keys.asciidoc
@@ -59,7 +59,7 @@ The following example retrieves all API keys for the `native1` realm:
 
 [source,js]
 --------------------------------------------------
-GET /_xpack/api_key?realm_name=native1
+GET /_security/api_key?realm_name=native1
 --------------------------------------------------
 // NOTCONSOLE
 
@@ -67,7 +67,7 @@ The following example retrieves all API keys for the user `myuser` in all realms
 
 [source,js]
 --------------------------------------------------
-GET /_xpack/api_key?username=myuser
+GET /_security/api_key?username=myuser
 --------------------------------------------------
 // NOTCONSOLE
 
@@ -76,7 +76,7 @@ Finally, the following example retrieves all API keys for the user `myuser` in
 
 [source,js]
 --------------------------------------------------
-GET /_xpack/api_key?username=myuser&realm_name=native1
+GET /_security/api_key?username=myuser&realm_name=native1
 --------------------------------------------------
 // NOTCONSOLE
 

--- a/x-pack/docs/en/rest-api/security/invalidate-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-api-keys.asciidoc
@@ -65,7 +65,7 @@ The following example invalidates all API keys for the `native1` realm immediate
 
 [source,js]
 --------------------------------------------------
-DELETE /_xpack/api_key
+DELETE /_security/api_key
 {
   "realm_name" : "native1"
 }
@@ -76,7 +76,7 @@ The following example invalidates all API keys for the user `myuser` in all real
 
 [source,js]
 --------------------------------------------------
-DELETE /_xpack/api_key
+DELETE /_security/api_key
 {
   "username" : "myuser"
 }
@@ -88,7 +88,7 @@ Finally, the following example invalidates all API keys for the user `myuser` in
 
 [source,js]
 --------------------------------------------------
-DELETE /_xpack/api_key
+DELETE /_security/api_key
 {
   "username" : "myuser",
   "realm_name" : "native1"


### PR DESCRIPTION
Correct the paths for examples in newly introduced `/_security/api_key`
Should I manually port to `6.7` `7.0` and `7.x`? Or will it be taken care of automatically? 
