### PR TITLE
Assert that named xcontent has been registered at serialization time.

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/NamedXContentRegistry.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/NamedXContentRegistry.java
@@ -119,15 +119,7 @@ public class NamedXContentRegistry {
      * @throws NamedObjectNotFoundException if the categoryClass or name is not registered
      */
     public <T, C> T parseNamedObject(Class<T> categoryClass, String name, XContentParser parser, C context) throws IOException {
-        Map<String, Entry> parsers = registry.get(categoryClass);
-        if (parsers == null) {
-            if (registry.isEmpty()) {
-                // The "empty" registry will never work so we throw a better exception as a hint.
-                throw new NamedObjectNotFoundException("named objects are not supported for this parser");
-            }
-            throw new NamedObjectNotFoundException("unknown named object category [" + categoryClass.getName() + "]");
-        }
-        Entry entry = parsers.get(name);
+        Entry entry = getEntry(categoryClass, name);
         if (entry == null) {
             throw new NamedObjectNotFoundException(parser.getTokenLocation(), "unable to parse " + categoryClass.getSimpleName() +
                 " with name [" + name + "]: parser not found");
@@ -139,6 +131,26 @@ public class NamedXContentRegistry {
                     "unable to parse " + categoryClass.getSimpleName() + " with name [" + name + "]: parser didn't match");
         }
         return categoryClass.cast(entry.parser.parse(parser, context));
+    }
+
+    public void assertNamedXContent(Class<?> categoryClass, String name) throws IOException {
+        Entry entry = getEntry(categoryClass, name);
+        if (entry == null) {
+            throw new NamedObjectNotFoundException("unable to serialize " + categoryClass.getSimpleName() + " with name [" + name +
+                "]: parser not found");
+        }
+    }
+
+    private Entry getEntry(Class<?> categoryClass, String name) {
+        Map<String, Entry> parsers = registry.get(categoryClass);
+        if (parsers == null) {
+            if (registry.isEmpty()) {
+                // The "empty" registry will never work so we throw a better exception as a hint.
+                throw new NamedObjectNotFoundException("named objects are not supported for this parser");
+            }
+            throw new NamedObjectNotFoundException("unknown named object category [" + categoryClass.getName() + "]");
+        }
+        return parsers.get(name);
     }
 
 }

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -208,7 +208,8 @@ public final class XContentBuilder implements Closeable, Flushable {
         this(xContent, os, Collections.emptySet(), Collections.emptySet(), registry);
     }
 
-    public XContentBuilder(XContent xContent, OutputStream os, Set<String> includes, Set<String> excludes, NamedXContentRegistry registry) throws IOException {
+    public XContentBuilder(XContent xContent, OutputStream os, Set<String> includes, Set<String> excludes,
+                           NamedXContentRegistry registry) throws IOException {
         this.bos = os;
         this.generator = xContent.createGenerator(bos, includes, excludes);
         this.registry = registry;

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentFactory.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentFactory.java
@@ -109,7 +109,8 @@ public class XContentFactory {
         throw new IllegalArgumentException("No matching content type for " + type);
     }
 
-    public static XContentBuilder contentBuilder(XContentType type, OutputStream stream, NamedXContentRegistry registry) throws IOException {
+    public static XContentBuilder contentBuilder(XContentType type, OutputStream stream,
+                                                 NamedXContentRegistry registry) throws IOException {
         XContent xContent;
         switch (type) {
             case JSON:

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentFactory.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentFactory.java
@@ -109,6 +109,27 @@ public class XContentFactory {
         throw new IllegalArgumentException("No matching content type for " + type);
     }
 
+    public static XContentBuilder contentBuilder(XContentType type, OutputStream stream, NamedXContentRegistry registry) throws IOException {
+        XContent xContent;
+        switch (type) {
+            case JSON:
+                xContent = JsonXContent.jsonXContent;
+                break;
+            case SMILE:
+                xContent = SmileXContent.smileXContent;
+                break;
+            case YAML:
+                xContent = YamlXContent.yamlXContent;
+                break;
+            case CBOR:
+                xContent = CborXContent.cborXContent;
+                break;
+            default:
+                throw new IllegalArgumentException("No matching content type for " + type);
+        }
+        return new XContentBuilder(xContent, stream, registry);
+    }
+
     /**
      * Returns a binary content builder for the provided content type.
      */

--- a/server/src/main/java/org/elasticsearch/gateway/MetaStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/MetaStateService.java
@@ -47,13 +47,14 @@ public class MetaStateService {
     private final NamedXContentRegistry namedXContentRegistry;
 
     // we allow subclasses in tests to redefine formats, e.g. to inject failures
-    protected MetaDataStateFormat<MetaData> META_DATA_FORMAT = MetaData.FORMAT;
+    protected MetaDataStateFormat<MetaData> META_DATA_FORMAT;
     protected MetaDataStateFormat<IndexMetaData> INDEX_META_DATA_FORMAT = IndexMetaData.FORMAT;
     protected MetaDataStateFormat<Manifest> MANIFEST_FORMAT = Manifest.FORMAT;
 
     public MetaStateService(NodeEnvironment nodeEnv, NamedXContentRegistry namedXContentRegistry) {
         this.nodeEnv = nodeEnv;
         this.namedXContentRegistry = namedXContentRegistry;
+        META_DATA_FORMAT = MetaData.format(namedXContentRegistry);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
@@ -190,7 +190,7 @@ public class ChecksumBlobStoreFormat<T extends ToXContent> extends BlobStoreForm
     }
 
     protected void write(T obj, StreamOutput streamOutput) throws IOException {
-        try (XContentBuilder builder = XContentFactory.contentBuilder(xContentType, streamOutput)) {
+        try (XContentBuilder builder = XContentFactory.contentBuilder(xContentType, streamOutput, namedXContentRegistry)) {
             builder.startObject();
             obj.toXContent(builder, SNAPSHOT_ONLY_FORMAT_PARAMS);
             builder.endObject();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
@@ -401,7 +401,7 @@ public class MetaDataTests extends ESTestCase {
     public void testXContentWithIndexGraveyard() throws IOException {
         final IndexGraveyard graveyard = IndexGraveyardTests.createRandom();
         final MetaData originalMeta = MetaData.builder().indexGraveyard(graveyard).build();
-        final XContentBuilder builder = JsonXContent.contentBuilder();
+        final XContentBuilder builder = xContentBuilder(JsonXContent.jsonXContent);
         builder.startObject();
         originalMeta.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
@@ -414,7 +414,7 @@ public class MetaDataTests extends ESTestCase {
     public void testXContentClusterUUID() throws IOException {
         final MetaData originalMeta = MetaData.builder().clusterUUID(UUIDs.randomBase64UUID())
             .clusterUUIDCommitted(randomBoolean()).build();
-        final XContentBuilder builder = JsonXContent.contentBuilder();
+        final XContentBuilder builder = xContentBuilder(JsonXContent.jsonXContent);
         builder.startObject();
         originalMeta.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
@@ -467,7 +467,7 @@ public class MetaDataTests extends ESTestCase {
 
         MetaData metaData = MetaData.builder().coordinationMetaData(originalMeta).build();
 
-        final XContentBuilder builder = JsonXContent.contentBuilder();
+        final XContentBuilder builder = xContentBuilder(JsonXContent.jsonXContent);
         builder.startObject();
         metaData.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
@@ -145,7 +145,7 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
                         .putAlias(newAliasMetaDataBuilder("alias-bar3").routing("routing-bar")))
                 .build();
 
-        String metaDataSource = MetaData.Builder.toXContent(metaData);
+        String metaDataSource = MetaData.Builder.toXContent(metaData, xContentRegistry());
 
         MetaData parsedMetaData = MetaData.Builder.fromXContent(createParser(JsonXContent.jsonXContent, metaDataSource));
 

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
@@ -322,7 +322,7 @@ public class GatewayMetaStateTests extends ESAllocationTestCase {
 
         MetaStateServiceWithFailures(int invertedFailRate, NodeEnvironment nodeEnv, NamedXContentRegistry namedXContentRegistry) {
             super(nodeEnv, namedXContentRegistry);
-            META_DATA_FORMAT = wrap(MetaData.FORMAT);
+            META_DATA_FORMAT = wrap(MetaData.format(namedXContentRegistry));
             INDEX_META_DATA_FORMAT = wrap(IndexMetaData.FORMAT);
             MANIFEST_FORMAT = wrap(Manifest.FORMAT);
             failRandomly = false;

--- a/server/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
@@ -39,7 +39,9 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
 
@@ -419,11 +421,15 @@ public class MetaDataStateFormatTests extends ESTestCase {
         writeAndReadStateSuccessfully(format, paths);
     }
 
-    private static MetaDataStateFormat<MetaData> metaDataFormat() {
+    private MetaDataStateFormat<MetaData> metaDataFormat() {
         return new MetaDataStateFormat<MetaData>(MetaData.GLOBAL_STATE_FILE_PREFIX) {
             @Override
             public void toXContent(XContentBuilder builder, MetaData state) throws IOException {
                 MetaData.Builder.toXContent(state, builder, ToXContent.EMPTY_PARAMS);
+            }
+
+            protected XContentBuilder newXContentBuilder(XContentType type, OutputStream stream) throws IOException {
+                return XContentFactory.contentBuilder(type, stream, xContentRegistry());
             }
 
             @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -125,6 +125,7 @@ import org.junit.Rule;
 import org.junit.internal.AssumptionViolatedException;
 import org.junit.rules.RuleChain;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -1276,6 +1277,10 @@ public abstract class ESTestCase extends LuceneTestCase {
      */
     protected final XContentParser createParser(XContent xContent, BytesReference data) throws IOException {
         return xContent.createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, data.streamInput());
+    }
+
+    protected final XContentBuilder xContentBuilder(XContent xContent) throws IOException {
+        return new XContentBuilder(xContent, new ByteArrayOutputStream(), xContentRegistry());
     }
 
     /**


### PR DESCRIPTION
Forgetting to register named xcontent can cause severe bugs, like #40128

In addition to checking that named xcontent has been registered on parse time,
this change adds the possibility to validate whether named xcontent has been registered
as part of serialization via the `XContentBuilder#writeNamedXContent(...)` method.
This change changes custom metadata to use this method instead just serializing
the custom metadata.

Because of this change, XContentBuilder now needs a reference to a NamedXContentRegistry,
otherwise it can't validate at serialization time whether the named xcontent has been
registered.

This is a follow up for #40130