### PR TITLE
[DATA-FRAME] Adding _validate API endpoint

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
@@ -29,7 +29,7 @@ public class DataFrameMessages {
 
     public static final String REST_DATA_FRAME_FAILED_TO_SERIALIZE_TRANSFORM = "Failed to serialise transform [{0}]";
 
-    public static final String FAILED_TO_CREATE_DESTINATION_INDEX = "Could not create destination index [{0}] for transform[{1}]";
+    public static final String FAILED_TO_CREATE_DESTINATION_INDEX = "Could not create destination index [{0}] for transform [{1}]";
     public static final String FAILED_TO_LOAD_TRANSFORM_CONFIGURATION =
             "Failed to load data frame transform configuration for transform [{0}]";
     public static final String FAILED_TO_PARSE_TRANSFORM_CONFIGURATION =

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/ValidateDataFrameTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/ValidateDataFrameTransformAction.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.dataframe.action;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
+import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class ValidateDataFrameTransformAction extends Action<AcknowledgedResponse> {
+
+    public static final ValidateDataFrameTransformAction INSTANCE = new ValidateDataFrameTransformAction();
+    public static final String NAME = "cluster:admin/data_frame/validate";
+
+    private ValidateDataFrameTransformAction() {
+        super(NAME);
+    }
+
+    @Override
+    public AcknowledgedResponse newResponse() {
+        return new AcknowledgedResponse();
+    }
+
+    public static class Request extends MasterNodeReadRequest<Request> {
+
+        private DataFrameTransformConfig config;
+
+        public Request(DataFrameTransformConfig config) {
+            this.setConfig(config);
+        }
+
+        public Request() { }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.config = new DataFrameTransformConfig(in);
+        }
+
+        public static Request fromXContent(final XContentParser parser) throws IOException {
+            return new Request(DataFrameTransformConfig.fromXContent(parser, null, false));
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        public DataFrameTransformConfig getConfig() {
+            return config;
+        }
+
+        public void setConfig(DataFrameTransformConfig config) {
+            this.config = config;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            this.config.writeTo(out);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(config);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            Request other = (Request) obj;
+            return Objects.equals(config, other.config);
+        }
+    }
+
+    public static class RequestBuilder extends MasterNodeReadOperationRequestBuilder<Request, AcknowledgedResponse, RequestBuilder> {
+
+        protected RequestBuilder(ElasticsearchClient client, ValidateDataFrameTransformAction action) {
+            super(client, action, new Request());
+        }
+    }
+
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/GroupConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/GroupConfig.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.core.dataframe.DataFrameMessages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -156,7 +157,14 @@ public class GroupConfig implements Writeable, ToXContentObject {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser::getTokenLocation);
             token = parser.nextToken();
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
-            SingleGroupSource.Type groupType = SingleGroupSource.Type.valueOf(parser.currentName().toUpperCase(Locale.ROOT));
+            String typeString = parser.currentName().toUpperCase(Locale.ROOT);
+
+            // `valueOf` fails with a message about a missing enum constant if we don't verify its existence before hand
+            if(Arrays.stream(SingleGroupSource.Type.values()).map(String::valueOf).noneMatch(v -> v.equals(typeString))) {
+                throw new ParsingException(parser.getTokenLocation(), "invalid grouping type: " + parser.currentName());
+            }
+
+            SingleGroupSource.Type groupType = SingleGroupSource.Type.valueOf(typeString);
 
             token = parser.nextToken();
             ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser::getTokenLocation);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/action/ValidateDataFrameTransformActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/action/ValidateDataFrameTransformActionRequestTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.dataframe.action;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.dataframe.action.ValidateDataFrameTransformAction.Request;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfigTests;
+import org.junit.Before;
+
+import static java.util.Collections.emptyList;
+
+public class ValidateDataFrameTransformActionRequestTests extends AbstractWireSerializingTestCase<Request> {
+
+    private NamedWriteableRegistry namedWriteableRegistry;
+    private NamedXContentRegistry namedXContentRegistry;
+
+    @Before
+    public void registerAggregationNamedObjects() throws Exception {
+        // register aggregations as NamedWriteable
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, emptyList());
+        namedWriteableRegistry = new NamedWriteableRegistry(searchModule.getNamedWriteables());
+        namedXContentRegistry = new NamedXContentRegistry(searchModule.getNamedXContents());
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return namedWriteableRegistry;
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        return namedXContentRegistry;
+    }
+
+    @Override
+    protected Request createTestInstance() {
+        return new Request(DataFrameTransformConfigTests.randomDataFrameTransformConfig());
+    }
+
+    @Override
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
+    }
+
+}

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrame.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrame.java
@@ -47,6 +47,7 @@ import org.elasticsearch.xpack.core.dataframe.action.PreviewDataFrameTransformAc
 import org.elasticsearch.xpack.core.dataframe.action.PutDataFrameTransformAction;
 import org.elasticsearch.xpack.core.dataframe.action.StartDataFrameTransformAction;
 import org.elasticsearch.xpack.core.dataframe.action.StopDataFrameTransformAction;
+import org.elasticsearch.xpack.core.dataframe.action.ValidateDataFrameTransformAction;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.dataframe.action.TransportDeleteDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.action.TransportGetDataFrameTransformsAction;
@@ -55,6 +56,7 @@ import org.elasticsearch.xpack.dataframe.action.TransportPreviewDataFrameTransfo
 import org.elasticsearch.xpack.dataframe.action.TransportPutDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.action.TransportStartDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.action.TransportStopDataFrameTransformAction;
+import org.elasticsearch.xpack.dataframe.action.TransportValidateDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.persistence.DataFrameInternalIndex;
 import org.elasticsearch.xpack.dataframe.persistence.DataFrameTransformsConfigManager;
 import org.elasticsearch.xpack.dataframe.rest.action.RestDeleteDataFrameTransformAction;
@@ -64,6 +66,7 @@ import org.elasticsearch.xpack.dataframe.rest.action.RestPreviewDataFrameTransfo
 import org.elasticsearch.xpack.dataframe.rest.action.RestPutDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.rest.action.RestStartDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.rest.action.RestStopDataFrameTransformAction;
+import org.elasticsearch.xpack.dataframe.rest.action.RestValidateDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.transforms.DataFrameTransformPersistentTasksExecutor;
 
 import java.io.IOException;
@@ -135,7 +138,8 @@ public class DataFrame extends Plugin implements ActionPlugin, PersistentTaskPlu
                 new RestDeleteDataFrameTransformAction(settings, restController),
                 new RestGetDataFrameTransformsAction(settings, restController),
                 new RestGetDataFrameTransformsStatsAction(settings, restController),
-                new RestPreviewDataFrameTransformAction(settings, restController)
+                new RestPreviewDataFrameTransformAction(settings, restController),
+                new RestValidateDataFrameTransformAction(settings, restController)
         );
     }
 
@@ -152,7 +156,8 @@ public class DataFrame extends Plugin implements ActionPlugin, PersistentTaskPlu
                 new ActionHandler<>(DeleteDataFrameTransformAction.INSTANCE, TransportDeleteDataFrameTransformAction.class),
                 new ActionHandler<>(GetDataFrameTransformsAction.INSTANCE, TransportGetDataFrameTransformsAction.class),
                 new ActionHandler<>(GetDataFrameTransformsStatsAction.INSTANCE, TransportGetDataFrameTransformsStatsAction.class),
-                new ActionHandler<>(PreviewDataFrameTransformAction.INSTANCE, TransportPreviewDataFrameTransformAction.class)
+                new ActionHandler<>(PreviewDataFrameTransformAction.INSTANCE, TransportPreviewDataFrameTransformAction.class),
+                new ActionHandler<>(ValidateDataFrameTransformAction.INSTANCE, TransportValidateDataFrameTransformAction.class)
                 );
     }
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportValidateDataFrameTransformAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportValidateDataFrameTransformAction.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.dataframe.action;
+
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.license.LicenseUtils;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.XPackPlugin;
+import org.elasticsearch.xpack.core.dataframe.DataFrameMessages;
+import org.elasticsearch.xpack.core.dataframe.action.ValidateDataFrameTransformAction;
+import org.elasticsearch.xpack.core.dataframe.action.ValidateDataFrameTransformAction.Request;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
+import org.elasticsearch.xpack.dataframe.persistence.DataFrameTransformsConfigManager;
+import org.elasticsearch.xpack.dataframe.transforms.pivot.Pivot;
+
+
+public class TransportValidateDataFrameTransformAction extends TransportMasterNodeReadAction<Request, AcknowledgedResponse> {
+
+    private final XPackLicenseState licenseState;
+    private final DataFrameTransformsConfigManager dataFrameTransformsConfigManager;
+    private final Client client;
+
+    @Inject
+    public TransportValidateDataFrameTransformAction(TransportService transportService, ThreadPool threadPool, ActionFilters actionFilters,
+                                                     IndexNameExpressionResolver indexNameExpressionResolver, ClusterService clusterService,
+                                                     XPackLicenseState licenseState,
+                                                     DataFrameTransformsConfigManager dataFrameTransformsConfigManager, Client client) {
+        super(ValidateDataFrameTransformAction.NAME, transportService, clusterService, threadPool, actionFilters,
+            indexNameExpressionResolver, Request::new);
+        this.licenseState = licenseState;
+        this.dataFrameTransformsConfigManager = dataFrameTransformsConfigManager;
+        this.client = client;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected AcknowledgedResponse newResponse() {
+        return new AcknowledgedResponse();
+    }
+
+    @Override
+    protected void masterOperation(Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener) throws Exception {
+        if (!licenseState.isDataFrameAllowed()) {
+            listener.onFailure(LicenseUtils.newComplianceException(XPackField.DATA_FRAME));
+            return;
+        }
+
+        XPackPlugin.checkReadyForXPackCustomMetadata(state);
+
+        DataFrameTransformConfig config = request.getConfig();
+
+        // quick check whether a transform task exists with the same ID
+        if (PersistentTasksCustomMetaData.getTaskWithId(state, config.getId()) != null) {
+            listener.onFailure(new ResourceAlreadyExistsException(
+                DataFrameMessages.getMessage(DataFrameMessages.REST_PUT_DATA_FRAME_TRANSFORM_EXISTS, config.getId())));
+            return;
+        }
+
+        String[] destIndex = indexNameExpressionResolver.concreteIndexNames(state,
+            IndicesOptions.lenientExpandOpen(),
+            config.getDestination());
+
+        if (destIndex.length > 0) {
+            listener.onFailure(new ResourceAlreadyExistsException(
+                DataFrameMessages.getMessage("Target index [{0}] already exists", config.getDestination())));
+            return;
+        }
+
+        String[] srcIndices = indexNameExpressionResolver.concreteIndexNames(state,
+            IndicesOptions.lenientExpandOpen(),
+            config.getSource());
+
+        if (srcIndices.length == 0) {
+            listener.onFailure(new IndexNotFoundException(config.getSource()));
+            return;
+        }
+
+        ActionListener<Boolean> pivotValidationListener = ActionListener.wrap(
+            r -> listener.onResponse(new AcknowledgedResponse(true)),
+            listener::onFailure
+        );
+
+        ActionListener<DataFrameTransformConfig> transformConfigListener = ActionListener.wrap(
+            transformConfig -> listener.onFailure(new ResourceAlreadyExistsException(
+                DataFrameMessages.getMessage(DataFrameMessages.REST_PUT_DATA_FRAME_TRANSFORM_EXISTS, config.getId()))),
+            ex -> {
+                if (ex instanceof ResourceNotFoundException) {
+                    Pivot pivot = new Pivot(config.getSource(), config.getQueryConfig().getQuery(), config.getPivotConfig());
+                    pivot.validate(client, pivotValidationListener);
+                } else { // something failed while checking for existing config...
+                    listener.onFailure(ex);
+                }
+            }
+        );
+
+        dataFrameTransformsConfigManager.getTransformConfiguration(config.getId(), transformConfigListener);
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(Request request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+    }
+
+}

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestValidateDataFrameTransformAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestValidateDataFrameTransformAction.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.dataframe.rest.action;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
+import org.elasticsearch.xpack.core.dataframe.action.ValidateDataFrameTransformAction;
+
+import java.io.IOException;
+
+public class RestValidateDataFrameTransformAction extends BaseRestHandler {
+
+    public RestValidateDataFrameTransformAction(Settings settings, RestController controller) {
+        super(settings);
+        controller.registerHandler(RestRequest.Method.POST, DataFrameField.REST_BASE_PATH + "transforms/_validate", this);
+    }
+
+    @Override
+    public String getName() {
+        return "data_frame_validate_transform_action";
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        XContentParser parser = restRequest.contentParser();
+
+        ValidateDataFrameTransformAction.Request request = ValidateDataFrameTransformAction.Request.fromXContent(parser);
+        return channel -> client.execute(ValidateDataFrameTransformAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/Pivot.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/Pivot.java
@@ -99,7 +99,7 @@ public class Pivot {
             }
             listener.onResponse(true);
         }, e->{
-            listener.onFailure(new RuntimeException("Failed to test query",e));
+            listener.onFailure(new RuntimeException("Failed to test query", e));
         }));
     }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.validate_data_frame_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.validate_data_frame_transform.json
@@ -1,0 +1,14 @@
+{
+  "data_frame.validate_data_frame_transform": {
+    "documentation": "TODO",
+    "methods": [ "POST" ],
+    "url": {
+      "path": "/_data_frame/transforms/_validate",
+      "paths": [ "/_data_frame/transforms/_validate" ]
+    },
+    "body": {
+      "description" : "The definition for the data_frame transform to validate",
+      "required": true
+    }
+  }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/validate_transforms.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/validate_transforms.yml
@@ -1,0 +1,205 @@
+setup:
+  - do:
+      indices.create:
+        index: airline-data
+        body:
+          mappings:
+            properties:
+              time:
+                type: date
+              airline:
+                type: keyword
+              responsetime:
+                type: float
+              event_rate:
+                type: integer
+
+---
+"Test validate transform configuration":
+  - do:
+      catch: /Required \[source, dest\]/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+
+          }
+
+  - do:
+      catch: /\[id\] must not be null/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "source": "airline-data",
+             "dest": "airline-data-transformed"
+          }
+
+  - do:
+      catch: /Data frame transform configuration must specify exactly 1 function/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed"
+          }
+
+  - do:
+      catch: /Required \[aggregations\]/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}}
+              }
+          }
+  - do:
+      catch: /invalid grouping type[:] significant_terms/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"significant_terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+              }
+          }
+  - do:
+      catch: /Unsupported aggregation type \[stats\]/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"stats": {"field": "responsetime"}}}
+              }
+          }
+  - do:
+      catch: /\[avg\] unknown field \[bad-field\], parser not found/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"bad-field": "responsetime"}}}
+              }
+          }
+  - do:
+      catch: /\[data_frame_terms_group\] unknown field \[bad-field\], parser not found/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"bad-field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+              }
+          }
+  - do:
+      catch: /no \[query\] registered for \[bad-query\]/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+              },
+             "query": { "bad-query": {} }
+          }
+  - do:
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+              }
+          }
+  - match: { acknowledged: true }
+
+---
+"Test validate transform configuration with missing source":
+  - do:
+      catch: /no such index \[airline-data-missing\]/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data-missing",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+              }
+          }
+---
+"Test validate transform configuration with existing target":
+  - do:
+      indices.create:
+        index: airline-data-transformed
+
+  - do:
+      catch: /Target index \[airline-data-transformed\] already exists/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+              }
+          }
+
+---
+"Test validate transform configuration with existing transform":
+
+  - do:
+      data_frame.put_data_frame_transform:
+        transform_id: airline-transform
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+              }
+          }
+
+  - do:
+      catch: /Transform with id \[airline-transform\] already exists/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+              }
+          }
+  - do:
+      data_frame.delete_data_frame_transform:
+        transform_id: airline-transform


### PR DESCRIPTION
This adds the `_validate` API endpoint. 

Validates:
* Pivot config
* Strictly parses the aggs and query
* Existence of source index
* That the target index does not already exist
* That no existing transform has the given ID.

I debated around putting in validations verifying that the user can READ from the source index and can create the destination index. I can still put those in if the prevailing thought is that I should.