### PR TITLE
[BACKPORT] Add pre-upgrade check to test cluster routing allocation is enabled

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/upgrade/IndexUpgradeCheckVersion.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/upgrade/IndexUpgradeCheckVersion.java
@@ -6,7 +6,7 @@
 package org.elasticsearch.xpack.core.upgrade;
 
 public final class IndexUpgradeCheckVersion {
-    public static final int UPRADE_VERSION = 6;
+    public static final int UPGRADE_VERSION = 6;
 
     private IndexUpgradeCheckVersion() {}
 

--- a/x-pack/plugin/upgrade/src/test/java/org/elasticsearch/xpack/upgrade/IndexUpgradeIT.java
+++ b/x-pack/plugin/upgrade/src/test/java/org/elasticsearch/xpack/upgrade/IndexUpgradeIT.java
@@ -96,7 +96,7 @@ public class IndexUpgradeIT extends IndexUpgradeIntegTestCase {
                     }
                 },
                 client(), internalCluster().clusterService(internalCluster().getMasterName()), Strings.EMPTY_ARRAY, null,
-                listener -> {
+                (cs, listener) -> {
                     assertFalse(preUpgradeIsCalled.getAndSet(true));
                     assertFalse(postUpgradeIsCalled.get());
                     listener.onResponse(val);


### PR DESCRIPTION
When following the steps mentioned in upgrade guide
https://www.elastic.co/guide/en/elastic-stack/6.6/upgrading-elastic-stack.html
if we disable the cluster shard allocation but fail to enable it after
upgrading the nodes and plugins, the next step of upgrading internal
indices fails. As we did not check the bulk request response for reindexing,
we delete the old index assuming it has been created. This is fatal
as we cannot recover from this state.

This commit adds a pre-upgrade check to test the cluster shard
allocation setting and fail upgrade if it is disabled. In case there
are search or bulk failures then we remove the read-only block and
fail the upgrade index request.

Closes #39339
