### PR TITLE
Adapt bwc after the backport of replicated closed indices

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,8 +160,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/39506" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -986,7 +986,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             closeIndex(index);
         }
 
-        if (getOldClusterVersion().onOrAfter(Version.V_8_0_0)) {
+        if (getOldClusterVersion().onOrAfter(Version.V_7_1_0)) {
             ensureGreenLongWait(index);
             assertClosedIndex(index, true);
         } else {

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -341,7 +341,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
         }
 
         final Version indexVersionCreated = indexVersionCreated(indexName);
-        if (indexVersionCreated.onOrAfter(Version.V_8_0_0)) {
+        if (indexVersionCreated.onOrAfter(Version.V_7_1_0)) {
             // index was created on a version that supports the replication of closed indices,
             // so we expect the index to be closed and replicated
             ensureGreen(indexName);
@@ -370,7 +370,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
             closeIndex(indexName);
         }
 
-        if (minimumNodeVersion.onOrAfter(Version.V_8_0_0)) {
+        if (minimumNodeVersion.onOrAfter(Version.V_7_1_0)) {
             // index is created on a version that supports the replication of closed indices,
             // so we expect the index to be closed and replicated
             ensureGreen(indexName);

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
@@ -50,10 +50,10 @@
                 )
                 $/
 ---
-"Test cat indices output for closed index (pre 8.0.0)":
+"Test cat indices output for closed index (pre 7.1.0)":
   - skip:
-      version: "8.0.0 - "
-      reason:  "closed indices are replicated starting version 8.0"
+      version: "7.1.0 - "
+      reason:  "closed indices are replicated starting version 7.1.0"
 
   - do:
       indices.create:
@@ -93,8 +93,8 @@
 ---
 "Test cat indices output for closed index":
   - skip:
-      version: " - 7.99.99"
-      reason:  "closed indices are replicated starting version 8.0"
+      version: " - 7.0.99"
+      reason:  "closed indices are replicated starting version 7.1.0"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.recovery/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.recovery/10_basic.yml
@@ -79,8 +79,8 @@
 ---
 "Test cat recovery output for closed index":
   - skip:
-      version: " - 7.99.99"
-      reason: closed indices are replicated starting version 8.0.0
+      version: " - 7.0.99"
+      reason: closed indices are replicated starting version 7.1.0
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.allocation_explain/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.allocation_explain/10_basic.yml
@@ -58,8 +58,8 @@
 ---
 "Cluster shard allocation explanation test with a closed index":
   - skip:
-      version: " - 7.99.99"
-      reason: closed indices are replicated starting version 8.0.0
+      version: " - 7.0.99"
+      reason: closed indices are replicated starting version 7.1.0
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yml
@@ -133,10 +133,10 @@
   - is_true: indices.test_index.shards
 
 ---
-"cluster health with closed index (pre 8.0)":
+"cluster health with closed index (pre 7.1.0)":
   - skip:
-      version: "8.0.0 - "
-      reason:  "closed indices are replicated starting version 8.0"
+      version: "7.1.0 - "
+      reason:  "closed indices are replicated starting version 7.1.0"
 
   - do:
       indices.create:
@@ -209,8 +209,8 @@
 ---
 "cluster health with closed index":
   - skip:
-      version: " - 7.99.99"
-      reason:  "closed indices are replicated starting version 8.0"
+      version: " - 7.0.99"
+      reason:  "closed indices are replicated starting version 7.1.0"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/30_indices_options.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/30_indices_options.yml
@@ -31,8 +31,8 @@ setup:
 ---
 "cluster health with expand_wildcards":
   - skip:
-      version: " - 7.99.99"
-      reason:  "indices options has been introduced in cluster health request starting version 8.0"
+      version: " - 7.0.99"
+      reason:  "indices options has been introduced in cluster health request starting version 7.1.0"
 
   - do:
       cluster.health:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
@@ -65,8 +65,8 @@
 ---
 "Close index with wait_for_active_shards set to all":
   - skip:
-      version: " - 7.99.99"
-      reason:  "closed indices are replicated starting version 8.0"
+      version: " - 7.0.99"
+      reason:  "closed indices are replicated starting version 7.1.0"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.recovery/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.recovery/10_basic.yml
@@ -42,8 +42,8 @@
 ---
 "Indices recovery test for closed index":
   - skip:
-      version: " - 7.99.99"
-      reason: closed indices are replicated starting version 8.0.0
+      version: " - 7.0.99"
+      reason: closed indices are replicated starting version 7.1.0
 
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -84,7 +84,7 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
         if (in.getVersion().onOrAfter(Version.V_6_2_0)) {
             waitForNoInitializingShards = in.readBoolean();
         }
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_1_0)) {
             indicesOptions = IndicesOptions.readIndicesOptions(in);
         } else {
             indicesOptions = IndicesOptions.lenientExpandOpen();
@@ -121,7 +121,7 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
         if (out.getVersion().onOrAfter(Version.V_6_2_0)) {
             out.writeBoolean(waitForNoInitializingShards);
         }
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_1_0)) {
             indicesOptions.writeIndicesOptions(out);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.java
@@ -40,7 +40,7 @@ public class CloseIndexRequest extends AcknowledgedRequest<CloseIndexRequest> im
 
     private String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
-    private ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT; // Changes this to NONE on 7.x to keep previous behavior
+    private ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT;
 
     public CloseIndexRequest() {
     }
@@ -118,7 +118,7 @@ public class CloseIndexRequest extends AcknowledgedRequest<CloseIndexRequest> im
         super.readFrom(in);
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_1_0)) {
             waitForActiveShards = ActiveShardCount.readFrom(in);
         } else {
             waitForActiveShards = ActiveShardCount.NONE;
@@ -130,7 +130,7 @@ public class CloseIndexRequest extends AcknowledgedRequest<CloseIndexRequest> im
         super.writeTo(out);
         out.writeStringArray(indices);
         indicesOptions.writeIndicesOptions(out);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_1_0)) {
             waitForActiveShards.writeTo(out);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexResponse.java
@@ -37,7 +37,7 @@ public class CloseIndexResponse extends ShardsAcknowledgedResponse {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_1_0)) {
             readShardsAcknowledged(in);
         }
     }
@@ -45,7 +45,7 @@ public class CloseIndexResponse extends ShardsAcknowledgedResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_1_0)) {
             writeShardsAcknowledged(out);
         }
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexStateService.java
@@ -402,7 +402,7 @@ public class MetaDataIndexStateService {
 
         // Remove the index routing table of closed indices if the cluster is in a mixed version
         // that does not support the replication of closed indices
-        final boolean removeRoutingTable = currentState.nodes().getMinNodeVersion().before(Version.V_8_0_0);
+        final boolean removeRoutingTable = currentState.nodes().getMinNodeVersion().before(Version.V_7_1_0);
 
         final MetaData.Builder metadata = MetaData.builder(currentState.metaData());
         final ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestTests.java
@@ -57,9 +57,9 @@ public class ClusterHealthRequestTests extends ESTestCase {
 
     public void testBwcSerialization() throws Exception {
         for (int runs = 0; runs < randomIntBetween(5, 20); runs++) {
-            // Generate a random cluster health request in version < 8.0.0 and serializes it
+            // Generate a random cluster health request in version < 7.1.0 and serializes it
             final BytesStreamOutput out = new BytesStreamOutput();
-            out.setVersion(randomVersionBetween(random(), Version.V_6_3_0, getPreviousVersion(Version.V_8_0_0)));
+            out.setVersion(randomVersionBetween(random(), Version.V_6_3_0, getPreviousVersion(Version.V_7_1_0)));
 
             final ClusterHealthRequest expected = randomRequest();
             {
@@ -112,9 +112,9 @@ public class ClusterHealthRequestTests extends ESTestCase {
             // Generate a random cluster health request in current version
             final ClusterHealthRequest expected = randomRequest();
 
-            // Serialize to node in version < 8.0.0
+            // Serialize to node in version < 7.1.0
             final BytesStreamOutput out = new BytesStreamOutput();
-            out.setVersion(randomVersionBetween(random(), Version.V_6_3_0, getPreviousVersion(Version.V_8_0_0)));
+            out.setVersion(randomVersionBetween(random(), Version.V_6_3_0, getPreviousVersion(Version.V_7_1_0)));
             expected.writeTo(out);
 
             // Deserialize and check the cluster health request

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequestTests.java
@@ -54,7 +54,7 @@ public class CloseIndexRequestTests extends ESTestCase {
         {
             final CloseIndexRequest request = randomRequest();
             try (BytesStreamOutput out = new BytesStreamOutput()) {
-                out.setVersion(randomVersionBetween(random(), Version.V_6_4_0, VersionUtils.getPreviousVersion(Version.V_8_0_0)));
+                out.setVersion(randomVersionBetween(random(), Version.V_6_4_0, VersionUtils.getPreviousVersion(Version.V_7_1_0)));
                 request.writeTo(out);
 
                 try (StreamInput in = out.bytes().streamInput()) {
@@ -77,7 +77,7 @@ public class CloseIndexRequestTests extends ESTestCase {
 
                 final CloseIndexRequest deserializedRequest = new CloseIndexRequest();
                 try (StreamInput in = out.bytes().streamInput()) {
-                    in.setVersion(randomVersionBetween(random(), Version.V_6_4_0, VersionUtils.getPreviousVersion(Version.V_8_0_0)));
+                    in.setVersion(randomVersionBetween(random(), Version.V_6_4_0, VersionUtils.getPreviousVersion(Version.V_7_1_0)));
                     deserializedRequest.readFrom(in);
                 }
                 assertEquals(sample.getParentTask(), deserializedRequest.getParentTask());

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/close/CloseIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/close/CloseIndexResponseTests.java
@@ -48,7 +48,7 @@ public class CloseIndexResponseTests extends ESTestCase {
         {
             final CloseIndexResponse response = randomResponse();
             try (BytesStreamOutput out = new BytesStreamOutput()) {
-                out.setVersion(randomVersionBetween(random(), Version.V_6_0_0, VersionUtils.getPreviousVersion(Version.V_8_0_0)));
+                out.setVersion(randomVersionBetween(random(), Version.V_6_0_0, VersionUtils.getPreviousVersion(Version.V_7_1_0)));
                 response.writeTo(out);
 
                 final AcknowledgedResponse deserializedResponse = new AcknowledgedResponse();
@@ -65,7 +65,7 @@ public class CloseIndexResponseTests extends ESTestCase {
 
                 final CloseIndexResponse deserializedResponse = new CloseIndexResponse();
                 try (StreamInput in = out.bytes().streamInput()) {
-                    in.setVersion(randomVersionBetween(random(), Version.V_6_0_0, VersionUtils.getPreviousVersion(Version.V_8_0_0)));
+                    in.setVersion(randomVersionBetween(random(), Version.V_6_0_0, VersionUtils.getPreviousVersion(Version.V_7_1_0)));
                     deserializedResponse.readFrom(in);
                 }
                 assertThat(deserializedResponse.isAcknowledged(), equalTo(response.isAcknowledged()));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexStateServiceTests.java
@@ -138,9 +138,9 @@ public class MetaDataIndexStateServiceTests extends ESTestCase {
         state = ClusterState.builder(state)
             .nodes(DiscoveryNodes.builder(state.nodes())
                 .add(new DiscoveryNode("old_node", buildNewFakeTransportAddress(), emptyMap(),
-                    new HashSet<>(Arrays.asList(DiscoveryNode.Role.values())), Version.V_7_1_0))
+                    new HashSet<>(Arrays.asList(DiscoveryNode.Role.values())), Version.V_7_0_0))
                 .add(new DiscoveryNode("new_node", buildNewFakeTransportAddress(), emptyMap(),
-                    new HashSet<>(Arrays.asList(DiscoveryNode.Role.values())), Version.V_8_0_0)))
+                    new HashSet<>(Arrays.asList(DiscoveryNode.Role.values())), Version.V_7_1_0)))
             .build();
 
         state = MetaDataIndexStateService.closeRoutingTable(state, blockedIndices, results);

--- a/server/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.indices;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -212,13 +211,8 @@ public class IndicesLifecycleListenerIT extends ESIntegTestCase {
         assertThat(stateChangeListenerNode1.afterCloseSettings.getAsInt(SETTING_NUMBER_OF_SHARDS, -1), equalTo(6));
         assertThat(stateChangeListenerNode1.afterCloseSettings.getAsInt(SETTING_NUMBER_OF_REPLICAS, -1), equalTo(1));
 
-        if (Version.CURRENT.onOrAfter(Version.V_8_0_0)) {
-            assertShardStatesMatch(stateChangeListenerNode1, 6, CLOSED, CREATED, RECOVERING, POST_RECOVERY, STARTED);
-            assertShardStatesMatch(stateChangeListenerNode2, 6, CLOSED, CREATED, RECOVERING, POST_RECOVERY, STARTED);
-        } else {
-            assertShardStatesMatch(stateChangeListenerNode1, 6, CLOSED);
-            assertShardStatesMatch(stateChangeListenerNode2, 6, CLOSED);
-        }
+        assertShardStatesMatch(stateChangeListenerNode1, 6, CLOSED, CREATED, RECOVERING, POST_RECOVERY, STARTED);
+        assertShardStatesMatch(stateChangeListenerNode2, 6, CLOSED, CREATED, RECOVERING, POST_RECOVERY, STARTED);
     }
 
     private static void assertShardStatesMatch(final IndexShardStateChangeListener stateChangeListener,


### PR DESCRIPTION
This pull request adapts the bwc layer et reenables the bwc tests after #39506 has been backported to 7.x.