### PR TITLE
Making snapshot deletes distributed across data nodes.

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
@@ -19,13 +19,20 @@
 
 package org.elasticsearch.cluster;
 
+import com.carrotsearch.hppc.ObjectContainer;
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState.Custom;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.snapshots.Snapshot;
 
 import java.io.IOException;
@@ -48,7 +55,7 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
         this(Collections.emptyList());
     }
 
-    private SnapshotDeletionsInProgress(List<Entry> entries) {
+    public SnapshotDeletionsInProgress(List<Entry> entries) {
         this.entries = Collections.unmodifiableList(entries);
     }
 
@@ -99,6 +106,16 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
         return entries.isEmpty() == false;
     }
 
+    public Entry getEntry(final Snapshot snapshot) {
+        for (Entry entry : entries) {
+            final Snapshot curr = entry.getSnapshot();
+            if (curr.equals(snapshot)) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
     @Override
     public String getWriteableName() {
         return TYPE;
@@ -146,6 +163,32 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
                 builder.field("snapshot", entry.snapshot.getSnapshotId().getName());
                 builder.humanReadableField("start_time_millis", "start_time", new TimeValue(entry.startTime));
                 builder.field("repository_state_id", entry.repositoryStateId);
+                builder.field("version", entry.version);
+                builder.startArray("indices_to_cleanup");
+                {
+                    for (IndexId index : entry.indicesToCleanup) {
+                        index.toXContent(builder, params);
+                    }
+                }
+                builder.endArray();
+                builder.startArray("shards");
+                {
+                    for (ObjectObjectCursor<Tuple<ShardId, String>, ShardSnapshotDeletionStatus> shardEntry : entry.shards) {
+                        ShardId shardId = shardEntry.key.v1();
+                        String snapshotIndexId = shardEntry.key.v2();
+                        ShardSnapshotDeletionStatus status = shardEntry.value;
+                        builder.startObject();
+                        {
+                            builder.field("index", shardId.getIndex());
+                            builder.field("shard", shardId.getId());
+                            builder.field("snapshot_index_id", snapshotIndexId);
+                            builder.field("state", status.state());
+                            builder.field("node", status.nodeId());
+                        }
+                        builder.endObject();
+                    }
+                }
+                builder.endArray();
             }
             builder.endObject();
         }
@@ -172,17 +215,57 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
         private final Snapshot snapshot;
         private final long startTime;
         private final long repositoryStateId;
+        private final int version;
+        private final List<IndexId> indicesToCleanup;
+        private final ImmutableOpenMap<Tuple<ShardId, String>, ShardSnapshotDeletionStatus> shards;
 
         public Entry(Snapshot snapshot, long startTime, long repositoryStateId) {
+            this(snapshot, startTime, repositoryStateId, 0, null, null);
+        }
+
+        public Entry(final Snapshot snapshot,
+                     final long startTime,
+                     final long repositoryStateId,
+                     final int version,
+                     final List<IndexId> indicesToCleanup,
+                     final ImmutableOpenMap<Tuple<ShardId, String>, ShardSnapshotDeletionStatus> shards) {
             this.snapshot = snapshot;
             this.startTime = startTime;
             this.repositoryStateId = repositoryStateId;
+            this.version = version;
+            this.indicesToCleanup = indicesToCleanup == null ? Collections.emptyList() : indicesToCleanup;
+            this.shards = shards == null ? ImmutableOpenMap.of() : shards;
         }
 
         public Entry(StreamInput in) throws IOException {
             this.snapshot = new Snapshot(in);
             this.startTime = in.readVLong();
             this.repositoryStateId = in.readLong();
+            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+                this.version = in.readInt();
+                int indices = in.readVInt();
+                List<IndexId> indexBuilder = new ArrayList<>();
+                for (int i = 0; i < indices; i++) {
+                    indexBuilder.add(new IndexId(in.readString(), in.readString()));
+                }
+                this.indicesToCleanup = indexBuilder;
+                ImmutableOpenMap.Builder<Tuple<ShardId, String>, ShardSnapshotDeletionStatus> builder = ImmutableOpenMap.builder();
+                int shards = in.readVInt();
+                for (int i = 0; i < shards; i++) {
+                    ShardId shardId = ShardId.readShardId(in);
+                    String indexId = in.readString();
+                    builder.put(new Tuple<>(shardId, indexId), new ShardSnapshotDeletionStatus(in));
+                }
+                this.shards = builder.build();
+            } else {
+                this.version = 0;
+                this.indicesToCleanup = Collections.emptyList();
+                this.shards = ImmutableOpenMap.of();
+            }
+        }
+
+        public Entry(Entry entry, ImmutableOpenMap<Tuple<ShardId, String>, ShardSnapshotDeletionStatus> shards) {
+            this(entry.snapshot, entry.startTime, entry.repositoryStateId, entry.version, entry.indicesToCleanup, shards);
         }
 
         /**
@@ -199,11 +282,23 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
             return startTime;
         }
 
+        public int getVersion() {
+            return version;
+        }
+
         /**
          * The repository state id at the time the snapshot deletion began.
          */
         public long getRepositoryStateId() {
             return repositoryStateId;
+        }
+
+        public List<IndexId> getIndicesToCleanup() {
+            return indicesToCleanup;
+        }
+
+        public ImmutableOpenMap<Tuple<ShardId, String>, ShardSnapshotDeletionStatus> getShards() {
+            return shards;
         }
 
         @Override
@@ -217,12 +312,15 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
             Entry that = (Entry) o;
             return snapshot.equals(that.snapshot)
                        && startTime == that.startTime
-                       && repositoryStateId == that.repositoryStateId;
+                       && repositoryStateId == that.repositoryStateId
+                       && version == that.version
+                       && indicesToCleanup.equals(that.indicesToCleanup)
+                       && shards.equals(that.shards);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(snapshot, startTime, repositoryStateId);
+            return Objects.hash(snapshot, startTime, repositoryStateId, version, indicesToCleanup, shards);
         }
 
         @Override
@@ -230,6 +328,150 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
             snapshot.writeTo(out);
             out.writeVLong(startTime);
             out.writeLong(repositoryStateId);
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+                out.writeInt(version);
+                out.writeVInt(indicesToCleanup.size());
+                for (IndexId index : indicesToCleanup) {
+                    index.writeTo(out);
+                }
+                out.writeVInt(shards.size());
+                for (ObjectObjectCursor<Tuple<ShardId, String>, ShardSnapshotDeletionStatus> shardEntry : shards) {
+                    shardEntry.key.v1().writeTo(out);
+                    out.writeString(shardEntry.key.v2());
+                    shardEntry.value.writeTo(out);
+                }
+            }
         }
     }
+
+    /**
+     * Checks if all shard deletions in the list have completed
+     *
+     * @param shards list of shard deletion statuses
+     * @return true if all shard deletions have completed (either successfully or failed), false otherwise
+     */
+    public static boolean completed(ObjectContainer<ShardSnapshotDeletionStatus> shards) {
+        for (ObjectCursor<ShardSnapshotDeletionStatus> status : shards) {
+            if (status.value.state().completed() == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static class ShardSnapshotDeletionStatus {
+        private final State state;
+        private final String nodeId;
+        private final String reason;
+
+        public ShardSnapshotDeletionStatus(String nodeId, State state) {
+            this(nodeId, state, null);
+        }
+
+        public ShardSnapshotDeletionStatus(String nodeId, State state, String reason) {
+            this.nodeId = nodeId;
+            this.state = state;
+            this.reason = reason;
+            // If the state is failed we have to have a reason for this failure
+            assert state.failed() == false || reason != null;
+        }
+
+        public ShardSnapshotDeletionStatus(StreamInput in) throws IOException {
+            nodeId = in.readOptionalString();
+            state = State.fromValue(in.readByte());
+            reason = in.readOptionalString();
+        }
+
+        public State state() {
+            return state;
+        }
+
+        public String nodeId() {
+            return nodeId;
+        }
+
+        public String reason() {
+            return reason;
+        }
+
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeOptionalString(nodeId);
+            out.writeByte(state.value);
+            out.writeOptionalString(reason);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            ShardSnapshotDeletionStatus status = (ShardSnapshotDeletionStatus) o;
+
+            if (nodeId != null ? !nodeId.equals(status.nodeId) : status.nodeId != null) return false;
+            if (reason != null ? !reason.equals(status.reason) : status.reason != null) return false;
+            if (state != status.state) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = state != null ? state.hashCode() : 0;
+            result = 31 * result + (nodeId != null ? nodeId.hashCode() : 0);
+            result = 31 * result + (reason != null ? reason.hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "ShardSnapshotDeletionStatus[state=" + state + ", nodeId=" + nodeId + ", reason=" + reason + "]";
+        }
+    }
+
+    public enum State {
+        INIT((byte) 0, false, false),
+        STARTED((byte) 1, false, false),
+        SUCCESS((byte) 2, true, false),
+        FAILED((byte) 3, true, true);
+
+        private byte value;
+
+        private boolean completed;
+
+        private boolean failed;
+
+        State(byte value, boolean completed, boolean failed) {
+            this.value = value;
+            this.completed = completed;
+            this.failed = failed;
+        }
+
+        public byte value() {
+            return value;
+        }
+
+        public boolean completed() {
+            return completed;
+        }
+
+        public boolean failed() {
+            return failed;
+        }
+
+        public static State fromValue(byte value) {
+            switch (value) {
+                case 0:
+                    return INIT;
+                case 1:
+                    return STARTED;
+                case 2:
+                    return SUCCESS;
+                case 3:
+                    return FAILED;
+                default:
+                    throw new IllegalArgumentException("No snapshot deletion state for value [" + value + "]");
+            }
+        }
+    }
+
 }

--- a/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotDeletionStatus.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotDeletionStatus.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.snapshots;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Represent shard snapshot deletion status
+ */
+public class IndexShardSnapshotDeletionStatus {
+
+    /**
+     * Snapshot Deletion Stage
+     */
+    public enum Stage {
+        /**
+         * Shard snapshot deletion hasn't started yet
+         */
+        INIT,
+        /**
+         * Shard snapshot deletion in progress
+         */
+        STARTED,
+        /**
+         * Shard snapshot deletion completed successfully
+         */
+        DONE,
+        /**
+         * Shard snapshot deletion failed
+         */
+        FAILURE
+    }
+
+    private final AtomicReference<Stage> stage;
+    private final int version;
+    private long startTime;
+    private long totalTime;
+    private String failure;
+
+    private IndexShardSnapshotDeletionStatus(final Stage stage, final int version, final long startTime,
+                                             final long totalTime, final String failure) {
+        this.stage = new AtomicReference<>(Objects.requireNonNull(stage));
+        this.version = version;
+        this.startTime = startTime;
+        this.totalTime = totalTime;
+        this.failure = failure;
+    }
+
+    public synchronized void moveToStarted(final long startTime) {
+        if (stage.compareAndSet(Stage.INIT, Stage.STARTED)) {
+            this.startTime = startTime;
+        } else {
+            throw new IllegalStateException("Unable to move the shard snapshot deletion status to [STARTED]: " +
+                "expecting [INIT] but got [" + stage.get() + "]");
+        }
+    }
+
+    public synchronized void moveToDone(final long endTime) {
+        if (stage.compareAndSet(Stage.STARTED, Stage.DONE)) {
+            this.totalTime = Math.max(0L, endTime - startTime);
+        } else {
+            throw new IllegalStateException("Unable to move the shard snapshot deletion status to [DONE]: " +
+                "expecting [STARTED] but got [" + stage.get() + "]");
+        }
+    }
+
+    public synchronized void moveToFailed(final long endTime, final String failure) {
+        if (stage.getAndSet(Stage.FAILURE) != Stage.FAILURE) {
+            this.totalTime = Math.max(0L, endTime - startTime);
+            this.failure = failure;
+        }
+    }
+
+    public boolean isFailed() {
+        return stage.get() == Stage.FAILURE;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public synchronized IndexShardSnapshotDeletionStatus.Copy asCopy() {
+        return new IndexShardSnapshotDeletionStatus.Copy(stage.get(), version, startTime, totalTime, failure);
+    }
+
+    public static IndexShardSnapshotDeletionStatus newInitializing(final int version) {
+        return new IndexShardSnapshotDeletionStatus(Stage.INIT, version, 0L, 0L, null);
+    }
+
+    public static class Copy {
+
+        private final Stage stage;
+        private final int version;
+        private final long startTime;
+        private final long totalTime;
+        private final String failure;
+
+        public Copy(final Stage stage, final int version, final long startTime, final long totalTime,
+                    final String failure) {
+            this.stage = stage;
+            this.version = version;
+            this.startTime = startTime;
+            this.totalTime = totalTime;
+            this.failure = failure;
+        }
+
+        public Stage getStage() {
+            return stage;
+        }
+
+        public int getVersion() {
+            return version;
+        }
+
+        public long getStartTime() {
+            return startTime;
+        }
+
+        public long getTotalTime() {
+            return totalTime;
+        }
+
+        public String getFailure() {
+            return failure;
+        }
+
+        @Override
+        public String toString() {
+            return "index shard snapshot deletion status (" +
+                "stage=" + stage +
+                ", version=" + version +
+                ", startTime=" + startTime +
+                ", totalTime=" + totalTime +
+                ", failure='" + failure + '\'' +
+                ')';
+        }
+
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.component.LifecycleListener;
 import org.elasticsearch.index.shard.IndexShard;
@@ -37,6 +38,7 @@ import org.elasticsearch.snapshots.SnapshotShardFailure;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 public class FilterRepository implements Repository {
 
@@ -133,6 +135,42 @@ public class FilterRepository implements Repository {
     @Override
     public IndexShardSnapshotStatus getShardSnapshotStatus(SnapshotId snapshotId, Version version, IndexId indexId, ShardId shardId) {
         return in.getShardSnapshotStatus(snapshotId, version, indexId, shardId);
+    }
+
+    @Override
+    public SnapshotInfo getSnapshotInfoOrNull(SnapshotId snapshotId) {
+        return in.getSnapshotInfoOrNull(snapshotId);
+    }
+
+    @Override
+    public RepositoryData initiateSnapshotDelete(SnapshotId snapshotId, SnapshotInfo snapshotInfo, long repositoryStateId) {
+        return in.initiateSnapshotDelete(snapshotId, snapshotInfo, repositoryStateId);
+    }
+
+    @Override
+    public List<Tuple<ShardId, String>> getShardsToDeleteForSnapshot(SnapshotId snapshotId, SnapshotInfo snapshotInfo,
+                                                                     RepositoryData repositoryData) {
+        return in.getShardsToDeleteForSnapshot(snapshotId, snapshotInfo, repositoryData);
+    }
+
+    @Override
+    public void deleteIndicesMetaData(SnapshotInfo snapshot, Set<String> indexIds) {
+        in.deleteIndicesMetaData(snapshot, indexIds);
+    }
+
+    @Override
+    public void deleteShard(SnapshotId snapshotId, int version, String indexId, ShardId shardId) {
+        in.deleteShard(snapshotId, version, indexId, shardId);
+    }
+
+    @Override
+    public void cleanUpIndices(List<IndexId> indicesToCleanUp) {
+        in.cleanUpIndices(indicesToCleanUp);
+    }
+
+    @Override
+    public boolean isDistributedSnapshotDeletionEnabled() {
+        return in.isDistributedSnapshotDeletionEnabled();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
@@ -36,6 +37,7 @@ import org.elasticsearch.snapshots.SnapshotShardFailure;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -230,5 +232,80 @@ public interface Repository extends LifecycleComponent {
      */
     IndexShardSnapshotStatus getShardSnapshotStatus(SnapshotId snapshotId, Version version, IndexId indexId, ShardId shardId);
 
+    /**
+     * Retrieve snapshot info for the provided snapshot id
+     *
+     * @param snapshotId snapshot id
+     * @return snapshot info
+     */
+    default SnapshotInfo getSnapshotInfoOrNull(SnapshotId snapshotId) {
+        throw new RuntimeException("Operation not supported for this repository");
+    }
+
+    /**
+     * Initiate snapshot delete
+     *
+     * @param snapshotId        snapshot id
+     * @param snapshotInfo      snapshot info
+     * @param repositoryStateId repository state id
+     * @return repository data
+     */
+    default RepositoryData initiateSnapshotDelete(SnapshotId snapshotId, SnapshotInfo snapshotInfo,
+                                                  long repositoryStateId) {
+        throw new RuntimeException("Operation not supported for this repository");
+    }
+
+    /**
+     * Retrieve shards to delete for the provided snapshot id
+     *
+     * @param snapshotId     snapshot id
+     * @param snapshotInfo   snapshot info
+     * @param repositoryData repository data
+     * @return list of the shard ids with their snapshot index id that are part of this snapshot
+     */
+    default List<Tuple<ShardId, String>> getShardsToDeleteForSnapshot(SnapshotId snapshotId, SnapshotInfo snapshotInfo,
+                                                                      RepositoryData repositoryData) {
+        throw new RuntimeException("Operation not supported for this repository");
+    }
+
+    /**
+     * Delete indices meta data for the given set of index ids
+     *
+     * @param snapshot snapshot info
+     * @param indexIds Set of index ids who index meta data need to be deleted
+     */
+    default void deleteIndicesMetaData(SnapshotInfo snapshot, Set<String> indexIds) {
+        throw new RuntimeException("Operation not supported for this repository");
+    }
+
+    /**
+     * Delete shard snapshot
+     *
+     * @param snapshotId snapshot id
+     * @param version    version of elasticsearch that created this snapshot
+     * @param indexId    the snapshotted index id
+     * @param shardId    shard id
+     */
+    default void deleteShard(SnapshotId snapshotId, int version, String indexId, ShardId shardId) {
+        throw new RuntimeException("Operation not supported for this repository");
+    }
+
+    /**
+     * Clean up repository indices that are no longer part of any snapshots.
+     *
+     * @param indicesToCleanUp list of indices to be cleaned up
+     */
+    default void cleanUpIndices(List<IndexId> indicesToCleanUp) {
+        throw new RuntimeException("Operation not supported for this repository");
+    }
+
+    /**
+     * Indicates if late assignment of node to snapshot a shard is enabled.
+     *
+     * @return true if enabled, false otherwise.
+     */
+    default boolean isDistributedSnapshotDeletionEnabled() {
+        return false;
+    }
 
 }

--- a/server/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -484,6 +484,8 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             // completely stopping. In this case the retried delete snapshot operation on the new master can fail
             // with SnapshotMissingException
         }
+        // Make sure that the delete goes through
+        Thread.sleep(100);
 
         logger.info("--> making sure that snapshot no longer exists");
         assertThrows(client().admin().cluster().prepareGetSnapshots("test-repo").setSnapshots("test-snap").execute(),

--- a/server/src/test/java/org/elasticsearch/snapshots/DistributedSnapshotDeletionsIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/DistributedSnapshotDeletionsIT.java
@@ -1,0 +1,387 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.snapshots;
+
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.snapshots.mockstore.MockRepository;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThrows;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, transportClientRatio = 0)
+public class DistributedSnapshotDeletionsIT extends AbstractSnapshotIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(MockRepository.Plugin.class, org.elasticsearch.test.transport.MockTransportService.TestPlugin.class);
+    }
+
+    public void testDeleteSnapshot() throws Exception {
+        logger.info("--> start 1 master and 3 data nodes");
+        internalCluster().startMasterOnlyNode();
+        internalCluster().startDataOnlyNode();
+        internalCluster().startDataOnlyNode(); // Start an additional data-node
+        internalCluster().startDataOnlyNode(); // Start an additional data-node
+        Client client = client();
+
+        String repoName = "test-repo";
+        Path repo = randomRepoPath();
+        logger.info("-->  creating repository at {}", repo.toAbsolutePath());
+        assertAcked(client.admin().cluster().preparePutRepository(repoName)
+            .setType("mock").setSettings(Settings.builder()
+                .put("location", repo)
+                .put("compress", false)
+                .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
+        int numberOfFilesBeforeSnapshot = numberOfFiles(repo);
+
+        createIndex("test-idx-1", "test-idx-2", "test-idx-3");
+        logger.info("--> indexing some data");
+        indexRandom(true,
+            client().prepareIndex("test-idx-1", "_doc").setSource("foo", "bar"),
+            client().prepareIndex("test-idx-2", "_doc").setSource("foo", "bar"),
+            client().prepareIndex("test-idx-3", "_doc").setSource("foo", "bar"));
+
+        CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot(repoName, "test-snap-1")
+                                                                      .setWaitForCompletion(true).setIndices("test-idx-*").get();
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(),
+                   equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
+
+        logger.info("--> delete snapshot");
+        ActionFuture<AcknowledgedResponse> future = client.admin().cluster().prepareDeleteSnapshot(repoName,"test-snap-1").execute();
+        future.actionGet(1, TimeUnit.MINUTES);
+
+        logger.info("--> make sure snapshot doesn't exist");
+        assertThrows(client.admin().cluster().prepareGetSnapshots(repoName).addSnapshots("test-snap-1"), SnapshotMissingException.class);
+
+        // Subtract four files that will remain in the repository:
+        //   (1) index-1
+        //   (2) index-0 (because we keep the previous version) and
+        //   (3) index-latest
+        //   (4) incompatible-snapshots
+        assertThat("not all files were deleted during snapshot cancellation",
+            numberOfFilesBeforeSnapshot, equalTo(numberOfFiles(repo) - 4));
+        logger.info("--> done");
+    }
+
+    public void testDeleteSnapshotWithoutData() throws Exception {
+        logger.info("--> start 1 master and 3 data nodes");
+        internalCluster().startMasterOnlyNode();
+        internalCluster().startDataOnlyNode();
+        internalCluster().startDataOnlyNode(); // Start an additional data-node
+        internalCluster().startDataOnlyNode(); // Start an additional data-node
+        Client client = client();
+
+        String repoName = "test-repo";
+        Path repo = randomRepoPath();
+        logger.info("-->  creating repository at {}", repo.toAbsolutePath());
+        assertAcked(client.admin().cluster().preparePutRepository(repoName)
+            .setType("mock").setSettings(Settings.builder()
+                .put("location", repo)
+                .put("compress", false)
+                .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
+        int numberOfFilesBeforeSnapshot = numberOfFiles(repo);
+
+        CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot(repoName, "test-snap-1")
+                                                                      .setWaitForCompletion(true).setIndices("test-idx-*").get();
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(0));
+
+        logger.info("--> delete snapshot");
+        ActionFuture<AcknowledgedResponse> future = client.admin().cluster().prepareDeleteSnapshot(repoName,"test-snap-1").execute();
+        future.actionGet(1, TimeUnit.MINUTES);
+
+        logger.info("--> make sure snapshot doesn't exist");
+        assertThrows(client.admin().cluster().prepareGetSnapshots(repoName).addSnapshots("test-snap-1"), SnapshotMissingException.class);
+
+        // Subtract four files that will remain in the repository:
+        //   (1) index-1
+        //   (2) index-0 (because we keep the previous version) and
+        //   (3) index-latest
+        //   (4) incompatible-snapshots
+        assertThat("not all files were deleted during snapshot cancellation",
+            numberOfFilesBeforeSnapshot, equalTo(numberOfFiles(repo) - 4));
+        logger.info("--> done");
+    }
+
+    public void testDeleteSnapshotWithDataNodeOutage() throws Exception {
+        logger.info("--> start 1 master and 3 data nodes");
+        internalCluster().startMasterOnlyNode();
+        String dataNode = internalCluster().startDataOnlyNode();
+        internalCluster().startDataOnlyNode(); // Start an additional data-node
+        internalCluster().startDataOnlyNode(); // Start an additional data-node
+        Client client = client();
+
+        String repoName = "test-repo";
+        Path repo = randomRepoPath();
+        logger.info("-->  creating repository at {}", repo.toAbsolutePath());
+        assertAcked(client.admin().cluster().preparePutRepository(repoName)
+            .setType("mock").setSettings(Settings.builder()
+                .put("location", repo)
+                .put("compress", false)
+                .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
+        int numberOfFilesBeforeSnapshot = numberOfFiles(repo);
+
+        createIndex("test-idx-1", "test-idx-2", "test-idx-3");
+        logger.info("--> indexing some data");
+        indexRandom(true,
+            client().prepareIndex("test-idx-1", "_doc").setSource("foo", "bar"),
+            client().prepareIndex("test-idx-2", "_doc").setSource("foo", "bar"),
+            client().prepareIndex("test-idx-3", "_doc").setSource("foo", "bar"));
+
+        logger.info("--> creating snapshot");
+        CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot(repoName, "test-snap-1")
+                                                                      .setWaitForCompletion(true).setIndices("test-idx-*").get();
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(),
+                   equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
+
+        ((MockRepository)internalCluster().getInstance(RepositoriesService.class, dataNode).repository(repoName)).blockOnDataFiles(true);
+
+        logger.info("--> delete snapshot");
+        ActionFuture<AcknowledgedResponse> future = client.admin().cluster().prepareDeleteSnapshot(repoName,"test-snap-1").execute();
+
+        logger.info("--> waiting for block to kick in on node [{}]", dataNode);
+        waitForBlock(dataNode, repoName, TimeValue.timeValueSeconds(10));
+
+        logger.info("--> stopping node [{}]", dataNode);
+        stopNode(dataNode);
+
+        try {
+            future.actionGet(1, TimeUnit.MINUTES);
+        } catch (Exception e) {
+            logger.info("--> the node where the client is connected is down, sleep for 10 seconds before proceeding");
+            Thread.sleep(10 * 1000);
+        }
+
+        logger.info("--> make sure snapshot doesn't exist");
+        assertThrows(client().admin().cluster().prepareGetSnapshots(repoName).addSnapshots("test-snap-1"), SnapshotMissingException.class);
+
+        // Subtract four files that will remain in the repository:
+        //   (1) index-1
+        //   (2) index-0 (because we keep the previous version) and
+        //   (3) index-latest
+        //   (4) incompatible-snapshots
+        assertThat("not all files were deleted during snapshot cancellation",
+            numberOfFilesBeforeSnapshot, equalTo(numberOfFiles(repo) - 4));
+        logger.info("--> done");
+    }
+
+    public void testDeleteSnapshotWithMasterNodeOutage() throws Exception {
+        logger.info("--> start 3 master and 3 data nodes");
+        internalCluster().startMasterOnlyNode();
+        internalCluster().startMasterOnlyNode();
+        internalCluster().startMasterOnlyNode();
+        String dataNode = internalCluster().startDataOnlyNode();
+        internalCluster().startDataOnlyNode();
+        internalCluster().startDataOnlyNode();
+        Client client = client();
+
+        String repoName = "test-repo";
+        Path repo = randomRepoPath();
+        logger.info("-->  creating repository at {}", repo.toAbsolutePath());
+        assertAcked(client.admin().cluster().preparePutRepository(repoName)
+            .setType("mock").setSettings(Settings.builder()
+                .put("location", repo)
+                .put("compress", false)
+                .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
+        int numberOfFilesBeforeSnapshot = numberOfFiles(repo);
+
+        createIndex("test-idx-1", "test-idx-2", "test-idx-3");
+        logger.info("--> indexing some data");
+        indexRandom(true,
+            client().prepareIndex("test-idx-1", "_doc").setSource("foo", "bar"),
+            client().prepareIndex("test-idx-2", "_doc").setSource("foo", "bar"),
+            client().prepareIndex("test-idx-3", "_doc").setSource("foo", "bar"));
+
+        logger.info("--> creating snapshot");
+        CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot(repoName, "test-snap-1")
+                                                                      .setWaitForCompletion(true).setIndices("test-idx-*").get();
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(),
+                   equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
+
+        ((MockRepository)internalCluster().getInstance(RepositoriesService.class, dataNode).repository(repoName)).blockOnDataFiles(true);
+
+        logger.info("--> delete snapshot");
+        ActionFuture<AcknowledgedResponse> future = client.admin().cluster().prepareDeleteSnapshot(repoName,"test-snap-1").execute();
+
+        logger.info("--> waiting for block to kick in on node [{}]", dataNode);
+        waitForBlock(dataNode, repoName, TimeValue.timeValueSeconds(10));
+
+        String masterNode = internalCluster().getMasterName();
+        logger.info("--> stopping current master [{}]", masterNode);
+        stopNode(masterNode);
+
+        logger.info("--> unblocking blocked node [{}]", dataNode);
+        unblockNode(repoName, dataNode);
+
+        try {
+            future.actionGet(1, TimeUnit.MINUTES);
+        } catch (Exception e) {
+            logger.info("--> new master may not be elected, sleep for 10 seconds");
+            Thread.sleep(10 * 1000);
+        }
+
+        logger.info("--> make sure snapshot doesn't exist");
+        assertThrows(client().admin().cluster().prepareGetSnapshots(repoName).addSnapshots("test-snap-1"), SnapshotMissingException.class);
+
+        // Subtract four files that will remain in the repository:
+        //   (1) index-1
+        //   (2) index-0 (because we keep the previous version) and
+        //   (3) index-latest
+        //   (4) incompatible-snapshots
+        assertThat("not all files were deleted during snapshot cancellation",
+            numberOfFilesBeforeSnapshot, equalTo(numberOfFiles(repo) - 4));
+        logger.info("--> done");
+    }
+
+    public void testDeleteSnapshotWithBothMasterAndDataNodeOutage() throws Exception {
+        logger.info("--> start 3 master and 3 data nodes");
+        internalCluster().startMasterOnlyNode();
+        internalCluster().startMasterOnlyNode();
+        internalCluster().startMasterOnlyNode();
+        String dataNode = internalCluster().startDataOnlyNode();
+        internalCluster().startDataOnlyNode();
+        internalCluster().startDataOnlyNode();
+        Client client = client();
+
+        String repoName = "test-repo";
+        Path repo = randomRepoPath();
+        logger.info("-->  creating repository at {}", repo.toAbsolutePath());
+        assertAcked(client.admin().cluster().preparePutRepository(repoName)
+            .setType("mock").setSettings(Settings.builder()
+                .put("location", repo)
+                .put("compress", false)
+                .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
+        int numberOfFilesBeforeSnapshot = numberOfFiles(repo);
+
+        createIndex("test-idx-1", "test-idx-2", "test-idx-3");
+        logger.info("--> indexing some data");
+        indexRandom(true,
+            client().prepareIndex("test-idx-1", "_doc").setSource("foo", "bar"),
+            client().prepareIndex("test-idx-2", "_doc").setSource("foo", "bar"),
+            client().prepareIndex("test-idx-3", "_doc").setSource("foo", "bar"));
+
+        logger.info("--> creating snapshot");
+        CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot(repoName, "test-snap-1")
+                                                                      .setWaitForCompletion(true).setIndices("test-idx-*").get();
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(),
+                   equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
+
+        ((MockRepository)internalCluster().getInstance(RepositoriesService.class, dataNode).repository(repoName)).blockOnDataFiles(true);
+
+        logger.info("--> delete snapshot");
+        ActionFuture<AcknowledgedResponse> future = client.admin().cluster().prepareDeleteSnapshot(repoName,"test-snap-1").execute();
+
+        logger.info("--> waiting for block to kick in on node [{}]", dataNode);
+        waitForBlock(dataNode, repoName, TimeValue.timeValueSeconds(10));
+
+        String masterNode = internalCluster().getMasterName();
+        logger.info("--> stopping current master [{}] and data node [{}]", masterNode, dataNode);
+        stopNode(masterNode);
+        stopNode(dataNode);
+
+        try {
+            future.actionGet(1, TimeUnit.MINUTES);
+        } catch (Exception e) {
+            logger.info("--> new master may not be elected, sleep for 10 seconds");
+            Thread.sleep(10 * 1000);
+        }
+
+        logger.info("--> make sure snapshot doesn't exist");
+        assertThrows(client().admin().cluster().prepareGetSnapshots(repoName).addSnapshots("test-snap-1"), SnapshotMissingException.class);
+
+        // Subtract four files that will remain in the repository:
+        //   (1) index-1
+        //   (2) index-0 (because we keep the previous version) and
+        //   (3) index-latest
+        //   (4) incompatible-snapshots
+        assertThat("not all files were deleted during snapshot cancellation",
+            numberOfFilesBeforeSnapshot, equalTo(numberOfFiles(repo) - 4));
+        logger.info("--> done");
+    }
+
+    public void testDeleteSnapshotWithOneNode() throws Exception {
+        logger.info("--> start 1 node");
+        internalCluster().startNode(Settings.builder()
+            .put("thread_pool.snapshot.core", 1)
+            .put("thread_pool.snapshot.max", 1)
+            .build());
+        Client client = client();
+
+        String repoName = "test-repo";
+        Path repo = randomRepoPath();
+        logger.info("-->  creating repository at {}", repo.toAbsolutePath());
+        assertAcked(client.admin().cluster().preparePutRepository(repoName)
+            .setType("mock").setSettings(Settings.builder()
+                .put("location", repo)
+                .put("compress", false)
+                .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
+        int numberOfFilesBeforeSnapshot = numberOfFiles(repo);
+
+        createIndex("test-idx-1", "test-idx-2", "test-idx-3");
+        logger.info("--> indexing some data");
+        indexRandom(true,
+            client().prepareIndex("test-idx-1", "_doc").setSource("foo", "bar"),
+            client().prepareIndex("test-idx-2", "_doc").setSource("foo", "bar"),
+            client().prepareIndex("test-idx-3", "_doc").setSource("foo", "bar"));
+
+        logger.info("--> creating snapshot");
+        CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot(repoName, "test-snap-1")
+                                                                      .setWaitForCompletion(true).setIndices("test-idx-*").get();
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(),
+                   equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
+
+        logger.info("--> delete snapshot");
+        ActionFuture<AcknowledgedResponse> future = client.admin().cluster().prepareDeleteSnapshot(repoName,"test-snap-1").execute();
+        future.actionGet(1, TimeUnit.MINUTES);
+
+        logger.info("--> make sure snapshot doesn't exist");
+        assertThrows(client.admin().cluster().prepareGetSnapshots(repoName).addSnapshots("test-snap-1"), SnapshotMissingException.class);
+
+        // Subtract four files that will remain in the repository:
+        //   (1) index-1
+        //   (2) index-0 (because we keep the previous version) and
+        //   (3) index-latest
+        //   (4) incompatible-snapshots
+        assertThat("not all files were deleted during snapshot cancellation",
+            numberOfFilesBeforeSnapshot, equalTo(numberOfFiles(repo) - 4));
+        logger.info("--> done");
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/snapshots/MinThreadsSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/MinThreadsSnapshotRestoreIT.java
@@ -81,7 +81,8 @@ public class MinThreadsSnapshotRestoreIT extends AbstractSnapshotIntegTestCase {
         client().admin().cluster().prepareCreateSnapshot(repo, snapshot2).setWaitForCompletion(true).get();
 
         String blockedNode = internalCluster().getMasterName();
-        ((MockRepository)internalCluster().getInstance(RepositoriesService.class, blockedNode).repository(repo)).blockOnDataFiles(true);
+        ((MockRepository)internalCluster().getInstance(RepositoriesService.class, blockedNode).repository(repo))
+            .setBlockOnDeleteSnapFile(true);
         logger.info("--> start deletion of first snapshot");
         ActionFuture<AcknowledgedResponse> future =
             client().admin().cluster().prepareDeleteSnapshot(repo, snapshot2).execute();
@@ -127,7 +128,8 @@ public class MinThreadsSnapshotRestoreIT extends AbstractSnapshotIntegTestCase {
         client().admin().cluster().prepareCreateSnapshot(repo, snapshot1).setWaitForCompletion(true).get();
 
         String blockedNode = internalCluster().getMasterName();
-        ((MockRepository)internalCluster().getInstance(RepositoriesService.class, blockedNode).repository(repo)).blockOnDataFiles(true);
+        ((MockRepository)internalCluster().getInstance(RepositoriesService.class, blockedNode).repository(repo))
+            .setBlockOnDeleteSnapFile(true);
         logger.info("--> start deletion of snapshot");
         ActionFuture<AcknowledgedResponse> future = client().admin().cluster().prepareDeleteSnapshot(repo, snapshot1).execute();
         logger.info("--> waiting for block to kick in on node [{}]", blockedNode);
@@ -182,7 +184,8 @@ public class MinThreadsSnapshotRestoreIT extends AbstractSnapshotIntegTestCase {
         client().admin().indices().prepareClose(index, index2).get();
 
         String blockedNode = internalCluster().getMasterName();
-        ((MockRepository)internalCluster().getInstance(RepositoriesService.class, blockedNode).repository(repo)).blockOnDataFiles(true);
+        ((MockRepository)internalCluster().getInstance(RepositoriesService.class, blockedNode).repository(repo))
+            .setBlockOnDeleteSnapFile(true);
         logger.info("--> start deletion of snapshot");
         ActionFuture<AcknowledgedResponse> future = client().admin().cluster().prepareDeleteSnapshot(repo, snapshot2).execute();
         logger.info("--> waiting for block to kick in on node [{}]", blockedNode);


### PR DESCRIPTION
Unlike snapshot creation operation, snapshot deletion operation is executed
in master. This is acceptable for small to medium sized clusters where the
delete operation completes in less than a minute. But, for bigger clusters with
few thousand primary shards, the deletion operation takes considerable amount of
time as there is only one thread working on deleting the snapshot data index by
index, shard by shard.

To reduce the time spent on deletion, parallelizing (distributing) the snapshot deletes
across all data nodes similar to snapshot creation but with no tight coupling between
data node and snapshot shards that are getting deleted.

With this changes, for a cluster with 3 dedicated masters and 20 data nodes and 20,000
primary shards, the deletion took around 1 minute where as without this change it took
around 70 minutes.
