### PR TITLE
[ML] Data Frame HLRC start & stop APIs

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameClient.java
@@ -23,6 +23,8 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.core.AcknowledgedResponse;
 import org.elasticsearch.client.dataframe.DeleteDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.PutDataFrameTransformRequest;
+import org.elasticsearch.client.dataframe.StartDataFrameTransformRequest;
+import org.elasticsearch.client.dataframe.StartDataFrameTransformResponse;
 import org.elasticsearch.client.dataframe.StopDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.StopDataFrameTransformResponse;
 
@@ -114,6 +116,47 @@ public final class DataFrameClient {
                 DataFrameRequestConverters::deleteDataFrameTransform,
                 options,
                 AcknowledgedResponse::fromXContent,
+                listener,
+                Collections.emptySet());
+    }
+
+
+    /**
+     * Start a data frame transform
+     * <p>
+     * For additional info
+     * see <a href="https://www.TODO.com">Start Data Frame transform documentation</a>
+     *
+     * @param request The start data frame transform request
+     * @param options Additional request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @return A response object indicating request success
+     * @throws IOException when there is a serialization issue sending the request or receiving the response
+     */
+    public StartDataFrameTransformResponse startDataFrameTransform(StartDataFrameTransformRequest request, RequestOptions options)
+            throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(request,
+                DataFrameRequestConverters::startDataFrameTransform,
+                options,
+                StartDataFrameTransformResponse::fromXContent,
+                Collections.emptySet());
+    }
+
+    /**
+     * Start a data frame transform asynchronously and notifies listener on completion
+     * <p>
+     * For additional info
+     * see <a href="https://www.TODO.com">Start Data Frame transform documentation</a>
+     *
+     * @param request The start data frame transform request
+     * @param options Additional request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @param listener Listener to be notified upon request completion
+     */
+    public void startDataFrameTransformAsync(StartDataFrameTransformRequest request, RequestOptions options,
+                                            ActionListener<StartDataFrameTransformResponse> listener) {
+        restHighLevelClient.performRequestAsyncAndParseEntity(request,
+                DataFrameRequestConverters::startDataFrameTransform,
+                options,
+                StartDataFrameTransformResponse::fromXContent,
                 listener,
                 Collections.emptySet());
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameClient.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.core.AcknowledgedResponse;
 import org.elasticsearch.client.dataframe.DeleteDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.PutDataFrameTransformRequest;
+import org.elasticsearch.client.dataframe.StopDataFrameTransformRequest;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -110,6 +111,46 @@ public final class DataFrameClient {
                                               ActionListener<AcknowledgedResponse> listener) {
         restHighLevelClient.performRequestAsyncAndParseEntity(request,
                 DataFrameRequestConverters::deleteDataFrameTransform,
+                options,
+                AcknowledgedResponse::fromXContent,
+                listener,
+                Collections.emptySet());
+    }
+
+    /**
+     * Stop a data frame transform
+     * <p>
+     * For additional info
+     * see <a href="https://www.TODO.com">Stop Data Frame transform documentation</a>
+     *
+     * @param request The stop data frame transform request
+     * @param options Additional request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @return An AcknowledgedResponse object indicating request success
+     * @throws IOException when there is a serialization issue sending the request or receiving the response
+     */
+    public AcknowledgedResponse stopDataFrameTransform(StopDataFrameTransformRequest request, RequestOptions options)
+            throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(request,
+                DataFrameRequestConverters::stopDataFrameTransform,
+                options,
+                AcknowledgedResponse::fromXContent,
+                Collections.emptySet());
+    }
+
+    /**
+     * Stop a data frame transform asynchronously and notifies listener on completion
+     * <p>
+     * For additional info
+     * see <a href="https://www.TODO.com">Stop Data Frame transform documentation</a>
+     *
+     * @param request The stop data frame transform request
+     * @param options Additional request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @param listener Listener to be notified upon request completion
+     */
+    public void stopDataFrameTransformAsync(StopDataFrameTransformRequest request, RequestOptions options,
+                                              ActionListener<AcknowledgedResponse> listener) {
+        restHighLevelClient.performRequestAsyncAndParseEntity(request,
+                DataFrameRequestConverters::stopDataFrameTransform,
                 options,
                 AcknowledgedResponse::fromXContent,
                 listener,

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameClient.java
@@ -24,6 +24,7 @@ import org.elasticsearch.client.core.AcknowledgedResponse;
 import org.elasticsearch.client.dataframe.DeleteDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.PutDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.StopDataFrameTransformRequest;
+import org.elasticsearch.client.dataframe.StopDataFrameTransformResponse;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -128,12 +129,12 @@ public final class DataFrameClient {
      * @return An AcknowledgedResponse object indicating request success
      * @throws IOException when there is a serialization issue sending the request or receiving the response
      */
-    public AcknowledgedResponse stopDataFrameTransform(StopDataFrameTransformRequest request, RequestOptions options)
+    public StopDataFrameTransformResponse stopDataFrameTransform(StopDataFrameTransformRequest request, RequestOptions options)
             throws IOException {
         return restHighLevelClient.performRequestAndParseEntity(request,
                 DataFrameRequestConverters::stopDataFrameTransform,
                 options,
-                AcknowledgedResponse::fromXContent,
+                StopDataFrameTransformResponse::fromXContent,
                 Collections.emptySet());
     }
 
@@ -148,11 +149,11 @@ public final class DataFrameClient {
      * @param listener Listener to be notified upon request completion
      */
     public void stopDataFrameTransformAsync(StopDataFrameTransformRequest request, RequestOptions options,
-                                              ActionListener<AcknowledgedResponse> listener) {
+                                              ActionListener<StopDataFrameTransformResponse> listener) {
         restHighLevelClient.performRequestAsyncAndParseEntity(request,
                 DataFrameRequestConverters::stopDataFrameTransform,
                 options,
-                AcknowledgedResponse::fromXContent,
+                StopDataFrameTransformResponse::fromXContent,
                 listener,
                 Collections.emptySet());
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameClient.java
@@ -169,7 +169,7 @@ public final class DataFrameClient {
      *
      * @param request The stop data frame transform request
      * @param options Additional request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @return An AcknowledgedResponse object indicating request success
+     * @return A response object indicating request success
      * @throws IOException when there is a serialization issue sending the request or receiving the response
      */
     public StopDataFrameTransformResponse stopDataFrameTransform(StopDataFrameTransformRequest request, RequestOptions options)

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameRequestConverters.java
@@ -20,9 +20,11 @@
 package org.elasticsearch.client;
 
 import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.elasticsearch.client.dataframe.DeleteDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.PutDataFrameTransformRequest;
+import org.elasticsearch.client.dataframe.StopDataFrameTransformRequest;
 
 import java.io.IOException;
 
@@ -49,5 +51,22 @@ final class DataFrameRequestConverters {
                 .addPathPart(request.getId())
                 .build();
         return new Request(HttpDelete.METHOD_NAME, endpoint);
+    }
+
+    static Request stopDataFrameTransform(StopDataFrameTransformRequest stopRequest) {
+            String endpoint = new RequestConverters.EndpointBuilder()
+                    .addPathPartAsIs("_data_frame", "transforms")
+                    .addPathPart(stopRequest.getId())
+                    .addPathPartAsIs("_stop")
+                    .build();
+            Request request = new Request(HttpPost.METHOD_NAME, endpoint);
+            RequestConverters.Params params = new RequestConverters.Params(request);
+            if (stopRequest.getWaitForCompletion() != null) {
+                params.withWaitForCompletion(stopRequest.getWaitForCompletion());
+            }
+            if (stopRequest.getTimeout() != null) {
+                params.withTimeout(stopRequest.getTimeout());
+            }
+            return request;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameRequestConverters.java
@@ -24,6 +24,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.elasticsearch.client.dataframe.DeleteDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.PutDataFrameTransformRequest;
+import org.elasticsearch.client.dataframe.StartDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.StopDataFrameTransformRequest;
 
 import java.io.IOException;
@@ -51,6 +52,20 @@ final class DataFrameRequestConverters {
                 .addPathPart(request.getId())
                 .build();
         return new Request(HttpDelete.METHOD_NAME, endpoint);
+    }
+
+    static Request startDataFrameTransform(StartDataFrameTransformRequest startRequest) {
+        String endpoint = new RequestConverters.EndpointBuilder()
+                .addPathPartAsIs("_data_frame", "transforms")
+                .addPathPart(startRequest.getId())
+                .addPathPartAsIs("_start")
+                .build();
+        Request request = new Request(HttpPost.METHOD_NAME, endpoint);
+        RequestConverters.Params params = new RequestConverters.Params(request);
+        if (startRequest.getTimeout() != null) {
+            params.withTimeout(startRequest.getTimeout());
+        }
+        return request;
     }
 
     static Request stopDataFrameTransform(StopDataFrameTransformRequest stopRequest) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/AcknowledgedTasksResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/AcknowledgedTasksResponse.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.core;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.TaskOperationFailure;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.TriFunction;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class AcknowledgedTasksResponse {
+
+    protected static final ParseField TASK_FAILURES = new ParseField("task_failures");
+    protected static final ParseField NODE_FAILURES = new ParseField("node_failures");
+
+    protected static <T extends AcknowledgedTasksResponse> ConstructingObjectParser<T, Void> generateParser(
+            String name,
+            TriFunction<Boolean, List<TaskOperationFailure>, List<? extends ElasticsearchException>, T> ctor,
+            String ackFieldName) {
+
+        ConstructingObjectParser<T, Void> parser = new ConstructingObjectParser<>(name, true,
+                args -> ctor.apply((boolean) args[0], (List<TaskOperationFailure>) args[1], (List<ElasticsearchException>) args[2]));
+        parser.declareBoolean(constructorArg(), new ParseField(ackFieldName));
+        parser.declareObjectArray(optionalConstructorArg(), (p, c) -> TaskOperationFailure.fromXContent(p), TASK_FAILURES);
+        parser.declareObjectArray(optionalConstructorArg(), (p, c) -> ElasticsearchException.fromXContent(p), NODE_FAILURES);
+        return parser;
+    }
+
+    private boolean acknowledged;
+    private List<TaskOperationFailure> taskFailures;
+    private List<ElasticsearchException> nodeFailures;
+
+    AcknowledgedTasksResponse(boolean acknowledged, List<TaskOperationFailure> taskFailures,
+                                     List<? extends ElasticsearchException> nodeFailures) {
+        this.acknowledged = acknowledged;
+        this.taskFailures = taskFailures == null ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(taskFailures));
+        this.nodeFailures = nodeFailures == null ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(nodeFailures));
+    }
+
+    boolean isAcknowledged() {
+        return acknowledged;
+    }
+
+    public List<TaskOperationFailure> getTaskFailures() {
+        return taskFailures;
+    }
+
+    public List<ElasticsearchException> getNodeFailures() {
+        return nodeFailures;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        AcknowledgedTasksResponse other = (AcknowledgedTasksResponse) obj;
+        return acknowledged == other.acknowledged
+                && taskFailures.equals(other.taskFailures)
+                && nodeFailures.equals(other.nodeFailures);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(acknowledged, taskFailures, nodeFailures);
+    }
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/AcknowledgedTasksResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/AcknowledgedTasksResponse.java
@@ -21,6 +21,7 @@ package org.elasticsearch.client.core;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.TaskOperationFailure;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
@@ -38,6 +39,7 @@ public class AcknowledgedTasksResponse {
     protected static final ParseField TASK_FAILURES = new ParseField("task_failures");
     protected static final ParseField NODE_FAILURES = new ParseField("node_failures");
 
+    @SuppressWarnings("unchecked")
     protected static <T extends AcknowledgedTasksResponse> ConstructingObjectParser<T, Void> generateParser(
             String name,
             TriFunction<Boolean, List<TaskOperationFailure>, List<? extends ElasticsearchException>, T> ctor,
@@ -55,14 +57,14 @@ public class AcknowledgedTasksResponse {
     private List<TaskOperationFailure> taskFailures;
     private List<ElasticsearchException> nodeFailures;
 
-    AcknowledgedTasksResponse(boolean acknowledged, List<TaskOperationFailure> taskFailures,
-                                     List<? extends ElasticsearchException> nodeFailures) {
+    public AcknowledgedTasksResponse(boolean acknowledged, @Nullable List<TaskOperationFailure> taskFailures,
+                                     @Nullable List<? extends ElasticsearchException> nodeFailures) {
         this.acknowledged = acknowledged;
         this.taskFailures = taskFailures == null ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(taskFailures));
         this.nodeFailures = nodeFailures == null ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(nodeFailures));
     }
 
-    boolean isAcknowledged() {
+    public boolean isAcknowledged() {
         return acknowledged;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StartDataFrameTransformRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StartDataFrameTransformRequest.java
@@ -21,7 +21,6 @@ package org.elasticsearch.client.dataframe;
 
 import org.elasticsearch.client.Validatable;
 import org.elasticsearch.client.ValidationException;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.unit.TimeValue;
 
 import java.util.Objects;
@@ -31,14 +30,13 @@ public class StartDataFrameTransformRequest implements Validatable {
 
     private final String id;
     // TODO The REST endpoint does not accept the timeout parameter yet
-    private final TimeValue timeout;
+    private TimeValue timeout;
 
     public StartDataFrameTransformRequest(String id) {
         this.id = id;
-        this.timeout = null;
     }
 
-    public StartDataFrameTransformRequest(String id, @Nullable TimeValue timeout) {
+    public StartDataFrameTransformRequest(String id, TimeValue timeout) {
         this.id = id;
         this.timeout = timeout;
     }
@@ -47,9 +45,12 @@ public class StartDataFrameTransformRequest implements Validatable {
         return id;
     }
 
-    @Nullable
     public TimeValue getTimeout() {
         return timeout;
+    }
+
+    public void setTimeout(TimeValue timeout) {
+        this.timeout = timeout;
     }
 
     @Override

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StartDataFrameTransformRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StartDataFrameTransformRequest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.dataframe;
+
+import org.elasticsearch.client.Validatable;
+import org.elasticsearch.client.ValidationException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.unit.TimeValue;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class StartDataFrameTransformRequest implements Validatable {
+
+    private final String id;
+    // TODO The REST endpoint does not accept the timeout parameter yet
+    private final TimeValue timeout;
+
+    public StartDataFrameTransformRequest(String id) {
+        this.id = id;
+        this.timeout = null;
+    }
+
+    public StartDataFrameTransformRequest(String id, @Nullable TimeValue timeout) {
+        this.id = id;
+        this.timeout = timeout;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @Nullable
+    public TimeValue getTimeout() {
+        return timeout;
+    }
+
+    @Override
+    public Optional<ValidationException> validate() {
+        if (id == null) {
+            ValidationException validationException = new ValidationException();
+            validationException.addValidationError("data frame transform id must not be null");
+            return Optional.of(validationException);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, timeout);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        StartDataFrameTransformRequest other = (StartDataFrameTransformRequest) obj;
+        return Objects.equals(this.id, other.id)
+                && Objects.equals(this.timeout, other.timeout);
+    }
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StartDataFrameTransformRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StartDataFrameTransformRequest.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 public class StartDataFrameTransformRequest implements Validatable {
 
     private final String id;
-    // TODO The REST endpoint does not accept the timeout parameter yet
     private TimeValue timeout;
 
     public StartDataFrameTransformRequest(String id) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StartDataFrameTransformResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StartDataFrameTransformResponse.java
@@ -34,7 +34,7 @@ public class StartDataFrameTransformResponse extends AcknowledgedTasksResponse {
     private static final String STARTED = "started";
 
     private static final ConstructingObjectParser<StartDataFrameTransformResponse, Void> PARSER =
-            AcknowledgedTasksResponse.generateParser("stop_data_frame_transform_response", StartDataFrameTransformResponse::new, STARTED);
+            AcknowledgedTasksResponse.generateParser("start_data_frame_transform_response", StartDataFrameTransformResponse::new, STARTED);
 
     public static StartDataFrameTransformResponse fromXContent(final XContentParser parser) throws IOException {
         return PARSER.parse(parser, null);

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StartDataFrameTransformResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StartDataFrameTransformResponse.java
@@ -29,23 +29,23 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.List;
 
-public class StopDataFrameTransformResponse extends AcknowledgedTasksResponse {
+public class StartDataFrameTransformResponse extends AcknowledgedTasksResponse {
 
-    private static final String STOPPED = "stopped";
+    private static final String STARTED = "started";
 
-    private static final ConstructingObjectParser<StopDataFrameTransformResponse, Void> PARSER =
-            AcknowledgedTasksResponse.generateParser("stop_data_frame_transform_response", StopDataFrameTransformResponse::new, STOPPED);
+    private static final ConstructingObjectParser<StartDataFrameTransformResponse, Void> PARSER =
+            AcknowledgedTasksResponse.generateParser("stop_data_frame_transform_response", StartDataFrameTransformResponse::new, STARTED);
 
-    public static StopDataFrameTransformResponse fromXContent(final XContentParser parser) throws IOException {
+    public static StartDataFrameTransformResponse fromXContent(final XContentParser parser) throws IOException {
         return PARSER.parse(parser, null);
     }
 
-    public StopDataFrameTransformResponse(boolean stopped, @Nullable List<TaskOperationFailure> taskFailures,
+    public StartDataFrameTransformResponse(boolean started, @Nullable List<TaskOperationFailure> taskFailures,
                                           @Nullable List<? extends ElasticsearchException> nodeFailures) {
-        super(stopped, taskFailures, nodeFailures);
+        super(started, taskFailures, nodeFailures);
     }
 
-    public boolean isStopped() {
+    public boolean isStarted() {
         return isAcknowledged();
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StopDataFrameTransformRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StopDataFrameTransformRequest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.dataframe;
+
+import org.elasticsearch.client.Validatable;
+import org.elasticsearch.client.ValidationException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.unit.TimeValue;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class StopDataFrameTransformRequest implements Validatable {
+
+    private final String id;
+    private final Boolean waitForCompletion;
+    private final TimeValue timeout;
+
+    public StopDataFrameTransformRequest(String id) {
+        this.id = id;
+        waitForCompletion = null;
+        timeout = null;
+    }
+
+    public StopDataFrameTransformRequest(String id, @Nullable Boolean waitForCompletion, @Nullable TimeValue timeout) {
+        this.id = id;
+        this.waitForCompletion = waitForCompletion;
+        this.timeout = timeout;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Boolean getWaitForCompletion() {
+        return waitForCompletion;
+    }
+
+    public TimeValue getTimeout() {
+        return timeout;
+    }
+
+    @Override
+    public Optional<ValidationException> validate() {
+        if (id == null) {
+            ValidationException validationException = new ValidationException();
+            validationException.addValidationError("data frame transform id must not be null");
+            return Optional.of(validationException);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, waitForCompletion, timeout);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        StopDataFrameTransformRequest other = (StopDataFrameTransformRequest) obj;
+        return Objects.equals(this.id, other.id)
+                && Objects.equals(this.waitForCompletion, other.waitForCompletion)
+                && Objects.equals(this.timeout, other.timeout);
+    }
+
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StopDataFrameTransformRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StopDataFrameTransformRequest.java
@@ -21,7 +21,6 @@ package org.elasticsearch.client.dataframe;
 
 import org.elasticsearch.client.Validatable;
 import org.elasticsearch.client.ValidationException;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.unit.TimeValue;
 
 import java.util.Objects;
@@ -30,8 +29,8 @@ import java.util.Optional;
 public class StopDataFrameTransformRequest implements Validatable {
 
     private final String id;
-    private final Boolean waitForCompletion;
-    private final TimeValue timeout;
+    private Boolean waitForCompletion;
+    private TimeValue timeout;
 
     public StopDataFrameTransformRequest(String id) {
         this.id = id;
@@ -39,7 +38,7 @@ public class StopDataFrameTransformRequest implements Validatable {
         timeout = null;
     }
 
-    public StopDataFrameTransformRequest(String id, @Nullable Boolean waitForCompletion, @Nullable TimeValue timeout) {
+    public StopDataFrameTransformRequest(String id, Boolean waitForCompletion, TimeValue timeout) {
         this.id = id;
         this.waitForCompletion = waitForCompletion;
         this.timeout = timeout;
@@ -49,8 +48,16 @@ public class StopDataFrameTransformRequest implements Validatable {
         return id;
     }
 
+    public void setWaitForCompletion(Boolean waitForCompletion) {
+        this.waitForCompletion = waitForCompletion;
+    }
+
     public Boolean getWaitForCompletion() {
         return waitForCompletion;
+    }
+
+    public void setTimeout(TimeValue timeout) {
+        this.timeout = timeout;
     }
 
     public TimeValue getTimeout() {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StopDataFrameTransformResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StopDataFrameTransformResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.dataframe;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.TaskOperationFailure;
+import org.elasticsearch.client.core.AcknowledgedTasksResponse;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.List;
+
+public class StopDataFrameTransformResponse extends AcknowledgedTasksResponse {
+
+    private static final String STOPPED = "stopped";
+
+    private static final ConstructingObjectParser<StopDataFrameTransformResponse, Void> PARSER =
+            AcknowledgedTasksResponse.generateParser("start_rollup_job_response", StopDataFrameTransformResponse::new, STOPPED);
+
+    public static StopDataFrameTransformResponse fromXContent(final XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
+    public StopDataFrameTransformResponse(boolean stopped, @Nullable List<TaskOperationFailure> taskFailures,
+                                          @Nullable List<? extends ElasticsearchException> nodeFailures) {
+        super(stopped, taskFailures, nodeFailures);
+    }
+
+    public boolean isStopped() {
+        return isAcknowledged();
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/DataFrameRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/DataFrameRequestConvertersTests.java
@@ -20,12 +20,15 @@
 package org.elasticsearch.client;
 
 import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.elasticsearch.client.dataframe.DeleteDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.PutDataFrameTransformRequest;
+import org.elasticsearch.client.dataframe.StopDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.client.dataframe.transforms.DataFrameTransformConfigTests;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -65,5 +68,37 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
 
         assertEquals(HttpDelete.METHOD_NAME, request.getMethod());
         assertThat(request.getEndpoint(), equalTo("/_data_frame/transforms/foo"));
+    }
+
+    public void testStopDataFrameTransform() {
+        String id = randomAlphaOfLength(10);
+        Boolean waitForCompletion = null;
+        if (randomBoolean()) {
+            waitForCompletion = randomBoolean();
+        }
+        TimeValue timeValue = null;
+        if (randomBoolean()) {
+            timeValue = TimeValue.parseTimeValue(randomTimeValue(), "timeout");
+        }
+        StopDataFrameTransformRequest stopRequest = new StopDataFrameTransformRequest(id, waitForCompletion, timeValue);
+
+
+        Request request = DataFrameRequestConverters.stopDataFrameTransform(stopRequest);
+        assertEquals(HttpPost.METHOD_NAME, request.getMethod());
+        assertThat(request.getEndpoint(), equalTo("/_data_frame/transforms/" + stopRequest.getId() + "/_stop"));
+
+        if (waitForCompletion != null) {
+            assertTrue(request.getParameters().containsKey("wait_for_completion"));
+            assertEquals(stopRequest.getWaitForCompletion(), Boolean.parseBoolean(request.getParameters().get("wait_for_completion")));
+        } else {
+            assertFalse(request.getParameters().containsKey("wait_for_completion"));
+        }
+
+        if (timeValue != null) {
+            assertTrue(request.getParameters().containsKey("timeout"));
+            assertEquals(stopRequest.getTimeout(), TimeValue.parseTimeValue(request.getParameters().get("timeout"), "timeout"));
+        } else {
+            assertFalse(request.getParameters().containsKey("timeout"));
+        }
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/DataFrameRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/DataFrameRequestConvertersTests.java
@@ -24,6 +24,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.elasticsearch.client.dataframe.DeleteDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.PutDataFrameTransformRequest;
+import org.elasticsearch.client.dataframe.StartDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.StopDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.client.dataframe.transforms.DataFrameTransformConfigTests;
@@ -68,6 +69,26 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
 
         assertEquals(HttpDelete.METHOD_NAME, request.getMethod());
         assertThat(request.getEndpoint(), equalTo("/_data_frame/transforms/foo"));
+    }
+
+    public void testStartDataFrameTransform() {
+        String id = randomAlphaOfLength(10);
+        TimeValue timeValue = null;
+        if (randomBoolean()) {
+            timeValue = TimeValue.parseTimeValue(randomTimeValue(), "timeout");
+        }
+        StartDataFrameTransformRequest startRequest = new StartDataFrameTransformRequest(id, timeValue);
+
+        Request request = DataFrameRequestConverters.startDataFrameTransform(startRequest);
+        assertEquals(HttpPost.METHOD_NAME, request.getMethod());
+        assertThat(request.getEndpoint(), equalTo("/_data_frame/transforms/" + startRequest.getId() + "/_start"));
+
+        if (timeValue != null) {
+            assertTrue(request.getParameters().containsKey("timeout"));
+            assertEquals(startRequest.getTimeout(), TimeValue.parseTimeValue(request.getParameters().get("timeout"), "timeout"));
+        } else {
+            assertFalse(request.getParameters().containsKey("timeout"));
+        }
     }
 
     public void testStopDataFrameTransform() {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/DataFrameTransformIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/DataFrameTransformIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.client.core.AcknowledgedResponse;
 import org.elasticsearch.client.dataframe.DeleteDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.PutDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.StopDataFrameTransformRequest;
+import org.elasticsearch.client.dataframe.StopDataFrameTransformResponse;
 import org.elasticsearch.client.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.client.dataframe.transforms.QueryConfig;
 import org.elasticsearch.client.dataframe.transforms.pivot.AggregationConfig;
@@ -118,8 +119,11 @@ public class DataFrameTransformIT extends ESRestHighLevelClientTestCase {
         assertTrue(ack.isAcknowledged());
 
         StopDataFrameTransformRequest stopRequest = new StopDataFrameTransformRequest(id);
-        execute(stopRequest, client::stopDataFrameTransform, client::stopDataFrameTransformAsync);
-        assertTrue(ack.isAcknowledged());
+        StopDataFrameTransformResponse stopResponse =
+                execute(stopRequest, client::stopDataFrameTransform, client::stopDataFrameTransformAsync);
+        assertTrue(stopResponse.isStopped());
+        assertNull(stopResponse.getNodeFailures());
+        assertNull(stopResponse.getTaskFailures());
     }
 }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/core/AcknowledgedTasksResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/core/AcknowledgedTasksResponseTests.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.core;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.TaskOperationFailure;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiPredicate;
+
+import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
+
+public class AcknowledgedTasksResponseTests extends ESTestCase {
+
+    public void testFromXContent() throws IOException {
+        xContentTester(this::createParser,
+                this::createTestInstance,
+                AcknowledgedTasksResponseTests::toXContent,
+                AcknowledgedTasksResponseTests::fromXContent)
+                .assertEqualsConsumer(this::assertEqualInstances)
+                .assertToXContentEquivalence(false)
+                .supportsUnknownFields(false)
+                .test();
+    }
+
+    // Serialisation of TaskOperationFailure changes the error
+    // so use a custom compare method
+    private void assertEqualInstances(AcknowledgedTasksResponse expectedInstance, AcknowledgedTasksResponse actual) {
+        assertNotSame(expectedInstance, actual);
+        assertEquals(expectedInstance.isAcknowledged(), actual.isAcknowledged());
+
+        List<TaskOperationFailure> expectedTaskFailures = expectedInstance.getTaskFailures();
+        List<TaskOperationFailure> actualTaskFailures = actual.getTaskFailures();
+
+        assertListEquals(expectedTaskFailures, actualTaskFailures, (a, b) ->
+                Objects.equals(a.getNodeId(), b.getNodeId())
+                        && Objects.equals(a.getTaskId(), b.getTaskId())
+                        && Objects.equals(a.getStatus(), b.getStatus())
+        );
+
+
+        List<ElasticsearchException> expectedExceptions = expectedInstance.getNodeFailures();
+        List<ElasticsearchException> actualExceptions = actual.getNodeFailures();
+
+        assertListEquals(expectedExceptions, actualExceptions, (a, b) -> a != null && b != null);
+    }
+
+    private <T> void assertListEquals(List<T> expected, List<T> actual, BiPredicate<T, T> comparator) {
+        if (expected == null) {
+            assertNull(actual);
+            return;
+        } else {
+            assertNotNull(actual);
+        }
+
+        assertEquals(expected.size(), actual.size());
+        for (int i=0; i<expected.size(); i++) {
+            assertTrue(comparator.test(expected.get(i), actual.get(i)));
+        }
+    }
+
+    private static AcknowledgedTasksResponse fromXContent(XContentParser parser) {
+        return AcknowledgedTasksResponse.generateParser("ack_tasks_response",
+                AcknowledgedTasksResponse::new, "acknowleged")
+                .apply(parser, null);
+    }
+
+    private AcknowledgedTasksResponse createTestInstance() {
+        List<TaskOperationFailure> taskFailures = null;
+        if (randomBoolean()) {
+            taskFailures = new ArrayList<>();
+            int numTaskFailures = randomIntBetween(1, 4);
+            for (int i=0; i<numTaskFailures; i++) {
+                taskFailures.add(new TaskOperationFailure(randomAlphaOfLength(4), randomNonNegativeLong(), new IllegalStateException()));
+            }
+        }
+        List<ElasticsearchException> nodeFailures = null;
+        if (randomBoolean()) {
+            nodeFailures = new ArrayList<>();
+            int numNodeFailures = randomIntBetween(1, 4);
+            for (int i=0; i<numNodeFailures; i++) {
+                nodeFailures.add(new ElasticsearchException("AcknowledgedTasksResponseTest"));
+            }
+        }
+
+        return new AcknowledgedTasksResponse(randomBoolean(), taskFailures, nodeFailures);
+    }
+
+    public static void toXContent(AcknowledgedTasksResponse response, XContentBuilder builder) throws IOException {
+        builder.startObject();
+        {
+            builder.field("acknowleged", response.isAcknowledged());
+
+            List<TaskOperationFailure> taskFailures = response.getTaskFailures();
+            if (taskFailures != null && taskFailures.isEmpty() == false) {
+                builder.startArray(AcknowledgedTasksResponse.TASK_FAILURES.getPreferredName());
+                for (TaskOperationFailure failure : taskFailures) {
+                    builder.startObject();
+                    failure.toXContent(builder, ToXContent.EMPTY_PARAMS);
+                    builder.endObject();
+                }
+                builder.endArray();
+            }
+
+            List<ElasticsearchException> nodeFailures = response.getNodeFailures();
+            if (nodeFailures != null && nodeFailures.isEmpty() == false) {
+                builder.startArray(AcknowledgedTasksResponse.NODE_FAILURES.getPreferredName());
+                for (ElasticsearchException failure : nodeFailures) {
+                    builder.startObject();
+                    failure.toXContent(builder, ToXContent.EMPTY_PARAMS);
+                    builder.endObject();
+                }
+                builder.endArray();
+            }
+        }
+        builder.endObject();
+    }
+
+}
+
+

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/StartDataFrameTransformRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/StartDataFrameTransformRequestTests.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.dataframe;
+
+import org.elasticsearch.client.ValidationException;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class StartDataFrameTransformRequestTests extends ESTestCase {
+    public void testValidate_givenNullId() {
+        StartDataFrameTransformRequest request = new StartDataFrameTransformRequest(null, null);
+        Optional<ValidationException> validate = request.validate();
+        assertTrue(validate.isPresent());
+        assertThat(validate.get().getMessage(), containsString("data frame transform id must not be null"));
+    }
+
+    public void testValidate_givenValid() {
+        StartDataFrameTransformRequest request = new StartDataFrameTransformRequest("foo", null);
+        Optional<ValidationException> validate = request.validate();
+        assertFalse(validate.isPresent());
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/StopDataFrameTransformRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/StopDataFrameTransformRequestTests.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.dataframe;
+
+import org.elasticsearch.client.ValidationException;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class StopDataFrameTransformRequestTests extends ESTestCase {
+    public void testValidate_givenNullId() {
+        StopDataFrameTransformRequest request = new StopDataFrameTransformRequest(null);
+        Optional<ValidationException> validate = request.validate();
+        assertTrue(validate.isPresent());
+        assertThat(validate.get().getMessage(), containsString("data frame transform id must not be null"));
+    }
+
+    public void testValidate_givenValid() {
+        StopDataFrameTransformRequest request = new StopDataFrameTransformRequest("foo");
+        Optional<ValidationException> validate = request.validate();
+        assertFalse(validate.isPresent());
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
@@ -39,6 +39,7 @@ import org.elasticsearch.client.dataframe.transforms.pivot.PivotConfig;
 import org.elasticsearch.client.dataframe.transforms.pivot.TermsGroupSource;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.CreateIndexResponse;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -176,8 +177,16 @@ public class DataFrameTransformDocumentationIT extends ESRestHighLevelClientTest
         {
             // tag::start-data-frame-transform-request
             StartDataFrameTransformRequest request =
-                    new StartDataFrameTransformRequest("mega-transform");
+                    new StartDataFrameTransformRequest("mega-transform");  // <1>
             // end::start-data-frame-transform-request
+
+            // tag::start-data-frame-transform-request-options
+            request.setTimeout(TimeValue.timeValueSeconds(20));  // <1>
+            // end::start-data-frame-transform-request-options
+
+
+            // TODO null the timeout value until it is supported in the REST api
+            request.setTimeout(null);
 
             // tag::start-data-frame-transform-execute
             StartDataFrameTransformResponse response =
@@ -190,8 +199,16 @@ public class DataFrameTransformDocumentationIT extends ESRestHighLevelClientTest
         {
             // tag::stop-data-frame-transform-request
             StopDataFrameTransformRequest request =
-                    new StopDataFrameTransformRequest("mega-transform");
+                    new StopDataFrameTransformRequest("mega-transform"); // <1>
             // end::stop-data-frame-transform-request
+
+            // tag::stop-data-frame-transform-request-options
+            request.setWaitForCompletion(Boolean.TRUE);  // <1>
+            request.setTimeout(TimeValue.timeValueSeconds(30));  // <2>
+            // end::stop-data-frame-transform-request-options
+
+            // TODO null the timeout value until it is supported in the REST api
+            request.setTimeout(null);
 
             // tag::stop-data-frame-transform-execute
             StopDataFrameTransformResponse response =

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.AcknowledgedResponse;
 import org.elasticsearch.client.dataframe.DeleteDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.PutDataFrameTransformRequest;
+import org.elasticsearch.client.dataframe.StopDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.client.dataframe.transforms.QueryConfig;
 import org.elasticsearch.client.dataframe.transforms.pivot.AggregationConfig;
@@ -150,6 +151,13 @@ public class DataFrameTransformDocumentationIT extends ESRestHighLevelClientTest
 
             assertTrue(latch.await(30L, TimeUnit.SECONDS));
         }
+
+        // Stop the Data Frame
+        // tag::stop-data-frame-transform-request
+        StopDataFrameTransformRequest stopRequest =
+                new StopDataFrameTransformRequest("reviewer-avg-rating");
+        // end::stop-data-frame-transform-request
+
     }
 
     public void testDeleteDataFrameTransform() throws IOException, InterruptedException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
@@ -27,7 +27,10 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.AcknowledgedResponse;
 import org.elasticsearch.client.dataframe.DeleteDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.PutDataFrameTransformRequest;
+import org.elasticsearch.client.dataframe.StartDataFrameTransformRequest;
+import org.elasticsearch.client.dataframe.StartDataFrameTransformResponse;
 import org.elasticsearch.client.dataframe.StopDataFrameTransformRequest;
+import org.elasticsearch.client.dataframe.StopDataFrameTransformResponse;
 import org.elasticsearch.client.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.client.dataframe.transforms.QueryConfig;
 import org.elasticsearch.client.dataframe.transforms.pivot.AggregationConfig;
@@ -151,13 +154,113 @@ public class DataFrameTransformDocumentationIT extends ESRestHighLevelClientTest
 
             assertTrue(latch.await(30L, TimeUnit.SECONDS));
         }
+    }
 
-        // Stop the Data Frame
-        // tag::stop-data-frame-transform-request
-        StopDataFrameTransformRequest stopRequest =
-                new StopDataFrameTransformRequest("reviewer-avg-rating");
-        // end::stop-data-frame-transform-request
+    public void testStartStop() throws IOException, InterruptedException {
+        createIndex("source-data");
 
+        RestHighLevelClient client = highLevelClient();
+
+        QueryConfig queryConfig = new QueryConfig(new MatchAllQueryBuilder());
+        GroupConfig groupConfig = new GroupConfig(Collections.singletonMap("reviewer", new TermsGroupSource("user_id")));
+        AggregatorFactories.Builder aggBuilder = new AggregatorFactories.Builder();
+        aggBuilder.addAggregator(AggregationBuilders.avg("avg_rating").field("stars"));
+        AggregationConfig aggConfig = new AggregationConfig(aggBuilder);
+        PivotConfig pivotConfig = new PivotConfig(groupConfig, aggConfig);
+
+        DataFrameTransformConfig transformConfig = new DataFrameTransformConfig("mega-transform",
+                "source-data", "pivot-dest", queryConfig, pivotConfig);
+
+        client.dataFrame().putDataFrameTransform(new PutDataFrameTransformRequest(transformConfig), RequestOptions.DEFAULT);
+
+        {
+            // tag::start-data-frame-transform-request
+            StartDataFrameTransformRequest request =
+                    new StartDataFrameTransformRequest("mega-transform");
+            // end::start-data-frame-transform-request
+
+            // tag::start-data-frame-transform-execute
+            StartDataFrameTransformResponse response =
+                    client.dataFrame().startDataFrameTransform(
+                            request, RequestOptions.DEFAULT);
+            // end::start-data-frame-transform-execute
+
+            assertTrue(response.isStarted());
+        }
+        {
+            // tag::stop-data-frame-transform-request
+            StopDataFrameTransformRequest request =
+                    new StopDataFrameTransformRequest("mega-transform");
+            // end::stop-data-frame-transform-request
+
+            // tag::stop-data-frame-transform-execute
+            StopDataFrameTransformResponse response =
+                    client.dataFrame().stopDataFrameTransform(
+                            request, RequestOptions.DEFAULT);
+            // end::stop-data-frame-transform-execute
+
+            assertTrue(response.isStopped());
+        }
+        {
+            // tag::start-data-frame-transform-execute-listener
+            ActionListener<StartDataFrameTransformResponse> listener =
+                    new ActionListener<StartDataFrameTransformResponse>() {
+                        @Override
+                        public void onResponse(
+                                StartDataFrameTransformResponse response) {
+                            // <1>
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            // <2>
+                        }
+                    };
+            // end::start-data-frame-transform-execute-listener
+
+            // Replace the empty listener by a blocking listener in test
+            final CountDownLatch latch = new CountDownLatch(1);
+            ActionListener<StartDataFrameTransformResponse> ackListener = listener;
+            listener = new LatchedActionListener<>(listener, latch);
+
+            StartDataFrameTransformRequest request = new StartDataFrameTransformRequest("mega-transform");
+            // tag::start-data-frame-transform-execute-async
+            client.dataFrame().startDataFrameTransformAsync(
+                    request, RequestOptions.DEFAULT, listener); // <1>
+            // end::start-data-frame-transform-execute-async
+
+            assertTrue(latch.await(30L, TimeUnit.SECONDS));
+        }
+        {
+            // tag::stop-data-frame-transform-execute-listener
+            ActionListener<StopDataFrameTransformResponse> listener =
+                    new ActionListener<StopDataFrameTransformResponse>() {
+                        @Override
+                        public void onResponse(
+                                StopDataFrameTransformResponse response) {
+                            // <1>
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            // <2>
+                        }
+                    };
+            // end::stop-data-frame-transform-execute-listener
+
+            // Replace the empty listener by a blocking listener in test
+            final CountDownLatch latch = new CountDownLatch(1);
+            ActionListener<StopDataFrameTransformResponse> ackListener = listener;
+            listener = new LatchedActionListener<>(listener, latch);
+
+            StopDataFrameTransformRequest request = new StopDataFrameTransformRequest("mega-transform");
+            // tag::stop-data-frame-transform-execute-async
+            client.dataFrame().stopDataFrameTransformAsync(
+                    request, RequestOptions.DEFAULT, listener); // <1>
+            // end::stop-data-frame-transform-execute-async
+
+            assertTrue(latch.await(30L, TimeUnit.SECONDS));
+        }
     }
 
     public void testDeleteDataFrameTransform() throws IOException, InterruptedException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
@@ -204,10 +204,6 @@ public class DataFrameTransformDocumentationIT extends ESRestHighLevelClientTest
             request.setTimeout(TimeValue.timeValueSeconds(20));  // <1>
             // end::start-data-frame-transform-request-options
 
-
-            // TODO null the timeout value until it is supported in the REST api
-            request.setTimeout(null);
-
             // tag::start-data-frame-transform-execute
             StartDataFrameTransformResponse response =
                     client.dataFrame().startDataFrameTransform(

--- a/docs/java-rest/high-level/dataframe/start_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/start_data_frame.asciidoc
@@ -1,16 +1,16 @@
 --
-:api: stop-data-frame-transform
-:request: StopDataFrameTransformRequest
-:response: StopDataFrameTransformResponse
+:api: start-data-frame-transform
+:request: StartDataFrameTransformRequest
+:response: StartDataFrameTransformResponse
 --
 [id="{upid}-{api}"]
-=== Stop Data Frame Transform API
+=== Start Data Frame Transform API
 
-Stop a started {dataframe-job}.
+Start a {dataframe-job}.
 It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Stop Data Frame Request
+==== Start Data Frame Request
 
 A +{request}+ object requires a non-null `id`.
 
@@ -18,7 +18,7 @@ A +{request}+ object requires a non-null `id`.
 ---------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 ---------------------------------------------------
-<1> Constructing a new stop request referencing an existing {dataframe-job}
+<1> Constructing a new start request referencing an existing {dataframe-job}
 
 ==== Optional Arguments
 
@@ -28,11 +28,10 @@ The following arguments are optional.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request-options]
 --------------------------------------------------
-<1> If true wait for the data frame task to stop before responding
-<2> Controls the amount of time to wait until the {dataframe-job} stops.
+<1> Controls the amount of time to wait until the {dataframe-job} starts.
 
 include::../execution.asciidoc[]
 
 ==== Response
 
-The returned +{response}+ object acknowledges the {dataframe-job} has stopped.
+The returned +{response}+ object acknowledges the {dataframe-job} has started.

--- a/docs/java-rest/high-level/dataframe/stop_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/stop_data_frame.asciidoc
@@ -1,7 +1,7 @@
 --
 :api: stop-data-frame-transform
 :request: StopDataFrameTransformRequest
-:response: AcknowledgedResponse
+:response: StopDataFrameTransformResponse
 --
 [id="{upid}-{api}"]
 === Stop Data Frame Transform API
@@ -18,7 +18,7 @@ A +{request}+ object requires a non-null `id`.
 ---------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 ---------------------------------------------------
-<1> Constructing a new request referencing an existing {dataframe-job}
+<1> Constructing a new stop request referencing an existing {dataframe-job}
 
 ==== Optional Arguments
 

--- a/docs/java-rest/high-level/dataframe/stop_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/stop_data_frame.asciidoc
@@ -1,0 +1,39 @@
+--
+:api: stop-data-frame-transform
+:request: StopDataFrameTransformRequest
+:response: AcknowledgedResponse
+--
+[id="{upid}-{api}"]
+=== Stop Data Frame Transform API
+
+Stop a started {dataframe-job}.
+It accepts a +{request}+ object and responds with a +{response}+ object.
+
+[id="{upid}-{api}-request"]
+==== Stop Data Frame Request
+
+A +{request}+ object requires a non-null `id`.
+
+["source","java",subs="attributes,callouts,macros"]
+---------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-request]
+---------------------------------------------------
+<1> Constructing a new request referencing an existing {dataframe-job}
+
+==== Optional Arguments
+
+The following arguments are optional.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-request-options]
+--------------------------------------------------
+<1> If true wait for the data frame task to stop before responding
+<2> Controls the amount of time to wait until the {dataframe-job} stops.
+The default value is 30 seconds.
+
+include::../execution.asciidoc[]
+
+==== Response
+
+The returned +{response}+ object acknowledges the {dataframe-job} has stopped.

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -556,6 +556,10 @@ The Java High Level REST Client supports the following Data Frame APIs:
 
 * <<{upid}-put-data-frame-transform>>
 * <<{upid}-delete-data-frame-transform>>
+* <<{upid}-start-data-frame-transform>>
+* <<{upid}-stop-data-frame-transform>>
 
 include::dataframe/put_data_frame.asciidoc[]
 include::dataframe/delete_data_frame.asciidoc[]
+include::dataframe/start_data_frame.asciidoc[]
+include::dataframe/stop_data_frame.asciidoc[]

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestStartDataFrameTransformAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestStartDataFrameTransformAction.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.dataframe.rest.action;
 
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -13,7 +14,6 @@ import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
-import org.elasticsearch.xpack.core.rollup.RollupField;
 import org.elasticsearch.xpack.core.dataframe.action.StartDataFrameTransformAction;
 
 import java.io.IOException;
@@ -27,9 +27,11 @@ public class RestStartDataFrameTransformAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
-        String id = restRequest.param(RollupField.ID.getPreferredName());
+        String id = restRequest.param(DataFrameField.ID.getPreferredName());
         StartDataFrameTransformAction.Request request = new StartDataFrameTransformAction.Request(id);
-
+        if (restRequest.hasParam(DataFrameField.TIMEOUT.getPreferredName())) {
+            request.timeout(restRequest.paramAsTime(DataFrameField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT));
+        }
         return channel -> client.execute(StartDataFrameTransformAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.start_data_frame_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.start_data_frame_transform.json
@@ -11,6 +11,13 @@
           "required": true,
           "description": "The id of the transform to start"
         }
+      },
+      "params": {
+        "timeout": {
+          "type": "time",
+          "required": false,
+          "description": "Controls the time to wait for the transform to start"
+        }
       }
     },
     "body": null


### PR DESCRIPTION
On the server side both these APIs inherit `BaseTasksResponse` which returns node failures etc. This PR adds a `AcknowledgedTasksResponse` for parsing the response.

The `TaskOperationFailure` class was added in #29546 and the decision was made there not to implement `equals` & `hashcode` as the serialisation of ElasticsearchExceptions changes them wrapping the error in an outer exception. This made writing the unit tests a little bit more complicated as a custom equals method was required. 