### PR TITLE
Fix IndexSearcher wrappers interaction with AssertingIndexSearcher

### DIFF
--- a/server/src/main/java/org/apache/lucene/search/XIndexSearcher.java
+++ b/server/src/main/java/org/apache/lucene/search/XIndexSearcher.java
@@ -43,4 +43,9 @@ public class XIndexSearcher extends IndexSearcher {
     public void search(List<LeafReaderContext> leaves, Weight weight, Collector collector) throws IOException {
         in.search(leaves, weight, collector);
     }
+
+    @Override
+    public Weight createWeight(Query query, ScoreMode scoreMode, float boost) throws IOException {
+        return in.createWeight(query, scoreMode, boost);
+    }
 }


### PR DESCRIPTION
This commit ensures that we delegate the creation of the query weight to the AssertingIndexSearcher
when possible (if the query does not need to access distributed frequency statistics). This fixes test failures that uses a ContextIndexSearcher wrapped with an AssertingIndexSearcher.

Relates #39071