### PR TITLE
[ML] changing bwc serialization versions after backports

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/AggProvider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/AggProvider.java
@@ -68,7 +68,7 @@ class AggProvider implements Writeable, ToXContentObject {
     }
 
     static AggProvider fromStream(StreamInput in) throws IOException {
-        if (in.getVersion().onOrAfter(Version.CURRENT)) { // Has our bug fix for query/agg providers
+        if (in.getVersion().onOrAfter(Version.V_6_7_0)) { // Has our bug fix for query/agg providers
             return new AggProvider(in.readMap(), in.readOptionalWriteable(AggregatorFactories.Builder::new), in.readException());
         } else if (in.getVersion().onOrAfter(Version.V_6_6_0)) { // Has the bug, but supports lazy objects
             return new AggProvider(in.readMap(), null, null);
@@ -91,7 +91,7 @@ class AggProvider implements Writeable, ToXContentObject {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(Version.CURRENT)) { // Has our bug fix for query/agg providers
+        if (out.getVersion().onOrAfter(Version.V_6_7_0)) { // Has our bug fix for query/agg providers
             out.writeMap(aggs);
             out.writeOptionalWriteable(parsedAggs);
             out.writeException(parsingException);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -311,7 +311,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
      */
     public List<String> getQueryDeprecations(NamedXContentRegistry namedXContentRegistry) {
         List<String> deprecations = new ArrayList<>();
-        parseAggregations(namedXContentRegistry, deprecations);
+        parseQuery(namedXContentRegistry, deprecations);
         return deprecations;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
@@ -120,7 +120,7 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
                 in.readStringList();
             }
         }
-        if (in.getVersion().before(Version.V_7_1_0)) {
+        if (in.getVersion().before(Version.V_7_0_0)) {
             this.queryProvider = QueryProvider.fromParsedQuery(in.readOptionalNamedWriteable(QueryBuilder.class));
             this.aggProvider = AggProvider.fromParsedAggs(in.readOptionalWriteable(AggregatorFactories.Builder::new));
         } else {
@@ -166,7 +166,7 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
             out.writeBoolean(true);
             out.writeStringCollection(Collections.emptyList());
         }
-        if (out.getVersion().before(Version.V_7_1_0)) {
+        if (out.getVersion().before(Version.V_7_0_0)) {
             out.writeOptionalNamedWriteable(queryProvider == null ? null : queryProvider.getParsedQuery());
             out.writeOptionalWriteable(aggProvider == null ? null : aggProvider.getParsedAggs());
         } else {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/QueryProvider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/QueryProvider.java
@@ -74,7 +74,7 @@ class QueryProvider implements Writeable, ToXContentObject {
     }
 
     static QueryProvider fromStream(StreamInput in) throws IOException {
-        if (in.getVersion().onOrAfter(Version.CURRENT)) { // Has our bug fix for query/agg providers
+        if (in.getVersion().onOrAfter(Version.V_6_7_0)) { // Has our bug fix for query/agg providers
             return new QueryProvider(in.readMap(), in.readOptionalNamedWriteable(QueryBuilder.class), in.readException());
         } else if (in.getVersion().onOrAfter(Version.V_6_6_0)) { // Has the bug, but supports lazy objects
             return new QueryProvider(in.readMap(), null, null);
@@ -95,7 +95,7 @@ class QueryProvider implements Writeable, ToXContentObject {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(Version.CURRENT)) { // Has our bug fix for query/agg providers
+        if (out.getVersion().onOrAfter(Version.V_6_7_0)) { // Has our bug fix for query/agg providers
             out.writeMap(query);
             out.writeOptionalNamedWriteable(parsedQuery);
             out.writeException(parsingException);

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/40_ml_datafeed_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/40_ml_datafeed_crud.yml
@@ -1,8 +1,5 @@
 ---
 "Test old cluster datafeed":
-  - skip:
-      reason: "Skip past versions until #39776 backported"
-      version: "all"
   - do:
       ml.get_datafeeds:
         datafeed_id: old-cluster-datafeed
@@ -18,9 +15,6 @@
 
 ---
 "Put job and datafeed in mixed cluster":
-  - skip:
-      reason: "Skip past versions until #39776 backported"
-      version: "all"
   - do:
       ml.put_job:
         job_id: mixed-cluster-datafeed-job

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/40_ml_datafeed_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/40_ml_datafeed_crud.yml
@@ -1,8 +1,5 @@
 ---
 "Put job and datafeed in old cluster":
-  - skip:
-      reason: "Skip past versions until #39776 backported"
-      version: "all"
   - do:
       ml.put_job:
         job_id: old-cluster-datafeed-job

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/40_ml_datafeed_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/40_ml_datafeed_crud.yml
@@ -17,9 +17,6 @@ setup:
 
 ---
 "Test old and mixed cluster datafeeds":
-  - skip:
-      reason: "Skip past versions until #39776 backported"
-      version: "all"
   - do:
       ml.get_datafeeds:
         datafeed_id: old-cluster-datafeed


### PR DESCRIPTION
This addresses the bwc supported version after all the backports were merged and re-enables bwc tests for ML datafeeds. 