### PR TITLE
Only count some fields types for deprecation check

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -19,8 +19,11 @@ import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -255,6 +258,15 @@ public class IndexDeprecationChecks {
         return null;
     }
 
+
+    private static final Set<String> TYPES_THAT_DONT_COUNT;
+    static {
+        HashSet<String> typesThatDontCount = new HashSet<>();
+        typesThatDontCount.add("binary");
+        typesThatDontCount.add("geo_point");
+        typesThatDontCount.add("geo_shape");
+        TYPES_THAT_DONT_COUNT = Collections.unmodifiableSet(typesThatDontCount);
+    }
     /* Counts the number of fields in a mapping, designed to count the as closely as possible to
      * org.elasticsearch.index.search.QueryParserHelper#checkForTooManyFields
      */
@@ -268,7 +280,8 @@ public class IndexDeprecationChecks {
         for (Map.Entry<?, ?> entry : properties.entrySet()) {
             Map<String, Object> valueMap = (Map<String, Object>) entry.getValue();
             if (valueMap.containsKey("type")
-                && (valueMap.get("type").equals("object") && valueMap.containsKey("properties") == false) == false) {
+                && (valueMap.get("type").equals("object") && valueMap.containsKey("properties") == false) == false
+                && (TYPES_THAT_DONT_COUNT.contains(valueMap.get("type")) == false)) {
                 fields++;
             }
 
@@ -276,7 +289,8 @@ public class IndexDeprecationChecks {
             if (values != null) {
                 for (Map.Entry<?, ?> multifieldEntry : values.entrySet()) {
                     Map<String, Object> multifieldValueMap = (Map<String, Object>) multifieldEntry.getValue();
-                    if (multifieldValueMap.containsKey("type")) {
+                    if (multifieldValueMap.containsKey("type")
+                        && (TYPES_THAT_DONT_COUNT.contains(valueMap.get("type")) == false)) {
                         fields++;
                     }
                     if (multifieldValueMap.containsKey("properties")) {

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -446,7 +446,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
                 }
                 mappingBuilder.endObject();
             } else {
-                mappingBuilder.field("type", randomFrom("array", "binary", "range", "boolean", "date", "ip", "keyword", "text"));
+                mappingBuilder.field("type", randomFrom("array", "range", "boolean", "date", "ip", "keyword", "text"));
                 fieldCount.incrementAndGet();
             }
         }


### PR DESCRIPTION
Some field types are not used for queries which use auto-expansion, in
particular, `binary`, `geo_point`, and `geo_shape`. This was causing the
count returned by the deprecation check and the count returned by the
query-time deprecation warning to be misaligned for indices with fields
of those types, with the count returned by the deprecation check being
larger.
