### PR TITLE
Dump cluster state if ensureGreen timed out in QA tests

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -456,4 +456,15 @@ public class RecoveryIT extends AbstractRollingTestCase {
             assertThat(XContentMapValues.extractValue("index.verified_before_close", settings), nullValue());
         }
     }
+
+    public void testTooManyReplicas() throws Exception {
+        final String index = "recover_with_too_many_replicas";
+        if (CLUSTER_TYPE == ClusterType.OLD) {
+            Settings.Builder settings = Settings.builder()
+                .put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+                .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 10);
+            createIndex(index, settings.build());
+            ensureGreen(index);
+        }
+    }
 }

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -456,15 +456,4 @@ public class RecoveryIT extends AbstractRollingTestCase {
             assertThat(XContentMapValues.extractValue("index.verified_before_close", settings), nullValue());
         }
     }
-
-    public void testTooManyReplicas() throws Exception {
-        final String index = "recover_with_too_many_replicas";
-        if (CLUSTER_TYPE == ClusterType.OLD) {
-            Settings.Builder settings = Settings.builder()
-                .put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
-                .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 10);
-            createIndex(index, settings.build());
-            ensureGreen(index);
-        }
-    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -805,7 +805,20 @@ public abstract class ESRestTestCase extends ESTestCase {
         request.addParameter("wait_for_no_relocating_shards", "true");
         request.addParameter("timeout", "70s");
         request.addParameter("level", "shards");
-        client().performRequest(request);
+        try {
+            client().performRequest(request);
+        } catch (ResponseException e) {
+            if (e.getResponse().getStatusLine().getStatusCode() == HttpStatus.SC_REQUEST_TIMEOUT) {
+                try {
+                    final Response clusterStateResponse = client().performRequest(new Request("GET", "/_cluster/state"));
+                    fail("timed out waiting for green state for index [" + index + "] " +
+                        "cluster state [" + EntityUtils.toString(clusterStateResponse.getEntity()) + "]");
+                } catch (Exception inner) {
+                    e.addSuppressed(inner);
+                }
+            }
+            throw e;
+        }
     }
 
     /**


### PR DESCRIPTION
When the method ensureGreen in QA tests is timed out, it does not provide enough info for us to investigate why the testing index is not green yet. With this change, we will dump the cluster state if ensureGreen timed out.

Relates #32027