### PR TITLE
Avoid deprecated API usage in TaskOperationFailure (#39303)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/TaskOperationFailure.java
+++ b/server/src/main/java/org/elasticsearch/action/TaskOperationFailure.java
@@ -33,7 +33,6 @@ import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
-import static org.elasticsearch.ExceptionsHelper.detailedMessage;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 
 /**
@@ -102,10 +101,6 @@ public final class TaskOperationFailure implements Writeable, ToXContentFragment
         return this.taskId;
     }
 
-    public String getReason() {
-        return detailedMessage(reason);
-    }
-
     public RestStatus getStatus() {
         return status;
     }
@@ -116,7 +111,7 @@ public final class TaskOperationFailure implements Writeable, ToXContentFragment
 
     @Override
     public String toString() {
-        return "[" + nodeId + "][" + taskId + "] failed, reason [" + getReason() + "]";
+        return "[" + nodeId + "][" + taskId + "] failed, reason [" + reason + "]";
     }
 
     public static TaskOperationFailure fromXContent(XContentParser parser) {

--- a/server/src/test/java/org/elasticsearch/action/TaskOperationFailureTests.java
+++ b/server/src/test/java/org/elasticsearch/action/TaskOperationFailureTests.java
@@ -46,9 +46,6 @@ public class TaskOperationFailureTests extends AbstractXContentTestCase<TaskOper
         assertThat(newInstance.getStatus(), equalTo(expectedInstance.getStatus()));
         // XContent loses the original exception and wraps it as a message in Elasticsearch exception
         assertThat(newInstance.getCause().getMessage(), equalTo("Elasticsearch exception [type=illegal_state_exception, reason=message]"));
-        // getReason returns Exception class and the message
-        assertThat(newInstance.getReason(),
-            equalTo("ElasticsearchException[Elasticsearch exception [type=illegal_state_exception, reason=message]]"));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -615,7 +615,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         testTasksRequest.setActions("internal:testAction[n]"); // pick all test actions
         TestTasksResponse response = ActionTestUtils.executeBlocking(tasksActions[0], testTasksRequest);
         assertThat(response.getTaskFailures(), hasSize(1)); // one task failed
-        assertThat(response.getTaskFailures().get(0).getReason(), containsString("Task level failure"));
+        assertThat(response.getTaskFailures().get(0).getCause().getMessage(), containsString("Task level failure"));
         // Get successful responses from all nodes except one
         assertEquals(testNodes.length - 1, response.tasks.size());
         assertEquals(0, response.getNodeFailures().size()); // no nodes failed


### PR DESCRIPTION
With this commit we remove usage of the deprecated method
`ExceptionsHelper#detailedMessage` in the class `TaskOperationFailure`.

Relates #19069