### PR TITLE
Fix Fuzziness#asDistance(String)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/unit/Fuzziness.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/Fuzziness.java
@@ -186,7 +186,7 @@ public final class Fuzziness implements ToXContentFragment, Writeable {
     }
 
     public int asDistance(String text) {
-        if (this.equals(AUTO)) { //AUTO
+        if (this.equals(AUTO) || isAutoWithCustomValues()) { //AUTO
             final int len = termLen(text);
             if (len < lowDistance) {
                 return 0;

--- a/server/src/test/java/org/elasticsearch/common/unit/FuzzinessTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/FuzzinessTests.java
@@ -169,4 +169,28 @@ public class FuzzinessTests extends ESTestCase {
         StreamInput streamInput = output.bytes().streamInput();
         return new Fuzziness(streamInput);
     }
+
+    public void testAsDistanceString() {
+        Fuzziness fuzziness = Fuzziness.build("0");
+        assertEquals(0, fuzziness.asDistance(randomAlphaOfLengthBetween(0, 10)));
+        fuzziness = Fuzziness.build("1");
+        assertEquals(1, fuzziness.asDistance(randomAlphaOfLengthBetween(0, 10)));
+        fuzziness = Fuzziness.build("2");
+        assertEquals(2, fuzziness.asDistance(randomAlphaOfLengthBetween(0, 10)));
+
+        fuzziness = Fuzziness.build("AUTO");
+        assertEquals(0, fuzziness.asDistance(""));
+        assertEquals(0, fuzziness.asDistance("ab"));
+        assertEquals(1, fuzziness.asDistance("abc"));
+        assertEquals(1, fuzziness.asDistance("abcde"));
+        assertEquals(2, fuzziness.asDistance("abcdef"));
+
+        fuzziness = Fuzziness.build("AUTO:5,7");
+        assertEquals(0, fuzziness.asDistance(""));
+        assertEquals(0, fuzziness.asDistance("abcd"));
+        assertEquals(1, fuzziness.asDistance("abcde"));
+        assertEquals(1, fuzziness.asDistance("abcdef"));
+        assertEquals(2, fuzziness.asDistance("abcdefg"));
+
+    }
 }


### PR DESCRIPTION
Currently Fuzziness#asDistance(String) doesn't work for custom AUTO values. If
the fuzziness is AUTO, the method returns the correct edit distance to use,
depending on the input string, but for custom AUTO values it currently always
returns an edit distance of 1. Correcting this and adding unit and integration
tests to catch these cases.

Closes #39614