### PR TITLE
SQL: Don't allow inexact fields for MIN/MAX

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Max.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Max.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.sql.type.DataType;
 
 import java.util.List;
 
+import static org.elasticsearch.xpack.sql.expression.TypeResolutions.isExact;
 import static org.elasticsearch.xpack.sql.expression.TypeResolutions.isNumericOrDate;
 
 /**
@@ -47,7 +48,7 @@ public class Max extends NumericAggregate implements EnclosedAgg {
     @Override
     protected TypeResolution resolveType() {
         if (field().dataType().isString()) {
-            return TypeResolution.TYPE_RESOLVED;
+            return isExact(field(), sourceText(), ParamOrdinal.DEFAULT);
         } else {
             return isNumericOrDate(field(), sourceText(), ParamOrdinal.DEFAULT);
         }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Min.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Min.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.sql.type.DataType;
 
 import java.util.List;
 
+import static org.elasticsearch.xpack.sql.expression.TypeResolutions.isExact;
 import static org.elasticsearch.xpack.sql.expression.TypeResolutions.isNumericOrDate;
 
 /**
@@ -50,7 +51,7 @@ public class Min extends NumericAggregate implements EnclosedAgg {
     @Override
     protected TypeResolution resolveType() {
         if (field().dataType().isString()) {
-            return TypeResolution.TYPE_RESOLVED;
+            return isExact(field(), sourceText(), ParamOrdinal.DEFAULT);
         } else {
             return isNumericOrDate(field(), sourceText(), ParamOrdinal.DEFAULT);
         }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -717,6 +717,18 @@ public class VerifierErrorMessagesTests extends ESTestCase {
             error("SELECT FIRST(int) FROM test GROUP BY text HAVING FIRST(int) > 10"));
     }
 
+    public void testMinOnInexactUnsupported() {
+        assertEquals("1:8: [MIN(text)] cannot operate on field of data type [text]: " +
+                "No keyword/multi-field defined exact matches for [text]; define one or use MATCH/QUERY instead",
+            error("SELECT MIN(text) FROM test"));
+    }
+
+    public void testMaxOnInexactUnsupported() {
+        assertEquals("1:8: [MAX(text)] cannot operate on field of data type [text]: " +
+                "No keyword/multi-field defined exact matches for [text]; define one or use MATCH/QUERY instead",
+            error("SELECT MAX(text) FROM test"));
+    }
+
     public void testMinOnKeywordGroupByHavingUnsupported() {
         assertEquals("1:52: HAVING filter is unsupported for function [MIN(keyword)]",
             error("SELECT MIN(keyword) FROM test GROUP BY text HAVING MIN(keyword) > 10"));


### PR DESCRIPTION
MIN/MAX on strings are supported and are implemented with
TopAggs FIRST/LAST respectively, but they cannot operate on
`text` fields without underlying `keyword` fields => inexact.

Follows: #39427
