### PR TITLE
SQL: [Tests] Remove wrong assertions for JDBC getDate

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
@@ -821,10 +821,6 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
             
             assertEquals(results.getDate("test_date"), new java.sql.Date(connCalendar.getTimeInMillis()));
             assertEquals(results.getDate(9), new java.sql.Date(connCalendar.getTimeInMillis()));
-            assertEquals(results.getObject("test_date", java.sql.Date.class),
-                    new java.sql.Date(randomLongDate - (randomLongDate % 86400000L)));
-            assertEquals(results.getObject(9, java.sql.Date.class),
-                    new java.sql.Date(randomLongDate - (randomLongDate % 86400000L)));
 
             // bulk validation for all fields which are not of type date
             validateErrorsForDateTimeTestsWithoutCalendar(results::getDate);


### PR DESCRIPTION
Remove wrong assertions using calculations to remove date
from the epoch millis, as this should be done only with
the use of a Calendar set to the random timezone of the
test.

Follows: #39978
