### PR TITLE
fix index refresh in test within 20_mix_typeless_typeful (#39198)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/20_mix_typeless_typeful.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/20_mix_typeless_typeful.yml
@@ -104,8 +104,8 @@
 "Implicitly create a typeless index while there is a typed template":
 
  - skip:
-      version: "all"
-      reason: "awaits fix in #39198"
+      version: " - 6.99.99"
+      reason: needs typeless index operations to work on typed indices
 
  - do:
       indices.put_template:
@@ -123,6 +123,11 @@
       index:
           index: test-1
           body: { bar: 42 }
+
+# ensures dynamic mapping update is visible to get_mapping
+ - do:
+     cluster.health:
+         wait_for_events: normal
 
  - do:
       indices.get_mapping:


### PR DESCRIPTION
the test "Implicitly create a typeless ... typed template"
fails occasionally because the index operation hasn't
propogated to update the index mapping in time for the
following assertion about a dynamically mapped field "bar".

error failed with:

```
field [test-1.mappings.my_type.properties.bar] doesn't have a true value
Expected: not null
     but: was null
```

refreshing the index should resolve this timing issue.