### PR TITLE
Remove beta label from CCR

### DIFF
--- a/docs/reference/ccr/apis/auto-follow/delete-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/delete-auto-follow-pattern.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Delete auto-follow pattern</titleabbrev>
 ++++
 
-beta[]
-
 Delete auto-follow patterns.
 
 ==== Description

--- a/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Get auto-follow pattern</titleabbrev>
 ++++
 
-beta[]
-
 Get auto-follow patterns.
 
 ==== Description

--- a/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Create auto-follow pattern</titleabbrev>
 ++++
 
-beta[]
-
 Creates an auto-follow pattern.
 
 ==== Description

--- a/docs/reference/ccr/apis/ccr-apis.asciidoc
+++ b/docs/reference/ccr/apis/ccr-apis.asciidoc
@@ -3,8 +3,6 @@
 [[ccr-apis]]
 == Cross-cluster replication APIs
 
-beta[]
-
 You can use the following APIs to perform {ccr} operations.
 
 [float]

--- a/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Get follower info</titleabbrev>
 ++++
 
-beta[]
-
 Retrieves information about all follower indices.
 
 ==== Description

--- a/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Get follower stats</titleabbrev>
 ++++
 
-beta[]
-
 Get follower stats.
 
 ==== Description

--- a/docs/reference/ccr/apis/follow/post-pause-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-pause-follow.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Pause follower</titleabbrev>
 ++++
 
-beta[]
-
 Pauses a follower index.
 
 ==== Description

--- a/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Resume follower</titleabbrev>
 ++++
 
-beta[]
-
 Resumes a follower index.
 
 ==== Description

--- a/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Unfollow</titleabbrev>
 ++++
 
-beta[]
-
 Converts a follower index to a regular index.
 
 ==== Description

--- a/docs/reference/ccr/apis/follow/put-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/put-follow.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Create follower</titleabbrev>
 ++++
 
-beta[]
-
 Creates a follower index.
 
 ==== Description

--- a/docs/reference/ccr/apis/get-ccr-stats.asciidoc
+++ b/docs/reference/ccr/apis/get-ccr-stats.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Get CCR stats</titleabbrev>
 ++++
 
-beta[]
-
 Get {ccr} stats.
 
 ==== Description

--- a/docs/reference/ccr/auto-follow.asciidoc
+++ b/docs/reference/ccr/auto-follow.asciidoc
@@ -3,8 +3,6 @@
 [[ccr-auto-follow]]
 === Automatically following indices
 
-beta[]
-
 In time series use cases where you want to follow new indices that are
 periodically created (such as daily Beats indices), manually configuring follower
 indices for each new leader index can be an operational burden. The auto-follow

--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -3,8 +3,6 @@
 [[ccr-getting-started]]
 == Getting started with {ccr}
 
-beta[]
-
 This getting-started guide for {ccr} shows you how to:
 
 * <<ccr-getting-started-remote-cluster,Connect a local cluster to a remote

--- a/docs/reference/ccr/index.asciidoc
+++ b/docs/reference/ccr/index.asciidoc
@@ -6,9 +6,7 @@
 [partintro]
 --
 
-beta[]
-
-The {ccr} (CCR) feature enables replication of indices in remote clusters to a 
+The {ccr} (CCR) feature enables replication of indices in remote clusters to a
 local cluster. This functionality can be used in some common production use
 cases:
 

--- a/docs/reference/ccr/overview.asciidoc
+++ b/docs/reference/ccr/overview.asciidoc
@@ -3,8 +3,6 @@
 [[ccr-overview]]
 == Overview
 
-beta[]
-
 Cross-cluster replication is done on an index-by-index basis. Replication is
 configured at the index level. For each configured replication there is a
 replication source index called the _leader index_ and a replication target

--- a/docs/reference/ccr/requirements.asciidoc
+++ b/docs/reference/ccr/requirements.asciidoc
@@ -3,8 +3,6 @@
 [[ccr-requirements]]
 === Requirements for leader indices
 
-beta[]
-
 Cross-cluster replication works by replaying the history of individual write
 operations that were performed on the shards of the leader index. This means that the
 history of these operations needs to be retained on the leader shards so that


### PR DESCRIPTION
This commit removes the beta label from CCR.

Closes #30086
