### PR TITLE
Document monitoring node stats collection timeout (#39846)

### DIFF
--- a/docs/reference/settings/monitoring-settings.asciidoc
+++ b/docs/reference/settings/monitoring-settings.asciidoc
@@ -71,6 +71,10 @@ to pass through this cluster.
 
 Sets the timeout for collecting the cluster statistics. Defaults to `10s`.
 
+`xpack.monitoring.collection.node.stats.timeout`::
+
+Sets the timeout for collecting the node statistics. Defaults to `10s`.
+
 `xpack.monitoring.collection.indices` (<<cluster-update-settings,Dynamic>>)::
 
 Controls which indices Monitoring collects data from. Defaults to all indices. Specify the index names


### PR DESCRIPTION
With this commit we document the setting
`xpack.monitoring.collection.node.stats.timeout` that has been missing
so far in the docs.

Supersedes #31043