### PR TITLE
[DOCS] Adds anchors for ruby client

### DIFF
--- a/docs/ruby/client.asciidoc
+++ b/docs/ruby/client.asciidoc
@@ -1,3 +1,4 @@
+[[ruby_client]]
 == The Ruby Client
 
 The `elasticsearch` http://rubygems.org/gems/elasticsearch[Rubygem] provides a low-level client

--- a/docs/ruby/copyright.asciidoc
+++ b/docs/ruby/copyright.asciidoc
@@ -1,3 +1,4 @@
+[[copyright]]
 == Copyright and License
 
 This software is Copyright (c) 2013-2018 by Elasticsearch BV.

--- a/docs/ruby/model.asciidoc
+++ b/docs/ruby/model.asciidoc
@@ -1,3 +1,4 @@
+[[activemodel_activerecord]]
 == ActiveModel / ActiveRecord
 
 The `elasticsearch-model` http://rubygems.org/gems/elasticsearch-model[Rubygem]

--- a/docs/ruby/persistence.asciidoc
+++ b/docs/ruby/persistence.asciidoc
@@ -1,3 +1,4 @@
+[[persistence]]
 == Persistence
 
 The `elasticsearch-persistence` http://rubygems.org/gems/elasticsearch-persistence[Rubygem]

--- a/docs/ruby/rails.asciidoc
+++ b/docs/ruby/rails.asciidoc
@@ -1,3 +1,4 @@
+[[ruby_on_rails]]
 == Ruby On Rails
 
 The `elasticsearch-rails` http://rubygems.org/gems/elasticsearch-rails[Rubygem]


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/691

This PR adds explicit anchors for the pages in the Ruby API documentation: https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/current/index.html