### PR TITLE
SQL: move some sql-spec tests to a locale "aware" file

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/resources/agg-ordering.sql-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/agg-ordering.sql-spec
@@ -110,11 +110,5 @@ SELECT gender AS g, first_name AS f, last_name AS l FROM test_emp GROUP BY f, ge
 multipleGroupingsAndOrderingByGroups_8
 SELECT gender AS g, first_name, last_name FROM test_emp GROUP BY g, last_name, first_name ORDER BY gender ASC, first_name DESC, last_name ASC;
 
-multipleGroupingsAndOrderingByGroupsWithFunctions_1
-SELECT first_name f, last_name l, gender g, CONCAT(UCASE(first_name), LCASE(last_name)) c FROM test_emp GROUP BY gender, l, f, c ORDER BY c DESC, first_name, l ASC, g;
-
-multipleGroupingsAndOrderingByGroupsWithFunctions_2
+multipleGroupingsAndOrderingByGroupsWithFunctions
 SELECT first_name f, last_name l, gender g, CONCAT(first_name, last_name) c FROM test_emp GROUP BY gender, l, f, c ORDER BY gender, c DESC, first_name, last_name ASC;
-
-multipleGroupingsAndOrderingByGroupsWithFunctions_3
-SELECT first_name f, last_name l, LCASE(gender) g, CONCAT(UCASE(first_name), LCASE(last_name)) c FROM test_emp GROUP BY f, LCASE(gender), l, c ORDER BY c DESC, first_name, l ASC, g;

--- a/x-pack/plugin/sql/qa/src/main/resources/case-functions.sql-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/case-functions.sql-spec
@@ -17,3 +17,9 @@ SELECT UCASE('ElAsTiC') upper;
 
 ucaseInline3
 SELECT UCASE(' elastic ') upper;
+
+multipleGroupingsAndOrderingByGroupsWithFunctions_1
+SELECT first_name f, last_name l, gender g, CONCAT(UCASE(first_name), LCASE(last_name)) c FROM test_emp GROUP BY gender, l, f, c ORDER BY c DESC, first_name, l ASC, g;
+
+multipleGroupingsAndOrderingByGroupsWithFunctions_2
+SELECT first_name f, last_name l, LCASE(gender) g, CONCAT(UCASE(first_name), LCASE(last_name)) c FROM test_emp GROUP BY f, LCASE(gender), l, c ORDER BY c DESC, first_name, l ASC, g;


### PR DESCRIPTION
LCASE and UCASE function tests are problematic when they run in specific Locales where uppercasing/lowercasing some letters produces a different letter. Tests in `case-functions` are ignored if they run with some specific Locales.
This PR fixes https://github.com/elastic/elasticsearch/issues/40165.