### PR TITLE
[DOCS] Adds link to list of built-in users

### DIFF
--- a/docs/reference/commands/setup-passwords.asciidoc
+++ b/docs/reference/commands/setup-passwords.asciidoc
@@ -3,8 +3,8 @@
 [[setup-passwords]]
 == elasticsearch-setup-passwords
 
-The `elasticsearch-setup-passwords` command sets the passwords for the built-in
-`elastic`, `kibana`, `logstash_system`, `beats_system`, and `apm_system` users.
+The `elasticsearch-setup-passwords` command sets the passwords for the
+{stack-ov}/built-in-users.html[built-in users].
 
 [float]
 === Synopsis

--- a/x-pack/docs/en/security/configuring-es.asciidoc
+++ b/x-pack/docs/en/security/configuring-es.asciidoc
@@ -55,8 +55,7 @@ help you get up and running. The +elasticsearch-setup-passwords+ command is the
 simplest method to set the built-in users' passwords for the first time.
 
 For example, you can run the command in an "interactive" mode, which prompts you
-to enter new passwords for the `elastic`, `kibana`, `beats_system`,
-`logstash_system`, and `apm_system` users:
+to enter new passwords for the built-in users:
 
 [source,shell]
 --------------------------------------------------


### PR DESCRIPTION
There are a couple of places in the Elasticsearch Reference where we list the built-in users. Those lists get out-dated fairly often, so this PR replaces those lists with a link to the definitive list in the Stack Overview. 