### PR TITLE
SQL: fix COUNT DISTINCT column name

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/resources/agg.sql-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/agg.sql-spec
@@ -89,6 +89,8 @@ SELECT (emp_no % 3) + 1 AS e, (languages % 3) + 1 AS l FROM test_emp GROUP BY e,
 
 // COUNT
 aggCountImplicit
+SELECT COUNT(*) FROM test_emp;
+aggCountImplicitAlias
 SELECT COUNT(*) AS count FROM test_emp;
 aggCountImplicitWithCast
 SELECT CAST(COUNT(*) AS INT) c FROM "test_emp";
@@ -109,6 +111,8 @@ SELECT gender g, CAST(COUNT(*) AS INT) c FROM "test_emp" WHERE emp_no < 10020 GR
 aggCountWithAlias
 SELECT gender g, COUNT(*) c FROM "test_emp" GROUP BY g ORDER BY gender;
 countDistinct
+SELECT COUNT(DISTINCT "hire_date") FROM test_emp;
+countDistinctAlias
 SELECT COUNT(DISTINCT hire_date) AS count FROM test_emp;
 countDistinctAndCountSimpleWithAlias
 SELECT COUNT(*) cnt, COUNT(DISTINCT first_name) as names, gender FROM test_emp GROUP BY gender ORDER BY gender;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Count.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Count.java
@@ -64,16 +64,6 @@ public class Count extends AggregateFunction {
     }
 
     @Override
-    public String name() {
-        if (distinct()) {
-            StringBuilder sb = new StringBuilder(super.name());
-            sb.insert(sb.indexOf("(") + 1, "DISTINCT ");
-            return sb.toString();
-        }
-        return super.name();
-    }
-
-    @Override
     public AggregateFunctionAttribute toAttribute() {
         // COUNT(*) gets its value from the parent aggregation on which _count is called
         if (field() instanceof Literal) {


### PR DESCRIPTION
This PR removes the need for a custom named column in case of a DISTINCT COUNT function.

Fixes https://github.com/elastic/elasticsearch/issues/39511.