### PR TITLE
Add 6.7.0 release highlights

### DIFF
--- a/docs/reference/release-notes/highlights-6.7.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.7.0.asciidoc
@@ -1,0 +1,54 @@
+[[release-highlights-6.7.0]]
+== 6.7.0 release highlights
+++++
+<titleabbrev>6.7.0</titleabbrev>
+++++
+
+See also <<release-notes-6.7.0,{es} 6.7.0 release notes>>.
+
+[float]
+=== Cross-cluster replication
+
+We have introduced cross-cluster replication in 6.5.0 as a beta feature and it
+is now mature enough that we make it generally available. Cross-cluster
+replication enables you to replicate indices that exist in remote clusters to
+your local cluster. You create an index in your local cluster (known as
+a _follower index_) that follows an index (known as a _leader index_) in a
+remote cluster. You can also automatically follow indices in a remote cluster
+that match a pattern. The individual write operations that occur on the leader
+indices are then replayed on the follower indices. This functionality is useful
+for replicating data to a second cluster for disaster recovery purposes and for
+geo-proximity so that reads can be served locally.
+
+For more information, see {stack-ov}/xpack-ccr.html[Cross-cluster replication]
+and <<ccr-apis>>.
+
+=== Index lifecycle management
+
+We have introduced index lifecycle management in 6.6.0 as a beta feature and it
+is now mature enough that we make it generally available. The index lifecycle
+management feature breaks the lifecycle of an index into four phases: hot,
+warm, cold, and delete phase. You can define an index lifecycle policy which
+enables you to:
+
+* Have one primary shard on each hot node to maximize indexing throughput.
+* Replace the hot index with a new empty index as soon as the existing index is “full” or after a time period. 
+* Move the old index to warm nodes, where it can be shrunk to a single shard and force-merged down to a single segment for optimized storage and querying. 
+* Later, move the index to cold nodes for cheaper storage.
+
+See <<index-lifecycle-management>>. 
+
+[float]
+=== {es-sql}
+
+We have introduced {es-sql} in 6.6.0 as an experimental feature and it is now
+mature enough that we make it generally available. This feature enables
+users who are familiar with SQL to use SQL statements to query {es} indices.
+In addition to querying through the SQL API, you can use the
+<<sql-translate,Translate API>> to see how SQL queries are translated to
+native {es} queries. There are four methods to access {es-sql}: through the
+<<sql-rest, REST endpoints>>, the <<sql-cli,SQL command line interface>>, the
+<<sql-jdbc,JDBC driver>>, and the <<sql-odbc,ODBC driver>>.
+
+
+For more information, see <<xpack-sql, SQL Access>>.

--- a/docs/reference/release-notes/highlights-6.7.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.7.0.asciidoc
@@ -9,8 +9,8 @@ See also <<release-notes-6.7.0,{es} 6.7.0 release notes>>.
 [float]
 === Cross-cluster replication
 
-We have introduced cross-cluster replication in 6.5.0 as a beta feature and it
-is now mature enough that we make it generally available. Cross-cluster
+We introduced cross-cluster replication in 6.5.0 as a beta feature, it is now
+mature enough to declare the feature GA (general availability). Cross-cluster
 replication enables you to replicate indices that exist in remote clusters to
 your local cluster. You create an index in your local cluster (known as
 a _follower index_) that follows an index (known as a _leader index_) in a
@@ -25,11 +25,11 @@ and <<ccr-apis>>.
 
 === Index lifecycle management
 
-We have introduced index lifecycle management in 6.6.0 as a beta feature and it
-is now mature enough that we make it generally available. The index lifecycle
-management feature breaks the lifecycle of an index into four phases: hot,
-warm, cold, and delete phase. You can define an index lifecycle policy which
-enables you to:
+We introduced index lifecycle management in 6.6.0 as a beta feature, it is now
+mature enough to declare the feature GA (general availability). The index
+lifecycle management feature breaks the lifecycle of an index into four phases:
+hot, warm, cold, and delete phase. You can define an index lifecycle policy
+which enables you to:
 
 * Have one primary shard on each hot node to maximize indexing throughput.
 * Replace the hot index with a new empty index as soon as the existing index is “full” or after a time period. 
@@ -41,10 +41,10 @@ See <<index-lifecycle-management>>.
 [float]
 === {es-sql}
 
-We have introduced {es-sql} in 6.3.0 as an experimental feature and it is now
-mature enough that we make it generally available. This feature enables
-users who are familiar with SQL to use SQL statements to query {es} indices.
-In addition to querying through the SQL API, you can use the
+We introduced {es-sql} in 6.3.0 as an experimental feature, it is now
+mature enough to declare the feature GA (general availability). This feature
+enables users who are familiar with SQL to use SQL statements to query {es}
+indices. In addition to querying through the SQL API, you can use the
 <<sql-translate,Translate API>> to see how SQL queries are translated to
 native {es} queries. There are four methods to access {es-sql}: through the
 <<sql-rest, REST endpoints>>, the <<sql-cli,SQL command line interface>>, the

--- a/docs/reference/release-notes/highlights-6.7.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.7.0.asciidoc
@@ -41,7 +41,7 @@ See <<index-lifecycle-management>>.
 [float]
 === {es-sql}
 
-We have introduced {es-sql} in 6.6.0 as an experimental feature and it is now
+We have introduced {es-sql} in 6.3.0 as an experimental feature and it is now
 mature enough that we make it generally available. This feature enables
 users who are familiar with SQL to use SQL statements to query {es} indices.
 In addition to querying through the SQL API, you can use the

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -9,6 +9,7 @@
 This section summarizes the most important changes in each release. For the 
 full list, see <<es-release-notes>> and <<breaking-changes>>. 
 
+* <<release-highlights-6.7.0>>
 * <<release-highlights-6.6.0>>
 * <<release-highlights-6.5.0>>
 * <<release-highlights-6.4.0>>
@@ -16,6 +17,7 @@ full list, see <<es-release-notes>> and <<breaking-changes>>.
 
 --
 
+include::highlights-6.7.0.asciidoc[]
 include::highlights-6.6.0.asciidoc[]
 include::highlights-6.5.0.asciidoc[]
 include::highlights-6.4.0.asciidoc[]


### PR DESCRIPTION
With this commit we document the highlight features of the Elasticsearch
6.7.0 release.