### PR TITLE
[BACKPORT] Correct documentation link for authorization engine example (#40261)

### DIFF
--- a/x-pack/docs/en/security/authorization/custom-authorization.asciidoc
+++ b/x-pack/docs/en/security/authorization/custom-authorization.asciidoc
@@ -75,7 +75,7 @@ implementation.
 
 Sample code that illustrates the structure and implementation of a custom
 authorization engine is provided in the
-https://github.com/elastic/elasticsearch/tree/master/plugin/examples/security-example-authorization-engine[elasticsearch]
+https://github.com/elastic/elasticsearch/tree/master/plugins/examples/security-authorization-engine[elasticsearch]
 repository on GitHub. You can use this code as a starting point for creating your
 own authorization engine.
 


### PR DESCRIPTION
This commit fixes the link for authorization engine example.