### PR TITLE
Allow setting of `copy_settings` in the HLRC

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
@@ -342,6 +342,7 @@ final class IndicesRequestConverters {
         params.withTimeout(resizeRequest.timeout());
         params.withMasterTimeout(resizeRequest.masterNodeTimeout());
         params.withWaitForActiveShards(resizeRequest.getTargetIndexRequest().waitForActiveShards(), ActiveShardCount.DEFAULT);
+        params.withCopySettings(resizeRequest.getCopySettings());
 
         request.setEntity(RequestConverters.createEntity(resizeRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -909,6 +909,17 @@ final class RequestConverters {
             return withWaitForActiveShards(activeShardCount, ActiveShardCount.DEFAULT);
         }
 
+        /**
+         * @deprecated <code>copy_settings</code> defaults to <code>true</code> and can not be set to false
+         */
+        @Deprecated
+        Params withCopySettings(Boolean setCopySettings) {
+            if (setCopySettings != null) {
+                return putParam("copy_settings", setCopySettings.toString());
+            }
+            return this;
+        }
+
         Params withIndicesOptions(IndicesOptions indicesOptions) {
             if (indicesOptions != null) {
                 withIgnoreUnavailable(indicesOptions.ignoreUnavailable());

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -910,7 +910,7 @@ final class RequestConverters {
         }
 
         /**
-         * @deprecated <code>copy_settings</code> can not be set to false. If unset, behaves as <code>false</code> and wont copy settings.
+         * @deprecated <code>copy_settings</code> can not be set to false. If unset, behaves as <code>false</code> and won't copy settings.
          */
         @Deprecated
         Params withCopySettings(Boolean setCopySettings) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -910,7 +910,7 @@ final class RequestConverters {
         }
 
         /**
-         * @deprecated <code>copy_settings</code> defaults to <code>true</code> and can not be set to false
+         * @deprecated <code>copy_settings</code> can not be set to false. If unset, behaves as <code>false</code> and wont copy settings.
          */
         @Deprecated
         Params withCopySettings(Boolean setCopySettings) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
@@ -869,7 +869,7 @@ public class IndicesRequestConvertersTests extends ESTestCase {
         resizeRequest.setResizeType(resizeType);
         Map<String, String> expectedParams = new HashMap<>();
 
-        if (ESTestCase.randomBoolean()) {
+        if (randomBoolean()) {
             resizeRequest.setCopySettings(Boolean.TRUE);
             expectedParams.put("copy_settings", "true");
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
@@ -24,7 +24,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
-import org.apache.logging.log4j.core.impl.ExtendedStackTraceElement;
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.indices.alias.Alias;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
@@ -870,7 +870,7 @@ public class IndicesRequestConvertersTests extends ESTestCase {
         Map<String, String> expectedParams = new HashMap<>();
 
         if (randomBoolean()) {
-            resizeRequest.setCopySettings(Boolean.TRUE);
+            resizeRequest.setCopySettings(true);
             expectedParams.put("copy_settings", "true");
         }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
@@ -24,6 +24,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.logging.log4j.core.impl.ExtendedStackTraceElement;
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.indices.alias.Alias;
@@ -868,6 +869,12 @@ public class IndicesRequestConvertersTests extends ESTestCase {
         ResizeRequest resizeRequest = new ResizeRequest(indices[0], indices[1]);
         resizeRequest.setResizeType(resizeType);
         Map<String, String> expectedParams = new HashMap<>();
+
+        if (ESTestCase.randomBoolean()) {
+            resizeRequest.setCopySettings(Boolean.TRUE);
+            expectedParams.put("copy_settings", "true");
+        }
+
         RequestConvertersTests.setRandomMasterTimeout(resizeRequest, expectedParams);
         RequestConvertersTests.setRandomTimeout(resizeRequest::timeout, resizeRequest.timeout(), expectedParams);
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -1684,7 +1684,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         request.setWaitForActiveShards(ActiveShardCount.DEFAULT); // <2>
         // end::shrink-index-request-waitForActiveShards
         // tag::shrink-index-request-copySettings
-        request.setCopySettings(Boolean.TRUE); // <1>
+        request.setCopySettings(true); // <1>
         // end::shrink-index-request-copySettings
         // tag::shrink-index-request-settings
         request.getTargetIndexRequest().settings(Settings.builder()

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -1683,9 +1683,13 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         request.setWaitForActiveShards(2); // <1>
         request.setWaitForActiveShards(ActiveShardCount.DEFAULT); // <2>
         // end::shrink-index-request-waitForActiveShards
+        // tag::shrink-index-request-copySettings
+        request.setCopySettings(Boolean.TRUE); // <1>
+        // end::shrink-index-request-copySettings
         // tag::shrink-index-request-settings
         request.getTargetIndexRequest().settings(Settings.builder()
-                .put("index.number_of_shards", 2)); // <1>
+                .put("index.number_of_shards", 2) // <1>
+                .putNull("index.routing.allocation.require._name")); // <2>
         // end::shrink-index-request-settings
         // tag::shrink-index-request-aliases
         request.getTargetIndexRequest().alias(new Alias("target_alias")); // <1>

--- a/docs/java-rest/high-level/indices/shrink_index.asciidoc
+++ b/docs/java-rest/high-level/indices/shrink_index.asciidoc
@@ -51,8 +51,8 @@ returns a response, as an `ActiveShardCount`
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request-copySettings]
 --------------------------------------------------
-<1> Use `Boolean.TRUE` to copy the settings from the source index to the target
-index. This cannot be `Boolean.FALSE`. If this method is not used, default behavior is not to copy.
+<1> Use `true` to copy the settings from the source index to the target
+index. This cannot be `false`. If this method is not used, default behavior is not to copy.
 This parameter will be removed in 8.0.0.
 
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/indices/shrink_index.asciidoc
+++ b/docs/java-rest/high-level/indices/shrink_index.asciidoc
@@ -49,10 +49,19 @@ returns a response, as an `ActiveShardCount`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-request-copySettings]
+--------------------------------------------------
+<1> Use `Boolean.TRUE` to copy the settings from the source index to the target
+index. This cannot be `Boolean.FALSE`. If this method is not used, default behavior is not to copy.
+This parameter will be removed in 8.0.0.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request-settings]
 --------------------------------------------------
 <1> The settings to apply to the target index, which include the number of
 shards to create for it
+<2> Remove the allocation requirement copied from the source index
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/indices/shrink_index.asciidoc
+++ b/docs/java-rest/high-level/indices/shrink_index.asciidoc
@@ -52,8 +52,8 @@ returns a response, as an `ActiveShardCount`
 include-tagged::{doc-tests-file}[{api}-request-copySettings]
 --------------------------------------------------
 <1> Use `true` to copy the settings from the source index to the target
-index. This cannot be `false`. If this method is not used, default behavior is not to copy.
-This parameter will be removed in 8.0.0.
+index. This cannot be `false`. If this method is not used, default behavior is
+not to copy. This parameter will be removed in 8.0.0.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------


### PR DESCRIPTION
#30255 introduced the `copy_settings` parameter in 6.x.
This commit adds support for setting it via `setCopySettings` in the
HLRC.
