### PR TITLE
[DOCS] Fixes edit_url attributes that were externalized as text strings

### DIFF
--- a/x-pack/docs/en/security/configuring-es.asciidoc
+++ b/x-pack/docs/en/security/configuring-es.asciidoc
@@ -136,12 +136,16 @@ Events are logged to a dedicated `<clustername>_audit.json` file in
 
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/securing-communications/securing-elasticsearch.asciidoc
 include::{es-repo-dir}/security/securing-communications/securing-elasticsearch.asciidoc[]
+
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/securing-communications/configuring-tls-docker.asciidoc
 include::{es-repo-dir}/security/securing-communications/configuring-tls-docker.asciidoc[]
+
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/securing-communications/enabling-cipher-suites.asciidoc
 include::{es-repo-dir}/security/securing-communications/enabling-cipher-suites.asciidoc[]
+
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/securing-communications/separating-node-client-traffic.asciidoc
 include::{es-repo-dir}/security/securing-communications/separating-node-client-traffic.asciidoc[]
+
 :edit_url:
 include::authentication/configuring-active-directory-realm.asciidoc[]
 include::authentication/configuring-file-realm.asciidoc[]
@@ -149,8 +153,10 @@ include::authentication/configuring-ldap-realm.asciidoc[]
 include::authentication/configuring-native-realm.asciidoc[]
 include::authentication/configuring-pki-realm.asciidoc[]
 include::authentication/configuring-saml-realm.asciidoc[]
+
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/configuring-kerberos-realm.asciidoc
 include::authentication/configuring-kerberos-realm.asciidoc[]
+
 :edit_url: 
 include::fips-140-compliance.asciidoc[]
 include::{es-repo-dir}/security/reference/files.asciidoc[]

--- a/x-pack/docs/en/security/configuring-es.asciidoc
+++ b/x-pack/docs/en/security/configuring-es.asciidoc
@@ -153,6 +153,5 @@ include::authentication/configuring-saml-realm.asciidoc[]
 include::authentication/configuring-kerberos-realm.asciidoc[]
 :edit_url: 
 include::fips-140-compliance.asciidoc[]
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/reference/files.asciidoc
 include::{es-repo-dir}/security/reference/files.asciidoc[]
 


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/40131
