### PR TITLE
[BACKPORT] Add pre-upgrade check to test cluster routing allocation is enabled

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/upgrade/IndexUpgradeCheckVersion.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/upgrade/IndexUpgradeCheckVersion.java
@@ -6,7 +6,7 @@
 package org.elasticsearch.xpack.core.upgrade;
 
 public final class IndexUpgradeCheckVersion {
-    public static final int UPRADE_VERSION = 6;
+    public static final int UPGRADE_VERSION = 6;
 
     private IndexUpgradeCheckVersion() {}
 

--- a/x-pack/plugin/upgrade/src/main/java/org/elasticsearch/xpack/upgrade/IndexUpgradeCheck.java
+++ b/x-pack/plugin/upgrade/src/main/java/org/elasticsearch/xpack/upgrade/IndexUpgradeCheck.java
@@ -5,10 +5,13 @@
  */
 package org.elasticsearch.xpack.upgrade;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider.Allocation;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
@@ -19,7 +22,6 @@ import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.xpack.core.upgrade.IndexUpgradeCheckVersion;
 
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -52,7 +54,17 @@ public class IndexUpgradeCheck<T> extends AbstractComponent {
                              Function<IndexMetaData, UpgradeActionRequired> actionRequired,
                              Client client, ClusterService clusterService, String[] types, Script updateScript) {
         this(name, actionRequired, client, clusterService, types, updateScript,
-                listener -> listener.onResponse(null), (t, listener) -> listener.onResponse(TransportResponse.Empty.INSTANCE));
+                (cs, listener) -> {
+                    Allocation clusterRoutingAllocation = EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING
+                            .get(cs.getMetaData().settings());
+                    if (Allocation.NONE == clusterRoutingAllocation) {
+                        listener.onFailure(new ElasticsearchException(
+                                "pre-upgrade check failed, please enable cluster routing allocation using setting [{}]",
+                                EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey()));
+                    } else {
+                        listener.onResponse(null);
+                    }
+                }, (t, listener) -> listener.onResponse(TransportResponse.Empty.INSTANCE));
     }
 
     /**
@@ -70,11 +82,11 @@ public class IndexUpgradeCheck<T> extends AbstractComponent {
     public IndexUpgradeCheck(String name,
                              Function<IndexMetaData, UpgradeActionRequired> actionRequired,
                              Client client, ClusterService clusterService, String[] types, Script updateScript,
-                             Consumer<ActionListener<T>> preUpgrade,
+                             BiConsumer<ClusterState, ActionListener<T>> preUpgrade,
                              BiConsumer<T, ActionListener<TransportResponse.Empty>> postUpgrade) {
         this.name = name;
         this.actionRequired = actionRequired;
-        this.reindexer = new InternalIndexReindexer<>(client, clusterService, IndexUpgradeCheckVersion.UPRADE_VERSION, updateScript,
+        this.reindexer = new InternalIndexReindexer<>(client, clusterService, IndexUpgradeCheckVersion.UPGRADE_VERSION, updateScript,
                 types, preUpgrade, postUpgrade);
     }
 
@@ -106,5 +118,10 @@ public class IndexUpgradeCheck<T> extends AbstractComponent {
     public void upgrade(TaskId task, IndexMetaData indexMetaData, ClusterState state,
                         ActionListener<BulkByScrollResponse> listener) {
         reindexer.upgrade(task, indexMetaData.getIndex().getName(), state, listener);
+    }
+
+    // pkg scope for testing
+    InternalIndexReindexer getInternalIndexReindexer() {
+        return reindexer;
     }
 }

--- a/x-pack/plugin/upgrade/src/test/java/org/elasticsearch/xpack/upgrade/IndexUpgradeIT.java
+++ b/x-pack/plugin/upgrade/src/test/java/org/elasticsearch/xpack/upgrade/IndexUpgradeIT.java
@@ -97,7 +97,7 @@ public class IndexUpgradeIT extends IndexUpgradeIntegTestCase {
                     }
                 },
                 client(), internalCluster().clusterService(internalCluster().getMasterName()), Strings.EMPTY_ARRAY, null,
-                listener -> {
+                (cs, listener) -> {
                     assertFalse(preUpgradeIsCalled.getAndSet(true));
                     assertFalse(postUpgradeIsCalled.get());
                     listener.onResponse(val);

--- a/x-pack/plugin/upgrade/src/test/java/org/elasticsearch/xpack/upgrade/IndexUpgradeWatcherIT.java
+++ b/x-pack/plugin/upgrade/src/test/java/org/elasticsearch/xpack/upgrade/IndexUpgradeWatcherIT.java
@@ -106,7 +106,7 @@ public class IndexUpgradeWatcherIT extends IndexUpgradeIntegTestCase {
         AtomicReference<Boolean> listenerResult = new AtomicReference<>();
         ActionListener<Boolean> listener = createLatchListener(latch, listenerResult, exception);
 
-        Upgrade.preWatchesIndexUpgrade(client, listener);
+        Upgrade.preWatchesIndexUpgrade(client, getClusterState(), listener);
 
         assertThat("Latch was not counted down", latch.await(10, TimeUnit.SECONDS), is(true));
         assertThat(exception.get(), is(nullValue()));
@@ -138,6 +138,11 @@ public class IndexUpgradeWatcherIT extends IndexUpgradeIntegTestCase {
 
         boolean isWatcherStopped = new WatcherClient(client).prepareWatcherStats().get().watcherMetaData().manuallyStopped();
         assertThat(isWatcherStopped, is(expectWatcherToBeRestartedByUpgrade == false));
+    }
+
+    private ClusterState getClusterState() {
+        ClusterService masterTokenService = internalCluster().getInstance(ClusterService.class, internalCluster().getMasterName());
+        return masterTokenService.state();
     }
 
     private void ensureWatcherIsInCorrectState(WatcherClient watcherClient,
@@ -183,7 +188,7 @@ public class IndexUpgradeWatcherIT extends IndexUpgradeIntegTestCase {
         AtomicReference<Boolean> listenerResult = new AtomicReference<>();
         ActionListener<Boolean> listener = createLatchListener(latch, listenerResult, exception);
 
-        Upgrade.preTriggeredWatchesIndexUpgrade(client, listener);
+        Upgrade.preTriggeredWatchesIndexUpgrade(client, getClusterState(), listener);
 
         assertThat("Latch was not counted down", latch.await(10, TimeUnit.SECONDS), is(true));
         assertThat(exception.get(), is(nullValue()));
@@ -235,7 +240,7 @@ public class IndexUpgradeWatcherIT extends IndexUpgradeIntegTestCase {
             AtomicReference<Boolean> listenerResult = new AtomicReference<>();
             ActionListener<Boolean> listener = createLatchListener(latch, listenerResult, exception);
             logger.info("running Upgrade.preTriggeredWatchesIndexUpgrade()");
-            Upgrade.preTriggeredWatchesIndexUpgrade(client, listener);
+            Upgrade.preTriggeredWatchesIndexUpgrade(client, getClusterState(), listener);
             assertThat("Latch was not counted down", latch.await(10, TimeUnit.SECONDS), is(true));
             assertThat(exception.get(), is(nullValue()));
             assertThat(listenerResult.get(), is(true));
@@ -264,7 +269,7 @@ public class IndexUpgradeWatcherIT extends IndexUpgradeIntegTestCase {
             AtomicReference<Boolean> listenerResult = new AtomicReference<>();
             ActionListener<Boolean> listener = createLatchListener(latch, listenerResult, exception);
             logger.info("running Upgrade.preWatchesIndexUpgrade()");
-            Upgrade.preWatchesIndexUpgrade(client, listener);
+            Upgrade.preWatchesIndexUpgrade(client, getClusterState(), listener);
             assertThat("Latch was not counted down", latch.await(10, TimeUnit.SECONDS), is(true));
             assertThat(exception.get(), is(nullValue()));
             assertThat(listenerResult.get(), is(true));

--- a/x-pack/plugin/upgrade/src/test/java/org/elasticsearch/xpack/upgrade/InternalIndexReindexerIT.java
+++ b/x-pack/plugin/upgrade/src/test/java/org/elasticsearch/xpack/upgrade/InternalIndexReindexerIT.java
@@ -6,8 +6,11 @@
 package org.elasticsearch.xpack.upgrade;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
+
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -19,6 +22,7 @@ import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -26,13 +30,16 @@ import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.protocol.xpack.migration.UpgradeActionRequired;
 import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.tasks.TaskId;
-import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+import org.elasticsearch.xpack.core.upgrade.IndexUpgradeCheckVersion;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,10 +52,13 @@ import java.util.function.Function;
 import static org.elasticsearch.test.VersionUtils.randomVersionBetween;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThrows;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsEqual.equalTo;
 
+@ClusterScope(scope=Scope.TEST)
 public class InternalIndexReindexerIT extends IndexUpgradeIntegTestCase {
 
     @Override
@@ -77,14 +87,13 @@ public class InternalIndexReindexerIT extends IndexUpgradeIntegTestCase {
 
     public void testUpgradeIndex() throws Exception {
         createTestIndex("test");
-        InternalIndexReindexer reindexer = createIndexReindexer(123, script("add_bar"), Strings.EMPTY_ARRAY);
+        InternalIndexReindexer reindexer = createIndexReindexer(script("add_bar"), Strings.EMPTY_ARRAY);
         PlainActionFuture<BulkByScrollResponse> future = PlainActionFuture.newFuture();
         reindexer.upgrade(new TaskId("abc", 123), "test", clusterState(), future);
         BulkByScrollResponse response = future.actionGet();
         assertThat(response.getCreated(), equalTo(2L));
 
-        SearchResponse searchResponse = client().prepareSearch("test-123").get();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
+        SearchResponse searchResponse = client().prepareSearch("test-" + IndexUpgradeCheckVersion.UPGRADE_VERSION).get();
         assertThat(searchResponse.getHits().getHits().length, equalTo(2));
         for (SearchHit hit : searchResponse.getHits().getHits()) {
             assertThat(hit.getId(), startsWith("bar-"));
@@ -94,7 +103,7 @@ public class InternalIndexReindexerIT extends IndexUpgradeIntegTestCase {
 
         GetAliasesResponse aliasesResponse = client().admin().indices().prepareGetAliases("test").get();
         assertThat(aliasesResponse.getAliases().size(), equalTo(1));
-        List<AliasMetaData> testAlias = aliasesResponse.getAliases().get("test-123");
+        List<AliasMetaData> testAlias = aliasesResponse.getAliases().get("test-" + IndexUpgradeCheckVersion.UPGRADE_VERSION);
         assertNotNull(testAlias);
         assertThat(testAlias.size(), equalTo(1));
         assertThat(testAlias.get(0).alias(), equalTo("test"));
@@ -102,8 +111,8 @@ public class InternalIndexReindexerIT extends IndexUpgradeIntegTestCase {
 
     public void testTargetIndexExists() throws Exception {
         createTestIndex("test");
-        createTestIndex("test-123");
-        InternalIndexReindexer reindexer = createIndexReindexer(123, script("add_bar"), Strings.EMPTY_ARRAY);
+        createTestIndex("test-" + IndexUpgradeCheckVersion.UPGRADE_VERSION);
+        InternalIndexReindexer reindexer = createIndexReindexer(script("add_bar"), Strings.EMPTY_ARRAY);
         PlainActionFuture<BulkByScrollResponse> future = PlainActionFuture.newFuture();
         reindexer.upgrade(new TaskId("abc", 123), "test", clusterState(), future);
         assertThrows(future, ResourceAlreadyExistsException.class);
@@ -115,14 +124,14 @@ public class InternalIndexReindexerIT extends IndexUpgradeIntegTestCase {
     public void testTargetIndexExistsAsAlias() throws Exception {
         createTestIndex("test");
         createTestIndex("test-foo");
-        client().admin().indices().prepareAliases().addAlias("test-foo", "test-123").get();
-        InternalIndexReindexer reindexer = createIndexReindexer(123, script("add_bar"), Strings.EMPTY_ARRAY);
+        client().admin().indices().prepareAliases().addAlias("test-foo", "test-" + IndexUpgradeCheckVersion.UPGRADE_VERSION).get();
+        InternalIndexReindexer reindexer = createIndexReindexer(script("add_bar"), Strings.EMPTY_ARRAY);
         PlainActionFuture<BulkByScrollResponse> future = PlainActionFuture.newFuture();
         reindexer.upgrade(new TaskId("abc", 123), "test", clusterState(), future);
         assertThrows(future, InvalidIndexNameException.class);
 
         // Make sure that the index is not marked as read-only
-        client().prepareIndex("test-123", "doc").setSource("foo", "bar").get();
+        client().prepareIndex("test-" + IndexUpgradeCheckVersion.UPGRADE_VERSION, "doc").setSource("foo", "bar").get();
     }
 
     public void testSourceIndexIsReadonly() throws Exception {
@@ -130,7 +139,7 @@ public class InternalIndexReindexerIT extends IndexUpgradeIntegTestCase {
         try {
             Settings settings = Settings.builder().put(IndexMetaData.INDEX_READ_ONLY_SETTING.getKey(), true).build();
             assertAcked(client().admin().indices().prepareUpdateSettings("test").setSettings(settings).get());
-            InternalIndexReindexer reindexer = createIndexReindexer(123, script("add_bar"), Strings.EMPTY_ARRAY);
+            InternalIndexReindexer reindexer = createIndexReindexer(script("add_bar"), Strings.EMPTY_ARRAY);
             PlainActionFuture<BulkByScrollResponse> future = PlainActionFuture.newFuture();
             reindexer.upgrade(new TaskId("abc", 123), "test", clusterState(), future);
             assertThrows(future, IllegalStateException.class);
@@ -144,12 +153,30 @@ public class InternalIndexReindexerIT extends IndexUpgradeIntegTestCase {
         }
     }
 
+    public void testReindexingFailureWithClusterRoutingAllocationDisabled() throws Exception {
+        createTestIndex("test");
+
+        Settings settings = Settings.builder().put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "none")
+                .build();
+        ClusterUpdateSettingsResponse clusterUpdateResponse = client().admin().cluster().prepareUpdateSettings()
+                .setTransientSettings(settings).get();
+        assertThat(clusterUpdateResponse.isAcknowledged(), is(true));
+        assertThat(clusterUpdateResponse.getTransientSettings()
+                .get(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey()), is("none"));
+
+        InternalIndexReindexer reindexer = createIndexReindexer(script("add_bar"), Strings.EMPTY_ARRAY);
+        PlainActionFuture<BulkByScrollResponse> future = PlainActionFuture.newFuture();
+        reindexer.upgrade(new TaskId("abc", 123), "test", clusterState(), future);
+        ElasticsearchException e = expectThrows(ElasticsearchException.class, () -> future.actionGet());
+        assertThat(e.getMessage(), containsString(
+                "pre-upgrade check failed, please enable cluster routing allocation using setting [cluster.routing.allocation.enable]"));
+    }
 
     public void testReindexingFailure() throws Exception {
         createTestIndex("test");
         // Make sure that the index is not marked as read-only
         client().prepareIndex("test", "doc").setSource("foo", "bar").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
-        InternalIndexReindexer reindexer = createIndexReindexer(123, script("fail"), Strings.EMPTY_ARRAY);
+        InternalIndexReindexer reindexer = createIndexReindexer(script("fail"), Strings.EMPTY_ARRAY);
         PlainActionFuture<BulkByScrollResponse> future = PlainActionFuture.newFuture();
         reindexer.upgrade(new TaskId("abc", 123), "test", clusterState(), future);
         assertThrows(future, RuntimeException.class);
@@ -161,7 +188,7 @@ public class InternalIndexReindexerIT extends IndexUpgradeIntegTestCase {
     public void testMixedNodeVersion() throws Exception {
         createTestIndex("test");
 
-        InternalIndexReindexer reindexer = createIndexReindexer(123, script("add_bar"), Strings.EMPTY_ARRAY);
+        InternalIndexReindexer reindexer = createIndexReindexer(script("add_bar"), Strings.EMPTY_ARRAY);
         PlainActionFuture<BulkByScrollResponse> future = PlainActionFuture.newFuture();
         reindexer.upgrade(new TaskId("abc", 123), "test", withRandomOldNode(), future);
         assertThrows(future, IllegalStateException.class);
@@ -183,11 +210,9 @@ public class InternalIndexReindexerIT extends IndexUpgradeIntegTestCase {
         return new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, name, new HashMap<>());
     }
 
-    private InternalIndexReindexer createIndexReindexer(int version, Script transformScript, String[] types) {
-        return new InternalIndexReindexer<Void>(client(), internalCluster().clusterService(internalCluster().getMasterName()),
-                version, transformScript, types, voidActionListener -> voidActionListener.onResponse(null),
-                (aVoid, listener) -> listener.onResponse(TransportResponse.Empty.INSTANCE));
-
+    private InternalIndexReindexer createIndexReindexer(Script transformScript, String[] types) {
+        return new IndexUpgradeCheck("test", imd -> UpgradeActionRequired.UPGRADE, client(),
+                internalCluster().clusterService(internalCluster().getMasterName()), types, transformScript).getInternalIndexReindexer();
     }
 
     private ClusterState clusterState() {


### PR DESCRIPTION
When following the steps mentioned in upgrade guide
https://www.elastic.co/guide/en/elastic-stack/6.6/upgrading-elastic-stack.html
if we disable the cluster shard allocation but fail to enable it after
upgrading the nodes and plugins, the next step of upgrading internal
indices fails. As we did not check the bulk request response for reindexing,
we delete the old index assuming it has been created. This is fatal
as we cannot recover from this state.

This commit adds a pre-upgrade check to test the cluster shard
allocation setting and fail upgrade if it is disabled. In case there
are search or bulk failures then we remove the read-only block and
fail the upgrade index request.

Closes #39339