### PR TITLE
Index on rollup.rollup_search.json is a list (#39097)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup_search.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup_search.json
@@ -7,9 +7,9 @@
       "paths": [ "{index}/_rollup_search", "{index}/{type}/_rollup_search" ],
       "parts": {
         "index": {
-          "type": "string",
+          "type": "list",
           "required": true,
-          "description": "The index or index-pattern (containing rollup or regular data) that should be searched"
+          "description": "The indices or index-pattern(s) (containing rollup or regular data) that should be searched"
         },
         "type": {
           "type": "string",


### PR DESCRIPTION
And not a string since it accepts comma separated list of indices.

(cherry picked from commit cf34d50b3a983b5fc0c9c7aa279cecd4aa10e28b)