### PR TITLE
metric on watcher stats is a list not an enum (#39114)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.stats.json
@@ -7,14 +7,14 @@
       "paths": [ "/_watcher/stats", "/_watcher/stats/{metric}" ],
       "parts": {
         "metric": {
-          "type" : "enum",
+          "type" : "list",
           "options" : ["_all", "queued_watches", "current_watches", "pending_watches"],
           "description" : "Controls what additional stat metrics should be include in the response"
         }
       },
       "params": {
         "metric": {
-          "type" : "enum",
+          "type" : "list",
           "options" : ["_all", "queued_watches", "current_watches", "pending_watches"],
           "description" : "Controls what additional stat metrics should be include in the response"
         },


### PR DESCRIPTION
`enum` is a single option from a known list of `options`
`list` is an array of unknown values
`flags` are multiple options from a list of known `options`.

We don't support the `flags` type but a `list` with `options` acts as one. This is already the case for other API's taking metric such as `node.stats.json`. 

watcher.stats behaves the same as other API's as `metrics` and as such accepts the following `GET _xpack/watcher/stats/queued_watches,current_watches`

(cherry picked from commit 4c00a025b8ac9b397b27c4ae2f799553d6499412)
