### PR TITLE
Remove sizing from `Recycler#obtain`

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/recycler/AbstractRecycler.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/AbstractRecycler.java
@@ -29,11 +29,6 @@ abstract class AbstractRecycler<T> implements Recycler<T> {
     }
 
     @Override
-    public V<T> obtain() {
-        return obtain(-1);
-    }
-
-    @Override
     public void close() {
         // no-op by default
     }

--- a/server/src/main/java/org/elasticsearch/common/recycler/AbstractRecyclerC.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/AbstractRecyclerC.java
@@ -22,7 +22,7 @@ package org.elasticsearch.common.recycler;
 public abstract class AbstractRecyclerC<T> implements Recycler.C<T> {
 
     @Override
-    public abstract T newInstance(int sizing);
+    public abstract T newInstance();
 
     @Override
     public abstract void recycle(T value);

--- a/server/src/main/java/org/elasticsearch/common/recycler/ConcurrentDequeRecycler.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/ConcurrentDequeRecycler.java
@@ -33,7 +33,7 @@ public class ConcurrentDequeRecycler<T> extends DequeRecycler<T> {
     final AtomicInteger size;
 
     public ConcurrentDequeRecycler(C<T> c, int maxSize) {
-        super(c, ConcurrentCollections.<T>newDeque(), maxSize);
+        super(c, ConcurrentCollections.newDeque(), maxSize);
         this.size = new AtomicInteger();
     }
 
@@ -45,8 +45,8 @@ public class ConcurrentDequeRecycler<T> extends DequeRecycler<T> {
     }
 
     @Override
-    public V<T> obtain(int sizing) {
-        final V<T> v = super.obtain(sizing);
+    public V<T> obtain() {
+        final V<T> v = super.obtain();
         if (v.isRecycled()) {
             size.decrementAndGet();
         }

--- a/server/src/main/java/org/elasticsearch/common/recycler/DequeRecycler.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/DequeRecycler.java
@@ -47,10 +47,10 @@ public class DequeRecycler<T> extends AbstractRecycler<T> {
     }
 
     @Override
-    public V<T> obtain(int sizing) {
+    public V<T> obtain() {
         final T v = deque.pollFirst();
         if (v == null) {
-            return new DV(c.newInstance(sizing), false);
+            return new DV(c.newInstance(), false);
         }
         return new DV(v, true);
     }

--- a/server/src/main/java/org/elasticsearch/common/recycler/FilterRecycler.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/FilterRecycler.java
@@ -30,11 +30,6 @@ abstract class FilterRecycler<T> implements Recycler<T> {
     }
 
     @Override
-    public Recycler.V<T> obtain(int sizing) {
-        return wrap(getDelegate().obtain(sizing));
-    }
-
-    @Override
     public Recycler.V<T> obtain() {
         return wrap(getDelegate().obtain());
     }

--- a/server/src/main/java/org/elasticsearch/common/recycler/NoneRecycler.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/NoneRecycler.java
@@ -27,8 +27,8 @@ public class NoneRecycler<T> extends AbstractRecycler<T> {
     }
 
     @Override
-    public V<T> obtain(int sizing) {
-        return new NV<>(c.newInstance(sizing));
+    public V<T> obtain() {
+        return new NV<>(c.newInstance());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/recycler/Recycler.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/Recycler.java
@@ -34,7 +34,7 @@ public interface Recycler<T> extends Releasable {
     interface C<T> {
 
         /** Create a new empty instance of the given size. */
-        T newInstance(int sizing);
+        T newInstance();
 
         /** Recycle the data. This operation is called when the data structure is released. */
         void recycle(T value);
@@ -57,5 +57,4 @@ public interface Recycler<T> extends Releasable {
 
     V<T> obtain();
 
-    V<T> obtain(int sizing);
 }

--- a/server/src/main/java/org/elasticsearch/common/recycler/Recyclers.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/Recyclers.java
@@ -73,13 +73,6 @@ public enum Recyclers {
             }
 
             @Override
-            public Recycler.V<T> obtain(int sizing) {
-                synchronized (lock) {
-                    return super.obtain(sizing);
-                }
-            }
-
-            @Override
             public Recycler.V<T> obtain() {
                 synchronized (lock) {
                     return super.obtain();

--- a/server/src/main/java/org/elasticsearch/common/util/PageCacheRecycler.java
+++ b/server/src/main/java/org/elasticsearch/common/util/PageCacheRecycler.java
@@ -107,7 +107,7 @@ public class PageCacheRecycler implements Releasable {
         final int maxBytePageCount = (int) (bytesWeight * maxPageCount / totalWeight);
         bytePage = build(type, maxBytePageCount, availableProcessors, new AbstractRecyclerC<byte[]>() {
             @Override
-            public byte[] newInstance(int sizing) {
+            public byte[] newInstance() {
                 return new byte[BYTE_PAGE_SIZE];
             }
             @Override
@@ -119,7 +119,7 @@ public class PageCacheRecycler implements Releasable {
         final int maxIntPageCount = (int) (intsWeight * maxPageCount / totalWeight);
         intPage = build(type, maxIntPageCount, availableProcessors, new AbstractRecyclerC<int[]>() {
             @Override
-            public int[] newInstance(int sizing) {
+            public int[] newInstance() {
                 return new int[INT_PAGE_SIZE];
             }
             @Override
@@ -131,7 +131,7 @@ public class PageCacheRecycler implements Releasable {
         final int maxLongPageCount = (int) (longsWeight * maxPageCount / totalWeight);
         longPage = build(type, maxLongPageCount, availableProcessors, new AbstractRecyclerC<long[]>() {
             @Override
-            public long[] newInstance(int sizing) {
+            public long[] newInstance() {
                 return new long[LONG_PAGE_SIZE];
             }
             @Override
@@ -143,7 +143,7 @@ public class PageCacheRecycler implements Releasable {
         final int maxObjectPageCount = (int) (objectsWeight * maxPageCount / totalWeight);
         objectPage = build(type, maxObjectPageCount, availableProcessors, new AbstractRecyclerC<Object[]>() {
             @Override
-            public Object[] newInstance(int sizing) {
+            public Object[] newInstance() {
                 return new Object[OBJECT_PAGE_SIZE];
             }
             @Override

--- a/server/src/test/java/org/elasticsearch/common/recycler/AbstractRecyclerTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/recycler/AbstractRecyclerTestCase.java
@@ -36,7 +36,7 @@ public abstract class AbstractRecyclerTestCase extends ESTestCase {
     protected static final Recycler.C<byte[]> RECYCLER_C = new AbstractRecyclerC<byte[]>() {
 
         @Override
-        public byte[] newInstance(int sizing) {
+        public byte[] newInstance() {
             byte[] value = new byte[10];
             // "fresh" is intentionally not 0 to ensure we covered this code path
             Arrays.fill(value, FRESH);


### PR DESCRIPTION
Currently there is a method `Recycler#obtain(size)` that allows a size
parameter to be passed. However all implementations ignore this
parameter and just allocate a page size based on other settings. This
commit removes this method.