### PR TITLE
Introducing a new snapshot segments threadpool to uploads segments of shards in parallel

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/AbstractPrioritizedRunnable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/AbstractPrioritizedRunnable.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common.util.concurrent;
+
+/**
+ * Wrapper over {@link AbstractRunnable} which provides priority.
+ * <p>
+ * Priority is done by natural ordering.
+ * 0 has higher priority than 1, 1 has higher priority than 2 and so on.
+ */
+public abstract class AbstractPrioritizedRunnable extends AbstractRunnable implements Comparable<AbstractPrioritizedRunnable> {
+
+    private final Long priority;
+
+    protected AbstractPrioritizedRunnable(long priority) {
+        this.priority = priority;
+    }
+
+    public Long getPriority() {
+        return priority;
+    }
+
+    public int compareTo(AbstractPrioritizedRunnable other) {
+        return this.priority.compareTo(other.priority);
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
@@ -37,6 +37,9 @@ import org.elasticsearch.snapshots.SnapshotShardFailure;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class FilterRepository implements Repository {
 
@@ -122,6 +125,13 @@ public class FilterRepository implements Repository {
     public void snapshotShard(IndexShard shard, Store store, SnapshotId snapshotId, IndexId indexId, IndexCommit snapshotIndexCommit,
                               IndexShardSnapshotStatus snapshotStatus) {
         in.snapshotShard(shard, store, snapshotId, indexId, snapshotIndexCommit, snapshotStatus);
+    }
+
+    @Override
+    public void snapshotShard(IndexShard shard, Store store, SnapshotId snapshotId, IndexId indexId, IndexCommit snapshotIndexCommit,
+                              IndexShardSnapshotStatus snapshotStatus, Optional<AtomicInteger> priorityGenerator,
+                              Optional<Executor> executor) {
+        in.snapshotShard(shard, store, snapshotId, indexId, snapshotIndexCommit, snapshotStatus, priorityGenerator, executor);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
@@ -215,7 +215,8 @@ public class RestThreadPoolAction extends AbstractCatAction {
                         keepAlive = poolInfo.getKeepAlive().toString();
                     }
 
-                    if (poolInfo.getThreadPoolType() == ThreadPool.ThreadPoolType.SCALING) {
+                    if (poolInfo.getThreadPoolType() == ThreadPool.ThreadPoolType.SCALING ||
+                        poolInfo.getThreadPoolType() == ThreadPool.ThreadPoolType.PRIORITIZED_SCALING) {
                         assert poolInfo.getMin() >= 0;
                         core = poolInfo.getMin();
                         assert poolInfo.getMax() > 0;

--- a/server/src/main/java/org/elasticsearch/threadpool/PrioritizedScalingExecutorBuilder.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/PrioritizedScalingExecutorBuilder.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.threadpool;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.node.Node;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A builder for prioritized scaling executors.
+ */
+public final class PrioritizedScalingExecutorBuilder
+    extends ExecutorBuilder<PrioritizedScalingExecutorBuilder.PrioritizedScalingExecutorSettings> {
+
+    private final Setting<Integer> coreSetting;
+    private final Setting<Integer> maxSetting;
+    private final Setting<TimeValue> keepAliveSetting;
+
+    /**
+     * Construct a scaling executor builder; the settings will have the
+     * key prefix "thread_pool." followed by the executor name.
+     *
+     * @param name      the name of the executor
+     * @param core      the minimum number of threads in the pool
+     * @param max       the maximum number of threads in the pool
+     * @param keepAlive the time that spare threads above {@code core}
+     *                  threads will be kept alive
+     */
+    public PrioritizedScalingExecutorBuilder(final String name, final int core, final int max, final TimeValue keepAlive) {
+        this(name, core, max, keepAlive, "thread_pool." + name);
+    }
+
+    /**
+     * Construct a scaling executor builder; the settings will have the
+     * specified key prefix.
+     *
+     * @param name      the name of the executor
+     * @param core      the minimum number of threads in the pool
+     * @param max       the maximum number of threads in the pool
+     * @param keepAlive the time that spare threads above {@code core}
+     *                  threads will be kept alive
+     * @param prefix    the prefix for the settings keys
+     */
+    public PrioritizedScalingExecutorBuilder(final String name, final int core, final int max, final TimeValue keepAlive,
+                                             final String prefix) {
+        super(name);
+        this.coreSetting =
+            Setting.intSetting(settingsKey(prefix, "core"), core, Setting.Property.NodeScope);
+        this.maxSetting = Setting.intSetting(settingsKey(prefix, "max"), max, Setting.Property.NodeScope);
+        this.keepAliveSetting =
+            Setting.timeSetting(settingsKey(prefix, "keep_alive"), keepAlive, Setting.Property.NodeScope);
+    }
+
+    @Override
+    public List<Setting<?>> getRegisteredSettings() {
+        return Arrays.asList(coreSetting, maxSetting, keepAliveSetting);
+    }
+
+    @Override
+    PrioritizedScalingExecutorSettings getSettings(Settings settings) {
+        final String nodeName = Node.NODE_NAME_SETTING.get(settings);
+        final int coreThreads = coreSetting.get(settings);
+        final int maxThreads = maxSetting.get(settings);
+        final TimeValue keepAlive = keepAliveSetting.get(settings);
+        return new PrioritizedScalingExecutorSettings(nodeName, coreThreads, maxThreads, keepAlive);
+    }
+
+    ThreadPool.ExecutorHolder build(final PrioritizedScalingExecutorBuilder.PrioritizedScalingExecutorSettings settings,
+                                    final ThreadContext threadContext) {
+        TimeValue keepAlive = settings.keepAlive;
+        int core = settings.core;
+        int max = settings.max;
+        final ThreadPool.Info info = new ThreadPool.Info(name(), ThreadPool.ThreadPoolType.PRIORITIZED_SCALING, core, max, keepAlive,
+            null);
+        final ThreadFactory threadFactory = EsExecutors.daemonThreadFactory(EsExecutors.threadName(settings.nodeName, name()));
+        final ExecutorService executor =
+            EsExecutors.newPrioritizedScaling(
+                settings.nodeName + "/" + name(),
+                core,
+                max,
+                keepAlive.millis(),
+                TimeUnit.MILLISECONDS,
+                threadFactory,
+                threadContext);
+        return new ThreadPool.ExecutorHolder(executor, info);
+    }
+
+    @Override
+    String formatInfo(ThreadPool.Info info) {
+        return String.format(
+            Locale.ROOT,
+            "name [%s], core [%d], max [%d], keep alive [%s]",
+            info.getName(),
+            info.getMin(),
+            info.getMax(),
+            info.getKeepAlive());
+    }
+
+    static class PrioritizedScalingExecutorSettings extends ExecutorBuilder.ExecutorSettings {
+
+        private final int core;
+        private final int max;
+        private final TimeValue keepAlive;
+
+        PrioritizedScalingExecutorSettings(final String nodeName, final int core, final int max, final TimeValue keepAlive) {
+            super(nodeName);
+            this.core = core;
+            this.max = max;
+            this.keepAlive = keepAlive;
+        }
+    }
+
+
+}

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractPrioritizedRunnableTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractPrioritizedRunnableTests.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common.util.concurrent;
+
+import org.elasticsearch.test.ESTestCase;
+
+import org.mockito.InOrder;
+
+import java.util.concurrent.Callable;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests {@link AbstractPrioritizedRunnable}
+ */
+public class AbstractPrioritizedRunnableTests extends ESTestCase {
+    public void testRunSuccess() throws Exception {
+        Callable<?> runCallable = mock(Callable.class);
+
+        AbstractPrioritizedRunnable runnable = new AbstractPrioritizedRunnable(1) {
+            @Override
+            public void onFailure(Exception e) {
+                fail(e.toString());
+            }
+
+            @Override
+            protected void doRun() throws Exception {
+                runCallable.call();
+            }
+        };
+
+        runnable.run();
+
+        verify(runCallable).call();
+    }
+
+    public void testRunFailure() throws Exception {
+        RuntimeException exception = new RuntimeException();
+
+        AbstractPrioritizedRunnable runnable = new AbstractPrioritizedRunnable(1) {
+            @Override
+            public void onFailure(Exception e) {
+                assertSame(exception, e);
+            }
+
+            @Override
+            protected void doRun() throws Exception {
+                throw exception;
+            }
+        };
+
+        runnable.run();
+    }
+
+    public void testOnAfterSuccess() throws Exception {
+        Callable<?> runCallable = mock(Callable.class);
+        Callable<?> afterCallable = mock(Callable.class);
+
+        AbstractPrioritizedRunnable runnable = new AbstractPrioritizedRunnable(1) {
+            @Override
+            public void onFailure(Exception e) {
+                fail(e.toString());
+            }
+
+            @Override
+            protected void doRun() throws Exception {
+                runCallable.call();
+            }
+
+            @Override
+            public void onAfter() {
+                try {
+                    afterCallable.call();
+                }
+                catch (Exception e) {
+                    fail(e.toString());
+                }
+            }
+        };
+
+        runnable.run();
+
+        InOrder inOrder = inOrder(runCallable, afterCallable);
+
+        inOrder.verify(runCallable).call();
+        inOrder.verify(afterCallable).call();
+
+    }
+
+    public void testOnAfterFailure() throws Exception {
+        RuntimeException exception = new RuntimeException();
+        Callable<?> afterCallable = mock(Callable.class);
+
+        AbstractPrioritizedRunnable runnable = new AbstractPrioritizedRunnable(1) {
+            @Override
+            public void onFailure(Exception e) {
+                assertSame(exception, e);
+            }
+
+            @Override
+            protected void doRun() throws Exception {
+                throw exception;
+            }
+
+            @Override
+            public void onAfter() {
+                try {
+                    afterCallable.call();
+                }
+                catch (Exception e) {
+                    fail(e.toString());
+                }
+            }
+        };
+
+        runnable.run();
+
+        verify(afterCallable).call();
+    }
+
+    public void testOnRejection() throws Exception {
+        RuntimeException exception = new RuntimeException();
+        Callable<?> failureCallable = mock(Callable.class);
+
+        AbstractPrioritizedRunnable runnable = new AbstractPrioritizedRunnable(1) {
+            @Override
+            public void onFailure(Exception e) {
+                assertSame(exception, e);
+
+                try {
+                    failureCallable.call();
+                }
+                catch (Exception inner) {
+                    inner.addSuppressed(e);
+                    fail(inner.toString());
+                }
+            }
+
+            @Override
+            protected void doRun() throws Exception {
+                fail("Not tested");
+            }
+        };
+
+        runnable.onRejection(exception);
+    }
+
+    public void testIsForceExecutuonDefaultsFalse() {
+        AbstractPrioritizedRunnable runnable = new AbstractPrioritizedRunnable(1) {
+            @Override
+            public void onFailure(Exception e) {
+                fail(e.toString());
+            }
+
+            @Override
+            protected void doRun() throws Exception {
+                fail("Not tested");
+            }
+        };
+
+        assertFalse(runnable.isForceExecution());
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -159,6 +159,16 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
         return null;
     }
 
+    public static String errorNodeWithIndex(final String repositoryName, final String indexName, double errorRate) {
+        for(String node : internalCluster().nodesInclude(indexName)) {
+            ((MockRepository)internalCluster().getInstance(RepositoriesService.class, node).repository(repositoryName))
+                .randomDataFileIOExceptionRate(errorRate);
+            return node;
+        }
+        fail("No nodes for the index " + indexName + " found");
+        return null;
+    }
+
     public static void blockAllDataNodes(String repository) {
         for(RepositoriesService repositoriesService : internalCluster().getDataNodeInstances(RepositoriesService.class)) {
             ((MockRepository)repositoriesService.repository(repository)).blockOnDataFiles(true);

--- a/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -87,7 +87,7 @@ public class MockRepository extends FsRepository {
 
     private final double randomControlIOExceptionRate;
 
-    private final double randomDataFileIOExceptionRate;
+    private volatile double randomDataFileIOExceptionRate;
 
     private final boolean useLuceneCorruptionException;
 
@@ -173,6 +173,10 @@ public class MockRepository extends FsRepository {
         blockOnWriteIndexFile = false;
         blockAndFailOnWriteSnapFile = false;
         this.notifyAll();
+    }
+
+    public void randomDataFileIOExceptionRate(double rate) {
+        randomDataFileIOExceptionRate = rate;
     }
 
     public void blockOnDataFiles(boolean blocked) {

--- a/server/src/test/java/org/elasticsearch/threadpool/PrioritizedScalingThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/PrioritizedScalingThreadPoolTests.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.threadpool;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.AbstractPrioritizedRunnable;
+import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.equalTo;
+
+public class PrioritizedScalingThreadPoolTests extends ESThreadPoolTestCase {
+
+    public void testPrioritizedScalingThreadPoolConfiguration() throws InterruptedException {
+        final String threadPoolName = randomThreadPool(ThreadPool.ThreadPoolType.PRIORITIZED_SCALING);
+        final Settings.Builder builder = Settings.builder();
+
+        final int core;
+        if (randomBoolean()) {
+            core = randomIntBetween(0, 8);
+            builder.put("thread_pool." + threadPoolName + ".core", core);
+        } else {
+            core = "generic".equals(threadPoolName) ? 4 : 1; // the defaults
+        }
+
+        final int maxBasedOnNumberOfProcessors;
+        if (randomBoolean()) {
+            final int processors = randomIntBetween(1, 64);
+            maxBasedOnNumberOfProcessors = expectedSize(threadPoolName, processors);
+            builder.put("processors", processors);
+        } else {
+            maxBasedOnNumberOfProcessors = expectedSize(threadPoolName, Runtime.getRuntime().availableProcessors());
+        }
+
+        final int expectedMax;
+        if (maxBasedOnNumberOfProcessors < core || randomBoolean()) {
+            expectedMax = randomIntBetween(Math.max(1, core), 16);
+            builder.put("thread_pool." + threadPoolName + ".max", expectedMax);
+        }  else {
+            expectedMax = maxBasedOnNumberOfProcessors;
+        }
+
+        final long keepAlive;
+        if (randomBoolean()) {
+            keepAlive = randomIntBetween(1, 300);
+            builder.put("thread_pool." + threadPoolName + ".keep_alive", keepAlive + "s");
+        } else {
+            keepAlive = "generic".equals(threadPoolName) ? 30 : 300; // the defaults
+        }
+
+        runPrioritizedScalingThreadPoolTest(builder.build(), (clusterSettings, threadPool) -> {
+            final Executor executor = threadPool.executor(threadPoolName);
+            assertThat(executor, instanceOf(EsThreadPoolExecutor.class));
+            final EsThreadPoolExecutor esThreadPoolExecutor = (EsThreadPoolExecutor)executor;
+            final ThreadPool.Info info = info(threadPool, threadPoolName);
+
+            assertThat(info.getName(), equalTo(threadPoolName));
+            assertThat(info.getThreadPoolType(), equalTo(ThreadPool.ThreadPoolType.PRIORITIZED_SCALING));
+
+            assertThat(info.getKeepAlive().seconds(), equalTo(keepAlive));
+            assertThat(esThreadPoolExecutor.getKeepAliveTime(TimeUnit.SECONDS), equalTo(keepAlive));
+
+            assertNull(info.getQueueSize());
+            assertThat(esThreadPoolExecutor.getQueue().remainingCapacity(), equalTo(Integer.MAX_VALUE));
+
+            assertThat(info.getMin(), equalTo(core));
+            assertThat(esThreadPoolExecutor.getCorePoolSize(), equalTo(core));
+            assertThat(info.getMax(), equalTo(expectedMax));
+            assertThat(esThreadPoolExecutor.getMaximumPoolSize(), equalTo(expectedMax));
+        });
+    }
+
+    private int expectedSize(final String threadPoolName, final int numberOfProcessors) {
+        final Map<String, Function<Integer, Integer>> sizes = new HashMap<>();
+        sizes.put(ThreadPool.Names.SNAPSHOT_SEGMENTS, ThreadPool::halfNumberOfProcessors);
+        return sizes.get(threadPoolName).apply(numberOfProcessors);
+    }
+
+    public void testPrioritizedScalingThreadPoolIsBounded() throws InterruptedException {
+        final String threadPoolName = randomThreadPool(ThreadPool.ThreadPoolType.PRIORITIZED_SCALING);
+        final int size = randomIntBetween(32, 512);
+        final Settings settings = Settings.builder().put("thread_pool." + threadPoolName + ".max", size).build();
+        runPrioritizedScalingThreadPoolTest(settings, (clusterSettings, threadPool) -> {
+            final CountDownLatch latch = new CountDownLatch(1);
+            final int numberOfTasks = 2 * size;
+            final CountDownLatch taskLatch = new CountDownLatch(numberOfTasks);
+            for (int i = 0; i < numberOfTasks; i++) {
+                threadPool.executor(threadPoolName).execute(getRunnable(latch, taskLatch));
+            }
+            final ThreadPoolStats.Stats stats = stats(threadPool, threadPoolName);
+            assertThat(stats.getQueue(), equalTo(numberOfTasks - size));
+            assertThat(stats.getLargest(), equalTo(size));
+            latch.countDown();
+            try {
+                taskLatch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public void testPrioritizedScalingThreadPoolThreadsAreTerminatedAfterKeepAlive() throws InterruptedException {
+        final String threadPoolName = randomThreadPool(ThreadPool.ThreadPoolType.PRIORITIZED_SCALING);
+        final int min = "generic".equals(threadPoolName) ? 4 : 1;
+        final Settings settings =
+            Settings.builder()
+                .put("thread_pool." + threadPoolName + ".max", 128)
+                .put("thread_pool." + threadPoolName + ".keep_alive", "1ms")
+                .build();
+        runPrioritizedScalingThreadPoolTest(settings, ((clusterSettings, threadPool) -> {
+            final CountDownLatch latch = new CountDownLatch(1);
+            final CountDownLatch taskLatch = new CountDownLatch(128);
+            for (int i = 0; i < 128; i++) {
+                threadPool.executor(threadPoolName).execute(getRunnable(latch, taskLatch));
+            }
+            int threads = stats(threadPool, threadPoolName).getThreads();
+            assertEquals(128, threads);
+            latch.countDown();
+            // this while loop is the core of this test; if threads
+            // are correctly idled down by the pool, the number of
+            // threads in the pool will drop to the min for the pool
+            // but if threads are not correctly idled down by the pool,
+            // this test will just timeout waiting for them to idle
+            // down
+            do {
+                spinForAtLeastOneMillisecond();
+            } while (stats(threadPool, threadPoolName).getThreads() > min);
+            try {
+                taskLatch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }));
+    }
+
+    private void runPrioritizedScalingThreadPoolTest(
+        final Settings settings,
+        final BiConsumer<ClusterSettings, ThreadPool> consumer) throws InterruptedException {
+        ThreadPool threadPool = null;
+        try {
+            final String test = Thread.currentThread().getStackTrace()[2].getMethodName();
+            final Settings nodeSettings = Settings.builder().put(settings).put("node.name", test).build();
+            threadPool = new ThreadPool(nodeSettings);
+            final ClusterSettings clusterSettings = new ClusterSettings(nodeSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+            consumer.accept(clusterSettings, threadPool);
+        } finally {
+            terminateThreadPoolIfNeeded(threadPool);
+        }
+    }
+
+    private Runnable getRunnable(CountDownLatch latch, CountDownLatch taskLatch) {
+        return new AbstractPrioritizedRunnable(1) {
+            @Override
+            public void onFailure(Exception e) {
+
+            }
+
+            @Override
+            protected void doRun() throws Exception {
+                try {
+                    latch.await();
+                    taskLatch.countDown();
+                } catch (final InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueue.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueue.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.AbstractPrioritizedRunnable;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPoolInfo;
 import org.elasticsearch.threadpool.ThreadPoolStats;
@@ -134,6 +135,9 @@ public class DeterministicTaskQueue {
      * Schedule a task for immediate execution.
      */
     public void scheduleNow(final Runnable task) {
+        if (task instanceof AbstractPrioritizedRunnable) {
+            task.run();
+        }
         if (executionDelayVariabilityMillis > 0 && random.nextBoolean()) {
             final long executionDelay = RandomNumbers.randomLongBetween(random, 1, executionDelayVariabilityMillis);
             final DeferredTask deferredTask = new DeferredTask(currentTimeMillis + executionDelay, task);


### PR DESCRIPTION
Current Behavior:
The snapshot thread pool max size is determined by the number of processors by 2
capped at 5. Each snapshot thread works on snapshotting one shard. So, at any point
in time at max there will be 5 shards uploaded in parallel. This works good
for cases where the number of shards to be snapshotted is greater than 5. But,
for cases where there are lesser number of shards, the snapshot threads are
under utilized. This problem is more visible towards the end of a snapshot, where
snapshot is complete for most of the shards and in progress for 1 or 2 shards.

Proposed Behavior:
Introducing a new prioritized thread pool to upload segments of various shards in
parallel, this will prioritize uploading segments of one shard at a time. Thus the
snapshot processing capacity is fully utilized throughout the entire span of snapshot.
Prioritizing one shard also results in releasing the shard lock (held by snapshot) sooner.