### PR TITLE
Remove non-existent variable from Painless context docs

### DIFF
--- a/docs/painless/painless-contexts/painless-similarity-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-similarity-context.asciidoc
@@ -7,14 +7,6 @@ documents in a query.
 
 *Variables*
 
-`params` (`Map`, read-only)::
-        User-defined parameters passed in as part of the query.
-
-*Variables*
-
-`params` (`Map`, read-only)::
-        User-defined parameters passed in at query-time.
-
 `weight` (`float`, read-only)::
         The weight as calculated by a <<painless-weight-context,weight script>>
 

--- a/docs/painless/painless-contexts/painless-weight-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-weight-context.asciidoc
@@ -11,9 +11,6 @@ Queries that contain multiple terms calculate a separate weight for each term.
 
 *Variables*
 
-`params` (`Map`, read-only)::
-        User-defined parameters passed in as part of the query.
-
 `query.boost` (`float`, read-only)::
         The boost value if provided by the query.  If this is not provided the
         value is `1.0f`.


### PR DESCRIPTION
The `params` variable has been erroneously added as available to Painless scripts in the similarity and weight contexts.  This removes that variable from the docs. 