### PR TITLE
Fail command-line client's auto-URL detection with helpful message

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/tool/CommandLineHttpClient.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/tool/CommandLineHttpClient.java
@@ -27,7 +27,6 @@ import javax.net.ssl.HttpsURLConnection;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.URL;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/tool/CommandLineHttpClient.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/tool/CommandLineHttpClient.java
@@ -154,13 +154,13 @@ public class CommandLineHttpClient {
                 // this sucks but a port can be specified with a value of 0, we'll never be able to connect to it so just default to
                 // what we know
                 if (port <= 0) {
-                    throw new IllegalStateException("unable to determine http port from settings, please use the -u option to provide the" +
-                            " url");
+                    throw new IllegalStateException("unable to determine http port from settings");
                 }
             }
             return scheme + "://" + InetAddresses.toUriString(publishAddress) + ":" + port;
-        } catch (IOException e) {
-            throw new UncheckedIOException("failed to resolve default URL", e);
+        } catch (Exception e) {
+            throw new IllegalStateException("unable to determine default URL from settings, please use the -u option to explicitly " +
+                "provide the url", e);
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/CommandLineHttpClientTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/CommandLineHttpClientTests.java
@@ -27,6 +27,8 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
+import static org.hamcrest.Matchers.containsString;
+
 /**
  * This class tests {@link CommandLineHttpClient} For extensive tests related to
  * ssl settings can be found {@link SSLConfigurationSettingsTests}
@@ -61,6 +63,15 @@ public class CommandLineHttpClientTests extends ESTestCase {
         assertNotNull("Should have http response", httpResponse);
         assertEquals("Http status code does not match", 200, httpResponse.getHttpStatus());
         assertEquals("Http response body does not match", "complete", httpResponse.getResponseBody().get("test"));
+    }
+
+    public void testGetDefaultURLFailsWithHelpfulMessage() {
+        Settings settings = Settings.builder()
+            .put("network.host", "_ec2:privateIpv4_")
+            .build();
+        CommandLineHttpClient client = new CommandLineHttpClient(settings, environment);
+        assertThat(expectThrows(IllegalStateException.class, () -> client.getDefaultURL()).getMessage(),
+            containsString("unable to determine default URL from settings, please use the -u option to explicitly provide the url"));
     }
 
     private MockWebServer createMockWebServer() {


### PR DESCRIPTION
The setup-passwords tool gives cryptic messages in case where custom discovery providers are used (see #33580). As the URL auto-detection logic should be seen as best effort, this PR improves the exception message to make it clearer what needs to be done to fix the issue.

Relates #33580