### PR TITLE
Fix ldap mock socket to bind ip protocol correctly

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/common/network/InetAddressHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/common/network/InetAddressHelper.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.common.network;
 
+import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.SocketException;
 
@@ -18,5 +19,13 @@ public class InetAddressHelper {
 
     public static InetAddress[] getAllAddresses() throws SocketException {
         return NetworkUtils.getAllAddresses();
+    }
+
+    public static InetAddress[] filterIPV4(InetAddress[] addresses){
+        return NetworkUtils.filterIPV4(addresses);
+    }
+
+    public static InetAddress[] filterIPV6(InetAddress[] addresses){
+        return NetworkUtils.filterIPV6(addresses);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/common/network/InetAddressHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/common/network/InetAddressHelper.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.common.network;
 
-import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.SocketException;
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactoryLoadBalancingTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactoryLoadBalancingTests.java
@@ -175,6 +175,8 @@ public class SessionFactoryLoadBalancingTests extends LdapTestCase {
     @SuppressForbidden(reason = "Allow opening socket for test")
     private MockSocket openMockSocket(InetAddress remoteAddress, int remotePort, InetAddress localAddress, int localPort)
             throws IOException {
+        logger.info("baz - remote: " + remoteAddress + " - " + remotePort);
+        logger.info("baz - local: " + localAddress + " - " + localPort);
         final MockSocket socket = new MockSocket();
         socket.setReuseAddress(true); // allow binding even if the previous socket is in timed wait state.
         socket.setSoLinger(true, 0); // close immediately as we are not writing anything here.
@@ -333,7 +335,9 @@ public class SessionFactoryLoadBalancingTests extends LdapTestCase {
                             .filter(addr -> openedSockets.stream().noneMatch(s -> addr.equals(s.getLocalAddress())))
                             .filter(addr -> blacklistedAddress.contains(addr) == false)
                             .collect(Collectors.toList());
-
+                        logger.info("baz - all: " + Arrays.toString(InetAddressHelper.getAllAddresses()));
+                        logger.info("baz - only of same protocol: " + Arrays.toString(allAddresses));
+                        logger.info("baz - filtered: " + inetAddressesToBind);
                         for (InetAddress localAddress : inetAddressesToBind) {
                             try {
                                 final Socket socket = openMockSocket(serverAddress, serverPort, localAddress, portToBind);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactoryLoadBalancingTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactoryLoadBalancingTests.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.network.InetAddressHelper;
-import org.elasticsearch.common.network.NetworkUtils;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -33,7 +32,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.net.Inet4Address;
-import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NoRouteToHostException;


### PR DESCRIPTION
The ldap mock socket binding was failing on linux due to a ipv6 socket
trying to connect to an ipv4 address. This fix ensures that only the
same protocol is used from client to server.
