### PR TITLE
SQL: values in datetime script aggs should be treated as long

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/resources/datetime.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/datetime.csv-spec
@@ -381,3 +381,11 @@ Bezalel
 Bojan  
 
 ;
+
+// datetime in aggregations
+doubleCastOfDateInAggs
+SELECT CAST (CAST (birth_date AS VARCHAR) AS TIMESTAMP) a FROM test_emp WHERE YEAR(birth_date) = 1965 GROUP BY a;
+    a:ts
+---------------
+1965-01-03T00:00:00Z
+;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByKey.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByKey.java
@@ -42,7 +42,7 @@ public abstract class GroupByKey extends Agg {
             } else if (script.outputType() == DataType.DATE) {
                 builder.valueType(ValueType.LONG);
             } else if (script.outputType() == DataType.DATETIME) {
-                builder.valueType(ValueType.DATE);
+                builder.valueType(ValueType.LONG);
             } else if (script.outputType() == DataType.BOOLEAN) {
                 builder.valueType(ValueType.BOOLEAN);
             } else if (script.outputType() == DataType.IP) {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryFolderTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryFolderTests.java
@@ -302,7 +302,7 @@ public class QueryFolderTests extends ESTestCase {
                 "\"source\":\"InternalSqlScriptUtils.add(InternalSqlScriptUtils.docValue(doc,params.v0)," +
                 "InternalSqlScriptUtils.intervalYearMonth(params.v1,params.v2))\",\"lang\":\"painless\",\"params\":{" +
                 "\"v0\":\"date\",\"v1\":\"P1Y2M\",\"v2\":\"INTERVAL_YEAR_TO_MONTH\"}},\"missing_bucket\":true," +
-                "\"value_type\":\"date\",\"order\":\"asc\"}}}]}}}"));
+                "\"value_type\":\"long\",\"order\":\"asc\"}}}]}}}"));
         assertEquals(2, ee.output().size());
         assertThat(ee.output().get(0).toString(), startsWith("count(*){a->"));
         assertThat(ee.output().get(1).toString(), startsWith("a{s->"));


### PR DESCRIPTION
When a query is translated into script terms agg where key has a date
type, it should generate a terms agg with value_type long instead of
date, otherwise the key gets formatted as a string, which confuses
hit extractor.

Fixes #37042
