### PR TITLE
Add //KIBANA to README.asciidoc

### DIFF
--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -5,7 +5,10 @@ See: https://github.com/elastic/docs
 
 Snippets marked with `// CONSOLE` are automatically annotated with "VIEW IN
 CONSOLE" and "COPY AS CURL" in the documentation and are automatically tested
-by the command `gradle :docs:check`. To test just the docs from a single page,
+by the command `gradle :docs:check`. Snippets marked with `// KIBANA` are
+annotated with only "COPY AS CURL".
+
+To test just the docs from a single page,
 use e.g. `gradle :docs:check -Dtests.method="\*rollover*"`.
 
 NOTE: If you have an elasticsearch-extra folder alongside your elasticsearch


### PR DESCRIPTION
This PR adds a blurb about how to use //KIBANA to mark code snippets that work in curl but not in the Kibana Console.  It's commonly used in the Kibana User Guide (e.g. https://www.elastic.co/guide/en/kibana/master/spaces-api-post.html) but I am also using it in https://github.com/elastic/elasticsearch/pull/39530