### PR TITLE
Do not use hard links on MacOS in EvilNodeTests

### DIFF
--- a/qa/evil-tests/src/test/java/org/elasticsearch/node/EvilNodeTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/node/EvilNodeTests.java
@@ -39,13 +39,7 @@ public class EvilNodeTests extends ESTestCase {
     public void testDefaultPathDataIncludedInPathData() throws IOException {
         final Path zero = createTempDir().toAbsolutePath();
         final Path one = createTempDir().toAbsolutePath();
-        // creating hard links to directories is okay on macOS so we exercise it here
-        final int random;
-        if (Constants.MAC_OS_X) {
-            random = randomFrom(0, 1, 2);
-        } else {
-            random = randomFrom(0, 1);
-        }
+        final int random = randomFrom(0, 1);
         final Path defaultPathData;
         final Path choice = randomFrom(zero, one);
         switch (random) {
@@ -55,10 +49,6 @@ public class EvilNodeTests extends ESTestCase {
             case 1:
                 defaultPathData = createTempDir().toAbsolutePath().resolve("link");
                 Files.createSymbolicLink(defaultPathData, choice);
-                break;
-            case 2:
-                defaultPathData = createTempDir().toAbsolutePath().resolve("link");
-                Files.createLink(defaultPathData, choice);
                 break;
             default:
                 throw new AssertionError(Integer.toString(random));

--- a/qa/evil-tests/src/test/java/org/elasticsearch/node/EvilNodeTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/node/EvilNodeTests.java
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class EvilNodeTests extends ESTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/39302")
     public void testDefaultPathDataIncludedInPathData() throws IOException {
         final Path zero = createTempDir().toAbsolutePath();
         final Path one = createTempDir().toAbsolutePath();


### PR DESCRIPTION
With this commit we don't test hard links anymore on MacOS in
`EvilNodeTests`. Directory hard links were once supported on the HFS+
file system (as an undocumented feature) but are gone with the APFS
file system. Attempting to create a directory hard link using the `link`
system call on APFS results in `EPERM`.

See also https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/APFS_Guide/FAQ/FAQ.html

Closes #39302