### PR TITLE
Run HDFS with compiler java instead of runtime

### DIFF
--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -114,7 +114,7 @@ for (String principal : principals) {
 for (String fixtureName : ['hdfsFixture', 'haHdfsFixture', 'secureHdfsFixture', 'secureHaHdfsFixture']) {
   project.tasks.create(fixtureName, org.elasticsearch.gradle.test.AntFixture) {
     dependsOn project.configurations.hdfsFixture
-    executable = new File(project.runtimeJavaHome, 'bin/java')
+    executable = new File(project.compilerJavaHome, 'bin/java')
     env 'CLASSPATH', "${ -> project.configurations.hdfsFixture.asPath }"
     waitCondition = { fixture, ant ->
       // the hdfs.MiniHDFS fixture writes the ports file when
@@ -129,7 +129,7 @@ for (String fixtureName : ['hdfsFixture', 'haHdfsFixture', 'secureHdfsFixture', 
       dependsOn krb5kdcFixture, krb5AddPrincipals
       Path krb5Config = project(':test:fixtures:krb5kdc-fixture').buildDir.toPath().resolve("conf").resolve("krb5.conf")
       miniHDFSArgs.add("-Djava.security.krb5.conf=${krb5Config}");
-      if (project.runtimeJavaVersion == JavaVersion.VERSION_1_9) {
+      if (project.compilerJavaHome == JavaVersion.VERSION_1_9) {
         miniHDFSArgs.add('--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED')
       }
     }
@@ -175,7 +175,7 @@ project.afterEvaluate {
 
       restIntegTestTask.clusterConfig.extraConfigFile("repository-hdfs/krb5.keytab", "${elasticsearchKT}")
       jvmArgs = jvmArgs + " " + "-Djava.security.krb5.conf=${krb5conf}"
-      if (project.runtimeJavaVersion == JavaVersion.VERSION_1_9) {
+      if (project.compilerJavaHome == JavaVersion.VERSION_1_9) {
         jvmArgs = jvmArgs + " " + '--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED'
       }
 
@@ -186,7 +186,7 @@ project.afterEvaluate {
         restIntegTestTaskRunner.systemProperty "test.krb5.principal.es", "elasticsearch@${realm}"
         restIntegTestTaskRunner.systemProperty "test.krb5.principal.hdfs", "hdfs/hdfs.build.elastic.co@${realm}"
         restIntegTestTaskRunner.jvmArg "-Djava.security.krb5.conf=${krb5conf}"
-        if (project.runtimeJavaVersion == JavaVersion.VERSION_1_9) {
+        if (project.compilerJavaHome == JavaVersion.VERSION_1_9) {
           restIntegTestTaskRunner.jvmArg '--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED'
         }
 


### PR DESCRIPTION
We support a number of JVMs as a runtime java and for some of them
(i.e. a JVM in FIPS 140 approved only mode) it doesn't make sense
to run the hdfs-fixture with these.

This changes repository-hdfs tests to run with compiler java version
so that it'll never run in a fips approved only JVM

Resolves #40079