### PR TITLE
Fix snapshot restore logging on fresh restore

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/FileRestoreContext.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/FileRestoreContext.java
@@ -31,7 +31,6 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.util.iterable.Iterables;
-import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.snapshots.IndexShardRestoreFailedException;
@@ -119,7 +118,7 @@ public abstract class FileRestoreContext {
                 // store can still have existing files but they will be deleted just before being
                 // restored.
                 recoveryTargetMetadata = indexShard.snapshotStoreMetadata();
-            } catch (IndexNotFoundException e) {
+            } catch (org.apache.lucene.index.IndexNotFoundException e) {
                 // happens when restore to an empty shard, not a big deal
                 logger.trace("[{}] [{}] restoring from to an empty shard", shardId, snapshotId);
                 recoveryTargetMetadata = Store.MetadataSnapshot.EMPTY;


### PR DESCRIPTION
I noticed that restoring a snapshot was issuing some warning logs in unreleased versions of ES. This is related to a recent refactoring (#37130) where imports got mixed up (changing Lucene's IndexNotFoundException to Elasticsearch's IndexNotFoundException).

```
[2019-03-20T08:23:05,900][WARN ][o.e.r.b.FileRestoreContext] [node_sd3] [[ozhh][3]] [ekpkzxuvvj/2EsdxbQhQD2nUOdjdbcpvA] Can't read metadata from store, will not reuse local files during restore
org.apache.lucene.index.IndexNotFoundException: no segments* file found in store(ByteSizeCachingDirectory(ElasticsearchMockDirectoryWrapper(NIOFSDirectory@/private/var/folders/68/3gzf12zs4qb0q_gfjw5lx1fm0000gn/T/org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests_B1EF8FCB6B58CEB6-001/tempDir-002/d0/nodes/3/indices/zv7n3ue8Qbifn_j4sJ3L7A/3/index lockFactory=org.apache.lucene.store.NativeFSLockFactory@3b1e9f9c))): files: [write.lock]
	at org.apache.lucene.index.SegmentInfos$FindSegmentsFile.run(SegmentInfos.java:675) ~[lucene-core-8.0.0.jar:8.0.0 2ae4746365c1ee72a0047ced7610b2096e438979 - jimczi - 2019-03-08 11:58:55]
	at org.apache.lucene.index.SegmentInfos$FindSegmentsFile.run(SegmentInfos.java:632) ~[lucene-core-8.0.0.jar:8.0.0 2ae4746365c1ee72a0047ced7610b2096e438979 - jimczi - 2019-03-08 11:58:55]
	at org.apache.lucene.index.SegmentInfos.readLatestCommit(SegmentInfos.java:434) ~[lucene-core-8.0.0.jar:8.0.0 2ae4746365c1ee72a0047ced7610b2096e438979 - jimczi - 2019-03-08 11:58:55]
	at org.elasticsearch.common.lucene.Lucene.readSegmentInfos(Lucene.java:150) ~[main/:?]
	at org.elasticsearch.index.store.Store.readSegmentsInfo(Store.java:213) ~[main/:?]
	at org.elasticsearch.index.store.Store.access$300(Store.java:132) ~[main/:?]
	at org.elasticsearch.index.store.Store$MetadataSnapshot.loadMetadata(Store.java:865) ~[main/:?]
	at org.elasticsearch.index.store.Store$MetadataSnapshot.<init>(Store.java:798) ~[main/:?]
	at org.elasticsearch.index.store.Store.getMetadata(Store.java:299) ~[main/:?]
	at org.elasticsearch.index.shard.IndexShard.snapshotStoreMetadata(IndexShard.java:1187) ~[main/:?]
	at org.elasticsearch.repositories.blobstore.FileRestoreContext.restore(FileRestoreContext.java:121) [main/:?]
	at org.elasticsearch.repositories.blobstore.BlobStoreRepository.restoreShard(BlobStoreRepository.java:873) [main/:?]
	at org.elasticsearch.index.shard.StoreRecovery.restore(StoreRecovery.java:473) [main/:?]
	at org.elasticsearch.index.shard.StoreRecovery.lambda$recoverFromRepository$5(StoreRecovery.java:279) [main/:?]
	at org.elasticsearch.index.shard.StoreRecovery.executeRecovery(StoreRecovery.java:302) [main/:?]
	at org.elasticsearch.index.shard.StoreRecovery.recoverFromRepository(StoreRecovery.java:277) [main/:?]
	at org.elasticsearch.index.shard.IndexShard.restoreFromRepository(IndexShard.java:1692) [main/:?]
	at org.elasticsearch.index.shard.IndexShard.lambda$startRecovery$10(IndexShard.java:2362) [main/:?]
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:677) [main/:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
```