### PR TITLE
[DOCS] Updates X-Pack settings table

### DIFF
--- a/docs/reference/settings/configuring-xes.asciidoc
+++ b/docs/reference/settings/configuring-xes.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>{xpack} Settings</titleabbrev>
 ++++
 
-include::{asciidoc-dir}/../../shared/settings.asciidoc[]
+include::{asciidoc-dir}/../../shared/settings65.asciidoc[]
 include::license-settings.asciidoc[]
 include::ml-settings.asciidoc[]
 include::notification-settings.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/694
This PR updates the Elasticsearch Reference to use the appropriate shared table of X-Pack settings.  In particular, it needs a table that includes the Logs UI and Infrastructure UI settings but excludes the CCR settings (which are introduced in 6.7).
