### PR TITLE
Move TransportMessageListener to TransportService

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transport.java
@@ -53,9 +53,7 @@ public interface Transport extends LifecycleComponent {
      */
     RequestHandlerRegistry<? extends TransportRequest> getRequestHandler(String action);
 
-    void addMessageListener(TransportMessageListener listener);
-
-    boolean removeMessageListener(TransportMessageListener listener);
+    void setMessageListener(TransportMessageListener listener);
 
     /**
      * The address the transport is bound on.

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -64,6 +64,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
@@ -77,6 +78,7 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
     public static final String HANDSHAKE_ACTION_NAME = "internal:transport/handshake";
 
     private final CountDownLatch blockIncomingRequestsLatch = new CountDownLatch(1);
+    private final DelegatingTransportMessageListener messageListener = new DelegatingTransportMessageListener();
     protected final Transport transport;
     protected final ConnectionManager connectionManager;
     protected final ThreadPool threadPool;
@@ -223,7 +225,7 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
 
     @Override
     protected void doStart() {
-        transport.addMessageListener(this);
+        transport.setMessageListener(this);
         connectionManager.addListener(this);
         transport.start();
         if (transport.boundAddress() != null && logger.isInfoEnabled()) {
@@ -480,6 +482,14 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
             return;
         }
         connectionManager.disconnectFromNode(node);
+    }
+
+    public void addMessageListener(TransportMessageListener listener) {
+        messageListener.listeners.add(listener);
+    }
+
+    public boolean removeMessageListener(TransportMessageListener listener) {
+        return messageListener.listeners.remove(listener);
     }
 
     public void addConnectionListener(TransportConnectionListener listener) {
@@ -854,38 +864,6 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         transport.registerRequestHandler(reg);
     }
 
-    /** called by the {@link Transport} implementation once a request has been sent */
-    public void onRequestSent(DiscoveryNode node, long requestId, String action, TransportRequest request,
-                              TransportRequestOptions options) {
-        if (traceEnabled() && shouldTraceAction(action)) {
-            traceRequestSent(node, requestId, action, options);
-        }
-    }
-
-    protected boolean traceEnabled() {
-        return tracerLog.isTraceEnabled();
-    }
-
-    /** called by the {@link Transport} implementation once a response was sent to calling node */
-    @Override
-    public void onResponseSent(long requestId, String action, TransportResponse response) {
-        if (traceEnabled() && shouldTraceAction(action)) {
-            traceResponseSent(requestId, action);
-        }
-    }
-
-    /** called by the {@link Transport} implementation after an exception was sent as a response to an incoming request */
-    @Override
-    public void onResponseSent(long requestId, String action, Exception e) {
-        if (traceEnabled() && shouldTraceAction(action)) {
-            traceResponseSent(requestId, action, e);
-        }
-    }
-
-    protected void traceResponseSent(long requestId, String action, Exception e) {
-        tracerLog.trace(() -> new ParameterizedMessage("[{}][{}] sent error response", requestId, action), e);
-    }
-
     /**
      * called by the {@link Transport} implementation when an incoming request arrives but before
      * any parsing of it has happened (with the exception of the requestId and action)
@@ -897,23 +875,52 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         } catch (InterruptedException e) {
             logger.trace("interrupted while waiting for incoming requests block to be removed");
         }
-        if (traceEnabled() && shouldTraceAction(action)) {
-            traceReceivedRequest(requestId, action);
+        if (tracerLog.isTraceEnabled() && shouldTraceAction(action)) {
+            tracerLog.trace("[{}][{}] received request", requestId, action);
         }
+        messageListener.onRequestReceived(requestId, action);
     }
 
-    public RequestHandlerRegistry<? extends TransportRequest> getRequestHandler(String action) {
-        return transport.getRequestHandler(action);
+    /** called by the {@link Transport} implementation once a request has been sent */
+    @Override
+    public void onRequestSent(DiscoveryNode node, long requestId, String action, TransportRequest request,
+                              TransportRequestOptions options) {
+        if (tracerLog.isTraceEnabled() && shouldTraceAction(action)) {
+            tracerLog.trace("[{}][{}] sent to [{}] (timeout: [{}])", requestId, action, node, options.timeout());
+        }
+        messageListener.onRequestSent(node, requestId, action, request, options);
     }
-
 
     @Override
     public void onResponseReceived(long requestId, Transport.ResponseContext holder) {
         if (holder == null) {
             checkForTimeout(requestId);
-        } else if (traceEnabled() && shouldTraceAction(holder.action())) {
-            traceReceivedResponse(requestId, holder.connection().getNode(), holder.action());
+        } else if (tracerLog.isTraceEnabled() && shouldTraceAction(holder.action())) {
+            tracerLog.trace("[{}][{}] received response from [{}]", requestId, holder.action(), holder.connection().getNode());
         }
+        messageListener.onResponseReceived(requestId, holder);
+    }
+
+    /** called by the {@link Transport} implementation once a response was sent to calling node */
+    @Override
+    public void onResponseSent(long requestId, String action, TransportResponse response) {
+        if (tracerLog.isTraceEnabled() && shouldTraceAction(action)) {
+            tracerLog.trace("[{}][{}] sent response", requestId, action);
+        }
+        messageListener.onResponseSent(requestId, action, response);
+    }
+
+    /** called by the {@link Transport} implementation after an exception was sent as a response to an incoming request */
+    @Override
+    public void onResponseSent(long requestId, String action, Exception e) {
+        if (tracerLog.isTraceEnabled() && shouldTraceAction(action)) {
+            tracerLog.trace(() -> new ParameterizedMessage("[{}][{}] sent error response", requestId, action), e);
+        }
+        messageListener.onResponseSent(requestId, action, e);
+    }
+
+    public RequestHandlerRegistry<? extends TransportRequest> getRequestHandler(String action) {
+        return transport.getRequestHandler(action);
     }
 
     private void checkForTimeout(long requestId) {
@@ -935,14 +942,14 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
             sourceNode = null;
         }
         // call tracer out of lock
-        if (traceEnabled() == false) {
+        if (tracerLog.isTraceEnabled() == false) {
             return;
         }
         if (action == null) {
             assert sourceNode == null;
-            traceUnresolvedResponse(requestId);
+            tracerLog.trace("[{}] received response but can't resolve it to a request", requestId);
         } else if (shouldTraceAction(action)) {
-            traceReceivedResponse(requestId, sourceNode, action);
+            tracerLog.trace("[{}][{}] received response from [{}]", requestId, action, sourceNode);
         }
     }
 
@@ -970,26 +977,6 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         } catch (EsRejectedExecutionException ex) {
             logger.debug("Rejected execution on onConnectionClosed", ex);
         }
-    }
-
-    protected void traceReceivedRequest(long requestId, String action) {
-        tracerLog.trace("[{}][{}] received request", requestId, action);
-    }
-
-    protected void traceResponseSent(long requestId, String action) {
-        tracerLog.trace("[{}][{}] sent response", requestId, action);
-    }
-
-    protected void traceReceivedResponse(long requestId, DiscoveryNode sourceNode, String action) {
-        tracerLog.trace("[{}][{}] received response from [{}]", requestId, action, sourceNode);
-    }
-
-    protected void traceUnresolvedResponse(long requestId) {
-        tracerLog.trace("[{}] received response but can't resolve it to a request", requestId);
-    }
-
-    protected void traceRequestSent(DiscoveryNode node, long requestId, String action, TransportRequestOptions options) {
-        tracerLog.trace("[{}][{}] sent to [{}] (timeout: [{}])", requestId, action, node, options.timeout());
     }
 
     final class TimeoutHandler implements Runnable {
@@ -1256,5 +1243,46 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
 
     private boolean isLocalNode(DiscoveryNode discoveryNode) {
         return Objects.requireNonNull(discoveryNode, "discovery node must not be null").equals(localNode);
+    }
+
+    private static final class DelegatingTransportMessageListener implements TransportMessageListener {
+
+        private final List<TransportMessageListener> listeners = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onRequestReceived(long requestId, String action) {
+            for (TransportMessageListener listener : listeners) {
+                listener.onRequestReceived(requestId, action);
+            }
+        }
+
+        @Override
+        public void onResponseSent(long requestId, String action, TransportResponse response) {
+            for (TransportMessageListener listener : listeners) {
+                listener.onResponseSent(requestId, action, response);
+            }
+        }
+
+        @Override
+        public void onResponseSent(long requestId, String action, Exception error) {
+            for (TransportMessageListener listener : listeners) {
+                listener.onResponseSent(requestId, action, error);
+            }
+        }
+
+        @Override
+        public void onRequestSent(DiscoveryNode node, long requestId, String action, TransportRequest request,
+                                  TransportRequestOptions finalOptions) {
+            for (TransportMessageListener listener : listeners) {
+                listener.onRequestSent(node, requestId, action, request, finalOptions);
+            }
+        }
+
+        @Override
+        public void onResponseReceived(long requestId, Transport.ResponseContext holder) {
+            for (TransportMessageListener listener : listeners) {
+                listener.onResponseReceived(requestId, holder);
+            }
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/client/transport/FailAndRetryMockTransport.java
+++ b/server/src/test/java/org/elasticsearch/client/transport/FailAndRetryMockTransport.java
@@ -229,13 +229,7 @@ abstract class FailAndRetryMockTransport<Response extends TransportResponse> imp
 
 
     @Override
-    public void addMessageListener(TransportMessageListener listener) {
+    public void setMessageListener(TransportMessageListener listener) {
         this.listener = listener;
     }
-
-    @Override
-    public boolean removeMessageListener(TransportMessageListener listener) {
-        throw new UnsupportedOperationException();
-    }
-
 }

--- a/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
@@ -387,12 +387,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
         }
 
         @Override
-        public void addMessageListener(TransportMessageListener listener) {
-        }
-
-        @Override
-        public boolean removeMessageListener(TransportMessageListener listener) {
-            throw new UnsupportedOperationException();
+        public void setMessageListener(TransportMessageListener listener) {
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
@@ -165,7 +165,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         CountDownLatch beginRelocationLatch = new CountDownLatch(1);
         CountDownLatch receivedShardExistsRequestLatch = new CountDownLatch(1);
         // use a tracer on the target node to track relocation start and end
-        transportService.transport().addMessageListener(new TransportMessageListener() {
+        transportService.addMessageListener(new TransportMessageListener() {
             @Override
             public void onRequestReceived(long requestId, String action) {
                 if (action.equals(PeerRecoveryTargetService.Actions.FILES_INFO)) {

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
@@ -264,20 +264,11 @@ public class MockTransport implements Transport, LifecycleComponent {
     }
 
     @Override
-    public void addMessageListener(TransportMessageListener listener) {
+    public void setMessageListener(TransportMessageListener listener) {
         if (this.listener != null) {
             throw new IllegalStateException("listener already set");
         }
         this.listener = listener;
-    }
-
-    @Override
-    public boolean removeMessageListener(TransportMessageListener listener) {
-        if (listener == this.listener) {
-            this.listener = null;
-            return true;
-        }
-        return false;
     }
 
     protected NamedWriteableRegistry writeableRegistry() {

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
@@ -95,13 +95,8 @@ public final class StubbableTransport implements Transport {
     }
 
     @Override
-    public void addMessageListener(TransportMessageListener listener) {
-        delegate.addMessageListener(listener);
-    }
-
-    @Override
-    public boolean removeMessageListener(TransportMessageListener listener) {
-        return delegate.removeMessageListener(listener);
+    public void setMessageListener(TransportMessageListener listener) {
+        delegate.setMessageListener(listener);
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -476,7 +476,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             assertThat(ExceptionsHelper.unwrapCause(e.getCause()).getMessage(), equalTo("simulated"));
         }
 
-        // use assert busy as call backs are sometime called after the response have been sent
+        // use assert busy as callbacks are called on a different thread
         assertBusy(() -> {
             assertThat(tracerA.requestsReceived.get(), equalTo(0));
             assertThat(tracerA.requestsSent.get(), equalTo(1));
@@ -495,7 +495,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             assertThat(ExceptionsHelper.unwrapCause(e.getCause()).getMessage(), equalTo("simulated"));
         }
 
-        // use assert busy as call backs are sometime called after the response have been sent
+        // use assert busy as callbacks are called on a different thread
         assertBusy(() -> {
             assertThat(tracerA.requestsReceived.get(), equalTo(1));
             assertThat(tracerA.requestsSent.get(), equalTo(1));
@@ -507,7 +507,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             assertThat(tracerB.responseSent.get(), equalTo(1));
         });
 
-        // Test send local request
+        // use assert busy as callbacks are called on a different thread
         try {
             serviceA.submitRequest(nodeA, ACTION, TransportRequest.Empty.INSTANCE, EmptyTransportResponseHandler.INSTANCE_SAME).get();
         } catch (ExecutionException e) {
@@ -515,7 +515,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             assertThat(ExceptionsHelper.unwrapCause(e.getCause()).getMessage(), equalTo("simulated"));
         }
 
-        // use assert busy as call backs are sometime called after the response have been sent
+        // use assert busy as callbacks are called on a different thread
         assertBusy(() -> {
             assertThat(tracerA.requestsReceived.get(), equalTo(2));
             assertThat(tracerA.requestsSent.get(), equalTo(2));

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -466,8 +466,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
         final CountingListener tracerA = new CountingListener();
         final CountingListener tracerB = new CountingListener();
-        serviceA.transport().addMessageListener(tracerA);
-        serviceB.transport().addMessageListener(tracerB);
+        serviceA.addMessageListener(tracerA);
+        serviceB.addMessageListener(tracerB);
 
         try {
             serviceA.submitRequest(nodeB, ACTION, TransportRequest.Empty.INSTANCE, EmptyTransportResponseHandler.INSTANCE_SAME).get();
@@ -501,6 +501,26 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             assertThat(tracerA.requestsSent.get(), equalTo(1));
             assertThat(tracerA.responseReceived.get(), equalTo(1));
             assertThat(tracerA.responseSent.get(), equalTo(1));
+            assertThat(tracerB.requestsReceived.get(), equalTo(1));
+            assertThat(tracerB.requestsSent.get(), equalTo(1));
+            assertThat(tracerB.responseReceived.get(), equalTo(1));
+            assertThat(tracerB.responseSent.get(), equalTo(1));
+        });
+
+        // Test send local request
+        try {
+            serviceA.submitRequest(nodeA, ACTION, TransportRequest.Empty.INSTANCE, EmptyTransportResponseHandler.INSTANCE_SAME).get();
+        } catch (ExecutionException e) {
+            assertThat(e.getCause(), instanceOf(ElasticsearchException.class));
+            assertThat(ExceptionsHelper.unwrapCause(e.getCause()).getMessage(), equalTo("simulated"));
+        }
+
+        // use assert busy as call backs are sometime called after the response have been sent
+        assertBusy(() -> {
+            assertThat(tracerA.requestsReceived.get(), equalTo(2));
+            assertThat(tracerA.requestsSent.get(), equalTo(2));
+            assertThat(tracerA.responseReceived.get(), equalTo(2));
+            assertThat(tracerA.responseSent.get(), equalTo(2));
             assertThat(tracerB.requestsReceived.get(), equalTo(1));
             assertThat(tracerB.requestsSent.get(), equalTo(1));
             assertThat(tracerB.responseReceived.get(), equalTo(1));

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
@@ -874,7 +874,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                                     removeLeaseLatch.countDown();
                                     unfollowLatch.await();
 
-                                    senderTransportService.transport().addMessageListener(new TransportMessageListener() {
+                                    senderTransportService.addMessageListener(new TransportMessageListener() {
 
                                         @SuppressWarnings("rawtypes")
                                         @Override
@@ -886,7 +886,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                                                         new RetentionLeaseNotFoundException(retentionLeaseId);
                                                 context.handler().handleException(new RemoteTransportException(e.getMessage(), e));
                                                 responseLatch.countDown();
-                                                senderTransportService.transport().removeMessageListener(this);
+                                                senderTransportService.removeMessageListener(this);
                                             }
                                         }
 


### PR DESCRIPTION
Currently the TransportMessageListener is applied and used in the
Transport class. However, local requests and responses never make it to
this class. This PR moves the listener add/remove methods to the
TransportService. After this change the Transport can only have one
listener set with it. This one listener is the TransportService, which
will then propogate the events to the external listeners.