### PR TITLE
[DOCS] Updates version to 6.6.2

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -1,4 +1,4 @@
-:version:               6.6.1
+:version:               6.6.2
 :major-version:         6.x
 :lucene_version:        7.6.0
 :lucene_version_path:   7_6_0


### PR DESCRIPTION
This PR updates the version attributes that are used by various books in the Elasticsearch repo.