### PR TITLE
Stop auto-followers on shutdown

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/Ccr.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/Ccr.java
@@ -98,7 +98,6 @@ import org.elasticsearch.xpack.core.ccr.action.PutFollowAction;
 import org.elasticsearch.xpack.core.ccr.action.ResumeFollowAction;
 import org.elasticsearch.xpack.core.ccr.action.UnfollowAction;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/Ccr.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/Ccr.java
@@ -133,7 +133,6 @@ public class Ccr extends Plugin implements ActionPlugin, PersistentTaskPlugin, E
     private final SetOnce<CcrSettings> ccrSettings = new SetOnce<>();
     private final SetOnce<ThreadPool> threadPool = new SetOnce<>();
     private Client client;
-    private AutoFollowCoordinator autoFollowCoordinator;
     private final boolean transportClientMode;
 
     /**
@@ -180,18 +179,17 @@ public class Ccr extends Plugin implements ActionPlugin, PersistentTaskPlugin, E
         this.threadPool.set(threadPool);
         CcrRestoreSourceService restoreSourceService = new CcrRestoreSourceService(threadPool, ccrSettings);
         this.restoreSourceService.set(restoreSourceService);
-        this.autoFollowCoordinator = new AutoFollowCoordinator(
-                settings,
-                client,
-                clusterService,
-                ccrLicenseChecker,
-                threadPool::relativeTimeInMillis,
-                threadPool::absoluteTimeInMillis);
         return Arrays.asList(
                 ccrLicenseChecker,
                 restoreSourceService,
                 new CcrRepositoryManager(settings, clusterService, client),
-                autoFollowCoordinator);
+                new AutoFollowCoordinator(
+                        settings,
+                        client,
+                        clusterService,
+                        ccrLicenseChecker,
+                        threadPool::relativeTimeInMillis,
+                        threadPool::absoluteTimeInMillis));
     }
 
     @Override
@@ -348,11 +346,6 @@ public class Ccr extends Plugin implements ActionPlugin, PersistentTaskPlugin, E
     @Override
     public Collection<MappingRequestValidator> mappingRequestValidators() {
         return Collections.singletonList(CcrRequests.CCR_PUT_MAPPING_REQUEST_VALIDATOR);
-    }
-
-    @Override
-    public void close() throws IOException {
-        autoFollowCoordinator.close();
     }
 
 }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -130,6 +130,7 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
          * Synchronization is not necessary here; the field is volatile and the map is a copy-on-write map, any new auto-followers will not
          * start since we check started status of the coordinator before starting them.
          */
+        LOGGER.trace("stopping all auto-followers");
         autoFollowers.values().forEach(AutoFollower::stop);
     }
 
@@ -267,7 +268,7 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
 
             };
             newAutoFollowers.put(remoteCluster, autoFollower);
-            LOGGER.info("starting auto follower for remote cluster [{}]", remoteCluster);
+            LOGGER.info("starting auto-follower for remote cluster [{}]", remoteCluster);
             if (lifecycleState() == Lifecycle.State.STARTED) {
                 autoFollower.start();
             }
@@ -280,11 +281,11 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
             boolean exist = autoFollowMetadata.getPatterns().values().stream()
                 .anyMatch(pattern -> pattern.getRemoteCluster().equals(remoteCluster));
             if (exist == false) {
-                LOGGER.info("removing auto follower for remote cluster [{}]", remoteCluster);
+                LOGGER.info("removing auto-follower for remote cluster [{}]", remoteCluster);
                 autoFollower.removed = true;
                 removedRemoteClusters.add(remoteCluster);
             } else if (autoFollower.remoteClusterConnectionMissing) {
-                LOGGER.info("retrying auto follower [{}] after remote cluster connection was missing", remoteCluster);
+                LOGGER.info("retrying auto-follower for remote cluster [{}] after remote cluster connection was missing", remoteCluster);
                 autoFollower.remoteClusterConnectionMissing = false;
                 if (lifecycleState() == Lifecycle.State.STARTED) {
                     autoFollower.start();
@@ -352,7 +353,7 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
 
         void start() {
             if (stop) {
-                LOGGER.trace("stopping auto-follower for [{}]", remoteCluster);
+                LOGGER.trace("auto-follow is stopped for remote cluster [{}]", remoteCluster);
                 return;
             }
             if (removed) {
@@ -420,6 +421,7 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
         }
 
         void stop() {
+            LOGGER.trace("stopping auto-follower for remote cluster [{}]", remoteCluster);
             stop = true;
         }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -353,7 +353,7 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
 
         void start() {
             if (stop) {
-                LOGGER.trace("auto-follow is stopped for remote cluster [{}]", remoteCluster);
+                LOGGER.trace("auto-follower is stopped for remote cluster [{}]", remoteCluster);
                 return;
             }
             if (removed) {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -126,11 +126,11 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
 
     @Override
     protected void doStop() {
+        LOGGER.trace("stopping all auto-followers");
         /*
          * Synchronization is not necessary here; the field is volatile and the map is a copy-on-write map, any new auto-followers will not
          * start since we check started status of the coordinator before starting them.
          */
-        LOGGER.trace("stopping all auto-followers");
         autoFollowers.values().forEach(AutoFollower::stop);
     }
 
@@ -339,7 +339,7 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
         volatile boolean removed = false;
         private volatile CountDown autoFollowPatternsCountDown;
         private volatile AtomicArray<AutoFollowResult> autoFollowResults;
-        private volatile boolean stop = false;
+        private volatile boolean stop;
 
         AutoFollower(final String remoteCluster,
                      final Consumer<List<AutoFollowResult>> statsUpdater,


### PR DESCRIPTION
When shutting down a node, auto-followers will keep trying to run. This is happening even as transport services and other components are being closed. In some cases, this can lead to a stack overflow as we rapidly try to check the license state of the remote cluster, can not because the transport service is shutdown, and then immeidately retry again. This can happen faster than the shutdown, and we die with stack overflow. This commit adds a stop command to auto-followers so that this retry loop occurs at most once on shutdown.
