### PR TITLE
Give jspawnhelper execute permissions in bundled JDK

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -385,7 +385,7 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
       copySpec {
         from project(':distribution').tasks.getByName("extract${platform.capitalize()}Jdk")
         eachFile { FileCopyDetails details ->
-          if (details.relativePath.segments[-2] == 'bin') {
+          if (details.relativePath.segments[-2] == 'bin' || details.relativePath.segments[-1] == 'jspawnhelper') {
             details.mode = 0755
           }
         }

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -145,7 +145,7 @@ Closure commonPackageConfig(String type, boolean oss) {
         String[] segments = fcp.relativePath.segments
         for (int i = segments.length - 2; i > 2; --i) {
           directory('/' + segments[0..i].join('/'), 0755)
-          if (segments[-2] == 'bin') {
+          if (segments[-2] == 'bin' || segments[-1] == 'jspawnhelper') {
             fcp.mode = 0755
           } else {
             fcp.mode = 0644


### PR DESCRIPTION
The posix_spawn method of launching a process from Java
goes via an intermediate process called jspawnhelper
which lives in the lib directory rather than the bin
directory and hence got missed by the original chmod
loop.  This change adds jspawnhelper as a special case.
It's the only program that's in the lib directory in a
macOS JDK 11.