### PR TITLE
[DOCS] Updates API in Watcher transform context

### DIFF
--- a/docs/painless/painless-contexts/painless-watcher-context-example.asciidoc
+++ b/docs/painless/painless-contexts/painless-watcher-context-example.asciidoc
@@ -104,7 +104,7 @@ The following example shows the use of metadata and transforming dates into a re
 
 [source,Painless]
 ----
-POST _xpack/watcher/watch/_execute
+POST _watcher/watch/_execute
 {
   "watch" : {
     "metadata" : { "min_hits": 10000 },


### PR DESCRIPTION
This PR updates `POST _xpack/watcher/watch/_execute` to `POST _watcher/watch/_execute` in the following documentation:
https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-watcher-condition-context.html
https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-watcher-transform-context.html
