### PR TITLE
Mute testGetSslCertificates in FIPS

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
@@ -964,6 +964,7 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
     }
 
     public void testGetSslCertificates() throws Exception {
+        assumeFalse("Awaits fix: https://github.com/elastic/elasticsearch/issues/40041", inFipsJvm());
         RestHighLevelClient client = highLevelClient();
         {
             //tag::get-certificates-execute


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/issues/40041