### PR TITLE
Ensure flush happen before closing an index

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
@@ -108,7 +108,7 @@ public class TransportVerifyShardBeforeCloseAction extends TransportReplicationA
             throw new IllegalStateException("Index shard " + shardId + " must be blocked by " + request.clusterBlock() + " before closing");
         }
         indexShard.verifyShardBeforeIndexClosing();
-        indexShard.flush(new FlushRequest().force(true));
+        indexShard.flush(new FlushRequest().force(true).waitIfOngoing(true));
         logger.trace("{} shard is ready for closing", shardId);
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -63,7 +63,7 @@ public class CloseIndexIT extends ESIntegTestCase {
     public Settings indexSettings() {
         Settings.builder().put(super.indexSettings())
             .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(),
-                new ByteSizeValue(randomIntBetween(1, 100 * 1024), ByteSizeUnit.KB));
+                new ByteSizeValue(randomIntBetween(1, 4096), ByteSizeUnit.KB));
         return super.indexSettings();
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -29,7 +29,10 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaDataIndexStateService;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.test.BackgroundIndexer;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -55,6 +58,14 @@ import static org.hamcrest.Matchers.notNullValue;
 public class CloseIndexIT extends ESIntegTestCase {
 
     private static final int MAX_DOCS = 25_000;
+
+    @Override
+    public Settings indexSettings() {
+        Settings.builder().put(super.indexSettings())
+            .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(),
+                new ByteSizeValue(randomIntBetween(1, 100 * 1024), ByteSizeUnit.KB));
+        return super.indexSettings();
+    }
 
     public void testCloseMissingIndex() {
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareClose("test").get());


### PR DESCRIPTION
If there's an ongoing flush triggered by the translog flush threshold, we may fail to execute a flush because waitIfOngoing is false by default.

Relates to #36342