### PR TITLE
Override and mute InternalAutoDateHistogramTests#testReduceRandom()

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
@@ -110,6 +110,13 @@ public class InternalAutoDateHistogramTests extends InternalMultiBucketAggregati
     }
 
     @Override
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/39497")
+    // TODO: When resolving the above AwaitsFix, just delete this override. Method is only overriden to apply the annotation.
+    public void testReduceRandom() {
+        super.testReduceRandom();
+    }
+
+    @Override
     protected void assertReduced(InternalAutoDateHistogram reduced, List<InternalAutoDateHistogram> inputs) {
 
         long lowest = Long.MAX_VALUE;


### PR DESCRIPTION
This PR mutes the failing test from #39497 

