### PR TITLE
Fix Snapshot BwC with Version 5.6.x

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -555,8 +555,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                         })
                 );
             } else {
-                transportService.sendRequest(
-                    transportService.getLocalNode(), UPDATE_SNAPSHOT_STATUS_ACTION_NAME_V6,
+                transportService.sendRequest(masterNode, UPDATE_SNAPSHOT_STATUS_ACTION_NAME_V6,
                     new UpdateSnapshotStatusRequestV6(snapshot, shardId, status), INSTANCE_SAME);
             }
         } catch (Exception e) {

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -514,9 +514,6 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
     void sendSnapshotShardUpdate(Snapshot snapshot, ShardId shardId, ShardSnapshotStatus status, DiscoveryNode masterNode) {
         try {
             if (masterNode.getVersion().onOrAfter(Version.V_6_1_0)) {
-                UpdateIndexShardSnapshotStatusRequest request = new UpdateIndexShardSnapshotStatusRequest(snapshot, shardId, status);
-                transportService.sendRequest(transportService.getLocalNode(), UPDATE_SNAPSHOT_STATUS_ACTION_NAME, request, INSTANCE_SAME);
-            } else {
                 remoteFailedRequestDeduplicator.executeOnce(
                     new UpdateIndexShardSnapshotStatusRequest(snapshot, shardId, status),
                     new ActionListener<Void>() {
@@ -557,6 +554,10 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                             }
                         })
                 );
+            } else {
+                transportService.sendRequest(
+                    transportService.getLocalNode(), UPDATE_SNAPSHOT_STATUS_ACTION_NAME_V6,
+                    new UpdateSnapshotStatusRequestV6(snapshot, shardId, status), INSTANCE_SAME);
             }
         } catch (Exception e) {
             logger.warn(() -> new ParameterizedMessage("[{}] [{}] failed to update snapshot state", snapshot, status), e);


### PR DESCRIPTION
* We were sending the wrong snapshot shard status update format to 5.6 (but reading the correct version) so tests would fail with 5.6 masters but not with 5.6 nodes running against a 6.7 master
  * Fixed by using the bwc request with `5.6` exactly as it was used before #39502 
* Closes #39721


... marking as a non-issue since it's not a released bug.