### PR TITLE
removing background state update of Request object by RequestConverte…

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/CcrRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/CcrRequestConverters.java
@@ -48,9 +48,10 @@ final class CcrRequestConverters {
             .addPathPartAsIs("_ccr", "follow")
             .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withWaitForActiveShards(putFollowRequest.waitForActiveShards());
         request.setEntity(createEntity(putFollowRequest, REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterRequestConverters.java
@@ -36,22 +36,22 @@ final class ClusterRequestConverters {
     static Request clusterPutSettings(ClusterUpdateSettingsRequest clusterUpdateSettingsRequest) throws IOException {
         Request request = new Request(HttpPut.METHOD_NAME, "/_cluster/settings");
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(clusterUpdateSettingsRequest.timeout());
         parameters.withMasterTimeout(clusterUpdateSettingsRequest.masterNodeTimeout());
-
         request.setEntity(RequestConverters.createEntity(clusterUpdateSettingsRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
     static Request clusterGetSettings(ClusterGetSettingsRequest clusterGetSettingsRequest) throws IOException {
         Request request = new Request(HttpGet.METHOD_NAME, "/_cluster/settings");
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withLocal(clusterGetSettingsRequest.local());
         parameters.withIncludeDefaults(clusterGetSettingsRequest.includeDefaults());
         parameters.withMasterTimeout(clusterGetSettingsRequest.masterNodeTimeout());
-
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -63,7 +63,7 @@ final class ClusterRequestConverters {
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        new RequestConverters.Params(request)
+        RequestConverters.Params params = new RequestConverters.Params()
             .withWaitForStatus(healthRequest.waitForStatus())
             .withWaitForNoRelocatingShards(healthRequest.waitForNoRelocatingShards())
             .withWaitForNoInitializingShards(healthRequest.waitForNoInitializingShards())
@@ -74,6 +74,7 @@ final class ClusterRequestConverters {
             .withMasterTimeout(healthRequest.masterNodeTimeout())
             .withLocal(healthRequest.local())
             .withLevel(healthRequest.level());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleRequestConverters.java
@@ -41,113 +41,122 @@ final class IndexLifecycleRequestConverters {
     private IndexLifecycleRequestConverters() {}
 
     static Request getLifecyclePolicy(GetLifecyclePolicyRequest getLifecyclePolicyRequest) {
-        String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_ilm/policy")
+        final String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_ilm/policy")
                 .addCommaSeparatedPathParts(getLifecyclePolicyRequest.getPolicyNames()).build();
-        Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        final Request request = new Request(HttpGet.METHOD_NAME, endpoint);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(getLifecyclePolicyRequest.masterNodeTimeout());
         params.withTimeout(getLifecyclePolicyRequest.timeout());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
     static Request putLifecyclePolicy(PutLifecyclePolicyRequest putLifecycleRequest) throws IOException {
-        String endpoint = new RequestConverters.EndpointBuilder()
+        final String endpoint = new RequestConverters.EndpointBuilder()
             .addPathPartAsIs("_ilm/policy")
             .addPathPartAsIs(putLifecycleRequest.getName())
             .build();
-        Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        final Request request = new Request(HttpPut.METHOD_NAME, endpoint);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(putLifecycleRequest.masterNodeTimeout());
         params.withTimeout(putLifecycleRequest.timeout());
         request.setEntity(RequestConverters.createEntity(putLifecycleRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
     static Request deleteLifecyclePolicy(DeleteLifecyclePolicyRequest deleteLifecyclePolicyRequest) {
-        Request request = new Request(HttpDelete.METHOD_NAME,
+        final Request request = new Request(HttpDelete.METHOD_NAME,
             new RequestConverters.EndpointBuilder()
                 .addPathPartAsIs("_ilm/policy")
                 .addPathPartAsIs(deleteLifecyclePolicyRequest.getLifecyclePolicy())
                 .build());
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(deleteLifecyclePolicyRequest.masterNodeTimeout());
         params.withTimeout(deleteLifecyclePolicyRequest.timeout());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
     static Request removeIndexLifecyclePolicy(RemoveIndexLifecyclePolicyRequest removePolicyRequest) {
-        String[] indices = removePolicyRequest.indices() == null ?
+        final String[] indices = removePolicyRequest.indices() == null ?
                 Strings.EMPTY_ARRAY : removePolicyRequest.indices().toArray(new String[] {});
-        Request request = new Request(HttpPost.METHOD_NAME,
+        final Request request = new Request(HttpPost.METHOD_NAME,
                 new RequestConverters.EndpointBuilder()
                         .addCommaSeparatedPathParts(indices)
                         .addPathPartAsIs("_ilm", "remove")
                         .build());
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(removePolicyRequest.indicesOptions());
         params.withMasterTimeout(removePolicyRequest.masterNodeTimeout());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
     static Request startILM(StartILMRequest startILMRequest) {
-        Request request = new Request(HttpPost.METHOD_NAME,
+        final Request request = new Request(HttpPost.METHOD_NAME,
             new RequestConverters.EndpointBuilder()
                 .addPathPartAsIs("_ilm")
                 .addPathPartAsIs("start")
             .build());
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(startILMRequest.masterNodeTimeout());
         params.withTimeout(startILMRequest.timeout());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
     static Request stopILM(StopILMRequest stopILMRequest) {
-        Request request = new Request(HttpPost.METHOD_NAME,
+        final Request request = new Request(HttpPost.METHOD_NAME,
             new RequestConverters.EndpointBuilder()
                 .addPathPartAsIs("_ilm")
                 .addPathPartAsIs("stop")
             .build());
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(stopILMRequest.masterNodeTimeout());
         params.withTimeout(stopILMRequest.timeout());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
     static Request lifecycleManagementStatus(LifecycleManagementStatusRequest lifecycleManagementStatusRequest){
-        Request request = new Request(HttpGet.METHOD_NAME,
+        final Request request = new Request(HttpGet.METHOD_NAME,
             new RequestConverters.EndpointBuilder()
                 .addPathPartAsIs("_ilm")
                 .addPathPartAsIs("status")
             .build());
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(lifecycleManagementStatusRequest.masterNodeTimeout());
         params.withTimeout(lifecycleManagementStatusRequest.timeout());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
     static Request explainLifecycle(ExplainLifecycleRequest explainLifecycleRequest) {
-        Request request = new Request(HttpGet.METHOD_NAME,
+        final Request request = new Request(HttpGet.METHOD_NAME,
             new RequestConverters.EndpointBuilder()
                 .addCommaSeparatedPathParts(explainLifecycleRequest.getIndices())
                 .addPathPartAsIs("_ilm")
                 .addPathPartAsIs("explain")
             .build());
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(explainLifecycleRequest.indicesOptions());
         params.withMasterTimeout(explainLifecycleRequest.masterNodeTimeout());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
     static Request retryLifecycle(RetryLifecyclePolicyRequest retryLifecyclePolicyRequest) {
-        Request request = new Request(HttpPost.METHOD_NAME,
+        final Request request = new Request(HttpPost.METHOD_NAME,
             new RequestConverters.EndpointBuilder()
                 .addCommaSeparatedPathParts(retryLifecyclePolicyRequest.getIndices())
                 .addPathPartAsIs("_ilm")
                 .addPathPartAsIs("retry")
                 .build());
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(retryLifecyclePolicyRequest.masterNodeTimeout());
         params.withTimeout(retryLifecyclePolicyRequest.timeout());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
@@ -67,10 +67,11 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(deleteIndexRequest.indices());
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(deleteIndexRequest.timeout());
         parameters.withMasterTimeout(deleteIndexRequest.masterNodeTimeout());
         parameters.withIndicesOptions(deleteIndexRequest.indicesOptions());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -78,11 +79,12 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(openIndexRequest.indices(), "_open");
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(openIndexRequest.timeout());
         parameters.withMasterTimeout(openIndexRequest.masterNodeTimeout());
         parameters.withWaitForActiveShards(openIndexRequest.waitForActiveShards());
         parameters.withIndicesOptions(openIndexRequest.indicesOptions());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -90,10 +92,11 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(closeIndexRequest.indices(), "_close");
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(closeIndexRequest.timeout());
         parameters.withMasterTimeout(closeIndexRequest.masterNodeTimeout());
         parameters.withIndicesOptions(closeIndexRequest.indicesOptions());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -102,12 +105,12 @@ final class IndicesRequestConverters {
             .addPathPart(createIndexRequest.index()).build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(createIndexRequest.timeout());
         parameters.withMasterTimeout(createIndexRequest.masterNodeTimeout());
         parameters.withWaitForActiveShards(createIndexRequest.waitForActiveShards());
-
         request.setEntity(RequestConverters.createEntity(createIndexRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -116,24 +119,26 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(createIndexRequest.indices());
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(createIndexRequest.timeout());
         parameters.withMasterTimeout(createIndexRequest.masterNodeTimeout());
         parameters.withWaitForActiveShards(createIndexRequest.waitForActiveShards());
         parameters.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
 
         request.setEntity(RequestConverters.createEntity(createIndexRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
     static Request updateAliases(IndicesAliasesRequest indicesAliasesRequest) throws IOException {
         Request request = new Request(HttpPost.METHOD_NAME, "/_aliases");
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(indicesAliasesRequest.timeout());
         parameters.withMasterTimeout(indicesAliasesRequest.masterNodeTimeout());
 
         request.setEntity(RequestConverters.createEntity(indicesAliasesRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -141,10 +146,11 @@ final class IndicesRequestConverters {
     static Request putMapping(PutMappingRequest putMappingRequest) throws IOException {
         Request request = new Request(HttpPut.METHOD_NAME, RequestConverters.endpoint(putMappingRequest.indices(), "_mapping"));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(putMappingRequest.timeout());
         parameters.withMasterTimeout(putMappingRequest.masterNodeTimeout());
         request.setEntity(RequestConverters.createEntity(putMappingRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -162,12 +168,13 @@ final class IndicesRequestConverters {
         Request request = new Request(HttpPut.METHOD_NAME, RequestConverters.endpoint(putMappingRequest.indices(),
             "_mapping", putMappingRequest.type()));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(putMappingRequest.timeout());
         parameters.withMasterTimeout(putMappingRequest.masterNodeTimeout());
         parameters.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
 
         request.setEntity(RequestConverters.createEntity(putMappingRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -176,11 +183,11 @@ final class IndicesRequestConverters {
 
         Request request = new Request(HttpGet.METHOD_NAME, RequestConverters.endpoint(indices, "_mapping"));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(getMappingsRequest.masterNodeTimeout());
         parameters.withIndicesOptions(getMappingsRequest.indicesOptions());
         parameters.withLocal(getMappingsRequest.local());
-
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -191,12 +198,12 @@ final class IndicesRequestConverters {
 
         Request request = new Request(HttpGet.METHOD_NAME, RequestConverters.endpoint(indices, "_mapping", types));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(getMappingsRequest.masterNodeTimeout());
         parameters.withIndicesOptions(getMappingsRequest.indicesOptions());
         parameters.withLocal(getMappingsRequest.local());
         parameters.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
-
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -213,11 +220,11 @@ final class IndicesRequestConverters {
 
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withIndicesOptions(getFieldMappingsRequest.indicesOptions());
         parameters.withIncludeDefaults(getFieldMappingsRequest.includeDefaults());
         parameters.withLocal(getFieldMappingsRequest.local());
-
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -234,12 +241,12 @@ final class IndicesRequestConverters {
 
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withIndicesOptions(getFieldMappingsRequest.indicesOptions());
         parameters.withIncludeDefaults(getFieldMappingsRequest.includeDefaults());
         parameters.withLocal(getFieldMappingsRequest.local());
         parameters.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
-
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -247,8 +254,9 @@ final class IndicesRequestConverters {
         String[] indices = refreshRequest.indices() == null ? Strings.EMPTY_ARRAY : refreshRequest.indices();
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_refresh"));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withIndicesOptions(refreshRequest.indicesOptions());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -256,18 +264,20 @@ final class IndicesRequestConverters {
         String[] indices = flushRequest.indices() == null ? Strings.EMPTY_ARRAY : flushRequest.indices();
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_flush"));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withIndicesOptions(flushRequest.indicesOptions());
         parameters.putParam("wait_if_ongoing", Boolean.toString(flushRequest.waitIfOngoing()));
         parameters.putParam("force", Boolean.toString(flushRequest.force()));
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
     static Request flushSynced(SyncedFlushRequest syncedFlushRequest) {
         String[] indices = syncedFlushRequest.indices() == null ? Strings.EMPTY_ARRAY : syncedFlushRequest.indices();
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_flush/synced"));
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withIndicesOptions(syncedFlushRequest.indicesOptions());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -275,11 +285,12 @@ final class IndicesRequestConverters {
         String[] indices = forceMergeRequest.indices() == null ? Strings.EMPTY_ARRAY : forceMergeRequest.indices();
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_forcemerge"));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withIndicesOptions(forceMergeRequest.indicesOptions());
         parameters.putParam("max_num_segments", Integer.toString(forceMergeRequest.maxNumSegments()));
         parameters.putParam("only_expunge_deletes", Boolean.toString(forceMergeRequest.onlyExpungeDeletes()));
         parameters.putParam("flush", Boolean.toString(forceMergeRequest.flush()));
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -287,12 +298,13 @@ final class IndicesRequestConverters {
         String[] indices = clearIndicesCacheRequest.indices() == null ? Strings.EMPTY_ARRAY :clearIndicesCacheRequest.indices();
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_cache/clear"));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withIndicesOptions(clearIndicesCacheRequest.indicesOptions());
         parameters.putParam("query", Boolean.toString(clearIndicesCacheRequest.queryCache()));
         parameters.putParam("fielddata", Boolean.toString(clearIndicesCacheRequest.fieldDataCache()));
         parameters.putParam("request", Boolean.toString(clearIndicesCacheRequest.requestCache()));
         parameters.putParam("fields", String.join(",", clearIndicesCacheRequest.fields()));
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -306,9 +318,10 @@ final class IndicesRequestConverters {
 
         Request request = new Request(HttpHead.METHOD_NAME, RequestConverters.endpoint(indices, "_alias", aliases));
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(getAliasesRequest.indicesOptions());
         params.withLocal(getAliasesRequest.local());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -332,12 +345,13 @@ final class IndicesRequestConverters {
                 .addPathPart(resizeRequest.getTargetIndexRequest().index()).build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withTimeout(resizeRequest.timeout());
         params.withMasterTimeout(resizeRequest.masterNodeTimeout());
         params.withWaitForActiveShards(resizeRequest.getTargetIndexRequest().waitForActiveShards());
 
         request.setEntity(RequestConverters.createEntity(resizeRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -346,7 +360,7 @@ final class IndicesRequestConverters {
             .addPathPart(rolloverRequest.getNewIndexName()).build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withTimeout(rolloverRequest.timeout());
         params.withMasterTimeout(rolloverRequest.masterNodeTimeout());
         params.withWaitForActiveShards(rolloverRequest.getCreateIndexRequest().waitForActiveShards());
@@ -355,6 +369,7 @@ final class IndicesRequestConverters {
         }
 
         request.setEntity(RequestConverters.createEntity(rolloverRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -364,7 +379,7 @@ final class IndicesRequestConverters {
             .addPathPart(rolloverRequest.getNewIndexName()).build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withTimeout(rolloverRequest.timeout());
         params.withMasterTimeout(rolloverRequest.masterNodeTimeout());
         params.withWaitForActiveShards(rolloverRequest.getCreateIndexRequest().waitForActiveShards());
@@ -373,7 +388,7 @@ final class IndicesRequestConverters {
         }
         params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
         request.setEntity(RequestConverters.createEntity(rolloverRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
-
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -384,12 +399,12 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(indices, "_settings", names);
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(getSettingsRequest.indicesOptions());
         params.withLocal(getSettingsRequest.local());
         params.withIncludeDefaults(getSettingsRequest.includeDefaults());
         params.withMasterTimeout(getSettingsRequest.masterNodeTimeout());
-
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -404,14 +419,14 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(indices);
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(getIndexRequest.indicesOptions());
         params.withLocal(getIndexRequest.local());
         params.withIncludeDefaults(getIndexRequest.includeDefaults());
         params.withHuman(getIndexRequest.humanReadable());
         params.withMasterTimeout(getIndexRequest.masterNodeTimeout());
         params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
-
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -421,13 +436,13 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(indices);
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(getIndexRequest.indicesOptions());
         params.withLocal(getIndexRequest.local());
         params.withIncludeDefaults(getIndexRequest.includeDefaults());
         params.withHuman(getIndexRequest.humanReadable());
         params.withMasterTimeout(getIndexRequest.masterNodeTimeout());
-
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -444,12 +459,13 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(getIndexRequest.indices(), "");
         Request request = new Request(HttpHead.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withLocal(getIndexRequest.local());
         params.withHuman(getIndexRequest.humanReadable());
         params.withIndicesOptions(getIndexRequest.indicesOptions());
         params.withIncludeDefaults(getIndexRequest.includeDefaults());
         params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -461,11 +477,12 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(getIndexRequest.indices(), "");
         Request request = new Request(HttpHead.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withLocal(getIndexRequest.local());
         params.withHuman(getIndexRequest.humanReadable());
         params.withIndicesOptions(getIndexRequest.indicesOptions());
         params.withIncludeDefaults(getIndexRequest.includeDefaults());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -473,13 +490,14 @@ final class IndicesRequestConverters {
         String[] indices = updateSettingsRequest.indices() == null ? Strings.EMPTY_ARRAY : updateSettingsRequest.indices();
         Request request = new Request(HttpPut.METHOD_NAME, RequestConverters.endpoint(indices, "_settings"));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(updateSettingsRequest.timeout());
         parameters.withMasterTimeout(updateSettingsRequest.masterNodeTimeout());
         parameters.withIndicesOptions(updateSettingsRequest.indicesOptions());
         parameters.withPreserveExisting(updateSettingsRequest.isPreserveExisting());
 
         request.setEntity(RequestConverters.createEntity(updateSettingsRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -493,7 +511,7 @@ final class IndicesRequestConverters {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_template")
             .addPathPart(putIndexTemplateRequest.name()).build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(putIndexTemplateRequest.masterNodeTimeout());
         if (putIndexTemplateRequest.create()) {
             params.putParam("create", Boolean.TRUE.toString());
@@ -503,6 +521,7 @@ final class IndicesRequestConverters {
         }
         params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
         request.setEntity(RequestConverters.createEntity(putIndexTemplateRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -510,7 +529,7 @@ final class IndicesRequestConverters {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_template")
             .addPathPart(putIndexTemplateRequest.name()).build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(putIndexTemplateRequest.masterNodeTimeout());
         if (putIndexTemplateRequest.create()) {
             params.putParam("create", Boolean.TRUE.toString());
@@ -519,6 +538,7 @@ final class IndicesRequestConverters {
             params.putParam("cause", putIndexTemplateRequest.cause());
         }
         request.setEntity(RequestConverters.createEntity(putIndexTemplateRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -527,12 +547,13 @@ final class IndicesRequestConverters {
         String[] types = validateQueryRequest.types() == null || indices.length <= 0 ? Strings.EMPTY_ARRAY : validateQueryRequest.types();
         String endpoint = RequestConverters.endpoint(indices, types, "_validate/query");
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(validateQueryRequest.indicesOptions());
         params.putParam("explain", Boolean.toString(validateQueryRequest.explain()));
         params.putParam("all_shards", Boolean.toString(validateQueryRequest.allShards()));
         params.putParam("rewrite", Boolean.toString(validateQueryRequest.rewrite()));
         request.setEntity(RequestConverters.createEntity(validateQueryRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -541,9 +562,10 @@ final class IndicesRequestConverters {
         String[] aliases = getAliasesRequest.aliases() == null ? Strings.EMPTY_ARRAY : getAliasesRequest.aliases();
         String endpoint = RequestConverters.endpoint(indices, "_alias", aliases);
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(getAliasesRequest.indicesOptions());
         params.withLocal(getAliasesRequest.local());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -562,11 +584,12 @@ final class IndicesRequestConverters {
             .addCommaSeparatedPathParts(getIndexTemplatesRequest.names())
             .build();
         final Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        final RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withLocal(getIndexTemplatesRequest.isLocal());
         params.withMasterTimeout(getIndexTemplatesRequest.getMasterNodeTimeout());
         if (includeTypeName) {
             params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
+            request.addParameters(params.getRequestParams());
         }
         return request;
     }
@@ -577,9 +600,10 @@ final class IndicesRequestConverters {
             .addCommaSeparatedPathParts(indexTemplatesExistRequest.names())
             .build();
         final Request request = new Request(HttpHead.METHOD_NAME, endpoint);
-        final RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withLocal(indexTemplatesExistRequest.isLocal());
         params.withMasterTimeout(indexTemplatesExistRequest.getMasterNodeTimeout());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -598,22 +622,24 @@ final class IndicesRequestConverters {
     static Request freezeIndex(FreezeIndexRequest freezeIndexRequest) {
         String endpoint = RequestConverters.endpoint(freezeIndexRequest.getIndices(), "_freeze");
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(freezeIndexRequest.timeout());
         parameters.withMasterTimeout(freezeIndexRequest.masterNodeTimeout());
         parameters.withIndicesOptions(freezeIndexRequest.indicesOptions());
         parameters.withWaitForActiveShards(freezeIndexRequest.getWaitForActiveShards());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
     static Request unfreezeIndex(UnfreezeIndexRequest unfreezeIndexRequest) {
         String endpoint = RequestConverters.endpoint(unfreezeIndexRequest.getIndices(), "_unfreeze");
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(unfreezeIndexRequest.timeout());
         parameters.withMasterTimeout(unfreezeIndexRequest.masterNodeTimeout());
         parameters.withIndicesOptions(unfreezeIndexRequest.indicesOptions());
         parameters.withWaitForActiveShards(unfreezeIndexRequest.getWaitForActiveShards());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -621,8 +647,9 @@ final class IndicesRequestConverters {
         String name = deleteIndexTemplateRequest.name();
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_template").addPathPart(name).build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(deleteIndexTemplateRequest.masterNodeTimeout());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IngestRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IngestRequestConverters.java
@@ -41,8 +41,9 @@ final class IngestRequestConverters {
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(getPipelineRequest.masterNodeTimeout());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -53,10 +54,10 @@ final class IngestRequestConverters {
             .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(putPipelineRequest.timeout());
         parameters.withMasterTimeout(putPipelineRequest.masterNodeTimeout());
-
+        request.addParameters(parameters.getRequestParams());
         request.setEntity(RequestConverters.createEntity(putPipelineRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -68,10 +69,10 @@ final class IngestRequestConverters {
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(deletePipelineRequest.timeout());
         parameters.withMasterTimeout(deletePipelineRequest.masterNodeTimeout());
-
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -83,9 +84,10 @@ final class IngestRequestConverters {
         builder.addPathPartAsIs("_simulate");
         String endpoint = builder.build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.putParam("verbose", Boolean.toString(simulatePipelineRequest.isVerbose()));
         request.setEntity(RequestConverters.createEntity(simulatePipelineRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(params.getRequestParams());
         return request;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseRequestConverters.java
@@ -36,30 +36,33 @@ final class LicenseRequestConverters {
     static Request putLicense(PutLicenseRequest putLicenseRequest) {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_license").build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(putLicenseRequest.timeout());
         parameters.withMasterTimeout(putLicenseRequest.masterNodeTimeout());
         if (putLicenseRequest.isAcknowledge()) {
             parameters.putParam("acknowledge", "true");
         }
         request.setJsonEntity(putLicenseRequest.getLicenseDefinition());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
     static Request getLicense(GetLicenseRequest getLicenseRequest) {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_license").build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withLocal(getLicenseRequest.isLocal());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
     static Request deleteLicense(DeleteLicenseRequest deleteLicenseRequest) {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_license").build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(deleteLicenseRequest.timeout());
         parameters.withMasterTimeout(deleteLicenseRequest.masterNodeTimeout());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -67,11 +70,12 @@ final class LicenseRequestConverters {
         final String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_license", "start_trial").build();
         final Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.putParam("acknowledge", Boolean.toString(startTrialRequest.isAcknowledge()));
         if (startTrialRequest.getLicenseType() != null) {
             parameters.putParam("type", startTrialRequest.getLicenseType());
         }
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -80,12 +84,13 @@ final class LicenseRequestConverters {
             .addPathPartAsIs("_license", "start_basic")
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(startBasicRequest.timeout());
         parameters.withMasterTimeout(startBasicRequest.masterNodeTimeout());
         if (startBasicRequest.isAcknowledge()) {
             parameters.putParam("acknowledge", "true");
         }
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
@@ -105,11 +105,11 @@ final class MLRequestConverters {
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (getJobRequest.getAllowNoJobs() != null) {
             params.putParam("allow_no_jobs", Boolean.toString(getJobRequest.getAllowNoJobs()));
         }
-
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -122,10 +122,11 @@ final class MLRequestConverters {
                 .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (getJobStatsRequest.getAllowNoJobs() != null) {
             params.putParam("allow_no_jobs", Boolean.toString(getJobStatsRequest.getAllowNoJobs()));
         }
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -171,14 +172,14 @@ final class MLRequestConverters {
                 .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (deleteJobRequest.getForce() != null) {
             params.putParam("force", Boolean.toString(deleteJobRequest.getForce()));
         }
         if (deleteJobRequest.getWaitForCompletion() != null) {
             params.putParam("wait_for_completion", Boolean.toString(deleteJobRequest.getWaitForCompletion()));
         }
-
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -249,12 +250,12 @@ final class MLRequestConverters {
                 .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (getDatafeedRequest.getAllowNoDatafeeds() != null) {
             params.putParam(GetDatafeedRequest.ALLOW_NO_DATAFEEDS.getPreferredName(),
                     Boolean.toString(getDatafeedRequest.getAllowNoDatafeeds()));
         }
-
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -265,10 +266,11 @@ final class MLRequestConverters {
                 .addPathPart(deleteDatafeedRequest.getDatafeedId())
                 .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (deleteDatafeedRequest.getForce() != null) {
             params.putParam("force", Boolean.toString(deleteDatafeedRequest.getForce()));
         }
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -305,10 +307,11 @@ final class MLRequestConverters {
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (getDatafeedStatsRequest.getAllowNoDatafeeds() != null) {
             params.putParam("allow_no_datafeeds", Boolean.toString(getDatafeedStatsRequest.getAllowNoDatafeeds()));
         }
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -331,13 +334,14 @@ final class MLRequestConverters {
             .addPathPart(Strings.collectionToCommaDelimitedString(deleteForecastRequest.getForecastIds()))
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (deleteForecastRequest.getAllowNoForecasts() != null) {
             params.putParam("allow_no_forecasts", Boolean.toString(deleteForecastRequest.getAllowNoForecasts()));
         }
         if (deleteForecastRequest.timeout() != null) {
             params.putParam("timeout", deleteForecastRequest.timeout().getStringRep());
         }
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -453,7 +457,7 @@ final class MLRequestConverters {
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (postDataRequest.getResetStart() != null) {
             params.putParam(PostDataRequest.RESET_START.getPreferredName(), postDataRequest.getResetStart());
         }
@@ -469,6 +473,7 @@ final class MLRequestConverters {
                 createContentType(postDataRequest.getXContentType()));
             request.setEntity(byteEntity);
         }
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -594,13 +599,14 @@ final class MLRequestConverters {
             .addPathPart(getFiltersRequest.getFilterId())
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (getFiltersRequest.getSize() != null) {
             params.putParam(PageParams.SIZE.getPreferredName(), getFiltersRequest.getSize().toString());
         }
         if (getFiltersRequest.getFrom() != null) {
             params.putParam(PageParams.FROM.getPreferredName(), getFiltersRequest.getFrom().toString());
         }
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -628,11 +634,12 @@ final class MLRequestConverters {
     static Request setUpgradeMode(SetUpgradeModeRequest setUpgradeModeRequest) {
         String endpoint = new EndpointBuilder().addPathPartAsIs("_ml", "set_upgrade_mode").build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.putParam(SetUpgradeModeRequest.ENABLED.getPreferredName(), Boolean.toString(setUpgradeModeRequest.isEnabled()));
         if (setUpgradeModeRequest.getTimeout() != null) {
             params.putParam(SetUpgradeModeRequest.TIMEOUT.getPreferredName(), setUpgradeModeRequest.getTimeout().toString());
         }
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -650,7 +657,7 @@ final class MLRequestConverters {
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (findFileStructureRequest.getLinesToSample() != null) {
             params.putParam(FindFileStructureRequest.LINES_TO_SAMPLE.getPreferredName(),
                 findFileStructureRequest.getLinesToSample().toString());
@@ -700,6 +707,7 @@ final class MLRequestConverters {
         BytesRef source = sample.toBytesRef();
         HttpEntity byteEntity = new NByteArrayEntity(source.bytes, source.offset, source.length, createContentType(XContentType.JSON));
         request.setEntity(byteEntity);
+        request.addParameters(params.getRequestParams());
         return request;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RollupRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RollupRequestConverters.java
@@ -68,11 +68,12 @@ final class RollupRequestConverters {
             .build();
 
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(stopRollupJobRequest.timeout());
         if (stopRollupJobRequest.waitForCompletion() != null) {
             parameters.withWaitForCompletion(stopRollupJobRequest.waitForCompletion());
         }
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/SecurityRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/SecurityRequestConverters.java
@@ -66,8 +66,9 @@ final class SecurityRequestConverters {
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
         request.setEntity(createEntity(changePasswordRequest, REQUEST_BODY_CONTENT_TYPE));
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(changePasswordRequest.getRefreshPolicy());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -87,8 +88,9 @@ final class SecurityRequestConverters {
             .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
         request.setEntity(createEntity(putUserRequest, REQUEST_BODY_CONTENT_TYPE));
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(putUserRequest.getRefreshPolicy());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -98,8 +100,9 @@ final class SecurityRequestConverters {
             .addPathPart(deleteUserRequest.getName())
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(deleteUserRequest.getRefreshPolicy());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -110,8 +113,9 @@ final class SecurityRequestConverters {
             .build();
         final Request request = new Request(HttpPut.METHOD_NAME, endpoint);
         request.setEntity(createEntity(putRoleMappingRequest, REQUEST_BODY_CONTENT_TYPE));
-        final RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(putRoleMappingRequest.getRefreshPolicy());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -139,8 +143,9 @@ final class SecurityRequestConverters {
             .addPathPart(setUserEnabledRequest.isEnabled() ? "_enable" : "_disable")
             .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(setUserEnabledRequest.getRefreshPolicy());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -161,9 +166,11 @@ final class SecurityRequestConverters {
         final String endpoint = builder.addPathPartAsIs("_clear_cache").build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
         if (clearRealmCacheRequest.getUsernames().isEmpty() == false) {
-            RequestConverters.Params params = new RequestConverters.Params(request);
+            RequestConverters.Params params = new RequestConverters.Params();
             params.putParam("usernames", Strings.collectionToCommaDelimitedString(clearRealmCacheRequest.getUsernames()));
+            request.addParameters(params.getRequestParams());
         }
+
         return request;
     }
 
@@ -182,8 +189,9 @@ final class SecurityRequestConverters {
             .addPathPart(deleteRoleMappingRequest.getName())
             .build();
         final Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        final RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(deleteRoleMappingRequest.getRefreshPolicy());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -193,8 +201,9 @@ final class SecurityRequestConverters {
             .addPathPart(deleteRoleRequest.getName())
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(deleteRoleRequest.getRefreshPolicy());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -231,8 +240,9 @@ final class SecurityRequestConverters {
     static Request putPrivileges(final PutPrivilegesRequest putPrivilegesRequest) throws IOException {
         Request request = new Request(HttpPut.METHOD_NAME, "/_security/privilege");
         request.setEntity(createEntity(putPrivilegesRequest, REQUEST_BODY_CONTENT_TYPE));
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(putPrivilegesRequest.getRefreshPolicy());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -243,8 +253,9 @@ final class SecurityRequestConverters {
             .addCommaSeparatedPathParts(deletePrivilegeRequest.getPrivileges())
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(deletePrivilegeRequest.getRefreshPolicy());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -255,16 +266,18 @@ final class SecurityRequestConverters {
             .build();
         final Request request = new Request(HttpPut.METHOD_NAME, endpoint);
         request.setEntity(createEntity(putRoleRequest, REQUEST_BODY_CONTENT_TYPE));
-        final RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(putRoleRequest.getRefreshPolicy());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
     static Request createApiKey(final CreateApiKeyRequest createApiKeyRequest) throws IOException {
         final Request request = new Request(HttpPost.METHOD_NAME, "/_security/api_key");
         request.setEntity(createEntity(createApiKeyRequest, REQUEST_BODY_CONTENT_TYPE));
-        final RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(createApiKeyRequest.getRefreshPolicy());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -288,7 +301,8 @@ final class SecurityRequestConverters {
     static Request invalidateApiKey(final InvalidateApiKeyRequest invalidateApiKeyRequest) throws IOException {
         final Request request = new Request(HttpDelete.METHOD_NAME, "/_security/api_key");
         request.setEntity(createEntity(invalidateApiKeyRequest, REQUEST_BODY_CONTENT_TYPE));
-        final RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
+        request.addParameters(params.getRequestParams());
         return request;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/SnapshotRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/SnapshotRequestConverters.java
@@ -46,9 +46,10 @@ final class SnapshotRequestConverters {
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(getRepositoriesRequest.masterNodeTimeout());
         parameters.withLocal(getRepositoriesRequest.local());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -56,11 +57,11 @@ final class SnapshotRequestConverters {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPart("_snapshot").addPathPart(putRepositoryRequest.name()).build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(putRepositoryRequest.masterNodeTimeout());
         parameters.withTimeout(putRepositoryRequest.timeout());
         parameters.withVerify(putRepositoryRequest.verify());
-
+        request.addParameters(parameters.getRequestParams());
         request.setEntity(RequestConverters.createEntity(putRepositoryRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -70,9 +71,10 @@ final class SnapshotRequestConverters {
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(deleteRepositoryRequest.masterNodeTimeout());
         parameters.withTimeout(deleteRepositoryRequest.timeout());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -83,9 +85,10 @@ final class SnapshotRequestConverters {
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(verifyRepositoryRequest.masterNodeTimeout());
         parameters.withTimeout(verifyRepositoryRequest.timeout());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -95,10 +98,11 @@ final class SnapshotRequestConverters {
             .addPathPart(createSnapshotRequest.snapshot())
             .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(createSnapshotRequest.masterNodeTimeout());
         params.withWaitForCompletion(createSnapshotRequest.waitForCompletion());
         request.setEntity(RequestConverters.createEntity(createSnapshotRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -114,11 +118,11 @@ final class SnapshotRequestConverters {
 
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(getSnapshotsRequest.masterNodeTimeout());
         parameters.putParam("ignore_unavailable", Boolean.toString(getSnapshotsRequest.ignoreUnavailable()));
         parameters.putParam("verbose", Boolean.toString(getSnapshotsRequest.verbose()));
-
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -130,9 +134,10 @@ final class SnapshotRequestConverters {
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(snapshotsStatusRequest.masterNodeTimeout());
         parameters.withIgnoreUnavailable(snapshotsStatusRequest.ignoreUnavailable());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -143,10 +148,11 @@ final class SnapshotRequestConverters {
             .addPathPartAsIs("_restore")
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(restoreSnapshotRequest.masterNodeTimeout());
         parameters.withWaitForCompletion(restoreSnapshotRequest.waitForCompletion());
         request.setEntity(RequestConverters.createEntity(restoreSnapshotRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 
@@ -157,8 +163,9 @@ final class SnapshotRequestConverters {
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(deleteSnapshotRequest.masterNodeTimeout());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/TasksRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/TasksRequestConverters.java
@@ -32,12 +32,13 @@ final class TasksRequestConverters {
 
     static Request cancelTasks(CancelTasksRequest cancelTasksRequest) {
         Request request = new Request(HttpPost.METHOD_NAME, "/_tasks/_cancel");
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withTimeout(cancelTasksRequest.getTimeout())
             .withTaskId(cancelTasksRequest.getTaskId())
             .withNodes(cancelTasksRequest.getNodes())
             .withParentTaskId(cancelTasksRequest.getParentTaskId())
             .withActions(cancelTasksRequest.getActions());
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -46,7 +47,7 @@ final class TasksRequestConverters {
             throw new IllegalArgumentException("TaskId cannot be used for list tasks request");
         }
         Request request  = new Request(HttpGet.METHOD_NAME, "/_tasks");
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withTimeout(listTaskRequest.getTimeout())
             .withDetailed(listTaskRequest.getDetailed())
             .withWaitForCompletion(listTaskRequest.getWaitForCompletion())
@@ -54,6 +55,7 @@ final class TasksRequestConverters {
             .withNodes(listTaskRequest.getNodes())
             .withActions(listTaskRequest.getActions())
             .putParam("group_by", "none");
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -62,9 +64,10 @@ final class TasksRequestConverters {
                 .addPathPartAsIs(getTaskRequest.getNodeId() + ":" + Long.toString(getTaskRequest.getTaskId()))
                 .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withTimeout(getTaskRequest.getTimeout())
             .withWaitForCompletion(getTaskRequest.getWaitForCompletion());
+        request.addParameters(params.getRequestParams());
         return request;
     }
     

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/WatcherRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/WatcherRequestConverters.java
@@ -69,7 +69,7 @@ final class WatcherRequestConverters {
             .build();
 
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request)
+        RequestConverters.Params params = new RequestConverters.Params()
             .withIfSeqNo(putWatchRequest.ifSeqNo())
             .withIfPrimaryTerm(putWatchRequest.ifPrimaryTerm());
         if (putWatchRequest.isActive() == false) {
@@ -78,6 +78,7 @@ final class WatcherRequestConverters {
         ContentType contentType = RequestConverters.createContentType(putWatchRequest.xContentType());
         BytesReference source = putWatchRequest.getSource();
         request.setEntity(new NByteArrayEntity(source.toBytesRef().bytes, 0, source.length(), contentType));
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -118,7 +119,7 @@ final class WatcherRequestConverters {
             .addPathPartAsIs("_execute").build();
 
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (executeWatchRequest.isDebug()) {
             params.putParam("debug", "true");
         }
@@ -130,6 +131,7 @@ final class WatcherRequestConverters {
         }
 
         request.setEntity(RequestConverters.createEntity(executeWatchRequest, XContentType.JSON));
+        request.addParameters(params.getRequestParams());
         return request;
     }
 
@@ -158,7 +160,7 @@ final class WatcherRequestConverters {
         RequestConverters.EndpointBuilder builder = new RequestConverters.EndpointBuilder().addPathPartAsIs("_watcher", "stats");
         String endpoint = builder.build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         StringBuilder metric = new StringBuilder();
         if (watcherStatsRequest.includeCurrentWatches()) {
             metric.append("current_watches");
@@ -172,6 +174,7 @@ final class WatcherRequestConverters {
         if (metric.length() > 0) {
             parameters.putParam("metric", metric.toString());
         }
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/XPackRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/XPackRequestConverters.java
@@ -46,8 +46,9 @@ final class XPackRequestConverters {
 
     static Request usage(XPackUsageRequest usageRequest) {
         Request request = new Request(HttpGet.METHOD_NAME, "/_xpack/usage");
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(usageRequest.masterNodeTimeout());
+        request.addParameters(parameters.getRequestParams());
         return request;
     }
 }

--- a/client/rest/src/main/java/org/elasticsearch/client/Request.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/Request.java
@@ -22,7 +22,6 @@ package org.elasticsearch.client;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -48,6 +47,14 @@ public final class Request {
     public Request(String method, String endpoint) {
         this.method = Objects.requireNonNull(method, "method cannot be null");
         this.endpoint = Objects.requireNonNull(endpoint, "endpoint cannot be null");
+    }
+
+    /**
+     * copy the params into {@linkplain Request}.
+     * @param paramSource map holding the properties for request to copy from
+     */
+    public void addParameters(Map<String, String> paramSource){
+        paramSource.forEach(this::addParameter);
     }
 
     /**
@@ -150,7 +157,7 @@ public final class Request {
         b.append("Request{");
         b.append("method='").append(method).append('\'');
         b.append(", endpoint='").append(endpoint).append('\'');
-        if (false == parameters.isEmpty()) {
+        if (parameters.isEmpty() == false) {
             b.append(", params=").append(parameters);
         }
         if (entity != null) {


### PR DESCRIPTION
Changes required for removing background state update of request object by RequestConverters.Params object
[https://github.com/elastic/elasticsearch/issues/39666](https://github.com/elastic/elasticsearch/issues/39666)