### PR TITLE
Remove Obsolete BWC Serialization Logic

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.action.admin.indices.analyze;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.single.shard.SingleShardRequest;
 import org.elasticsearch.common.Strings;
@@ -252,9 +251,7 @@ public class AnalyzeRequest extends SingleShardRequest<AnalyzeRequest> implement
         field = in.readOptionalString();
         explain = in.readBoolean();
         attributes = in.readStringArray();
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_beta1)) {
-            normalizer = in.readOptionalString();
-        }
+        normalizer = in.readOptionalString();
     }
 
     @Override
@@ -268,9 +265,7 @@ public class AnalyzeRequest extends SingleShardRequest<AnalyzeRequest> implement
         out.writeOptionalString(field);
         out.writeBoolean(explain);
         out.writeStringArray(attributes);
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_beta1)) {
-            out.writeOptionalString(normalizer);
-        }
+        out.writeOptionalString(normalizer);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.cache.clear;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -83,9 +82,6 @@ public class ClearIndicesCacheRequest extends BroadcastRequest<ClearIndicesCache
         super.readFrom(in);
         queryCache = in.readBoolean();
         fieldDataCache = in.readBoolean();
-        if (in.getVersion().before(Version.V_6_0_0_beta1)) {
-            in.readBoolean(); // recycler
-        }
         fields = in.readStringArray();
         requestCache = in.readBoolean();
     }
@@ -95,9 +91,6 @@ public class ClearIndicesCacheRequest extends BroadcastRequest<ClearIndicesCache
         super.writeTo(out);
         out.writeBoolean(queryCache);
         out.writeBoolean(fieldDataCache);
-        if (out.getVersion().before(Version.V_6_0_0_beta1)) {
-            out.writeBoolean(false); // recycler
-        }
         out.writeStringArrayNullable(fields);
         out.writeBoolean(requestCache);
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.admin.indices.create;
 
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.admin.indices.alias.Alias;
@@ -442,26 +441,11 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         for (int i = 0; i < size; i++) {
             final String type = in.readString();
             String source = in.readString();
-            if (in.getVersion().before(Version.V_6_0_0_alpha1)) { // TODO change to 5.3.0 after backport
-                // we do not know the content type that comes from earlier versions so we autodetect and convert
-                source = XContentHelper.convertToJson(new BytesArray(source), false, false, XContentFactory.xContentType(source));
-            }
             mappings.put(type, source);
-        }
-        if (in.getVersion().before(Version.V_6_5_0)) {
-            // This used to be the size of custom metadata classes
-            int customSize = in.readVInt();
-            assert customSize == 0 : "unexpected custom metadata when none is supported";
-            if (customSize > 0) {
-                throw new IllegalStateException("unexpected custom metadata when none is supported");
-            }
         }
         int aliasesSize = in.readVInt();
         for (int i = 0; i < aliasesSize; i++) {
             aliases.add(Alias.read(in));
-        }
-        if (in.getVersion().before(Version.V_7_0_0)) {
-            in.readBoolean(); // updateAllTypes
         }
         waitForActiveShards = ActiveShardCount.readFrom(in);
     }
@@ -477,16 +461,9 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
             out.writeString(entry.getKey());
             out.writeString(entry.getValue());
         }
-        if (out.getVersion().before(Version.V_6_5_0)) {
-            // Size of custom index metadata, which is removed
-            out.writeVInt(0);
-        }
         out.writeVInt(aliases.size());
         for (Alias alias : aliases) {
             alias.writeTo(out);
-        }
-        if (out.getVersion().before(Version.V_7_0_0)) {
-            out.writeBoolean(true); // updateAllTypes
         }
         waitForActiveShards.writeTo(out);
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.get;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.info.ClusterInfoRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -81,9 +80,7 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
             features[i] = Feature.fromId(in.readByte());
         }
         humanReadable = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
-            includeDefaults = in.readBoolean();
-        }
+        includeDefaults = in.readBoolean();
     }
 
     public GetIndexRequest features(Feature... features) {
@@ -155,9 +152,6 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
             out.writeByte(feature.id);
         }
         out.writeBoolean(humanReadable);
-        if (out.getVersion().onOrAfter(Version.V_6_4_0)) {
-            out.writeBoolean(includeDefaults);
-        }
+        out.writeBoolean(includeDefaults);
     }
-
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -22,7 +22,6 @@ package org.elasticsearch.action.admin.indices.get;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
 import org.apache.lucene.util.CollectionUtil;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
@@ -193,11 +192,9 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
         settings = settingsMapBuilder.build();
 
         ImmutableOpenMap.Builder<String, Settings> defaultSettingsMapBuilder = ImmutableOpenMap.builder();
-        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
-            int defaultSettingsSize = in.readVInt();
-            for (int i = 0; i < defaultSettingsSize ; i++) {
-                defaultSettingsMapBuilder.put(in.readString(), Settings.readSettingsFromStream(in));
-            }
+        int defaultSettingsSize = in.readVInt();
+        for (int i = 0; i < defaultSettingsSize; i++) {
+            defaultSettingsMapBuilder.put(in.readString(), Settings.readSettingsFromStream(in));
         }
         defaultSettings = defaultSettingsMapBuilder.build();
     }
@@ -228,12 +225,10 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
             out.writeString(indexEntry.key);
             Settings.writeSettingsToStream(indexEntry.value, out);
         }
-        if (out.getVersion().onOrAfter(Version.V_6_4_0)) {
-            out.writeVInt(defaultSettings.size());
-            for (ObjectObjectCursor<String, Settings> indexEntry : defaultSettings) {
-                out.writeString(indexEntry.key);
-                Settings.writeSettingsToStream(indexEntry.value, out);
-            }
+        out.writeVInt(defaultSettings.size());
+        for (ObjectObjectCursor<String, Settings> indexEntry : defaultSettings) {
+            out.writeString(indexEntry.key);
+            Settings.writeSettingsToStream(indexEntry.value, out);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -22,7 +22,6 @@ package org.elasticsearch.action.admin.indices.mapping.put;
 import com.carrotsearch.hppc.ObjectHashSet;
 
 import org.elasticsearch.ElasticsearchGenerationException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -308,15 +307,8 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         type = in.readOptionalString();
         source = in.readString();
-        if (in.getVersion().before(Version.V_7_0_0)) {
-            in.readBoolean(); // updateAllTypes
-        }
         concreteIndex = in.readOptionalWriteable(Index::new);
-        if (in.getVersion().onOrAfter(Version.V_6_7_0)) {
-            origin = in.readOptionalString();
-        } else {
-            origin = null;
-        }
+        origin = in.readOptionalString();
     }
 
     @Override
@@ -326,13 +318,8 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
         indicesOptions.writeIndicesOptions(out);
         out.writeOptionalString(type);
         out.writeString(source);
-        if (out.getVersion().before(Version.V_7_0_0)) {
-            out.writeBoolean(true); // updateAllTypes
-        }
         out.writeOptionalWriteable(concreteIndex);
-        if (out.getVersion().onOrAfter(Version.V_6_7_0)) {
-            out.writeOptionalString(origin);
-        }
+        out.writeOptionalString(origin);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.open;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
@@ -141,9 +140,7 @@ public class OpenIndexRequest extends AcknowledgedRequest<OpenIndexRequest> impl
         super.readFrom(in);
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-            waitForActiveShards = ActiveShardCount.readFrom(in);
-        }
+        waitForActiveShards = ActiveShardCount.readFrom(in);
     }
 
     @Override
@@ -151,8 +148,6 @@ public class OpenIndexRequest extends AcknowledgedRequest<OpenIndexRequest> impl
         super.writeTo(out);
         out.writeStringArray(indices);
         indicesOptions.writeIndicesOptions(out);
-        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-            waitForActiveShards.writeTo(out);
-        }
+        waitForActiveShards.writeTo(out);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
@@ -22,7 +22,6 @@ package org.elasticsearch.action.admin.indices.shards;
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -163,10 +162,6 @@ public class IndicesShardStoresResponse extends ActionResponse implements ToXCon
         @Override
         public void readFrom(StreamInput in) throws IOException {
             node = new DiscoveryNode(in);
-            if (in.getVersion().before(Version.V_6_0_0_alpha1)) {
-                // legacy version
-                in.readLong();
-            }
             allocationId = in.readOptionalString();
             allocationStatus = AllocationStatus.readFrom(in);
             if (in.readBoolean()) {
@@ -177,10 +172,6 @@ public class IndicesShardStoresResponse extends ActionResponse implements ToXCon
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             node.writeTo(out);
-            if (out.getVersion().before(Version.V_6_0_0_alpha1)) {
-                // legacy version
-                out.writeLong(-1L);
-            }
             out.writeOptionalString(allocationId);
             allocationStatus.writeTo(out);
             if (storeException != null) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeAction.java
@@ -19,14 +19,12 @@
 
 package org.elasticsearch.action.admin.indices.shrink;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.Action;
 
 public class ResizeAction extends Action<ResizeResponse> {
 
     public static final ResizeAction INSTANCE = new ResizeAction();
     public static final String NAME = "indices:admin/resize";
-    public static final Version COMPATIBILITY_VERSION = Version.V_6_1_0; // TODO remove this once it's backported
 
     private ResizeAction() {
         super(NAME);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.action.admin.indices.shrink;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.admin.indices.alias.Alias;
@@ -94,16 +93,8 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         targetIndexRequest = new CreateIndexRequest();
         targetIndexRequest.readFrom(in);
         sourceIndex = in.readString();
-        if (in.getVersion().onOrAfter(ResizeAction.COMPATIBILITY_VERSION)) {
-            type = in.readEnum(ResizeType.class);
-        } else {
-            type = ResizeType.SHRINK; // BWC this used to be shrink only
-        }
-        if (in.getVersion().before(Version.V_6_4_0)) {
-            copySettings = null;
-        } else {
-            copySettings = in.readOptionalBoolean();
-        }
+        type = in.readEnum(ResizeType.class);
+        copySettings = in.readOptionalBoolean();
     }
 
     @Override
@@ -111,15 +102,8 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         super.writeTo(out);
         targetIndexRequest.writeTo(out);
         out.writeString(sourceIndex);
-        if (out.getVersion().onOrAfter(ResizeAction.COMPATIBILITY_VERSION)) {
-            out.writeEnum(type);
-        }
-        // noinspection StatementWithEmptyBody
-        if (out.getVersion().before(Version.V_6_4_0)) {
-
-        } else {
-            out.writeOptionalBoolean(copySettings);
-        }
+        out.writeEnum(type);
+        out.writeOptionalBoolean(copySettings);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -34,7 +34,6 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaDataCreateIndexService;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -192,16 +191,5 @@ public class TransportResizeAction extends TransportMasterNodeAction<ResizeReque
                 .recoverFrom(metaData.getIndex())
                 .resizeType(resizeRequest.getResizeType())
                 .copySettings(resizeRequest.getCopySettings() == null ? false : resizeRequest.getCopySettings());
-    }
-
-    @Override
-    protected String getMasterActionName(DiscoveryNode node) {
-        if (node.getVersion().onOrAfter(ResizeAction.COMPATIBILITY_VERSION)){
-            return super.getMasterActionName(node);
-        } else {
-            // this is for BWC - when we send this to version that doesn't have ResizeAction.NAME registered
-            // we have to send to shrink instead.
-            return ShrinkAction.NAME;
-        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/delete/DeleteRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/delete/DeleteRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.delete;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
 import org.elasticsearch.action.DocWriteRequest;
@@ -279,18 +278,10 @@ public class DeleteRequest extends ReplicatedWriteRequest<DeleteRequest>
         type = in.readString();
         id = in.readString();
         routing = in.readOptionalString();
-        if (in.getVersion().before(Version.V_7_0_0)) {
-            in.readOptionalString(); // _parent
-        }
         version = in.readLong();
         versionType = VersionType.fromValue(in.readByte());
-        if (in.getVersion().onOrAfter(Version.V_6_6_0)) {
-            ifSeqNo = in.readZLong();
-            ifPrimaryTerm = in.readVLong();
-        } else {
-            ifSeqNo = UNASSIGNED_SEQ_NO;
-            ifPrimaryTerm = UNASSIGNED_PRIMARY_TERM;
-        }
+        ifSeqNo = in.readZLong();
+        ifPrimaryTerm = in.readVLong();
     }
 
     @Override
@@ -301,20 +292,10 @@ public class DeleteRequest extends ReplicatedWriteRequest<DeleteRequest>
         out.writeString(type());
         out.writeString(id);
         out.writeOptionalString(routing());
-        if (out.getVersion().before(Version.V_7_0_0)) {
-            out.writeOptionalString(null); // _parent
-        }
         out.writeLong(version);
         out.writeByte(versionType.getValue());
-        if (out.getVersion().onOrAfter(Version.V_6_6_0)) {
-            out.writeZLong(ifSeqNo);
-            out.writeVLong(ifPrimaryTerm);
-        } else if (ifSeqNo != UNASSIGNED_SEQ_NO || ifPrimaryTerm != UNASSIGNED_PRIMARY_TERM) {
-            assert false : "setIfMatch [" + ifSeqNo + "], currentDocTem [" + ifPrimaryTerm + "]";
-            throw new IllegalStateException(
-                "sequence number based compare and write is not supported until all nodes are on version 7.0 or higher. " +
-                    "Stream version [" + out.getVersion() + "]");
-        }
+        out.writeZLong(ifSeqNo);
+        out.writeVLong(ifPrimaryTerm);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.fieldcaps;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -67,20 +66,14 @@ public class FieldCapabilitiesIndexRequest
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         fields = in.readStringArray();
-        if (in.getVersion().onOrAfter(Version.V_6_2_0)) {
-            originalIndices = OriginalIndices.readOriginalIndices(in);
-        } else {
-            originalIndices = OriginalIndices.NONE;
-        }
+        originalIndices = OriginalIndices.readOriginalIndices(in);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeStringArray(fields);
-        if (out.getVersion().onOrAfter(Version.V_6_2_0)) {
-            OriginalIndices.writeOriginalIndices(originalIndices, out);
-        }
+        OriginalIndices.writeOriginalIndices(originalIndices, out);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.get;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
@@ -194,9 +193,6 @@ public class MultiGetRequest extends ActionRequest
             type = in.readOptionalString();
             id = in.readString();
             routing = in.readOptionalString();
-            if (in.getVersion().before(Version.V_7_0_0)) {
-                in.readOptionalString(); // _parent
-            }
             storedFields = in.readOptionalStringArray();
             version = in.readLong();
             versionType = VersionType.fromValue(in.readByte());
@@ -210,9 +206,6 @@ public class MultiGetRequest extends ActionRequest
             out.writeOptionalString(type);
             out.writeString(id);
             out.writeOptionalString(routing);
-            if (out.getVersion().before(Version.V_7_0_0)) {
-                out.writeOptionalString(null); // _parent
-            }
             out.writeOptionalStringArray(storedFields);
             out.writeLong(version);
             out.writeByte(versionType.getValue());

--- a/server/src/main/java/org/elasticsearch/action/ingest/WriteableIngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/WriteableIngestDocument.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.ingest;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,9 +31,7 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.IngestDocument.MetaData;
 
 import java.io.IOException;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -112,12 +109,6 @@ final class WriteableIngestDocument implements Writeable, ToXContentFragment {
     WriteableIngestDocument(StreamInput in) throws IOException {
         Map<String, Object> sourceAndMetadata = in.readMap();
         Map<String, Object> ingestMetadata = in.readMap();
-        if (in.getVersion().before(Version.V_6_0_0_beta1)) {
-            ingestMetadata.computeIfPresent("timestamp", (k, o) -> {
-                Date date = (Date) o;
-                return date.toInstant().atZone(ZoneId.systemDefault());
-            });
-        }
         this.ingestDocument = new IngestDocument(sourceAndMetadata, ingestMetadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/main/MainResponse.java
@@ -82,9 +82,6 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         clusterName.writeTo(out);
         out.writeString(clusterUuid);
         Build.writeBuild(build, out);
-        if (out.getVersion().before(Version.V_7_0_0)) {
-            out.writeBoolean(true);
-        }
     }
 
     @Override
@@ -95,9 +92,6 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         clusterName = new ClusterName(in);
         clusterUuid = in.readString();
         build = Build.readBuild(in);
-        if (in.getVersion().before(Version.V_7_0_0)) {
-            in.readBoolean();
-        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
@@ -68,14 +68,6 @@ public final class ResyncReplicationRequest extends ReplicatedWriteRequest<Resyn
     public void readFrom(final StreamInput in) throws IOException {
         //  TODO: https://github.com/elastic/elasticsearch/issues/38556
         //assert Version.CURRENT.major <= 7;
-        if (in.getVersion().equals(Version.V_6_0_0)) {
-            /*
-             * Resync replication request serialization was broken in 6.0.0 due to the elements of the stream not being prefixed with a
-             * byte indicating the type of the operation.
-             */
-            // TODO: remove this check in 8.0.0 which provides no BWC guarantees with 6.x.
-            throw new IllegalStateException("resync replication request serialization is broken in 6.0.0");
-        }
         super.readFrom(in);
         if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
             trimAboveSeqNo = in.readZLong();

--- a/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -116,12 +116,12 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
 
     @Override
     protected WritePrimaryResult<ResyncReplicationRequest, ResyncReplicationResponse> shardOperationOnPrimary(
-        ResyncReplicationRequest request, IndexShard primary) throws Exception {
-        final ResyncReplicationRequest replicaRequest = performOnPrimary(request, primary);
+        ResyncReplicationRequest request, IndexShard primary) {
+        final ResyncReplicationRequest replicaRequest = performOnPrimary(request);
         return new WritePrimaryResult<>(replicaRequest, new ResyncReplicationResponse(), null, null, primary, logger);
     }
 
-    public static ResyncReplicationRequest performOnPrimary(ResyncReplicationRequest request, IndexShard primary) {
+    public static ResyncReplicationRequest performOnPrimary(ResyncReplicationRequest request) {
         return request;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.search;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
@@ -170,9 +169,7 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
         for (int i = 0; i < items.length; i++) {
             items[i] = Item.readItem(in);
         }
-        if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
-            tookInMillis = in.readVLong();
-        }
+        tookInMillis = in.readVLong();
     }
 
     @Override
@@ -182,9 +179,7 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
         for (Item item : items) {
             item.writeTo(out);
         }
-        if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-            out.writeVLong(tookInMillis);
-        }
+        out.writeVLong(tookInMillis);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ResizeAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ResizeAllocationDecider.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cluster.routing.allocation.decider;
 
-import org.elasticsearch.action.admin.indices.shrink.ResizeAction;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNode;
@@ -64,9 +63,6 @@ public class ResizeAllocationDecider extends AllocationDecider {
                 return allocation.decision(Decision.NO, NAME, "source primary shard [%s] is not active", shardId);
             }
             if (node != null) { // we might get called from the 2 param canAllocate method..
-                if (node.node().getVersion().before(ResizeAction.COMPATIBILITY_VERSION)) {
-                    return allocation.decision(Decision.NO, NAME, "node [%s] is too old to split a shard", node.nodeId());
-                }
                 if (sourceShardRouting.currentNodeId().equals(node.nodeId())) {
                     return allocation.decision(Decision.YES, NAME, "source primary is allocated on this node");
                 } else {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
@@ -20,15 +20,11 @@
 package org.elasticsearch.action.admin.indices.get;
 
 import org.apache.lucene.util.CollectionUtil;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesResponseTests;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponseTests;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -36,31 +32,15 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.RandomCreateIndexGenerator;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.test.AbstractStreamableXContentTestCase;
-import org.junit.Assert;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
 
-import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
-import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
-import static org.elasticsearch.index.IndexSettings.INDEX_REFRESH_INTERVAL_SETTING;
-
 public class GetIndexResponseTests extends AbstractStreamableXContentTestCase<GetIndexResponse> {
-
-    /**
-     * The following byte response was generated from the v6.3.0 tag
-     */
-    private static final String TEST_6_3_0_RESPONSE_BYTES =
-        "AQhteV9pbmRleAEIbXlfaW5kZXgBA2RvYwNkb2OePID6KURGTACqVkrLTM1JiTdUsqpWKqksSFWyUiouKcrMS1eqrQUAAAD//" +
-            "wMAAAABCG15X2luZGV4AgZhbGlhczEAAQJyMQECcjEGYWxpYXMyAX8jNXYiREZMAKpWKkktylWyqlaqTE0sUrIyMjA0q60FAAAA//" +
-            "8DAAAAAQhteV9pbmRleAIYaW5kZXgubnVtYmVyX29mX3JlcGxpY2FzAAExFmluZGV4Lm51bWJlcl9vZl9zaGFyZHMAATI=";
-    private static final GetIndexResponse TEST_6_3_0_RESPONSE_INSTANCE = getExpectedTest630Response();
 
     @Override
     protected GetIndexResponse doParseInstance(XContentParser parser) throws IOException {
@@ -113,86 +93,6 @@ public class GetIndexResponseTests extends AbstractStreamableXContentTestCase<Ge
         return
             f -> f.equals("") || f.contains(".settings") || f.contains(".defaults") || f.contains(".mappings") ||
             f.contains(".aliases");
-    }
-
-    private static ImmutableOpenMap<String, List<AliasMetaData>> getTestAliases(String indexName) {
-        ImmutableOpenMap.Builder<String, List<AliasMetaData>> aliases = ImmutableOpenMap.builder();
-        List<AliasMetaData> indexAliases = new ArrayList<>();
-        indexAliases.add(new AliasMetaData.Builder("alias1").routing("r1").build());
-        indexAliases.add(new AliasMetaData.Builder("alias2").filter("{\"term\": {\"year\": 2016}}").build());
-        aliases.put(indexName, Collections.unmodifiableList(indexAliases));
-        return aliases.build();
-    }
-
-    private static ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> getTestMappings(String indexName) {
-        ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetaData>> mappings = ImmutableOpenMap.builder();
-        ImmutableOpenMap.Builder<String, MappingMetaData> indexMappings = ImmutableOpenMap.builder();
-        try {
-            indexMappings.put(
-                "doc",
-                new MappingMetaData("doc",
-                    Collections.singletonMap("field_1", Collections.singletonMap("type", "string"))
-                )
-            );
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-        mappings.put(indexName, indexMappings.build());
-        return mappings.build();
-    }
-
-    private static ImmutableOpenMap<String, Settings> getTestSettings(String indexName) {
-        ImmutableOpenMap.Builder<String, Settings> settings = ImmutableOpenMap.builder();
-        Settings.Builder indexSettings = Settings.builder();
-        indexSettings.put(SETTING_NUMBER_OF_SHARDS, 2);
-        indexSettings.put(SETTING_NUMBER_OF_REPLICAS, 1);
-        settings.put(indexName, indexSettings.build());
-        return settings.build();
-    }
-
-    private static GetIndexResponse getExpectedTest630Response() {
-        // The only difference between this snippet and the one used for generation TEST_6_3_0_RESPONSE_BYTES is the
-        // constructor for GetIndexResponse which also takes defaultSettings now.
-        String indexName = "my_index";
-        String indices[] = { indexName };
-        return
-            new GetIndexResponse(
-                indices, getTestMappings(indexName), getTestAliases(indexName), getTestSettings(indexName),
-                ImmutableOpenMap.of()
-            );
-    }
-
-    private static GetIndexResponse getResponseWithDefaultSettings() {
-        String indexName = "my_index";
-        String indices[] = { indexName };
-        ImmutableOpenMap.Builder<String, Settings> defaultSettings = ImmutableOpenMap.builder();
-        Settings.Builder indexDefaultSettings = Settings.builder();
-        indexDefaultSettings.put(INDEX_REFRESH_INTERVAL_SETTING.getKey(), "1s");
-        defaultSettings.put(indexName, indexDefaultSettings.build());
-        return
-            new GetIndexResponse(
-                indices, getTestMappings(indexName), getTestAliases(indexName), getTestSettings(indexName),
-                defaultSettings.build()
-            );
-    }
-
-    public void testCanDecode622Response() throws IOException {
-        StreamInput si = StreamInput.wrap(Base64.getDecoder().decode(TEST_6_3_0_RESPONSE_BYTES));
-        si.setVersion(Version.V_6_3_0);
-        GetIndexResponse response = new GetIndexResponse();
-        response.readFrom(si);
-
-        Assert.assertEquals(TEST_6_3_0_RESPONSE_INSTANCE, response);
-    }
-
-    public void testCanOutput622Response() throws IOException {
-        GetIndexResponse responseWithExtraFields = getResponseWithDefaultSettings();
-        BytesStreamOutput bso = new BytesStreamOutput();
-        bso.setVersion(Version.V_6_3_0);
-        responseWithExtraFields.writeTo(bso);
-        String base64OfResponse = Base64.getEncoder().encodeToString(BytesReference.toBytes(bso.bytes()));
-
-        Assert.assertEquals(TEST_6_3_0_RESPONSE_BYTES, base64OfResponse);
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -897,7 +897,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
     private TransportWriteAction.WritePrimaryResult<ResyncReplicationRequest, ResyncReplicationResponse> executeResyncOnPrimary(
         IndexShard primary, ResyncReplicationRequest request) throws Exception {
         final TransportWriteAction.WritePrimaryResult<ResyncReplicationRequest, ResyncReplicationResponse> result =
-            new TransportWriteAction.WritePrimaryResult<>(TransportResyncReplicationAction.performOnPrimary(request, primary),
+            new TransportWriteAction.WritePrimaryResult<>(TransportResyncReplicationAction.performOnPrimary(request),
                 new ResyncReplicationResponse(), null, null, primary, logger);
         TransportWriteActionTestHelper.performPostWriteActions(primary, request, result.location, logger);
         return result;


### PR DESCRIPTION
* We only support 7.0+ now in 8.0 => all BwC serialization logic pertaining to 6.x and older is dead code
