### PR TITLE
Correct authenticate response for API key

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -471,8 +471,9 @@ public class ApiKeyService {
             final Map<String, Object> metadata = (Map<String, Object>) creator.get("metadata");
             final Map<String, Object> roleDescriptors = (Map<String, Object>) source.get("role_descriptors");
             final Map<String, Object> limitedByRoleDescriptors = (Map<String, Object>) source.get("limited_by_role_descriptors");
-            final String[] roleNames = (roleDescriptors != null) ? roleDescriptors.keySet().toArray(Strings.EMPTY_ARRAY)
-                : limitedByRoleDescriptors.keySet().toArray(Strings.EMPTY_ARRAY);
+            final String[] roleNames = (roleDescriptors != null && roleDescriptors.isEmpty() == false)
+                    ? roleDescriptors.keySet().toArray(Strings.EMPTY_ARRAY)
+                    : limitedByRoleDescriptors.keySet().toArray(Strings.EMPTY_ARRAY);
             final User apiKeyUser = new User(principal, roleNames, null, null, metadata, true);
             final Map<String, Object> authResultMetadata = new HashMap<>();
             authResultMetadata.put(API_KEY_ROLE_DESCRIPTORS_KEY, roleDescriptors);


### PR DESCRIPTION
When creating the role names for the authenticated API key,
if role descriptors is null or empty then the API key is
restricted to the roles of authenticated user when created.
As the check for empty role descriptors was missing, the
authenticate API would return `User` with role names as empty
array instead of the role names derived from the authenticated user.
This commit fixes the check and adds a test for the same.
