### PR TITLE
[ML] Correct small inconsistencies in ml APIs spec and docs 

### DIFF
--- a/docs/reference/ml/apis/eventresource.asciidoc
+++ b/docs/reference/ml/apis/eventresource.asciidoc
@@ -13,15 +13,15 @@ An events resource has the following properties:
   (string) A description of the scheduled event.
 
 `end_time`::
-  (string) The timestamp for the end of the scheduled event. The datetime string
-  is in ISO 8601 format.
+  (date) The timestamp for the end of the scheduled event
+  in milliseconds since the epoch or ISO 8601 format.
 
 `event_id`::
   (string) An automatically-generated identifier for the scheduled event.
 
 `start_time`::
- (string) The timestamp for the beginning of the scheduled event. The datetime
- string is in ISO 8601 format.
+ (date) The timestamp for the beginning of the scheduled event
+ in milliseconds since the epoch or ISO 8601 format.
 
 For more information, see
 {xpack-ref}/ml-calendars.html[Calendars and Scheduled Events].

--- a/docs/reference/ml/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/apis/get-calendar.asciidoc
@@ -30,6 +30,7 @@ You can get information for a single calendar or for all calendars by using
 
 ==== Request Body
 
+`page`::
 `from`:::
     (integer) Skips the specified number of calendars.
 

--- a/docs/reference/ml/apis/post-calendar-event.asciidoc
+++ b/docs/reference/ml/apis/post-calendar-event.asciidoc
@@ -27,7 +27,9 @@ of which must have a start time, end time, and description.
 ==== Request Body
 
 `events`::
-  (array) A list of one of more scheduled events. See <<ml-event-resource>>.
+  (array) A list of one of more scheduled events. The event's start and end times
+  may be specified as integer milliseconds since the epoch or as a string in ISO 8601
+  format. See <<ml-event-resource>>.
 
 
 ==== Authorization

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestDeleteForecastAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestDeleteForecastAction.java
@@ -36,6 +36,9 @@ public class RestDeleteForecastAction extends BaseRestHandler {
                 "}/_forecast/{" + Forecast.FORECAST_ID.getPreferredName() + "}", this,
             DELETE, MachineLearning.PRE_V7_BASE_PATH + "anomaly_detectors/{" + Job.ID.getPreferredName() +
                 "}/_forecast/{" + Forecast.FORECAST_ID.getPreferredName() + "}", deprecationLogger);
+        controller.registerHandler(
+                DELETE, MachineLearning.BASE_PATH + "anomaly_detectors/{" + Job.ID.getPreferredName() +
+                        "}/_forecast/", this);
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_calendars.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_calendars.json
@@ -24,6 +24,8 @@
         }
       }
     },
-    "body": null
+    "body": {
+      "description": "The from and size parameters optionally sent in the body"
+    }
   }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/calendar_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/calendar_crud.yml
@@ -127,6 +127,20 @@
   - length: { calendars: 1}
   - match: { calendars.0.calendar_id: calendar2 }
 
+  - do:
+      ml.get_calendars:
+        body: >
+          {
+            "page": {
+              "from": 1,
+              "size": 2
+            }
+          }
+  - match: { count: 3 }
+  - length: { calendars: 2}
+  - match: { calendars.0.calendar_id: calendar2 }
+  - match: { calendars.1.calendar_id: calendar3 }
+
 ---
 "Test PageParams with ID is invalid":
   - do:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_forecast.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_forecast.yml
@@ -137,3 +137,11 @@ setup:
         forecast_id: _all
         allow_no_forecasts: true
   - match: { acknowledged: true }
+
+---
+"Test delete all where no forecast_id is set":
+  - do:
+      ml.delete_forecast:
+        job_id: delete-forecast-job
+        allow_no_forecasts: true
+  - match: { acknowledged: true }


### PR DESCRIPTION
Backport of #39801 

Closes #39677

- ml.get_calendars accepts POST requests with a body but in the rest spec body was null which makes the language clients think that is not the case.
- Correct the docs for ml.get_calendars using page parameters in the body.

Closes #39673 by registering the missing URL for delete forecast where the forecast id is not specified.
Closes #39676 with a doc change in eventresource.asciidoc.