### PR TITLE
Combine overriddenOps and skippedOps in translog

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/translog/MultiSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/MultiSnapshot.java
@@ -58,16 +58,7 @@ final class MultiSnapshot implements Translog.Snapshot {
 
     @Override
     public int skippedOperations() {
-        int skippedOperations = overriddenOperations;
-        for (TranslogSnapshot translog : translogs) {
-            skippedOperations += translog.skippedOperations();
-        }
-        return skippedOperations;
-    }
-
-    @Override
-    public int overriddenOperations() {
-        return overriddenOperations;
+        return Arrays.stream(translogs).mapToInt(TranslogSnapshot::skippedOperations).sum() + overriddenOperations;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -936,9 +936,6 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
         /**
          * The number of operations have been skipped (overridden or trimmed) in the snapshot so far.
-         * If two operations have the same sequence number, then the operation with a lower term will
-         * be overridden by the operation with a higher term. Operations with sequence numbers that
-         * higher than trimmedAboveSeqNo of its translog checkpoint will be skipped.
          * Unlike {@link #totalOperations()}, this value is updated each time after {@link #next()}) is called.
          */
         default int skippedOperations() {

--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -936,17 +936,12 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
         /**
          * The number of operations have been skipped (overridden or trimmed) in the snapshot so far.
+         * If two operations have the same sequence number, then the operation with a lower term will
+         * be overridden by the operation with a higher term. Operations with sequence numbers that
+         * higher than trimmedAboveSeqNo of its translog checkpoint will be skipped.
+         * Unlike {@link #totalOperations()}, this value is updated each time after {@link #next()}) is called.
          */
         default int skippedOperations() {
-            return 0;
-        }
-
-        /**
-         * The number of operations have been overridden (eg. superseded) in the snapshot so far.
-         * If two operations have the same sequence number, the operation with a lower term will be overridden by the operation
-         * with a higher term. Unlike {@link #totalOperations()}, this value is updated each time after {@link #next()}) is called.
-         */
-        default int overriddenOperations() {
             return 0;
         }
 
@@ -983,11 +978,6 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         @Override
         public int skippedOperations() {
             return filteredOpsCount + delegate.skippedOperations();
-        }
-
-        @Override
-        public int overriddenOperations() {
-            return delegate.overriddenOperations();
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/replication/IndexLevelReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/replication/IndexLevelReplicationTests.java
@@ -584,7 +584,6 @@ public class IndexLevelReplicationTests extends ESIndexLevelReplicationTestCase 
                 assertThat(op2.seqNo(), equalTo(op1.seqNo()));
                 assertThat(op2.primaryTerm(), greaterThan(op1.primaryTerm()));
                 assertThat("Remaining of snapshot should contain init operations", snapshot, containsOperationsInAnyOrder(initOperations));
-                assertThat(snapshot.overriddenOperations(), equalTo(0));
                 assertThat(snapshot.skippedOperations(), equalTo(1));
             }
 

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -715,7 +715,6 @@ public class TranslogTests extends ESTestCase {
             Translog.Snapshot filter = new Translog.SeqNoFilterSnapshot(snapshot, between(200, 300), between(300, 400)); // out range
             assertThat(filter, SnapshotMatchers.size(0));
             assertThat(filter.totalOperations(), equalTo(snapshot.totalOperations()));
-            assertThat(filter.overriddenOperations(), equalTo(snapshot.overriddenOperations()));
             assertThat(filter.skippedOperations(), equalTo(snapshot.totalOperations()));
         }
         try (Translog.Snapshot snapshot = translog.newSnapshot()) {
@@ -726,7 +725,6 @@ public class TranslogTests extends ESTestCase {
             Translog.Snapshot filter = new Translog.SeqNoFilterSnapshot(snapshot, fromSeqNo, toSeqNo);
             assertThat(filter, SnapshotMatchers.containsOperationsInAnyOrder(selectedOps));
             assertThat(filter.totalOperations(), equalTo(snapshot.totalOperations()));
-            assertThat(filter.overriddenOperations(), equalTo(snapshot.overriddenOperations()));
             assertThat(filter.skippedOperations(), equalTo(snapshot.skippedOperations() + operations.size() - selectedOps.size()));
         }
     }


### PR DESCRIPTION
These two stats are not important enough to be distinguishable. This change combines them into a single stat.

Closes #33317