### PR TITLE
Migrate Streamable to writeable for index package backport(#37381)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
@@ -228,22 +228,22 @@ public class CommonStats implements Writeable, ToXContentFragment {
     }
 
     public CommonStats(StreamInput in) throws IOException {
-        docs = in.readOptionalStreamable(DocsStats::new);
-        store = in.readOptionalStreamable(StoreStats::new);
-        indexing = in.readOptionalStreamable(IndexingStats::new);
-        get = in.readOptionalStreamable(GetStats::new);
+        docs = in.readOptionalWriteable(DocsStats::new);
+        store = in.readOptionalWriteable(StoreStats::new);
+        indexing = in.readOptionalWriteable(IndexingStats::new);
+        get = in.readOptionalWriteable(GetStats::new);
         search = in.readOptionalWriteable(SearchStats::new);
-        merge = in.readOptionalStreamable(MergeStats::new);
-        refresh =  in.readOptionalStreamable(RefreshStats::new);
-        flush =  in.readOptionalStreamable(FlushStats::new);
-        warmer =  in.readOptionalStreamable(WarmerStats::new);
-        queryCache = in.readOptionalStreamable(QueryCacheStats::new);
-        fieldData =  in.readOptionalStreamable(FieldDataStats::new);
-        completion =  in.readOptionalStreamable(CompletionStats::new);
-        segments =  in.readOptionalStreamable(SegmentsStats::new);
-        translog = in.readOptionalStreamable(TranslogStats::new);
-        requestCache = in.readOptionalStreamable(RequestCacheStats::new);
-        recoveryStats = in.readOptionalStreamable(RecoveryStats::new);
+        merge = in.readOptionalWriteable(MergeStats::new);
+        refresh = in.readOptionalWriteable(RefreshStats::new);
+        flush = in.readOptionalWriteable(FlushStats::new);
+        warmer = in.readOptionalWriteable(WarmerStats::new);
+        queryCache = in.readOptionalWriteable(QueryCacheStats::new);
+        fieldData = in.readOptionalWriteable(FieldDataStats::new);
+        completion = in.readOptionalWriteable(CompletionStats::new);
+        segments = in.readOptionalWriteable(SegmentsStats::new);
+        translog = in.readOptionalWriteable(TranslogStats::new);
+        requestCache = in.readOptionalWriteable(RequestCacheStats::new);
+        recoveryStats = in.readOptionalWriteable(RecoveryStats::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/cache/query/QueryCacheStats.java
+++ b/server/src/main/java/org/elasticsearch/index/cache/query/QueryCacheStats.java
@@ -23,6 +23,7 @@ import org.apache.lucene.search.DocIdSet;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -30,15 +31,23 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class QueryCacheStats implements Streamable, ToXContentFragment {
+public class QueryCacheStats implements Streamable, Writeable, ToXContentFragment {
 
-    long ramBytesUsed;
-    long hitCount;
-    long missCount;
-    long cacheCount;
-    long cacheSize;
+    private long ramBytesUsed;
+    private long hitCount;
+    private long missCount;
+    private long cacheCount;
+    private long cacheSize;
 
     public QueryCacheStats() {
+    }
+
+    public QueryCacheStats(StreamInput in) throws IOException {
+        ramBytesUsed = in.readLong();
+        hitCount = in.readLong();
+        missCount = in.readLong();
+        cacheCount = in.readLong();
+        cacheSize = in.readLong();
     }
 
     public QueryCacheStats(long ramBytesUsed, long hitCount, long missCount, long cacheCount, long cacheSize) {
@@ -109,11 +118,7 @@ public class QueryCacheStats implements Streamable, ToXContentFragment {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        ramBytesUsed = in.readLong();
-        hitCount = in.readLong();
-        missCount = in.readLong();
-        cacheCount = in.readLong();
-        cacheSize = in.readLong();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/cache/request/RequestCacheStats.java
+++ b/server/src/main/java/org/elasticsearch/index/cache/request/RequestCacheStats.java
@@ -22,21 +22,28 @@ package org.elasticsearch.index.cache.request;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class RequestCacheStats implements Streamable, ToXContentFragment {
+public class RequestCacheStats implements Streamable, Writeable, ToXContentFragment {
 
-    long memorySize;
-    long evictions;
-    long hitCount;
-    long missCount;
+    private long memorySize;
+    private long evictions;
+    private long hitCount;
+    private long missCount;
 
     public RequestCacheStats() {
+    }
+
+    public RequestCacheStats(StreamInput in) throws IOException {
+        memorySize = in.readVLong();
+        evictions = in.readVLong();
+        hitCount = in.readVLong();
+        missCount = in.readVLong();
     }
 
     public RequestCacheStats(long memorySize, long evictions, long hitCount, long missCount) {
@@ -75,10 +82,7 @@ public class RequestCacheStats implements Streamable, ToXContentFragment {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        memorySize = in.readVLong();
-        evictions = in.readVLong();
-        hitCount = in.readVLong();
-        missCount = in.readVLong();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
@@ -20,20 +20,19 @@
 package org.elasticsearch.index.engine;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Iterator;
 
-public class SegmentsStats implements Streamable, ToXContentFragment {
+public class SegmentsStats implements Streamable, Writeable, ToXContentFragment {
 
     private long count;
     private long memoryInBytes;
@@ -78,6 +77,30 @@ public class SegmentsStats implements Streamable, ToXContentFragment {
             .build();
 
     public SegmentsStats() {}
+
+    public SegmentsStats(StreamInput in) throws IOException {
+        count = in.readVLong();
+        memoryInBytes = in.readLong();
+        termsMemoryInBytes = in.readLong();
+        storedFieldsMemoryInBytes = in.readLong();
+        termVectorsMemoryInBytes = in.readLong();
+        normsMemoryInBytes = in.readLong();
+        pointsMemoryInBytes = in.readLong();
+        docValuesMemoryInBytes = in.readLong();
+        indexWriterMemoryInBytes = in.readLong();
+        versionMapMemoryInBytes = in.readLong();
+        bitsetMemoryInBytes = in.readLong();
+        maxUnsafeAutoIdTimestamp = in.readLong();
+
+        int size = in.readVInt();
+        ImmutableOpenMap.Builder<String, Long> map = ImmutableOpenMap.builder(size);
+        for (int i = 0; i < size; i++) {
+            String key = in.readString();
+            Long value = in.readLong();
+            map.put(key, value);
+        }
+        fileSizes = map.build();
+    }
 
     public void add(long count, long memoryInBytes) {
         this.count += count;
@@ -347,27 +370,7 @@ public class SegmentsStats implements Streamable, ToXContentFragment {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        count = in.readVLong();
-        memoryInBytes = in.readLong();
-        termsMemoryInBytes = in.readLong();
-        storedFieldsMemoryInBytes = in.readLong();
-        termVectorsMemoryInBytes = in.readLong();
-        normsMemoryInBytes = in.readLong();
-        pointsMemoryInBytes = in.readLong();
-        docValuesMemoryInBytes = in.readLong();
-        indexWriterMemoryInBytes = in.readLong();
-        versionMapMemoryInBytes = in.readLong();
-        bitsetMemoryInBytes = in.readLong();
-        maxUnsafeAutoIdTimestamp = in.readLong();
-
-        int size = in.readVInt();
-        ImmutableOpenMap.Builder<String, Long> map = ImmutableOpenMap.builder(size);
-        for (int i = 0; i < size; i++) {
-            String key = in.readString();
-            Long value = in.readLong();
-            map.put(key, value);
-        }
-        fileSizes = map.build();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -31,20 +32,26 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Objects;
 
-public class FieldDataStats implements Streamable, ToXContentFragment {
+public class FieldDataStats implements Streamable, Writeable, ToXContentFragment {
 
     private static final String FIELDDATA = "fielddata";
     private static final String MEMORY_SIZE = "memory_size";
     private static final String MEMORY_SIZE_IN_BYTES = "memory_size_in_bytes";
     private static final String EVICTIONS = "evictions";
     private static final String FIELDS = "fields";
-    long memorySize;
-    long evictions;
+    private long memorySize;
+    private long evictions;
     @Nullable
-    FieldMemoryStats fields;
+    private FieldMemoryStats fields;
 
     public FieldDataStats() {
 
+    }
+
+    public FieldDataStats(StreamInput in) throws IOException {
+        memorySize = in.readVLong();
+        evictions = in.readVLong();
+        fields = in.readOptionalWriteable(FieldMemoryStats::new);
     }
 
     public FieldDataStats(long memorySize, long evictions, @Nullable FieldMemoryStats fields) {
@@ -84,9 +91,7 @@ public class FieldDataStats implements Streamable, ToXContentFragment {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        memorySize = in.readVLong();
-        evictions = in.readVLong();
-        fields = in.readOptionalWriteable(FieldMemoryStats::new);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/flush/FlushStats.java
+++ b/server/src/main/java/org/elasticsearch/index/flush/FlushStats.java
@@ -23,13 +23,14 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class FlushStats implements Streamable, ToXContentFragment {
+public class FlushStats implements Streamable, Writeable, ToXContentFragment {
 
     private long total;
     private long periodic;
@@ -37,6 +38,14 @@ public class FlushStats implements Streamable, ToXContentFragment {
 
     public FlushStats() {
 
+    }
+
+    public FlushStats(StreamInput in) throws IOException {
+        total = in.readVLong();
+        totalTimeInMillis = in.readVLong();
+        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
+            periodic = in.readVLong();
+        }
     }
 
     public FlushStats(long total, long periodic, long totalTimeInMillis) {
@@ -112,11 +121,7 @@ public class FlushStats implements Streamable, ToXContentFragment {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        total = in.readVLong();
-        totalTimeInMillis = in.readVLong();
-        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
-            periodic = in.readVLong();
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/get/GetStats.java
+++ b/server/src/main/java/org/elasticsearch/index/get/GetStats.java
@@ -22,13 +22,14 @@ package org.elasticsearch.index.get;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class GetStats implements Streamable, ToXContentFragment {
+public class GetStats implements Streamable, Writeable, ToXContentFragment {
 
     private long existsCount;
     private long existsTimeInMillis;
@@ -37,6 +38,14 @@ public class GetStats implements Streamable, ToXContentFragment {
     private long current;
 
     public GetStats() {
+    }
+
+    public GetStats(StreamInput in) throws IOException {
+        existsCount = in.readVLong();
+        existsTimeInMillis = in.readVLong();
+        missingCount = in.readVLong();
+        missingTimeInMillis = in.readVLong();
+        current = in.readVLong();
     }
 
     public GetStats(long existsCount, long existsTimeInMillis, long missingCount, long missingTimeInMillis, long current) {
@@ -136,11 +145,7 @@ public class GetStats implements Streamable, ToXContentFragment {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        existsCount = in.readVLong();
-        existsTimeInMillis = in.readVLong();
-        missingCount = in.readVLong();
-        missingTimeInMillis = in.readVLong();
-        current = in.readVLong();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/merge/MergeStats.java
+++ b/server/src/main/java/org/elasticsearch/index/merge/MergeStats.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.merge;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -29,7 +30,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class MergeStats implements Streamable, ToXContentFragment {
+public class MergeStats implements Streamable, Writeable, ToXContentFragment {
 
     private long total;
     private long totalTimeInMillis;
@@ -49,6 +50,20 @@ public class MergeStats implements Streamable, ToXContentFragment {
 
     public MergeStats() {
 
+    }
+
+    public MergeStats(StreamInput in) throws IOException {
+        total = in.readVLong();
+        totalTimeInMillis = in.readVLong();
+        totalNumDocs = in.readVLong();
+        totalSizeInBytes = in.readVLong();
+        current = in.readVLong();
+        currentNumDocs = in.readVLong();
+        currentSizeInBytes = in.readVLong();
+        // Added in 2.0:
+        totalStoppedTimeInMillis = in.readVLong();
+        totalThrottledTimeInMillis = in.readVLong();
+        totalBytesPerSecAutoThrottle = in.readVLong();
     }
 
     public void add(long totalMerges, long totalMergeTime, long totalNumDocs, long totalSizeInBytes,
@@ -225,17 +240,7 @@ public class MergeStats implements Streamable, ToXContentFragment {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        total = in.readVLong();
-        totalTimeInMillis = in.readVLong();
-        totalNumDocs = in.readVLong();
-        totalSizeInBytes = in.readVLong();
-        current = in.readVLong();
-        currentNumDocs = in.readVLong();
-        currentSizeInBytes = in.readVLong();
-        // Added in 2.0:
-        totalStoppedTimeInMillis = in.readVLong();
-        totalThrottledTimeInMillis = in.readVLong();
-        totalBytesPerSecAutoThrottle = in.readVLong();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/recovery/RecoveryStats.java
+++ b/server/src/main/java/org/elasticsearch/index/recovery/RecoveryStats.java
@@ -21,8 +21,8 @@ package org.elasticsearch.index.recovery;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -34,13 +34,19 @@ import java.util.concurrent.atomic.AtomicLong;
  * Recovery related statistics, starting at the shard level and allowing aggregation to
  * indices and node level
  */
-public class RecoveryStats implements ToXContentFragment, Streamable {
+public class RecoveryStats implements ToXContentFragment, Writeable, Streamable {
 
     private final AtomicInteger currentAsSource = new AtomicInteger();
     private final AtomicInteger currentAsTarget = new AtomicInteger();
     private final AtomicLong throttleTimeInNanos = new AtomicLong();
 
     public RecoveryStats() {
+    }
+
+    public RecoveryStats(StreamInput in) throws IOException {
+        currentAsSource.set(in.readVInt());
+        currentAsTarget.set(in.readVInt());
+        throttleTimeInNanos.set(in.readLong());
     }
 
     public void add(RecoveryStats recoveryStats) {
@@ -108,12 +114,6 @@ public class RecoveryStats implements ToXContentFragment, Streamable {
         return builder;
     }
 
-    public static RecoveryStats readRecoveryStats(StreamInput in) throws IOException {
-        RecoveryStats stats = new RecoveryStats();
-        stats.readFrom(in);
-        return stats;
-    }
-
     static final class Fields {
         static final String RECOVERY = "recovery";
         static final String CURRENT_AS_SOURCE = "current_as_source";
@@ -124,9 +124,7 @@ public class RecoveryStats implements ToXContentFragment, Streamable {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        currentAsSource.set(in.readVInt());
-        currentAsTarget.set(in.readVInt());
-        throttleTimeInNanos.set(in.readLong());
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/refresh/RefreshStats.java
+++ b/server/src/main/java/org/elasticsearch/index/refresh/RefreshStats.java
@@ -22,15 +22,15 @@ package org.elasticsearch.index.refresh;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Objects;
 
-public class RefreshStats implements Streamable, ToXContentFragment {
+public class RefreshStats implements Streamable, Writeable, ToXContentFragment {
 
     private long total;
 
@@ -42,7 +42,12 @@ public class RefreshStats implements Streamable, ToXContentFragment {
     private int listeners;
 
     public RefreshStats() {
+    }
 
+    public RefreshStats(StreamInput in) throws IOException {
+        total = in.readVLong();
+        totalTimeInMillis = in.readVLong();
+        listeners = in.readVInt();
     }
 
     public RefreshStats(long total, long totalTimeInMillis, int listeners) {
@@ -104,9 +109,7 @@ public class RefreshStats implements Streamable, ToXContentFragment {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        total = in.readVLong();
-        totalTimeInMillis = in.readVLong();
-        listeners = in.readVInt();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/shard/DocsStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/DocsStats.java
@@ -23,20 +23,31 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.store.StoreStats;
 
 import java.io.IOException;
 
-public class DocsStats implements Streamable, ToXContentFragment {
+public class DocsStats implements Streamable, Writeable, ToXContentFragment {
 
-    long count = 0;
-    long deleted = 0;
-    long totalSizeInBytes = 0;
+    private long count = 0;
+    private long deleted = 0;
+    private long totalSizeInBytes = 0;
 
     public DocsStats() {
 
+    }
+
+    public DocsStats(StreamInput in) throws IOException {
+        count = in.readVLong();
+        deleted = in.readVLong();
+        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
+            totalSizeInBytes = in.readVLong();
+        } else {
+            totalSizeInBytes = -1;
+        }
     }
 
     public DocsStats(long count, long deleted, long totalSizeInBytes) {
@@ -84,13 +95,7 @@ public class DocsStats implements Streamable, ToXContentFragment {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        count = in.readVLong();
-        deleted = in.readVLong();
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-            totalSizeInBytes = in.readVLong();
-        } else {
-            totalSizeInBytes = -1;
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexingStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexingStats.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -32,9 +33,9 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class IndexingStats implements Streamable, ToXContentFragment {
+public class IndexingStats implements Streamable, Writeable, ToXContentFragment {
 
-    public static class Stats implements Streamable, ToXContentFragment {
+    public static class Stats implements Streamable, Writeable, ToXContentFragment {
 
         private long indexCount;
         private long indexTimeInMillis;
@@ -48,6 +49,19 @@ public class IndexingStats implements Streamable, ToXContentFragment {
         private boolean isThrottled;
 
         Stats() {}
+
+        public Stats(StreamInput in) throws IOException {
+            indexCount = in.readVLong();
+            indexTimeInMillis = in.readVLong();
+            indexCurrent = in.readVLong();
+            indexFailedCount = in.readVLong();
+            deleteCount = in.readVLong();
+            deleteTimeInMillis = in.readVLong();
+            deleteCurrent = in.readVLong();
+            noopUpdateCount = in.readVLong();
+            isThrottled = in.readBoolean();
+            throttleTimeInMillis = in.readLong();
+        }
 
         public Stats(long indexCount, long indexTimeInMillis, long indexCurrent, long indexFailedCount, long deleteCount,
                         long deleteTimeInMillis, long deleteCurrent, long noopUpdateCount, boolean isThrottled, long throttleTimeInMillis) {
@@ -133,24 +147,9 @@ public class IndexingStats implements Streamable, ToXContentFragment {
             return noopUpdateCount;
         }
 
-        public static Stats readStats(StreamInput in) throws IOException {
-            Stats stats = new Stats();
-            stats.readFrom(in);
-            return stats;
-        }
-
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            indexCount = in.readVLong();
-            indexTimeInMillis = in.readVLong();
-            indexCurrent = in.readVLong();
-            indexFailedCount = in.readVLong();
-            deleteCount = in.readVLong();
-            deleteTimeInMillis = in.readVLong();
-            deleteCurrent = in.readVLong();
-            noopUpdateCount = in.readVLong();
-            isThrottled = in.readBoolean();
-            throttleTimeInMillis = in.readLong();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -187,13 +186,20 @@ public class IndexingStats implements Streamable, ToXContentFragment {
         }
     }
 
-    private Stats totalStats;
+    private final Stats totalStats;
 
     @Nullable
     private Map<String, Stats> typeStats;
 
     public IndexingStats() {
         totalStats = new Stats();
+    }
+
+    public IndexingStats(StreamInput in) throws IOException {
+        totalStats = new Stats(in);
+        if (in.readBoolean()) {
+            typeStats = in.readMap(StreamInput::readString, Stats::new);
+        }
     }
 
     public IndexingStats(Stats totalStats, @Nullable Map<String, Stats> typeStats) {
@@ -278,10 +284,7 @@ public class IndexingStats implements Streamable, ToXContentFragment {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        totalStats = Stats.readStats(in);
-        if (in.readBoolean()) {
-            typeStats = in.readMap(StreamInput::readString, Stats::readStats);
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardId.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardId.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.Index;
@@ -32,15 +33,18 @@ import java.io.IOException;
 /**
  * Allows for shard level components to be injected with the shard id.
  */
-public class ShardId implements Streamable, Comparable<ShardId>, ToXContentFragment {
+public class ShardId implements Streamable, Comparable<ShardId>, ToXContentFragment, Writeable {
 
-    private Index index;
+    private final Index index;
 
-    private int shardId;
+    private final int shardId;
 
-    private int hashCode;
+    private final int hashCode;
 
-    private ShardId() {
+    public ShardId(StreamInput in) throws IOException {
+        index = new Index(in);
+        shardId = in.readVInt();
+        hashCode = computeHashCode();
     }
 
     public ShardId(Index index, int shardId) {
@@ -110,16 +114,12 @@ public class ShardId implements Streamable, Comparable<ShardId>, ToXContentFragm
     }
 
     public static ShardId readShardId(StreamInput in) throws IOException {
-        ShardId shardId = new ShardId();
-        shardId.readFrom(in);
-        return shardId;
+        return new ShardId(in);
     }
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        index = new Index(in);
-        shardId = in.readVInt();
-        hashCode = computeHashCode();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/store/StoreStats.java
+++ b/server/src/main/java/org/elasticsearch/index/store/StoreStats.java
@@ -23,19 +23,26 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class StoreStats implements Streamable, ToXContentFragment {
+public class StoreStats implements Streamable, Writeable, ToXContentFragment {
 
     private long sizeInBytes;
 
     public StoreStats() {
 
+    }
+
+    public StoreStats(StreamInput in) throws IOException {
+        sizeInBytes = in.readVLong();
+        if (in.getVersion().before(Version.V_6_0_0_alpha1)) {
+            in.readVLong(); // throttleTimeInNanos
+        }
     }
 
     public StoreStats(long sizeInBytes) {
@@ -68,10 +75,7 @@ public class StoreStats implements Streamable, ToXContentFragment {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        sizeInBytes = in.readVLong();
-        if (in.getVersion().before(Version.V_6_0_0_alpha1)) {
-            in.readVLong(); // throttleTimeInNanos
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogStats.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogStats.java
@@ -23,13 +23,14 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class TranslogStats implements Streamable, ToXContentFragment {
+public class TranslogStats implements Streamable, Writeable, ToXContentFragment {
 
     private long translogSizeInBytes;
     private int numberOfOperations;
@@ -38,6 +39,21 @@ public class TranslogStats implements Streamable, ToXContentFragment {
     private long earliestLastModifiedAge;
 
     public TranslogStats() {
+    }
+
+    public TranslogStats(StreamInput in) throws IOException {
+        numberOfOperations = in.readVInt();
+        translogSizeInBytes = in.readVLong();
+        if (in.getVersion().onOrAfter(Version.V_6_0_0_beta1)) {
+            uncommittedOperations = in.readVInt();
+            uncommittedSizeInBytes = in.readVLong();
+        } else {
+            uncommittedOperations = numberOfOperations;
+            uncommittedSizeInBytes = translogSizeInBytes;
+        }
+        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
+            earliestLastModifiedAge = in.readVLong();
+        }
     }
 
     public TranslogStats(int numberOfOperations, long translogSizeInBytes, int uncommittedOperations, long uncommittedSizeInBytes,
@@ -116,18 +132,7 @@ public class TranslogStats implements Streamable, ToXContentFragment {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        numberOfOperations = in.readVInt();
-        translogSizeInBytes = in.readVLong();
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_beta1)) {
-            uncommittedOperations = in.readVInt();
-            uncommittedSizeInBytes = in.readVLong();
-        } else {
-            uncommittedOperations = numberOfOperations;
-            uncommittedSizeInBytes = translogSizeInBytes;
-        }
-        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
-            earliestLastModifiedAge = in.readVLong();
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/warmer/WarmerStats.java
+++ b/server/src/main/java/org/elasticsearch/index/warmer/WarmerStats.java
@@ -22,14 +22,14 @@ package org.elasticsearch.index.warmer;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class WarmerStats implements Streamable, ToXContentFragment {
+public class WarmerStats implements Streamable, Writeable, ToXContentFragment {
 
     private long current;
 
@@ -39,6 +39,12 @@ public class WarmerStats implements Streamable, ToXContentFragment {
 
     public WarmerStats() {
 
+    }
+
+    public WarmerStats(StreamInput in) throws IOException {
+        current = in.readVLong();
+        total = in.readVLong();
+        totalTimeInMillis = in.readVLong();
     }
 
     public WarmerStats(long current, long total, long totalTimeInMillis) {
@@ -107,9 +113,7 @@ public class WarmerStats implements Streamable, ToXContentFragment {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        current = in.readVLong();
-        total = in.readVLong();
-        totalTimeInMillis = in.readVLong();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionStats.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionStats.java
@@ -23,13 +23,14 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class CompletionStats implements Streamable, ToXContentFragment {
+public class CompletionStats implements Streamable, Writeable, ToXContentFragment {
 
     private static final String COMPLETION = "completion";
     private static final String SIZE_IN_BYTES = "size_in_bytes";
@@ -41,6 +42,11 @@ public class CompletionStats implements Streamable, ToXContentFragment {
     private FieldMemoryStats fields;
 
     public CompletionStats() {
+    }
+
+    public CompletionStats(StreamInput in) throws IOException {
+        sizeInBytes = in.readVLong();
+        fields = in.readOptionalWriteable(FieldMemoryStats::new);
     }
 
     public CompletionStats(long size, @Nullable FieldMemoryStats fields) {
@@ -62,8 +68,7 @@ public class CompletionStats implements Streamable, ToXContentFragment {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        sizeInBytes = in.readVLong();
-        fields = in.readOptionalWriteable(FieldMemoryStats::new);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/fielddata/FieldDataStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/FieldDataStatsTests.java
@@ -30,16 +30,14 @@ public class FieldDataStatsTests extends ESTestCase {
 
     public void testSerialize() throws IOException {
         FieldMemoryStats map = randomBoolean() ? null : FieldMemoryStatsTests.randomFieldMemoryStats();
-        FieldDataStats stats = new FieldDataStats(randomNonNegativeLong(), randomNonNegativeLong(), map == null ? null :
-            map);
+        FieldDataStats stats = new FieldDataStats(randomNonNegativeLong(), randomNonNegativeLong(), map);
         BytesStreamOutput out = new BytesStreamOutput();
         stats.writeTo(out);
-        FieldDataStats read = new FieldDataStats();
         StreamInput input = out.bytes().streamInput();
-        read.readFrom(input);
+        FieldDataStats read = new FieldDataStats(input);
         assertEquals(-1, input.read());
-        assertEquals(stats.evictions, read.evictions);
-        assertEquals(stats.memorySize, read.memorySize);
+        assertEquals(stats.getEvictions(), read.getEvictions());
+        assertEquals(stats.getMemorySize(), read.getMemorySize());
         assertEquals(stats.getFields(), read.getFields());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/refresh/RefreshStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/refresh/RefreshStatsTests.java
@@ -19,36 +19,23 @@
 
 package org.elasticsearch.index.refresh;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.test.ESTestCase;
 
-public class RefreshStatsTests extends AbstractStreamableTestCase<RefreshStats> {
-    @Override
-    protected RefreshStats createTestInstance() {
-        return new RefreshStats(randomNonNegativeLong(), randomNonNegativeLong(), between(0, Integer.MAX_VALUE));
-    }
+import java.io.IOException;
 
-    @Override
-    protected RefreshStats createBlankInstance() {
-        return new RefreshStats();
-    }
+public class RefreshStatsTests extends ESTestCase {
 
-    @Override
-    protected RefreshStats mutateInstance(RefreshStats instance) {
-        long total = instance.getTotal();
-        long totalInMillis = instance.getTotalTimeInMillis();
-        int listeners = instance.getListeners();
-        switch (randomInt(2)) {
-        case 0:
-            total += between(1, 2000);
-            break;
-        case 1:
-            totalInMillis += between(1, 2000);
-            break;
-        case 2:
-        default:
-            listeners += between(1, 2000);
-            break;
-        }
-        return new RefreshStats(total, totalInMillis, listeners);
+    public void testSerialize() throws IOException {
+        RefreshStats stats = new RefreshStats(randomNonNegativeLong(), randomNonNegativeLong(), between(0, Integer.MAX_VALUE));
+        BytesStreamOutput out = new BytesStreamOutput();
+        stats.writeTo(out);
+        StreamInput input = out.bytes().streamInput();
+        RefreshStats read = new RefreshStats(input);
+        assertEquals(-1, input.read());
+        assertEquals(stats.getTotal(), read.getTotal());
+        assertEquals(stats.getListeners(), read.getListeners());
+        assertEquals(stats.getTotalTimeInMillis(), read.getTotalTimeInMillis());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/shard/DocsStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/DocsStatsTests.java
@@ -66,8 +66,7 @@ public class DocsStatsTests extends ESTestCase {
             originalStats.writeTo(out);
             BytesReference bytes = out.bytes();
             try (StreamInput in = bytes.streamInput()) {
-                DocsStats cloneStats = new DocsStats();
-                cloneStats.readFrom(in);
+                DocsStats cloneStats = new DocsStats(in);
                 assertThat(cloneStats.getCount(), equalTo(originalStats.getCount()));
                 assertThat(cloneStats.getDeleted(), equalTo(originalStats.getDeleted()));
                 assertThat(cloneStats.getAverageSizeInBytes(), equalTo(originalStats.getAverageSizeInBytes()));

--- a/server/src/test/java/org/elasticsearch/index/suggest/stats/CompletionsStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/suggest/stats/CompletionsStatsTests.java
@@ -31,13 +31,11 @@ public class CompletionsStatsTests extends ESTestCase {
 
     public void testSerialize() throws IOException {
         FieldMemoryStats map = randomBoolean() ? null : FieldMemoryStatsTests.randomFieldMemoryStats();
-        CompletionStats stats = new CompletionStats(randomNonNegativeLong(), map == null ? null :
-            map);
+        CompletionStats stats = new CompletionStats(randomNonNegativeLong(), map);
         BytesStreamOutput out = new BytesStreamOutput();
         stats.writeTo(out);
-        CompletionStats read = new CompletionStats();
         StreamInput input = out.bytes().streamInput();
-        read.readFrom(input);
+        CompletionStats read = new CompletionStats(input);
         assertEquals(-1, input.read());
         assertEquals(stats.getSizeInBytes(), read.getSizeInBytes());
         assertEquals(stats.getFields(), read.getFields());

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -380,8 +380,7 @@ public class TranslogTests extends ESTestCase {
             BytesStreamOutput out = new BytesStreamOutput();
             stats.writeTo(out);
             StreamInput in = out.bytes().streamInput();
-            stats = new TranslogStats();
-            stats.readFrom(in);
+            stats = new TranslogStats(in);
         }
         return stats;
     }
@@ -475,9 +474,7 @@ public class TranslogTests extends ESTestCase {
             final TranslogStats stats = stats();
             final BytesStreamOutput out = new BytesStreamOutput();
             stats.writeTo(out);
-            final TranslogStats copy = new TranslogStats();
-            copy.readFrom(out.bytes().streamInput());
-
+            final TranslogStats copy = new TranslogStats(out.bytes().streamInput());
             assertThat(copy.estimatedNumberOfOperations(), equalTo(4));
             assertThat(copy.getTranslogSizeInBytes(), equalTo(expectedSizeInBytes));
 


### PR DESCRIPTION
Migrate streamable classes from index package to Writeable and clean up access modifiers

Related to #34389
backport#37381
