### PR TITLE
Gracefully handle index resolution when there are no indexes

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterState;
@@ -159,6 +160,9 @@ public class IndexNameExpressionResolver {
         }
 
         if (expressions.isEmpty()) {
+            if (metaData.getIndices().isEmpty() && !options.allowNoIndices()) {
+                throw new ResourceNotFoundException("No indices existing");
+            }
             if (!options.allowNoIndices()) {
                 IndexNotFoundException infe = new IndexNotFoundException((String)null);
                 infe.setResources("index_expression", indexExpressions);


### PR DESCRIPTION
This PR handles case in which there are no indices

After this patch:
```
curl -X PUT   http://localhost:9200/_settings   -H 'Content-Type: application/json'   -d '{
    "index.blocks.read_only_allow_delete": "true"
}'
{"error":{"root_cause":[{"type":"resource_not_found_exception","reason":"No indices existing"}],"type":"resource_not_found_exception","reason":"No indices existing"},"status":404}
```
```
curl -X PUT   http://localhost:9200/_settings?allow_no_indices=true   -H 'Content-Type: application/json'   -d '{
    "index.blocks.read_only_allow_delete": "true"
}'
{"acknowledged":true}
```

Original issue: https://github.com/elastic/elasticsearch/issues/38964