### PR TITLE
[DOCS] Adds placeholder for data frame preview API

### DIFF
--- a/docs/reference/data-frames/apis/index.asciidoc
+++ b/docs/reference/data-frames/apis/index.asciidoc
@@ -1,0 +1,13 @@
+[role="xpack"]
+[testenv="basic"]
+[[data-frame-apis]]
+== {dataframe-cap} APIs
+
+[float]
+[[data-frame-transform-apis]]
+=== {dataframe-transforms-cap}
+
+* <<preview-data-frame-transform,Preview {dataframe-transforms}>>
+
+//PREVIEW
+include::preview-data-frame-transform.asciidoc[]

--- a/docs/reference/data-frames/apis/preview-data-frame-transform.asciidoc
+++ b/docs/reference/data-frames/apis/preview-data-frame-transform.asciidoc
@@ -27,7 +27,8 @@ reduce the data.
 
 ==== Examples
 
-The following example obtains a preview of the `datafeed-farequote` {dfeed}:
+The following example obtains a preview of a {dataframe-transform} on the {kib}
+eCommerce sample data:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/data-frames/apis/preview-data-frame-transform.asciidoc
+++ b/docs/reference/data-frames/apis/preview-data-frame-transform.asciidoc
@@ -1,0 +1,79 @@
+[role="xpack"]
+[testenv="basic"]
+[[preview-data-frame-transform]]
+=== Preview {dataframe-transforms} API
+++++
+<titleabbrev>Preview {dataframe-transforms}</titleabbrev>
+++++
+
+Previews a {dataframe-transform}.
+
+
+==== Request
+
+`POST _data_frame/transforms/_preview`
+
+//==== Description
+//==== Path Parameters
+//==== Authorization
+
+==== Request Body
+
+`source`:: The source index or index pattern.
+
+`pivot`:: Defines the pivot function `group by` fields and the aggregation to
+reduce the data.
+
+
+==== Examples
+
+The following example obtains a preview of the `datafeed-farequote` {dfeed}:
+
+[source,js]
+--------------------------------------------------
+POST _data_frame/transforms/_preview
+{
+  "source": "kibana_sample_data_ecommerce",
+  "pivot": {
+    "group_by": {
+      "customer_id": {
+        "terms": {
+          "field": "customer_id"
+        }
+      }
+    },
+    "aggregations": {
+      "max_price": {
+        "max": {
+          "field": "taxful_total_price"
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[skip:set up sample data]
+
+The data that is returned for this example is as follows:
+[source,js]
+----
+{
+  "preview" : [
+    {
+      "max_price" : 171.0,
+      "customer_id" : "10"
+    },
+    {
+      "max_price" : 233.0,
+      "customer_id" : "11"
+    },
+    {
+      "max_price" : 200.0,
+      "customer_id" : "12"
+    }
+    ...
+  ]
+}
+----
+// NOTCONSOLE

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -23,6 +23,7 @@ directly to configure and access {xpack} features.
 
 include::info.asciidoc[]
 include::{es-repo-dir}/ccr/apis/ccr-apis.asciidoc[]
+include::{es-repo-dir}/data-frames/apis/index.asciidoc[]
 include::{es-repo-dir}/graph/explore.asciidoc[]
 include::{es-repo-dir}/indices/apis/freeze.asciidoc[]
 include::{es-repo-dir}/ilm/apis/ilm-api.asciidoc[]


### PR DESCRIPTION
This PR creates a placeholder for the preview data frame transform API documentation.

The location of these files can be changed as needed. 