### PR TITLE
[Backport 6.7] Remove missing variable from error message (#39321)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
@@ -110,7 +110,7 @@ class ClusterConfiguration {
         }
         if (ant.properties.containsKey("failed.${seedNode.transportPortsFile.path}".toString())) {
             throw new GradleException("Failed to locate seed node transport file [${seedNode.transportPortsFile}]: " +
-                    "timed out waiting for it to be created after ${waitSeconds} seconds")
+                    "timed out waiting for it to be created after 40 seconds")
         }
         return seedNode.transportUri()
     }


### PR DESCRIPTION
When test clusters are stood up, one of the steps in the wait task is to wait for 
ports files to appear. An exception throw was added if this were to time out
instead of failing with no information, but the exception text uses a missing 
variable which further obfuscates the problem.

Backports #39321 