### PR TITLE
[DATA-FRAME] Adding _validate API endpoint

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
@@ -27,9 +27,13 @@ public class DataFrameMessages {
     public static final String REST_PUT_DATA_FRAME_INCONSISTENT_ID =
             "Inconsistent id; ''{0}'' specified in the body differs from ''{1}'' specified as a URL argument";
 
+    public static final String REST_VALIDATE_DATA_FRAME_MISSING_SOURCE_INDEX = "Source index [{0}] not found";
+    public static final String REST_VALIDATE_DATA_FRAME_DEST_INDEX_EXISTS = "Target index [{0}] already exists";
+    public static final String REST_VALIDATE_VALIDATION_ERROR_MSG = "Validation failed errors: [{0}], warnings: [{1}]";
+
     public static final String REST_DATA_FRAME_FAILED_TO_SERIALIZE_TRANSFORM = "Failed to serialise transform [{0}]";
 
-    public static final String FAILED_TO_CREATE_DESTINATION_INDEX = "Could not create destination index [{0}] for transform[{1}]";
+    public static final String FAILED_TO_CREATE_DESTINATION_INDEX = "Could not create destination index [{0}] for transform [{1}]";
     public static final String FAILED_TO_LOAD_TRANSFORM_CONFIGURATION =
             "Failed to load data frame transform configuration for transform [{0}]";
     public static final String FAILED_TO_PARSE_TRANSFORM_CONFIGURATION =

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/ValidateDataFrameTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/ValidateDataFrameTransformAction.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.dataframe.action;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
+import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+public class ValidateDataFrameTransformAction extends Action<ValidateDataFrameTransformAction.Response> {
+
+    public static final ValidateDataFrameTransformAction INSTANCE = new ValidateDataFrameTransformAction();
+    public static final String NAME = "cluster:admin/data_frame/validate";
+
+    private ValidateDataFrameTransformAction() {
+        super(NAME);
+    }
+
+    @Override
+    public Response newResponse() {
+        return new Response();
+    }
+
+    public static class Request extends MasterNodeReadRequest<Request> {
+
+        private DataFrameTransformConfig config;
+
+        public Request(DataFrameTransformConfig config) {
+            this.setConfig(config);
+        }
+
+        public Request() { }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.config = new DataFrameTransformConfig(in);
+        }
+
+        public static Request fromXContent(final XContentParser parser) throws IOException {
+            return new Request(DataFrameTransformConfig.fromXContent(parser, null, false));
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        public DataFrameTransformConfig getConfig() {
+            return config;
+        }
+
+        public void setConfig(DataFrameTransformConfig config) {
+            this.config = config;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            this.config.writeTo(out);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(config);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            Request other = (Request) obj;
+            return Objects.equals(config, other.config);
+        }
+    }
+
+    public static class RequestBuilder extends MasterNodeReadOperationRequestBuilder<Request, Response, RequestBuilder> {
+
+        protected RequestBuilder(ElasticsearchClient client, ValidateDataFrameTransformAction action) {
+            super(client, action, new Request());
+        }
+    }
+
+    public static class Response extends ActionResponse implements ToXContentObject {
+
+        private List<String> warnings;
+
+        public Response() {
+        }
+
+        public Response(Set<String> warnings) {
+            this.warnings = Collections.unmodifiableList(new ArrayList<>(warnings));
+        }
+
+        public Response(List<String> warnings) {
+            this.warnings = Collections.unmodifiableList(new ArrayList<>(warnings));
+        }
+
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            warnings = Collections.unmodifiableList(in.readStringList());
+        }
+
+        public List<String> getWarnings() {
+            return warnings;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeStringCollection(warnings);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("warnings", warnings);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(warnings);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Response other = (Response) obj;
+            return Objects.equals(warnings, other.warnings);
+        }
+    }
+
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/GroupConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/GroupConfig.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.core.dataframe.DataFrameMessages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -156,7 +157,14 @@ public class GroupConfig implements Writeable, ToXContentObject {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser::getTokenLocation);
             token = parser.nextToken();
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
-            SingleGroupSource.Type groupType = SingleGroupSource.Type.valueOf(parser.currentName().toUpperCase(Locale.ROOT));
+            String typeString = parser.currentName().toUpperCase(Locale.ROOT);
+
+            // `valueOf` fails with a message about a missing enum constant if we don't verify its existence before hand
+            if(Arrays.stream(SingleGroupSource.Type.values()).map(String::valueOf).noneMatch(v -> v.equals(typeString))) {
+                throw new ParsingException(parser.getTokenLocation(), "invalid grouping type: " + parser.currentName());
+            }
+
+            SingleGroupSource.Type groupType = SingleGroupSource.Type.valueOf(typeString);
 
             token = parser.nextToken();
             ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser::getTokenLocation);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/action/ValidateDataFrameTransformActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/action/ValidateDataFrameTransformActionRequestTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.dataframe.action;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.dataframe.action.ValidateDataFrameTransformAction.Request;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfigTests;
+import org.junit.Before;
+
+import static java.util.Collections.emptyList;
+
+public class ValidateDataFrameTransformActionRequestTests extends AbstractWireSerializingTestCase<Request> {
+
+    private NamedWriteableRegistry namedWriteableRegistry;
+    private NamedXContentRegistry namedXContentRegistry;
+
+    @Before
+    public void registerAggregationNamedObjects() throws Exception {
+        // register aggregations as NamedWriteable
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, emptyList());
+        namedWriteableRegistry = new NamedWriteableRegistry(searchModule.getNamedWriteables());
+        namedXContentRegistry = new NamedXContentRegistry(searchModule.getNamedXContents());
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return namedWriteableRegistry;
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        return namedXContentRegistry;
+    }
+
+    @Override
+    protected Request createTestInstance() {
+        return new Request(DataFrameTransformConfigTests.randomDataFrameTransformConfig());
+    }
+
+    @Override
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
+    }
+
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/action/ValidateDataFrameTransformActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/action/ValidateDataFrameTransformActionResponseTests.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.dataframe.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.dataframe.action.ValidateDataFrameTransformAction.Response;
+
+import java.util.Arrays;
+
+
+public class ValidateDataFrameTransformActionResponseTests extends AbstractWireSerializingTestCase<Response> {
+
+    @Override
+    protected Response createTestInstance() {
+        return new ValidateDataFrameTransformAction.Response(Arrays.asList(generateRandomStringArray(10, 12, false)));
+    }
+
+    @Override
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
+    }
+
+}

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrame.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrame.java
@@ -47,6 +47,7 @@ import org.elasticsearch.xpack.core.dataframe.action.PreviewDataFrameTransformAc
 import org.elasticsearch.xpack.core.dataframe.action.PutDataFrameTransformAction;
 import org.elasticsearch.xpack.core.dataframe.action.StartDataFrameTransformAction;
 import org.elasticsearch.xpack.core.dataframe.action.StopDataFrameTransformAction;
+import org.elasticsearch.xpack.core.dataframe.action.ValidateDataFrameTransformAction;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.dataframe.action.TransportDeleteDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.action.TransportGetDataFrameTransformsAction;
@@ -55,6 +56,7 @@ import org.elasticsearch.xpack.dataframe.action.TransportPreviewDataFrameTransfo
 import org.elasticsearch.xpack.dataframe.action.TransportPutDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.action.TransportStartDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.action.TransportStopDataFrameTransformAction;
+import org.elasticsearch.xpack.dataframe.action.TransportValidateDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.persistence.DataFrameInternalIndex;
 import org.elasticsearch.xpack.dataframe.persistence.DataFrameTransformsConfigManager;
 import org.elasticsearch.xpack.dataframe.rest.action.RestDeleteDataFrameTransformAction;
@@ -64,6 +66,7 @@ import org.elasticsearch.xpack.dataframe.rest.action.RestPreviewDataFrameTransfo
 import org.elasticsearch.xpack.dataframe.rest.action.RestPutDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.rest.action.RestStartDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.rest.action.RestStopDataFrameTransformAction;
+import org.elasticsearch.xpack.dataframe.rest.action.RestValidateDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.transforms.DataFrameTransformPersistentTasksExecutor;
 
 import java.io.IOException;
@@ -135,7 +138,8 @@ public class DataFrame extends Plugin implements ActionPlugin, PersistentTaskPlu
                 new RestDeleteDataFrameTransformAction(settings, restController),
                 new RestGetDataFrameTransformsAction(settings, restController),
                 new RestGetDataFrameTransformsStatsAction(settings, restController),
-                new RestPreviewDataFrameTransformAction(settings, restController)
+                new RestPreviewDataFrameTransformAction(settings, restController),
+                new RestValidateDataFrameTransformAction(settings, restController)
         );
     }
 
@@ -152,7 +156,8 @@ public class DataFrame extends Plugin implements ActionPlugin, PersistentTaskPlu
                 new ActionHandler<>(DeleteDataFrameTransformAction.INSTANCE, TransportDeleteDataFrameTransformAction.class),
                 new ActionHandler<>(GetDataFrameTransformsAction.INSTANCE, TransportGetDataFrameTransformsAction.class),
                 new ActionHandler<>(GetDataFrameTransformsStatsAction.INSTANCE, TransportGetDataFrameTransformsStatsAction.class),
-                new ActionHandler<>(PreviewDataFrameTransformAction.INSTANCE, TransportPreviewDataFrameTransformAction.class)
+                new ActionHandler<>(PreviewDataFrameTransformAction.INSTANCE, TransportPreviewDataFrameTransformAction.class),
+                new ActionHandler<>(ValidateDataFrameTransformAction.INSTANCE, TransportValidateDataFrameTransformAction.class)
                 );
     }
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportValidateDataFrameTransformAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportValidateDataFrameTransformAction.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.dataframe.action;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.license.LicenseUtils;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.XPackPlugin;
+import org.elasticsearch.xpack.core.dataframe.DataFrameMessages;
+import org.elasticsearch.xpack.core.dataframe.action.ValidateDataFrameTransformAction;
+import org.elasticsearch.xpack.core.dataframe.action.ValidateDataFrameTransformAction.Request;
+import org.elasticsearch.xpack.core.dataframe.action.ValidateDataFrameTransformAction.Response;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
+import org.elasticsearch.xpack.dataframe.persistence.DataFrameTransformsConfigManager;
+import org.elasticsearch.xpack.dataframe.transforms.pivot.Pivot;
+import org.elasticsearch.xpack.dataframe.transforms.pivot.PivotException;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.xpack.core.dataframe.DataFrameMessages.REST_VALIDATE_VALIDATION_ERROR_MSG;
+
+
+public class TransportValidateDataFrameTransformAction extends TransportMasterNodeReadAction<Request, Response> {
+
+    private final XPackLicenseState licenseState;
+    private final DataFrameTransformsConfigManager dataFrameTransformsConfigManager;
+    private final Client client;
+
+    @Inject
+    public TransportValidateDataFrameTransformAction(TransportService transportService, ThreadPool threadPool, ActionFilters actionFilters,
+                                                     IndexNameExpressionResolver indexNameExpressionResolver, ClusterService clusterService,
+                                                     XPackLicenseState licenseState,
+                                                     DataFrameTransformsConfigManager dataFrameTransformsConfigManager, Client client) {
+        super(ValidateDataFrameTransformAction.NAME, transportService, clusterService, threadPool, actionFilters,
+            indexNameExpressionResolver, Request::new);
+        this.licenseState = licenseState;
+        this.dataFrameTransformsConfigManager = dataFrameTransformsConfigManager;
+        this.client = client;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected Response newResponse() {
+        return new Response();
+    }
+
+    @Override
+    protected void masterOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
+        if (!licenseState.isDataFrameAllowed()) {
+            listener.onFailure(LicenseUtils.newComplianceException(XPackField.DATA_FRAME));
+            return;
+        }
+
+        Set<String> errors = new LinkedHashSet<>();
+        Set<String> warnings = new LinkedHashSet<>();
+
+        XPackPlugin.checkReadyForXPackCustomMetadata(state);
+
+        DataFrameTransformConfig config = request.getConfig();
+
+        // quick check whether a transform task exists with the same ID
+        if (PersistentTasksCustomMetaData.getTaskWithId(state, config.getId()) != null) {
+            errors.add(DataFrameMessages.getMessage(DataFrameMessages.REST_PUT_DATA_FRAME_TRANSFORM_EXISTS, config.getId()));
+        }
+
+        String[] destIndex = indexNameExpressionResolver.concreteIndexNames(state,
+            IndicesOptions.lenientExpandOpen(),
+            config.getDestination());
+
+        if (destIndex.length > 0) {
+            errors.add(DataFrameMessages.getMessage(DataFrameMessages.REST_VALIDATE_DATA_FRAME_DEST_INDEX_EXISTS, config.getDestination()));
+        }
+
+        String[] srcIndices = indexNameExpressionResolver.concreteIndexNames(state,
+            IndicesOptions.lenientExpandOpen(),
+            config.getSource());
+
+        if (srcIndices.length == 0) {
+            errors.add(DataFrameMessages.getMessage(DataFrameMessages.REST_VALIDATE_DATA_FRAME_MISSING_SOURCE_INDEX, config.getSource()));
+            listener.onFailure(ValidationException.fromErrorsAndWarnings(errors, warnings));
+            return;
+        }
+        final Pivot pivot = new Pivot(config.getSource(), config.getQueryConfig().getQuery(), config.getPivotConfig());
+
+        ActionListener<List<Map<String, Object>>> pivotValidationListener = ActionListener.wrap(
+            r -> {
+                if (r.isEmpty()) {
+                    warnings.add("Configuration returned empty results from source index [" + config.getSource() + "]");
+                }
+                if (errors.isEmpty()) {
+                    listener.onResponse(new Response(warnings));
+                } else {
+                    listener.onFailure(ValidationException.fromErrorsAndWarnings(errors, warnings));
+                }
+            },
+            ex -> {
+                if (ex instanceof PivotException) {
+                    errors.add(ex.getMessage());
+                    listener.onFailure(ValidationException.fromErrorsAndWarnings(errors, warnings));
+                } else {
+                    listener.onFailure(ex);
+                }
+            }
+        );
+
+        ActionListener<DataFrameTransformConfig> transformConfigListener = ActionListener.wrap(
+            transformConfig -> {
+                pivot.validate(client, pivotValidationListener);
+                listener.onFailure(ValidationException.fromErrorsAndWarnings(errors, warnings));
+            },
+            ex -> {
+                if (ex instanceof ResourceNotFoundException) {
+                    pivot.validate(client, pivotValidationListener);
+                } else { // something failed while checking for existing config...
+                    listener.onFailure(ex);
+                }
+            }
+        );
+
+        dataFrameTransformsConfigManager.getTransformConfiguration(config.getId(), transformConfigListener);
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(Request request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+    }
+
+    public static class ValidationException extends ElasticsearchException {
+
+        static ValidationException fromErrorsAndWarnings(Set<String> errors, Set<String> warnings) {
+            String msg = DataFrameMessages.getMessage(REST_VALIDATE_VALIDATION_ERROR_MSG,
+                Strings.collectionToDelimitedString(errors, ", "),
+                Strings.collectionToDelimitedString(warnings, ", "));
+            return new ValidationException(msg);
+        }
+
+        ValidationException(String msg) {
+            super(msg);
+        }
+
+        @Override
+        public final RestStatus status() {
+            return RestStatus.BAD_REQUEST;
+        }
+    }
+
+}

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestValidateDataFrameTransformAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestValidateDataFrameTransformAction.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.dataframe.rest.action;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
+import org.elasticsearch.xpack.core.dataframe.action.ValidateDataFrameTransformAction;
+
+import java.io.IOException;
+
+public class RestValidateDataFrameTransformAction extends BaseRestHandler {
+
+    public RestValidateDataFrameTransformAction(Settings settings, RestController controller) {
+        super(settings);
+        controller.registerHandler(RestRequest.Method.POST, DataFrameField.REST_BASE_PATH + "transforms/_validate", this);
+    }
+
+    @Override
+    public String getName() {
+        return "data_frame_validate_transform_action";
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        XContentParser parser = restRequest.contentParser();
+
+        ValidateDataFrameTransformAction.Request request = ValidateDataFrameTransformAction.Request.fromXContent(parser);
+        return channel -> client.execute(ValidateDataFrameTransformAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/PivotException.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/PivotException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.dataframe.transforms.pivot;
+
+/**
+ * Class for Exceptions thrown specifically by Pivot
+ */
+public class PivotException extends RuntimeException {
+
+    public PivotException() {
+        super();
+    }
+
+    public PivotException(String message) {
+        super(message);
+    }
+
+    public PivotException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.validate_data_frame_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.validate_data_frame_transform.json
@@ -1,0 +1,14 @@
+{
+  "data_frame.validate_data_frame_transform": {
+    "documentation": "TODO",
+    "methods": [ "POST" ],
+    "url": {
+      "path": "/_data_frame/transforms/_validate",
+      "paths": [ "/_data_frame/transforms/_validate" ]
+    },
+    "body": {
+      "description" : "The definition for the data_frame transform to validate",
+      "required": true
+    }
+  }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/validate_transforms.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/validate_transforms.yml
@@ -1,0 +1,200 @@
+setup:
+  - do:
+      indices.create:
+        index: airline-data
+        body:
+          mappings:
+            properties:
+              time:
+                type: date
+              airline:
+                type: keyword
+              responsetime:
+                type: float
+              event_rate:
+                type: integer
+
+---
+"Test validate transform configuration":
+  - do:
+      catch: /Required \[source, dest\]/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+
+          }
+
+  - do:
+      catch: /\[id\] must not be null/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "source": "airline-data",
+             "dest": "airline-data-transformed"
+          }
+
+  - do:
+      catch: /Data frame transform configuration must specify exactly 1 function/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed"
+          }
+
+  - do:
+      catch: /Required \[aggregations\]/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}}
+              }
+          }
+  - do:
+      catch: /invalid grouping type[:] significant_terms/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"significant_terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+              }
+          }
+  - do:
+      catch: /Unsupported aggregation type \[stats\]/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"stats": {"field": "responsetime"}}}
+              }
+          }
+  - do:
+      catch: /\[avg\] unknown field \[bad-field\], parser not found/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"bad-field": "responsetime"}}}
+              }
+          }
+  - do:
+      catch: /\[data_frame_terms_group\] unknown field \[bad-field\], parser not found/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"bad-field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+              }
+          }
+  - do:
+      catch: /no \[query\] registered for \[bad-query\]/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+              },
+             "query": { "bad-query": {} }
+          }
+  - do:
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+              }
+          }
+  - match: { warnings.0: "Configuration returned empty results from source index [airline-data]" }
+
+  - do:
+      index:
+        index: airline-data
+        id: 1
+        body: >
+          {
+            "time": "2017-02-18T00:00:00Z",
+            "airline": "foo",
+            "responsetime": 1.0,
+            "event_rate": 5
+          }
+  - do:
+      indices.refresh:
+        index: airline-data
+
+  - do:
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+              }
+          }
+  - match: { warnings: [] }
+
+---
+"Test validate transform configuration with errors":
+  - do:
+      indices.create:
+        index: airline-data-transformed
+  - do:
+      data_frame.put_data_frame_transform:
+        transform_id: airline-transform
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data",
+             "dest": "airline-data-transformed-again",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+              }
+          }
+  - do:
+      catch: /Validation failed errors[:] \[Transform with id \[airline-transform\] already exists, Target index \[airline-data-transformed\] already exists, Source index \[airline-data-missing\] not found\]/
+      data_frame.validate_data_frame_transform:
+        body: >
+          {
+             "id": "airline-transform",
+             "source": "airline-data-missing",
+             "dest": "airline-data-transformed",
+             "pivot": {
+                "group_by": { "airline": {"terms": {"field": "airline"}}},
+                "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+              }
+          }
+  - do:
+      data_frame.delete_data_frame_transform:
+        transform_id: airline-transform


### PR DESCRIPTION
This adds a new _validate endpoint for the DataFrame's API.

I thought about simply returning some errors as they occurred, but as an API user, I changed my mind and decided that trying to collect the errors as they occur and return them all would be best. 

Additionally, I have the endpoint return a warning if NO data is found given the query + aggs provided in the config.

From an API first type of design, it makes sense to return warnings via the API instead of requiring the UI to look for them. However, if folks believe this adds undue complexity, it can be rethought. 

If validation errors are found, I collect them in a comma delimited string and return a `BAD_REQUEST`. 