### PR TITLE
[DOCS] Replaces CCS terms with attributes

### DIFF
--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -33,4 +33,4 @@ the configured remote cluster alias.
 
 `skip_unavailable`::
     Whether the remote cluster is skipped in case it is searched through
-    a cross cluster search request but none of its nodes are available.
+    a {ccs} request but none of its nodes are available.

--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -32,6 +32,11 @@
   The {ccr} feature enables you to replicate indices in remote clusters to your
   local cluster. For more information, see 
   {stack-ov}/xpack-ccr.html[{ccr-cap}].  
+    
+[[glossary-ccs]] {ccs} (CCS)::
+
+  The {ccs} feature enables any node to act as a federated client across
+  multiple clusters. See <<modules-cross-cluster-search>>.    
 
 [[glossary-document]] document ::
 

--- a/docs/reference/modules.asciidoc
+++ b/docs/reference/modules.asciidoc
@@ -78,10 +78,10 @@ The modules in this section are:
     Remote clusters are used in features that work by connecting across clusters
     on the transport layer.
 
-<<modules-cross-cluster-search, Cross cluster Search>>::
+<<modules-cross-cluster-search, {ccs-cap}>>::
 
-    Cross cluster search enables executing search requests across more than one cluster without joining them and acts
-    as a federated client across them.
+    {ccs-cap} enables executing search requests across more than one cluster
+    without joining them and acts as a federated client across them.
 --
 
 

--- a/docs/reference/modules/cross-cluster-search.asciidoc
+++ b/docs/reference/modules/cross-cluster-search.asciidoc
@@ -1,15 +1,15 @@
 [[modules-cross-cluster-search]]
-== Cross Cluster Search
+== {ccs-cap}
 
-The _cross cluster search_ feature allows any node to act as a federated client across
-multiple clusters. A cross cluster search node won't join the remote cluster, instead
+The _{ccs}_ feature allows any node to act as a federated client across
+multiple clusters. A {ccs} node won't join the remote cluster, instead
 it connects to a remote cluster in a light fashion in order to execute
 federated search requests.
 
 [float]
-=== Using cross cluster search
+=== Using {ccs}
 
-Cross-cluster search requires <<modules-remote-clusters,configuring remote clusters>>.
+{ccs-cap} requires <<modules-remote-clusters,configuring remote clusters>>.
 
 [source,js]
 --------------------------------
@@ -185,7 +185,7 @@ will be prefixed with their remote cluster name:
 [float]
 === Skipping disconnected clusters
 
-By default all remote clusters that are searched via Cross Cluster Search need to be available when
+By default all remote clusters that are searched via {ccs} need to be available when
 the search request is executed, otherwise the whole request fails and no search results are returned
 despite some of the clusters are available. Remote clusters can be made optional through the
 boolean `skip_unavailable` setting, set to `false` by default.
@@ -278,9 +278,9 @@ GET /cluster_one:twitter,cluster_two:twitter,twitter/_search <1>
 
 [float]
 [[ccs-reduction]]
-=== CCS reduction phase
+=== {ccs-cap} reduction phase
 
-Cross-cluster search requests can be executed in two ways:
+{ccs-cap} (CCS) requests can be executed in two ways:
 
 - the CCS coordinating node minimizes network round-trips by sending one search
 request to each cluster. Each cluster performs the search independently,

--- a/docs/reference/modules/ml-node.asciidoc
+++ b/docs/reference/modules/ml-node.asciidoc
@@ -64,7 +64,7 @@ node.ml: false <5>
 <1> Disable the `node.master` role (enabled by default).
 <2> Disable the `node.data` role (enabled by default).
 <3> The `node.ingest` role is enabled by default.
-<4> Disable cross-cluster search (enabled by default).
+<4> Disable {ccs} (enabled by default).
 <5> Disable the `node.ml` role (enabled by default in {xpack}).
 
 To create a dedicated coordinating node when {xpack} is installed, set:
@@ -80,7 +80,7 @@ node.ml: false <5>
 <1> Disable the `node.master` role (enabled by default).
 <2> Disable the `node.data` role (enabled by default).
 <3> Disable the `node.ingest` role (enabled by default).
-<4> Disable cross-cluster search (enabled by default).
+<4> Disable {ccs} (enabled by default).
 <5> Disable the `node.ml` role (enabled by default in {xpack}).
 
 [float]
@@ -111,6 +111,6 @@ xpack.ml.enabled: true <6>
 <1> Disable the `node.master` role (enabled by default).
 <2> Disable the `node.data` role (enabled by default).
 <3> Disable the `node.ingest` role (enabled by default).
-<4> Disable cross-cluster search (enabled by default).
+<4> Disable {ccs} (enabled by default).
 <5> The `node.ml` role is enabled by default in {xpack}.
 <6> The `xpack.ml.enabled` setting is enabled by default in {xpack}.

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -98,7 +98,7 @@ cluster.remote.connect: false <4>
 <1> The `node.master` role is enabled by default.
 <2> Disable the `node.data` role (enabled by default).
 <3> Disable the `node.ingest` role (enabled by default).
-<4> Disable cross-cluster search (enabled by default).
+<4> Disable {ccs} (enabled by default).
 
 ifdef::include-xpack[]
 NOTE: These settings apply only when {xpack} is not installed. To create a
@@ -129,7 +129,7 @@ cluster.remote.connect: false <4>
 <1> Disable the `node.master` role (enabled by default).
 <2> The `node.data` role is enabled by default.
 <3> Disable the `node.ingest` role (enabled by default).
-<4> Disable cross-cluster search (enabled by default).
+<4> Disable {ccs} (enabled by default).
 
 ifdef::include-xpack[]
 NOTE: These settings apply only when {xpack} is not installed. To create a
@@ -157,7 +157,7 @@ cluster.remote.connect: false <4>
 <1> Disable the `node.master` role (enabled by default).
 <2> Disable the `node.data` role (enabled by default).
 <3> The `node.ingest` role is enabled by default.
-<4> Disable cross-cluster search (enabled by default).
+<4> Disable {ccs} (enabled by default).
 
 ifdef::include-xpack[]
 NOTE: These settings apply only when {xpack} is not installed. To create a
@@ -197,7 +197,7 @@ cluster.remote.connect: false <4>
 <1> Disable the `node.master` role (enabled by default).
 <2> Disable the `node.data` role (enabled by default).
 <3> Disable the `node.ingest` role (enabled by default).
-<4> Disable cross-cluster search (enabled by default).
+<4> Disable {ccs} (enabled by default).
 
 ifdef::include-xpack[]
 NOTE: These settings apply only when {xpack} is not installed. To create a

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -4,13 +4,13 @@
 ifndef::include-xpack[]
 The _remote clusters_ module enables you to establish uni-directional
 connections to a remote cluster. This functionality is used in
-<<modules-cross-cluster-search,cross-cluster search>>.
+<<modules-cross-cluster-search,{ccs}>>.
 endif::[]
 ifdef::include-xpack[]
 The _remote clusters_ module enables you to establish uni-directional
 connections to a remote cluster. This functionality is used in
 {stack-ov}/xpack-ccr.html[{ccr}] and
-<<modules-cross-cluster-search,cross-cluster search>>.
+<<modules-cross-cluster-search,{ccs}>>.
 endif::[]
 
 Remote cluster connections work by configuring a remote cluster and connecting

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -117,7 +117,7 @@ And here is a sample response:
 
     Defaults to `true`. Set to `false` to disable minimizing network round-trips
     between the coordinating node and the remote clusters when executing
-    cross-cluster search requests. See <<ccs-reduction>> for more.
+    {ccs} requests. See <<ccs-reduction>> for more.
 
 
 Out of the above, the `search_type`, `request_cache` and the `allow_partial_search_results` 

--- a/docs/reference/sql/concepts.asciidoc
+++ b/docs/reference/sql/concepts.asciidoc
@@ -58,7 +58,7 @@ Further more, an {es} `cluster` can be connected to other ++cluster++s in a _fed
 single cluster::
 Multiple {es} instances typically distributed across machines, running within the same namespace.
 multiple clusters::
-Multiple clusters, each with its own namespace, connected to each other in a federated setup (see <<modules-cross-cluster-search, Cross cluster Search>>).
+Multiple clusters, each with its own namespace, connected to each other in a federated setup (see <<modules-cross-cluster-search, {ccs-cap}>>).
 
 |===
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/39516

This PR increases the use of attributes for CCS references, so that the same hyphenation is used throughout the Elasticsearch Reference. It also adds a glossary entry.