### PR TITLE
ilm.explain_lifecycle documents human again (#39113)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.explain_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.explain_lifecycle.json
@@ -11,13 +11,7 @@
           "description" : "The name of the index to explain"
         }
       },
-      "params": {
-        "human": {
-          "type" : "boolean",
-          "default" : "false",
-          "description" : "Return data such as dates in a human readable format"
-        }
-      }
+      "params": {}
     },
     "body": null
   }


### PR DESCRIPTION
This is already exposed as a `_common.json` global parameter.

(cherry picked from commit e84050c0307bb5d5cea8eacc6b63b34248a41a01)