### PR TITLE
[ML-DataFrame] change internal index to index doc_type, id, source and dest

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameField.java
@@ -24,6 +24,8 @@ public final class DataFrameField {
     public static final ParseField WAIT_FOR_COMPLETION = new ParseField("wait_for_completion");
     public static final ParseField STATS_FIELD = new ParseField("stats");
     public static final ParseField INDEX_DOC_TYPE = new ParseField("doc_type");
+    public static final ParseField SOURCE = new ParseField("source");
+    public static final ParseField DESTINATION = new ParseField("dest");
 
     // common strings
     public static final String TASK_NAME = "data_frame/transforms";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/PreviewDataFrameTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/PreviewDataFrameTransformAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
 
 import java.io.IOException;
@@ -58,7 +59,7 @@ public class PreviewDataFrameTransformAction extends Action<PreviewDataFrameTran
         public static Request fromXContent(final XContentParser parser) throws IOException {
             Map<String, Object> content = parser.map();
             // Destination and ID are not required for Preview, so we just supply our own
-            content.put(DataFrameTransformConfig.DESTINATION.getPreferredName(), "unused-transform-preview-index");
+            content.put(DataFrameField.DESTINATION.getPreferredName(), "unused-transform-preview-index");
             try(XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(content);
                 XContentParser newParser = XContentType.JSON
                     .xContent()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformConfig.java
@@ -38,8 +38,6 @@ public class DataFrameTransformConfig extends AbstractDiffable<DataFrameTransfor
 
     private static final String NAME = "data_frame_transform_config";
     public static final ParseField HEADERS = new ParseField("headers");
-    public static final ParseField SOURCE = new ParseField("source");
-    public static final ParseField DESTINATION = new ParseField("dest");
     public static final ParseField QUERY = new ParseField("query");
 
     // types of transforms
@@ -99,8 +97,8 @@ public class DataFrameTransformConfig extends AbstractDiffable<DataFrameTransfor
                 });
 
         parser.declareString(optionalConstructorArg(), DataFrameField.ID);
-        parser.declareString(constructorArg(), SOURCE);
-        parser.declareString(constructorArg(), DESTINATION);
+        parser.declareString(constructorArg(), DataFrameField.SOURCE);
+        parser.declareString(constructorArg(), DataFrameField.DESTINATION);
 
         parser.declareString(optionalConstructorArg(), DataFrameField.INDEX_DOC_TYPE);
         parser.declareObject(optionalConstructorArg(), (p, c) -> p.mapStrings(), HEADERS);
@@ -121,8 +119,8 @@ public class DataFrameTransformConfig extends AbstractDiffable<DataFrameTransfor
                                     final QueryConfig queryConfig,
                                     final PivotConfig pivotConfig) {
         this.id = ExceptionsHelper.requireNonNull(id, DataFrameField.ID.getPreferredName());
-        this.source = ExceptionsHelper.requireNonNull(source, SOURCE.getPreferredName());
-        this.dest = ExceptionsHelper.requireNonNull(dest, DESTINATION.getPreferredName());
+        this.source = ExceptionsHelper.requireNonNull(source, DataFrameField.SOURCE.getPreferredName());
+        this.dest = ExceptionsHelper.requireNonNull(dest, DataFrameField.DESTINATION.getPreferredName());
         this.queryConfig = ExceptionsHelper.requireNonNull(queryConfig, QUERY.getPreferredName());
         this.setHeaders(headers == null ? Collections.emptyMap() : headers);
         this.pivotConfig = pivotConfig;
@@ -197,8 +195,8 @@ public class DataFrameTransformConfig extends AbstractDiffable<DataFrameTransfor
     public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
         builder.startObject();
         builder.field(DataFrameField.ID.getPreferredName(), id);
-        builder.field(SOURCE.getPreferredName(), source);
-        builder.field(DESTINATION.getPreferredName(), dest);
+        builder.field(DataFrameField.SOURCE.getPreferredName(), source);
+        builder.field(DataFrameField.DESTINATION.getPreferredName(), dest);
         if (queryConfig != null) {
             builder.field(QUERY.getPreferredName(), queryConfig);
         }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameInternalIndex.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameInternalIndex.java
@@ -29,7 +29,6 @@ public final class DataFrameInternalIndex {
     public static final String INDEX_NAME = INDEX_TEMPLATE_NAME;
 
     // constants for mappings
-    public static final String ENABLED = "enabled";
     public static final String DYNAMIC = "dynamic";
     public static final String PROPERTIES = "properties";
     public static final String TYPE = "type";
@@ -58,10 +57,8 @@ public final class DataFrameInternalIndex {
         builder.startObject(MapperService.SINGLE_MAPPING_NAME);
         addMetaInformation(builder);
 
-        // no need to analyze anything, we use the config index as key value store, revisit if we decide to search on it
-        builder.field(ENABLED, false);
         // do not allow anything outside of the defined schema
-        builder.field(DYNAMIC, "strict");
+        builder.field(DYNAMIC, "false");
         // the schema definitions
         builder.startObject(PROPERTIES);
         // overall doc type
@@ -81,6 +78,12 @@ public final class DataFrameInternalIndex {
     private static XContentBuilder addDataFrameTransformsConfigMappings(XContentBuilder builder) throws IOException {
         return builder
             .startObject(DataFrameField.ID.getPreferredName())
+                .field(TYPE, KEYWORD)
+            .endObject()
+            .startObject(DataFrameField.SOURCE.getPreferredName())
+                .field(TYPE, KEYWORD)
+            .endObject()
+            .startObject(DataFrameField.DESTINATION.getPreferredName())
                 .field(TYPE, KEYWORD)
             .endObject();
     }


### PR DESCRIPTION
change internal index to index doc_type, id, source and dest

Note: this is related to #39836 which requires this change in order to get delete by query to work. In addition it adds indexing of the source and dest fields.