### PR TITLE
Edit doctype in Percolate Query Document

### DIFF
--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -160,7 +160,7 @@ Index the document we want to percolate:
 
 [source,js]
 --------------------------------------------------
-PUT /my-index/message/1
+PUT /my-index/doctype/1
 {
   "message" : "A new bonsai tree in the office"
 }
@@ -173,7 +173,7 @@ Index response:
 --------------------------------------------------
 {
   "_index": "my-index",
-  "_type": "message",
+  "_type": "doctype",
   "_id": "1",
   "_version": 1,
   "_shards": {
@@ -198,7 +198,7 @@ GET /my-index/_search
             "field": "query",
             "document_type" : "doctype",
             "index" : "my-index",
-            "type" : "message",
+            "type" : "doctype",
             "id" : "1",
             "version" : 1 <1>
         }


### PR DESCRIPTION
When I run the query as documented, I created an unintended new mapping.

```js
PUT /my-index/message/1
{
  "message" : "A new bonsai tree in the office"
}
```

```js
GET /my-index/_search
{
  "my-index": {
    "mappings": {
      "doctype": {
        "properties": {
          "message": {
            "type": "text"
          }
        }
      },
      "message": {
        "properties": {
          "message": {
            "type": "text",
            "fields": {
              "keyword": {
                "type": "keyword",
                "ignore_above": 256
              }
            }
          }
        }
      },
      "queries": {
        "properties": {
          "query": {
            "type": "percolator"
          }
        }
      }
    }
  }
}
```

Therefore, it is necessary to change the data structure to put

example
```diff
-PUT /my-index/message/1
+PUT /my-index/doctype/1
```

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?

ok

- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?

ok
