### PR TITLE
[DOCS] Moves monitoring settings

### DIFF
--- a/docs/reference/monitoring/configuring-monitoring.asciidoc
+++ b/docs/reference/monitoring/configuring-monitoring.asciidoc
@@ -18,4 +18,3 @@ To learn about monitoring in general, see
 include::collecting-monitoring-data.asciidoc[]
 include::configuring-metricbeat.asciidoc[]
 include::indices.asciidoc[]
-include::{es-repo-dir}/settings/monitoring-settings.asciidoc[]

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -57,6 +57,8 @@ include::settings/license-settings.asciidoc[]
 
 include::settings/ml-settings.asciidoc[]
 
+include::settings/monitoring-settings.asciidoc[]
+
 include::settings/security-settings.asciidoc[]
 
 include::settings/sql-settings.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/39870

This PR moves the monitoring settings to the same location as the other settings, under "Configuring Elasticsearch" in the Elasticsearch Reference.
