### PR TITLE
Safe publication of AutoFollowCoordinator

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -101,7 +101,6 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
         this.ccrLicenseChecker = Objects.requireNonNull(ccrLicenseChecker, "ccrLicenseChecker");
         this.relativeMillisTimeProvider = relativeMillisTimeProvider;
         this.absoluteMillisTimeProvider = absoluteMillisTimeProvider;
-        clusterService.addListener(this);
         this.recentAutoFollowErrors = new LinkedHashMap<String, Tuple<Long, ElasticsearchException>>() {
             @Override
             protected boolean removeEldestEntry(final Map.Entry<String, Tuple<Long, ElasticsearchException>> eldest) {
@@ -121,11 +120,12 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
 
     @Override
     protected void doStart() {
-
+        clusterService.addListener(this);
     }
 
     @Override
     protected void doStop() {
+        clusterService.removeListener(this);
         LOGGER.trace("stopping all auto-followers");
         /*
          * Synchronization is not necessary here; the field is volatile and the map is a copy-on-write map, any new auto-followers will not


### PR DESCRIPTION
We were leaking a reference to an AutoFollowCoordinator during construction, violating safe publication according to the JLS specification. This commit addresses this by waiting to register AutoFollowCoordinator with the ClusterApplierService after the AutoFollowCoordinator is fully constructed. We also remove ourselves as a listener when stopping.

Relates #38560