### PR TITLE
Add empty task to prevent failing bwc check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -475,3 +475,6 @@ allprojects {
 
 task internalClusterTest {
 }
+
+task bwcTestSnapshots {
+}


### PR DESCRIPTION
It's too much effort for what it's worth to backport the splitting f bwc tests  here, 
so instead we are adding this empty task to prevent the check from failing. 
The BWC tests will continue to run in check 1 and check 2. 