### PR TITLE
Add lower bound on poll_interval

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleSettings.java
@@ -16,8 +16,8 @@ public class LifecycleSettings {
     public static final String LIFECYCLE_NAME = "index.lifecycle.name";
     public static final String LIFECYCLE_INDEXING_COMPLETE = "index.lifecycle.indexing_complete";
 
-    public static final Setting<TimeValue> LIFECYCLE_POLL_INTERVAL_SETTING = Setting.positiveTimeSetting(LIFECYCLE_POLL_INTERVAL,
-        TimeValue.timeValueMinutes(10), Setting.Property.Dynamic, Setting.Property.NodeScope);
+    public static final Setting<TimeValue> LIFECYCLE_POLL_INTERVAL_SETTING = Setting.timeSetting(LIFECYCLE_POLL_INTERVAL,
+        TimeValue.timeValueMinutes(10), TimeValue.timeValueSeconds(1), Setting.Property.Dynamic, Setting.Property.NodeScope);
     public static final Setting<String> LIFECYCLE_NAME_SETTING = Setting.simpleString(LIFECYCLE_NAME,
         Setting.Property.Dynamic, Setting.Property.IndexScope);
     public static final Setting<Boolean> LIFECYCLE_INDEXING_COMPLETE_SETTING = Setting.boolSetting(LIFECYCLE_INDEXING_COMPLETE, false,


### PR DESCRIPTION
#39163

Add lower bound on poll_interval 

```
$ curl -H "Content-Type: application/json" -X PUT -d '{
  "persistent": {
    "indices.lifecycle.poll_interval": "1ms",
    "logger.org.elasticsearch.xpack.indexlifecycle": "TRACE"
  }
}' localhost:9200/_cluster/settings

{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"failed to parse value [1ms] for setting [indices.lifecycle.poll_interval], must be >= [1s]"}],"type":"illegal_argument_exception","reason":"failed to parse value [1ms] for setting [indices.lifecycle.poll_interval], must be >= [1s]"},"status":400}

```