### PR TITLE
[DOCS] Corrected API path for invalidate token and SSL certificate examples

### DIFF
--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -92,6 +92,7 @@ buildRestTests.docs = fileTree(projectDir) {
     exclude 'build'
     // These file simply doesn't pass yet. We should figure out how to fix them.
     exclude 'en/watcher/reference/actions.asciidoc'
+    exclude 'en/rest-api/security/ssl.asciidoc'
 }
 
 Map<String, String> setups = buildRestTests.setups

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -93,6 +93,7 @@ buildRestTests.docs = fileTree(projectDir) {
     // These file simply doesn't pass yet. We should figure out how to fix them.
     exclude 'en/watcher/reference/actions.asciidoc'
     exclude 'en/rest-api/security/ssl.asciidoc'
+    exclude 'en/rest-api/security/invalidate-tokens.asciidoc'
 }
 
 Map<String, String> setups = buildRestTests.setups

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -93,7 +93,6 @@ buildRestTests.docs = fileTree(projectDir) {
     // These file simply doesn't pass yet. We should figure out how to fix them.
     exclude 'en/watcher/reference/actions.asciidoc'
     exclude 'en/rest-api/security/ssl.asciidoc'
-    exclude 'en/rest-api/security/invalidate-tokens.asciidoc'
 }
 
 Map<String, String> setups = buildRestTests.setups

--- a/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
@@ -64,7 +64,7 @@ POST /_security/oauth2/token
   "grant_type" : "client_credentials"
 }
 --------------------------------------------------
-// KIBANA
+// CONSOLE
 // TEST
 
 The get token API returns the following information about the access token:
@@ -77,7 +77,7 @@ The get token API returns the following information about the access token:
   "expires_in" : 1200
 }
 --------------------------------------------------
-// KIBANA
+// CONSOLE
 // TESTRESPONSE[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
 
 This access token can now be immediately invalidated, as shown in the following
@@ -90,7 +90,7 @@ DELETE /_security/oauth2/token
   "token" : "dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ=="
 }
 --------------------------------------------------
-// KIBANA
+// CONSOLE
 // TEST[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
 // TEST[continued]
 
@@ -106,7 +106,7 @@ POST /_security/oauth2/token
   "password" : "x-pack-test-password"
 }
 --------------------------------------------------
-// KIBANA
+// CONSOLE
 // TEST
 
 The get token API returns the following information:
@@ -120,7 +120,7 @@ The get token API returns the following information:
   "refresh_token": "vLBPvmAB6KvwvJZr27cS"
 }
 --------------------------------------------------
-// KIBANA
+// CONSOLE
 // TESTRESPONSE[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
 // TESTRESPONSE[s/vLBPvmAB6KvwvJZr27cS/$body.refresh_token/]
 
@@ -134,7 +134,7 @@ DELETE /_security/oauth2/token
   "refresh_token" : "vLBPvmAB6KvwvJZr27cS"
 }
 --------------------------------------------------
-// KIBANA
+// CONSOLE
 // TEST[s/vLBPvmAB6KvwvJZr27cS/$body.refresh_token/]
 // TEST[continued]
 
@@ -148,7 +148,7 @@ DELETE /_security/oauth2/token
   "realm_name" : "saml1"
 }
 --------------------------------------------------
-// KIBANA
+// CONSOLE
 // TEST
 
 The following example invalidates all access tokens and refresh tokens for the
@@ -161,7 +161,7 @@ DELETE /_security/oauth2/token
   "username" : "myuser"
 }
 --------------------------------------------------
-// KIBANA
+// CONSOLE
 // TEST
 
 Finally, the following example invalidates all access tokens and refresh tokens
@@ -175,7 +175,7 @@ DELETE /_security/oauth2/token
   "realm_name" : "saml1"
 }
 --------------------------------------------------
-// KIBANA
+// CONSOLE
 // TEST
 
 A successful call returns a JSON structure that contains the number of tokens

--- a/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
@@ -144,7 +144,8 @@ DELETE /_security/oauth2/token
   "realm_name" : "saml1"
 }
 --------------------------------------------------
-// NOTCONSOLE
+// CONSOLE
+// TEST
 
 The following example invalidates all access tokens and refresh tokens for the
 user `myuser` in all realms immediately:
@@ -156,7 +157,7 @@ DELETE /_security/oauth2/token
   "username" : "myuser"
 }
 --------------------------------------------------
-// NOTCONSOLE
+// CONSOLE
 
 Finally, the following example invalidates all access tokens and refresh tokens
 for the user `myuser` in the `saml1` realm immediately:
@@ -169,7 +170,7 @@ DELETE /_security/oauth2/token
   "realm_name" : "saml1"
 }
 --------------------------------------------------
-// NOTCONSOLE
+// CONSOLE
 
 A successful call returns a JSON structure that contains the number of tokens
 that were invalidated, the number of tokens that had already been invalidated,

--- a/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
@@ -64,7 +64,8 @@ POST /_security/oauth2/token
   "grant_type" : "client_credentials"
 }
 --------------------------------------------------
-// CONSOLE
+// KIBANA
+// TEST
 
 The get token API returns the following information about the access token:
 
@@ -76,6 +77,7 @@ The get token API returns the following information about the access token:
   "expires_in" : 1200
 }
 --------------------------------------------------
+// KIBANA
 // TESTRESPONSE[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
 
 This access token can now be immediately invalidated, as shown in the following
@@ -104,7 +106,7 @@ POST /_security/oauth2/token
   "password" : "x-pack-test-password"
 }
 --------------------------------------------------
-// CONSOLE
+// KIBANA
 // TEST
 
 The get token API returns the following information:
@@ -118,6 +120,7 @@ The get token API returns the following information:
   "refresh_token": "vLBPvmAB6KvwvJZr27cS"
 }
 --------------------------------------------------
+// KIBANA
 // TESTRESPONSE[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
 // TESTRESPONSE[s/vLBPvmAB6KvwvJZr27cS/$body.refresh_token/]
 
@@ -159,6 +162,7 @@ DELETE /_security/oauth2/token
 }
 --------------------------------------------------
 // KIBANA
+// TEST
 
 Finally, the following example invalidates all access tokens and refresh tokens
 for the user `myuser` in the `saml1` realm immediately:
@@ -172,6 +176,7 @@ DELETE /_security/oauth2/token
 }
 --------------------------------------------------
 // KIBANA
+// TEST
 
 A successful call returns a JSON structure that contains the number of tokens
 that were invalidated, the number of tokens that had already been invalidated,

--- a/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
@@ -54,8 +54,8 @@ be specified.
 
 ==== Examples
 
-For example, if you create a token using the 
-`client_credentials` `grant_type` as follows:
+For example, if you create a token using the `client_credentials` grant type as
+follows:
 
 [source,js]
 --------------------------------------------------
@@ -66,7 +66,7 @@ POST /_security/oauth2/token
 --------------------------------------------------
 // CONSOLE
 
-The Get Token API returns the following information about the access token:
+The get token API returns the following information about the access token:
 
 [source,js]
 --------------------------------------------------
@@ -78,8 +78,8 @@ The Get Token API returns the following information about the access token:
 --------------------------------------------------
 // TESTRESPONSE[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
 
-
-The following example invalidates the specified token immediately:
+This access token can now be immediately invalidated, as shown in the following
+example:
 
 [source,js]
 --------------------------------------------------
@@ -107,7 +107,7 @@ POST /_security/oauth2/token
 // CONSOLE
 // TEST
 
-The Get Token API returns the following information:
+The get token API returns the following information:
 
 [source,js]
 --------------------------------------------------
@@ -122,7 +122,7 @@ The Get Token API returns the following information:
 // TESTRESPONSE[s/vLBPvmAB6KvwvJZr27cS/$body.refresh_token/]
 
 The refresh token can now also be immediately invalidated as shown 
-in the following example:"
+in the following example:
 
 [source,js]
 --------------------------------------------------
@@ -134,7 +134,6 @@ DELETE /_security/oauth2/token
 // CONSOLE
 // TEST[s/vLBPvmAB6KvwvJZr27cS/$body.refresh_token/]
 // TEST[continued]
-
 
 The following example invalidates all access tokens and refresh tokens for the
 `saml1` realm immediately:

--- a/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
@@ -66,7 +66,7 @@ POST /_security/oauth2/token
 --------------------------------------------------
 // CONSOLE
 
-The API returns the following information about the access token:
+The Get Token API returns the following information about the access token:
 
 [source,js]
 --------------------------------------------------

--- a/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
@@ -22,7 +22,8 @@ can no longer be used. That time period is defined by the
 The refresh tokens returned by the <<security-api-get-token,get token API>> are
 only valid for 24 hours. They can also be used exactly once.
 
-If you want to invalidate one or more access or refresh tokens immediately, use this invalidate token API.
+If you want to invalidate one or more access or refresh tokens immediately, use
+this invalidate token API.
 
 
 ==== Request Body
@@ -31,22 +32,25 @@ The following parameters can be specified in the body of a DELETE request and
 pertain to invalidating tokens:
 
 `token` (optional)::
-(string) An access token. This parameter cannot be used any of `refresh_token`, `realm_name` or
-         `username` are used.
+(string) An access token. This parameter cannot be used any of `refresh_token`,
+`realm_name` or `username` are used.
 
 `refresh_token` (optional)::
-(string) A refresh token. This parameter cannot be used any of `refresh_token`, `realm_name` or
-                          `username` are used.
+(string) A refresh token. This parameter cannot be used any of `refresh_token`,
+`realm_name` or `username` are used.
 
 `realm_name` (optional)::
-(string) The name of an authentication realm. This parameter cannot be used with either `refresh_token` or `token`.
+(string) The name of an authentication realm. This parameter cannot be used with
+either `refresh_token` or `token`.
 
 `username` (optional)::
-(string) The username of a user. This parameter cannot be used with either `refresh_token` or `token`
+(string) The username of a user. This parameter cannot be used with either
+`refresh_token` or `token`
 
-NOTE: While all parameters are optional, at least one of them is required. More specifically, either one of `token`
-or `refresh_token` parameters is required. If none of these two are specified, then `realm_name` and/or `username`
-need to be specified.
+NOTE: While all parameters are optional, at least one of them is required. More
+specifically, either one of `token` or `refresh_token` parameters is required.
+If none of these two are specified, then `realm_name` and/or `username` need to
+be specified.
 
 ==== Examples
 
@@ -72,34 +76,36 @@ DELETE /_security/oauth2/token
 --------------------------------------------------
 // NOTCONSOLE
 
-The following example invalidates all access tokens and refresh tokens for the `saml1` realm immediately:
+The following example invalidates all access tokens and refresh tokens for the
+`saml1` realm immediately:
 
 [source,js]
 --------------------------------------------------
-DELETE /_xpack/security/oauth2/token
+DELETE /_security/oauth2/token
 {
   "realm_name" : "saml1"
 }
 --------------------------------------------------
 // NOTCONSOLE
 
-The following example invalidates all access tokens and refresh tokens for the user `myuser` in all realms immediately:
+The following example invalidates all access tokens and refresh tokens for the
+user `myuser` in all realms immediately:
 
 [source,js]
 --------------------------------------------------
-DELETE /_xpack/security/oauth2/token
+DELETE /_security/oauth2/token
 {
   "username" : "myuser"
 }
 --------------------------------------------------
 // NOTCONSOLE
 
-Finally, the following example invalidates all access tokens and refresh tokens for the user `myuser` in
- the `saml1` realm immediately:
+Finally, the following example invalidates all access tokens and refresh tokens
+for the user `myuser` in the `saml1` realm immediately:
 
 [source,js]
 --------------------------------------------------
-DELETE /_xpack/security/oauth2/token
+DELETE /_security/oauth2/token
 {
   "username" : "myuser",
   "realm_name" : "saml1"
@@ -107,9 +113,9 @@ DELETE /_xpack/security/oauth2/token
 --------------------------------------------------
 // NOTCONSOLE
 
-A successful call returns a JSON structure that contains the number of tokens that were invalidated, the number
-of tokens that had already been invalidated, and potentially a list of errors encountered while invalidating
-specific tokens.
+A successful call returns a JSON structure that contains the number of tokens
+that were invalidated, the number of tokens that had already been invalidated,
+and potentially a list of errors encountered while invalidating specific tokens.
 
 [source,js]
 --------------------------------------------------

--- a/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
@@ -88,7 +88,7 @@ DELETE /_security/oauth2/token
   "token" : "dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ=="
 }
 --------------------------------------------------
-// CONSOLE
+// KIBANA
 // TEST[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
 // TEST[continued]
 
@@ -131,7 +131,7 @@ DELETE /_security/oauth2/token
   "refresh_token" : "vLBPvmAB6KvwvJZr27cS"
 }
 --------------------------------------------------
-// CONSOLE
+// KIBANA
 // TEST[s/vLBPvmAB6KvwvJZr27cS/$body.refresh_token/]
 // TEST[continued]
 
@@ -145,7 +145,7 @@ DELETE /_security/oauth2/token
   "realm_name" : "saml1"
 }
 --------------------------------------------------
-// CONSOLE
+// KIBANA
 // TEST
 
 The following example invalidates all access tokens and refresh tokens for the
@@ -158,7 +158,7 @@ DELETE /_security/oauth2/token
   "username" : "myuser"
 }
 --------------------------------------------------
-// CONSOLE
+// KIBANA
 
 Finally, the following example invalidates all access tokens and refresh tokens
 for the user `myuser` in the `saml1` realm immediately:
@@ -171,7 +171,7 @@ DELETE /_security/oauth2/token
   "realm_name" : "saml1"
 }
 --------------------------------------------------
-// CONSOLE
+// KIBANA
 
 A successful call returns a JSON structure that contains the number of tokens
 that were invalidated, the number of tokens that had already been invalidated,

--- a/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
@@ -93,7 +93,7 @@ DELETE /_security/oauth2/token
 // TEST[continued]
 
 If you used the `password` grant type to obtain a token for a user, the response
-contains a refresh token. For example:
+might also contain a refresh token. For example:
 
 [source,js]
 --------------------------------------------------

--- a/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
@@ -103,18 +103,36 @@ POST /_security/oauth2/token
   "password" : "x-pack-test-password"
 }
 --------------------------------------------------
-// NOTCONSOLE
+// CONSOLE
+// TEST
 
-The following example invalidates the specified refresh token immediately:
+The API returns the following information:
+
+[source,js]
+--------------------------------------------------
+{
+  "access_token" : "dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==",
+  "type" : "Bearer",
+  "expires_in" : 1200,
+  "refresh_token": "vLBPvmAB6KvwvJZr27cS"
+}
+--------------------------------------------------
+// TESTRESPONSE[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
+// TESTRESPONSE[s/vLBPvmAB6KvwvJZr27cS/$body.refresh_token/]
+
+You can invalidate the specified refresh token as follows:
 
 [source,js]
 --------------------------------------------------
 DELETE /_security/oauth2/token
 {
-  "refresh_token" : "movUJjPGRRC0PQ7+NW0eag"
+  "refresh_token" : "vLBPvmAB6KvwvJZr27cS"
 }
 --------------------------------------------------
-// NOTCONSOLE
+// CONSOLE
+// TEST[s/vLBPvmAB6KvwvJZr27cS/$body.refresh_token/]
+// TEST[continued]
+
 
 The following example invalidates all access tokens and refresh tokens for the
 `saml1` realm immediately:

--- a/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
@@ -54,6 +54,30 @@ be specified.
 
 ==== Examples
 
+For example, if you create the following token:
+
+[source,js]
+--------------------------------------------------
+POST /_security/oauth2/token
+{
+  "grant_type" : "client_credentials"
+}
+--------------------------------------------------
+// CONSOLE
+
+The API returns the following information about the access token:
+
+[source,js]
+--------------------------------------------------
+{
+  "access_token" : "dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==",
+  "type" : "Bearer",
+  "expires_in" : 1200
+}
+--------------------------------------------------
+// TESTRESPONSE[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
+
+
 The following example invalidates the specified token immediately:
 
 [source,js]
@@ -63,9 +87,25 @@ DELETE /_security/oauth2/token
   "token" : "dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ=="
 }
 --------------------------------------------------
+// CONSOLE
+// TEST[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
+// TEST[continued]
+
+If you used the `password` grant type to obtain a token for a user, the response
+contains a refresh token. For example:
+
+[source,js]
+--------------------------------------------------
+POST /_security/oauth2/token
+{
+  "grant_type" : "password",
+  "username" : "test_admin",
+  "password" : "x-pack-test-password"
+}
+--------------------------------------------------
 // NOTCONSOLE
 
-whereas the following example invalidates the specified refresh token immediately:
+The following example invalidates the specified refresh token immediately:
 
 [source,js]
 --------------------------------------------------

--- a/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
@@ -107,7 +107,7 @@ POST /_security/oauth2/token
 // CONSOLE
 // TEST
 
-The API returns the following information:
+The Get Token API returns the following information:
 
 [source,js]
 --------------------------------------------------

--- a/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
@@ -121,7 +121,8 @@ The Get Token API returns the following information:
 // TESTRESPONSE[s/dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==/$body.access_token/]
 // TESTRESPONSE[s/vLBPvmAB6KvwvJZr27cS/$body.refresh_token/]
 
-You can invalidate the specified refresh token as follows:
+The refresh token can now also be immediately invalidated as shown 
+in the following example:"
 
 [source,js]
 --------------------------------------------------

--- a/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-tokens.asciidoc
@@ -54,7 +54,8 @@ be specified.
 
 ==== Examples
 
-For example, if you create the following token:
+For example, if you create a token using the 
+`client_credentials` `grant_type` as follows:
 
 [source,js]
 --------------------------------------------------

--- a/x-pack/docs/en/rest-api/security/ssl.asciidoc
+++ b/x-pack/docs/en/rest-api/security/ssl.asciidoc
@@ -78,7 +78,7 @@ node of {es}:
 
 [source,js]
 --------------------------------------------------
-GET /_xpack/certificates
+GET /_ssl/certificates
 --------------------------------------------------
 // CONSOLE
 // TEST[skip:todo]

--- a/x-pack/docs/en/rest-api/security/ssl.asciidoc
+++ b/x-pack/docs/en/rest-api/security/ssl.asciidoc
@@ -81,9 +81,16 @@ node of {es}:
 GET /_ssl/certificates
 --------------------------------------------------
 // CONSOLE
-// TEST[skip:todo]
+// TEST
 
 The API returns the following results:
+////
+[source,js]
+----
+[ ]
+----
+// TESTRESPONSE
+////
 [source,js]
 ----
 [

--- a/x-pack/docs/en/rest-api/security/ssl.asciidoc
+++ b/x-pack/docs/en/rest-api/security/ssl.asciidoc
@@ -84,13 +84,7 @@ GET /_ssl/certificates
 // TEST
 
 The API returns the following results:
-////
-[source,js]
-----
-[ ]
-----
-// TESTRESPONSE
-////
+
 [source,js]
 ----
 [


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/39517

This PR corrects some out-dated examples in the invalidate token API and the SSL certificate API.
It also wraps some long lines of text.

Ideally we can enable the tests on these APIs so that we catch changes like this.