### PR TITLE
Fix JsonLoggerTests.testJsonInStacktraceMessageIsSplitted

### DIFF
--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
@@ -174,7 +174,7 @@ public class JsonLoggerTests extends ESTestCase {
                     logLine("file", Level.ERROR, "sample-name", "test", "error message " + json),
 
                     //stacktrace field will have each json line will in a separate array element
-                    stacktraceWith(("java.lang.Exception: " + json).split("\n"))
+                    stacktraceWith(("java.lang.Exception: " + json).split(LINE_SEPARATOR))
                 )
             ));
         }


### PR DESCRIPTION
a test was splitting a json log message with a wrong line separator.
Using System.lineSeparator consistently prevents this problem

closes #39829