### PR TITLE
[DOCS] path_hierarchy tokenizer examples

### DIFF
--- a/docs/reference/analysis/tokenizers.asciidoc
+++ b/docs/reference/analysis/tokenizers.asciidoc
@@ -155,3 +155,7 @@ include::tokenizers/simplepattern-tokenizer.asciidoc[]
 include::tokenizers/simplepatternsplit-tokenizer.asciidoc[]
 
 include::tokenizers/pathhierarchy-tokenizer.asciidoc[]
+
+include::tokenizers/pathhierarchy-tokenizer-examples.asciidoc[]
+
+

--- a/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer-examples.asciidoc
+++ b/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer-examples.asciidoc
@@ -7,10 +7,10 @@ file paths. If indexing a file path along with the data, the use of the
 by different parts of the file path string.
 
 
-This example configures an index to have two customer analyzers and applies
-those analyzers to subfields of a text field called `file_path` that will 
+This example configures an index to have two custom analyzers and applies
+those analyzers to multifields of the `file_path` text field that will 
 store filenames. One of the two analyzers uses reverse tokenization.
-Some sample documents are then indexed in to represent some file paths
+Some sample documents are then indexed to represent some file paths
 for photos inside photo folders of two different users.
 
 

--- a/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer-examples.asciidoc
+++ b/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer-examples.asciidoc
@@ -1,0 +1,195 @@
+[[analysis-pathhierarchy-tokenizer-examples]]
+=== Example tokenizing file paths
+
+A common use-case for the `path_hierarchy` tokenizer is filtering results by 
+file paths. If indexing a file path along with the data, the use of the 
+`path_hierarchy` tokenizer to analyze the path allows filtering the results 
+by different parts of the file path string.
+
+
+This example configures an index to have two customer analyzers and applies
+those analyzers to subfields of a text field called `file_path` that will 
+store filenames. One of the two analyzers uses reverse tokenization.
+Some sample documents are then indexed in to represent some file paths
+for photos inside photo folders of two different users.
+
+
+[source,js]
+--------------------------------------------------
+PUT /file-path-test/
+{
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "custom_path_tree": {
+          "tokenizer": "custom_hierarchy"
+        },
+        "custom_path_tree_reversed": {
+          "tokenizer": "custom_hierarchy_reversed"
+        }
+      },
+      "tokenizer": {
+        "custom_hierarchy": {
+          "type": "path_hierarchy",
+          "delimiter": "/",
+          "search_analyzer": "keyword"
+        },
+        "custom_hierarchy_reversed": {
+          "type": "path_hierarchy",
+          "delimiter": "/",
+          "search_analyzer": "keyword",
+          "reverse": "true"
+        }
+      }
+    }
+  },
+  "mappings": {
+    "_doc": {
+      "properties": {
+        "file_path": {
+          "type": "text",
+          "fields": {
+            "tree": {
+              "type": "text",
+              "analyzer": "custom_path_tree"
+            },
+            "tree_reversed": {
+              "type": "text",
+              "analyzer": "custom_path_tree_reversed"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+POST /file-path-test/_doc/1
+{
+  "file_path": "/User/alice/photos/2017/05/16/my_photo1.jpg"
+}
+
+POST /file-path-test/_doc/2
+{
+  "file_path": "/User/alice/photos/2017/05/16/my_photo2.jpg"
+}
+
+POST /file-path-test/_doc/3
+{
+  "file_path": "/User/alice/photos/2017/05/16/my_photo3.jpg"
+}
+
+POST /file-path-test/_doc/4
+{
+  "file_path": "/User/alice/photos/2017/05/15/my_photo1.jpg"
+}
+
+POST /file-path-test/_doc/5
+{
+  "file_path": "/User/bob/photos/2017/05/16/my_photo1.jpg"
+}
+--------------------------------------------------
+// CONSOLE
+// TESTSETUP
+
+
+A search for a particular file path string against the text field matches all 
+the example documents, with Bob's documents ranking highest due to `bob` also 
+being one of the terms created by the standard analyzer boosting relevance for
+Bob's documents.
+
+[source,js]
+--------------------------------------------------
+GET file-path-test/_search
+{
+  "query": {
+    "match": {
+      "file_path": "/User/bob/photos/2017/05"
+    }
+  }
+}
+--------------------------------------------------
+// CONSOLE
+
+
+It's simple to match or filter documents with file paths that exist within a
+particular directory using the `file_path.tree` field.
+
+[source,js]
+--------------------------------------------------
+GET file-path-test/_search
+{
+  "query": {
+    "term": {
+      "file_path.tree": "/User/alice/photos/2017/05/16"
+    }
+  }
+}
+--------------------------------------------------
+// CONSOLE
+
+With the reverse parameter for this tokenizer, it's also possible to match
+from the other end of the file path, such as individual file names or a deep
+level subdirectory. The following example shows a search for all files named
+`my_photo1.jpg` within any directory via the `file_path.tree_reversed` field 
+configured to use the reverse parameter in the mapping.
+
+
+[source,js]
+--------------------------------------------------
+GET file-path-test/_search
+{
+  "query": {
+    "term": {
+      "file_path.tree_reversed": {
+        "value": "my_photo1.jpg"
+      }
+    }
+  }
+}
+--------------------------------------------------
+// CONSOLE
+
+
+Viewing the tokens generated with both forward and reverse is instructive
+in showing the tokens created for the same file path value.
+
+
+[source,js]
+--------------------------------------------------
+POST file-path-test/_analyze
+{
+  "analyzer": "custom_path_tree",
+  "text": "/User/alice/photos/2017/05/16/my_photo1.jpg"
+}
+
+POST file-path-test/_analyze
+{
+  "analyzer": "custom_path_tree_reversed",
+  "text": "/User/alice/photos/2017/05/16/my_photo1.jpg"
+}
+--------------------------------------------------
+// CONSOLE
+
+
+It's also useful to be able to filter with file paths when combined with other
+types of searches, such as this example looking for any files paths with `16` 
+that also must be in Alice's photo directoryy.
+
+[source,js]
+--------------------------------------------------
+GET file-path-test/_search
+{
+  "query": {
+    "bool" : {
+      "must" : {
+        "match" : { "file_path" : "16" }
+      },
+      "filter": {
+        "term" : { "file_path.tree" : "/User/alice" }
+      }
+    }
+  }
+}
+--------------------------------------------------
+// CONSOLE

--- a/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer-examples.asciidoc
+++ b/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer-examples.asciidoc
@@ -31,7 +31,7 @@ PUT file-path-test
       "tokenizer": {
         "custom_hierarchy": {
           "type": "path_hierarchy",
-          "delimiter": "/",
+          "delimiter": "/"
         },
         "custom_hierarchy_reversed": {
           "type": "path_hierarchy",

--- a/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer-examples.asciidoc
+++ b/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer-examples.asciidoc
@@ -32,12 +32,10 @@ PUT file-path-test
         "custom_hierarchy": {
           "type": "path_hierarchy",
           "delimiter": "/",
-          "search_analyzer": "keyword"
         },
         "custom_hierarchy_reversed": {
           "type": "path_hierarchy",
           "delimiter": "/",
-          "search_analyzer": "keyword",
           "reverse": "true"
         }
       }
@@ -174,7 +172,7 @@ POST file-path-test/_analyze
 
 It's also useful to be able to filter with file paths when combined with other
 types of searches, such as this example looking for any files paths with `16` 
-that also must be in Alice's photo directoryy.
+that also must be in Alice's photo directory.
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer-examples.asciidoc
+++ b/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer-examples.asciidoc
@@ -1,5 +1,5 @@
 [[analysis-pathhierarchy-tokenizer-examples]]
-=== Example tokenizing file paths
+=== Path Hierarchy Tokenizer Examples
 
 A common use-case for the `path_hierarchy` tokenizer is filtering results by 
 file paths. If indexing a file path along with the data, the use of the 

--- a/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer-examples.asciidoc
+++ b/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer-examples.asciidoc
@@ -16,7 +16,7 @@ for photos inside photo folders of two different users.
 
 [source,js]
 --------------------------------------------------
-PUT /file-path-test/
+PUT file-path-test
 {
   "settings": {
     "analysis": {
@@ -64,27 +64,27 @@ PUT /file-path-test/
   }
 }
 
-POST /file-path-test/_doc/1
+POST file-path-test/_doc/1
 {
   "file_path": "/User/alice/photos/2017/05/16/my_photo1.jpg"
 }
 
-POST /file-path-test/_doc/2
+POST file-path-test/_doc/2
 {
   "file_path": "/User/alice/photos/2017/05/16/my_photo2.jpg"
 }
 
-POST /file-path-test/_doc/3
+POST file-path-test/_doc/3
 {
   "file_path": "/User/alice/photos/2017/05/16/my_photo3.jpg"
 }
 
-POST /file-path-test/_doc/4
+POST file-path-test/_doc/4
 {
   "file_path": "/User/alice/photos/2017/05/15/my_photo1.jpg"
 }
 
-POST /file-path-test/_doc/5
+POST file-path-test/_doc/5
 {
   "file_path": "/User/bob/photos/2017/05/16/my_photo1.jpg"
 }

--- a/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer.asciidoc
@@ -173,4 +173,4 @@ If we were to set `reverse` to `true`, it would produce the following:
 
 [float]
 === Detailed Examples
-See <<analysis-pathhierarchy-tokenizer-examples, detailed examples here>>:: 
+See <<analysis-pathhierarchy-tokenizer-examples, detailed examples here>>. 

--- a/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer.asciidoc
@@ -173,6 +173,4 @@ If we were to set `reverse` to `true`, it would produce the following:
 
 [float]
 === Detailed Examples
-See detailed  <<analysis-pathhierarchy-tokenizer-examples, examples here>>:: 
-
-include::tokenizers/pathhierarchy-tokenizer-examples.asciidoc[]
+See <<analysis-pathhierarchy-tokenizer-examples, detailed examples here>>:: 

--- a/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/pathhierarchy-tokenizer.asciidoc
@@ -170,3 +170,9 @@ If we were to set `reverse` to `true`, it would produce the following:
 ---------------------------
 [ one/two/three/, two/three/, three/ ]
 ---------------------------
+
+[float]
+=== Detailed Examples
+See detailed  <<analysis-pathhierarchy-tokenizer-examples, examples here>>:: 
+
+include::tokenizers/pathhierarchy-tokenizer-examples.asciidoc[]


### PR DESCRIPTION
Additional examples for a common use case for `path_hierarchy` tokenizer.

Fixes https://github.com/elastic/elasticsearch/issues/17138