### PR TITLE
Map value field to double in MovAvgIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/MovAvgIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/MovAvgIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.collect.EvictingQueue;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.search.aggregations.metrics.Avg;
@@ -110,7 +111,12 @@ public class MovAvgIT extends ESIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        createIndex("idx");
+        prepareCreate("idx").addMapping("type",
+            XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties")
+                .startObject(VALUE_FIELD).field("type", "double").endObject()
+                .endObject()
+                .endObject().endObject()).execute().get();
         createIndex("idx_unmapped");
         List<IndexRequestBuilder> builders = new ArrayList<>();
 


### PR DESCRIPTION
We were accidentally not mapping the index, which meant dynamic mapping was choosing floats for the values.  This led to enough loss of precision for the aggregated values to differ slightly from the test doubles, which accumulated into large differences in the holt output.

This test fix adds an explicit mapping.

Only being merged in 7.x and earlier, since MovAvg was removed from 8.0

Closes https://github.com/elastic/elasticsearch/issues/40181