### PR TITLE
Stop clearing all watches in the mock trigger engine.

### DIFF
--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/BasicWatcherTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/BasicWatcherTests.java
@@ -216,7 +216,6 @@ public class BasicWatcherTests extends AbstractWatcherIntegrationTestCase {
         testConditionSearch(templateRequest(searchSourceBuilder, "events"));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/39306")
     public void testConditionSearchWithIndexedTemplate() throws Exception {
         SearchSourceBuilder searchSourceBuilder = searchSource().query(matchQuery("level", "a"));
         assertAcked(client().admin().cluster().preparePutStoredScript()

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/ScheduleTriggerEngineMock.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/ScheduleTriggerEngineMock.java
@@ -66,7 +66,8 @@ public class ScheduleTriggerEngineMock extends ScheduleTriggerEngine {
 
     @Override
     public void pauseExecution() {
-        watches.clear();
+        // No action is needed because this engine does not trigger watches on a schedule (instead
+        // they must be triggered manually).
     }
 
     @Override


### PR DESCRIPTION
Our watcher integration tests use `ScheduleTriggerEngineMock` to give more
control over when watches are triggered. This mock trigger engine maintains a
reference to all registered watches.  We've seen a few instances of tests
failing because `ScheduleTriggerEngineMock` could no longer find a watch that
was previously added (for example #35503, #37882, and #39306)

The issue seems to be that after the tests starts, there can be a change in
local shard routing, which then causes the watch service to be loaded. This in
turn calls `ScheduleTriggerEngineMock#pauseExecution`, which clears all watches
that this mock object holds. Subsequent calls to
`ScheduleTriggerEngineMock#trigger` then fail to find the requested watches.

This PR proposes to stop clearing the watches in
`ScheduleTriggerEngineMock#pauseExecution`. Usually, pausing execution on a
trigger engine will stop scheduled watches from running. However, the mock
trigger engine does not run watches on a schedule, and instead allows them to
be triggered manually. So arguably, no action should be taken in
`pauseExecution`, and in particular it doesn't make sense to clear the list of
registered watches.

Addresses #35503 and #39306.