### PR TITLE
Adding an example in the Set processor documentation to address #30604 (#39941)

### DIFF
--- a/docs/reference/ingest/processors/script.asciidoc
+++ b/docs/reference/ingest/processors/script.asciidoc
@@ -101,8 +101,3 @@ The response from the above index request:
 In the above response, you can see that our document was actually indexed into `my_index` instead of
 `any_index`. This type of manipulation is often convenient in pipelines that have various branches of transformation,
 and depending on the progress made, indexed into different indices.
-
-[[set-processor]]
-=== Set Processor
-Sets one field and associates it with the specified value. If the field already exists,
-its value will be replaced with the provided one.

--- a/docs/reference/ingest/processors/set.asciidoc
+++ b/docs/reference/ingest/processors/set.asciidoc
@@ -1,3 +1,8 @@
+[[set-processor]]
+=== Set Processor
+Sets one field and associates it with the specified value. If the field already exists,
+its value will be replaced with the provided one.
+
 [[set-options]]
 .Set Options
 [options="header"]
@@ -12,10 +17,69 @@ include::common-options.asciidoc[]
 [source,js]
 --------------------------------------------------
 {
+  "description" : "sets the value of count to 1"
   "set": {
-    "field": "host.os.name",
-    "value": "{{os}}"
+    "field": "count",
+    "value": 1
   }
 }
 --------------------------------------------------
 // NOTCONSOLE
+
+This processor can also be used to copy data from one field to another. For example:
+
+[source,js]
+--------------------------------------------------
+PUT _ingest/pipeline/set_os
+{
+  "description": "sets the value of host.os.name from the field os",
+  "processors": [
+    {
+      "set": {
+        "field": "host.os.name",
+        "value": "{{os}}"
+      }
+    }
+  ]
+}
+
+POST _ingest/pipeline/set_os/_simulate
+{
+  "docs": [
+    {
+      "_source": {
+        "os": "Ubuntu"
+      }
+    }
+  ]
+}
+--------------------------------------------------
+// CONSOLE
+
+Result:
+[source,js]
+--------------------------------------------------
+{
+  "docs" : [
+    {
+      "doc" : {
+        "_index" : "_index",
+        "_type" : "_doc",
+        "_id" : "_id",
+        "_source" : {
+          "host" : {
+            "os" : {
+              "name" : "Ubuntu"
+            }
+          },
+          "os" : "Ubuntu"
+        },
+        "_ingest" : {
+          "timestamp" : "2019-03-11T21:54:37.909224Z"
+        }
+      }
+    }
+  ]
+}
+--------------------------------------------------
+// TESTRESPONSE[s/2019-03-11T21:54:37.909224Z/$body.docs.0.doc._ingest.timestamp/]


### PR DESCRIPTION
* Added an example of using set to copy values from one field to another.

* Modified the document type to match the test.