### PR TITLE
[DOCS] Adds ML PRs to 6.6.2 release notes

### DIFF
--- a/docs/reference/release-notes/6.6.asciidoc
+++ b/docs/reference/release-notes/6.6.asciidoc
@@ -39,7 +39,9 @@ Features/Watcher::
 * Only flush Watcher's bulk processor if Watcher is enabled {pull}38803[#38803] (issue: {issue}38798[#38798])
 
 Machine Learning::
-* [ML] Stop the ML memory tracker before closing node {pull}39111[#39111] (issue: {issue}37117[#37117])
+* Stop the ML memory tracker before closing nodes {pull}39111[#39111] (issue: {issue}37117[#37117])
+* Fix an issue where interim results would be calculated after advancing time
+into an empty bucket {ml-pull}416[#416]
 
 SQL::
 * SQL: Fix merging of incompatible multi-fields {pull}39560[#39560] (issue: {issue}39547[#39547])

--- a/docs/reference/release-notes/6.6.asciidoc
+++ b/docs/reference/release-notes/6.6.asciidoc
@@ -41,7 +41,7 @@ Features/Watcher::
 Machine Learning::
 * Stop the ML memory tracker before closing nodes {pull}39111[#39111] (issue: {issue}37117[#37117])
 * Fix an issue where interim results would be calculated after advancing time
-into an empty bucket {ml-pull}416[#416]
+into an empty bucket {ml-pull}416[#416] (issue: {ml-issue}324[#324])
 
 SQL::
 * SQL: Fix merging of incompatible multi-fields {pull}39560[#39560] (issue: {issue}39547[#39547])


### PR DESCRIPTION
This PR adds 6.6.2 PRs from the ml-cpp repo (per https://github.com/elastic/ml-cpp/blob/6.6/docs/CHANGELOG.asciidoc) to the Elasticsearch 6.6.2 Release Notes.

