### PR TITLE
Find and use non local IPv4 address while testing IP filtering

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
@@ -5,6 +5,8 @@
  */
 package org.elasticsearch.xpack.security.transport.filter;
 
+import com.google.common.primitives.Ints;
+
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkAddress;
@@ -26,6 +28,9 @@ import org.mockito.ArgumentCaptor;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,6 +40,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -140,7 +146,8 @@ public class IPFilterTests extends ESTestCase {
         ipFilter = new IPFilter(settings, auditTrail, clusterSettings, licenseState);
         ipFilter.setBoundTransportAddress(transport.boundAddress(), transport.profileBoundAddresses());
         assertAddressIsAllowed("127.0.0.1");
-        assertAddressIsDenied("192.168.0.1");
+        // when "localhost" is used, ES considers all local addresses see PatternRule#isLocalhost()
+        assertAddressIsDenied(randomNonLocalIPv4Address());
         assertAddressIsAllowedForProfile("client", "192.168.0.1");
         assertAddressIsDeniedForProfile("client", "192.168.0.2");
     }
@@ -161,7 +168,8 @@ public class IPFilterTests extends ESTestCase {
         clusterSettings.updateDynamicSettings(newSettings, updatedSettingsBuilder, Settings.builder(), "test");
         clusterSettings.applySettings(updatedSettingsBuilder.build());
         assertAddressIsAllowed("127.0.0.1");
-        assertAddressIsDenied("192.168.0.1");
+        // when "localhost" is used, ES considers all local addresses see PatternRule#isLocalhost()
+        assertAddressIsDenied(randomNonLocalIPv4Address());
         assertAddressIsAllowedForProfile("client", "192.168.0.1", "192.168.0.2");
         assertAddressIsDeniedForProfile("client", "192.168.0.3");
     }
@@ -297,4 +305,22 @@ public class IPFilterTests extends ESTestCase {
     private void assertAddressIsDenied(String ... inetAddresses) {
         assertAddressIsDeniedForProfile("default", inetAddresses);
     }
+
+    private String randomNonLocalIPv4Address() throws SocketException, UnknownHostException {
+        String ipv4Address = null;
+        int noOfRetries = 0;
+        do {
+            noOfRetries++;
+            final InetAddress address = InetAddress.getByAddress(Ints.toByteArray(randomInt()));
+            if (address.isAnyLocalAddress() || address.isLoopbackAddress() || NetworkInterface.getByInetAddress(address) != null) {
+                continue;
+            } else {
+                ipv4Address = NetworkAddress.format(address);
+                break;
+            }
+        } while (ipv4Address == null && noOfRetries < 25);
+        assertThat("could not generate random IPv4 address which is not local address", ipv4Address, notNullValue());
+        return ipv4Address;
+    }
+
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
@@ -5,8 +5,7 @@
  */
 package org.elasticsearch.xpack.security.transport.filter;
 
-import com.google.common.primitives.Ints;
-
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkAddress;
@@ -311,7 +310,7 @@ public class IPFilterTests extends ESTestCase {
         int noOfRetries = 0;
         do {
             noOfRetries++;
-            final InetAddress address = InetAddress.getByAddress(Ints.toByteArray(randomInt()));
+            final InetAddress address = InetAddress.getByAddress(Numbers.intToBytes(randomInt()));
             if (address.isAnyLocalAddress() || address.isLoopbackAddress() || NetworkInterface.getByInetAddress(address) != null) {
                 continue;
             } else {


### PR DESCRIPTION
For pattern "n:localhost" [PatternRule#isLocalhost()](https://github.com/elastic/elasticsearch/blob/d22c4b8db3267521483f92d9ed9d53e3e7f3a430/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/PatternRule.java#L115) matches
any local address, loopback address.

_[Note: I think for "localhost" this should not consider IP address
as a match when they are bound to network interfaces. It should just
be a loopback address check unless the intent is to match all local addresses.
This class is adopted from Netty3 and I am not sure if this is intended
behavior or if I am missing something]_

For now, I have fixed this assuming the PatternRule#isLocalhost check is
correct by avoiding the use of local address to check address denied.

Closes #40194
