### PR TITLE
Propagate exceptions in o.e.common.io.Streams. (#39042)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/Streams.java
+++ b/server/src/main/java/org/elasticsearch/common/io/Streams.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.common.io;
 
-import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStream;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -72,24 +71,22 @@ public abstract class Streams {
     public static long copy(InputStream in, OutputStream out, byte[] buffer) throws IOException {
         Objects.requireNonNull(in, "No InputStream specified");
         Objects.requireNonNull(out, "No OutputStream specified");
-        boolean success = false;
-        try {
-            long byteCount = 0;
-            int bytesRead;
-            while ((bytesRead = in.read(buffer)) != -1) {
-                out.write(buffer, 0, bytesRead);
-                byteCount += bytesRead;
-            }
-            out.flush();
-            success = true;
-            return byteCount;
-        } finally {
-            if (success) {
-                IOUtils.close(in, out);
-            } else {
-                IOUtils.closeWhileHandlingException(in, out);
-            }
+        // Leverage try-with-resources to close in and out so that exceptions in close() are either propagated or added as suppressed
+        // exceptions to the main exception
+        try (InputStream in2 = in; OutputStream out2 = out) {
+            return doCopy(in2, out2, buffer);
         }
+    }
+
+    private static long doCopy(InputStream in, OutputStream out, byte[] buffer) throws IOException {
+        long byteCount = 0;
+        int bytesRead;
+        while ((bytesRead = in.read(buffer)) != -1) {
+            out.write(buffer, 0, bytesRead);
+            byteCount += bytesRead;
+        }
+        out.flush();
+        return byteCount;
     }
 
     /**
@@ -103,14 +100,8 @@ public abstract class Streams {
     public static void copy(byte[] in, OutputStream out) throws IOException {
         Objects.requireNonNull(in, "No input byte array specified");
         Objects.requireNonNull(out, "No OutputStream specified");
-        try {
-            out.write(in);
-        } finally {
-            try {
-                out.close();
-            } catch (IOException ex) {
-                // do nothing
-            }
+        try (OutputStream out2 = out) {
+            out2.write(in);
         }
     }
 
@@ -131,25 +122,23 @@ public abstract class Streams {
     public static int copy(Reader in, Writer out) throws IOException {
         Objects.requireNonNull(in, "No Reader specified");
         Objects.requireNonNull(out, "No Writer specified");
-        boolean success = false;
-        try {
-            int byteCount = 0;
-            char[] buffer = new char[BUFFER_SIZE];
-            int bytesRead;
-            while ((bytesRead = in.read(buffer)) != -1) {
-                out.write(buffer, 0, bytesRead);
-                byteCount += bytesRead;
-            }
-            out.flush();
-            success = true;
-            return byteCount;
-        } finally {
-            if (success) {
-                IOUtils.close(in, out);
-            } else {
-                IOUtils.closeWhileHandlingException(in, out);
-            }
+        // Leverage try-with-resources to close in and out so that exceptions in close() are either propagated or added as suppressed
+        // exceptions to the main exception
+        try (Reader in2 = in; Writer out2 = out) {
+            return doCopy(in2, out2);
         }
+    }
+
+    private static int doCopy(Reader in, Writer out) throws IOException {
+        int byteCount = 0;
+        char[] buffer = new char[BUFFER_SIZE];
+        int bytesRead;
+        while ((bytesRead = in.read(buffer)) != -1) {
+            out.write(buffer, 0, bytesRead);
+            byteCount += bytesRead;
+        }
+        out.flush();
+        return byteCount;
     }
 
     /**
@@ -163,14 +152,8 @@ public abstract class Streams {
     public static void copy(String in, Writer out) throws IOException {
         Objects.requireNonNull(in, "No input String specified");
         Objects.requireNonNull(out, "No Writer specified");
-        try {
-            out.write(in);
-        } finally {
-            try {
-                out.close();
-            } catch (IOException ex) {
-                // do nothing
-            }
+        try (Writer out2 = out) {
+            out2.write(in);
         }
     }
 


### PR DESCRIPTION
This commit propagates some exceptions that were previously swallowed and also
makes sure that exceptions closing streams are either propagated if the try
block succeeded or added as suppressed exceptions otherwise.