### PR TITLE
BACKPORT Refactor Token Service

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
@@ -61,13 +61,13 @@ public final class TransportSamlAuthenticateAction extends HandledTransportActio
                 }
                 assert authentication != null : "authentication should never be null at this point";
                 final Map<String, Object> tokenMeta = (Map<String, Object>) result.getMetadata().get(SamlRealm.CONTEXT_TOKEN_DATA);
-                tokenService.createUserToken(authentication, originatingAuthentication,
-                        ActionListener.wrap(tuple -> {
+                tokenService.createOAuth2Tokens(authentication, originatingAuthentication,
+                        tokenMeta, true, ActionListener.wrap(tuple -> {
                             final String tokenString = tokenService.getAccessTokenAsString(tuple.v1());
                             final TimeValue expiresIn = tokenService.getExpirationDelay();
                             listener.onResponse(
                                     new SamlAuthenticateResponse(authentication.getUser().principal(), tokenString, tuple.v2(), expiresIn));
-                        }, listener::onFailure), tokenMeta, true);
+                        }, listener::onFailure));
             }, e -> {
                 logger.debug(() -> new ParameterizedMessage("SamlToken [{}] could not be authenticated", saml), e);
                 listener.onFailure(e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
@@ -91,7 +91,7 @@ public final class TransportSamlInvalidateSessionAction
             return;
         }
 
-        tokenService.findActiveTokensForRealm(realm.name(), ActionListener.wrap(tokens -> {
+        tokenService.findActiveTokensForRealm(realm.name(), containsMetadata(tokenMetadata), ActionListener.wrap(tokens -> {
                 logger.debug("Found [{}] token pairs to invalidate for SAML metadata [{}]", tokens.size(), tokenMetadata);
                 if (tokens.isEmpty()) {
                     listener.onResponse(0);
@@ -101,7 +101,7 @@ public final class TransportSamlInvalidateSessionAction
                     tokens.forEach(tuple -> invalidateTokenPair(tuple, groupedListener));
                 }
             }, listener::onFailure
-        ), containsMetadata(tokenMetadata));
+        ));
     }
 
     private void invalidateTokenPair(Tuple<UserToken, String> tokenPair, ActionListener<TokensInvalidationResult> listener) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
@@ -28,7 +28,6 @@ import org.elasticsearch.xpack.security.authc.saml.SamlRedirect;
 import org.elasticsearch.xpack.security.authc.saml.SamlUtils;
 import org.opensaml.saml.saml2.core.LogoutRequest;
 
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -73,7 +72,7 @@ public final class TransportSamlLogoutAction
                             ));
                         }, listener::onFailure
                 ));
-            } catch (IOException | ElasticsearchException e) {
+            } catch (ElasticsearchException e) {
                 logger.debug("Internal exception during SAML logout", e);
                 listener.onFailure(e);
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -19,6 +19,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest.OpType;
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.DocWriteResponse.Result;
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
@@ -47,10 +48,13 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.hash.MessageDigests;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -65,7 +69,6 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -106,6 +109,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
 import java.time.Clock;
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
@@ -225,22 +229,22 @@ public final class TokenService {
     }
 
     /**
-     * Creates a token based on the provided authentication and metadata with an auto-generated token id.
-     * The created token will be stored in the security index.
+     * Creates an access token and optionally a refresh token as well, based on the provided authentication and metadata with an
+     * auto-generated token document id. The created tokens are stored in the security index.
      */
-    public void createUserToken(Authentication authentication, Authentication originatingClientAuth,
-                                ActionListener<Tuple<UserToken, String>> listener, Map<String, Object> metadata,
-                                boolean includeRefreshToken) throws IOException {
-        createUserToken(UUIDs.randomBase64UUID(), authentication, originatingClientAuth, listener, metadata, includeRefreshToken);
+    public void createOAuth2Tokens(Authentication authentication, Authentication originatingClientAuth,
+                                   Map<String, Object> metadata, boolean includeRefreshToken,
+                                   ActionListener<Tuple<UserToken, String>> listener) {
+        createOAuth2Tokens(UUIDs.randomBase64UUID(), authentication, originatingClientAuth, metadata, includeRefreshToken, listener);
     }
 
     /**
-     * Create a token based on the provided authentication and metadata with the given token id.
-     * The created token will be stored in the security index.
+     * Create an access token and optionally a refresh token as well, based on the provided authentication and metadata, with the given
+     * token document id. The created tokens are be stored in the security index.
      */
-    private void createUserToken(String userTokenId, Authentication authentication, Authentication originatingClientAuth,
-                                 ActionListener<Tuple<UserToken, String>> listener, Map<String, Object> metadata,
-                                 boolean includeRefreshToken) throws IOException {
+    private void createOAuth2Tokens(String userTokenId, Authentication authentication, Authentication originatingClientAuth,
+                                    Map<String, Object> metadata, boolean includeRefreshToken,
+                                    ActionListener<Tuple<UserToken, String>> listener) {
         ensureEnabled();
         if (authentication == null) {
             listener.onFailure(traceLog("create token", new IllegalArgumentException("authentication must be provided")));
@@ -254,8 +258,10 @@ public final class TokenService {
             final Authentication tokenAuth = new Authentication(authentication.getUser(), authentication.getAuthenticatedBy(),
                 authentication.getLookedUpBy(), version, AuthenticationType.TOKEN, authentication.getMetadata());
             final UserToken userToken = new UserToken(userTokenId, version, tokenAuth, expiration, metadata);
+            final String documentId = getTokenDocumentId(userToken);
             final String refreshToken = includeRefreshToken ? UUIDs.randomBase64UUID() : null;
 
+            final IndexRequest request;
             try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
                 builder.startObject();
                 builder.field("doc_type", TOKEN_DOC_TYPE);
@@ -278,43 +284,26 @@ public final class TokenService {
                         .field("realm", authentication.getAuthenticatedBy().getName())
                         .endObject();
                 builder.endObject();
-                final String documentId = getTokenDocumentId(userToken);
-                IndexRequest request =
-                        client.prepareIndex(SECURITY_INDEX_NAME, SINGLE_MAPPING_NAME, documentId)
+                request = client.prepareIndex(SECURITY_INDEX_NAME, SINGLE_MAPPING_NAME, documentId)
                                 .setOpType(OpType.CREATE)
                                 .setSource(builder)
                                 .setRefreshPolicy(RefreshPolicy.WAIT_UNTIL)
                                 .request();
-                securityIndex.prepareIndexIfNeededThenExecute(ex -> listener.onFailure(traceLog("prepare security index", documentId, ex)),
-                    () -> executeAsyncWithOrigin(client, SECURITY_ORIGIN, IndexAction.INSTANCE, request,
-                        ActionListener.wrap(indexResponse -> listener.onResponse(new Tuple<>(userToken, refreshToken)),
-                            listener::onFailure))
-                );
+            } catch (IOException e) {
+                // unexpected exception
+                listener.onFailure(e);
+                return;
             }
-        }
-    }
-
-    /**
-     * Reconstructs the {@link UserToken} from the existing {@code userTokenSource} and call the listener with the {@link UserToken} and the
-     * refresh token string
-     */
-    private void reIssueTokens(Map<String, Object> userTokenSource,
-                               String refreshToken, ActionListener<Tuple<UserToken, String>> listener) {
-        final String authString = (String) userTokenSource.get("authentication");
-        final Integer version = (Integer) userTokenSource.get("version");
-        final Map<String, Object> metadata = (Map<String, Object>) userTokenSource.get("metadata");
-        final String id = (String) userTokenSource.get("id");
-        final Long expiration = (Long) userTokenSource.get("expiration_time");
-
-        Version authVersion = Version.fromId(version);
-        try (StreamInput in = StreamInput.wrap(Base64.getDecoder().decode(authString))) {
-            in.setVersion(authVersion);
-            Authentication authentication = new Authentication(in);
-            UserToken userToken = new UserToken(id, authVersion, authentication, Instant.ofEpochMilli(expiration), metadata);
-            listener.onResponse(new Tuple<>(userToken, refreshToken));
-        } catch (IOException e) {
-            logger.error("Unable to decode existing user token", e);
-            listener.onFailure(invalidGrantException("could not refresh the requested token"));
+            securityIndex.prepareIndexIfNeededThenExecute(ex -> listener.onFailure(traceLog("prepare security index", documentId, ex)),
+                    () -> executeAsyncWithOrigin(client, SECURITY_ORIGIN, IndexAction.INSTANCE, request, ActionListener
+                            .wrap(indexResponse -> {
+                                if (indexResponse.getResult() == Result.CREATED) {
+                                    listener.onResponse(new Tuple<>(userToken, refreshToken));
+                                } else {
+                                    listener.onFailure(traceLog("create token",
+                                            new ElasticsearchException("failed to create token document [{}]", indexResponse)));
+                                }
+                            }, listener::onFailure)));
         }
     }
 
@@ -329,19 +318,13 @@ public final class TokenService {
             if (token == null) {
                 listener.onResponse(null);
             } else {
-                try {
-                    decodeToken(token, ActionListener.wrap(userToken -> {
-                        if (userToken != null) {
-                            checkIfTokenIsValid(userToken, listener);
-                        } else {
-                            listener.onResponse(null);
-                        }
-                    }, listener::onFailure));
-                } catch (IOException e) {
-                    // could happen with a token that is not ours
-                    logger.debug("invalid token", e);
-                    listener.onResponse(null);
-                }
+                decodeToken(token, ActionListener.wrap(userToken -> {
+                    if (userToken != null) {
+                        checkIfTokenIsValid(userToken, listener);
+                    } else {
+                        listener.onResponse(null);
+                    }
+                }, listener::onFailure));
             }
         } else {
             listener.onResponse(null);
@@ -352,8 +335,7 @@ public final class TokenService {
      * Reads the authentication and metadata from the given token.
      * This method does not validate whether the token is expired or not.
      */
-    public void getAuthenticationAndMetaData(String token, ActionListener<Tuple<Authentication, Map<String, Object>>> listener)
-            throws IOException {
+    public void getAuthenticationAndMetaData(String token, ActionListener<Tuple<Authentication, Map<String, Object>>> listener) {
         decodeToken(token, ActionListener.wrap(
                 userToken -> {
                     if (userToken == null) {
@@ -371,7 +353,7 @@ public final class TokenService {
      */
     void getUserTokenFromId(String userTokenId, ActionListener<UserToken> listener) {
         if (securityIndex.isAvailable() == false) {
-            logger.warn("failed to get token [{}] since index is not available", userTokenId);
+            logger.warn("failed to get access token [{}] because index is not available", userTokenId);
             listener.onResponse(null);
         } else {
             securityIndex.checkIndexVersionThenExecute(
@@ -404,10 +386,10 @@ public final class TokenService {
                             // if the index or the shard is not there / available we assume that
                             // the token is not valid
                             if (isShardNotAvailableException(e)) {
-                                logger.warn("failed to get token [{}] since index is not available", userTokenId);
+                                logger.warn("failed to get access token [{}] because index is not available", userTokenId);
                                 listener.onResponse(null);
                             } else {
-                                logger.error(new ParameterizedMessage("failed to get token [{}]", userTokenId), e);
+                                logger.error(new ParameterizedMessage("failed to get access token [{}]", userTokenId), e);
                                 listener.onFailure(e);
                             }
                         }), client::get);
@@ -422,49 +404,60 @@ public final class TokenService {
      * we can restrain the amount of resources consumed by the key computation to a single thread.
      * For tokens created in an after 7.1.0 cluster, the token is just the token document Id so this is used directly without decryption
      */
-    void decodeToken(String token, ActionListener<UserToken> listener) throws IOException {
-        // We intentionally do not use try-with resources since we need to keep the stream open if we need to compute a key!
-        byte[] bytes = token.getBytes(StandardCharsets.UTF_8);
-        StreamInput in = new InputStreamStreamInput(Base64.getDecoder().wrap(new ByteArrayInputStream(bytes)), bytes.length);
-        final Version version = Version.readVersion(in);
-        if (version.onOrAfter(Version.V_7_1_0)) {
-            // The token was created in a > 7.1.0 cluster so it contains the tokenId as a String
-            String usedTokenId = in.readString();
-            getUserTokenFromId(usedTokenId, listener);
-        } else {
-            // The token was created in a < 7.1.0 cluster so we need to decrypt it to get the tokenId
+    void decodeToken(String token, ActionListener<UserToken> listener) {
+        final byte[] bytes = token.getBytes(StandardCharsets.UTF_8);
+        try (StreamInput in = new InputStreamStreamInput(Base64.getDecoder().wrap(new ByteArrayInputStream(bytes)), bytes.length)) {
+            final Version version = Version.readVersion(in);
             in.setVersion(version);
-            if (in.available() < MINIMUM_BASE64_BYTES) {
-                logger.debug("invalid token, smaller than [{}] bytes", MINIMUM_BASE64_BYTES);
-                listener.onResponse(null);
-                return;
-            }
-            final BytesKey decodedSalt = new BytesKey(in.readByteArray());
-            final BytesKey passphraseHash = new BytesKey(in.readByteArray());
-            KeyAndCache keyAndCache = keyCache.get(passphraseHash);
-            if (keyAndCache != null) {
-                getKeyAsync(decodedSalt, keyAndCache, ActionListener.wrap(decodeKey -> {
-                    try {
-                        final byte[] iv = in.readByteArray();
-                        final Cipher cipher = getDecryptionCipher(iv, decodeKey, version, decodedSalt);
-                        decryptTokenId(in, cipher, version, ActionListener.wrap(tokenId -> getUserTokenFromId(tokenId, listener),
-                            listener::onFailure));
-                    } catch (GeneralSecurityException e) {
-                        // could happen with a token that is not ours
-                        logger.warn("invalid token", e);
-                        listener.onResponse(null);
-                    } finally {
-                        in.close();
-                    }
-                }, e -> {
-                    IOUtils.closeWhileHandlingException(in);
-                    listener.onFailure(e);
-                }));
+            if (version.onOrAfter(Version.V_7_1_0)) {
+                // The token was created in a > 7.1.0 cluster so it contains the tokenId as a String
+                String usedTokenId = in.readString();
+                getUserTokenFromId(usedTokenId, listener);
             } else {
-                IOUtils.closeWhileHandlingException(in);
-                logger.debug("invalid key {} key: {}", passphraseHash, keyCache.cache.keySet());
-                listener.onResponse(null);
+                // The token was created in a < 7.1.0 cluster so we need to decrypt it to get the tokenId
+                if (in.available() < MINIMUM_BASE64_BYTES) {
+                    logger.debug("invalid token, smaller than [{}] bytes", MINIMUM_BASE64_BYTES);
+                    listener.onResponse(null);
+                    return;
+                }
+                final BytesKey decodedSalt = new BytesKey(in.readByteArray());
+                final BytesKey passphraseHash = new BytesKey(in.readByteArray());
+                final byte[] iv = in.readByteArray();
+                final BytesStreamOutput out = new BytesStreamOutput();
+                Streams.copy(in, out);
+                final byte[] encryptedTokenId = BytesReference.toBytes(out.bytes());
+                final KeyAndCache keyAndCache = keyCache.get(passphraseHash);
+                if (keyAndCache != null) {
+                    getKeyAsync(decodedSalt, keyAndCache, ActionListener.wrap(decodeKey -> {
+                        if (decodeKey != null) {
+                            try {
+                                final Cipher cipher = getDecryptionCipher(iv, decodeKey, version, decodedSalt);
+                                final String tokenId = decryptTokenId(encryptedTokenId, cipher, version);
+                                getUserTokenFromId(tokenId, listener);
+                            } catch (IOException | GeneralSecurityException e) {
+                                // could happen with a token that is not ours
+                                logger.warn("invalid token", e);
+                                listener.onResponse(null);
+                            }
+                        } else {
+                            // could happen with a token that is not ours
+                            listener.onResponse(null);
+                            return;
+                        }
+                    }, listener::onFailure));
+                } else {
+                    logger.debug(() -> new ParameterizedMessage("invalid key {} key: {}", passphraseHash, keyCache.cache.keySet()));
+                    listener.onResponse(null);
+                }
             }
+        } catch (IOException e) {
+            // could happen with a token that is not ours
+            if (logger.isDebugEnabled()) {
+               logger.debug("built in token service unable to decode token", e);
+            } else {
+                logger.warn("built in token service unable to decode token");
+            }
+            listener.onResponse(null);
         }
     }
 
@@ -479,43 +472,38 @@ public final class TokenService {
              * some additional latency.
              */
             client.threadPool().executor(THREAD_POOL_NAME)
-                    .submit(new KeyComputingRunnable(decodedSalt, listener, keyAndCache));
+                    .submit(new KeyComputingRunnable(decodedSalt, keyAndCache, listener));
         }
     }
 
-    private static void decryptTokenId(StreamInput in, Cipher cipher, Version version, ActionListener<String> listener) throws IOException {
-        try (CipherInputStream cis = new CipherInputStream(in, cipher); StreamInput decryptedInput = new InputStreamStreamInput(cis)) {
+    private static String decryptTokenId(byte[] encryptedTokenId, Cipher cipher, Version version) throws IOException {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(encryptedTokenId);
+                CipherInputStream cis = new CipherInputStream(bais, cipher);
+                StreamInput decryptedInput = new InputStreamStreamInput(cis)) {
             decryptedInput.setVersion(version);
-            listener.onResponse(decryptedInput.readString());
+            return decryptedInput.readString();
         }
     }
 
     /**
-     * This method performs the steps necessary to invalidate a token so that it may no longer be
+     * This method performs the steps necessary to invalidate an access token so that it may no longer be
      * used. The process of invalidation involves performing an update to the token document and setting
-     * the <code>invalidated</code> field to <code>true</code>
+     * the {@code access_token.invalidated} field to {@code true}
      */
-    public void invalidateAccessToken(String tokenString, ActionListener<TokensInvalidationResult> listener) {
+    public void invalidateAccessToken(String accessToken, ActionListener<TokensInvalidationResult> listener) {
         ensureEnabled();
-        if (Strings.isNullOrEmpty(tokenString)) {
-            logger.trace("No token-string provided");
-            listener.onFailure(new IllegalArgumentException("token must be provided"));
+        if (Strings.isNullOrEmpty(accessToken)) {
+            listener.onFailure(traceLog("no access token provided", new IllegalArgumentException("access token must be provided")));
         } else {
             maybeStartTokenRemover();
             final Iterator<TimeValue> backoff = DEFAULT_BACKOFF.iterator();
-            try {
-                decodeToken(tokenString, ActionListener.wrap(userToken -> {
-                    if (userToken == null) {
-                        listener.onFailure(traceLog("invalidate token", tokenString, malformedTokenException()));
-                    } else {
-                        indexInvalidation(Collections.singleton(userToken.getId()), listener, backoff,
-                            "access_token", null);
-                    }
-                }, listener::onFailure));
-            } catch (IOException e) {
-                logger.error("received a malformed token as part of a invalidation request", e);
-                listener.onFailure(malformedTokenException());
-            }
+            decodeToken(accessToken, ActionListener.wrap(userToken -> {
+                if (userToken == null) {
+                    listener.onFailure(traceLog("invalidate token", accessToken, malformedTokenException()));
+                } else {
+                    indexInvalidation(Collections.singleton(userToken.getId()), backoff, "access_token", null, listener);
+                }
+            }, listener::onFailure));
         }
     }
 
@@ -528,11 +516,11 @@ public final class TokenService {
         ensureEnabled();
         if (userToken == null) {
             logger.trace("No access token provided");
-            listener.onFailure(new IllegalArgumentException("token must be provided"));
+            listener.onFailure(new IllegalArgumentException("access token must be provided"));
         } else {
             maybeStartTokenRemover();
             final Iterator<TimeValue> backoff = DEFAULT_BACKOFF.iterator();
-            indexInvalidation(Collections.singleton(userToken.getId()), listener, backoff, "access_token", null);
+            indexInvalidation(Collections.singleton(userToken.getId()), backoff, "access_token", null, listener);
         }
     }
 
@@ -552,10 +540,10 @@ public final class TokenService {
             maybeStartTokenRemover();
             final Iterator<TimeValue> backoff = DEFAULT_BACKOFF.iterator();
             findTokenFromRefreshToken(refreshToken,
-                ActionListener.wrap(searchResponse -> {
-                    final String docId = getTokenIdFromDocumentId(searchResponse.getHits().getAt(0).getId());
-                    indexInvalidation(Collections.singletonList(docId), listener, backoff, "refresh_token", null);
-                }, listener::onFailure), backoff);
+                backoff, ActionListener.wrap(searchResponse -> {
+                    final String docId = getTokenIdFromDocumentId(searchResponse.getId());
+                    indexInvalidation(Collections.singletonList(docId), backoff, "refresh_token", null, listener);
+                }, listener::onFailure));
         }
     }
 
@@ -588,14 +576,14 @@ public final class TokenService {
                 if (Strings.hasText(username)) {
                     filter = isOfUser(username);
                 }
-                findActiveTokensForRealm(realmName, ActionListener.wrap(tokenTuples -> {
+                findActiveTokensForRealm(realmName, filter, ActionListener.wrap(tokenTuples -> {
                     if (tokenTuples.isEmpty()) {
                         logger.warn("No tokens to invalidate for realm [{}] and username [{}]", realmName, username);
                         listener.onResponse(TokensInvalidationResult.emptyResult());
                     } else {
                         invalidateAllTokens(tokenTuples.stream().map(t -> t.v1().getId()).collect(Collectors.toList()), listener);
                     }
-                }, listener::onFailure), filter);
+                }, listener::onFailure));
             }
         }
     }
@@ -612,9 +600,9 @@ public final class TokenService {
         // Invalidate the refresh tokens first so that they cannot be used to get new
         // access tokens while we invalidate the access tokens we currently know about
         final Iterator<TimeValue> backoff = DEFAULT_BACKOFF.iterator();
-        indexInvalidation(accessTokenIds, ActionListener.wrap(result ->
-                indexInvalidation(accessTokenIds, listener, backoff, "access_token", result),
-            listener::onFailure), backoff, "refresh_token", null);
+        indexInvalidation(accessTokenIds, backoff, "refresh_token", null, ActionListener.wrap(result ->
+                    indexInvalidation(accessTokenIds, backoff, "access_token", result, listener),
+                listener::onFailure));
     }
 
     /**
@@ -623,15 +611,15 @@ public final class TokenService {
      * an exponential backoff policy.
      *
      * @param tokenIds        the tokens to invalidate
-     * @param listener        the listener to notify upon completion
      * @param backoff         the amount of time to delay between attempts
      * @param srcPrefix       the prefix to use when constructing the doc to update, either refresh_token or access_token depending on
      *                        what type of tokens should be invalidated
      * @param previousResult  if this not the initial attempt for invalidation, it contains the result of invalidating
      *                        tokens up to the point of the retry. This result is added to the result of the current attempt
+     * @param listener        the listener to notify upon completion
      */
-    private void indexInvalidation(Collection<String> tokenIds, ActionListener<TokensInvalidationResult> listener,
-                                   Iterator<TimeValue> backoff, String srcPrefix, @Nullable TokensInvalidationResult previousResult) {
+    private void indexInvalidation(Collection<String> tokenIds, Iterator<TimeValue> backoff, String srcPrefix,
+                                   @Nullable TokensInvalidationResult previousResult, ActionListener<TokensInvalidationResult> listener) {
         if (tokenIds.isEmpty()) {
             logger.warn("No [{}] tokens provided for invalidation", srcPrefix);
             listener.onFailure(invalidGrantException("No tokens provided for invalidation"));
@@ -664,15 +652,15 @@ public final class TokenService {
                                 final String failedTokenDocId = getTokenIdFromDocumentId(bulkItemResponse.getFailure().getId());
                                 if (isShardNotAvailableException(cause)) {
                                     retryTokenDocIds.add(failedTokenDocId);
-                                }
-                                else {
+                                } else {
                                     traceLog("invalidate access token", failedTokenDocId, cause);
                                     failedRequestResponses.add(new ElasticsearchException("Error invalidating " + srcPrefix + ": ", cause));
                                 }
                             } else {
                                 UpdateResponse updateResponse = bulkItemResponse.getResponse();
                                 if (updateResponse.getResult() == DocWriteResponse.Result.UPDATED) {
-                                    logger.debug("Invalidated [{}] for doc [{}]", srcPrefix, updateResponse.getGetResult().getId());
+                                    logger.debug(() -> new ParameterizedMessage("Invalidated [{}] for doc [{}]",
+                                            srcPrefix, updateResponse.getGetResult().getId()));
                                     invalidated.add(updateResponse.getGetResult().getId());
                                 } else if (updateResponse.getResult() == DocWriteResponse.Result.NOOP) {
                                     previouslyInvalidated.add(updateResponse.getGetResult().getId());
@@ -685,7 +673,7 @@ public final class TokenService {
                             final TokensInvalidationResult incompleteResult = new TokensInvalidationResult(invalidated,
                                         previouslyInvalidated, failedRequestResponses);
                             final Runnable retryWithContextRunnable = client.threadPool().getThreadContext().preserveContext(
-                                        () -> indexInvalidation(retryTokenDocIds, listener, backoff, srcPrefix, incompleteResult));
+                                        () -> indexInvalidation(retryTokenDocIds, backoff, srcPrefix, incompleteResult, listener));
                             client.threadPool().schedule(retryWithContextRunnable, backoff.next(), GENERIC);
                         } else {
                             if (retryTokenDocIds.isEmpty() == false) {
@@ -707,7 +695,7 @@ public final class TokenService {
                         if (isShardNotAvailableException(cause) && backoff.hasNext()) {
                             logger.debug("failed to invalidate tokens, retrying ");
                             final Runnable retryWithContextRunnable = client.threadPool().getThreadContext()
-                                    .preserveContext(() -> indexInvalidation(tokenIds, listener, backoff, srcPrefix, previousResult));
+                                    .preserveContext(() -> indexInvalidation(tokenIds, backoff, srcPrefix, previousResult, listener));
                             client.threadPool().schedule(retryWithContextRunnable, backoff.next(), GENERIC);
                         } else {
                             listener.onFailure(e);
@@ -724,29 +712,26 @@ public final class TokenService {
         final Instant refreshRequested = clock.instant();
         final Iterator<TimeValue> backoff = DEFAULT_BACKOFF.iterator();
         findTokenFromRefreshToken(refreshToken,
-            ActionListener.wrap(searchResponse -> {
+            backoff,
+            ActionListener.wrap(tokenDocHit -> {
                 final Authentication clientAuth = Authentication.readFromContext(client.threadPool().getThreadContext());
-                final SearchHit tokenDocHit = searchResponse.getHits().getHits()[0];
-                final String tokenDocId = tokenDocHit.getId();
-                innerRefresh(tokenDocId, tokenDocHit.getSourceAsMap(), tokenDocHit.getSeqNo(), tokenDocHit.getPrimaryTerm(), clientAuth,
-                    listener, backoff, refreshRequested);
-            }, listener::onFailure),
-            backoff);
+                innerRefresh(tokenDocHit.getId(), tokenDocHit.getSourceAsMap(), tokenDocHit.getSeqNo(), tokenDocHit.getPrimaryTerm(),
+                        clientAuth, backoff, refreshRequested, listener);
+            }, listener::onFailure));
     }
 
     /**
      * Performs an asynchronous search request for the token document that contains the {@code refreshToken} and calls the listener with the
      * {@link SearchResponse}. In case of recoverable errors the SearchRequest is retried using an exponential backoff policy.
      */
-    private void findTokenFromRefreshToken(String refreshToken, ActionListener<SearchResponse> listener,
-                                           Iterator<TimeValue> backoff) {
+    private void findTokenFromRefreshToken(String refreshToken, Iterator<TimeValue> backoff, ActionListener<SearchHit> listener) {
         final Consumer<Exception> onFailure = ex -> listener.onFailure(traceLog("find token by refresh token", refreshToken, ex));
         final Consumer<Exception> maybeRetryOnFailure = ex -> {
             if (backoff.hasNext()) {
                 final TimeValue backofTimeValue = backoff.next();
                 logger.debug("retrying after [" + backofTimeValue + "] back off");
                 final Runnable retryWithContextRunnable = client.threadPool().getThreadContext()
-                        .preserveContext(() -> findTokenFromRefreshToken(refreshToken, listener, backoff));
+                        .preserveContext(() -> findTokenFromRefreshToken(refreshToken, backoff, listener));
                 client.threadPool().schedule(retryWithContextRunnable, backofTimeValue, GENERIC);
             } else {
                 logger.warn("failed to find token from refresh token after all retries");
@@ -755,7 +740,7 @@ public final class TokenService {
         };
         final SecurityIndexManager frozenSecurityIndex = securityIndex.freeze();
         if (frozenSecurityIndex.indexExists() == false) {
-            logger.warn("security index does not exist therefore refresh token [{}] cannot be validated", refreshToken);
+            logger.warn("security index does not exist therefore refresh token cannot be validated");
             listener.onFailure(invalidGrantException("could not refresh the requested token"));
         } else if (frozenSecurityIndex.isAvailable() == false) {
             logger.debug("security index is not available to find token from refresh token, retrying");
@@ -774,12 +759,12 @@ public final class TokenService {
                             logger.debug("find token from refresh token response timed out, retrying");
                             maybeRetryOnFailure.accept(invalidGrantException("could not refresh the requested token"));
                         } else if (searchResponse.getHits().getHits().length < 1) {
-                            logger.warn("could not find token document with refresh_token [{}]", refreshToken);
+                            logger.warn("could not find token document for refresh token");
                             onFailure.accept(invalidGrantException("could not refresh the requested token"));
                         } else if (searchResponse.getHits().getHits().length > 1) {
                             onFailure.accept(new IllegalStateException("multiple tokens share the same refresh token"));
                         } else {
-                            listener.onResponse(searchResponse);
+                            listener.onResponse(searchResponse.getHits().getAt(0));
                         }
                     }, e -> {
                         if (isShardNotAvailableException(e)) {
@@ -794,304 +779,275 @@ public final class TokenService {
     }
 
     /**
-     * Performs the actual refresh of the token with retries in case of certain exceptions that may be recoverable. The
-     * refresh involves two steps:
-     * First, we check if the token document is still valid for refresh ({@link TokenService#checkTokenDocForRefresh(Map, Authentication)}
-     * Then, in the case that the token has been refreshed within the previous 30 seconds (see
-     * {@link TokenService#checkLenientlyIfTokenAlreadyRefreshed(Map, Authentication)}), we do not create a new token document
-     * but instead retrieve the one that was created by the original refresh and return a user token and
-     * refresh token based on that ( see {@link TokenService#reIssueTokens(Map, String, ActionListener)} ).
-     * Otherwise this token document gets its refresh_token marked as refreshed, while also storing the Instant when it was
-     * refreshed along with a pointer to the new token document that holds the refresh_token that supersedes this one. The new
-     * document that contains the new access token and refresh token is created and finally the new access token and refresh token are
-     * returned to the listener.
+     * Performs the actual refresh of the token with retries in case of certain exceptions that may be recoverable. The refresh involves two
+     * steps: First, we check if the token document is still valid for refresh. Then, in the case that the token has been refreshed within
+     * the previous 30 seconds, we do not create a new token document but instead retrieve the one that was created by the original refresh
+     * and return an access token and refresh token based on that. Otherwise this token document gets its refresh_token marked as refreshed,
+     * while also storing the Instant when it was refreshed along with a pointer to the new token document that holds the refresh_token that
+     * supersedes this one. The new document that contains the new access token and refresh token is created and finally the new access
+     * token and refresh token are returned to the listener.
      */
     private void innerRefresh(String tokenDocId, Map<String, Object> source, long seqNo, long primaryTerm, Authentication clientAuth,
-                              ActionListener<Tuple<UserToken, String>> listener, Iterator<TimeValue> backoff, Instant refreshRequested) {
-        logger.debug("Attempting to refresh token [{}]", tokenDocId);
+                              Iterator<TimeValue> backoff, Instant refreshRequested, ActionListener<Tuple<UserToken, String>> listener) {
+        logger.debug("Attempting to refresh token stored in token document [{}]", tokenDocId);
         final Consumer<Exception> onFailure = ex -> listener.onFailure(traceLog("refresh token", tokenDocId, ex));
-        final Optional<ElasticsearchSecurityException> invalidSource = checkTokenDocForRefresh(source, clientAuth);
-        if (invalidSource.isPresent()) {
-            onFailure.accept(invalidSource.get());
-        } else {
-            if (eligibleForMultiRefresh(source, refreshRequested)) {
-                final Map<String, Object> refreshTokenSrc = (Map<String, Object>) source.get("refresh_token");
-                final String supersedingTokenDocId = (String) refreshTokenSrc.get("superseded_by");
-                logger.debug("Token document [{}] was recently refreshed, attempting to reuse [{}] for returning an " +
-                    "access token and refresh token", tokenDocId, supersedingTokenDocId);
-                final ActionListener<GetResponse> getSupersedingListener = new ActionListener<GetResponse>() {
-                    private final Consumer<Exception> maybeRetryOnFailure = ex -> {
-                        if (backoff.hasNext()) {
-                            final TimeValue backofTimeValue = backoff.next();
-                            logger.debug("retrying after [" + backofTimeValue + "] back off");
-                            final Runnable retryWithContextRunnable = client.threadPool().getThreadContext()
-                                    .preserveContext(() -> getTokenDocAsync(supersedingTokenDocId, this));
-                            client.threadPool().schedule(retryWithContextRunnable, backofTimeValue, GENERIC);
-                        } else {
-                            logger.warn("back off retries exhausted");
-                            onFailure.accept(ex);
-                        }
-                    };
-
-                    @Override
-                    public void onResponse(GetResponse response) {
-                        if (response.isExists()) {
-                            logger.debug("Found superseding token document [{}] ", supersedingTokenDocId);
-                            final Map<String, Object> supersedingTokenSource = response.getSource();
-                            final Map<String, Object> supersedingUserTokenSource = (Map<String, Object>)
-                                ((Map<String, Object>) supersedingTokenSource.get("access_token")).get("user_token");
-                            final Map<String, Object> supersedingRefreshTokenSrc =
-                                (Map<String, Object>) supersedingTokenSource.get("refresh_token");
-                            final String supersedingRefreshTokenValue = (String) supersedingRefreshTokenSrc.get("token");
-                            reIssueTokens(supersedingUserTokenSource, supersedingRefreshTokenValue, listener);
-                        } else {
-                            // We retry this since the creation of the superseding token document might already be in flight but not
-                            // yet completed, triggered by a refresh request that came a few milliseconds ago
-                            logger.info("could not find superseding token document [{}] for token document [{}], retrying",
-                                    supersedingTokenDocId, tokenDocId);
-                            maybeRetryOnFailure.accept(invalidGrantException("could not refresh the requested token"));
-                        }
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        if (isShardNotAvailableException(e)) {
-                            logger.info("could not find superseding token document [{}] for refresh, retrying", supersedingTokenDocId);
-                            maybeRetryOnFailure.accept(invalidGrantException("could not refresh the requested token"));
-                        } else {
-                            logger.warn("could not find superseding token document [{}] for refresh", supersedingTokenDocId);
-                            onFailure.accept(invalidGrantException("could not refresh the requested token"));
-                        }
+        final Tuple<RefreshTokenStatus, Optional<ElasticsearchSecurityException>> checkRefreshResult;
+        try {
+            checkRefreshResult = checkTokenDocumentForRefresh(clock.instant(), clientAuth, source);
+        } catch (DateTimeException | IllegalStateException e) {
+            onFailure.accept(new ElasticsearchSecurityException("invalid token document", e));
+            return;
+        }
+        if (checkRefreshResult.v2().isPresent()) {
+            onFailure.accept(checkRefreshResult.v2().get());
+            return;
+        }
+        final RefreshTokenStatus refreshTokenStatus = checkRefreshResult.v1();
+        if (refreshTokenStatus.isRefreshed()) {
+            logger.debug("Token document [{}] was recently refreshed, when a new token document [{}] was generated. Reusing that result.",
+                    tokenDocId, refreshTokenStatus.getSupersedingDocId());
+            getTokenDocAsync(refreshTokenStatus.getSupersedingDocId(), new ActionListener<GetResponse>() {
+                private final Consumer<Exception> maybeRetryOnFailure = ex -> {
+                    if (backoff.hasNext()) {
+                        final TimeValue backofTimeValue = backoff.next();
+                        logger.debug("retrying after [" + backofTimeValue + "] back off");
+                        final Runnable retryWithContextRunnable = client.threadPool().getThreadContext()
+                                .preserveContext(() -> getTokenDocAsync(refreshTokenStatus.getSupersedingDocId(), this));
+                        client.threadPool().schedule(retryWithContextRunnable, backofTimeValue, GENERIC);
+                    } else {
+                        logger.warn("back off retries exhausted");
+                        onFailure.accept(ex);
                     }
                 };
-                getTokenDocAsync(supersedingTokenDocId, getSupersedingListener);
-            } else {
-                final Map<String, Object> userTokenSource = (Map<String, Object>)
-                    ((Map<String, Object>) source.get("access_token")).get("user_token");
-                final String authString = (String) userTokenSource.get("authentication");
-                final Integer version = (Integer) userTokenSource.get("version");
-                final Map<String, Object> metadata = (Map<String, Object>) userTokenSource.get("metadata");
-                Version authVersion = Version.fromId(version);
-                Authentication authentication;
-                try (StreamInput in = StreamInput.wrap(Base64.getDecoder().decode(authString))) {
-                    in.setVersion(authVersion);
-                    authentication = new Authentication(in);
-                } catch (IOException e) {
-                    logger.error("failed to decode the authentication stored with token document [{}]", tokenDocId);
-                    onFailure.accept(invalidGrantException("could not refresh the requested token"));
-                    return;
+
+                @Override
+                public void onResponse(GetResponse response) {
+                    if (response.isExists()) {
+                        logger.debug("found superseding token document [{}] for token document [{}]",
+                                refreshTokenStatus.getSupersedingDocId(), tokenDocId);
+                        final Tuple<UserToken, String> parsedTokens;
+                        try {
+                            parsedTokens = parseTokensFromDocument(response.getSource(), null);
+                        } catch (IllegalStateException | DateTimeException e) {
+                            logger.error("unable to decode existing user token", e);
+                            listener.onFailure(new ElasticsearchSecurityException("could not refresh the requested token", e));
+                            return;
+                        }
+                        listener.onResponse(parsedTokens);
+                    } else {
+                        // We retry this since the creation of the superseding token document might already be in flight but not
+                        // yet completed, triggered by a refresh request that came a few milliseconds ago
+                        logger.info("could not find superseding token document [{}] for token document [{}], retrying",
+                                refreshTokenStatus.getSupersedingDocId(), tokenDocId);
+                        maybeRetryOnFailure.accept(invalidGrantException("could not refresh the requested token"));
+                    }
                 }
-                final String newUserTokenId = UUIDs.randomBase64UUID();
-                final Instant refreshTime = clock.instant();
-                Map<String, Object> updateMap = new HashMap<>();
-                updateMap.put("refreshed", true);
-                updateMap.put("refresh_time", refreshTime.toEpochMilli());
-                updateMap.put("superseded_by", getTokenDocumentId(newUserTokenId));
-                UpdateRequestBuilder updateRequest =
-                    client.prepareUpdate(SecurityIndexManager.SECURITY_INDEX_NAME, SINGLE_MAPPING_NAME, tokenDocId)
-                        .setDoc("refresh_token", updateMap)
-                        .setFetchSource(true)
-                        .setRefreshPolicy(RefreshPolicy.IMMEDIATE);
-                assert seqNo != SequenceNumbers.UNASSIGNED_SEQ_NO : "expected an assigned sequence number";
-                updateRequest.setIfSeqNo(seqNo);
-                assert primaryTerm != SequenceNumbers.UNASSIGNED_PRIMARY_TERM : "expected an assigned primary term";
-                updateRequest.setIfPrimaryTerm(primaryTerm);
-                executeAsyncWithOrigin(client.threadPool().getThreadContext(), SECURITY_ORIGIN, updateRequest.request(),
-                    ActionListener.<UpdateResponse>wrap(
-                        updateResponse -> {
-                            if (updateResponse.getResult() == DocWriteResponse.Result.UPDATED) {
-                                logger.debug("updated the original token document to {}", updateResponse.getGetResult().sourceAsMap());
-                                createUserToken(newUserTokenId, authentication, clientAuth, listener, metadata, true);
-                            } else if (backoff.hasNext()) {
-                                logger.info("failed to update the original token document [{}], the update result was [{}]. Retrying",
+
+                @Override
+                public void onFailure(Exception e) {
+                    if (isShardNotAvailableException(e)) {
+                        logger.info("could not find superseding token document [{}] for refresh, retrying",
+                                refreshTokenStatus.getSupersedingDocId());
+                        maybeRetryOnFailure.accept(invalidGrantException("could not refresh the requested token"));
+                    } else {
+                        logger.warn("could not find superseding token document [{}] for refresh", refreshTokenStatus.getSupersedingDocId());
+                        onFailure.accept(invalidGrantException("could not refresh the requested token"));
+                    }
+                }
+            });
+        } else {
+            final String newUserTokenId = UUIDs.randomBase64UUID();
+            final Map<String, Object> updateMap = new HashMap<>();
+            updateMap.put("refreshed", true);
+            updateMap.put("refresh_time", clock.instant().toEpochMilli());
+            updateMap.put("superseded_by", getTokenDocumentId(newUserTokenId));
+            assert seqNo != SequenceNumbers.UNASSIGNED_SEQ_NO : "expected an assigned sequence number";
+            assert primaryTerm != SequenceNumbers.UNASSIGNED_PRIMARY_TERM : "expected an assigned primary term";
+            final UpdateRequestBuilder updateRequest = client.prepareUpdate(SECURITY_INDEX_NAME, SINGLE_MAPPING_NAME, tokenDocId)
+                    .setDoc("refresh_token", updateMap)
+                    .setFetchSource(true)
+                    .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                    .setIfSeqNo(seqNo)
+                    .setIfPrimaryTerm(primaryTerm);
+            executeAsyncWithOrigin(client.threadPool().getThreadContext(), SECURITY_ORIGIN, updateRequest.request(),
+                    ActionListener.<UpdateResponse>wrap(updateResponse -> {
+                        if (updateResponse.getResult() == DocWriteResponse.Result.UPDATED) {
+                            logger.debug(() -> new ParameterizedMessage("updated the original token document to {}",
+                                    updateResponse.getGetResult().sourceAsMap()));
+                            final Tuple<UserToken, String> parsedTokens = parseTokensFromDocument(source, null);
+                            final UserToken toRefreshUserToken = parsedTokens.v1();
+                            createOAuth2Tokens(newUserTokenId, toRefreshUserToken.getAuthentication(), clientAuth,
+                                    toRefreshUserToken.getMetadata(), true, listener);
+                        } else if (backoff.hasNext()) {
+                            logger.info("failed to update the original token document [{}], the update result was [{}]. Retrying",
                                     tokenDocId, updateResponse.getResult());
-                                final Runnable retryWithContextRunnable = client.threadPool().getThreadContext()
-                                        .preserveContext(() -> innerRefresh(tokenDocId, source, seqNo, primaryTerm, clientAuth, listener,
-                                                backoff, refreshRequested));
-                                client.threadPool().schedule(retryWithContextRunnable, backoff.next(), GENERIC);
-                            } else {
-                                logger.info("failed to update the original token document [{}] after all retries, " +
-                                    "the update result was [{}]. ", tokenDocId, updateResponse.getResult());
-                                listener.onFailure(invalidGrantException("could not refresh the requested token"));
-                            }
-                        }, e -> {
-                            Throwable cause = ExceptionsHelper.unwrapCause(e);
-                            if (cause instanceof VersionConflictEngineException) {
-                                //The document has been updated by another thread, get it again.
-                                logger.debug("version conflict while updating document [{}], attempting to get it again", tokenDocId);
-                                final ActionListener<GetResponse> getListener = new ActionListener<GetResponse>() {
-                                    @Override
-                                    public void onResponse(GetResponse response) {
-                                        if (response.isExists()) {
-                                            innerRefresh(tokenDocId, response.getSource(), response.getSeqNo(), response.getPrimaryTerm(),
-                                                    clientAuth, listener, backoff, refreshRequested);
+                            final Runnable retryWithContextRunnable = client.threadPool().getThreadContext()
+                                    .preserveContext(() -> innerRefresh(tokenDocId, source, seqNo, primaryTerm, clientAuth, backoff,
+                                            refreshRequested, listener));
+                            client.threadPool().schedule(retryWithContextRunnable, backoff.next(), GENERIC);
+                        } else {
+                            logger.info("failed to update the original token document [{}] after all retries, the update result was [{}]. ",
+                                    tokenDocId, updateResponse.getResult());
+                            listener.onFailure(invalidGrantException("could not refresh the requested token"));
+                        }
+                    }, e -> {
+                        Throwable cause = ExceptionsHelper.unwrapCause(e);
+                        if (cause instanceof VersionConflictEngineException) {
+                            // The document has been updated by another thread, get it again.
+                            logger.debug("version conflict while updating document [{}], attempting to get it again", tokenDocId);
+                            getTokenDocAsync(tokenDocId, new ActionListener<GetResponse>() {
+                                @Override
+                                public void onResponse(GetResponse response) {
+                                    if (response.isExists()) {
+                                        innerRefresh(tokenDocId, response.getSource(), response.getSeqNo(), response.getPrimaryTerm(),
+                                                clientAuth, backoff, refreshRequested, listener);
+                                    } else {
+                                        logger.warn("could not find token document [{}] for refresh", tokenDocId);
+                                        onFailure.accept(invalidGrantException("could not refresh the requested token"));
+                                    }
+                                }
+
+                                @Override
+                                public void onFailure(Exception e) {
+                                    if (isShardNotAvailableException(e)) {
+                                        if (backoff.hasNext()) {
+                                            logger.info("could not get token document [{}] for refresh, retrying", tokenDocId);
+                                            final Runnable retryWithContextRunnable = client.threadPool().getThreadContext()
+                                                    .preserveContext(() -> getTokenDocAsync(tokenDocId, this));
+                                            client.threadPool().schedule(retryWithContextRunnable, backoff.next(), GENERIC);
                                         } else {
-                                            logger.warn("could not find token document [{}] for refresh", tokenDocId);
+                                            logger.warn("could not get token document [{}] for refresh after all retries", tokenDocId);
                                             onFailure.accept(invalidGrantException("could not refresh the requested token"));
                                         }
+                                    } else {
+                                        onFailure.accept(e);
                                     }
-
-                                    @Override
-                                    public void onFailure(Exception e) {
-                                        if (isShardNotAvailableException(e)) {
-                                            if (backoff.hasNext()) {
-                                                logger.info("could not get token document [{}] for refresh, retrying", tokenDocId);
-                                                final Runnable retryWithContextRunnable = client.threadPool().getThreadContext()
-                                                        .preserveContext(() -> getTokenDocAsync(tokenDocId, this));
-                                                client.threadPool().schedule(retryWithContextRunnable, backoff.next(), GENERIC);
-                                            } else {
-                                                logger.warn("could not get token document [{}] for refresh after all retries", tokenDocId);
-                                                onFailure.accept(invalidGrantException("could not refresh the requested token"));
-                                            }
-                                        } else {
-                                            onFailure.accept(e);
-                                        }
-                                    }
-                                };
-                                getTokenDocAsync(tokenDocId, getListener);
-                            } else if (isShardNotAvailableException(e)) {
-                                if (backoff.hasNext()) {
-                                    logger.debug("failed to update the original token document [{}], retrying", tokenDocId);
-                                    final Runnable retryWithContextRunnable = client.threadPool().getThreadContext().preserveContext(
-                                            () -> innerRefresh(tokenDocId, source, seqNo, primaryTerm, clientAuth, listener, backoff,
-                                                    refreshRequested));
-                                    client.threadPool().schedule(retryWithContextRunnable, backoff.next(), GENERIC);
-                                } else {
-                                    logger.warn("failed to update the original token document [{}], after all retries", tokenDocId);
-                                    onFailure.accept(invalidGrantException("could not refresh the requested token"));
                                 }
+                            });
+                        } else if (isShardNotAvailableException(e)) {
+                            if (backoff.hasNext()) {
+                                logger.debug("failed to update the original token document [{}], retrying", tokenDocId);
+                                final Runnable retryWithContextRunnable = client.threadPool().getThreadContext()
+                                        .preserveContext(() -> innerRefresh(tokenDocId, source, seqNo, primaryTerm, clientAuth, backoff,
+                                                refreshRequested, listener));
+                                client.threadPool().schedule(retryWithContextRunnable, backoff.next(), GENERIC);
                             } else {
-                                onFailure.accept(e);
+                                logger.warn("failed to update the original token document [{}], after all retries", tokenDocId);
+                                onFailure.accept(invalidGrantException("could not refresh the requested token"));
                             }
-                        }),
-                    client::update);
-            }
+                        } else {
+                            onFailure.accept(e);
+                        }
+                    }), client::update);
         }
     }
 
     private void getTokenDocAsync(String tokenDocId, ActionListener<GetResponse> listener) {
-        GetRequest getRequest =
-            client.prepareGet(SECURITY_INDEX_NAME, SINGLE_MAPPING_NAME, tokenDocId).request();
+        final GetRequest getRequest = client.prepareGet(SECURITY_INDEX_NAME, SINGLE_MAPPING_NAME, tokenDocId).request();
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), SECURITY_ORIGIN, getRequest, listener, client::get);
     }
 
     /**
-     * Performs checks on the retrieved source and returns an {@link Optional} with the exception
-     * if there is an issue that makes the retrieved token unsuitable to be refreshed
+     * A refresh token has a hardcoded maximum lifetime of 24h. This checks if the token document represents a valid token wrt this time
+     * interval.
      */
-    private Optional<ElasticsearchSecurityException> checkTokenDocForRefresh(Map<String, Object> source, Authentication clientAuth) {
-        final Map<String, Object> refreshTokenSrc = (Map<String, Object>) source.get("refresh_token");
-        final Map<String, Object> accessTokenSrc = (Map<String, Object>) source.get("access_token");
-        if (refreshTokenSrc == null || refreshTokenSrc.isEmpty()) {
-            return Optional.of(invalidGrantException("token document is missing the refresh_token object"));
-        } else if (accessTokenSrc == null || accessTokenSrc.isEmpty()) {
-            return Optional.of(invalidGrantException("token document is missing the access_token object"));
+    private static Optional<ElasticsearchSecurityException> checkTokenDocumentExpired(Instant now, Map<String, Object> source) {
+        final Long creationEpochMilli = (Long) source.get("creation_time");
+        if (creationEpochMilli == null) {
+            throw new IllegalStateException("token document is missing creation time value");
         } else {
-            final Boolean refreshed = (Boolean) refreshTokenSrc.get("refreshed");
-            final Boolean invalidated = (Boolean) refreshTokenSrc.get("invalidated");
-            final Long creationEpochMilli = (Long) source.get("creation_time");
-            final Instant creationTime = creationEpochMilli == null ? null : Instant.ofEpochMilli(creationEpochMilli);
-            final Map<String, Object> userTokenSrc = (Map<String, Object>) accessTokenSrc.get("user_token");
-            if (refreshed == null) {
-                return Optional.of(invalidGrantException("token document is missing refreshed value"));
-            } else if (invalidated == null) {
-                return Optional.of(invalidGrantException("token document is missing invalidated value"));
-            } else if (creationEpochMilli == null) {
-                return Optional.of(invalidGrantException("token document is missing creation time value"));
-            } else if (invalidated) {
-                return Optional.of(invalidGrantException("token has been invalidated"));
-            } else if (clock.instant().isAfter(creationTime.plus(24L, ChronoUnit.HOURS))) {
-                return Optional.of(invalidGrantException("refresh token is expired"));
-            } else if (userTokenSrc == null || userTokenSrc.isEmpty()) {
-                return Optional.of(invalidGrantException("token document is missing the user token info"));
-            } else if (userTokenSrc.get("authentication") == null) {
-                return Optional.of(invalidGrantException("token is missing authentication info"));
-            } else if (userTokenSrc.get("version") == null) {
-                return Optional.of(invalidGrantException("token is missing version value"));
-            } else if (userTokenSrc.get("metadata") == null) {
-                return Optional.of(invalidGrantException("token is missing metadata"));
+            final Instant creationTime = Instant.ofEpochMilli(creationEpochMilli);
+            if (now.isAfter(creationTime.plus(24L, ChronoUnit.HOURS))) {
+                return Optional.of(invalidGrantException("token document has expired"));
             } else {
-                return checkLenientlyIfTokenAlreadyRefreshed(source, clientAuth);
+                return Optional.empty();
             }
         }
     }
 
-    private Optional<ElasticsearchSecurityException> checkClient(Map<String, Object> refreshTokenSource, Authentication clientAuth) {
-        Map<String, Object> clientInfo = (Map<String, Object>) refreshTokenSource.get("client");
-        if (clientInfo == null) {
-            return Optional.of(invalidGrantException("token is missing client information"));
-        } else if (clientAuth.getUser().principal().equals(clientInfo.get("user")) == false) {
-            logger.warn("Token was originally created by [{}] but [{}] attempted to refresh it", clientInfo.get("user"),
-                clientAuth.getUser().principal());
+    /**
+     * Parses the {@code RefreshTokenStatus} from the token document and throws an exception if the document is malformed. Returns the
+     * parsed {@code RefreshTokenStatus} together with an {@code Optional} validation exception that encapsulates the various logic about
+     * when and by who a token can be refreshed.
+     */
+    private static Tuple<RefreshTokenStatus, Optional<ElasticsearchSecurityException>> checkTokenDocumentForRefresh(Instant now,
+            Authentication clientAuth, Map<String, Object> source) throws IllegalStateException, DateTimeException {
+        final RefreshTokenStatus refreshTokenStatus = RefreshTokenStatus.fromSourceMap(getRefreshTokenSourceMap(source));
+        final UserToken userToken = UserToken.fromSourceMap(getUserTokenSourceMap(source));
+        final ElasticsearchSecurityException validationException = checkTokenDocumentExpired(now, source).orElseGet(() -> {
+            if (refreshTokenStatus.isInvalidated()) {
+                return invalidGrantException("token has been invalidated");
+            } else {
+                return checkClientCanRefresh(refreshTokenStatus, clientAuth)
+                        .orElse(checkMultipleRefreshes(now, refreshTokenStatus, userToken).orElse(null));
+            }
+        });
+        return new Tuple<>(refreshTokenStatus, Optional.ofNullable(validationException));
+    }
+
+    /**
+     * Refresh tokens are bound to be used only by the client that originally created them. This check validates this condition, given the
+     * {@code Authentication} of the client that attempted the refresh operation.
+     */
+    private static Optional<ElasticsearchSecurityException> checkClientCanRefresh(RefreshTokenStatus refreshToken,
+                                                                                  Authentication clientAuthentication) {
+        if (clientAuthentication.getUser().principal().equals(refreshToken.getAssociatedUser()) == false) {
+            logger.warn("Token was originally created by [{}] but [{}] attempted to refresh it", refreshToken.getAssociatedUser(),
+                    clientAuthentication.getUser().principal());
             return Optional.of(invalidGrantException("tokens must be refreshed by the creating client"));
-        } else if (clientAuth.getAuthenticatedBy().getName().equals(clientInfo.get("realm")) == false) {
+        } else if (clientAuthentication.getAuthenticatedBy().getName().equals(refreshToken.getAssociatedRealm()) == false) {
             logger.warn("[{}] created the refresh token while authenticated by [{}] but is now authenticated by [{}]",
-                clientInfo.get("user"), clientInfo.get("realm"), clientAuth.getAuthenticatedBy().getName());
+                    refreshToken.getAssociatedUser(), refreshToken.getAssociatedRealm(),
+                    clientAuthentication.getAuthenticatedBy().getName());
             return Optional.of(invalidGrantException("tokens must be refreshed by the creating client"));
         } else {
             return Optional.empty();
         }
     }
 
+    private static Map<String, Object> getRefreshTokenSourceMap(Map<String, Object> source) {
+        final Map<String, Object> refreshTokenSource = (Map<String, Object>) source.get("refresh_token");
+        if (refreshTokenSource == null || refreshTokenSource.isEmpty()) {
+            throw new IllegalStateException("token document is missing the refresh_token object");
+        }
+        return refreshTokenSource;
+    }
+
+    private static Map<String, Object> getUserTokenSourceMap(Map<String, Object> source) {
+        final Map<String, Object> accessTokenSource = (Map<String, Object>) source.get("access_token");
+        if (accessTokenSource == null || accessTokenSource.isEmpty()) {
+            throw new IllegalStateException("token document is missing the access_token object");
+        }
+        final Map<String, Object> userTokenSource = (Map<String, Object>) accessTokenSource.get("user_token");
+        if (userTokenSource == null || userTokenSource.isEmpty()) {
+            throw new IllegalStateException("token document is missing the user token info");
+        }
+        return userTokenSource;
+    }
+
     /**
-     * Checks if the retrieved refresh token is already refreshed taking into consideration that we allow refresh tokens
-     * to be refreshed multiple times for a very small time window in order to gracefully handle multiple concurrent requests
-     * from clients
+     * Checks if the token can be refreshed once more. If a token has previously been refreshed, it can only by refreshed again inside a
+     * short span of time (30 s).
+     * 
+     * @return An {@code Optional} containing the exception in case this refresh token cannot be reused, or an empty <b>Optional</b> if
+     *         refreshing is allowed.
      */
-    @SuppressWarnings("unchecked")
-    private Optional<ElasticsearchSecurityException> checkLenientlyIfTokenAlreadyRefreshed(Map<String, Object> source,
-                                                                                           Authentication userAuth) {
-        final Map<String, Object> refreshTokenSrc = (Map<String, Object>) source.get("refresh_token");
-        final Map<String, Object> userTokenSource = (Map<String, Object>)
-            ((Map<String, Object>) source.get("access_token")).get("user_token");
-        final Integer version = (Integer) userTokenSource.get("version");
-        Version authVersion = Version.fromId(version);
-        final Boolean refreshed = (Boolean) refreshTokenSrc.get("refreshed");
-        if (refreshed) {
-            if (authVersion.onOrAfter(Version.V_7_1_0)) {
-                final Long refreshedEpochMilli = (Long) refreshTokenSrc.get("refresh_time");
-                final Instant refreshTime = refreshedEpochMilli == null ? null : Instant.ofEpochMilli(refreshedEpochMilli);
-                final String supersededBy = (String) refreshTokenSrc.get("superseded_by");
-                if (supersededBy == null) {
-                    return Optional.of(invalidGrantException("token document is missing superseded by value"));
-                } else if (refreshTime == null) {
-                    return Optional.of(invalidGrantException("token document is missing refresh time value"));
-                } else if (clock.instant().isAfter(refreshTime.plus(30L, ChronoUnit.SECONDS))) {
+    private static Optional<ElasticsearchSecurityException> checkMultipleRefreshes(Instant now, RefreshTokenStatus refreshToken,
+                                                                                   UserToken userToken) {
+        if (refreshToken.isRefreshed()) {
+            if (userToken.getVersion().onOrAfter(Version.V_7_1_0)) {
+                if (now.isAfter(refreshToken.getRefreshInstant().plus(30L, ChronoUnit.SECONDS))) {
                     return Optional.of(invalidGrantException("token has already been refreshed more than 30 seconds in the past"));
+                }
+                if (now.isBefore(refreshToken.getRefreshInstant().minus(30L, ChronoUnit.SECONDS))) {
+                    return Optional
+                            .of(invalidGrantException("token has been refreshed more than 30 seconds in the future, clock skew too great"));
                 }
             } else {
                 return Optional.of(invalidGrantException("token has already been refreshed"));
             }
         }
-        return checkClient(refreshTokenSrc, userAuth);
-    }
-
-    /**
-     * Checks if a refreshed token is eligible to be refreshed again. This is only allowed for versions after 7.1.0 and
-     * when the refresh_token contains the refresh_time and superseded_by fields and it has been refreshed in a specific
-     * time period of 60 seconds. The period is defined as 30 seconds before the token was refreshed until 30 seconds after. The
-     * time window needs to handle instants before the request time as we capture an instant early on in
-     * {@link TokenService#refreshToken(String, ActionListener)} and in the case of multiple concurrent requests,
-     * the {@code refreshRequested} when dealing with one of the subsequent requests might well be <em>before</em> the instant when
-     * the first of the requests refreshed the token.
-     *
-     * @param source The source of the token document that contains the originally refreshed token
-     * @param refreshRequested The instant when the this refresh request was acknowledged by the TokenService
-     */
-    private boolean eligibleForMultiRefresh(Map<String, Object> source, Instant refreshRequested) {
-        final Map<String, Object> refreshTokenSrc = (Map<String, Object>) source.get("refresh_token");
-        final Map<String, Object> userTokenSource = (Map<String, Object>)
-            ((Map<String, Object>) source.get("access_token")).get("user_token");
-        final Integer version = (Integer) userTokenSource.get("version");
-        Version authVersion = Version.fromId(version);
-        final Long refreshedEpochMilli = (Long) refreshTokenSrc.get("refresh_time");
-        final Instant refreshTime = refreshedEpochMilli == null ? null : Instant.ofEpochMilli(refreshedEpochMilli);
-        final String supersededBy = (String) refreshTokenSrc.get("superseded_by");
-        return authVersion.onOrAfter(Version.V_7_1_0)
-            && supersededBy != null
-            && refreshTime != null
-            && refreshRequested.isBefore(refreshTime.plus(30L, ChronoUnit.SECONDS))
-            && refreshRequested.isAfter(refreshTime.minus(30L, ChronoUnit.SECONDS));
+        return Optional.empty();
     }
 
     /**
@@ -1099,11 +1055,11 @@ public final class TokenService {
      * the specified realm.
      *
      * @param realmName The name of the realm for which to get the tokens
-     * @param listener  The listener to notify upon completion
      * @param filter    an optional Predicate to test the source of the found documents against
+     * @param listener  The listener to notify upon completion
      */
-    public void findActiveTokensForRealm(String realmName, ActionListener<Collection<Tuple<UserToken, String>>> listener,
-                                         @Nullable Predicate<Map<String, Object>> filter) {
+    public void findActiveTokensForRealm(String realmName, @Nullable Predicate<Map<String, Object>> filter,
+                                         ActionListener<Collection<Tuple<UserToken, String>>> listener) {
         ensureEnabled();
         final SecurityIndexManager frozenSecurityIndex = securityIndex.freeze();
         if (Strings.isNullOrEmpty(realmName)) {
@@ -1199,17 +1155,13 @@ public final class TokenService {
         };
     }
 
-
-    private Tuple<UserToken, String> filterAndParseHit(SearchHit hit, @Nullable Predicate<Map<String, Object>> filter) {
+    private Tuple<UserToken, String> filterAndParseHit(SearchHit hit, @Nullable Predicate<Map<String, Object>> filter)
+            throws IllegalStateException, DateTimeException {
         final Map<String, Object> source = hit.getSourceAsMap();
         if (source == null) {
             throw new IllegalStateException("token document did not have source but source should have been fetched");
         }
-        try {
-            return parseTokensFromDocument(source, filter);
-        } catch (IOException e) {
-            throw invalidGrantException("cannot read token from document");
-        }
+        return parseTokensFromDocument(source, filter);
     }
 
     /**
@@ -1221,26 +1173,14 @@ public final class TokenService {
      * satisfy it
      */
     private Tuple<UserToken, String> parseTokensFromDocument(Map<String, Object> source, @Nullable Predicate<Map<String, Object>> filter)
-        throws IOException {
+            throws IllegalStateException, DateTimeException {
         final String refreshToken = (String) ((Map<String, Object>) source.get("refresh_token")).get("token");
         final Map<String, Object> userTokenSource = (Map<String, Object>)
             ((Map<String, Object>) source.get("access_token")).get("user_token");
         if (null != filter && filter.test(userTokenSource) == false) {
             return null;
         }
-        final String id = (String) userTokenSource.get("id");
-        final Integer version = (Integer) userTokenSource.get("version");
-        final String authString = (String) userTokenSource.get("authentication");
-        final Long expiration = (Long) userTokenSource.get("expiration_time");
-        final Map<String, Object> metadata = (Map<String, Object>) userTokenSource.get("metadata");
-
-        Version authVersion = Version.fromId(version);
-        try (StreamInput in = StreamInput.wrap(Base64.getDecoder().decode(authString))) {
-            in.setVersion(authVersion);
-            Authentication authentication = new Authentication(in);
-            return new Tuple<>(new UserToken(id, Version.fromId(version), authentication, Instant.ofEpochMilli(expiration), metadata),
-                refreshToken);
-        }
+        return new Tuple<>(UserToken.fromSourceMap(userTokenSource), refreshToken);
     }
 
     private static String getTokenDocumentId(UserToken userToken) {
@@ -1274,7 +1214,7 @@ public final class TokenService {
             listener.onFailure(traceLog("validate token", userToken.getId(), expiredTokenException()));
         } else if (securityIndex.indexExists() == false) {
             // index doesn't exist so the token is considered invalid as we cannot verify its validity
-            logger.warn("failed to validate token [{}] since the security index doesn't exist", userToken.getId());
+            logger.warn("failed to validate access token because the security index doesn't exist");
             listener.onResponse(null);
         } else {
             securityIndex.checkIndexVersionThenExecute(listener::onFailure, () -> {
@@ -1305,7 +1245,7 @@ public final class TokenService {
                         // if the index or the shard is not there / available we assume that
                         // the token is not valid
                         if (isShardNotAvailableException(e)) {
-                            logger.warn("failed to get token [{}] since index is not available", userToken.getId());
+                            logger.warn("failed to get access token because index is not available");
                             listener.onResponse(null);
                         } else {
                             logger.error(new ParameterizedMessage("failed to get token [{}]", userToken.getId()), e);
@@ -1404,8 +1344,7 @@ public final class TokenService {
         return cipher;
     }
 
-    private Cipher getDecryptionCipher(byte[] iv, SecretKey key, Version version,
-                                       BytesKey salt) throws GeneralSecurityException {
+    private Cipher getDecryptionCipher(byte[] iv, SecretKey key, Version version, BytesKey salt) throws GeneralSecurityException {
         Cipher cipher = Cipher.getInstance(ENCRYPTION_CIPHER);
         cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, iv), secureRandom);
         cipher.updateAAD(ByteBuffer.allocate(4).putInt(version.id).array());
@@ -1520,13 +1459,13 @@ public final class TokenService {
     private class KeyComputingRunnable extends AbstractRunnable {
 
         private final BytesKey decodedSalt;
-        private final ActionListener<SecretKey> listener;
         private final KeyAndCache keyAndCache;
+        private final ActionListener<SecretKey> listener;
 
-        KeyComputingRunnable(BytesKey decodedSalt, ActionListener<SecretKey> listener, KeyAndCache keyAndCache) {
+        KeyComputingRunnable(BytesKey decodedSalt, KeyAndCache keyAndCache, ActionListener<SecretKey> listener) {
             this.decodedSalt = decodedSalt;
-            this.listener = listener;
             this.keyAndCache = keyAndCache;
+            this.listener = listener;
         }
 
         @Override
@@ -1656,7 +1595,7 @@ public final class TokenService {
         }
         createdTimeStamps.set(maxTimestamp);
         keyCache = new TokenKeys(Collections.unmodifiableMap(map), currentUsedKeyHash);
-        logger.debug("refreshed keys current: {}, keys: {}", currentUsedKeyHash, keyCache.cache.keySet());
+        logger.debug(() -> new ParameterizedMessage("refreshed keys current: {}, keys: {}", currentUsedKeyHash, keyCache.cache.keySet()));
     }
 
     private SecureString generateTokenKey() {
@@ -1685,22 +1624,22 @@ public final class TokenService {
         TokenMetaData tokenMetaData = generateSpareKey();
         clusterService.submitStateUpdateTask("publish next key to prepare key rotation",
             new TokenMetadataPublishAction(
-                ActionListener.wrap((res) -> {
+                tokenMetaData, ActionListener.wrap((res) -> {
                     if (res.isAcknowledged()) {
                         TokenMetaData metaData = rotateToSpareKey();
                         clusterService.submitStateUpdateTask("publish next key to prepare key rotation",
-                            new TokenMetadataPublishAction(listener, metaData));
+                            new TokenMetadataPublishAction(metaData, listener));
                     } else {
                         listener.onFailure(new IllegalStateException("not acked"));
                     }
-                }, listener::onFailure), tokenMetaData));
+                }, listener::onFailure)));
     }
 
     private final class TokenMetadataPublishAction extends AckedClusterStateUpdateTask<ClusterStateUpdateResponse> {
 
         private final TokenMetaData tokenMetaData;
 
-        protected TokenMetadataPublishAction(ActionListener<ClusterStateUpdateResponse> listener, TokenMetaData tokenMetaData) {
+        protected TokenMetadataPublishAction(TokenMetaData tokenMetaData, ActionListener<ClusterStateUpdateResponse> listener) {
             super(new AckedRequest() {
                 @Override
                 public TimeValue ackTimeout() {
@@ -1873,7 +1812,6 @@ public final class TokenService {
         }
     }
 
-
     private static final class TokenKeys {
         final Map<BytesKey, KeyAndCache> cache;
         final BytesKey currentTokenKeyHash;
@@ -1887,6 +1825,80 @@ public final class TokenService {
 
         KeyAndCache get(BytesKey passphraseHash) {
             return cache.get(passphraseHash);
+        }
+    }
+
+    /**
+     * Contains metadata associated with the refresh token that is used for validity checks, but does not contain the proper token string.
+     */
+    private static final class RefreshTokenStatus {
+
+        private final boolean invalidated;
+        private final String associatedUser;
+        private final String associatedRealm;
+        private final boolean refreshed;
+        @Nullable private final Instant refreshInstant;
+        @Nullable private final String supersededByDocId;
+
+        private RefreshTokenStatus(boolean invalidated, String associatedUser, String associatedRealm, boolean refreshed,
+                                   Instant refreshInstant, String supersededByDocId) {
+            this.invalidated = invalidated;
+            this.associatedUser = associatedUser;
+            this.associatedRealm = associatedRealm;
+            this.refreshed = refreshed;
+            this.refreshInstant = refreshInstant;
+            this.supersededByDocId = supersededByDocId;
+        }
+
+        boolean isInvalidated() {
+            return invalidated;
+        }
+
+        String getAssociatedUser() {
+            return associatedUser;
+        }
+
+        String getAssociatedRealm() {
+            return associatedRealm;
+        }
+
+        boolean isRefreshed() {
+            return refreshed;
+        }
+
+        @Nullable Instant getRefreshInstant() {
+            return refreshInstant;
+        }
+
+        @Nullable String getSupersedingDocId() {
+            return supersededByDocId;
+        }
+
+        static RefreshTokenStatus fromSourceMap(Map<String, Object> refreshTokenSource) {
+            final Boolean invalidated = (Boolean) refreshTokenSource.get("invalidated");
+            if (invalidated == null) {
+                throw new IllegalStateException("token document is missing the \"invalidated\" field");
+            }
+            final Map<String, Object> clientInfo = (Map<String, Object>) refreshTokenSource.get("client");
+            if (clientInfo == null) {
+                throw new IllegalStateException("token document is missing the \"client\" field");
+            }
+            if (false == clientInfo.containsKey("user")) {
+                throw new IllegalStateException("token document is missing the \"client.user\" field");
+            }
+            final String associatedUser = (String) clientInfo.get("user");
+            if (false == clientInfo.containsKey("realm")) {
+                throw new IllegalStateException("token document is missing the \"client.realm\" field");
+            }
+            final String associatedRealm = (String) clientInfo.get("realm");
+            final Boolean refreshed = (Boolean) refreshTokenSource.get("refreshed");
+            if (refreshed == null) {
+                throw new IllegalStateException("token document is missing the \"refreshed\" field");
+            }
+            final Long refreshEpochMilli = (Long) refreshTokenSource.get("refresh_time");
+            final Instant refreshInstant = refreshEpochMilli == null ? null : Instant.ofEpochMilli(refreshEpochMilli);
+            final String supersededBy = (String) refreshTokenSource.get("superseded_by");
+            return new RefreshTokenStatus(invalidated, associatedUser, associatedRealm, refreshed, refreshInstant, supersededBy);
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/UserToken.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/UserToken.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 
 import java.io.IOException;
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.Collections;
@@ -140,17 +141,31 @@ public final class UserToken implements Writeable, ToXContentObject {
         return builder.endObject();
     }
 
-    static UserToken fromSourceMap(Map<String, Object> source) throws IOException {
+    static UserToken fromSourceMap(Map<String, Object> source) throws IllegalStateException, DateTimeException {
         final String id = (String) source.get("id");
+        if (id == null) {
+            throw new IllegalStateException("user token source document does not have the \"id\" field");
+        }
         final Long expirationEpochMilli = (Long) source.get("expiration_time");
+        if (expirationEpochMilli == null) {
+            throw new IllegalStateException("user token source document does not have the \"expiration_time\" field");
+        }
         final Integer versionId = (Integer) source.get("version");
+        if (versionId == null) {
+            throw new IllegalStateException("user token source document does not have the \"version\" field");
+        }
         final Map<String, Object> metadata = (Map<String, Object>) source.get("metadata");
         final String authString = (String) source.get("authentication");
+        if (authString == null) {
+            throw new IllegalStateException("user token source document does not have the \"authentication\" field");
+        }
         final Version version = Version.fromId(versionId);
         try (StreamInput in = StreamInput.wrap(Base64.getDecoder().decode(authString))) {
             in.setVersion(version);
             Authentication authentication = new Authentication(in);
             return new UserToken(id, version, authentication, Instant.ofEpochMilli(expirationEpochMilli), metadata);
+        } catch (IOException e) {
+            throw new IllegalStateException("user token source document contains malformed \"authentication\" field", e);
         }
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionActionTests.java
@@ -356,7 +356,7 @@ public class TransportSamlInvalidateSessionActionTests extends SamlTestCase {
                 new RealmRef("native", NativeRealmSettings.TYPE, "node01"), null);
         final Map<String, Object> metadata = samlRealm.createTokenMetadata(nameId, session);
         final PlainActionFuture<Tuple<UserToken, String>> future = new PlainActionFuture<>();
-        tokenService.createUserToken(authentication, authentication, future, metadata, true);
+        tokenService.createOAuth2Tokens(authentication, authentication, metadata, true, future);
         return future.actionGet();
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutActionTests.java
@@ -239,7 +239,7 @@ public class TransportSamlLogoutActionTests extends SamlTestCase {
                 new SamlNameId(NameID.TRANSIENT, nameId, null, null, null), session);
 
         final PlainActionFuture<Tuple<UserToken, String>> future = new PlainActionFuture<>();
-        tokenService.createUserToken(authentication, authentication, future, tokenMetaData, true);
+        tokenService.createOAuth2Tokens(authentication, authentication, tokenMetaData, true, future);
         final UserToken userToken = future.actionGet().v1();
         mockGetTokenFromId(userToken, false, client);
         final String tokenString = tokenService.getAccessTokenAsString(userToken);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
@@ -25,8 +25,10 @@ import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
@@ -110,7 +112,8 @@ public class TransportCreateTokenActionTests extends ESTestCase {
         doAnswer(invocationOnMock -> {
             idxReqReference.set((IndexRequest) invocationOnMock.getArguments()[1]);
             ActionListener<IndexResponse> responseActionListener = (ActionListener<IndexResponse>) invocationOnMock.getArguments()[2];
-            responseActionListener.onResponse(new IndexResponse());
+            responseActionListener.onResponse(new IndexResponse(new ShardId(".security", UUIDs.randomBase64UUID(), randomInt()), "_doc",
+                    randomAlphaOfLength(4), randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), true));
             return null;
         }).when(client).execute(eq(IndexAction.INSTANCE), any(IndexRequest.class), any(ActionListener.class));
 


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/39808

This refactoring is in the context of the work related to moving security
tokens to a new index. In that regard, the Token Service has to work with
token documents stored in any of the two indices, albeit only as a transient
situation. I reckoned the added complexity as unmanageable,
hence this refactoring.

This is incomplete, as it fails to address the goal of minimizing .security accesses,
but I have stopped because otherwise it would've become a full blown rewrite
(if not already). I will follow-up with more targeted PRs.

In addition to being a true refactoring, some 400 errors moved to 500. Furthermore,
more stringed validation of various return result, has been implemented, notably the
one of the token document creation.
