### PR TITLE
Cleanup GrokProcessorGetAction class

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessorGetAction.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessorGetAction.java
@@ -21,26 +21,22 @@ package org.elasticsearch.ingest.common;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
-import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.StatusToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
-import org.elasticsearch.rest.action.RestBuilderListener;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.action.RestStatusToXContentListener;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
@@ -53,8 +49,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 
 public class GrokProcessorGetAction extends Action<GrokProcessorGetAction.Response> {
 
-    public static final GrokProcessorGetAction INSTANCE = new GrokProcessorGetAction();
-    public static final String NAME = "cluster:admin/ingest/processor/grok/get";
+    static final GrokProcessorGetAction INSTANCE = new GrokProcessorGetAction();
+    static final String NAME = "cluster:admin/ingest/processor/grok/get";
 
     private GrokProcessorGetAction() {
         super(NAME);
@@ -72,16 +68,10 @@ public class GrokProcessorGetAction extends Action<GrokProcessorGetAction.Respon
         }
     }
 
-    public static class RequestBuilder extends ActionRequestBuilder<Request, Response> {
-        public RequestBuilder(ElasticsearchClient client) {
-            super(client, GrokProcessorGetAction.INSTANCE, new Request());
-        }
-    }
-
-    public static class Response extends ActionResponse implements ToXContentObject {
+    public static class Response extends ActionResponse implements StatusToXContentObject {
         private Map<String, String> grokPatterns;
 
-        public Response(Map<String, String> grokPatterns) {
+        Response(Map<String, String> grokPatterns) {
             this.grokPatterns = grokPatterns;
         }
 
@@ -96,6 +86,11 @@ public class GrokProcessorGetAction extends Action<GrokProcessorGetAction.Respon
             builder.map(grokPatterns);
             builder.endObject();
             return builder;
+        }
+
+        @Override
+        public RestStatus status() {
+            return OK;
         }
 
         @Override
@@ -129,7 +124,7 @@ public class GrokProcessorGetAction extends Action<GrokProcessorGetAction.Respon
     }
 
     public static class RestAction extends BaseRestHandler {
-        public RestAction(Settings settings, RestController controller) {
+        RestAction(Settings settings, RestController controller) {
             super(settings);
             controller.registerHandler(GET, "/_ingest/processor/grok", this);
         }
@@ -140,14 +135,8 @@ public class GrokProcessorGetAction extends Action<GrokProcessorGetAction.Respon
         }
 
         @Override
-        protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-            return channel -> client.executeLocally(INSTANCE, new Request(), new RestBuilderListener<Response>(channel) {
-                @Override
-                public RestResponse buildResponse(Response response, XContentBuilder builder) throws Exception {
-                    response.toXContent(builder, ToXContent.EMPTY_PARAMS);
-                    return new BytesRestResponse(OK, builder);
-                }
-            });
+        protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+            return channel -> client.executeLocally(INSTANCE, new Request(), new RestStatusToXContentListener<>(channel));
         }
     }
 }


### PR DESCRIPTION
* Removed request builder. From 7.0, request builders are no longer used.
* Use RestStatusToXContentListener instead of custom RestBuilderListener in the rest action.
* Changed a few public constructor's and constants' visibility from public to package protected.
  (these are only used internally, so no need to for public visibility)