### PR TITLE
Add client jar for transport-nio

### DIFF
--- a/plugins/transport-nio/build.gradle
+++ b/plugins/transport-nio/build.gradle
@@ -21,6 +21,7 @@ apply plugin: "nebula.maven-scm"
 esplugin {
     description 'The nio transport.'
     classname 'org.elasticsearch.transport.nio.NioTransportPlugin'
+    hasClientJar = true
 }
 
 compileJava.options.compilerArgs << "-Xlint:-try"


### PR DESCRIPTION
This change marks the transport-nio plugin as having a client jar. The
nio transport can be used from a transport client and the
x-pack-transport artifact depends on the transport-nio jar but this jar
is not published. This change marks the transport-nio project as having
a client jar so that the jar may be published in the same way that we
publish the netty4 transport artifact.

The change to actually publish the jar will be handled separately as an
update to the release manager.