### PR TITLE
Upgrade bundled JDK and Docker images to JDK 12

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,7 +1,7 @@
 elasticsearch     = 8.0.0
 lucene            = 8.0.0
 
-bundled_jdk       = 11.0.2+9
+bundled_jdk       = 12+33
 
 # optional dependencies
 spatial4j         = 0.7

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -218,14 +218,14 @@ xpack.subprojects.findAll { it.parent == xpack }.each { Project xpackModule ->
  *****************************************************************************/
 // extract the bundled jdk version, broken into elements as: [feature, interim, update, build]
 // Note the "patch" version is not yet handled here, as it has not yet been used by java.
-Pattern JDK_VERSION = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)\\+(\\d+)")
+Pattern JDK_VERSION = Pattern.compile("(\\d+)(\\.\\d+\\.\\d+)?\\+(\\d+)")
 Matcher jdkVersionMatcher = JDK_VERSION.matcher(VersionProperties.bundledJdk)
 if (jdkVersionMatcher.matches() == false) {
   throw new IllegalArgumentException("Malformed jdk version [" + VersionProperties.bundledJdk + "]")
 }
-String jdkVersion = jdkVersionMatcher.group(1) + '.' + jdkVersionMatcher.group(2) + '.' + jdkVersionMatcher.group(3)
+String jdkVersion = jdkVersionMatcher.group(1) + (jdkVersionMatcher.group(2) != null ? (jdkVersionMatcher.group(2)) : "")
 String jdkMajor = jdkVersionMatcher.group(1)
-String jdkBuild = jdkVersionMatcher.group(4)
+String jdkBuild = jdkVersionMatcher.group(3)
 
 repositories {
   ivy {

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -22,8 +22,8 @@ ext.expansions = { oss ->
   final String elasticsearch = oss ? "elasticsearch-oss-${VersionProperties.elasticsearch}-${classifier}.tar.gz" : "elasticsearch-${VersionProperties.elasticsearch}-${classifier}.tar.gz"
   return [
     'elasticsearch'       : elasticsearch,
-    'jdkUrl'              : 'https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz',
-    'jdkVersion'          : '11.0.2',
+    'jdkUrl'              : 'https://download.java.net/java/GA/jdk12/GPL/openjdk-12_linux-x64_bin.tar.gz',
+    'jdkVersion'          : '12',
     'license'             : oss ? 'Apache-2.0' : 'Elastic License',
     'source_elasticsearch': local() ? "COPY $elasticsearch /opt/" : "RUN curl --retry 8 -s -L -O https://artifacts.elastic.co/downloads/elasticsearch/${elasticsearch}",
     'version'             : VersionProperties.elasticsearch


### PR DESCRIPTION
This commit bumps the JDK used the bundled JDK and the Docker images to JDK 12.

