### PR TITLE
Document the reduction in fault detection timeouts

### DIFF
--- a/docs/reference/migration/migrate_7_0/discovery.asciidoc
+++ b/docs/reference/migration/migrate_7_0/discovery.asciidoc
@@ -46,3 +46,13 @@ The `discovery.zen.no_master_block` setting is now known as
 `cluster.no_master_block`. Any value set for `discovery.zen.no_master_block` is
 now ignored. You should remove this setting and, if needed, set
 `cluster.no_master_block` appropriately after the upgrade.
+
+[float]
+==== Reduced default timeouts for fault detection
+
+By default the <<cluster-fault-detection,cluster fault detection>> subsystem
+now considers a node to be faulty if it fails to respond to 3 consecutive
+pings, each of which times out after 10 seconds. Thus a node that is
+unresponsive for longer than 30 seconds is liable to be removed from the
+cluster. Previously the default timeout for each ping was 30 seconds, so that
+an unresponsive node might be kept in the cluster for over 90 seconds.


### PR DESCRIPTION
The new cluster coordination subsystem introduced in 7.0 will only keep an
unresponsive node in the cluster for 30 seconds, whereas in earlier versions it
might have remained in the cluster for 90 seconds. This commit adds a note to
the migration documentation to that effect.