### PR TITLE
Adjust skip value in `use_field` tests

### DIFF
--- a/modules/analysis-common/src/test/resources/rest-api-spec/test/search.query/70_intervals.yml
+++ b/modules/analysis-common/src/test/resources/rest-api-spec/test/search.query/70_intervals.yml
@@ -23,7 +23,7 @@ setup:
 ---
 "Test use_field":
   - skip:
-      version: " - 7.9.99"  # TODO change to 7.0.99 after backport
+      version: " - 7.0.99"
       reason: "Implemented in 7.1"
   - do:
       search:


### PR DESCRIPTION
Now that the `use_field` option has been backported to the 7.x branch,
we can run BWC tests against all versions from 7.1

Follow up to #40157 