### PR TITLE
Add a note to purge the ingest-geoip plugin

### DIFF
--- a/docs/reference/migration/migrate_6_7.asciidoc
+++ b/docs/reference/migration/migrate_6_7.asciidoc
@@ -43,6 +43,24 @@ will result in an error. Additionally, there are two minor breaking changes here
 - `plugin.mandatory` is no longer compatible with `ingest-geoip` nor
   `ingest-user-agent`
 
+Elasticsearch 6.7.0 checks that there are no leftover geoip database files in
+the plugin configuration directory because the new module does not use them.
+Therefore, remove the `ingest-geoip` plugin prior to upgrading to 6.7.0 with
+the `--purge` option to also delete the old database files:
+
+[source,sh]
+------------------------------------------------------
+./bin/elasticsearch-plugin remove --purge ingest-geoip
+------------------------------------------------------
+
+Otherwise you will see the following error message upon startup (assuming
+`/etc/elasticsearch/ingest-geoip` as the plugin configuration directory):
+
+[source,text]
+---------------------------------------------------------------------------------------
+expected database [GeoLite2-ASN.mmdb] to not exist in [/etc/elasticsearch/ingest-geoip]
+---------------------------------------------------------------------------------------
+
 
 [float]
 [[breaking_67_settings_changes]]


### PR DESCRIPTION
The ingest-geoip module in 6.7.0 will check for any leftover database
files from the old plugin and will prevent node startup if they are
present. With this commit we add a note to the breaking changes docs for
6.7.0 that instructs users to use the `--purge` option when removing the
`ingest-geoip` plugin prior to upgrading to avoid this situation.

Closes #39495