### PR TITLE
[DOCS] Fixes version info for rolling upgrades

### DIFF
--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -10,13 +10,14 @@ running the older version.
 Rolling upgrades are supported:
 
 * Between minor versions
-* https://www.elastic.co/guide/en/elastic-stack/6.7/upgrading-elastic-stack.html[From 5.6 to 6.7]
-* From 6.7 to {version}
+* {stack-ref-67}/upgrading-elastic-stack.html[From 5.6 to 6.7]
+* {stack-ref-70}/upgrading-elastic-stack.html[From 6.7 to 7.0]
+* From {prev-major-version} to {version}
 
 Upgrading directly to {version} from 6.6 or earlier requires a
 <<restart-upgrade, full cluster restart>>.
 
-To perform a rolling upgrade from 6.7 to {version}:
+To perform a rolling upgrade from {prev-major-version} to {version}:
 
 . *Disable shard allocation*.
 +


### PR DESCRIPTION
Per @javanna, "the rolling upgrade page on master docs says that you can do a rolling upgrade from 6.7 to 8.0, which is incorrect".

This PR updates the version details in https://www.elastic.co/guide/en/elasticsearch/reference/master/rolling-upgrades.html. Additional PRs will be required to update the other pages in this section.

