### PR TITLE
SQL: Wrap ZonedDateTime parameters inside scripts

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/whitelist/InternalSqlScriptUtils.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/whitelist/InternalSqlScriptUtils.java
@@ -348,7 +348,7 @@ public final class InternalSqlScriptUtils {
     public static ZonedDateTime asDateTime(Object dateTime) {
         return (ZonedDateTime) asDateTime(dateTime, false);
     }
-    
+
     private static Object asDateTime(Object dateTime, boolean lenient) {
         if (dateTime == null) {
             return null;
@@ -363,7 +363,10 @@ public final class InternalSqlScriptUtils {
             if (dateTime instanceof Number) {
                 return DateUtils.asDateTime(((Number) dateTime).longValue());
             }
-    
+
+            if (dateTime instanceof String) {
+                return DateUtils.asDateTime(dateTime.toString());
+            }
             throw new SqlIllegalArgumentException("Invalid date encountered [{}]", dateTime);
         }
         return dateTime;


### PR DESCRIPTION
Painless allows ZonedDateTime objects to be passed natively to scripts
which creates problematic translate queries as the ZonedDateTime is
passed as a string instead.
Wrap this with a dedicated method to perform the conversion.

Fix #39877