### PR TITLE
[DOCS] Add upgrade step for changed realm settings

### DIFF
--- a/docs/reference/upgrade/cluster_restart.asciidoc
+++ b/docs/reference/upgrade/cluster_restart.asciidoc
@@ -55,6 +55,11 @@ Use the `elasticsearch-plugin` script to install the upgraded version of each
 installed Elasticsearch plugin. All plugins must be upgraded when you upgrade
 a node.
 
+. If you use {es} {security-features} to define realms, verify that your realm
+settings are up-to-date. The format of realm settings changed in version 7.0, in
+particular, the placement of the realm type changed. See
+<<realm-settings,Realm settings>>. 
+
 . *Start each upgraded node.*
 +
 --

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -72,6 +72,11 @@ Use the `elasticsearch-plugin` script to install the upgraded version of each
 installed Elasticsearch plugin. All plugins must be upgraded when you upgrade
 a node.
 
+. If you use {es} {security-features} to define realms, verify that your realm
+settings are up-to-date. The format of realm settings changed in version 7.0, in
+particular, the placement of the realm type changed. See
+<<realm-settings,Realm settings>>. 
+
 . *Start the upgraded node.*
 +
 --


### PR DESCRIPTION
This PR adds a step to the Elasticsearch upgrade steps (https://www.elastic.co/guide/en/elasticsearch/reference/master/rolling-upgrades.html and https://www.elastic.co/guide/en/elasticsearch/reference/master/restart-upgrade.html) to update your security realm settings per https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#include-realm-type-in-setting

If that step is not performed, you get errors like this when upgrading from 6.7 to 7.0:

> Caused by: java.lang.IllegalArgumentException: Incorrect realm settings found. Realm settings have been changed to include the type as part of the setting key.
For example 'xpack.security.authc.realms.file.my_file.order'
Found invalid config: xpack.security.authc.realms.file1.type, xpack.security.authc.realms.file1.order