### PR TITLE
Add doc values support for JSON fields.

### DIFF
--- a/docs/reference/mapping/types/json.asciidoc
+++ b/docs/reference/mapping/types/json.asciidoc
@@ -24,7 +24,7 @@ the following advantages:
 
 However, `json` fields present a trade-off in terms of search functionality.
 Only basic queries are allowed, with no support for numeric range queries or
-aggregations. Further information on the limitations can be found in the
+highlighting. Further information on the limitations can be found in the
 <<supported-operations, Supported operations>> section.
 
 NOTE: The `json` mapping type should **not** be used for indexing all JSON
@@ -107,9 +107,13 @@ Currently, `json` fields can be used with the following query types:
 
 When querying, it is not possible to refer to field keys using wildcards, as in
 `{ "term": {"labels.time*": 1541457010}}`. Note that all queries, including
-`range`, treat the values as string keywords.
+`range`, treat the values as string keywords. Highlighting is not supported on
+`json` fields.
 
-Aggregating, highlighting, or sorting on a `json` field is not supported.
+It is possible to sort on a `json` field, as well as perform simple
+keyword-style aggregations such as `terms`. As with queries, there is no
+special support for numerics -- all values in the JSON object are treated as
+keywords. WHen sorting, this implies that values are compared lexicographically.
 
 Finally, because of the way leaf values are stored in the index, the null
 character `\0` is not allowed to appear in the keys of the JSON object.

--- a/docs/reference/mapping/types/json.asciidoc
+++ b/docs/reference/mapping/types/json.asciidoc
@@ -113,7 +113,7 @@ When querying, it is not possible to refer to field keys using wildcards, as in
 It is possible to sort on a `json` field, as well as perform simple
 keyword-style aggregations such as `terms`. As with queries, there is no
 special support for numerics -- all values in the JSON object are treated as
-keywords. WHen sorting, this implies that values are compared lexicographically.
+keywords. When sorting, this implies that values are compared lexicographically.
 
 Finally, because of the way leaf values are stored in the index, the null
 character `\0` is not allowed to appear in the keys of the JSON object.

--- a/docs/reference/mapping/types/json.asciidoc
+++ b/docs/reference/mapping/types/json.asciidoc
@@ -154,6 +154,12 @@ parameters are accepted:
     objects. If a JSON field exceeds this limit, then an error will be
     thrown. Defaults to `20`.
 
+<<doc-values,`doc_values`>>::
+
+    Should the field be stored on disk in a column-stride fashion, so that it
+    can later be used for sorting, aggregations, or scripting? Accepts `true`
+    (default) or `false`.
+
 <<ignore-above,`ignore_above`>>::
 
     Leaf values longer than this limit will not be indexed. By default, there

--- a/docs/reference/mapping/types/json.asciidoc
+++ b/docs/reference/mapping/types/json.asciidoc
@@ -160,6 +160,12 @@ parameters are accepted:
     can later be used for sorting, aggregations, or scripting? Accepts `true`
     (default) or `false`.
 
+<<eager-global-ordinals,`eager_global_ordinals`>>::
+
+    Should global ordinals be loaded eagerly on refresh? Accepts `true` or `false`
+    (default). Enabling this is a good idea on fields that are frequently used for
+    terms aggregations.
+
 <<ignore-above,`ignore_above`>>::
 
     Leaf values longer than this limit will not be indexed. By default, there

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -51,6 +51,7 @@ import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
+import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
 import org.elasticsearch.index.fielddata.plain.AbstractAtomicOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetDVOrdinalsIndexFieldData;
@@ -385,7 +386,8 @@ public final class JsonFieldMapper extends FieldMapper {
                                    MultiValueMode sortMode,
                                    XFieldComparatorSource.Nested nested,
                                    boolean reverse) {
-            return delegate.sortField(missingValue, sortMode, nested, reverse);
+            XFieldComparatorSource source = new BytesRefFieldComparatorSource(this, missingValue, sortMode, nested);
+            return new SortField(getFieldName(), source, reverse);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -353,6 +353,15 @@ public final class JsonFieldMapper extends FieldMapper {
         }
     }
 
+    /**
+     * A field data implementation that gives access to the values associated with
+     * a particular JSON key.
+     *
+     * This class wraps the field data that is built directly on the keyed JSON field, and
+     * filters out values whose prefix doesn't match the requested key. Loading and caching
+     * is fully delegated to the wrapped field data, so that different {@link KeyedJsonIndexFieldData}
+     * for the same JSON field share the same global ordinals.
+     */
     public static class KeyedJsonIndexFieldData implements IndexOrdinalsFieldData {
         private final String key;
         private final IndexOrdinalsFieldData delegate;

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -150,6 +150,11 @@ public final class JsonFieldMapper extends FieldMapper {
             return this;
         }
 
+        public Builder eagerGlobalOrdinals(boolean eagerGlobalOrdinals) {
+            fieldType().setEagerGlobalOrdinals(eagerGlobalOrdinals);
+            return builder;
+        }
+
         public Builder ignoreAbove(int ignoreAbove) {
             if (ignoreAbove < 0) {
                 throw new IllegalArgumentException("[ignore_above] must be positive, got " + ignoreAbove);
@@ -195,6 +200,9 @@ public final class JsonFieldMapper extends FieldMapper {
                 Object propNode = entry.getValue();
                 if (propName.equals("depth_limit")) {
                     builder.depthLimit(XContentMapValues.nodeIntegerValue(propNode, -1));
+                    iterator.remove();
+                } else if (propName.equals("eager_global_ordinals")) {
+                    builder.eagerGlobalOrdinals(XContentMapValues.nodeBooleanValue(propNode, "eager_global_ordinals"));
                     iterator.remove();
                 } else if (propName.equals("ignore_above")) {
                     builder.ignoreAbove(XContentMapValues.nodeIntegerValue(propNode, -1));

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
@@ -38,6 +38,7 @@ import java.util.List;
  */
 public class JsonFieldParser {
     private static final String SEPARATOR = "\0";
+    private static final byte SEPARATOR_BYTE = '\0';
 
     private final String rootFieldName;
     private final String keyedFieldName;
@@ -161,7 +162,17 @@ public class JsonFieldParser {
         }
     }
 
-    public static String createKeyedValue(String key, String value) {
+    static String createKeyedValue(String key, String value) {
         return key + SEPARATOR + value;
+    }
+
+    static BytesRef extractKey(BytesRef keyedValue) {
+        int length;
+        for (length = 0; length < keyedValue.length; length++){
+            if (keyedValue.bytes[keyedValue.offset + length] == SEPARATOR_BYTE) {
+                break;
+            }
+        }
+        return new BytesRef(keyedValue.bytes, keyedValue.offset, length);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
@@ -105,7 +105,7 @@ public class KeyedJsonAtomicFieldData implements AtomicOrdinalsFieldData {
 
         long result = -1;
         while (low <= high) {
-            long mid = (low + high) / 2;
+            long mid = (low + high) >>> 1;
             final BytesRef term = delegate.lookupOrd(mid);
             int cmp = compare(key, term);
 
@@ -130,7 +130,7 @@ public class KeyedJsonAtomicFieldData implements AtomicOrdinalsFieldData {
 
         long result = -1;
         while (low <= high) {
-            long mid = (low + high) / 2;
+            long mid = (low + high) >>> 1;
             final BytesRef term = delegate.lookupOrd(mid);
             int cmp = compare(key, term);
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.plain.AbstractAtomicOrdinalsFieldData;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 
 /**
@@ -74,7 +75,7 @@ public class KeyedJsonAtomicFieldData implements AtomicOrdinalsFieldData {
             maxOrd = findMaxOrd(keyBytes, values);
             assert maxOrd >= 0;
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
 
         return new KeyedJsonDocValues(keyBytes, values, minOrd, maxOrd);

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
@@ -31,7 +31,6 @@ import org.elasticsearch.index.fielddata.plain.AbstractAtomicOrdinalsFieldData;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 
 /**
  * The atomic field data implementation for {@link JsonFieldMapper.KeyedJsonFieldType}.
@@ -57,7 +56,7 @@ public class KeyedJsonAtomicFieldData implements AtomicOrdinalsFieldData {
 
     @Override
     public Collection<Accountable> getChildResources() {
-        return Collections.emptyList();
+        return delegate.getChildResources();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
@@ -191,11 +191,13 @@ public class KeyedJsonAtomicFieldData implements AtomicOrdinalsFieldData {
          * Returns the (un-prefixed) term value for the requested ordinal.
          *
          * Note that this method can only be called on ordinals returned from {@link #nextOrd()}.
-         * Otherwise it may attempt to look up values that do not share the correct prefix, which
-         * can result in undefined behavior or an error.
          */
         @Override
         public BytesRef lookupOrd(long ord) throws IOException {
+            if (ord < minOrd || ord > maxOrd) {
+                throw new IllegalArgumentException("The provided ordinal [" + ord + "] is outside the valid " +
+                    "range. For keyed JSON fields, only ordinals returned from nextOrd can be passed to lookupOrd.");
+            }
             BytesRef keyedValue = delegate.lookupOrd(ord);
             int prefixLength = key.length + 1;
             int valueLength = keyedValue.length - prefixLength;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.SortedSetDocValues;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
@@ -214,6 +214,7 @@ public class KeyedJsonAtomicFieldData implements AtomicOrdinalsFieldData {
 
             long ord = delegate.nextOrd();
             if (ord != NO_MORE_ORDS && ord <= maxOrd) {
+                assert ord >= minOrd;
                 return ord;
             } else {
                 return NO_MORE_ORDS;
@@ -223,13 +224,19 @@ public class KeyedJsonAtomicFieldData implements AtomicOrdinalsFieldData {
         @Override
         public boolean advanceExact(int target) throws IOException {
             if (delegate.advanceExact(target)) {
-                for (long ord = delegate.nextOrd(); ord != NO_MORE_ORDS; ord = delegate.nextOrd()) {
-                     if (minOrd <= ord && ord <= maxOrd) {
-                         cachedNextOrd = ord;
-                         return true;
+                while (true) {
+                    long ord = delegate.nextOrd();
+                    if (ord == NO_MORE_ORDS || ord > maxOrd) {
+                        break;
+                    }
+
+                    if (ord >= minOrd) {
+                        cachedNextOrd = ord;
+                        return true;
                     }
                 }
             }
+
             cachedNextOrd = -1;
             return false;
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
@@ -33,6 +33,12 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 
+/**
+ * The atomic field data implementation for {@link JsonFieldMapper.KeyedJsonFieldType}.
+ *
+ * This class wraps the field data that is built directly on the keyed JSON field,
+ * and filters out values whose prefix doesn't match the requested key.
+ */
 public class KeyedJsonAtomicFieldData implements AtomicOrdinalsFieldData {
 
     private final String key;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
@@ -1,0 +1,120 @@
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.fielddata.AbstractSortedSetDocValues;
+import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.plain.AbstractAtomicOrdinalsFieldData;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+public class KeyedJsonAtomicFieldData implements AtomicOrdinalsFieldData {
+
+    private final String key;
+    private final AtomicOrdinalsFieldData delegate;
+
+    KeyedJsonAtomicFieldData(String key,
+                             AtomicOrdinalsFieldData delegate) {
+        this.key = key;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return delegate.ramBytesUsed();
+    }
+
+    @Override
+    public Collection<Accountable> getChildResources() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public SortedSetDocValues getOrdinalsValues() {
+        SortedSetDocValues values = delegate.getOrdinalsValues();
+        return new KeyedJsonDocValues(key, values);
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    public ScriptDocValues<?> getScriptValues() {
+        return AbstractAtomicOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION
+            .apply(getOrdinalsValues());
+    }
+
+    @Override
+    public SortedBinaryDocValues getBytesValues() {
+        return FieldData.toString(getOrdinalsValues());
+    }
+
+    private static class KeyedJsonDocValues extends AbstractSortedSetDocValues {
+
+        private final BytesRef prefix;
+        private final SortedSetDocValues delegate;
+
+        KeyedJsonDocValues(String key, SortedSetDocValues delegate) {
+            this.prefix = new BytesRef(JsonFieldParser.createKeyedValue(key, ""));
+            this.delegate = delegate;
+        }
+
+        @Override
+        public long getValueCount() {
+            return delegate.getValueCount();
+        }
+
+        @Override
+        public BytesRef lookupOrd(long ord) throws IOException {
+            BytesRef keyedValue = delegate.lookupOrd(ord);
+            int valueLength = keyedValue.length - prefix.length;
+            return new BytesRef(keyedValue.bytes, prefix.length, valueLength);
+        }
+
+        @Override
+        public long nextOrd() throws IOException {
+            for (long ord = delegate.nextOrd(); ord != NO_MORE_ORDS; ord = delegate.nextOrd()) {
+                if (accepted(ord)) {
+                    return ord;
+                }
+            }
+            return NO_MORE_ORDS;
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+            if (delegate.advanceExact(target)) {
+                for (long ord = delegate.nextOrd(); ord != NO_MORE_ORDS; ord = delegate.nextOrd()) {
+                    if (accepted(ord)) {
+                        boolean advanced = delegate.advanceExact(target);
+                        assert advanced;
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        private boolean accepted(long ord) throws IOException {
+            BytesRef value = delegate.lookupOrd(ord);
+            if (value.length < prefix.length) {
+                return false;
+            }
+
+            for (int i = 0; i < prefix.length; i++ ) {
+                if (value.bytes[value.offset + i] != prefix.bytes[prefix.offset + i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -22,14 +22,17 @@ package org.elasticsearch.index.fielddata;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.RAMDirectory;
 import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
@@ -55,6 +58,7 @@ import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -215,25 +219,65 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
         ifdService.clear();
     }
 
-    public void testJsonFields() {
+    public void testJsonFields() throws IOException {
+        // Set up the index service.
         IndexService indexService = createIndex("test");
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         IndexFieldDataService ifdService = new IndexFieldDataService(indexService.getIndexSettings(),
-            indicesService.getIndicesFieldDataCache(), indicesService.getCircuitBreakerService(), indexService.mapperService());
-        ifdService.clear();
+            indicesService.getIndicesFieldDataCache(),
+            indicesService.getCircuitBreakerService(),
+            indexService.mapperService());
 
         BuilderContext ctx = new BuilderContext(indexService.getIndexSettings().getSettings(), new ContentPath(1));
         JsonFieldMapper fieldMapper = new JsonFieldMapper.Builder("json").build(ctx);
 
-        KeyedJsonFieldType fieldType1 = fieldMapper.keyedFieldType("key");
-        IndexFieldData<?> fd1 = ifdService.getForField(fieldType1);
-        assertTrue(fd1 instanceof KeyedJsonIndexFieldData);
-        assertEquals("key", ((KeyedJsonIndexFieldData) fd1).getKey());
+        AtomicInteger onCacheCalled = new AtomicInteger();
+        ifdService.setListener(new IndexFieldDataCache.Listener() {
+            @Override
+            public void onCache(ShardId shardId, String fieldName, Accountable ramUsage) {
+                assertEquals(fieldMapper.keyedFieldName(), fieldName);
+                onCacheCalled.incrementAndGet();
+            }
+        });
 
+        // Add some documents.
+        Directory directory = newDirectory();
+        IndexWriterConfig config = new IndexWriterConfig(new KeywordAnalyzer());
+        IndexWriter writer = new IndexWriter(directory, config);
+
+        Document doc = new Document();
+        doc.add(new SortedSetDocValuesField("json._keyed", new BytesRef("some_key\0some_value")));
+        writer.addDocument(doc);
+        writer.commit();
+        writer.addDocument(doc);
+        DirectoryReader reader = ElasticsearchDirectoryReader.wrap(
+            DirectoryReader.open(writer),
+            new ShardId("test", "_na_", 1));
+
+        // Load global field data for subfield 'key'.
+        KeyedJsonFieldType fieldType1 = fieldMapper.keyedFieldType("key");
+        IndexFieldData<?> ifd1 = ifdService.getForField(fieldType1);
+        assertTrue(ifd1 instanceof KeyedJsonIndexFieldData);
+
+        KeyedJsonIndexFieldData fieldData1 = (KeyedJsonIndexFieldData) ifd1;
+        assertEquals("key", fieldData1.getKey());
+        fieldData1.loadGlobal(reader);
+        assertEquals(1, onCacheCalled.get());
+
+        // Load global field data for the subfield 'other_key'.
         KeyedJsonFieldType fieldType2 = fieldMapper.keyedFieldType("other_key");
-        IndexFieldData<?> fd2 = ifdService.getForField(fieldType2);
-        assertTrue(fd2 instanceof KeyedJsonIndexFieldData);
-        assertEquals("other_key", ((KeyedJsonIndexFieldData) fd2).getKey());
+        IndexFieldData<?> ifd2 = ifdService.getForField(fieldType2);
+        assertTrue(ifd2 instanceof KeyedJsonIndexFieldData);
+
+        KeyedJsonIndexFieldData fieldData2 = (KeyedJsonIndexFieldData) ifd2;
+        assertEquals("other_key", fieldData2.getKey());
+        fieldData2.loadGlobal(reader);
+        assertEquals(1, onCacheCalled.get());
+
+        ifdService.clear();
+        reader.close();
+        writer.close();
+        directory.close();
     }
 
     public void testSetCacheListenerTwice() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldMapperTests.java
@@ -387,6 +387,23 @@ public class JsonFieldMapperTests extends ESSingleNodeTestCase {
             mapper.parse(new SourceToParse("test", "type", "1", doc, XContentType.JSON)));
     }
 
+    public void testEagerGlobalOrdinals() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
+            .startObject("type")
+                .startObject("properties")
+                    .startObject("field")
+                        .field("type", "json")
+                        .field("eager_global_ordinals", true)
+                    .endObject().endObject()
+                .endObject().endObject());
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        FieldMapper fieldMapper = (FieldMapper) mapper.mappers().getMapper("field");
+        assertTrue(fieldMapper.fieldType().eagerGlobalOrdinals());
+    }
+
     public void testIgnoreAbove() throws IOException {
          String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
             .startObject("type")

--- a/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JsonFieldParserTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.mapper.MockFieldMapper.FakeFieldType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.XContentTestUtils;
 import org.junit.Before;
@@ -41,7 +42,9 @@ public class JsonFieldParserTests extends ESTestCase {
     public void setUp() throws Exception {
         super.setUp();
         parser = new JsonFieldParser("field", "field._keyed",
-            Integer.MAX_VALUE, Integer.MAX_VALUE, null);
+            new FakeFieldType(),
+            Integer.MAX_VALUE,
+            Integer.MAX_VALUE);
     }
 
     public void testTextValues() throws Exception {
@@ -218,7 +221,7 @@ public class JsonFieldParserTests extends ESTestCase {
             "\"parent2\": [{ \"key\" : { \"key\" : \"value\" }}]}";
         XContentParser xContentParser = createXContentParser(input);
         JsonFieldParser configuredParser = new JsonFieldParser("field", "field._keyed",
-            2, Integer.MAX_VALUE, null);
+            new FakeFieldType(), 2, Integer.MAX_VALUE);
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
             () -> configuredParser.parse(xContentParser));
@@ -230,7 +233,7 @@ public class JsonFieldParserTests extends ESTestCase {
             "\"parent2\": [{ \"key\" : { \"key\" : \"value\" }}]}";
         XContentParser xContentParser = createXContentParser(input);
         JsonFieldParser configuredParser = new JsonFieldParser("field", "field._keyed",
-             3, Integer.MAX_VALUE, null);
+            new FakeFieldType(), 3, Integer.MAX_VALUE);
 
         List<IndexableField> fields = configuredParser.parse(xContentParser);
         assertEquals(4, fields.size());
@@ -240,7 +243,7 @@ public class JsonFieldParserTests extends ESTestCase {
         String input = "{ \"key\": \"a longer field than usual\" }";
         XContentParser xContentParser = createXContentParser(input);
         JsonFieldParser configuredParser = new JsonFieldParser("field", "field._keyed",
-            Integer.MAX_VALUE, 10, null);
+            new FakeFieldType(), Integer.MAX_VALUE, 10);
 
         List<IndexableField> fields = configuredParser.parse(xContentParser);
         assertEquals(0, fields.size());
@@ -254,8 +257,11 @@ public class JsonFieldParserTests extends ESTestCase {
         assertEquals(0, fields.size());
 
         xContentParser = createXContentParser(input);
+
+        MappedFieldType fieldType = new FakeFieldType();
+        fieldType.setNullValue("placeholder");
         JsonFieldParser configuredParser = new JsonFieldParser("field", "field._keyed",
-            Integer.MAX_VALUE, Integer.MAX_VALUE, "placeholder");
+            fieldType, Integer.MAX_VALUE, Integer.MAX_VALUE);
 
         fields = configuredParser.parse(xContentParser);
         assertEquals(2, fields.size());

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldDataTests.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import java.io.IOException;
 
 import static org.apache.lucene.index.SortedSetDocValues.NO_MORE_ORDS;
+import static org.hamcrest.Matchers.containsString;
 
 public class KeyedJsonAtomicFieldDataTests extends ESTestCase {
     private AtomicOrdinalsFieldData delegate;
@@ -147,6 +148,14 @@ public class KeyedJsonAtomicFieldDataTests extends ESTestCase {
         BytesRef expectedValue = new BytesRef("value0");
         BytesRef value = docValues.lookupOrd(0);
         assertEquals(0, expectedValue.compareTo(value));
+    }
+
+    public void testLookupInvalidOrd() {
+        AtomicOrdinalsFieldData fieldData = new KeyedJsonAtomicFieldData("apple", delegate);
+        SortedSetDocValues docValues = fieldData.getOrdinalsValues();
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> docValues.lookupOrd(42));
+        assertThat(e.getMessage(), containsString("The provided ordinal [42] is outside the valid range."));
     }
 
     private static class MockAtomicOrdinalsFieldData extends AbstractAtomicOrdinalsFieldData {

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeyedJsonDocValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeyedJsonDocValuesTests.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.fielddata.AbstractSortedSetDocValues;
+import org.elasticsearch.index.mapper.KeyedJsonAtomicFieldData.KeyedJsonDocValues;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+
+import static org.apache.lucene.index.SortedSetDocValues.NO_MORE_ORDS;
+
+public class KeyedJsonDocValuesTests extends ESTestCase {
+    private SortedSetDocValues delegate;
+
+    @Before
+    public void setUpDelegate() {
+        BytesRef[] allTerms = new BytesRef[60];
+        long[] documentOrds = new long[50];
+        int index = 0;
+
+        for (int ord = 0; ord < allTerms.length; ord++) {
+            String key;
+            if (ord < 20) {
+                key = "apple";
+            } else if (ord < 30) {
+                key = "avocado";
+            } else if (ord < 40) {
+                key = "banana";
+            } else if (ord < 41) {
+                key = "cantaloupe";
+            } else {
+                key = "cucumber";
+            }
+
+            allTerms[ord] = prefixedValue(key, "value" + ord);
+
+            // Do not include the term 'avocado' in the mock document.
+            if (key.equals("avocado") == false) {
+                documentOrds[index++] = ord;
+            }
+        }
+
+        delegate = new MockSortedSetDocValues(allTerms, documentOrds);
+    }
+
+    private BytesRef prefixedValue(String key, String value) {
+        String term = JsonFieldParser.createKeyedValue(key, value);
+        return new BytesRef(term);
+    }
+
+    public void testFindOrdinalBounds() throws IOException {
+        testFindOrdinalBounds("apple", delegate, 0, 19);
+        testFindOrdinalBounds("avocado", delegate, 20, 29);
+        testFindOrdinalBounds("banana", delegate, 30, 39);
+        testFindOrdinalBounds("berry", delegate, -1, -1);
+        testFindOrdinalBounds("cantaloupe", delegate, 40, 40);
+        testFindOrdinalBounds("cucumber", delegate, 41, 59);
+
+        SortedSetDocValues emptyDelegate = new MockSortedSetDocValues(new BytesRef[0], new long[0]);
+        testFindOrdinalBounds("apple", emptyDelegate, -1, -1);
+
+        BytesRef[] terms = new BytesRef[] { prefixedValue("prefix", "value") };
+        SortedSetDocValues singleValueDelegate = new MockSortedSetDocValues(terms, new long[0]);
+        testFindOrdinalBounds("prefix", singleValueDelegate, 0, 0);
+        testFindOrdinalBounds("prefix1", singleValueDelegate, -1, -1);
+
+        terms = new BytesRef[] { prefixedValue("prefix", "value"),
+            prefixedValue("prefix1", "value"),
+            prefixedValue("prefix1", "value1"),
+            prefixedValue("prefix2", "value"),
+            prefixedValue("prefix3", "value")};
+        SortedSetDocValues oddLengthDelegate = new MockSortedSetDocValues(terms, new long[0]);
+        testFindOrdinalBounds("prefix", oddLengthDelegate, 0, 0);
+        testFindOrdinalBounds("prefix1", oddLengthDelegate, 1, 2);
+        testFindOrdinalBounds("prefix2", oddLengthDelegate, 3, 3);
+        testFindOrdinalBounds("prefix3", oddLengthDelegate, 4, 4);
+    }
+
+    public void testFindOrdinalBounds(String key,
+                                      SortedSetDocValues delegate,
+                                      int minOrd, int maxOrd) throws IOException {
+        BytesRef bytesKey = new BytesRef(key);
+        assertEquals(minOrd, KeyedJsonDocValues.findMinOrd(bytesKey, delegate));
+        assertEquals(maxOrd, KeyedJsonDocValues.findMaxOrd(bytesKey, delegate));
+    }
+
+    public void testAdvanceExact() throws IOException {
+        KeyedJsonDocValues avocadoDocValues = KeyedJsonDocValues.create("avocado", delegate);
+        assertFalse(avocadoDocValues.advanceExact(0));
+
+        KeyedJsonDocValues bananaDocValues = KeyedJsonDocValues.create("banana", delegate);
+        assertTrue(bananaDocValues.advanceExact(0));
+
+        KeyedJsonDocValues nonexistentDocValues = KeyedJsonDocValues.create("berry", delegate);
+        assertFalse(nonexistentDocValues.advanceExact(0));
+    }
+
+    public void testNextOrd() throws IOException {
+        KeyedJsonDocValues docValues = KeyedJsonDocValues.create("banana", delegate);
+        docValues.advanceExact(0);
+
+        int retrievedOrds = 0;
+        for (long ord = docValues.nextOrd(); ord != NO_MORE_ORDS; ord = docValues.nextOrd()) {
+            assertTrue(30 <= ord && ord < 40);
+            retrievedOrds++;
+
+            BytesRef prefixedTerm = delegate.lookupOrd(ord);
+            BytesRef key = JsonFieldParser.extractKey(prefixedTerm);
+            assertEquals("banana", key.utf8ToString());
+        }
+
+        assertEquals(10, retrievedOrds);
+    }
+
+    public void testLookupOrd() throws IOException {
+        KeyedJsonDocValues docValues = KeyedJsonDocValues.create("apple", delegate);
+
+        BytesRef expectedValue = new BytesRef("value0");
+        BytesRef value = docValues.lookupOrd(0);
+        assertEquals(0, expectedValue.compareTo(value));
+    }
+
+    private static class MockSortedSetDocValues extends AbstractSortedSetDocValues {
+        private final BytesRef[] allTerms;
+        private final long[] documentOrds;
+        private int index;
+
+        MockSortedSetDocValues(BytesRef[] allTerms,
+                               long[] documentOrds) {
+            this.allTerms = allTerms;
+            this.documentOrds = documentOrds;
+        }
+
+        @Override
+        public boolean advanceExact(int docID) {
+            index = 0;
+            return true;
+        }
+
+        @Override
+        public long nextOrd() {
+            if (index == documentOrds.length) {
+                return NO_MORE_ORDS;
+            }
+            return documentOrds[index++];
+        }
+
+        @Override
+        public BytesRef lookupOrd(long ord) {
+            return allTerms[(int) ord];
+        }
+
+        @Override
+        public long getValueCount() {
+            return allTerms.length;
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/RootJsonFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RootJsonFieldTypeTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
@@ -70,9 +71,12 @@ public class RootJsonFieldTypeTests extends FieldTypeTestCase {
     public void testExistsQuery() {
         RootJsonFieldType ft = new RootJsonFieldType();
         ft.setName("field");
+        assertEquals(
+            new TermQuery(new Term(FieldNamesFieldMapper.NAME, new BytesRef("field"))),
+            ft.existsQuery(null));
 
-        Query expected = new TermQuery(new Term(FieldNamesFieldMapper.NAME, new BytesRef("field")));
-        assertEquals(expected, ft.existsQuery(null));
+        ft.setHasDocValues(true);
+        assertEquals(new DocValuesFieldExistsQuery("field"), ft.existsQuery(null));
     }
 
     public void testFuzzyQuery() {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
@@ -1140,7 +1140,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
         assertThat(bucket2.getKeyAsString(), startsWith("v1.2."));
         assertEquals(1, bucket2.getDocCount());
     }
-
+    
     public void testKeyedJsonField() {
         // Aggregate on the 'priority' subfield.
         TermsAggregationBuilder priorityAgg = terms("terms")

--- a/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
@@ -21,10 +21,13 @@ package org.elasticsearch.search.lookup;
 import org.elasticsearch.index.fielddata.AtomicFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.mapper.JsonFieldMapper.KeyedJsonFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
+
+import java.util.function.Function;
 
 import static org.elasticsearch.search.lookup.LeafDocLookup.TYPES_DEPRECATION_MESSAGE;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
@@ -51,13 +54,7 @@ public class LeafDocLookupTests extends ESTestCase {
         when(mapperService.fullName("alias")).thenReturn(fieldType);
 
         docValues = mock(ScriptDocValues.class);
-
-        AtomicFieldData atomicFieldData = mock(AtomicFieldData.class);
-        doReturn(docValues).when(atomicFieldData).getScriptValues();
-
-        IndexFieldData<?> fieldData = mock(IndexFieldData.class);
-        when(fieldData.getFieldName()).thenReturn("field");
-        doReturn(atomicFieldData).when(fieldData).load(anyObject());
+        IndexFieldData<?> fieldData = createFieldData(docValues);
 
         docLookup = new LeafDocLookup(mapperService,
             ignored -> fieldData,
@@ -70,7 +67,7 @@ public class LeafDocLookupTests extends ESTestCase {
         assertEquals(docValues, fetchedDocValues);
     }
 
-    public void testLookupWithFieldAlias() {
+    public void testFieldAliases() {
         ScriptDocValues<?> fetchedDocValues = docLookup.get("alias");
         assertEquals(docValues, fetchedDocValues);
     }
@@ -79,5 +76,46 @@ public class LeafDocLookupTests extends ESTestCase {
         ScriptDocValues<?> fetchedDocValues = docLookup.get("_type");
         assertEquals(docValues, fetchedDocValues);
         assertWarnings(TYPES_DEPRECATION_MESSAGE);
+    }
+
+    public void testJsonFields() {
+        MapperService mapperService = mock(MapperService.class);
+
+        ScriptDocValues<?> docValues1 = mock(ScriptDocValues.class);
+        IndexFieldData<?> fieldData1 = createFieldData(docValues1);
+
+        ScriptDocValues<?> docValues2 = mock(ScriptDocValues.class);
+        IndexFieldData<?> fieldData2 = createFieldData(docValues2);
+
+        KeyedJsonFieldType fieldType1 = new KeyedJsonFieldType("key1");
+        fieldType1.setName("json._keyed");
+        when(mapperService.fullName("json.key1")).thenReturn(fieldType1);
+
+        KeyedJsonFieldType fieldType2 = new KeyedJsonFieldType("key2");
+        fieldType1.setName("json._keyed");
+        when(mapperService.fullName("json.key2")).thenReturn(fieldType2);
+
+        Function<MappedFieldType, IndexFieldData<?>> fieldDataSupplier = fieldType -> {
+            KeyedJsonFieldType jsonFieldType = (KeyedJsonFieldType) fieldType;
+            return jsonFieldType.key().equals("key1") ? fieldData1 : fieldData2;
+        };
+        LeafDocLookup jsonDocLookup = new LeafDocLookup(mapperService,
+            fieldDataSupplier,
+            new String[] { "type" },
+            null);
+
+        assertEquals(docValues1, jsonDocLookup.get("json.key1"));
+        assertEquals(docValues2, jsonDocLookup.get("json.key2"));
+    }
+
+    private IndexFieldData<?> createFieldData(ScriptDocValues scriptDocValues) {
+        AtomicFieldData atomicFieldData = mock(AtomicFieldData.class);
+        doReturn(scriptDocValues).when(atomicFieldData).getScriptValues();
+
+        IndexFieldData<?> fieldData = mock(IndexFieldData.class);
+        when(fieldData.getFieldName()).thenReturn("field");
+        doReturn(atomicFieldData).when(fieldData).load(anyObject());
+
+        return fieldData;
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -1836,12 +1836,5 @@ public class FieldSortIT extends ESIntegTestCase {
         assertSearchResponse(response);
         assertHitCount(response, 3);
         assertOrderedSearchHits(response, "2", "1", "3");
-
-        response = client().prepareSearch("test")
-            .addSort(new FieldSortBuilder("json_field.key").order(SortOrder.DESC).missing("Z"))
-            .get();
-        assertSearchResponse(response);
-        assertHitCount(response, 3);
-        assertOrderedSearchHits(response, "3", "2", "1");
     }
 }


### PR DESCRIPTION
This is a 'work in progress' PR: I am new to the doc values/ aggregations area, and was hoping to get some early feedback on the approach.

When `doc_values` are enabled, we now add two `SortedSetDocValuesFields` for each token: one containing the raw `value`, and another with `key\0value`. The root JSON field uses the standard `SortedSetDVOrdinalsIndexFieldData`. For keyed fields, this PR introduces a new type ` KeyedJsonIndexFieldData` that wraps the standard ordinals field data and filters out values that do not match the right prefix. This gives support for sorting on JSON fields, as well as simple keyword-style aggregations like `terms`.

One slightly tricky aspect is caching of these doc values. Given a keyed JSON field, we need to make sure we don't store values filtered on a certain prefix under the same cache key as ones filtered on a different prefix. However, we also want to load and cache global ordinals only once per keyed JSON field, as opposed to having a separate cache entry per prefix.