### PR TITLE
Update parent-join.asciidoc

### DIFF
--- a/docs/reference/mapping/types/parent-join.asciidoc
+++ b/docs/reference/mapping/types/parent-join.asciidoc
@@ -12,11 +12,13 @@ A parent/child relation can be defined as follows:
 PUT my_index
 {
   "mappings": {
-    "properties": {
-      "my_join_field": { <1>
-        "type": "join",
-        "relations": {
-          "question": "answer" <2>
+    "_doc": {
+      "properties": {
+        "my_join_field": { <1>
+          "type": "join",
+          "relations": {
+            "question": "answer" <2>
+          }
         }
       }
     }


### PR DESCRIPTION
Missing the "_doc" attribute in the sample code.  I simply add it and the code now works.  I'm working with the latest release, 6.6.1.  I was just practicing as hope to take the elastic certification exam and this failed when I pasted it into Kibana. 

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
