### PR TITLE
Remove Obsolete BwC Serialization Code

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -682,16 +682,8 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             index = in.readString();
             routingNumShards = in.readInt();
             version = in.readLong();
-            if (in.getVersion().onOrAfter(Version.V_6_5_0)) {
-                mappingVersion = in.readVLong();
-            } else {
-                mappingVersion = 1;
-            }
-            if (in.getVersion().onOrAfter(Version.V_6_5_0)) {
-                settingsVersion = in.readVLong();
-            } else {
-                settingsVersion = 1;
-            }
+            mappingVersion = in.readVLong();
+            settingsVersion = in.readVLong();
             state = State.fromId(in.readByte());
             settings = Settings.readSettingsFromStream(in);
             primaryTerms = in.readVLongArray();
@@ -703,13 +695,8 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
                 DiffableStringMap::readDiffFrom);
             inSyncAllocationIds = DiffableUtils.readImmutableOpenIntMapDiff(in, DiffableUtils.getVIntKeySerializer(),
                 DiffableUtils.StringSetValueSerializer.getInstance());
-            if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
-                rolloverInfos = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), RolloverInfo::new,
-                    RolloverInfo::readDiffFrom);
-            } else {
-                ImmutableOpenMap<String, RolloverInfo> emptyMap = ImmutableOpenMap.of();
-                rolloverInfos = DiffableUtils.diff(emptyMap, emptyMap, DiffableUtils.getStringKeySerializer());
-            }
+            rolloverInfos = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), RolloverInfo::new,
+                RolloverInfo::readDiffFrom);
         }
 
         @Override
@@ -717,12 +704,8 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             out.writeString(index);
             out.writeInt(routingNumShards);
             out.writeLong(version);
-            if (out.getVersion().onOrAfter(Version.V_6_5_0)) {
-                out.writeVLong(mappingVersion);
-            }
-            if (out.getVersion().onOrAfter(Version.V_6_5_0)) {
-                out.writeVLong(settingsVersion);
-            }
+            out.writeVLong(mappingVersion);
+            out.writeVLong(settingsVersion);
             out.writeByte(state.id);
             Settings.writeSettingsToStream(settings, out);
             out.writeVLongArray(primaryTerms);
@@ -730,9 +713,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             aliases.writeTo(out);
             customData.writeTo(out);
             inSyncAllocationIds.writeTo(out);
-            if (out.getVersion().onOrAfter(Version.V_6_4_0)) {
-                rolloverInfos.writeTo(out);
-            }
+            rolloverInfos.writeTo(out);
         }
 
         @Override
@@ -757,16 +738,8 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
     public static IndexMetaData readFrom(StreamInput in) throws IOException {
         Builder builder = new Builder(in.readString());
         builder.version(in.readLong());
-        if (in.getVersion().onOrAfter(Version.V_6_5_0)) {
-            builder.mappingVersion(in.readVLong());
-        } else {
-            builder.mappingVersion(1);
-        }
-        if (in.getVersion().onOrAfter(Version.V_6_5_0)) {
-            builder.settingsVersion(in.readVLong());
-        } else {
-            builder.settingsVersion(1);
-        }
+        builder.mappingVersion(in.readVLong());
+        builder.settingsVersion(in.readVLong());
         builder.setRoutingNumShards(in.readInt());
         builder.state(State.fromId(in.readByte()));
         builder.settings(readSettingsFromStream(in));
@@ -782,17 +755,10 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             builder.putAlias(aliasMd);
         }
         int customSize = in.readVInt();
-        if (in.getVersion().onOrAfter(Version.V_6_5_0)) {
-            for (int i = 0; i < customSize; i++) {
-                String key = in.readString();
-                DiffableStringMap custom = new DiffableStringMap(in);
-                builder.putCustom(key, custom);
-            }
-        } else {
-            assert customSize == 0 : "expected no custom index metadata";
-            if (customSize > 0) {
-                throw new IllegalStateException("unexpected custom metadata when none is supported");
-            }
+        for (int i = 0; i < customSize; i++) {
+            String key = in.readString();
+            DiffableStringMap custom = new DiffableStringMap(in);
+            builder.putCustom(key, custom);
         }
         int inSyncAllocationIdsSize = in.readVInt();
         for (int i = 0; i < inSyncAllocationIdsSize; i++) {
@@ -800,11 +766,9 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             Set<String> allocationIds = DiffableUtils.StringSetValueSerializer.getInstance().read(in, key);
             builder.putInSyncAllocationIds(key, allocationIds);
         }
-        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
-            int rolloverAliasesSize = in.readVInt();
-            for (int i = 0; i < rolloverAliasesSize; i++) {
-                builder.putRolloverInfo(new RolloverInfo(in));
-            }
+        int rolloverAliasesSize = in.readVInt();
+        for (int i = 0; i < rolloverAliasesSize; i++) {
+            builder.putRolloverInfo(new RolloverInfo(in));
         }
         return builder.build();
     }
@@ -813,12 +777,8 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(index.getName()); // uuid will come as part of settings
         out.writeLong(version);
-        if (out.getVersion().onOrAfter(Version.V_6_5_0)) {
-            out.writeVLong(mappingVersion);
-        }
-        if (out.getVersion().onOrAfter(Version.V_6_5_0)) {
-            out.writeVLong(settingsVersion);
-        }
+        out.writeVLong(mappingVersion);
+        out.writeVLong(settingsVersion);
         out.writeInt(routingNumShards);
         out.writeByte(state.id());
         writeSettingsToStream(settings, out);
@@ -831,25 +791,19 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
         for (ObjectCursor<AliasMetaData> cursor : aliases.values()) {
             cursor.value.writeTo(out);
         }
-        if (out.getVersion().onOrAfter(Version.V_6_5_0)) {
-            out.writeVInt(customData.size());
-            for (final ObjectObjectCursor<String, DiffableStringMap> cursor : customData) {
-                out.writeString(cursor.key);
-                cursor.value.writeTo(out);
-            }
-        } else {
-            out.writeVInt(0);
+        out.writeVInt(customData.size());
+        for (final ObjectObjectCursor<String, DiffableStringMap> cursor : customData) {
+            out.writeString(cursor.key);
+            cursor.value.writeTo(out);
         }
         out.writeVInt(inSyncAllocationIds.size());
         for (IntObjectCursor<Set<String>> cursor : inSyncAllocationIds) {
             out.writeVInt(cursor.key);
             DiffableUtils.StringSetValueSerializer.getInstance().write(cursor.value, out);
         }
-        if (out.getVersion().onOrAfter(Version.V_6_4_0)) {
-            out.writeVInt(rolloverInfos.size());
-            for (ObjectCursor<RolloverInfo> cursor : rolloverInfos.values()) {
-                cursor.value.writeTo(out);
-            }
+        out.writeVInt(rolloverInfos.size());
+        for (ObjectCursor<RolloverInfo> cursor : rolloverInfos.values()) {
+            cursor.value.writeTo(out);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
@@ -22,7 +22,6 @@ import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.common.Nullable;
@@ -188,11 +187,7 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
     public static IndexTemplateMetaData readFrom(StreamInput in) throws IOException {
         Builder builder = new Builder(in.readString());
         builder.order(in.readInt());
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
-            builder.patterns(in.readStringList());
-        } else {
-            builder.patterns(Collections.singletonList(in.readString()));
-        }
+        builder.patterns(in.readStringList());
         builder.settings(Settings.readSettingsFromStream(in));
         int mappingsSize = in.readVInt();
         for (int i = 0; i < mappingsSize; i++) {
@@ -202,14 +197,6 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
         for (int i = 0; i < aliasesSize; i++) {
             AliasMetaData aliasMd = new AliasMetaData(in);
             builder.putAlias(aliasMd);
-        }
-        if (in.getVersion().before(Version.V_6_5_0)) {
-            // Previously we allowed custom metadata
-            int customSize = in.readVInt();
-            assert customSize == 0 : "expected no custom metadata";
-            if (customSize > 0) {
-                throw new IllegalStateException("unexpected custom metadata when none is supported");
-            }
         }
         builder.version(in.readOptionalVInt());
         return builder.build();
@@ -223,11 +210,7 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
         out.writeInt(order);
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
-            out.writeStringCollection(patterns);
-        } else {
-            out.writeString(patterns.get(0));
-        }
+        out.writeStringCollection(patterns);
         Settings.writeSettingsToStream(settings, out);
         out.writeVInt(mappings.size());
         for (ObjectObjectCursor<String, CompressedXContent> cursor : mappings) {
@@ -237,9 +220,6 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
         out.writeVInt(aliases.size());
         for (ObjectCursor<AliasMetaData> cursor : aliases.values()) {
             cursor.value.writeTo(out);
-        }
-        if (out.getVersion().before(Version.V_6_5_0)) {
-            out.writeVInt(0);
         }
         out.writeOptionalVInt(version);
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -30,7 +29,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.DocumentMapper;
 
 import java.io.IOException;
@@ -171,16 +169,6 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
         source().writeTo(out);
         // routing
         out.writeBoolean(routing().required());
-        if (out.getVersion().before(Version.V_6_0_0_alpha1)) {
-            // timestamp
-            out.writeBoolean(false); // enabled
-            out.writeString(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern());
-            out.writeOptionalString("now"); // 5.x default
-            out.writeOptionalBoolean(null);
-        }
-        if (out.getVersion().before(Version.V_7_0_0)) {
-            out.writeBoolean(false); // hasParentField
-        }
     }
 
     @Override
@@ -210,19 +198,6 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
         source = CompressedXContent.readCompressedString(in);
         // routing
         routing = new Routing(in.readBoolean());
-        if (in.getVersion().before(Version.V_6_0_0_alpha1)) {
-            // timestamp
-            boolean enabled = in.readBoolean();
-            if (enabled) {
-                throw new IllegalArgumentException("_timestamp may not be enabled");
-            }
-            in.readString(); // format
-            in.readOptionalString(); // defaultTimestamp
-            in.readOptionalBoolean(); // ignoreMissing
-        }
-        if (in.getVersion().before(Version.V_7_0_0)) {
-            in.readBoolean(); // hasParentField
-        }
     }
 
     public static Diff<MappingMetaData> readDiffFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -22,11 +22,9 @@ package org.elasticsearch.cluster.metadata;
 import com.carrotsearch.hppc.ObjectHashSet;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.CollectionUtil;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.AliasesRequest;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterState.FeatureAware;
@@ -837,15 +835,9 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
 
         MetaDataDiff(StreamInput in) throws IOException {
             clusterUUID = in.readString();
-            if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
-                clusterUUIDCommitted = in.readBoolean();
-            }
+            clusterUUIDCommitted = in.readBoolean();
             version = in.readLong();
-            if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
-                coordinationMetaData = new CoordinationMetaData(in);
-            } else {
-                coordinationMetaData = CoordinationMetaData.EMPTY_META_DATA;
-            }
+            coordinationMetaData = new CoordinationMetaData(in);
             transientSettings = Settings.readSettingsFromStream(in);
             persistentSettings = Settings.readSettingsFromStream(in);
             indices = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), IndexMetaData::readFrom,
@@ -858,13 +850,9 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(clusterUUID);
-            if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-                out.writeBoolean(clusterUUIDCommitted);
-            }
+            out.writeBoolean(clusterUUIDCommitted);
             out.writeLong(version);
-            if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-                coordinationMetaData.writeTo(out);
-            }
+            coordinationMetaData.writeTo(out);
             Settings.writeSettingsToStream(transientSettings, out);
             Settings.writeSettingsToStream(persistentSettings, out);
             indices.writeTo(out);
@@ -892,12 +880,8 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
         Builder builder = new Builder();
         builder.version = in.readLong();
         builder.clusterUUID = in.readString();
-        if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
-            builder.clusterUUIDCommitted = in.readBoolean();
-        }
-        if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
-            builder.coordinationMetaData(new CoordinationMetaData(in));
-        }
+        builder.clusterUUIDCommitted = in.readBoolean();
+        builder.coordinationMetaData(new CoordinationMetaData(in));
         builder.transientSettings(readSettingsFromStream(in));
         builder.persistentSettings(readSettingsFromStream(in));
         int size = in.readVInt();
@@ -920,12 +904,8 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
     public void writeTo(StreamOutput out) throws IOException {
         out.writeLong(version);
         out.writeString(clusterUUID);
-        if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-            out.writeBoolean(clusterUUIDCommitted);
-        }
-        if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-            coordinationMetaData.writeTo(out);
-        }
+        out.writeBoolean(clusterUUIDCommitted);
+        coordinationMetaData.writeTo(out);
         writeSettingsToStream(transientSettings, out);
         writeSettingsToStream(persistentSettings, out);
         out.writeVInt(indices.size());

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RecoverySource.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RecoverySource.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.cluster.routing;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.RestoreInProgress;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -148,11 +147,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
         }
 
         private ExistingStoreRecoverySource(StreamInput in) throws IOException {
-            if (in.getVersion().onOrAfter(Version.V_6_5_0)) {
-                bootstrapNewHistoryUUID = in.readBoolean();
-            } else {
-                bootstrapNewHistoryUUID = false;
-            }
+            bootstrapNewHistoryUUID = in.readBoolean();
         }
 
         @Override
@@ -162,9 +157,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
 
         @Override
         protected void writeAdditionalFields(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(Version.V_6_5_0)) {
-                out.writeBoolean(bootstrapNewHistoryUUID);
-            }
+            out.writeBoolean(bootstrapNewHistoryUUID);
         }
 
         @Override
@@ -222,11 +215,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
         }
 
         SnapshotRecoverySource(StreamInput in) throws IOException {
-            if (in.getVersion().onOrAfter(Version.V_6_6_0)) {
-                restoreUUID = in.readString();
-            } else {
-                restoreUUID = RestoreInProgress.BWC_UUID;
-            }
+            restoreUUID = in.readString();
             snapshot = new Snapshot(in);
             version = Version.readVersion(in);
             index = in.readString();
@@ -250,9 +239,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
 
         @Override
         protected void writeAdditionalFields(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(Version.V_6_6_0)) {
-                out.writeString(restoreUUID);
-            }
+            out.writeString(restoreUUID);
             snapshot.writeTo(out);
             Version.writeVersion(version, out);
             out.writeString(index);

--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.common;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -397,11 +396,7 @@ public abstract class Rounding implements Writeable {
         @Override
         public void innerWriteTo(StreamOutput out) throws IOException {
             out.writeByte(unit.getId());
-            if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-                out.writeString(timeZone.getId());
-            } else {
-                out.writeString(DateUtils.zoneIdToDateTimeZone(timeZone).getID());
-            }
+            out.writeString(timeZone.getId());
         }
 
         @Override
@@ -522,11 +517,7 @@ public abstract class Rounding implements Writeable {
         @Override
         public void innerWriteTo(StreamOutput out) throws IOException {
             out.writeVLong(interval);
-            if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-                out.writeString(timeZone.getId());
-            } else {
-                out.writeString(DateUtils.zoneIdToDateTimeZone(timeZone).getID());
-            }
+            out.writeString(timeZone.getId());
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -19,14 +19,9 @@
 
 package org.elasticsearch.common.geo.builders;
 
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryFactory;
-
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Assertions;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.GeoShapeType;
 import org.elasticsearch.common.geo.parsers.GeoWKTParser;
@@ -35,6 +30,9 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.exception.InvalidShapeException;
 import org.locationtech.spatial4j.shape.Shape;
@@ -113,10 +111,7 @@ public abstract class ShapeBuilder<T extends Shape, G extends org.elasticsearch.
     protected static Coordinate readFromStream(StreamInput in) throws IOException {
         double x = in.readDouble();
         double y = in.readDouble();
-        Double z = null;
-        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
-            z = in.readOptionalDouble();
-        }
+        Double z = in.readOptionalDouble();
         return z == null ? new Coordinate(x, y) : new Coordinate(x, y, z);
     }
 
@@ -131,9 +126,7 @@ public abstract class ShapeBuilder<T extends Shape, G extends org.elasticsearch.
     protected static void writeCoordinateTo(Coordinate coordinate, StreamOutput out) throws IOException {
         out.writeDouble(coordinate.x);
         out.writeDouble(coordinate.y);
-        if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
-            out.writeOptionalDouble(Double.isNaN(coordinate.z) ? null : coordinate.z);
-        }
+        out.writeOptionalDouble(Double.isNaN(coordinate.z) ? null : coordinate.z);
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -303,10 +303,7 @@ public class Lucene {
 
     public static TotalHits readTotalHits(StreamInput in) throws IOException {
         long totalHits = in.readVLong();
-        TotalHits.Relation totalHitsRelation = TotalHits.Relation.EQUAL_TO;
-        if (in.getVersion().onOrAfter(org.elasticsearch.Version.V_7_0_0)) {
-            totalHitsRelation = in.readEnum(TotalHits.Relation.class);
-        }
+        TotalHits.Relation totalHitsRelation = in.readEnum(TotalHits.Relation.class);
         return new TotalHits(totalHits, totalHitsRelation);
     }
 
@@ -415,11 +412,7 @@ public class Lucene {
 
     public static void writeTotalHits(StreamOutput out, TotalHits totalHits) throws IOException {
         out.writeVLong(totalHits.value);
-        if (out.getVersion().onOrAfter(org.elasticsearch.Version.V_7_0_0)) {
-            out.writeEnum(totalHits.relation);
-        } else if (totalHits.value > 0 && totalHits.relation != TotalHits.Relation.EQUAL_TO) {
-            throw new IllegalArgumentException("Cannot serialize approximate total hit counts to nodes that are on a version < 7.0.0");
-        }
+        out.writeEnum(totalHits.relation);
     }
 
     public static void writeTopDocs(StreamOutput out, TopDocsAndMaxScore topDocs) throws IOException {
@@ -613,9 +606,8 @@ public class Lucene {
     }
 
     private static Number readExplanationValue(StreamInput in) throws IOException {
-        if (in.getVersion().onOrAfter(org.elasticsearch.Version.V_7_0_0)) {
-            final int numberType = in.readByte();
-            switch (numberType) {
+        final int numberType = in.readByte();
+        switch (numberType) {
             case 0:
                 return in.readFloat();
             case 1:
@@ -624,9 +616,6 @@ public class Lucene {
                 return in.readZLong();
             default:
                 throw new IOException("Unexpected number type: " + numberType);
-            }
-        } else {
-            return in.readFloat();
         }
     }
 
@@ -645,19 +634,15 @@ public class Lucene {
     }
 
     private static void writeExplanationValue(StreamOutput out, Number value) throws IOException {
-        if (out.getVersion().onOrAfter(org.elasticsearch.Version.V_7_0_0)) {
-            if (value instanceof Float) {
-                out.writeByte((byte) 0);
-                out.writeFloat(value.floatValue());
-            } else if (value instanceof Double) {
-                out.writeByte((byte) 1);
-                out.writeDouble(value.doubleValue());
-            } else {
-                out.writeByte((byte) 2);
-                out.writeZLong(value.longValue());
-            }
-        } else {
+        if (value instanceof Float) {
+            out.writeByte((byte) 0);
             out.writeFloat(value.floatValue());
+        } else if (value instanceof Double) {
+            out.writeByte((byte) 1);
+            out.writeDouble(value.doubleValue());
+        } else {
+            out.writeByte((byte) 2);
+            out.writeZLong(value.longValue());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -530,23 +530,15 @@ public final class Settings implements ToXContentFragment {
     public static Settings readSettingsFromStream(StreamInput in) throws IOException {
         Builder builder = new Builder();
         int numberOfSettings = in.readVInt();
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-            for (int i = 0; i < numberOfSettings; i++) {
-                String key = in.readString();
-                Object value = in.readGenericValue();
-                if (value == null) {
-                    builder.putNull(key);
-                } else if (value instanceof List) {
-                    builder.putList(key, (List<String>) value);
-                } else {
-                    builder.put(key, value.toString());
-                }
-            }
-        } else {
-            for (int i = 0; i < numberOfSettings; i++) {
-                String key = in.readString();
-                String value = in.readOptionalString();
-                builder.put(key, value);
+        for (int i = 0; i < numberOfSettings; i++) {
+            String key = in.readString();
+            Object value = in.readGenericValue();
+            if (value == null) {
+                builder.putNull(key);
+            } else if (value instanceof List) {
+                builder.putList(key, (List<String>) value);
+            } else {
+                builder.put(key, value.toString());
             }
         }
         return builder.build();
@@ -555,27 +547,10 @@ public final class Settings implements ToXContentFragment {
     public static void writeSettingsToStream(Settings settings, StreamOutput out) throws IOException {
         // pull settings to exclude secure settings in size()
         Set<Map.Entry<String, Object>> entries = settings.settings.entrySet();
-        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-            out.writeVInt(entries.size());
-            for (Map.Entry<String, Object> entry : entries) {
-                out.writeString(entry.getKey());
-                out.writeGenericValue(entry.getValue());
-            }
-        } else {
-            int size = entries.stream().mapToInt(e -> e.getValue() instanceof List ? ((List)e.getValue()).size() : 1).sum();
-            out.writeVInt(size);
-            for (Map.Entry<String, Object> entry : entries) {
-                if (entry.getValue() instanceof List) {
-                    int idx = 0;
-                    for (String value : (List<String>)entry.getValue()) {
-                        out.writeString(entry.getKey() + "." + idx++);
-                        out.writeOptionalString(value);
-                    }
-                } else {
-                    out.writeString(entry.getKey());
-                    out.writeOptionalString(toString(entry.getValue()));
-                }
-            }
+        out.writeVInt(entries.size());
+        for (Map.Entry<String, Object> entry : entries) {
+            out.writeString(entry.getKey());
+            out.writeGenericValue(entry.getValue());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -21,7 +21,6 @@ package org.elasticsearch.gateway;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
@@ -279,10 +278,6 @@ public class TransportNodesListGatewayStartedShards extends
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
-            if (in.getVersion().before(Version.V_6_0_0_alpha1)) {
-                // legacy version
-                in.readLong();
-            }
             allocationId = in.readOptionalString();
             primary = in.readBoolean();
             if (in.readBoolean()) {
@@ -293,10 +288,6 @@ public class TransportNodesListGatewayStartedShards extends
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            if (out.getVersion().before(Version.V_6_0_0_alpha1)) {
-                // legacy version
-                out.writeLong(-1L);
-            }
             out.writeOptionalString(allocationId);
             out.writeBoolean(primary);
             if (storeException != null) {

--- a/server/src/main/java/org/elasticsearch/index/engine/Segment.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Segment.java
@@ -21,13 +21,12 @@ package org.elasticsearch.index.engine;
 
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
-import org.apache.lucene.search.SortedSetSortField;
+import org.apache.lucene.search.SortedNumericSelector;
 import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.SortedSetSelector;
-import org.apache.lucene.search.SortedNumericSelector;
+import org.apache.lucene.search.SortedSetSortField;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Accountables;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -178,12 +177,8 @@ public class Segment implements Streamable {
             // verbose mode
             ramTree = readRamTree(in);
         }
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
-            segmentSort = readSegmentSort(in);
-        } else {
-            segmentSort = null;
-        }
-        if (in.getVersion().onOrAfter(Version.V_6_1_0) && in.readBoolean()) {
+        segmentSort = readSegmentSort(in);
+        if (in.readBoolean()) {
             attributes = in.readMap(StreamInput::readString, StreamInput::readString);
         } else {
             attributes = null;
@@ -208,15 +203,11 @@ public class Segment implements Streamable {
         if (verbose) {
             writeRamTree(out, ramTree);
         }
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
-            writeSegmentSort(out, segmentSort);
-        }
-        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-            boolean hasAttributes = attributes != null;
-            out.writeBoolean(hasAttributes);
-            if (hasAttributes) {
-                out.writeMap(attributes, StreamOutput::writeString, StreamOutput::writeString);
-            }
+        writeSegmentSort(out, segmentSort);
+        boolean hasAttributes = attributes != null;
+        out.writeBoolean(hasAttributes);
+        if (hasAttributes) {
+            out.writeMap(attributes, StreamOutput::writeString, StreamOutput::writeString);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/flush/FlushStats.java
+++ b/server/src/main/java/org/elasticsearch/index/flush/FlushStats.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.flush;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -43,9 +42,7 @@ public class FlushStats implements Streamable, Writeable, ToXContentFragment {
     public FlushStats(StreamInput in) throws IOException {
         total = in.readVLong();
         totalTimeInMillis = in.readVLong();
-        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
-            periodic = in.readVLong();
-        }
+        periodic = in.readVLong();
     }
 
     public FlushStats(long total, long periodic, long totalTimeInMillis) {
@@ -128,8 +125,6 @@ public class FlushStats implements Streamable, Writeable, ToXContentFragment {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(total);
         out.writeVLong(totalTimeInMillis);
-        if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
-            out.writeVLong(periodic);
-        }
+        out.writeVLong(periodic);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/get/GetResult.java
+++ b/server/src/main/java/org/elasticsearch/index/get/GetResult.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.get;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressorFactory;
@@ -385,13 +384,8 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
         index = in.readString();
         type = in.readOptionalString();
         id = in.readString();
-        if (in.getVersion().onOrAfter(Version.V_6_6_0)) {
-            seqNo = in.readZLong();
-            primaryTerm = in.readVLong();
-        } else {
-            seqNo = UNASSIGNED_SEQ_NO;
-            primaryTerm = UNASSIGNED_PRIMARY_TERM;
-        }
+        seqNo = in.readZLong();
+        primaryTerm = in.readVLong();
         version = in.readLong();
         exists = in.readBoolean();
         if (exists) {
@@ -417,10 +411,8 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
         out.writeString(index);
         out.writeOptionalString(type);
         out.writeString(id);
-        if (out.getVersion().onOrAfter(Version.V_6_6_0)) {
-            out.writeZLong(seqNo);
-            out.writeVLong(primaryTerm);
-        }
+        out.writeZLong(seqNo);
+        out.writeVLong(primaryTerm);
         out.writeLong(version);
         out.writeBoolean(exists);
         if (exists) {

--- a/server/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -33,7 +33,6 @@ import org.apache.lucene.spatial.prefix.RecursivePrefixTreeStrategy;
 import org.apache.lucene.spatial.query.SpatialArgs;
 import org.apache.lucene.spatial.query.SpatialOperation;
 import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
@@ -205,11 +204,7 @@ public class GeoShapeQueryBuilder extends AbstractQueryBuilder<GeoShapeQueryBuil
             indexedShapeType = in.readOptionalString();
             indexedShapeIndex = in.readOptionalString();
             indexedShapePath = in.readOptionalString();
-            if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
-                indexedShapeRouting = in.readOptionalString();
-            } else {
-                indexedShapeRouting = null;
-            }
+            indexedShapeRouting = in.readOptionalString();
         }
         relation = ShapeRelation.readFromStream(in);
         strategy = in.readOptionalWriteable(SpatialStrategy::readFromStream);
@@ -232,11 +227,7 @@ public class GeoShapeQueryBuilder extends AbstractQueryBuilder<GeoShapeQueryBuil
             out.writeOptionalString(indexedShapeType);
             out.writeOptionalString(indexedShapeIndex);
             out.writeOptionalString(indexedShapePath);
-            if (out.getVersion().onOrAfter(Version.V_6_4_0)) {
-                out.writeOptionalString(indexedShapeRouting);
-            } else if (indexedShapeRouting != null) {
-                throw new IllegalStateException("indexed shape routing cannot be serialized to older nodes");
-            }
+            out.writeOptionalString(indexedShapeRouting);
         }
         relation.writeTo(out);
         out.writeOptionalWriteable(strategy);

--- a/server/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
@@ -72,9 +71,7 @@ public class MatchPhraseQueryBuilder extends AbstractQueryBuilder<MatchPhraseQue
         fieldName = in.readString();
         value = in.readGenericValue();
         slop = in.readVInt();
-        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
-            zeroTermsQuery = ZeroTermsQuery.readFromStream(in);
-        }
+        zeroTermsQuery = ZeroTermsQuery.readFromStream(in);
         analyzer = in.readOptionalString();
     }
 
@@ -83,9 +80,7 @@ public class MatchPhraseQueryBuilder extends AbstractQueryBuilder<MatchPhraseQue
         out.writeString(fieldName);
         out.writeGenericValue(value);
         out.writeVInt(slop);
-        if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
-            zeroTermsQuery.writeTo(out);
-        }
+        zeroTermsQuery.writeTo(out);
         out.writeOptionalString(analyzer);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -111,13 +110,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
         super(in);
         fieldName = in.readString();
         value = in.readGenericValue();
-        if (in.getVersion().before(Version.V_6_0_0_rc1)) {
-            MatchQuery.Type.readFromStream(in);  // deprecated type
-        }
         operator = Operator.readFromStream(in);
-        if (in.getVersion().before(Version.V_6_0_0_rc1)) {
-            in.readVInt(); // deprecated slop
-        }
         prefixLength = in.readVInt();
         maxExpansions = in.readVInt();
         fuzzyTranspositions = in.readBoolean();
@@ -129,22 +122,14 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
         fuzzyRewrite = in.readOptionalString();
         fuzziness = in.readOptionalWriteable(Fuzziness::new);
         cutoffFrequency = in.readOptionalFloat();
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-            autoGenerateSynonymsPhraseQuery = in.readBoolean();
-        }
+        autoGenerateSynonymsPhraseQuery = in.readBoolean();
     }
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeString(fieldName);
         out.writeGenericValue(value);
-        if (out.getVersion().before(Version.V_6_0_0_rc1)) {
-            MatchQuery.Type.BOOLEAN.writeTo(out); // deprecated type
-        }
         operator.writeTo(out);
-        if (out.getVersion().before(Version.V_6_0_0_rc1)) {
-            out.writeVInt(MatchQuery.DEFAULT_PHRASE_SLOP); // deprecated slop
-        }
         out.writeVInt(prefixLength);
         out.writeVInt(maxExpansions);
         out.writeBoolean(fuzzyTranspositions);
@@ -156,9 +141,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
         out.writeOptionalString(fuzzyRewrite);
         out.writeOptionalWriteable(fuzziness);
         out.writeOptionalFloat(cutoffFrequency);
-        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-            out.writeBoolean(autoGenerateSynonymsPhraseQuery);
-        }
+        out.writeBoolean(autoGenerateSynonymsPhraseQuery);
     }
 
     /** Returns the field name used in this query. */

--- a/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
@@ -225,21 +224,12 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         maxExpansions = in.readVInt();
         minimumShouldMatch = in.readOptionalString();
         fuzzyRewrite = in.readOptionalString();
-        if (in.getVersion().before(Version.V_7_0_0)) {
-            in.readOptionalBoolean(); // unused use_dis_max flag
-        }
         tieBreaker = in.readOptionalFloat();
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-            lenient = in.readOptionalBoolean();
-        } else {
-            lenient = in.readBoolean();
-        }
+        lenient = in.readOptionalBoolean();
         cutoffFrequency = in.readOptionalFloat();
         zeroTermsQuery = MatchQuery.ZeroTermsQuery.readFromStream(in);
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-            autoGenerateSynonymsPhraseQuery = in.readBoolean();
-            fuzzyTranspositions = in.readBoolean();
-        }
+        autoGenerateSynonymsPhraseQuery = in.readBoolean();
+        fuzzyTranspositions = in.readBoolean();
     }
 
     @Override
@@ -259,21 +249,12 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         out.writeVInt(maxExpansions);
         out.writeOptionalString(minimumShouldMatch);
         out.writeOptionalString(fuzzyRewrite);
-        if (out.getVersion().before(Version.V_7_0_0)) {
-            out.writeOptionalBoolean(null);
-        }
         out.writeOptionalFloat(tieBreaker);
-        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-            out.writeOptionalBoolean(lenient);
-        } else {
-            out.writeBoolean(lenient == null ? MatchQuery.DEFAULT_LENIENCY : lenient);
-        }
+        out.writeOptionalBoolean(lenient);
         out.writeOptionalFloat(cutoffFrequency);
         zeroTermsQuery.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-            out.writeBoolean(autoGenerateSynonymsPhraseQuery);
-            out.writeBoolean(fuzzyTranspositions);
-        }
+        out.writeBoolean(autoGenerateSynonymsPhraseQuery);
+        out.writeBoolean(fuzzyTranspositions);
     }
 
     public Object value() {
@@ -616,7 +597,6 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         Operator operator = DEFAULT_OPERATOR;
         String minimumShouldMatch = null;
         String fuzzyRewrite = null;
-        Boolean useDisMax = null;
         Float tieBreaker = null;
         Float cutoffFrequency = null;
         Boolean lenient = null;

--- a/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -23,7 +23,6 @@ import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.automaton.Operations;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -195,10 +194,8 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         timeZone = in.readOptionalZoneId();
         escape = in.readBoolean();
         maxDeterminizedStates = in.readVInt();
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-            autoGenerateSynonymsPhraseQuery = in.readBoolean();
-            fuzzyTranspositions = in.readBoolean();
-        }
+        autoGenerateSynonymsPhraseQuery = in.readBoolean();
+        fuzzyTranspositions = in.readBoolean();
     }
 
     @Override
@@ -230,10 +227,8 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         out.writeOptionalZoneId(timeZone);
         out.writeBoolean(this.escape);
         out.writeVInt(this.maxDeterminizedStates);
-        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-            out.writeBoolean(autoGenerateSynonymsPhraseQuery);
-            out.writeBoolean(fuzzyTranspositions);
-        }
+        out.writeBoolean(autoGenerateSynonymsPhraseQuery);
+        out.writeBoolean(fuzzyTranspositions);
     }
 
     public String queryString() {

--- a/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
@@ -173,12 +172,10 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         settings.analyzeWildcard(in.readBoolean());
         minimumShouldMatch = in.readOptionalString();
         settings.quoteFieldSuffix(in.readOptionalString());
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-            settings.autoGenerateSynonymsPhraseQuery(in.readBoolean());
-            settings.fuzzyPrefixLength(in.readVInt());
-            settings.fuzzyMaxExpansions(in.readVInt());
-            settings.fuzzyTranspositions(in.readBoolean());
-        }
+        settings.autoGenerateSynonymsPhraseQuery(in.readBoolean());
+        settings.fuzzyPrefixLength(in.readVInt());
+        settings.fuzzyMaxExpansions(in.readVInt());
+        settings.fuzzyTranspositions(in.readBoolean());
     }
 
     @Override
@@ -197,12 +194,10 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         out.writeBoolean(settings.analyzeWildcard());
         out.writeOptionalString(minimumShouldMatch);
         out.writeOptionalString(settings.quoteFieldSuffix());
-        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-            out.writeBoolean(settings.autoGenerateSynonymsPhraseQuery());
-            out.writeVInt(settings.fuzzyPrefixLength());
-            out.writeVInt(settings.fuzzyMaxExpansions());
-            out.writeBoolean(settings.fuzzyTranspositions());
-        }
+        out.writeBoolean(settings.autoGenerateSynonymsPhraseQuery());
+        out.writeVInt(settings.fuzzyPrefixLength());
+        out.writeVInt(settings.fuzzyMaxExpansions());
+        out.writeBoolean(settings.fuzzyTranspositions());
     }
 
     /** Returns the text to parse the query from. */

--- a/server/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
@@ -22,8 +22,6 @@ package org.elasticsearch.index.query;
 import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -59,20 +57,12 @@ public class TypeQueryBuilder extends AbstractQueryBuilder<TypeQueryBuilder> {
      */
     public TypeQueryBuilder(StreamInput in) throws IOException {
         super(in);
-        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
-            type = in.readString();
-        } else {
-            type = in.readBytesRef().utf8ToString();
-        }
+        type = in.readString();
     }
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
-            out.writeString(type);
-        } else {
-            out.writeBytesRef(new BytesRef(type));
-        }
+        out.writeString(type);
     }
 
     public String type() {

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.index.query.functionscore;
 
 import org.apache.logging.log4j.LogManager;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -58,9 +57,7 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
         if (in.readBoolean()) {
             seed = in.readInt();
         }
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_beta1)) {
-            field = in.readOptionalString();
-        }
+        field = in.readOptionalString();
     }
 
     @Override
@@ -71,9 +68,7 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
         } else {
             out.writeBoolean(false);
         }
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_beta1)) {
-            out.writeOptionalString(field);
-        }
+        out.writeOptionalString(field);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/reindex/RemoteInfo.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/RemoteInfo.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.reindex;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -96,11 +95,7 @@ public class RemoteInfo implements Writeable, ToXContentObject {
         this.headers = unmodifiableMap(headers);
         socketTimeout = in.readTimeValue();
         connectTimeout = in.readTimeValue();
-        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
-            pathPrefix = in.readOptionalString();
-        } else {
-            pathPrefix = null;
-        }
+        pathPrefix = in.readOptionalString();
     }
 
     @Override
@@ -118,9 +113,7 @@ public class RemoteInfo implements Writeable, ToXContentObject {
         }
         out.writeTimeValue(socketTimeout);
         out.writeTimeValue(connectTimeout);
-        if (out.getVersion().onOrAfter(Version.V_6_4_0)) {
-            out.writeOptionalString(pathPrefix);
-        }
+        out.writeOptionalString(pathPrefix);
     }
 
     public String getScheme() {

--- a/server/src/main/java/org/elasticsearch/index/shard/DocsStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/DocsStats.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.shard;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -43,11 +42,7 @@ public class DocsStats implements Streamable, Writeable, ToXContentFragment {
     public DocsStats(StreamInput in) throws IOException {
         count = in.readVLong();
         deleted = in.readVLong();
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-            totalSizeInBytes = in.readVLong();
-        } else {
-            totalSizeInBytes = -1;
-        }
+        totalSizeInBytes = in.readVLong();
     }
 
     public DocsStats(long count, long deleted, long totalSizeInBytes) {

--- a/server/src/main/java/org/elasticsearch/index/store/StoreStats.java
+++ b/server/src/main/java/org/elasticsearch/index/store/StoreStats.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.store;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -40,9 +39,6 @@ public class StoreStats implements Streamable, Writeable, ToXContentFragment {
 
     public StoreStats(StreamInput in) throws IOException {
         sizeInBytes = in.readVLong();
-        if (in.getVersion().before(Version.V_6_0_0_alpha1)) {
-            in.readVLong(); // throttleTimeInNanos
-        }
     }
 
     public StoreStats(long sizeInBytes) {
@@ -81,9 +77,6 @@ public class StoreStats implements Streamable, Writeable, ToXContentFragment {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(sizeInBytes);
-        if (out.getVersion().before(Version.V_6_0_0_alpha1)) {
-            out.writeVLong(0L); // throttleTimeInNanos
-        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -1102,8 +1102,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
     public static class Index implements Operation {
 
-        public static final int FORMAT_6_0 = 8; // since 6.0.0
-        public static final int FORMAT_NO_PARENT = FORMAT_6_0 + 1; // since 7.0
+        public static final int FORMAT_NO_PARENT = 9; // since 7.0
         public static final int FORMAT_NO_VERSION_TYPE = FORMAT_NO_PARENT + 1;
         public static final int SERIALIZATION_FORMAT = FORMAT_NO_VERSION_TYPE;
 
@@ -1118,7 +1117,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
         private Index(final StreamInput in) throws IOException {
             final int format = in.readVInt(); // SERIALIZATION_FORMAT
-            assert format >= FORMAT_6_0 : "format was: " + format;
+            assert format >= FORMAT_NO_PARENT : "format was: " + format;
             id = in.readString();
             type = in.readString();
             source = in.readBytesReference();
@@ -1208,7 +1207,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         }
 
         private void write(final StreamOutput out) throws IOException {
-            final int format = out.getVersion().onOrAfter(Version.V_7_0_0) ? SERIALIZATION_FORMAT : FORMAT_6_0;
+            final int format = SERIALIZATION_FORMAT;
             out.writeVInt(format);
             out.writeString(id);
             out.writeString(type);
@@ -1371,7 +1370,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         }
 
         private void write(final StreamOutput out) throws IOException {
-            final int format = out.getVersion().onOrAfter(Version.V_7_0_0) ? SERIALIZATION_FORMAT : FORMAT_6_0;
+            final int format = SERIALIZATION_FORMAT;
             out.writeVInt(format);
             out.writeString(type);
             out.writeString(id);

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogStats.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogStats.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.index.translog;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -44,16 +43,9 @@ public class TranslogStats implements Streamable, Writeable, ToXContentFragment 
     public TranslogStats(StreamInput in) throws IOException {
         numberOfOperations = in.readVInt();
         translogSizeInBytes = in.readVLong();
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_beta1)) {
-            uncommittedOperations = in.readVInt();
-            uncommittedSizeInBytes = in.readVLong();
-        } else {
-            uncommittedOperations = numberOfOperations;
-            uncommittedSizeInBytes = translogSizeInBytes;
-        }
-        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
-            earliestLastModifiedAge = in.readVLong();
-        }
+        uncommittedOperations = in.readVInt();
+        uncommittedSizeInBytes = in.readVLong();
+        earliestLastModifiedAge = in.readVLong();
     }
 
     public TranslogStats(int numberOfOperations, long translogSizeInBytes, int uncommittedOperations, long uncommittedSizeInBytes,
@@ -139,12 +131,8 @@ public class TranslogStats implements Streamable, Writeable, ToXContentFragment 
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(numberOfOperations);
         out.writeVLong(translogSizeInBytes);
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_beta1)) {
-            out.writeVInt(uncommittedOperations);
-            out.writeVLong(uncommittedSizeInBytes);
-        }
-        if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
-            out.writeVLong(earliestLastModifiedAge);
-        }
+        out.writeVInt(uncommittedOperations);
+        out.writeVLong(uncommittedSizeInBytes);
+        out.writeVLong(earliestLastModifiedAge);
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/TermsLookup.java
+++ b/server/src/main/java/org/elasticsearch/indices/TermsLookup.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.indices;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -72,44 +71,19 @@ public class TermsLookup implements Writeable, ToXContentFragment {
      * Read from a stream.
      */
     public TermsLookup(StreamInput in) throws IOException {
-        if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
-            type = in.readOptionalString();
-        } else {
-            // Before 7.0, the type parameter was always non-null and serialized as a (non-optional) string.
-            type = in.readString();
-        }
+        type = in.readOptionalString();
         id = in.readString();
         path = in.readString();
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_beta1)) {
-            index = in.readString();
-        } else {
-            index = in.readOptionalString();
-            if (index == null) {
-                throw new IllegalStateException("index must not be null in a terms lookup");
-            }
-        }
+        index = in.readString();
         routing = in.readOptionalString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-            out.writeOptionalString(type);
-        } else {
-            if (type == null) {
-                throw new IllegalArgumentException("Typeless [terms] lookup queries are not supported if any " +
-                    "node is running a version before 7.0.");
-
-            }
-            out.writeString(type);
-        }
+        out.writeOptionalString(type);
         out.writeString(id);
         out.writeString(path);
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_beta1)) {
-            out.writeString(index);
-        } else {
-            out.writeOptionalString(index);
-        }
+        out.writeString(index);
         out.writeOptionalString(routing);
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFinalizeRecoveryRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFinalizeRecoveryRequest.java
@@ -19,10 +19,8 @@
 
 package org.elasticsearch.indices.recovery;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.transport.TransportRequest;
 
@@ -60,11 +58,7 @@ public class RecoveryFinalizeRecoveryRequest extends TransportRequest {
         super.readFrom(in);
         recoveryId = in.readLong();
         shardId = ShardId.readShardId(in);
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
-            globalCheckpoint = in.readZLong();
-        } else {
-            globalCheckpoint = SequenceNumbers.UNASSIGNED_SEQ_NO;
-        }
+        globalCheckpoint = in.readZLong();
     }
 
     @Override
@@ -72,9 +66,7 @@ public class RecoveryFinalizeRecoveryRequest extends TransportRequest {
         super.writeTo(out);
         out.writeLong(recoveryId);
         shardId.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
-            out.writeZLong(globalCheckpoint);
-        }
+        out.writeZLong(globalCheckpoint);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryPrepareForTranslogOperationsRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryPrepareForTranslogOperationsRequest.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.indices.recovery;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
@@ -47,14 +45,7 @@ class RecoveryPrepareForTranslogOperationsRequest extends TransportRequest {
         recoveryId = in.readLong();
         shardId = ShardId.readShardId(in);
         totalTranslogOps = in.readVInt();
-        if (in.getVersion().before(Version.V_6_0_0_alpha1)) {
-            in.readLong(); // maxUnsafeAutoIdTimestamp
-        }
-        if (in.getVersion().onOrAfter(Version.V_6_2_0)) {
-            fileBasedRecovery = in.readBoolean();
-        } else {
-            fileBasedRecovery = true;
-        }
+        fileBasedRecovery = in.readBoolean();
     }
 
     public long recoveryId() {
@@ -82,11 +73,6 @@ class RecoveryPrepareForTranslogOperationsRequest extends TransportRequest {
         out.writeLong(recoveryId);
         shardId.writeTo(out);
         out.writeVInt(totalTranslogOps);
-        if (out.getVersion().before(Version.V_6_0_0_alpha1)) {
-            out.writeLong(IndexRequest.UNSET_AUTO_GENERATED_TIMESTAMP); // maxUnsafeAutoIdTimestamp
-        }
-        if (out.getVersion().onOrAfter(Version.V_6_2_0)) {
-            out.writeBoolean(fileBasedRecovery);
-        }
+        out.writeBoolean(fileBasedRecovery);
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTranslogOperationsResponse.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTranslogOperationsResponse.java
@@ -19,10 +19,8 @@
 
 package org.elasticsearch.indices.recovery;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.transport.TransportResponse;
 
 import java.io.IOException;
@@ -36,21 +34,12 @@ final class RecoveryTranslogOperationsResponse extends TransportResponse {
 
     RecoveryTranslogOperationsResponse(final StreamInput in) throws IOException {
         super(in);
-        // before 6.0.0 we received an empty response so we have to maintain that
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
-            localCheckpoint = in.readZLong();
-        }
-        else {
-            localCheckpoint = SequenceNumbers.UNASSIGNED_SEQ_NO;
-        }
+        localCheckpoint = in.readZLong();
     }
 
     @Override
     public void writeTo(final StreamOutput out) throws IOException {
         super.writeTo(out);
-        // before 6.0.0 we responded with an empty response so we have to maintain that
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
-            out.writeZLong(localCheckpoint);
-        }
+        out.writeZLong(localCheckpoint);
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.indices.recovery;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -121,11 +120,7 @@ public class StartRecoveryRequest extends TransportRequest {
         targetNode = new DiscoveryNode(in);
         metadataSnapshot = new Store.MetadataSnapshot(in);
         primaryRelocation = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
-            startingSeqNo = in.readLong();
-        } else {
-            startingSeqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
-        }
+        startingSeqNo = in.readLong();
     }
 
     @Override
@@ -138,9 +133,6 @@ public class StartRecoveryRequest extends TransportRequest {
         targetNode.writeTo(out);
         metadataSnapshot.writeTo(out);
         out.writeBoolean(primaryRelocation);
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
-            out.writeLong(startingSeqNo);
-        }
+        out.writeLong(startingSeqNo);
     }
-
 }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.ingest;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -64,16 +63,14 @@ public class IngestStats implements Writeable, ToXContentFragment {
             String pipelineId = in.readString();
             Stats pipelineStat = new Stats(in);
             this.pipelineStats.add(new PipelineStat(pipelineId, pipelineStat));
-            if (in.getVersion().onOrAfter(Version.V_6_5_0)) {
-                int processorsSize = in.readVInt();
-                List<ProcessorStat> processorStatsPerPipeline = new ArrayList<>(processorsSize);
-                for (int j = 0; j < processorsSize; j++) {
-                    String processorName = in.readString();
-                    Stats processorStat = new Stats(in);
-                    processorStatsPerPipeline.add(new ProcessorStat(processorName, processorStat));
-                }
-                this.processorStats.put(pipelineId, processorStatsPerPipeline);
+            int processorsSize = in.readVInt();
+            List<ProcessorStat> processorStatsPerPipeline = new ArrayList<>(processorsSize);
+            for (int j = 0; j < processorsSize; j++) {
+                String processorName = in.readString();
+                Stats processorStat = new Stats(in);
+                processorStatsPerPipeline.add(new ProcessorStat(processorName, processorStat));
             }
+            this.processorStats.put(pipelineId, processorStatsPerPipeline);
         }
     }
 
@@ -84,16 +81,14 @@ public class IngestStats implements Writeable, ToXContentFragment {
         for (PipelineStat pipelineStat : pipelineStats) {
             out.writeString(pipelineStat.getPipelineId());
             pipelineStat.getStats().writeTo(out);
-            if (out.getVersion().onOrAfter(Version.V_6_5_0)) {
-                List<ProcessorStat> processorStatsForPipeline = processorStats.get(pipelineStat.getPipelineId());
-                if (processorStatsForPipeline == null) {
-                    out.writeVInt(0);
-                } else {
-                    out.writeVInt(processorStatsForPipeline.size());
-                    for (ProcessorStat processorStat : processorStatsForPipeline) {
-                        out.writeString(processorStat.getName());
-                        processorStat.getStats().writeTo(out);
-                    }
+            List<ProcessorStat> processorStatsForPipeline = processorStats.get(pipelineStat.getPipelineId());
+            if (processorStatsForPipeline == null) {
+                out.writeVInt(0);
+            } else {
+                out.writeVInt(processorStatsForPipeline.size());
+                for (ProcessorStat processorStat : processorStatsForPipeline) {
+                    out.writeString(processorStat.getName());
+                    processorStat.getStats().writeTo(out);
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsInfo.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.monitor.os;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -61,11 +60,7 @@ public class OsInfo implements Writeable, ToXContentFragment {
         this.availableProcessors = in.readInt();
         this.allocatedProcessors = in.readInt();
         this.name = in.readOptionalString();
-        if (in.getVersion().onOrAfter(Version.V_6_6_0)) {
-            this.prettyName = in.readOptionalString();
-        } else {
-            this.prettyName = null;
-        }
+        this.prettyName = in.readOptionalString();
         this.arch = in.readOptionalString();
         this.version = in.readOptionalString();
     }
@@ -76,9 +71,7 @@ public class OsInfo implements Writeable, ToXContentFragment {
         out.writeInt(availableProcessors);
         out.writeInt(allocatedProcessors);
         out.writeOptionalString(name);
-        if (out.getVersion().onOrAfter(Version.V_6_6_0)) {
-            out.writeOptionalString(prettyName);
-        }
+        out.writeOptionalString(prettyName);
         out.writeOptionalString(arch);
         out.writeOptionalString(version);
     }

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.monitor.os;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -413,15 +412,9 @@ public class OsStats implements Writeable, ToXContentFragment {
             cpuCfsPeriodMicros = in.readLong();
             cpuCfsQuotaMicros = in.readLong();
             cpuStat = new CpuStat(in);
-            if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-                memoryControlGroup = in.readOptionalString();
-                memoryLimitInBytes = in.readOptionalString();
-                memoryUsageInBytes = in.readOptionalString();
-            } else {
-                memoryControlGroup = null;
-                memoryLimitInBytes = null;
-                memoryUsageInBytes = null;
-            }
+            memoryControlGroup = in.readOptionalString();
+            memoryLimitInBytes = in.readOptionalString();
+            memoryUsageInBytes = in.readOptionalString();
         }
 
         @Override
@@ -432,11 +425,9 @@ public class OsStats implements Writeable, ToXContentFragment {
             out.writeLong(cpuCfsPeriodMicros);
             out.writeLong(cpuCfsQuotaMicros);
             cpuStat.writeTo(out);
-            if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-                out.writeOptionalString(memoryControlGroup);
-                out.writeOptionalString(memoryLimitInBytes);
-                out.writeOptionalString(memoryUsageInBytes);
-            }
+            out.writeOptionalString(memoryControlGroup);
+            out.writeOptionalString(memoryLimitInBytes);
+            out.writeOptionalString(memoryUsageInBytes);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetaData.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetaData.java
@@ -347,11 +347,7 @@ public final class PersistentTasksCustomMetaData extends AbstractNamedDiffable<M
             id = in.readString();
             allocationId = in.readLong();
             taskName = in.readString();
-            if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
-                params = (P) in.readNamedWriteable(PersistentTaskParams.class);
-            } else {
-                params = (P) in.readOptionalNamedWriteable(PersistentTaskParams.class);
-            }
+            params = (P) in.readNamedWriteable(PersistentTaskParams.class);
             state = in.readOptionalNamedWriteable(PersistentTaskState.class);
             assignment = new Assignment(in.readOptionalString(), in.readString());
             allocationIdOnLastStatusUpdate = in.readOptionalLong();
@@ -362,11 +358,7 @@ public final class PersistentTasksCustomMetaData extends AbstractNamedDiffable<M
             out.writeString(id);
             out.writeLong(allocationId);
             out.writeString(taskName);
-            if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
-                out.writeNamedWriteable(params);
-            } else {
-                out.writeOptionalNamedWriteable(params);
-            }
+            out.writeNamedWriteable(params);
             out.writeOptionalNamedWriteable(state);
             out.writeOptionalString(assignment.executorNode);
             out.writeString(assignment.explanation);

--- a/server/src/main/java/org/elasticsearch/persistent/StartPersistentTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/persistent/StartPersistentTaskAction.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.persistent;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
@@ -85,11 +84,7 @@ public class StartPersistentTaskAction extends Action<PersistentTaskResponse> {
             super.readFrom(in);
             taskId = in.readString();
             taskName = in.readString();
-            if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
-                params = in.readNamedWriteable(PersistentTaskParams.class);
-            } else {
-                params = in.readOptionalNamedWriteable(PersistentTaskParams.class);
-            }
+            params = in.readNamedWriteable(PersistentTaskParams.class);
         }
 
         @Override
@@ -97,11 +92,7 @@ public class StartPersistentTaskAction extends Action<PersistentTaskResponse> {
             super.writeTo(out);
             out.writeString(taskId);
             out.writeString(taskName);
-            if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
-                out.writeNamedWriteable(params);
-            } else {
-                out.writeOptionalNamedWriteable(params);
-            }
+            out.writeNamedWriteable(params);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
@@ -92,29 +92,11 @@ public class PluginInfo implements Writeable, ToXContentObject {
         this.name = in.readString();
         this.description = in.readString();
         this.version = in.readString();
-        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
-            elasticsearchVersion = Version.readVersion(in);
-            javaVersion = in.readString();
-        } else {
-            // the plugin must have the version of whichever node we are talking to, since this is enforced on startup
-            elasticsearchVersion = in.getVersion();
-            // this might not be true, but it is not important, we just need something here for bwc that is a valid java version string
-            javaVersion = "1.8";
-        }
+        elasticsearchVersion = Version.readVersion(in);
+        javaVersion = in.readString();
         this.classname = in.readString();
-        if (in.getVersion().onOrAfter(Version.V_6_2_0)) {
-            extendedPlugins = in.readStringList();
-        } else {
-            extendedPlugins = Collections.emptyList();
-        }
+        extendedPlugins = in.readStringList();
         hasNativeController = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_beta2) && in.getVersion().before(Version.V_6_3_0)) {
-            /*
-             * Elasticsearch versions in [6.0.0-beta2, 6.3.0) allowed plugins to specify that they require the keystore and this was
-             * serialized into the plugin info. Therefore, we have to read and ignore this value from the stream.
-             */
-            in.readBoolean();
-        }
     }
 
     @Override
@@ -122,22 +104,11 @@ public class PluginInfo implements Writeable, ToXContentObject {
         out.writeString(name);
         out.writeString(description);
         out.writeString(version);
-        if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
-            Version.writeVersion(elasticsearchVersion, out);
-            out.writeString(javaVersion);
-        }
+        Version.writeVersion(elasticsearchVersion, out);
+        out.writeString(javaVersion);
         out.writeString(classname);
-        if (out.getVersion().onOrAfter(Version.V_6_2_0)) {
-            out.writeStringCollection(extendedPlugins);
-        }
+        out.writeStringCollection(extendedPlugins);
         out.writeBoolean(hasNativeController);
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_beta2) && out.getVersion().before(Version.V_6_3_0)) {
-            /*
-             * Elasticsearch versions in [6.0.0-beta2, 6.3.0) allowed plugins to specify that they require the keystore and this was
-             * serialized into the plugin info. Therefore, we have to write out a value for this boolean.
-             */
-            out.writeBoolean(false);
-        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/script/ScriptStats.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptStats.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.script;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -42,16 +41,14 @@ public class ScriptStats implements Writeable, ToXContentFragment {
     public ScriptStats(StreamInput in) throws IOException {
         compilations = in.readVLong();
         cacheEvictions = in.readVLong();
-        compilationLimitTriggered = in.getVersion().onOrAfter(Version.V_7_0_0) ? in.readVLong() : 0;
+        compilationLimitTriggered = in.readVLong();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(compilations);
         out.writeVLong(cacheEvictions);
-        if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-            out.writeVLong(compilationLimitTriggered);
-        }
+        out.writeVLong(compilationLimitTriggered);
     }
 
     public long getCompilations() {

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search;
 
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
@@ -148,10 +147,8 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         type = in.readOptionalText();
         nestedIdentity = in.readOptionalWriteable(NestedIdentity::new);
         version = in.readLong();
-        if (in.getVersion().onOrAfter(Version.V_6_7_0)) {
-            seqNo = in.readZLong();
-            primaryTerm = in.readVLong();
-        }
+        seqNo = in.readZLong();
+        primaryTerm = in.readVLong();
         source = in.readBytesReference();
         if (source.length() == 0) {
             source = null;
@@ -220,10 +217,8 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         out.writeOptionalText(type);
         out.writeOptionalWriteable(nestedIdentity);
         out.writeLong(version);
-        if (out.getVersion().onOrAfter(Version.V_6_7_0)) {
-            out.writeZLong(seqNo);
-            out.writeVLong(primaryTerm);
-        }
+        out.writeZLong(seqNo);
+        out.writeVLong(primaryTerm);
         out.writeBytesReference(source);
         if (explanation == null) {
             out.writeBoolean(false);

--- a/server/src/main/java/org/elasticsearch/search/SearchHits.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHits.java
@@ -22,7 +22,6 @@ package org.elasticsearch.search;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.TotalHits.Relation;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -95,15 +94,9 @@ public final class SearchHits implements Writeable, ToXContentFragment, Iterable
                 hits[i] = new SearchHit(in);
             }
         }
-        if (in.getVersion().onOrAfter(Version.V_6_6_0)) {
-            sortFields = in.readOptionalArray(Lucene::readSortField, SortField[]::new);
-            collapseField = in.readOptionalString();
-            collapseValues = in.readOptionalArray(Lucene::readSortValue, Object[]::new);
-        } else {
-            sortFields = null;
-            collapseField = null;
-            collapseValues = null;
-        }
+        sortFields = in.readOptionalArray(Lucene::readSortField, SortField[]::new);
+        collapseField = in.readOptionalString();
+        collapseValues = in.readOptionalArray(Lucene::readSortValue, Object[]::new);
     }
 
     @Override
@@ -120,11 +113,9 @@ public final class SearchHits implements Writeable, ToXContentFragment, Iterable
                 hit.writeTo(out);
             }
         }
-        if (out.getVersion().onOrAfter(Version.V_6_6_0)) {
-            out.writeOptionalArray(Lucene::writeSortField, sortFields);
-            out.writeOptionalString(collapseField);
-            out.writeOptionalArray(Lucene::writeSortValue, collapseValues);
-        }
+        out.writeOptionalArray(Lucene::writeSortField, sortFields);
+        out.writeOptionalString(collapseField);
+        out.writeOptionalArray(Lucene::writeSortValue, collapseValues);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/SearchSortValues.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchSortValues.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.search;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -67,19 +66,13 @@ public class SearchSortValues implements ToXContentFragment, Writeable {
 
     SearchSortValues(StreamInput in) throws IOException {
         this.formattedSortValues = in.readArray(Lucene::readSortValue, Object[]::new);
-        if (in.getVersion().onOrAfter(Version.V_6_6_0)) {
-            this.rawSortValues = in.readArray(Lucene::readSortValue, Object[]::new);
-        } else {
-            this.rawSortValues = EMPTY_ARRAY;
-        }
+        this.rawSortValues = in.readArray(Lucene::readSortValue, Object[]::new);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeArray(Lucene::writeSortValue, this.formattedSortValues);
-        if (out.getVersion().onOrAfter(Version.V_6_6_0)) {
-            out.writeArray(Lucene::writeSortValue, this.rawSortValues);
-        }
+        out.writeArray(Lucene::writeSortValue, this.rawSortValues);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
@@ -18,12 +18,9 @@
  */
 package org.elasticsearch.search.aggregations;
 
-import org.apache.logging.log4j.LogManager;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.Comparators;
 import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -423,34 +420,11 @@ public class InternalOrder extends BucketOrder {
          * ONLY FOR HISTOGRAM ORDER: Backwards compatibility logic to read a {@link BucketOrder} from a {@link StreamInput}.
          *
          * @param in           stream with order data to read.
-         * @param bwcOrderFlag {@code true} to check {@code in.readBoolean()} in the backwards compat logic before reading
-         *                     the order. {@code false} to skip this flag (order always present).
          * @return order read from the stream
          * @throws IOException on error reading from the stream.
          */
-        public static BucketOrder readHistogramOrder(StreamInput in, boolean bwcOrderFlag) throws IOException {
-            if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha2)) {
-                return Streams.readOrder(in);
-            } else { // backwards compat logic
-                if (bwcOrderFlag == false || in.readBoolean()) {
-                    // translate the old histogram order IDs to the new order objects
-                    byte id = in.readByte();
-                    switch (id) {
-                        case 1: return KEY_ASC;
-                        case 2: return KEY_DESC;
-                        case 3: return COUNT_ASC;
-                        case 4: return COUNT_DESC;
-                        case 0: // aggregation order stream logic is backwards compatible
-                            boolean asc = in.readBoolean();
-                            String key = in.readString();
-                            return new Aggregation(key, asc);
-                        default: // not expecting compound order ID
-                            throw new RuntimeException("unknown histogram order id [" + id + "]");
-                    }
-                } else { // default to _key asc if no order specified
-                    return KEY_ASC;
-                }
-            }
+        public static BucketOrder readHistogramOrder(StreamInput in) throws IOException {
+            return Streams.readOrder(in);
         }
 
         /**
@@ -480,45 +454,10 @@ public class InternalOrder extends BucketOrder {
          *
          * @param order        order to write to the stream.
          * @param out          stream to write the order to.
-         * @param bwcOrderFlag {@code true} to always {@code out.writeBoolean(true)} for the backwards compat logic before
-         *                     writing the order. {@code false} to skip this flag.
          * @throws IOException on error writing to the stream.
          */
-        public static void writeHistogramOrder(BucketOrder order, StreamOutput out, boolean bwcOrderFlag) throws IOException {
-            if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha2)) {
-                order.writeTo(out);
-            } else { // backwards compat logic
-                if(bwcOrderFlag) { // need to add flag that determines if order exists
-                    out.writeBoolean(true); // order always exists
-                }
-                if (order instanceof CompoundOrder) {
-                    // older versions do not support histogram compound order; the best we can do here is use the first order.
-                    order = ((CompoundOrder) order).orderElements.get(0);
-                }
-                if (order instanceof Aggregation) {
-                    // aggregation order stream logic is backwards compatible
-                    order.writeTo(out);
-                } else {
-                    // convert the new order IDs to the old histogram order IDs.
-                    byte id;
-                    switch (order.id()) {
-                        case COUNT_DESC_ID:
-                            id = 4;
-                            break;
-                        case COUNT_ASC_ID:
-                            id = 3;
-                            break;
-                        case KEY_DESC_ID:
-                            id = 2;
-                            break;
-                        case KEY_ASC_ID:
-                            id = 1;
-                            break;
-                        default: throw new RuntimeException("unknown order id [" + order.id() + "]");
-                    }
-                    out.writeByte(id);
-                }
-            }
+        public static void writeHistogramOrder(BucketOrder order, StreamOutput out) throws IOException {
+            order.writeTo(out);
         }
     }
 
@@ -526,9 +465,6 @@ public class InternalOrder extends BucketOrder {
      * Contains logic for parsing a {@link BucketOrder} from a {@link XContentParser}.
      */
     public static class Parser {
-
-        private static final DeprecationLogger deprecationLogger =
-            new DeprecationLogger(LogManager.getLogger(Parser.class));
 
         /**
          * Parse a {@link BucketOrder} from {@link XContent}.

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.search.aggregations.bucket.composite;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -72,37 +71,25 @@ public class InternalComposite
         this.sourceNames = in.readStringList();
         this.formats = new ArrayList<>(sourceNames.size());
         for (int i = 0; i < sourceNames.size(); i++) {
-            if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
-                formats.add(in.readNamedWriteable(DocValueFormat.class));
-            } else {
-                formats.add(DocValueFormat.RAW);
-            }
+            formats.add(in.readNamedWriteable(DocValueFormat.class));
         }
         this.reverseMuls = in.readIntArray();
         this.buckets = in.readList((input) -> new InternalBucket(input, sourceNames, formats, reverseMuls));
-        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
-            this.afterKey = in.readBoolean() ? new CompositeKey(in) : null;
-        } else {
-            this.afterKey = buckets.size() > 0 ? buckets.get(buckets.size()-1).key : null;
-        }
+        this.afterKey = in.readBoolean() ? new CompositeKey(in) : null;
     }
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeVInt(size);
         out.writeStringCollection(sourceNames);
-        if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
-            for (DocValueFormat format : formats) {
-                out.writeNamedWriteable(format);
-            }
+        for (DocValueFormat format : formats) {
+            out.writeNamedWriteable(format);
         }
         out.writeIntArray(reverseMuls);
         out.writeList(buckets);
-        if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
-            out.writeBoolean(afterKey != null);
-            if (afterKey != null) {
-                afterKey.writeTo(out);
-            }
+        out.writeBoolean(afterKey != null);
+        if (afterKey != null) {
+            afterKey.writeTo(out);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
@@ -173,7 +173,7 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
     /** Read from a stream, for internal use only. */
     public DateHistogramAggregationBuilder(StreamInput in) throws IOException {
         super(in, ValuesSourceType.NUMERIC, ValueType.DATE);
-        order = InternalOrder.Streams.readHistogramOrder(in, true);
+        order = InternalOrder.Streams.readHistogramOrder(in);
         keyed = in.readBoolean();
         minDocCount = in.readVLong();
         interval = in.readLong();
@@ -184,7 +184,7 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
 
     @Override
     protected void innerWriteTo(StreamOutput out) throws IOException {
-        InternalOrder.Streams.writeHistogramOrder(order, out, true);
+        InternalOrder.Streams.writeHistogramOrder(order, out);
         out.writeBoolean(keyed);
         out.writeVLong(minDocCount);
         out.writeLong(interval);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregationBuilder.java
@@ -119,7 +119,7 @@ public class HistogramAggregationBuilder extends ValuesSourceAggregationBuilder<
     /** Read from a stream, for internal use only. */
     public HistogramAggregationBuilder(StreamInput in) throws IOException {
         super(in, ValuesSourceType.NUMERIC, ValueType.DOUBLE);
-        order = InternalOrder.Streams.readHistogramOrder(in, true);
+        order = InternalOrder.Streams.readHistogramOrder(in);
         keyed = in.readBoolean();
         minDocCount = in.readVLong();
         interval = in.readDouble();
@@ -130,7 +130,7 @@ public class HistogramAggregationBuilder extends ValuesSourceAggregationBuilder<
 
     @Override
     protected void innerWriteTo(StreamOutput out) throws IOException {
-        InternalOrder.Streams.writeHistogramOrder(order, out, true);
+        InternalOrder.Streams.writeHistogramOrder(order, out);
         out.writeBoolean(keyed);
         out.writeVLong(minDocCount);
         out.writeDouble(interval);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -241,7 +241,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
      */
     public InternalDateHistogram(StreamInput in) throws IOException {
         super(in);
-        order = InternalOrder.Streams.readHistogramOrder(in, false);
+        order = InternalOrder.Streams.readHistogramOrder(in);
         minDocCount = in.readVLong();
         if (minDocCount == 0) {
             emptyBucketInfo = new EmptyBucketInfo(in);
@@ -256,7 +256,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
-        InternalOrder.Streams.writeHistogramOrder(order, out, false);
+        InternalOrder.Streams.writeHistogramOrder(order, out);
         out.writeVLong(minDocCount);
         if (minDocCount == 0) {
             emptyBucketInfo.writeTo(out);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -233,7 +233,7 @@ public final class InternalHistogram extends InternalMultiBucketAggregation<Inte
      */
     public InternalHistogram(StreamInput in) throws IOException {
         super(in);
-        order = InternalOrder.Streams.readHistogramOrder(in, false);
+        order = InternalOrder.Streams.readHistogramOrder(in);
         minDocCount = in.readVLong();
         if (minDocCount == 0) {
             emptyBucketInfo = new EmptyBucketInfo(in);
@@ -247,7 +247,7 @@ public final class InternalHistogram extends InternalMultiBucketAggregation<Inte
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
-        InternalOrder.Streams.writeHistogramOrder(order, out, false);
+        InternalOrder.Streams.writeHistogramOrder(order, out);
         out.writeVLong(minDocCount);
         if (minDocCount == 0) {
             emptyBucketInfo.writeTo(out);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.search.aggregations.bucket.range;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -74,10 +73,7 @@ public final class InternalBinaryRange
         }
 
         private static Bucket createFromStream(StreamInput in, DocValueFormat format, boolean keyed) throws IOException {
-            String key = in.getVersion().onOrAfter(Version.V_6_4_0)
-                ? in.readString()
-                : in.readOptionalString();
-
+            String key = in.readString();
             BytesRef from = in.readBoolean() ? in.readBytesRef() : null;
             BytesRef to = in.readBoolean() ? in.readBytesRef() : null;
             long docCount = in.readLong();
@@ -88,11 +84,7 @@ public final class InternalBinaryRange
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(Version.V_6_4_0)) {
-                out.writeString(key);
-            } else {
-                out.writeOptionalString(key);
-            }
+            out.writeString(key);
             out.writeBoolean(from != null);
             if (from != null) {
                 out.writeBytesRef(from);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
@@ -140,9 +139,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
         }
         trackScores = in.readBoolean();
         version = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_6_7_0)) {
-            seqNoAndPrimaryTerm = in.readBoolean();
-        }
+        seqNoAndPrimaryTerm = in.readBoolean();
     }
 
     @Override
@@ -179,9 +176,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
         }
         out.writeBoolean(trackScores);
         out.writeBoolean(version);
-        if (out.getVersion().onOrAfter(Version.V_6_7_0)) {
-            out.writeBoolean(seqNoAndPrimaryTerm);
-        }
+        out.writeBoolean(seqNoAndPrimaryTerm);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketPipelineAggregationBuilder.java
@@ -20,8 +20,6 @@
 package org.elasticsearch.search.aggregations.pipeline;
 
 import com.carrotsearch.hppc.DoubleArrayList;
-
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -57,19 +55,13 @@ public class PercentilesBucketPipelineAggregationBuilder
             throws IOException {
         super(in, NAME);
         percents = in.readDoubleArray();
-
-        if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
-            keyed = in.readBoolean();
-        }
+        keyed = in.readBoolean();
     }
 
     @Override
     protected void innerWriteTo(StreamOutput out) throws IOException {
         out.writeDoubleArray(percents);
-
-        if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-            out.writeBoolean(keyed);
-        }
+        out.writeBoolean(keyed);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketPipelineAggregator.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.pipeline;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.DocValueFormat;
@@ -51,19 +50,13 @@ public class PercentilesBucketPipelineAggregator extends BucketMetricsPipelineAg
     public PercentilesBucketPipelineAggregator(StreamInput in) throws IOException {
         super(in);
         percents = in.readDoubleArray();
-
-        if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
-            keyed = in.readBoolean();
-        }
+        keyed = in.readBoolean();
     }
 
     @Override
     public void innerWriteTo(StreamOutput out) throws IOException {
         out.writeDoubleArray(percents);
-
-        if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-            out.writeBoolean(keyed);
-        }
+        out.writeBoolean(keyed);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceFieldConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceFieldConfig.java
@@ -19,13 +19,11 @@
 
 package org.elasticsearch.search.aggregations.support;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -85,11 +83,7 @@ public class MultiValuesSourceFieldConfig implements Writeable, ToXContentObject
         this.fieldName = in.readString();
         this.missing = in.readGenericValue();
         this.script = in.readOptionalWriteable(Script::new);
-        if (in.getVersion().before(Version.V_7_0_0)) {
-            this.timeZone = DateUtils.dateTimeZoneToZoneId(in.readOptionalTimeZone());
-        } else {
-            this.timeZone = in.readOptionalZoneId();
-        }
+        this.timeZone = in.readOptionalZoneId();
     }
 
     public Object getMissing() {
@@ -113,11 +107,7 @@ public class MultiValuesSourceFieldConfig implements Writeable, ToXContentObject
         out.writeString(fieldName);
         out.writeGenericValue(missing);
         out.writeOptionalWriteable(script);
-        if (out.getVersion().before(Version.V_7_0_0)) {
-            out.writeOptionalTimeZone(DateUtils.zoneIdToDateTimeZone(timeZone));
-        } else {
-            out.writeOptionalZoneId(timeZone);
-        }
+        out.writeOptionalZoneId(timeZone);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
@@ -18,10 +18,8 @@
  */
 package org.elasticsearch.search.aggregations.support;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
@@ -146,11 +144,7 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
         }
         format = in.readOptionalString();
         missing = in.readGenericValue();
-        if (in.getVersion().before(Version.V_7_0_0)) {
-            timeZone = DateUtils.dateTimeZoneToZoneId(in.readOptionalTimeZone());
-        } else {
-            timeZone = in.readOptionalZoneId();
-        }
+        timeZone = in.readOptionalZoneId();
     }
 
     @Override
@@ -171,11 +165,7 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
         }
         out.writeOptionalString(format);
         out.writeGenericValue(missing);
-        if (out.getVersion().before(Version.V_7_0_0)) {
-            out.writeOptionalTimeZone(DateUtils.zoneIdToDateTimeZone(timeZone));
-        } else {
-            out.writeOptionalZoneId(timeZone);
-        }
+        out.writeOptionalZoneId(timeZone);
         innerWriteTo(out);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.builder;
 
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
@@ -66,7 +65,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
 import static org.elasticsearch.search.internal.SearchContext.TRACK_TOTAL_HITS_ACCURATE;
@@ -204,21 +202,10 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         aggregations = in.readOptionalWriteable(AggregatorFactories.Builder::new);
         explain = in.readOptionalBoolean();
         fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
-        if (in.getVersion().before(Version.V_6_4_0)) {
-            List<String> dvFields = (List<String>) in.readGenericValue();
-            if (dvFields == null) {
-                docValueFields = null;
-            } else {
-                docValueFields = dvFields.stream()
-                        .map(field -> new FieldAndFormat(field, null))
-                        .collect(Collectors.toList());
-            }
+        if (in.readBoolean()) {
+            docValueFields = in.readList(FieldAndFormat::new);
         } else {
-            if (in.readBoolean()) {
-                docValueFields = in.readList(FieldAndFormat::new);
-            } else {
-                docValueFields = null;
-            }
+            docValueFields = null;
         }
         storedFieldsContext = in.readOptionalWriteable(StoredFieldsContext::new);
         from = in.readVInt();
@@ -249,21 +236,13 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         timeout = in.readOptionalTimeValue();
         trackScores = in.readBoolean();
         version = in.readOptionalBoolean();
-        if (in.getVersion().onOrAfter(Version.V_6_7_0)) {
-            seqNoAndPrimaryTerm = in.readOptionalBoolean();
-        } else {
-            seqNoAndPrimaryTerm = null;
-        }
+        seqNoAndPrimaryTerm = in.readOptionalBoolean();
         extBuilders = in.readNamedWriteableList(SearchExtBuilder.class);
         profile = in.readBoolean();
         searchAfterBuilder = in.readOptionalWriteable(SearchAfterBuilder::new);
         sliceBuilder = in.readOptionalWriteable(SliceBuilder::new);
         collapse = in.readOptionalWriteable(CollapseBuilder::new);
-        if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
-            trackTotalHitsUpTo = in.readOptionalInt();
-        } else {
-            trackTotalHitsUpTo = in.readBoolean() ? TRACK_TOTAL_HITS_ACCURATE : TRACK_TOTAL_HITS_DISABLED;
-        }
+        trackTotalHitsUpTo = in.readOptionalInt();
     }
 
     @Override
@@ -271,15 +250,9 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         out.writeOptionalWriteable(aggregations);
         out.writeOptionalBoolean(explain);
         out.writeOptionalWriteable(fetchSourceContext);
-        if (out.getVersion().before(Version.V_6_4_0)) {
-            out.writeGenericValue(docValueFields == null
-                    ? null
-                    : docValueFields.stream().map(ff -> ff.field).collect(Collectors.toList()));
-        } else {
-            out.writeBoolean(docValueFields != null);
-            if (docValueFields != null) {
-                out.writeList(docValueFields);
-            }
+        out.writeBoolean(docValueFields != null);
+        if (docValueFields != null) {
+            out.writeList(docValueFields);
         }
         out.writeOptionalWriteable(storedFieldsContext);
         out.writeVInt(from);
@@ -317,19 +290,13 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         out.writeOptionalTimeValue(timeout);
         out.writeBoolean(trackScores);
         out.writeOptionalBoolean(version);
-        if (out.getVersion().onOrAfter(Version.V_6_7_0)) {
-            out.writeOptionalBoolean(seqNoAndPrimaryTerm);
-        }
+        out.writeOptionalBoolean(seqNoAndPrimaryTerm);
         out.writeNamedWriteableList(extBuilders);
         out.writeBoolean(profile);
         out.writeOptionalWriteable(searchAfterBuilder);
         out.writeOptionalWriteable(sliceBuilder);
         out.writeOptionalWriteable(collapse);
-        if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-            out.writeOptionalInt(trackTotalHitsUpTo);
-        } else {
-            out.writeBoolean(trackTotalHitsUpTo == null ? true : trackTotalHitsUpTo > SearchContext.TRACK_TOTAL_HITS_DISABLED);
-        }
+        out.writeOptionalInt(trackTotalHitsUpTo);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.internal;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.Nullable;
@@ -119,20 +118,9 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
         nowInMillis = in.readVLong();
         requestCache = in.readOptionalBoolean();
         clusterAlias = in.readOptionalString();
-        if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
-            allowPartialSearchResults = in.readBoolean();
-        } else if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
-            allowPartialSearchResults = in.readOptionalBoolean();
-        } else {
-            allowPartialSearchResults = false;
-        }
-        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
-            indexRoutings = in.readStringArray();
-            preference = in.readOptionalString();
-        } else {
-            indexRoutings = Strings.EMPTY_ARRAY;
-            preference = null;
-        }
+        allowPartialSearchResults = in.readBoolean();
+        indexRoutings = in.readStringArray();
+        preference = in.readOptionalString();
     }
 
     protected final void innerWriteTo(StreamOutput out, boolean asKey) throws IOException {
@@ -151,16 +139,10 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
         }
         out.writeOptionalBoolean(requestCache);
         out.writeOptionalString(clusterAlias);
-        if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-            out.writeBoolean(allowPartialSearchResults);
-        } else if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
-            out.writeOptionalBoolean(allowPartialSearchResults);
-        }
+        out.writeBoolean(allowPartialSearchResults);
         if (asKey == false) {
-            if (out.getVersion().onOrAfter(Version.V_6_4_0)) {
-                out.writeStringArray(indexRoutings);
-                out.writeOptionalString(preference);
-            }
+            out.writeStringArray(indexRoutings);
+            out.writeOptionalString(preference);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/query/QuerySearchResult.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QuerySearchResult.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.query;
 
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.TotalHits;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
@@ -304,13 +303,8 @@ public final class QuerySearchResult extends SearchPhaseResult {
         terminatedEarly = in.readOptionalBoolean();
         profileShardResults = in.readOptionalWriteable(ProfileShardResult::new);
         hasProfileResults = profileShardResults != null;
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_beta1)) {
-            serviceTimeEWMA = in.readZLong();
-            nodeQueueSize = in.readInt();
-        } else {
-            serviceTimeEWMA = -1;
-            nodeQueueSize = -1;
-        }
+        serviceTimeEWMA = in.readZLong();
+        nodeQueueSize = in.readInt();
     }
 
     @Override
@@ -348,10 +342,8 @@ public final class QuerySearchResult extends SearchPhaseResult {
         out.writeBoolean(searchTimedOut);
         out.writeOptionalBoolean(terminatedEarly);
         out.writeOptionalWriteable(profileShardResults);
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_beta1)) {
-            out.writeZLong(serviceTimeEWMA);
-            out.writeInt(nodeQueueSize);
-        }
+        out.writeZLong(serviceTimeEWMA);
+        out.writeInt(nodeQueueSize);
     }
 
     public TotalHits getTotalHits() {

--- a/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -171,13 +171,9 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
         sortMode = in.readOptionalWriteable(SortMode::readFromStream);
         nestedFilter = in.readOptionalNamedWriteable(QueryBuilder.class);
         nestedPath = in.readOptionalString();
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-            nestedSort = in.readOptionalWriteable(NestedSortBuilder::new);
-        }
+        nestedSort = in.readOptionalWriteable(NestedSortBuilder::new);
         validation = GeoValidationMethod.readFromStream(in);
-        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
-            ignoreUnmapped = in.readBoolean();
-        }
+        ignoreUnmapped = in.readBoolean();
     }
 
     @Override
@@ -190,13 +186,9 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
         out.writeOptionalWriteable(sortMode);
         out.writeOptionalNamedWriteable(nestedFilter);
         out.writeOptionalString(nestedPath);
-        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-            out.writeOptionalWriteable(nestedSort);
-        }
+        out.writeOptionalWriteable(nestedSort);
         validation.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_6_4_0)) {
-            out.writeBoolean(ignoreUnmapped);
-        }
+        out.writeBoolean(ignoreUnmapped);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/sort/NestedSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/NestedSortBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.sort;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -54,11 +53,7 @@ public class NestedSortBuilder implements Writeable, ToXContentObject {
         path = in.readOptionalString();
         filter = in.readOptionalNamedWriteable(QueryBuilder.class);
         nestedSort = in.readOptionalWriteable(NestedSortBuilder::new);
-        if (in.getVersion().onOrAfter(Version.V_6_5_0)) {
-            maxChildren = in.readVInt();
-        } else {
-            maxChildren = Integer.MAX_VALUE;
-        }
+        maxChildren = in.readVInt();
     }
 
     public String getPath() {
@@ -98,9 +93,7 @@ public class NestedSortBuilder implements Writeable, ToXContentObject {
         out.writeOptionalString(path);
         out.writeOptionalNamedWriteable(filter);
         out.writeOptionalWriteable(nestedSort);
-        if (out.getVersion().onOrAfter(Version.V_6_5_0)) {
-            out.writeVInt(maxChildren);
-        }
+        out.writeVInt(maxChildren);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
@@ -121,9 +121,7 @@ public class ScriptSortBuilder extends SortBuilder<ScriptSortBuilder> {
         sortMode = in.readOptionalWriteable(SortMode::readFromStream);
         nestedPath = in.readOptionalString();
         nestedFilter = in.readOptionalNamedWriteable(QueryBuilder.class);
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-            nestedSort = in.readOptionalWriteable(NestedSortBuilder::new);
-        }
+        nestedSort = in.readOptionalWriteable(NestedSortBuilder::new);
     }
 
     @Override
@@ -134,9 +132,7 @@ public class ScriptSortBuilder extends SortBuilder<ScriptSortBuilder> {
         out.writeOptionalWriteable(sortMode);
         out.writeOptionalString(nestedPath);
         out.writeOptionalNamedWriteable(nestedFilter);
-        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-            out.writeOptionalWriteable(nestedSort);
-        }
+        out.writeOptionalWriteable(nestedSort);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.suggest;
 
 import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
@@ -40,8 +39,6 @@ import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry;
 import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option;
 import org.elasticsearch.search.suggest.completion.CompletionSuggestion;
-import org.elasticsearch.search.suggest.phrase.PhraseSuggestion;
-import org.elasticsearch.search.suggest.term.TermSuggestion;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -86,36 +83,11 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
     }
 
     public Suggest(StreamInput in) throws IOException {
-        // in older versions, Suggestion types were serialized as Streamable
-        if (in.getVersion().before(Version.V_7_0_0)) {
-            final int size = in.readVInt();
-            suggestions = new ArrayList<>(size);
-            for (int i = 0; i < size; i++) {
-                Suggestion<? extends Entry<? extends Option>> suggestion;
-                final int type = in.readVInt();
-                switch (type) {
-                    case TermSuggestion.TYPE:
-                        suggestion = new TermSuggestion(in);
-                        break;
-                    case CompletionSuggestion.TYPE:
-                        suggestion = new CompletionSuggestion(in);
-                        break;
-                    case PhraseSuggestion.TYPE:
-                        suggestion = new PhraseSuggestion(in);
-                        break;
-                    default:
-                        throw new IllegalArgumentException("Unknown suggestion type with ordinal " + type);
-                }
-                suggestions.add(suggestion);
-            }
-        } else {
-            int suggestionCount = in.readVInt();
-            suggestions = new ArrayList<>(suggestionCount);
-            for (int i = 0; i < suggestionCount; i++) {
-                suggestions.add(in.readNamedWriteable(Suggestion.class));
-            }
+        int suggestionCount = in.readVInt();
+        suggestions = new ArrayList<>(suggestionCount);
+        for (int i = 0; i < suggestionCount; i++) {
+            suggestions.add(in.readNamedWriteable(Suggestion.class));
         }
-
         hasScoreDocs = filter(CompletionSuggestion.class).stream().anyMatch(CompletionSuggestion::hasScoreDocs);
     }
 
@@ -154,18 +126,9 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        // in older versions, Suggestion types were serialized as Streamable
-        if (out.getVersion().before(Version.V_7_0_0)) {
-            out.writeVInt(suggestions.size());
-            for (Suggestion<?> command : suggestions) {
-                out.writeVInt(command.getWriteableType());
-                command.writeTo(out);
-            }
-        } else {
-            out.writeVInt(suggestions.size());
-            for (Suggestion<? extends Entry<? extends Option>> suggestion : suggestions) {
-                out.writeNamedWriteable(suggestion);
-            }
+        out.writeVInt(suggestions.size());
+        for (Suggestion<? extends Entry<? extends Option>> suggestion : suggestions) {
+            out.writeNamedWriteable(suggestion);
         }
     }
 
@@ -266,12 +229,6 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
         public Suggestion(StreamInput in) throws IOException {
             name = in.readString();
             size = in.readVInt();
-
-            // this is a hack to work around slightly different serialization order of earlier versions of TermSuggestion
-            if (in.getVersion().before(Version.V_7_0_0) && this instanceof TermSuggestion) {
-                TermSuggestion t = (TermSuggestion) this;
-                t.setSort(SortBy.readFromStream(in));
-            }
 
             int entriesCount = in.readVInt();
             entries.clear();
@@ -375,13 +332,6 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(name);
             out.writeVInt(size);
-
-            // this is a hack to work around slightly different serialization order in older versions of TermSuggestion
-            if (out.getVersion().before(Version.V_7_0_0) && this instanceof TermSuggestion) {
-                TermSuggestion termSuggestion = (TermSuggestion) this;
-                termSuggestion.getSort().writeTo(out);
-            }
-
             out.writeVInt(entries.size());
             for (Entry<?> entry : entries) {
                 entry.writeTo(out);

--- a/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestion.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestion.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.search.suggest.term;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -59,9 +58,7 @@ public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
 
     public TermSuggestion(StreamInput in) throws IOException {
         super(in);
-        if (in.getVersion().onOrAfter(Version.V_7_0_0)) {
-            sort = SortBy.readFromStream(in);
-        }
+        sort = SortBy.readFromStream(in);
     }
 
     // Same behaviour as comparators in suggest module, but for SuggestedWord
@@ -131,10 +128,7 @@ public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-
-        if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-            sort.writeTo(out);
-        }
+        sort.writeTo(out);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -227,13 +227,6 @@ public class RestoreService implements ClusterStateApplier {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     RestoreInProgress restoreInProgress = currentState.custom(RestoreInProgress.TYPE);
-                    if (currentState.getNodes().getMinNodeVersion().before(Version.V_7_0_0)) {
-                        // Check if another restore process is already running - cannot run two restore processes at the
-                        // same time in versions prior to 7.0
-                        if (restoreInProgress != null && restoreInProgress.isEmpty() == false) {
-                            throw new ConcurrentSnapshotExecutionException(snapshot, "Restore process is already running in this cluster");
-                        }
-                    }
                     // Check if the snapshot to restore is currently being deleted
                     SnapshotDeletionsInProgress deletionsInProgress = currentState.custom(SnapshotDeletionsInProgress.TYPE);
                     if (deletionsInProgress != null && deletionsInProgress.hasDeletionsInProgress()) {

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -75,8 +75,6 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
     private static final String SUCCESSFUL_SHARDS = "successful_shards";
     private static final String INCLUDE_GLOBAL_STATE = "include_global_state";
 
-    private static final Version INCLUDE_GLOBAL_STATE_INTRODUCED = Version.V_6_2_0;
-
     private static final Comparator<SnapshotInfo> COMPARATOR =
         Comparator.comparing(SnapshotInfo::startTime).thenComparing(SnapshotInfo::snapshotId);
 
@@ -295,9 +293,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             shardFailures = Collections.emptyList();
         }
         version = in.readBoolean() ? Version.readVersion(in) : null;
-        if (in.getVersion().onOrAfter(INCLUDE_GLOBAL_STATE_INTRODUCED)) {
-            includeGlobalState = in.readOptionalBoolean();
-        }
+        includeGlobalState = in.readOptionalBoolean();
     }
 
     /**
@@ -690,9 +686,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         } else {
             out.writeBoolean(false);
         }
-        if (out.getVersion().onOrAfter(INCLUDE_GLOBAL_STATE_INTRODUCED)) {
-            out.writeOptionalBoolean(includeGlobalState);
-        }
+        out.writeOptionalBoolean(includeGlobalState);
     }
 
     private static SnapshotState snapshotState(final String reason, final List<SnapshotShardFailure> shardFailures) {

--- a/server/src/main/java/org/elasticsearch/tasks/TaskInfo.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskInfo.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.tasks;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -99,11 +98,7 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         runningTimeNanos = in.readLong();
         cancellable = in.readBoolean();
         parentTaskId = TaskId.readFromStream(in);
-        if (in.getVersion().onOrAfter(Version.V_6_2_0)) {
-            headers = in.readMap(StreamInput::readString, StreamInput::readString);
-        } else {
-            headers = Collections.emptyMap();
-        }
+        headers = in.readMap(StreamInput::readString, StreamInput::readString);
     }
 
     @Override
@@ -117,9 +112,7 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         out.writeLong(runningTimeNanos);
         out.writeBoolean(cancellable);
         parentTaskId.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_6_2_0)) {
-            out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
-        }
+        out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
     }
 
     public TaskId getTaskId() {

--- a/server/src/main/java/org/elasticsearch/transport/InboundMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundMessage.java
@@ -99,12 +99,7 @@ public abstract class InboundMessage extends NetworkMessage implements Closeable
 
                 InboundMessage message;
                 if (TransportStatus.isRequest(status)) {
-                    final Set<String> features;
-                    if (remoteVersion.onOrAfter(Version.V_6_3_0)) {
-                        features = Collections.unmodifiableSet(new TreeSet<>(Arrays.asList(streamInput.readStringArray())));
-                    } else {
-                        features = Collections.emptySet();
-                    }
+                    final Set<String> features = Collections.unmodifiableSet(new TreeSet<>(Arrays.asList(streamInput.readStringArray())));
                     final String action = streamInput.readString();
                     message = new RequestMessage(threadContext, remoteVersion, status, requestId, action, features, streamInput);
                 } else {

--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionInfo.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionInfo.java
@@ -19,25 +19,17 @@
 
 package org.elasticsearch.transport;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
-
-import static java.util.Collections.emptyList;
 
 /**
  * This class encapsulates all remote cluster information to be rendered on
@@ -63,28 +55,7 @@ public final class RemoteConnectionInfo implements ToXContentFragment, Writeable
     }
 
     public RemoteConnectionInfo(StreamInput input) throws IOException {
-        if (input.getVersion().onOrAfter(Version.V_7_0_0)) {
-            seedNodes = Arrays.asList(input.readStringArray());
-        } else {
-            // versions prior to 7.0.0 sent the resolved transport address of the seed nodes
-            final List<TransportAddress> transportAddresses = input.readList(TransportAddress::new);
-            seedNodes =
-                    transportAddresses
-                            .stream()
-                            .map(a -> a.address().getHostString() + ":" + a.address().getPort())
-                            .collect(Collectors.toList());
-        }
-        if (input.getVersion().before(Version.V_7_0_0)) {
-            /*
-             * Versions before 7.0 sent the HTTP addresses of all nodes in the
-             * remote cluster here but it was expensive to fetch and we
-             * ultimately figured out how to do without it. So we removed it.
-             *
-             * We just throw any HTTP addresses received here on the floor
-             * because we don't need to do anything with them.
-             */
-            input.readList(TransportAddress::new);
-        }
+        seedNodes = Arrays.asList(input.readStringArray());
         connectionsPerCluster = input.readVInt();
         initialConnectionTimeout = input.readTimeValue();
         numNodesConnected = input.readVInt();
@@ -118,39 +89,7 @@ public final class RemoteConnectionInfo implements ToXContentFragment, Writeable
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
-            out.writeStringArray(seedNodes.toArray(new String[0]));
-        } else {
-            // versions prior to 7.0.0 received the resolved transport address of the seed nodes
-            out.writeList(seedNodes
-                    .stream()
-                    .map(
-                            s -> {
-                                final Tuple<String, Integer> hostPort = RemoteClusterAware.parseHostPort(s);
-                                assert hostPort.v2() != null : s;
-                                try {
-                                    return new TransportAddress(
-                                            InetAddress.getByAddress(hostPort.v1(), TransportAddress.META_ADDRESS.getAddress()),
-                                            hostPort.v2());
-                                } catch (final UnknownHostException e) {
-                                    throw new AssertionError(e);
-                                }
-                            })
-                    .collect(Collectors.toList()));
-        }
-        if (out.getVersion().before(Version.V_7_0_0)) {
-            /*
-             * Versions before 7.0 sent the HTTP addresses of all nodes in the
-             * remote cluster here but it was expensive to fetch and we
-             * ultimately figured out how to do without it. So we removed it.
-             *
-             * When sending this request to a node that expects HTTP addresses
-             * here we pretend that we didn't find any. This *should* be fine
-             * because, after all, we haven't been using this information for
-             * a while.
-             */
-            out.writeList(emptyList());
-        }
+        out.writeStringArray(seedNodes.toArray(new String[0]));
         out.writeVInt(connectionsPerCluster);
         out.writeTimeValue(initialConnectionTimeout);
         out.writeVInt(numNodesConnected);

--- a/server/src/main/java/org/elasticsearch/transport/TransportLogger.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportLogger.java
@@ -101,9 +101,7 @@ public final class TransportLogger {
                         context.readHeaders(streamInput);
                     }
                     // now we decode the features
-                    if (streamInput.getVersion().onOrAfter(Version.V_6_3_0)) {
-                        streamInput.readStringArray();
-                    }
+                    streamInput.readStringArray();
                     sb.append(", action: ").append(streamInput.readString());
                 }
                 sb.append(']');

--- a/server/src/test/java/org/elasticsearch/common/rounding/RoundingDuelTests.java
+++ b/server/src/test/java/org/elasticsearch/common/rounding/RoundingDuelTests.java
@@ -19,11 +19,8 @@
 
 package org.elasticsearch.common.rounding;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.VersionUtils;
 import org.joda.time.DateTimeZone;
 
 import java.time.ZoneOffset;
@@ -34,28 +31,6 @@ public class RoundingDuelTests extends ESTestCase  {
 
     // dont include nano/micro seconds as rounding would become zero then and throw an exception
     private static final String[] ALLOWED_TIME_SUFFIXES = new String[]{"d", "h", "ms", "s", "m"};
-
-    public void testSerialization() throws Exception {
-        org.elasticsearch.common.Rounding.DateTimeUnit randomDateTimeUnit =
-            randomFrom(org.elasticsearch.common.Rounding.DateTimeUnit.values());
-        org.elasticsearch.common.Rounding rounding;
-        if (randomBoolean()) {
-            rounding = org.elasticsearch.common.Rounding.builder(randomDateTimeUnit).timeZone(ZoneOffset.UTC).build();
-        } else {
-            rounding = org.elasticsearch.common.Rounding.builder(timeValue()).timeZone(ZoneOffset.UTC).build();
-        }
-        BytesStreamOutput output = new BytesStreamOutput();
-        output.setVersion(VersionUtils.getPreviousVersion(Version.V_7_0_0));
-        rounding.writeTo(output);
-
-        Rounding roundingJoda = Rounding.Streams.read(output.bytes().streamInput());
-        org.elasticsearch.common.Rounding roundingJavaTime =
-            org.elasticsearch.common.Rounding.read(output.bytes().streamInput());
-
-        int randomInt = randomIntBetween(1, 1_000_000_000);
-        assertThat(roundingJoda.round(randomInt), is(roundingJavaTime.round(randomInt)));
-        assertThat(roundingJoda.nextRoundingValue(randomInt), is(roundingJavaTime.nextRoundingValue(randomInt)));
-    }
 
     public void testDuellingImplementations() {
         org.elasticsearch.common.Rounding.DateTimeUnit randomDateTimeUnit =

--- a/server/src/test/java/org/elasticsearch/indices/TermsLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/TermsLookupTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.indices;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
@@ -82,13 +81,6 @@ public class TermsLookupTests extends ESTestCase {
                 assertEquals(deserializedLookup.hashCode(), termsLookup.hashCode());
                 assertNotSame(deserializedLookup, termsLookup);
             }
-        }
-
-        try (BytesStreamOutput output = new BytesStreamOutput()) {
-            output.setVersion(Version.V_6_7_0);
-            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> termsLookup.writeTo(output));
-            assertEquals("Typeless [terms] lookup queries are not supported if any " +
-                "node is running a version before 7.0.", e.getMessage());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
@@ -19,12 +19,10 @@
 
 package org.elasticsearch.ingest;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.VersionUtils;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -43,27 +41,6 @@ public class IngestStatsTests extends ESTestCase {
         IngestStats ingestStats = new IngestStats(totalStats, pipelineStats, processorStats);
         IngestStats serializedStats = serialize(ingestStats);
         assertIngestStats(ingestStats, serializedStats, true);
-    }
-
-    public void testReadLegacyStream() throws IOException {
-        IngestStats.Stats totalStats = new IngestStats.Stats(50, 100, 200, 300);
-        List<IngestStats.PipelineStat> pipelineStats = createPipelineStats();
-
-        //legacy output logic
-        BytesStreamOutput out = new BytesStreamOutput();
-        out.setVersion(VersionUtils.getPreviousVersion(Version.V_6_5_0));
-        totalStats.writeTo(out);
-        out.writeVInt(pipelineStats.size());
-        for (IngestStats.PipelineStat pipelineStat : pipelineStats) {
-            out.writeString(pipelineStat.getPipelineId());
-            pipelineStat.getStats().writeTo(out);
-        }
-
-        StreamInput in = out.bytes().streamInput();
-        in.setVersion(VersionUtils.getPreviousVersion(Version.V_6_5_0));
-        IngestStats serializedStats = new IngestStats(in);
-        IngestStats expectedStats = new IngestStats(totalStats, pipelineStats, Collections.emptyMap());
-        assertIngestStats(expectedStats, serializedStats, false);
     }
 
     private List<IngestStats.PipelineStat> createPipelineStats() {

--- a/server/src/test/java/org/elasticsearch/search/SearchHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchHitsTests.java
@@ -22,11 +22,9 @@ package org.elasticsearch.search;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.TestUtil;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.lucene.LuceneTests;
 import org.elasticsearch.common.text.Text;
@@ -39,10 +37,8 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.AbstractSerializingTestCase;
-import org.elasticsearch.test.VersionUtils;
 
 import java.io.IOException;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.function.Predicate;
 
@@ -270,38 +266,5 @@ public class SearchHitsTests extends AbstractSerializingTestCase<SearchHits> {
             }
 
         }
-    }
-
-    public void testReadFromPre6_6_0() throws IOException {
-        try (StreamInput in = StreamInput.wrap(Base64.getDecoder().decode("AQC/gAAAAAA="))) {
-            in.setVersion(VersionUtils.randomVersionBetween(random(), Version.V_6_0_0, VersionUtils.getPreviousVersion(Version.V_6_6_0)));
-            SearchHits searchHits = new SearchHits(in);
-            assertEquals(0, searchHits.getHits().length);
-            assertNotNull(searchHits.getTotalHits());
-            assertEquals(0L, searchHits.getTotalHits().value);
-            assertEquals(TotalHits.Relation.EQUAL_TO, searchHits.getTotalHits().relation);
-            assertEquals(-1F, searchHits.getMaxScore(), 0F);
-            assertNull(searchHits.getSortFields());
-            assertNull(searchHits.getCollapseField());
-            assertNull(searchHits.getCollapseValues());
-        }
-    }
-
-    public void testSerializationPre6_6_0() throws IOException {
-        Version version = VersionUtils.randomVersionBetween(random(), Version.V_6_0_0, VersionUtils.getPreviousVersion(Version.V_6_6_0));
-        SearchHits original = createTestItem(randomFrom(XContentType.values()), false, true, TotalHits.Relation.EQUAL_TO);
-        SearchHits deserialized = copyInstance(original, version);
-        assertArrayEquals(original.getHits(), deserialized.getHits());
-        assertEquals(original.getMaxScore(), deserialized.getMaxScore(), 0F);
-        if (original.getTotalHits() == null) {
-            assertNull(deserialized.getTotalHits());
-        } else {
-            assertNotNull(deserialized.getTotalHits());
-            assertEquals(original.getTotalHits().value, deserialized.getTotalHits().value);
-            assertEquals(original.getTotalHits().relation, deserialized.getTotalHits().relation);
-        }
-        assertNull(deserialized.getSortFields());
-        assertNull(deserialized.getCollapseField());
-        assertNull(deserialized.getCollapseValues());
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/SearchSortValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchSortValuesTests.java
@@ -20,9 +20,7 @@
 package org.elasticsearch.search;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.lucene.LuceneTests;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -32,11 +30,9 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.test.RandomObjects;
-import org.elasticsearch.test.VersionUtils;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Base64;
 
 public class SearchSortValuesTests extends AbstractSerializingTestCase<SearchSortValues> {
 
@@ -134,23 +130,5 @@ public class SearchSortValuesTests extends AbstractSerializingTestCase<SearchSor
         Object[] values = Arrays.copyOf(sortValues, sortValues.length + 1);
         values[sortValues.length] = randomSortValue(randomFrom(XContentType.values()), randomBoolean());
         return new SearchSortValues(values);
-    }
-
-    public void testSerializationPre6_6_0() throws IOException {
-        Version version = VersionUtils.randomVersionBetween(random(), Version.V_6_0_0, VersionUtils.getPreviousVersion(Version.V_6_6_0));
-        SearchSortValues original = createTestInstance();
-        SearchSortValues deserialized = copyInstance(original, version);
-        assertArrayEquals(original.getFormattedSortValues(), deserialized.getFormattedSortValues());
-        assertEquals(0, deserialized.getRawSortValues().length);
-    }
-
-    public void testReadFromPre6_6_0() throws IOException {
-        try (StreamInput in = StreamInput.wrap(Base64.getDecoder().decode("AwIAAAABAQEyBUAIAAAAAAAAAAAAAAAA"))) {
-            in.setVersion(VersionUtils.randomVersionBetween(random(), Version.V_6_0_0, VersionUtils.getPreviousVersion(Version.V_6_6_0)));
-            SearchSortValues deserialized = new SearchSortValues(in);
-            SearchSortValues expected = new SearchSortValues(new Object[]{1, "2", 3d});
-            assertEquals(expected, deserialized);
-            assertEquals(0, deserialized.getRawSortValues().length);
-        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/InternalOrderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/InternalOrderTests.java
@@ -18,15 +18,11 @@
  */
 package org.elasticsearch.search.aggregations;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.search.aggregations.InternalOrder.CompoundOrder;
 import org.elasticsearch.test.AbstractSerializingTestCase;
-import org.elasticsearch.test.VersionUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -84,28 +80,6 @@ public class InternalOrderTests extends AbstractSerializingTestCase<BucketOrder>
         assertEquals(expectedInstance.hashCode(), newInstance.hashCode());
         if(expectedInstance instanceof CompoundOrder || expectedInstance instanceof InternalOrder.Aggregation) {
             assertNotSame(newInstance, expectedInstance);
-        }
-    }
-
-    public void testHistogramOrderBwc() throws IOException {
-        for (int runs = 0; runs < NUMBER_OF_TEST_RUNS; runs++) {
-            BucketOrder order = createTestInstance();
-            Version bwcVersion = VersionUtils.randomVersionBetween(random(), VersionUtils.getFirstVersion(),
-                VersionUtils.getPreviousVersion(Version.V_6_0_0_alpha2));
-            boolean bwcOrderFlag = randomBoolean();
-            try (BytesStreamOutput out = new BytesStreamOutput()) {
-                out.setVersion(bwcVersion);
-                InternalOrder.Streams.writeHistogramOrder(order, out, bwcOrderFlag);
-                try (StreamInput in = out.bytes().streamInput()) {
-                    in.setVersion(bwcVersion);
-                    BucketOrder actual = InternalOrder.Streams.readHistogramOrder(in, bwcOrderFlag);
-                    BucketOrder expected = order;
-                    if (order instanceof CompoundOrder) {
-                        expected = ((CompoundOrder) order).orderElements.get(0);
-                    }
-                    assertEquals(expected, actual);
-                }
-            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/internal/ShardSearchTransportRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ShardSearchTransportRequestTests.java
@@ -40,7 +40,6 @@ import org.elasticsearch.index.query.RandomQueryBuilder;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.InvalidAliasNameException;
 import org.elasticsearch.search.AbstractSearchTestCase;
-import org.elasticsearch.test.VersionUtils;
 
 import java.io.IOException;
 
@@ -77,18 +76,6 @@ public class ShardSearchTransportRequestTests extends AbstractSearchTestCase {
         assertEquals(deserializedRequest.indexBoost(), shardSearchTransportRequest.indexBoost(), 0.0f);
         assertEquals(deserializedRequest.getClusterAlias(), shardSearchTransportRequest.getClusterAlias());
         assertEquals(shardSearchTransportRequest.allowPartialSearchResults(), deserializedRequest.allowPartialSearchResults());
-    }
-
-    public void testAllowPartialResultsSerializationPre7_0_0() throws IOException {
-        Version version = VersionUtils.randomVersionBetween(random(), Version.V_6_0_0, VersionUtils.getPreviousVersion(Version.V_7_0_0));
-        ShardSearchTransportRequest shardSearchTransportRequest = createShardSearchTransportRequest();
-        ShardSearchTransportRequest deserializedRequest =
-            copyWriteable(shardSearchTransportRequest, namedWriteableRegistry, ShardSearchTransportRequest::new, version);
-        if (version.before(Version.V_6_3_0)) {
-            assertFalse(deserializedRequest.allowPartialSearchResults());
-        } else {
-            assertEquals(shardSearchTransportRequest.allowPartialSearchResults(), deserializedRequest.allowPartialSearchResults());
-        }
     }
 
     private ShardSearchTransportRequest createShardSearchTransportRequest() throws IOException {

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -72,7 +72,6 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -850,33 +849,6 @@ public class RemoteClusterConnectionTests extends ESTestCase {
             assertEquals(info, remoteConnectionInfo);
             assertEquals(info.hashCode(), remoteConnectionInfo.hashCode());
             return randomBoolean() ? info : remoteConnectionInfo;
-        }
-    }
-
-    public void testRemoteConnectionInfoBwComp() throws IOException {
-        final Version version = VersionUtils.randomVersionBetween(random(),
-            Version.V_6_1_0, VersionUtils.getPreviousVersion(Version.V_7_0_0));
-        RemoteConnectionInfo expected =
-                new RemoteConnectionInfo("test_cluster", Arrays.asList("0.0.0.0:1"), 4, 4, new TimeValue(30, TimeUnit.MINUTES), false);
-
-        // This version was created using the serialization code in use from 6.1 but before 7.0
-        String encoded = "AQQAAAAABzAuMC4wLjAAAAABAQQAAAAABzAuMC4wLjAAAABQBDwEBAx0ZXN0X2NsdXN0ZXIA";
-        final byte[] data = Base64.getDecoder().decode(encoded);
-
-        try (StreamInput in = StreamInput.wrap(data)) {
-            in.setVersion(version);
-            RemoteConnectionInfo deserialized = new RemoteConnectionInfo(in);
-            assertEquals(expected, deserialized);
-
-            try (BytesStreamOutput out = new BytesStreamOutput()) {
-                out.setVersion(version);
-                deserialized.writeTo(out);
-                try (StreamInput in2 = StreamInput.wrap(out.bytes().toBytesRef().bytes)) {
-                    in2.setVersion(version);
-                    RemoteConnectionInfo deserialized2 = new RemoteConnectionInfo(in2);
-                    assertEquals(expected, deserialized2);
-                }
-            }
         }
     }
 


### PR DESCRIPTION
* Same as #39879 and #39883 <- no need for BwC logic that covers pre-7.0 versions in 8.0

------------------

This removes all easily fixable occurrences related to network IO in the `:server` module I hope.