### PR TITLE
Minor Cleanups in QueryPhase

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -40,7 +40,6 @@ import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.search.SearchTask;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
-import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
 import org.elasticsearch.common.util.concurrent.QueueResizingEsThreadPoolExecutor;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchPhase;
@@ -59,6 +58,7 @@ import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.LinkedList;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
 import static org.elasticsearch.search.query.QueryCollectorContext.createCancellableCollectorContext;
@@ -78,7 +78,7 @@ public class QueryPhase implements SearchPhase {
 
     private final AggregationPhase aggregationPhase;
     private final SuggestPhase suggestPhase;
-    private RescorePhase rescorePhase;
+    private final RescorePhase rescorePhase;
 
     public QueryPhase() {
         this.aggregationPhase = new AggregationPhase();
@@ -157,11 +157,10 @@ public class QueryPhase implements SearchPhase {
                         // now this gets interesting: since we sort in index-order, we can directly
                         // skip to the desired doc
                         if (after != null) {
-                            BooleanQuery bq = new BooleanQuery.Builder()
+                            query = new BooleanQuery.Builder()
                                 .add(query, BooleanClause.Occur.MUST)
                                 .add(new MinDocQuery(after.doc + 1), BooleanClause.Occur.FILTER)
                                 .build();
-                            query = bq;
                         }
                         // ... and stop collecting after ${size} matches
                         searchContext.terminateAfter(searchContext.size());
@@ -169,11 +168,10 @@ public class QueryPhase implements SearchPhase {
                         // now this gets interesting: since the search sort is a prefix of the index sort, we can directly
                         // skip to the desired doc
                         if (after != null) {
-                            BooleanQuery bq = new BooleanQuery.Builder()
+                            query = new BooleanQuery.Builder()
                                 .add(query, BooleanClause.Occur.MUST)
                                 .add(new SearchAfterSortedDocQuery(searchContext.sort().sort, (FieldDoc) after), BooleanClause.Occur.FILTER)
                                 .build();
-                            query = bq;
                         }
                     }
                 }
@@ -289,8 +287,7 @@ public class QueryPhase implements SearchPhase {
             for (QueryCollectorContext ctx : collectors) {
                 ctx.postProcess(result);
             }
-            EsThreadPoolExecutor executor = (EsThreadPoolExecutor)
-                    searchContext.indexShard().getThreadPool().executor(ThreadPool.Names.SEARCH);
+            ExecutorService executor = searchContext.indexShard().getThreadPool().executor(ThreadPool.Names.SEARCH);
             if (executor instanceof QueueResizingEsThreadPoolExecutor) {
                 QueueResizingEsThreadPoolExecutor rExecutor = (QueueResizingEsThreadPoolExecutor) executor;
                 queryResult.nodeQueueSize(rExecutor.getCurrentQueueSize());
@@ -311,7 +308,7 @@ public class QueryPhase implements SearchPhase {
      * @param query The query to execute
      * @param sf The query sort
      */
-    static boolean returnsDocsInOrder(Query query, SortAndFormats sf) {
+    private static boolean returnsDocsInOrder(Query query, SortAndFormats sf) {
         if (sf == null || Sort.RELEVANCE.equals(sf.sort)) {
             // sort by score
             // queries that return constant scores will return docs in index
@@ -327,7 +324,7 @@ public class QueryPhase implements SearchPhase {
      * Returns whether collection within the provided <code>reader</code> can be early-terminated if it sorts
      * with <code>sortAndFormats</code>.
      **/
-    static boolean canEarlyTerminate(IndexReader reader, SortAndFormats sortAndFormats) {
+    private static boolean canEarlyTerminate(IndexReader reader, SortAndFormats sortAndFormats) {
         if (sortAndFormats == null || sortAndFormats.sort == null) {
             return false;
         }


### PR DESCRIPTION
* Soften overly strict cast to allow the use of `DeterministicTaskQueue` in this class for the new tests incoming in #39504
* Remove two redundant variables and lower visibility in two possible spots
* Make field `final`

-------------------------

I only really needed the first change as a dependency for #39504 but I figured I'd clean up the other spots while I'm at it :)