### PR TITLE
Introduce ActionListener#empty()

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -208,4 +208,18 @@ public interface ActionListener<Response> {
             listener.onFailure(e);
         }
     }
+
+    class Empty<Response> implements ActionListener<Response> {
+        @Override
+        public void onResponse(Response response) {
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+        }
+    }
+
+    static <Response> ActionListener<Response> empty() {
+        return new Empty<>();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -113,7 +113,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     private final ShardStateAction shardStateAction;
     private final NodeMappingRefreshAction nodeMappingRefreshAction;
 
-    private static final ActionListener<Void> SHARD_STATE_ACTION_LISTENER = ActionListener.wrap(() -> {});
+    private static final ActionListener<Void> SHARD_STATE_ACTION_LISTENER = ActionListener.empty();
 
     private final Settings settings;
     // a list of shards that failed during recovery

--- a/server/src/main/java/org/elasticsearch/transport/TransportKeepAlive.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportKeepAlive.java
@@ -84,10 +84,7 @@ final class TransportKeepAlive implements Closeable {
 
         for (TcpChannel channel : nodeChannels) {
             scheduledPing.addChannel(channel);
-
-            channel.addCloseListener(ActionListener.wrap(() -> {
-                scheduledPing.removeChannel(channel);
-            }));
+            channel.addCloseListener(ActionListener.wrap(() -> scheduledPing.removeChannel(channel)));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerRetentionLeaseTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerRetentionLeaseTests.java
@@ -82,7 +82,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             }
             minimumRetainingSequenceNumbers[i] = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
             replicationTracker.addRetentionLease(
-                    Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.wrap(() -> {}));
+                    Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.empty());
             assertRetentionLeases(replicationTracker, i + 1, minimumRetainingSequenceNumbers, primaryTerm, 1 + i, true, false);
         }
 
@@ -118,11 +118,11 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
         final String id = randomAlphaOfLength(8);
         final long retainingSequenceNumber = randomNonNegativeLong();
         final String source = randomAlphaOfLength(8);
-        replicationTracker.addRetentionLease(id, retainingSequenceNumber, source, ActionListener.wrap(() -> {}));
+        replicationTracker.addRetentionLease(id, retainingSequenceNumber, source, ActionListener.empty());
         final long nextRetaininSequenceNumber = randomLongBetween(retainingSequenceNumber, Long.MAX_VALUE);
         final RetentionLeaseAlreadyExistsException e = expectThrows(
                 RetentionLeaseAlreadyExistsException.class,
-                () -> replicationTracker.addRetentionLease(id, nextRetaininSequenceNumber, source, ActionListener.wrap(() -> {})));
+                () -> replicationTracker.addRetentionLease(id, nextRetaininSequenceNumber, source, ActionListener.empty()));
         assertThat(e, hasToString(containsString("retention lease with ID [" + id + "] already exists")));
     }
 
@@ -187,7 +187,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             final String id = randomAlphaOfLength(8);
             final long retainingSequenceNumber = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
             retainingSequenceNumbers.put(id, retainingSequenceNumber);
-            replicationTracker.addRetentionLease(id, retainingSequenceNumber, "test", ActionListener.wrap(() -> {}));
+            replicationTracker.addRetentionLease(id, retainingSequenceNumber, "test", ActionListener.empty());
             // assert that the new retention lease callback was invoked
             assertTrue(invoked.get());
 
@@ -225,7 +225,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             }
             minimumRetainingSequenceNumbers[i] = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
             replicationTracker.addRetentionLease(
-                    Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.wrap(() -> {}));
+                    Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.empty());
         }
 
         for (int i = 0; i < length; i++) {
@@ -237,7 +237,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
              * Remove from the end since it will make the following assertion easier; we want to ensure that only the intended lease was
              * removed.
              */
-            replicationTracker.removeRetentionLease(Integer.toString(length - i - 1), ActionListener.wrap(() -> {}));
+            replicationTracker.removeRetentionLease(Integer.toString(length - i - 1), ActionListener.empty());
             assertRetentionLeases(
                     replicationTracker,
                     length - i - 1,
@@ -270,7 +270,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
         final String id = randomAlphaOfLength(8);
         final RetentionLeaseNotFoundException e = expectThrows(
                 RetentionLeaseNotFoundException.class,
-                () -> replicationTracker.removeRetentionLease(id, ActionListener.wrap(() -> {})));
+                () -> replicationTracker.removeRetentionLease(id, ActionListener.empty()));
         assertThat(e, hasToString(containsString("retention lease with ID [" + id + "] not found")));
     }
 
@@ -310,14 +310,14 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             final String id = randomAlphaOfLength(8);
             final long retainingSequenceNumber = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
             retainingSequenceNumbers.put(id, retainingSequenceNumber);
-            replicationTracker.addRetentionLease(id, retainingSequenceNumber, "test", ActionListener.wrap(() -> {}));
+            replicationTracker.addRetentionLease(id, retainingSequenceNumber, "test", ActionListener.empty());
             // assert that the new retention lease callback was invoked
             assertTrue(invoked.get());
 
             // reset the invocation marker so that we can assert the callback was not invoked when removing the lease
             invoked.set(false);
             retainingSequenceNumbers.remove(id);
-            replicationTracker.removeRetentionLease(id, ActionListener.wrap(() -> {}));
+            replicationTracker.removeRetentionLease(id, ActionListener.empty());
             assertTrue(invoked.get());
         }
     }
@@ -361,7 +361,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
         final long[] retainingSequenceNumbers = new long[1];
         retainingSequenceNumbers[0] = randomLongBetween(0, Long.MAX_VALUE);
         if (primaryMode) {
-            replicationTracker.addRetentionLease("0", retainingSequenceNumbers[0], "test-0", ActionListener.wrap(() -> {}));
+            replicationTracker.addRetentionLease("0", retainingSequenceNumbers[0], "test-0", ActionListener.empty());
         } else {
             final RetentionLeases retentionLeases = new RetentionLeases(
                     primaryTerm,
@@ -491,7 +491,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             }
             final long retainingSequenceNumber = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
             replicationTracker.addRetentionLease(
-                    Integer.toString(i), retainingSequenceNumber, "test-" + i, ActionListener.wrap(() -> {}));
+                    Integer.toString(i), retainingSequenceNumber, "test-" + i, ActionListener.empty());
         }
 
         final Path path = createTempDir();
@@ -531,7 +531,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             }
             final long retainingSequenceNumber = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
             replicationTracker.addRetentionLease(
-                    Integer.toString(i), retainingSequenceNumber, "test-" + i, ActionListener.wrap(() -> {}));
+                    Integer.toString(i), retainingSequenceNumber, "test-" + i, ActionListener.empty());
         }
 
         final Path path = createTempDir();
@@ -544,7 +544,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
                 try {
                     barrier.await();
                     final long retainingSequenceNumber = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
-                    replicationTracker.addRetentionLease(id, retainingSequenceNumber, "test-" + id, ActionListener.wrap(() -> {}));
+                    replicationTracker.addRetentionLease(id, retainingSequenceNumber, "test-" + id, ActionListener.empty());
                     replicationTracker.persistRetentionLeases(path);
                     barrier.await();
                 } catch (final BrokenBarrierException | InterruptedException | WriteStateException e) {

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseSyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseSyncActionTests.java
@@ -224,7 +224,7 @@ public class RetentionLeaseSyncActionTests extends ESTestCase {
         };
 
         // execution happens on the test thread, so no need to register an actual listener to callback
-        action.sync(indexShard.shardId(), retentionLeases, ActionListener.wrap(() -> {}));
+        action.sync(indexShard.shardId(), retentionLeases, ActionListener.empty());
         assertTrue(invoked.get());
     }
 

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardRetentionLeaseTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardRetentionLeaseTests.java
@@ -79,7 +79,7 @@ public class IndexShardRetentionLeaseTests extends IndexShardTestCase {
             for (int i = 0; i < length; i++) {
                 minimumRetainingSequenceNumbers[i] = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
                 indexShard.addRetentionLease(
-                        Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.wrap(() -> {}));
+                        Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.empty());
                 assertRetentionLeases(
                         indexShard, i + 1, minimumRetainingSequenceNumbers, primaryTerm, 1 + i, true, false);
             }
@@ -110,13 +110,13 @@ public class IndexShardRetentionLeaseTests extends IndexShardTestCase {
             for (int i = 0; i < length; i++) {
                 minimumRetainingSequenceNumbers[i] = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
                 indexShard.addRetentionLease(
-                        Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.wrap(() -> {}));
+                        Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.empty());
                 assertRetentionLeases(
                         indexShard, i + 1, minimumRetainingSequenceNumbers, primaryTerm, 1 + i, true, false);
             }
 
             for (int i = 0; i < length; i++) {
-                indexShard.removeRetentionLease(Integer.toString(length - i - 1), ActionListener.wrap(() -> {}));
+                indexShard.removeRetentionLease(Integer.toString(length - i - 1), ActionListener.empty());
                 assertRetentionLeases(
                         indexShard,
                         length - i - 1,
@@ -154,7 +154,7 @@ public class IndexShardRetentionLeaseTests extends IndexShardTestCase {
             final long[] retainingSequenceNumbers = new long[1];
             retainingSequenceNumbers[0] = randomLongBetween(0, Long.MAX_VALUE);
             if (primary) {
-                indexShard.addRetentionLease("0", retainingSequenceNumbers[0], "test-0", ActionListener.wrap(() -> {}));
+                indexShard.addRetentionLease("0", retainingSequenceNumbers[0], "test-0", ActionListener.empty());
             } else {
                 final RetentionLeases retentionLeases = new RetentionLeases(
                         primaryTerm,
@@ -224,7 +224,7 @@ public class IndexShardRetentionLeaseTests extends IndexShardTestCase {
                 minimumRetainingSequenceNumbers[i] = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
                 currentTimeMillis.set(TimeUnit.NANOSECONDS.toMillis(randomNonNegativeLong()));
                 indexShard.addRetentionLease(
-                        Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.wrap(() -> {}));
+                        Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.empty());
             }
 
             currentTimeMillis.set(TimeUnit.NANOSECONDS.toMillis(Long.MAX_VALUE));
@@ -275,7 +275,7 @@ public class IndexShardRetentionLeaseTests extends IndexShardTestCase {
             for (int i = 0; i < length; i++) {
                 minimumRetainingSequenceNumbers[i] = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
                 indexShard.addRetentionLease(
-                        Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.wrap(() -> {}));
+                        Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.empty());
             }
             final RetentionLeaseStats stats = indexShard.getRetentionLeaseStats();
             assertRetentionLeases(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/RemoteClusterLicenseCheckerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/RemoteClusterLicenseCheckerTests.java
@@ -278,7 +278,7 @@ public final class RemoteClusterLicenseCheckerTests extends ESTestCase {
 
             final List<String> remoteClusterAliases = Collections.singletonList("valid");
             licenseChecker.checkRemoteClusterLicenses(
-                    remoteClusterAliases, doubleInvocationProtectingListener(ActionListener.wrap(() -> {})));
+                    remoteClusterAliases, doubleInvocationProtectingListener(ActionListener.empty()));
 
             verify(client, times(1)).execute(same(XPackInfoAction.INSTANCE), any(), any());
         } finally {


### PR DESCRIPTION
Today we write `ActionListener.wrap(() -> {})` for an empty, do-nothing
`ActionListener` in a number of places. This auto-formats badly. As suggested
here[1] this commit introduces `ActionListener.empty()` for this situation
instead.

[1] https://github.com/elastic/elasticsearch/pull/39629/files#r262021809