### PR TITLE
Add roles and cluster privileges for data frame transforms

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
@@ -654,8 +654,8 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
 
             List<Role> roles = response.getRoles();
             assertNotNull(response);
-            // 25 system roles plus the three we created
-            assertThat(roles.size(), equalTo(28));
+            // 27 system roles plus the three we created
+            assertThat(roles.size(), equalTo(30));
         }
 
         {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/GetDataFrameTransformsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/GetDataFrameTransformsStatsAction.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 public class GetDataFrameTransformsStatsAction extends Action<GetDataFrameTransformsStatsAction.Response> {
 
     public static final GetDataFrameTransformsStatsAction INSTANCE = new GetDataFrameTransformsStatsAction();
-    public static final String NAME = "cluster:monitor/data_frame_stats/get";
+    public static final String NAME = "cluster:monitor/data_frame/stats/get";
     public GetDataFrameTransformsStatsAction() {
         super(NAME);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilege.java
@@ -40,11 +40,13 @@ public final class ClusterPrivilege extends Privilege {
     private static final Automaton MANAGE_TOKEN_AUTOMATON = patterns("cluster:admin/xpack/security/token/*");
     private static final Automaton MONITOR_AUTOMATON = patterns("cluster:monitor/*");
     private static final Automaton MONITOR_ML_AUTOMATON = patterns("cluster:monitor/xpack/ml/*");
+    private static final Automaton MONITOR_DATA_FRAME_AUTOMATON = patterns("cluster:monitor/data_frame/*");
     private static final Automaton MONITOR_WATCHER_AUTOMATON = patterns("cluster:monitor/xpack/watcher/*");
     private static final Automaton MONITOR_ROLLUP_AUTOMATON = patterns("cluster:monitor/xpack/rollup/*");
     private static final Automaton ALL_CLUSTER_AUTOMATON = patterns("cluster:*", "indices:admin/template/*");
     private static final Automaton MANAGE_AUTOMATON = minusAndMinimize(ALL_CLUSTER_AUTOMATON, MANAGE_SECURITY_AUTOMATON);
     private static final Automaton MANAGE_ML_AUTOMATON = patterns("cluster:admin/xpack/ml/*", "cluster:monitor/xpack/ml/*");
+    private static final Automaton MANAGE_DATA_FRAME_AUTOMATON = patterns("cluster:admin/data_frame/*", "cluster:monitor/data_frame/*");
     private static final Automaton MANAGE_WATCHER_AUTOMATON = patterns("cluster:admin/xpack/watcher/*", "cluster:monitor/xpack/watcher/*");
     private static final Automaton TRANSPORT_CLIENT_AUTOMATON = patterns("cluster:monitor/nodes/liveness", "cluster:monitor/state");
     private static final Automaton MANAGE_IDX_TEMPLATE_AUTOMATON = patterns("indices:admin/template/*");
@@ -62,10 +64,14 @@ public final class ClusterPrivilege extends Privilege {
     public static final ClusterPrivilege ALL =                   new ClusterPrivilege("all",                 ALL_CLUSTER_AUTOMATON);
     public static final ClusterPrivilege MONITOR =               new ClusterPrivilege("monitor",             MONITOR_AUTOMATON);
     public static final ClusterPrivilege MONITOR_ML =            new ClusterPrivilege("monitor_ml",          MONITOR_ML_AUTOMATON);
+    public static final ClusterPrivilege MONITOR_DATA_FRAME =
+            new ClusterPrivilege("monitor_data_frame_transforms", MONITOR_DATA_FRAME_AUTOMATON);
     public static final ClusterPrivilege MONITOR_WATCHER =       new ClusterPrivilege("monitor_watcher",     MONITOR_WATCHER_AUTOMATON);
     public static final ClusterPrivilege MONITOR_ROLLUP =        new ClusterPrivilege("monitor_rollup",      MONITOR_ROLLUP_AUTOMATON);
     public static final ClusterPrivilege MANAGE =                new ClusterPrivilege("manage",              MANAGE_AUTOMATON);
     public static final ClusterPrivilege MANAGE_ML =             new ClusterPrivilege("manage_ml",           MANAGE_ML_AUTOMATON);
+    public static final ClusterPrivilege MANAGE_DATA_FRAME =
+            new ClusterPrivilege("manage_data_frame_transforms", MANAGE_DATA_FRAME_AUTOMATON);
     public static final ClusterPrivilege MANAGE_TOKEN =          new ClusterPrivilege("manage_token",        MANAGE_TOKEN_AUTOMATON);
     public static final ClusterPrivilege MANAGE_WATCHER =        new ClusterPrivilege("manage_watcher",      MANAGE_WATCHER_AUTOMATON);
     public static final ClusterPrivilege MANAGE_ROLLUP =         new ClusterPrivilege("manage_rollup",       MANAGE_ROLLUP_AUTOMATON);
@@ -90,10 +96,12 @@ public final class ClusterPrivilege extends Privilege {
             .put("all", ALL)
             .put("monitor", MONITOR)
             .put("monitor_ml", MONITOR_ML)
+            .put("monitor_data_frame_transforms", MONITOR_DATA_FRAME)
             .put("monitor_watcher", MONITOR_WATCHER)
             .put("monitor_rollup", MONITOR_ROLLUP)
             .put("manage", MANAGE)
             .put("manage_ml", MANAGE_ML)
+            .put("manage_data_frame_transforms", MANAGE_DATA_FRAME)
             .put("manage_token", MANAGE_TOKEN)
             .put("manage_watcher", MANAGE_WATCHER)
             .put("manage_index_templates", MANAGE_IDX_TEMPLATES)

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -156,6 +156,12 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                         .privileges("view_index_metadata", "read", "write").build()
                         },
                         null, MetadataUtils.DEFAULT_RESERVED_METADATA))
+                .put("data_frame_transforms_admin", new RoleDescriptor("data_frame_transforms_admin",
+                        new String[] { "manage_data_frame_transforms" },
+                        null, null, null, null, MetadataUtils.DEFAULT_RESERVED_METADATA, null))
+                .put("data_frame_transforms_user", new RoleDescriptor("data_frame_transforms_user",
+                        new String[] { "monitor_data_frame_transforms" },
+                        null, null, null, null, MetadataUtils.DEFAULT_RESERVED_METADATA, null))
                 .put("watcher_admin", new RoleDescriptor("watcher_admin", new String[] { "manage_watcher" },
                         new RoleDescriptor.IndicesPrivileges[] {
                                 RoleDescriptor.IndicesPrivileges.builder().indices(Watch.INDEX, TriggeredWatchStoreField.INDEX_NAME,

--- a/x-pack/plugin/data-frame/qa/single-node-tests/build.gradle
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/build.gradle
@@ -7,6 +7,20 @@ dependencies {
 }
 
 integTestCluster {
-  setting 'xpack.security.enabled', 'false'
+  setting 'xpack.security.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'trial'
+
+  setupCommand 'setupDummyUser',
+          'bin/elasticsearch-users', 'useradd', 'x_pack_rest_user', '-p', 'x-pack-test-password', '-r', 'superuser'
+
+  waitCondition = { node, ant ->
+      File tmpFile = new File(node.cwd, 'wait.success')
+      ant.get(src: "http://${node.httpUri()}/_cluster/health?wait_for_nodes=>=${numNodes}&wait_for_status=yellow",
+              dest: tmpFile.toString(),
+              username: 'x_pack_rest_user',
+              password: 'x-pack-test-password',
+              ignoreerrors: true,
+              retries: 10)
+      return tmpFile.exists()
+  }
 }

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameGetAndGetStatsIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameGetAndGetStatsIT.java
@@ -21,6 +21,9 @@ public class DataFrameGetAndGetStatsIT extends DataFrameRestTestCase {
     private static final String TEST_USER_NAME = "df_user";
     private static final String BASIC_AUTH_VALUE_DATA_FRAME_USER =
         basicAuthHeaderValue(TEST_USER_NAME, TEST_PASSWORD_SECURE_STRING);
+    private static final String TEST_ADMIN_USER_NAME = "df_admin";
+    private static final String BASIC_AUTH_VALUE_DATA_FRAME_ADMIN =
+        basicAuthHeaderValue(TEST_ADMIN_USER_NAME, TEST_PASSWORD_SECURE_STRING);
 
     private static boolean indicesCreated = false;
 
@@ -41,6 +44,7 @@ public class DataFrameGetAndGetStatsIT extends DataFrameRestTestCase {
         createReviewsIndex();
         indicesCreated = true;
         setupUser(TEST_USER_NAME, Collections.singletonList("data_frame_transforms_user"));
+        setupUser(TEST_ADMIN_USER_NAME, Collections.singletonList("data_frame_transforms_admin"));
     }
 
     public void testGetAndGetStats() throws Exception {
@@ -50,43 +54,38 @@ public class DataFrameGetAndGetStatsIT extends DataFrameRestTestCase {
         startAndWaitForTransform("pivot_1", "pivot_reviews_1");
         startAndWaitForTransform("pivot_2", "pivot_reviews_2");
 
+        // Alternate testing between admin and lowly user, as both should be able to get the configs and stats
+        String authHeader = randomFrom(BASIC_AUTH_VALUE_DATA_FRAME_USER, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN);
+
         // check all the different ways to retrieve all stats
-        Request getRequest = new Request("GET", DATAFRAME_ENDPOINT + "_stats");
-        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        Request getRequest = createRequestWithAuth("GET", DATAFRAME_ENDPOINT + "_stats", authHeader);
         Map<String, Object> stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(2, XContentMapValues.extractValue("count", stats));
-        getRequest = new Request("GET", DATAFRAME_ENDPOINT + "_all/_stats");
-        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        getRequest = createRequestWithAuth("GET", DATAFRAME_ENDPOINT + "_all/_stats", authHeader);
         stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(2, XContentMapValues.extractValue("count", stats));
-        getRequest = new Request("GET", DATAFRAME_ENDPOINT + "*/_stats");
-        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        getRequest = createRequestWithAuth("GET", DATAFRAME_ENDPOINT + "*/_stats", authHeader);
         stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(2, XContentMapValues.extractValue("count", stats));
 
         // only pivot_1
-        getRequest = new Request("GET", DATAFRAME_ENDPOINT + "pivot_1/_stats");
-        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        getRequest = createRequestWithAuth("GET", DATAFRAME_ENDPOINT + "pivot_1/_stats", authHeader);
         stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(1, XContentMapValues.extractValue("count", stats));
 
         // check all the different ways to retrieve all transforms
-        getRequest = new Request("GET", DATAFRAME_ENDPOINT);
-        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        getRequest = createRequestWithAuth("GET", DATAFRAME_ENDPOINT, authHeader);
         Map<String, Object> transforms = entityAsMap(client().performRequest(getRequest));
         assertEquals(2, XContentMapValues.extractValue("count", transforms));
-        getRequest = new Request("GET", DATAFRAME_ENDPOINT + "_all");
-        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        getRequest = createRequestWithAuth("GET", DATAFRAME_ENDPOINT + "_all", authHeader);
         transforms = entityAsMap(client().performRequest(getRequest));
         assertEquals(2, XContentMapValues.extractValue("count", transforms));
-        getRequest = new Request("GET", DATAFRAME_ENDPOINT + "*");
-        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        getRequest = createRequestWithAuth("GET", DATAFRAME_ENDPOINT + "*", authHeader);
         transforms = entityAsMap(client().performRequest(getRequest));
         assertEquals(2, XContentMapValues.extractValue("count", transforms));
 
         // only pivot_1
-        getRequest = new Request("GET", DATAFRAME_ENDPOINT + "pivot_1");
-        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        getRequest = createRequestWithAuth("GET", DATAFRAME_ENDPOINT + "pivot_1", authHeader);
         transforms = entityAsMap(client().performRequest(getRequest));
         assertEquals(1, XContentMapValues.extractValue("count", transforms));
     }

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameGetAndGetStatsIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameGetAndGetStatsIT.java
@@ -11,9 +11,16 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
+
 public class DataFrameGetAndGetStatsIT extends DataFrameRestTestCase {
+
+    private static final String TEST_USER_NAME = "df_user";
+    private static final String BASIC_AUTH_VALUE_DATA_FRAME_USER =
+        basicAuthHeaderValue(TEST_USER_NAME, TEST_PASSWORD_SECURE_STRING);
 
     private static boolean indicesCreated = false;
 
@@ -33,6 +40,7 @@ public class DataFrameGetAndGetStatsIT extends DataFrameRestTestCase {
 
         createReviewsIndex();
         indicesCreated = true;
+        setupUser(TEST_USER_NAME, Collections.singletonList("data_frame_transforms_user"));
     }
 
     public void testGetAndGetStats() throws Exception {
@@ -43,29 +51,43 @@ public class DataFrameGetAndGetStatsIT extends DataFrameRestTestCase {
         startAndWaitForTransform("pivot_2", "pivot_reviews_2");
 
         // check all the different ways to retrieve all stats
-        Map<String, Object> stats = entityAsMap(client().performRequest(new Request("GET", DATAFRAME_ENDPOINT + "_stats")));
+        Request getRequest = new Request("GET", DATAFRAME_ENDPOINT + "_stats");
+        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        Map<String, Object> stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(2, XContentMapValues.extractValue("count", stats));
-        stats = entityAsMap(client().performRequest(new Request("GET", DATAFRAME_ENDPOINT + "_all/_stats")));
+        getRequest = new Request("GET", DATAFRAME_ENDPOINT + "_all/_stats");
+        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(2, XContentMapValues.extractValue("count", stats));
-        stats = entityAsMap(client().performRequest(new Request("GET", DATAFRAME_ENDPOINT + "*/_stats")));
+        getRequest = new Request("GET", DATAFRAME_ENDPOINT + "*/_stats");
+        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(2, XContentMapValues.extractValue("count", stats));
 
         // only pivot_1
-        stats = entityAsMap(client().performRequest(new Request("GET", DATAFRAME_ENDPOINT + "pivot_1/_stats")));
+        getRequest = new Request("GET", DATAFRAME_ENDPOINT + "pivot_1/_stats");
+        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(1, XContentMapValues.extractValue("count", stats));
 
         // check all the different ways to retrieve all transforms
-        Map<String, Object> transforms = entityAsMap(client().performRequest(new Request("GET", DATAFRAME_ENDPOINT)));
+        getRequest = new Request("GET", DATAFRAME_ENDPOINT);
+        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        Map<String, Object> transforms = entityAsMap(client().performRequest(getRequest));
         assertEquals(2, XContentMapValues.extractValue("count", transforms));
-        transforms = entityAsMap(client().performRequest(new Request("GET", DATAFRAME_ENDPOINT + "_all")));
+        getRequest = new Request("GET", DATAFRAME_ENDPOINT + "_all");
+        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        transforms = entityAsMap(client().performRequest(getRequest));
         assertEquals(2, XContentMapValues.extractValue("count", transforms));
-        transforms = entityAsMap(client().performRequest(new Request("GET", DATAFRAME_ENDPOINT + "*")));
+        getRequest = new Request("GET", DATAFRAME_ENDPOINT + "*");
+        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        transforms = entityAsMap(client().performRequest(getRequest));
         assertEquals(2, XContentMapValues.extractValue("count", transforms));
 
         // only pivot_1
-        transforms = entityAsMap(client().performRequest(new Request("GET", DATAFRAME_ENDPOINT + "pivot_1")));
+        getRequest = new Request("GET", DATAFRAME_ENDPOINT + "pivot_1");
+        addAuthHeaderToRequest(getRequest, BASIC_AUTH_VALUE_DATA_FRAME_USER);
+        transforms = entityAsMap(client().performRequest(getRequest));
         assertEquals(1, XContentMapValues.extractValue("count", transforms));
     }
-
-
 }

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFramePivotRestIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFramePivotRestIT.java
@@ -17,9 +17,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.equalTo;
 
 public class DataFramePivotRestIT extends DataFrameRestTestCase {
+
+    private static final String TEST_USER_NAME = "df_admin_plus_data";
+    private static final String DATA_ACCESS_ROLE = "test_data_access";
+    private static final String BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS =
+        basicAuthHeaderValue(TEST_USER_NAME, TEST_PASSWORD_SECURE_STRING);
 
     private static boolean indicesCreated = false;
 
@@ -39,15 +45,18 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
 
         createReviewsIndex();
         indicesCreated = true;
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
+        setupUser(TEST_USER_NAME, Arrays.asList("data_frame_transforms_admin", DATA_ACCESS_ROLE));
     }
 
     public void testSimplePivot() throws Exception {
         String transformId = "simplePivot";
         String dataFrameIndex = "pivot_reviews";
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 
-        createPivotReviewsTransform(transformId, dataFrameIndex, null);
+        createPivotReviewsTransform(transformId, dataFrameIndex, null, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
 
-        startAndWaitForTransform(transformId, dataFrameIndex);
+        startAndWaitForTransform(transformId, dataFrameIndex, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
 
         // we expect 27 documents as there shall be 27 user_id's
         Map<String, Object> indexStats = getAsMap(dataFrameIndex + "/_stats");
@@ -64,11 +73,12 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
     public void testSimplePivotWithQuery() throws Exception {
         String transformId = "simplePivotWithQuery";
         String dataFrameIndex = "pivot_reviews_user_id_above_20";
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
         String query = "\"match\": {\"user_id\": \"user_26\"}";
 
-        createPivotReviewsTransform(transformId, dataFrameIndex, query);
+        createPivotReviewsTransform(transformId, dataFrameIndex, query, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
 
-        startAndWaitForTransform(transformId, dataFrameIndex);
+        startAndWaitForTransform(transformId, dataFrameIndex, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
 
         // we expect only 1 document due to the query
         Map<String, Object> indexStats = getAsMap(dataFrameIndex + "/_stats");
@@ -79,13 +89,14 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
     public void testHistogramPivot() throws Exception {
         String transformId = "simpleHistogramPivot";
         String dataFrameIndex = "pivot_reviews_via_histogram";
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 
         final Request createDataframeTransformRequest = new Request("PUT", DATAFRAME_ENDPOINT + transformId);
+        addAuthHeaderToRequest(createDataframeTransformRequest, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
             + " \"source\": \"reviews\","
             + " \"dest\": \"" + dataFrameIndex + "\",";
-
 
         config += " \"pivot\": {"
             + "   \"group_by\": {"
@@ -99,7 +110,6 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
             + "         \"field\": \"stars\""
             + " } } } }"
             + "}";
-
 
         createDataframeTransformRequest.setJsonEntity(config);
         Map<String, Object> createDataframeTransformResponse = entityAsMap(client().performRequest(createDataframeTransformRequest));
@@ -117,13 +127,14 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
     public void testBiggerPivot() throws Exception {
         String transformId = "biggerPivot";
         String dataFrameIndex = "bigger_pivot_reviews";
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 
         final Request createDataframeTransformRequest = new Request("PUT", DATAFRAME_ENDPOINT + transformId);
+        addAuthHeaderToRequest(createDataframeTransformRequest, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
                 + " \"source\": \"reviews\","
                 + " \"dest\": \"" + dataFrameIndex + "\",";
-
 
         config += " \"pivot\": {"
                 + "   \"group_by\": {"
@@ -164,7 +175,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
         assertThat(createDataframeTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
         assertTrue(indexExists(dataFrameIndex));
 
-        startAndWaitForTransform(transformId, dataFrameIndex);
+        startAndWaitForTransform(transformId, dataFrameIndex, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
 
         // we expect 27 documents as there shall be 27 user_id's
         Map<String, Object> indexStats = getAsMap(dataFrameIndex + "/_stats");
@@ -191,13 +202,14 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
     public void testDateHistogramPivot() throws Exception {
         String transformId = "simpleDateHistogramPivot";
         String dataFrameIndex = "pivot_reviews_via_date_histogram";
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 
         final Request createDataframeTransformRequest = new Request("PUT", DATAFRAME_ENDPOINT + transformId);
+        addAuthHeaderToRequest(createDataframeTransformRequest, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
-            + " \"source\": \"reviews\","
+            + " \"source\": \"" + REVIEWS_INDEX_NAME + "\","
             + " \"dest\": \"" + dataFrameIndex + "\",";
-
 
         config += " \"pivot\": {"
             + "   \"group_by\": {"
@@ -217,7 +229,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
         assertThat(createDataframeTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
         assertTrue(indexExists(dataFrameIndex));
 
-        startAndWaitForTransform(transformId, dataFrameIndex);
+        startAndWaitForTransform(transformId, dataFrameIndex, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
 
         // we expect 21 documents as there shall be 21 days worth of docs
         Map<String, Object> indexStats = getAsMap(dataFrameIndex + "/_stats");
@@ -227,10 +239,11 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testPreviewTransform() throws Exception {
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
         final Request createPreviewRequest = new Request("POST", DATAFRAME_ENDPOINT + "_preview");
 
         String config = "{"
-            + " \"source\": \"reviews\",";
+            + " \"source\": \"" + REVIEWS_INDEX_NAME + "\",";
 
         config += " \"pivot\": {"
             + "   \"group_by\": {"
@@ -243,6 +256,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
             + " } } } }"
             + "}";
         createPreviewRequest.setJsonEntity(config);
+        addAuthHeaderToRequest(createPreviewRequest, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
         Map<String, Object> previewDataframeResponse = entityAsMap(client().performRequest(createPreviewRequest));
         List<Map<String, Object>> preview = (List<Map<String, Object>>)previewDataframeResponse.get("preview");
         assertThat(preview.size(), equalTo(393));
@@ -257,7 +271,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
         Map<String, Object> searchResult = getAsMap(query);
 
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
-        double actual = (double) ((List<?>) XContentMapValues.extractValue("hits.hits._source.avg_rating", searchResult)).get(0);
+        double actual = (Double) ((List<?>) XContentMapValues.extractValue("hits.hits._source.avg_rating", searchResult)).get(0);
         assertEquals(expected, actual, 0.000001);
     }
 }

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFramePivotRestIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFramePivotRestIT.java
@@ -91,11 +91,11 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
         String dataFrameIndex = "pivot_reviews_via_histogram";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 
-        final Request createDataframeTransformRequest = new Request("PUT", DATAFRAME_ENDPOINT + transformId);
-        addAuthHeaderToRequest(createDataframeTransformRequest, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
+        final Request createDataframeTransformRequest = createRequestWithAuth("PUT", DATAFRAME_ENDPOINT + transformId,
+            BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
-            + " \"source\": \"reviews\","
+            + " \"source\": \"" + REVIEWS_INDEX_NAME + "\","
             + " \"dest\": \"" + dataFrameIndex + "\",";
 
         config += " \"pivot\": {"
@@ -129,8 +129,8 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
         String dataFrameIndex = "bigger_pivot_reviews";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 
-        final Request createDataframeTransformRequest = new Request("PUT", DATAFRAME_ENDPOINT + transformId);
-        addAuthHeaderToRequest(createDataframeTransformRequest, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
+        final Request createDataframeTransformRequest = createRequestWithAuth("PUT", DATAFRAME_ENDPOINT + transformId,
+            BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
                 + " \"source\": \"reviews\","
@@ -204,8 +204,8 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
         String dataFrameIndex = "pivot_reviews_via_date_histogram";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 
-        final Request createDataframeTransformRequest = new Request("PUT", DATAFRAME_ENDPOINT + transformId);
-        addAuthHeaderToRequest(createDataframeTransformRequest, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
+        final Request createDataframeTransformRequest = createRequestWithAuth("PUT", DATAFRAME_ENDPOINT + transformId,
+            BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
             + " \"source\": \"" + REVIEWS_INDEX_NAME + "\","
@@ -240,7 +240,8 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
     @SuppressWarnings("unchecked")
     public void testPreviewTransform() throws Exception {
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
-        final Request createPreviewRequest = new Request("POST", DATAFRAME_ENDPOINT + "_preview");
+        final Request createPreviewRequest = createRequestWithAuth("POST", DATAFRAME_ENDPOINT + "_preview",
+            BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
             + " \"source\": \"" + REVIEWS_INDEX_NAME + "\",";
@@ -256,7 +257,6 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
             + " } } } }"
             + "}";
         createPreviewRequest.setJsonEntity(config);
-        addAuthHeaderToRequest(createPreviewRequest, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
         Map<String, Object> previewDataframeResponse = entityAsMap(client().performRequest(createPreviewRequest));
         List<Map<String, Object>> preview = (List<Map<String, Object>>)previewDataframeResponse.get("preview");
         assertThat(preview.size(), equalTo(393));

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameRestTestCase.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameRestTestCase.java
@@ -9,9 +9,13 @@ package org.elasticsearch.xpack.dataframe.integration;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -20,17 +24,31 @@ import org.elasticsearch.xpack.dataframe.persistence.DataFrameInternalIndex;
 import org.junit.AfterClass;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.equalTo;
 
 public abstract class DataFrameRestTestCase extends ESRestTestCase {
 
+    protected static final String TEST_PASSWORD = "x-pack-test-password";
+    protected static final SecureString TEST_PASSWORD_SECURE_STRING = new SecureString(TEST_PASSWORD.toCharArray());
+    private static final String BASIC_AUTH_VALUE_SUPER_USER = basicAuthHeaderValue("x_pack_rest_user", TEST_PASSWORD_SECURE_STRING);
+
+    protected static final String REVIEWS_INDEX_NAME = "reviews";
+
     protected static final String DATAFRAME_ENDPOINT = DataFrameField.REST_BASE_PATH + "transforms/";
+
+    @Override
+    protected Settings restClientSettings() {
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", BASIC_AUTH_VALUE_SUPER_USER).build();
+    }
 
     /**
      * Create a simple dataset for testing with reviewers, ratings and businesses
@@ -63,7 +81,7 @@ public abstract class DataFrameRestTestCase extends ESRestTestCase {
             }
             builder.endObject();
             final StringEntity entity = new StringEntity(Strings.toString(builder), ContentType.APPLICATION_JSON);
-            Request req = new Request("PUT", "reviews");
+            Request req = new Request("PUT", REVIEWS_INDEX_NAME);
             req.setEntity(entity);
             client().performRequest(req);
         }
@@ -72,7 +90,7 @@ public abstract class DataFrameRestTestCase extends ESRestTestCase {
         final StringBuilder bulk = new StringBuilder();
         int day = 10;
         for (int i = 0; i < numDocs; i++) {
-            bulk.append("{\"index\":{\"_index\":\"reviews\"}}\n");
+            bulk.append("{\"index\":{\"_index\":\"" + REVIEWS_INDEX_NAME + "\"}}\n");
             long user = Math.round(Math.pow(i * 31 % 1000, distributionTable[i % distributionTable.length]) % 27);
             int stars = distributionTable[(i * 33) % distributionTable.length];
             long business = Math.round(Math.pow(user * stars, distributionTable[i % distributionTable.length]) % 13);
@@ -113,10 +131,15 @@ public abstract class DataFrameRestTestCase extends ESRestTestCase {
     }
 
     protected void createPivotReviewsTransform(String transformId, String dataFrameIndex, String query) throws IOException {
+        createPivotReviewsTransform(transformId, dataFrameIndex, query, null);
+    }
+
+    protected void createPivotReviewsTransform(String transformId, String dataFrameIndex, String query, String authHeader)
+        throws IOException {
         final Request createDataframeTransformRequest = new Request("PUT", DATAFRAME_ENDPOINT + transformId);
 
         String config = "{"
-                + " \"source\": \"reviews\","
+                + " \"source\": \"" + REVIEWS_INDEX_NAME + "\","
                 + " \"dest\": \"" + dataFrameIndex + "\",";
 
         if (query != null) {
@@ -139,20 +162,40 @@ public abstract class DataFrameRestTestCase extends ESRestTestCase {
                 + "}";
 
         createDataframeTransformRequest.setJsonEntity(config);
+
+        if (authHeader != null) {
+            addAuthHeaderToRequest(createDataframeTransformRequest, authHeader);
+        }
+
         Map<String, Object> createDataframeTransformResponse = entityAsMap(client().performRequest(createDataframeTransformRequest));
         assertThat(createDataframeTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
         assertTrue(indexExists(dataFrameIndex));
     }
 
-    protected void startAndWaitForTransform(String transformId, String dataFrameIndex) throws IOException, Exception {
+    protected void startAndWaitForTransform(String transformId, String dataFrameIndex) throws Exception {
+        startAndWaitForTransform(transformId, dataFrameIndex, null);
+    }
+
+    protected void startAndWaitForTransform(String transformId, String dataFrameIndex, String authHeader) throws Exception {
         // start the transform
         final Request startTransformRequest = new Request("POST", DATAFRAME_ENDPOINT + transformId + "/_start");
+
+        if (authHeader != null) {
+            addAuthHeaderToRequest(startTransformRequest, authHeader);
+        }
+
         Map<String, Object> startTransformResponse = entityAsMap(client().performRequest(startTransformRequest));
         assertThat(startTransformResponse.get("started"), equalTo(Boolean.TRUE));
 
         // wait until the dataframe has been created and all data is available
         waitForDataFrameGeneration(transformId);
         refreshIndex(dataFrameIndex);
+    }
+
+    protected void addAuthHeaderToRequest(final Request request, final String authHeader) {
+        RequestOptions.Builder options = request.getOptions().toBuilder();
+        options.addHeader("Authorization", authHeader);
+        request.setOptions(options);
     }
 
     void waitForDataFrameGeneration(String transformId) throws Exception {
@@ -250,5 +293,28 @@ public abstract class DataFrameRestTestCase extends ESRestTestCase {
 
         Map<?, ?> transformStatsAsMap = (Map<?, ?>) ((List<?>) entityAsMap(statsResponse).get("transforms")).get(0);
         return (int) XContentMapValues.extractValue("state.generation", transformStatsAsMap);
+    }
+
+    protected void setupDataAccessRole(String role, String... indices) throws IOException {
+        String indicesStr = Arrays.stream(indices).collect(Collectors.joining("\",\"", "\"", "\""));
+        Request request = new Request("PUT", "/_security/role/" + role);
+        request.setJsonEntity("{"
+            + "  \"indices\" : ["
+            + "    { \"names\": [" + indicesStr + "], \"privileges\": [\"create_index\", \"read\", \"write\", \"view_index_metadata\"] }"
+            + "  ]"
+            + "}");
+        client().performRequest(request);
+    }
+
+    protected void setupUser(String user, List<String> roles) throws IOException {
+        String password = new String(TEST_PASSWORD_SECURE_STRING.getChars());
+
+        String rolesStr = roles.stream().collect(Collectors.joining("\",\"", "\"", "\""));
+        Request request = new Request("PUT", "/_security/user/" + user);
+        request.setJsonEntity("{"
+            + "  \"password\" : \"" + password + "\","
+            + "  \"roles\" : [ " + rolesStr + " ]"
+            + "}");
+        client().performRequest(request);
     }
 }


### PR DESCRIPTION
This change adds two new cluster privileges:

* manage_data_frame_transforms
* monitor_data_frame_transforms

And two new built-in roles:

* data_frame_transforms_admin
* data_frame_transforms_user

These permit access to the data frame transform endpoints.
(Index privileges are also required on the source and
destination indices for each data frame transform, but
since these indices are configurable they it is not
appropriate to grant them via built-in roles.)