### PR TITLE
Add tests for Painless casting from short and Short

### DIFF
--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/StandardCastTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/StandardCastTests.java
@@ -871,7 +871,7 @@ public class StandardCastTests extends ScriptTestCase {
 
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); String n = o;"));
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; String n = o;"));
-        expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((Byte)0); String n = (String)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); String n = (String)o;"));
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; String n = (String)o;"));
 
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); boolean b = o;"));
@@ -927,34 +927,196 @@ public class StandardCastTests extends ScriptTestCase {
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); Short b = o;"));
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; Short b = o;"));
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); Short b = (Short)o;"));
-        expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; short b = (Short)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; Short b = (Short)o;"));
 
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); Character b = o;"));
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; Character b = o;"));
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); Character b = (Character)o;"));
-        expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; char b = (Character)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; Character b = (Character)o;"));
 
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); Integer b = o;"));
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; Integer b = o;"));
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); Integer b = (Integer)o;"));
-        expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; int b = (Integer)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; Integer b = (Integer)o;"));
 
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); Long b = o;"));
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; Long b = o;"));
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); Long b = (Long)o;"));
-        expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; long b = (Long)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; Long b = (Long)o;"));
 
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); Float b = o;"));
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; Float b = o;"));
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); Float b = (Float)o;"));
-        expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; float b = (Float)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; Float b = (Float)o;"));
 
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); Double b = o;"));
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; Double b = o;"));
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); Double b = (Double)o;"));
-        expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; double b = (Double)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Byte o = null; Double b = (Double)o;"));
 
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); ArrayList b = o;"));
         expectScriptThrows(ClassCastException.class, () -> exec("Byte o = Byte.valueOf((byte)0); ArrayList b = (ArrayList)o;"));
+    }
+
+    public void testPrimitiveShortCasts() {
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Object n = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Object n = (Object)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Number n = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Number n = (Number)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; String n = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; String n = (String)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; boolean b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; boolean b = (boolean)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; byte b = o;"));
+        exec("short o = 0; byte b = (byte)o;");
+
+        exec("short o = 0; short b = o;");
+        exec("short o = 0; short b = (short)o;");
+
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; char b = o;"));
+        exec("short o = 0; char b = (char)o;");
+
+        exec("short o = 0; int b = o;");
+        exec("short o = 0; int b = (int)o;");
+
+        exec("short o = 0; long b = o;");
+        exec("short o = 0; long b = (long)o;");
+
+        exec("short o = 0; float b = o;");
+        exec("short o = 0; float b = (float)o;");
+
+        exec("short o = 0; double b = o;");
+        exec("short o = 0; double b = (double)o;");
+
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Boolean b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Boolean b = (Boolean)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Byte b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Byte b = (Byte)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Short b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Short b = (Short)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Character b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Character b = (Character)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Integer b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Integer b = (Integer)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Long b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Long b = (Long)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Float b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Float b = (Float)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Double b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = 0; Double b = (Double)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = Byte.valueOf((short)0); ArrayList b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("short o = Byte.valueOf((short)0); ArrayList b = (ArrayList)o;"));
+    }
+
+    public void testShortCasts() {
+        exec("Short o = Short.valueOf((short)0); Object n = o;");
+        exec("Short o = null; Object n = o;");
+        exec("Short o = Short.valueOf((short)0); Object n = (Object)o;");
+        exec("Short o = null; Object n = (Object)o;");
+
+        exec("Short o = Short.valueOf((short)0); Number n = o;");
+        exec("Short o = null; Number n = o;");
+        exec("Short o = Short.valueOf((short)0); Number n = (Number)o;");
+        exec("Short o = null; Number n = (Number)o;");
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); String n = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; String n = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((byte)0); String n = (String)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; String n = (String)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); boolean b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; boolean b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); boolean b = (boolean)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; boolean b = (boolean)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); byte b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; byte b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); byte b = (byte)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; byte b = (byte)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); short b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; short b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); short b = (short)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; short b = (short)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); char b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; char b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); char b = (char)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; char b = (char)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); int b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; int b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); int b = (int)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; int b = (int)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); long b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; long b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); long b = (long)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; long b = (long)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); float b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; float b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); float b = (float)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; float b = (float)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); double b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; double b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); double b = (double)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; double b = (double)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); Boolean b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; Boolean b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); Boolean b = (Boolean)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; Boolean b = (Boolean)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); Byte b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; Byte b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); Byte b = (Byte)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; Byte b = (Byte)o;"));
+
+        exec("Short o = Short.valueOf((short)0); Short b = o;");
+        exec("Short o = null; Short b = o;");
+        exec("Short o = Short.valueOf((short)0); Short b = (Short)o;");
+        exec("Short o = null; Short b = (Short)o;");
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); Character b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; Character b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); Character b = (Character)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; Character b = (Character)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); Integer b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; Integer b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); Integer b = (Integer)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; Integer b = (Integer)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); Long b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; Long b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); Long b = (Long)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; Long b = (Long)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); Float b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; Float b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); Float b = (Float)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; Float b = (Float)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); Double b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; Double b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); Double b = (Double)o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = null; Double b = (Double)o;"));
+
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); ArrayList b = o;"));
+        expectScriptThrows(ClassCastException.class, () -> exec("Short o = Short.valueOf((short)0); ArrayList b = (ArrayList)o;"));
     }
 }


### PR DESCRIPTION
This adds tests for casting from short and Short to other standard types in Painless.  This also corrects a few errors from byte and Byte cast tests.