### PR TITLE
Add documentation about index following

### DIFF
--- a/docs/reference/ccr/index-following.asciidoc
+++ b/docs/reference/ccr/index-following.asciidoc
@@ -3,30 +3,30 @@
 [[index-following]]
 === Index following
 
-Index following is the primary feature provided by {ccr}. You can use the
-{ref}/ccr-put-follow.html[put follower API] to creating a follower index and
-initiate following.
+Index following is the core feature provided by {ccr}. You can use the
+{ref}/ccr-put-follow.html[create follower API] to create a follower index and
+initiate the following of a leader index on a remote cluster.
 
 === Initiating following
 
-When you submit a {ref}/ccr-put-follow.html[put follower request], the follower
+When you submit a {ref}/ccr-put-follow.html[create follower request], the follower
 index is created on the follower cluster. Once the follower index is created,
-the <<remote-recovery, remote recovery>> process bulk transfers all of the index
-data from the leader cluster to the follower cluster. By default this recovery
-process will be asynchronous in relationship to the
-{ref}/ccr-put-follow.html[put follower request]. The request will return prior
+the <<remote-recovery, remote recovery>> process bulk transfers all of the Lucene
+segment files from the leader cluster to the follower cluster. By default this
+recovery process will be asynchronous in relationship to the
+{ref}/ccr-put-follow.html[create follower request]. The request will return prior
 to the <<remote-recovery, remote recovery>> process being completed. If you
 would like to wait on the process to complete, you can use the
-`wait_for_active_shards`parameter to do so.
+`wait_for_active_shards` parameter to do so.
 
 === Index following operation
 
-Once the follower index is creating, <<remote-recovery, remote recovery>> is
+Once the follower index is created, <<remote-recovery, remote recovery>> is
 complete, and the shards are active, the normal following process begins. During
-the normal following process, the follower will request new operations from the
-leader as indexing occurs on the leader. The intricacies of how operations are
-requested from the leader are governed by settings that can be configured in the
-{ref}/ccr-put-follow.html[put follower request].
+the following process, the follower will request new operations from the leader
+as indexing occurs on the leader. The intricacies of how operations are requested
+from the leader are governed by settings that can be configured in the
+{ref}/ccr-put-follow.html[create follower request].
 
 The {ref}/ccr-get-follow-stats.html[get follow stats api] can be used to monitor
 the following process.
@@ -47,13 +47,13 @@ If the follower is unable to replicate operations from a leader for a period of
 time, the following process can fail due to the leader lacking a complete history
 of operations necessary for the follower to replicate.
 
-Operations are replicated to the follower are identified using a sequence number
+Operations replicated to the follower are identified using a sequence number
 generated when the operation was initially performed. Lucene segment files are
-occasionally merged in order to optimizing searching and save space. When these
+occasionally merged in order to optimize searches and save space. When these
 merges occur, it is possible for operations associated with deleted or updated
 documents to be pruned during the merge. When the follower requests the sequence
-number for this operation, the process will fail due to the operation missing on
-the leader.
+number for a pruned operation, the process will fail due to the operation missing
+on the leader.
 
 This scenario is not possible in an append-only workflow. As documents are never
 deleted or updated, the underlying operation will not be pruned.
@@ -75,10 +75,11 @@ problem can be remedied before the follower falls fatally behind.
 
 If a follower falls sufficiently behind a leader that it can no longer replicate
 operations this can be detected using the
-{ref}/ccr-get-follow-stats.html[get follow stats api].
+{ref}/ccr-get-follow-stats.html[get follow stats api]. It will be reported as a
+`indices[].fatal_exception`.
 
-In order to restart the follower, the following process paused, the follower index
-closed, and the put follow api called again.
+In order to restart the follower, the following process must be paused, the follower
+index closed, and the create follower api called again.
 
 ["source","js"]
 ----------------------------------------------------------------------
@@ -90,6 +91,8 @@ PUT /follower-index-name/_ccr/follow
 ----------------------------------------------------------------------
 // NOTCONSOLE
 
-Calling the put follow api is a destructive action. All of the existing Lucene segment
-files will be deleted on the follower cluster. The <<remote-recovery, remote recovery>>
-process will be used to copy the Lucene segment files from the leader again.
+Calling the create follower api is a destructive action. All of the existing Lucene
+segment files will be deleted on the follower cluster. The
+<<remote-recovery, remote recovery>> process will be used to copy the Lucene segment
+files from the leader again. After the follower index has been reinitialized, the
+following process will be started again.

--- a/docs/reference/ccr/index-following.asciidoc
+++ b/docs/reference/ccr/index-following.asciidoc
@@ -1,0 +1,95 @@
+[role="xpack"]
+[testenv="platinum"]
+[[index-following]]
+=== Index following
+
+Index following is the primary feature provided by {ccr}. You can use the
+{ref}/ccr-put-follow.html[put follower API] to creating a follower index and
+initiate following.
+
+=== Initiating following
+
+When you submit a {ref}/ccr-put-follow.html[put follower request], the follower
+index is created on the follower cluster. Once the follower index is created,
+the <<remote-recovery, remote recovery>> process bulk transfers all of the index
+data from the leader cluster to the follower cluster. By default this recovery
+process will be asynchronous in relationship to the
+{ref}/ccr-put-follow.html[put follower request]. The request will return prior
+to the <<remote-recovery, remote recovery>> process being completed. If you
+would like to wait on the process to complete, you can use the
+`wait_for_active_shards`parameter to do so.
+
+=== Index following operation
+
+Once the follower index is creating, <<remote-recovery, remote recovery>> is
+complete, and the shards are active, the normal following process begins. During
+the normal following process, the follower will request new operations from the
+leader as indexing occurs on the leader. The intricacies of how operations are
+requested from the leader are governed by settings that can be configured in the
+{ref}/ccr-put-follow.html[put follower request].
+
+The {ref}/ccr-get-follow-stats.html[get follow stats api] can be used to monitor
+the following process.
+
+=== Index following paused
+
+It is possible to pause index following using the
+{ref}/ccr-post-pause-follow.html[pause following api]. While a follower is
+paused, it will not request new operations from the leader index. The follower
+index is still readable for search requests.
+
+To resume index following, use the
+{ref}/ccr-post-resume-follow.html[resume following api].
+
+=== Leader index retaining operations for replication
+
+If the follower is unable to replicate operations from a leader for a period of
+time, the following process can fail due to the leader lacking a complete history
+of operations necessary for the follower to replicate.
+
+Operations are replicated to the follower are identified using a sequence number
+generated when the operation was initially performed. Lucene segment files are
+occasionally merged in order to optimizing searching and save space. When these
+merges occur, it is possible for operations associated with deleted or updated
+documents to be pruned during the merge. When the follower requests the sequence
+number for this operation, the process will fail due to the operation missing on
+the leader.
+
+This scenario is not possible in an append-only workflow. As documents are never
+deleted or updated, the underlying operation will not be pruned.
+
+Elasticsearch attempts to mitigate this potential issue for update workflows using
+a Lucene feature called soft deletes. When a document is updated or deleted, the
+underlying operation is retained in the Lucene index for a period of time. This
+period of time is governed by the `index.soft_deletes.retention_lease.period`
+setting which defaults to `12 hours`.
+
+When a follower initiates the index following, it acquires a retention lease from
+the leader. This informs the leader that it should not allow a soft delete to be
+pruned until either the follower indicates that it has received the operation or
+the lease expires after `12 hours`. It is valuable to have monitoring in place to
+detect a follower replication issue prior to `12 hours` passing so that the
+problem can be remedied before the follower falls fatally behind.
+
+=== Remedying a follower that has fallen behind
+
+If a follower falls sufficiently behind a leader that it can no longer replicate
+operations this can be detected using the
+{ref}/ccr-get-follow-stats.html[get follow stats api].
+
+In order to restart the follower, the following process paused, the follower index
+closed, and the put follow api called again.
+
+["source","js"]
+----------------------------------------------------------------------
+POST /follower-index-name/_ccr/pause_follow
+
+POST /follower-index-name/_close
+
+PUT /follower-index-name/_ccr/follow
+----------------------------------------------------------------------
+// NOTCONSOLE
+
+Calling the put follow api is a destructive action. All of the existing Lucene segment
+files will be deleted on the follower cluster. The <<remote-recovery, remote recovery>>
+process will be used to copy the Lucene segment files from the leader again.

--- a/docs/reference/ccr/index-following.asciidoc
+++ b/docs/reference/ccr/index-following.asciidoc
@@ -10,9 +10,9 @@ initiate the following of a leader index on a remote cluster.
 === Initiating following
 
 When you submit a {ref}/ccr-put-follow.html[create follower request], the follower
-index is created on the follower cluster. Once the follower index is created,
+index is created on the local cluster. Once the follower index is created,
 the <<remote-recovery, remote recovery>> process bulk transfers all of the Lucene
-segment files from the leader cluster to the follower cluster. By default this
+segment files from the remote cluster to the local cluster. By default this
 recovery process will be asynchronous in relationship to the
 {ref}/ccr-put-follow.html[create follower request]. The request will return prior
 to the <<remote-recovery, remote recovery>> process being completed. If you
@@ -81,6 +81,67 @@ operations this can be detected using the
 In order to restart the follower, the following process must be paused, the follower
 index closed, and the create follower api called again.
 
+//////////////////////////
+
+[source,js]
+--------------------------------------------------
+PUT /_cluster/settings
+{
+  "persistent" : {
+    "cluster" : {
+      "remote" : {
+        "leader" : {
+          "seeds" : [
+            "127.0.0.1:9300"
+          ]
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[setup:host]
+// TEST[s/127.0.0.1:9300/\${transport_host}/]
+
+[source,js]
+--------------------------------------------------
+PUT /server-metrics
+{
+  "settings" : {
+    "index" : {
+      "number_of_shards" : 1,
+      "number_of_replicas" : 0
+    }
+  }
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+[source,js]
+--------------------------------------------------
+PUT /follower-index-name/_ccr/follow?wait_for_active_shards=1
+{
+  "remote_cluster" : "leader",
+  "leader_index" : "server-metrics"
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+[source,js]
+--------------------------------------------------
+{
+  "follow_index_created" : true,
+  "follow_index_shards_acked" : true,
+  "index_following_started" : true
+}
+--------------------------------------------------
+// TESTRESPONSE
+
+//////////////////////////
+
 ["source","js"]
 ----------------------------------------------------------------------
 POST /follower-index-name/_ccr/pause_follow
@@ -88,10 +149,15 @@ POST /follower-index-name/_ccr/pause_follow
 POST /follower-index-name/_close
 
 PUT /follower-index-name/_ccr/follow
+{
+  "remote_cluster" : "leader",
+  "leader_index" : "server-metrics"
+}
 ----------------------------------------------------------------------
-// NOTCONSOLE
+// CONSOLE
+// TEST[continued]
 
-Calling the create follower api is a destructive action. All of the existing Lucene
+Calling the create follower API is a destructive action. All of the existing Lucene
 segment files will be deleted on the follower cluster. The
 <<remote-recovery, remote recovery>> process will be used to copy the Lucene segment
 files from the leader again. After the follower index has been reinitialized, the

--- a/docs/reference/ccr/index.asciidoc
+++ b/docs/reference/ccr/index.asciidoc
@@ -18,6 +18,7 @@ This guide provides an overview of {ccr}:
 
 * <<ccr-overview>>
 * <<ccr-requirements>>
+* <<ccr-index-following>>
 * <<ccr-auto-follow>>
 * <<ccr-getting-started>>
 
@@ -25,6 +26,7 @@ This guide provides an overview of {ccr}:
 
 include::overview.asciidoc[]
 include::requirements.asciidoc[]
+include::index-following.asciidoc[]
 include::auto-follow.asciidoc[]
 include::getting-started.asciidoc[]
 include::remote-recovery.asciidoc[]

--- a/docs/reference/ccr/requirements.asciidoc
+++ b/docs/reference/ccr/requirements.asciidoc
@@ -32,11 +32,13 @@ Whether or not soft deletes are enabled on the index. Soft deletes can only be
 configured at index creation and only on indices created on or after 6.5.0. The
 default value is `true`.
 
-`index.soft_deletes.retention.operations`::
+`index.soft_deletes.retention_lease.period`::
 
-The number of soft deletes to retain. Soft deletes are collected during merges
-on the underlying Lucene index yet retained up to the number of operations
-configured by this setting. The default value is `0`.
+The maximum period to retain a shard retention lease before it is considered expired.
+Shard retention leases ensure that soft deletes are retained during merges on the
+Lucene index. If a soft delete is merged away before it can be replicated to a
+follower the following process can fail due to incomplete history on the leader. The
+default value is `12 hours`.
 
 For more information about index settings, see {ref}/index-modules.html[Index modules].
 

--- a/docs/reference/ccr/requirements.asciidoc
+++ b/docs/reference/ccr/requirements.asciidoc
@@ -34,11 +34,11 @@ default value is `true`.
 
 `index.soft_deletes.retention_lease.period`::
 
-The maximum period to retain a shard retention lease before it is considered expired.
-Shard retention leases ensure that soft deletes are retained during merges on the
-Lucene index. If a soft delete is merged away before it can be replicated to a
-follower the following process can fail due to incomplete history on the leader. The
-default value is `12 hours`.
+The maximum period to retain a shard history retention lease before it is considered
+expired. Shard history retention leases ensure that soft deletes are retained during
+merges on the Lucene index. If a soft delete is merged away before it can be replicated
+to a follower the following process will fail due to incomplete history on the leader.
+The default value is `12 hours`.
 
 For more information about index settings, see {ref}/index-modules.html[Index modules].
 


### PR DESCRIPTION
This commit adds high-level documenation about following an index using
ccr. This page is supposed to bridge the gap between the basic
getting-started guide and the lower-level api documenation pages.