### PR TITLE
msearch does not support an empty first line

### DIFF
--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -49,7 +49,8 @@ $ curl -H "Content-Type: application/x-ndjson" -XGET localhost:9200/_msearch --d
 // NOTCONSOLE
 
 Note, the above includes an example of an empty header (can also be just
-without any content) which is supported as well.
+without any content) which is supported as well but not when placed in the 
+very first line of the request.
 
 The response returns a `responses` array, which includes the search
 response and status code for each search request matching its order in


### PR DESCRIPTION
In documentation we are saying that `_msearch` can use empty headers:

> Note, the above includes an example of an empty header (can also be just without any content) which is supported as well.

This is true but not for the very first line of the request.

See this example:

```
DELETE /test
PUT /test/_doc/1
{
  "foo": "bar"
}
```

Running:


```
$ cat requests
```

```
{}
{ "query": {"match_all": {}}}

{ "query": {"match_all": {}}}

{ "query": {"match_all": {}}}

{ "query": {"match_all": {}}}
```

```
curl -H "Content-Type: application/x-ndjson" -XGET "http://127.0.0.1:9200/test/_msearch?pretty" --data-binary "@requests"; echo
```

Works well.

But running with:

```
$ cat requests
```

```

{ "query": {"match_all": {}}}

{ "query": {"match_all": {}}}

{ "query": {"match_all": {}}}

{ "query": {"match_all": {}}}
```

Gives:

```json
{
  "error" : {
    "root_cause" : [
      {
        "type" : "parsing_exception",
        "reason" : "Expected [START_OBJECT] but found [null]",
        "line" : 1,
        "col" : 0
      }
    ],
    "type" : "parsing_exception",
    "reason" : "Expected [START_OBJECT] but found [null]",
    "line" : 1,
    "col" : 0
  },
  "status" : 400
}
```

Related discussion: https://discuss.elastic.co/t/sending-multiple-count-requests-in-one-go/171456/14
