### PR TITLE
Update to github issues template to include an alternative ES version discovery command

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -22,7 +22,7 @@ Issues that do not follow these guidelines are likely to be closed.
 
 <!-- Bug report -->
 
-**Elasticsearch version** (`bin/elasticsearch --version`):
+**Elasticsearch version** (`bin/elasticsearch --version` or http(s) GET request to `[node_hostname]:[node_port]/` e.g. `localhost:9200/`):
 
 **Plugins installed**: []
 


### PR DESCRIPTION
The suggested change came as a follow up to https://github.com/elastic/elasticsearch/issues/38786.
If the node is already in trouble (memory issues), starting another node to get the version is not the right thing to do. Getting `/` from an unresponsive node might not work as well, but it's a valid alternative, as well.