### PR TITLE
[DOCS] Fixes breaking changes for low level client

### DIFF
--- a/docs/reference/migration/migrate_7_0/low_level_restclient.asciidoc
+++ b/docs/reference/migration/migrate_7_0/low_level_restclient.asciidoc
@@ -3,6 +3,13 @@
 === Low-level REST client changes
 
 [float]
+==== Support for `maxRetryTimeout` removed from RestClient
+
+`RestClient` and `RestClientBuilder` no longer support the `maxRetryTimeout`
+setting. The setting was removed as its counting mechanism was not accurate
+and caused issues while adding little value.
+
+[float]
 ==== Deprecated flavors of performRequest have been removed
 
 We deprecated the flavors of `performRequest` and `performRequestAsync` that

--- a/docs/reference/migration/migrate_7_0/restclient.asciidoc
+++ b/docs/reference/migration/migrate_7_0/restclient.asciidoc
@@ -21,12 +21,3 @@ The Cluster Health API used to default to `shards` level to ease migration
 from transport client that doesn't support the `level` parameter and always
 returns information including indices and shards details. The level default
 value has been aligned with the Elasticsearch default level: `cluster`.
-
-=== Low-level REST client changes
-
-[float]
-==== Support for `maxRetryTimeout` removed from RestClient
-
-`RestClient` and `RestClientBuilder` no longer support the `maxRetryTimeout`
-setting. The setting was removed as its counting mechanism was not accurate
-and caused issues while adding little value.


### PR DESCRIPTION
The Elasticsearch breaking changes contain a section that's not embedded properly:

![image](https://user-images.githubusercontent.com/26471269/54139877-b847ec00-43df-11e9-9ea1-464b362b94ac.png)

This was caused by an extra low-level REST client section that was missing the appropriate float attributes.  