### PR TITLE
Reformat elasticsearch-node messages

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/DetachClusterCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/DetachClusterCommand.java
@@ -32,14 +32,16 @@ public class DetachClusterCommand extends ElasticsearchNodeCommand {
 
     static final String NODE_DETACHED_MSG = "Node was successfully detached from the cluster";
     static final String CONFIRMATION_MSG =
-                    "-------------------------------------------------------------------------------\n" +
-                    "\n" +
-                    "You should run this tool only if you have permanently lost all\n" +
-                    "your master-eligible nodes, and you cannot restore the cluster\n" +
-                    "from a snapshot, or you have already run `elasticsearch-node unsafe-bootstrap`\n" +
-                    "on a master-eligible node that formed a cluster with this node.\n" +
-                    "This tool can cause arbitrary data loss and its use should be your last resort.\n" +
-                    "Do you want to proceed?\n";
+        DELIMITER +
+            "\n" +
+            "You should only run this tool if you have permanently lost all of the\n" +
+            "master-eligible nodes in this cluster and you cannot restore the cluster\n" +
+            "from a snapshot, or you have already unsafely bootstrapped a new cluster\n" +
+            "by running `elasticsearch-node unsafe-bootstrap` on a master-eligible\n" +
+            "node that belonged to the same cluster as this node. This tool can cause\n" +
+            "arbitrary data loss and its use should be your last resort.\n" +
+            "\n" +
+            "Do you want to proceed?\n";
 
     public DetachClusterCommand() {
         super("Detaches this node from its cluster, allowing it to unsafely join a new cluster");

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ElasticsearchNodeCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ElasticsearchNodeCommand.java
@@ -44,8 +44,10 @@ import java.util.Objects;
 public abstract class ElasticsearchNodeCommand extends EnvironmentAwareCommand {
     private static final Logger logger = LogManager.getLogger(ElasticsearchNodeCommand.class);
     protected final NamedXContentRegistry namedXContentRegistry;
+    static final String DELIMITER = "------------------------------------------------------------------------\n";
+
     static final String STOP_WARNING_MSG =
-            "--------------------------------------------------------------------------\n" +
+            DELIMITER +
                     "\n" +
                     "    WARNING: Elasticsearch MUST be stopped before running this tool." +
                     "\n";

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapMasterCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapMasterCommand.java
@@ -45,15 +45,17 @@ public class UnsafeBootstrapMasterCommand extends ElasticsearchNodeCommand {
     static final String CLUSTER_STATE_TERM_VERSION_MSG_FORMAT =
             "Current node cluster state (term, version) pair is (%s, %s)";
     static final String CONFIRMATION_MSG =
-            "--------------------------------------------------------------------------\n" +
+        DELIMITER +
             "\n" +
-            "You should run this tool only if you have permanently lost half\n" +
-            "or more of the master-eligible nodes, and you cannot restore the cluster\n" +
-            "from a snapshot. This tool can cause arbitrary data loss and its use " +
-            "should be your last resort.\n" +
-            "If you have multiple survived master eligible nodes, consider running\n" +
-            "this tool on the node with the highest cluster state (term, version) pair.\n" +
+            "You should only run this tool if you have permanently lost half or more\n" +
+            "of the master-eligible nodes in this cluster, and you cannot restore the\n" +
+            "cluster from a snapshot. This tool can cause arbitrary data loss and its\n" +
+            "use should be your last resort. If you have multiple surviving master\n" +
+            "eligible nodes, you should run this tool on the node with the highest\n" +
+            "cluster state (term, version) pair.\n" +
+            "\n" +
             "Do you want to proceed?\n";
+
     static final String NOT_MASTER_NODE_MSG = "unsafe-bootstrap tool can only be run on master eligible node";
 
     static final String NO_NODE_METADATA_FOUND_MSG = "no node meta data is found, node has not been started yet?";


### PR DESCRIPTION
Flows the warning messages emitted by the `elasticsearch-node` tool to a width
of 72 characters and tweaks the wording slightly.