### PR TITLE
Make the `type` parameter optional when percolating existing documents.

### DIFF
--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -134,7 +134,7 @@ The following parameters are required when percolating a document:
          This is an optional parameter.
 `document`:: The source of the document being percolated.
 `documents`:: Like the `document` parameter, but accepts multiple documents via a json array.
-`document_type`:: The type / mapping of the document being percolated. This setting is deprecated and only required for indices created before 6.0
+`document_type`:: The type / mapping of the document being percolated. This parameter is deprecated and will be removed in Elasticsearch 8.0.
 
 Instead of specifying the source of the document being percolated, the source can also be retrieved from an already
 stored document. The `percolate` query will then internally execute a get request to fetch that document.
@@ -143,7 +143,7 @@ In that case the `document` parameter can be substituted with the following para
 
 [horizontal]
 `index`:: The index the document resides in. This is a required parameter.
-`type`:: The type of the document to fetch. This is a required parameter.
+`type`:: The type of the document to fetch. This parameter is deprecated and will be removed in Elasticsearch 8.0.
 `id`:: The id of the document to fetch. This is a required parameter.
 `routing`:: Optionally, routing to be used to fetch document to percolate.
 `preference`:: Optionally, preference to be used to fetch document to percolate.
@@ -323,7 +323,6 @@ GET /my-index/_search
         "percolate" : {
             "field": "query",
             "index" : "my-index",
-            "type" : "_doc",
             "id" : "2",
             "version" : 1 <1>
         }

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
@@ -96,6 +96,10 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
     public static final String NAME = "percolate";
 
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(ParseField.class));
+    static final String DOCUMENT_TYPE_DEPRECATION_MESSAGE = "[types removal] Types are deprecated in [percolate] queries. " +
+            "The [document_type] should no longer be specified.";
+    static final String TYPE_DEPRECATION_MESSAGE = "[types removal] Types are deprecated in [percolate] queries. " +
+            "The [type] of the indexed document should no longer be specified.";
 
     static final ParseField DOCUMENT_FIELD = new ParseField("document");
     static final ParseField DOCUMENTS_FIELD = new ParseField("documents");
@@ -117,6 +121,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
     private final XContentType documentXContentType;
 
     private final String indexedDocumentIndex;
+    @Deprecated
     private final String indexedDocumentType;
     private final String indexedDocumentId;
     private final String indexedDocumentRouting;
@@ -219,9 +224,6 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         }
         if (indexedDocumentIndex == null) {
             throw new IllegalArgumentException("[index] is a required argument");
-        }
-        if (indexedDocumentType == null) {
-            throw new IllegalArgumentException("[type] is a required argument");
         }
         if (indexedDocumentId == null) {
             throw new IllegalArgumentException("[id] is a required argument");
@@ -521,7 +523,13 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
                     XContentHelper.xContentType(source));
             }
         }
-        GetRequest getRequest = new GetRequest(indexedDocumentIndex, indexedDocumentType, indexedDocumentId);
+        GetRequest getRequest;
+        if (indexedDocumentType != null) {
+            deprecationLogger.deprecatedAndMaybeLog("percolate_with_type", TYPE_DEPRECATION_MESSAGE);
+            getRequest = new GetRequest(indexedDocumentIndex, indexedDocumentType, indexedDocumentId);
+        } else {
+            getRequest = new GetRequest(indexedDocumentIndex, indexedDocumentId);
+        }
         getRequest.preference("_local");
         getRequest.routing(indexedDocumentRouting);
         getRequest.preference(indexedDocumentPreference);
@@ -533,13 +541,14 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
             client.get(getRequest, ActionListener.wrap(getResponse -> {
                 if (getResponse.isExists() == false) {
                     throw new ResourceNotFoundException(
-                        "indexed document [{}/{}/{}] couldn't be found", indexedDocumentIndex, indexedDocumentType, indexedDocumentId
+                        "indexed document [{}{}/{}] couldn't be found", indexedDocumentIndex,
+                        indexedDocumentType == null ? "" : "/" + indexedDocumentType, indexedDocumentId
                     );
                 }
                 if(getResponse.isSourceEmpty()) {
                     throw new IllegalArgumentException(
-                        "indexed document [" + indexedDocumentIndex + "/" + indexedDocumentType + "/" + indexedDocumentId
-                            + "] source disabled"
+                        "indexed document [" + indexedDocumentIndex + (indexedDocumentType == null ? "" : "/" + indexedDocumentType) +
+                        "/" + indexedDocumentId + "] source disabled"
                     );
                 }
                 documentSupplier.set(getResponse.getSourceAsBytesRef());
@@ -554,7 +563,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         // Call nowInMillis() so that this query becomes un-cacheable since we
         // can't be sure that it doesn't use now or scripts
         context.nowInMillis();
-        if (indexedDocumentIndex != null || indexedDocumentType != null || indexedDocumentId != null || documentSupplier != null) {
+        if (indexedDocumentIndex != null || indexedDocumentId != null || documentSupplier != null) {
             throw new IllegalStateException("query builder must be rewritten first");
         }
 
@@ -577,7 +586,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         final MapperService mapperService = context.getMapperService();
         String type = mapperService.documentMapper().type();
         if (documentType != null) {
-            deprecationLogger.deprecated("[document_type] parameter has been deprecated because types have been deprecated");
+            deprecationLogger.deprecatedAndMaybeLog("percolate_with_document_type", DOCUMENT_TYPE_DEPRECATION_MESSAGE);
             if (documentType.equals(type) == false) {
                 throw new IllegalArgumentException("specified document_type [" + documentType +
                     "] is not equal to the actual type [" + type + "]");

--- a/modules/percolator/src/test/resources/rest-api-spec/test/11_basic_with_types.yml
+++ b/modules/percolator/src/test/resources/rest-api-spec/test/11_basic_with_types.yml
@@ -1,33 +1,34 @@
 ---
 "Test percolator basics via rest":
 
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       indices.create:
+        include_type_name: true
         index: queries_index
         body:
           mappings:
-            properties:
-              query:
-                type: percolator
-              foo:
-                type: keyword
+            queries_type:
+              properties:
+                query:
+                  type: percolator
+                foo:
+                  type: keyword
 
   - do:
       indices.create:
+        include_type_name: true
         index: documents_index
         body:
           mappings:
-            properties:
-              foo:
-                type: keyword
+            documents_type:
+              properties:
+                foo:
+                  type: keyword
 
   - do:
       index:
         index: queries_index
+        type: queries_type
         id:   test_percolator
         body:
           query:
@@ -36,6 +37,7 @@
   - do:
       index:
         index: documents_index
+        type: documents_type
         id: some_id
         body:
           foo: bar
@@ -51,6 +53,7 @@
               percolate:
                 field: query
                 document:
+                  document_type: queries_type
                   foo: bar
   - match:  { hits.total:     1  }
 
@@ -62,6 +65,7 @@
           - query:
               percolate:
                 field: query
+                document_type: queries_type
                 document:
                   foo: bar
   - match:  { responses.0.hits.total:     1  }
@@ -74,6 +78,7 @@
               percolate:
                 field: query
                 index: documents_index
+                type: documents_type
                 id: some_id 
   - match:  { hits.total:     1  }
 
@@ -86,5 +91,6 @@
               percolate:
                 field: query
                 index: documents_index
+                type: documents_type
                 id: some_id
   - match:  { responses.0.hits.total:     1  }


### PR DESCRIPTION
`document_type` is the type to use for parsing the document to percolate, which
is already optional and deprecated. However `percotale` queries also have the
ability to percolate existing documents, identified by an index, an id and a
type. This change makes the latter optional and deprecated.

Closes #39963