### PR TITLE
Change licence expiration date pattern

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
@@ -114,7 +114,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
 
     public static final String LICENSE_JOB = "licenseJob";
 
-    private static final DateFormatter DATE_FORMATTER = DateFormatter.forPattern("EEEE, MMMMM dd, yyyy");
+    private static final DateFormatter DATE_FORMATTER = DateFormatter.forPattern("EEEE, MMMM dd, yyyy");
 
     private static final String ACKNOWLEDGEMENT_HEADER = "This license update requires acknowledgement. To acknowledge the license, " +
             "please read the following messages and update the license again, this time with the \"acknowledge=true\" parameter:";
@@ -134,11 +134,15 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
     }
 
     private void logExpirationWarning(long expirationMillis, boolean expired) {
+        logger.warn("{}", buildExpirationMessage(expirationMillis, expired));
+    }
+
+    static CharSequence buildExpirationMessage(long expirationMillis, boolean expired) {
         String expiredMsg = expired ? "expired" : "will expire";
         String general = LoggerMessageFormat.format(null, "License [{}] on [{}].\n" +
-                "# If you have a new license, please update it. Otherwise, please reach out to\n" +
-                "# your support contact.\n" +
-                "# ", expiredMsg, DATE_FORMATTER.formatMillis(expirationMillis));
+            "# If you have a new license, please update it. Otherwise, please reach out to\n" +
+            "# your support contact.\n" +
+            "# ", expiredMsg, DATE_FORMATTER.formatMillis(expirationMillis));
         if (expired) {
             general = general.toUpperCase(Locale.ROOT);
         }
@@ -161,7 +165,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
                 }
             }
         });
-        logger.warn("{}", builder);
+        return builder;
     }
 
     private void populateExpirationCallbacks() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
@@ -34,7 +34,7 @@ public class LicenseServiceTests extends ESTestCase {
     }
 
     public void testLogExpirationWarningOnJdk8() {
-        assumeTrue("this is for JDK9+", JavaVersion.current().equals(JavaVersion.parse("8")));
+        assumeTrue("this is for JDK8 only", JavaVersion.current().equals(JavaVersion.parse("8")));
 
         long time = LocalDate.of(2018, 11, 15).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
         final boolean expired = randomBoolean();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
@@ -1,22 +1,8 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
  */
-
 package org.elasticsearch.license;
 
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.license;
+
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+import static org.hamcrest.Matchers.startsWith;
+
+public class LicenseServiceTests extends ESTestCase {
+
+    public void testLogExpirationWarning() {
+        long time = LocalDate.of(2018, 11, 15).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
+        final boolean expired = randomBoolean();
+        final String message = LicenseService.buildExpirationMessage(time, expired).toString();
+        if (expired) {
+            assertThat(message, startsWith("LICENSE [EXPIRED] ON [THU, NOV 15, 2018].\n"));
+        } else {
+            assertThat(message, startsWith("License [will expire] on [Thu, Nov 15, 2018].\n"));
+        }
+    }
+
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
@@ -20,7 +20,7 @@ import static org.hamcrest.Matchers.startsWith;
  */
 public class LicenseServiceTests extends ESTestCase {
 
-    public void testLogExpirationWarningOnJdk9AndNewser() {
+    public void testLogExpirationWarningOnJdk9AndNewer() {
         assumeTrue("this is for JDK9+", JavaVersion.current().compareTo(JavaVersion.parse("9")) >= 0);
 
         long time = LocalDate.of(2018, 11, 15).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();


### PR DESCRIPTION
Due to migration from joda - java licence expiration 'full date' format
has to use 4-char pattern (MMMM). However since jdk9 the date with ROOT
locale will still return abbreviated days and month names.

closes #39136