### PR TITLE
Only recommend disabling allocation of replicas in a rolling upgrade

### DIFF
--- a/docs/reference/upgrade/disable-shard-alloc.asciidoc
+++ b/docs/reference/upgrade/disable-shard-alloc.asciidoc
@@ -3,15 +3,16 @@ When you shut down a node, the allocation process waits for
 `index.unassigned.node_left.delayed_timeout` (by default, one minute) before
 starting to replicate the shards on that node to other nodes in the cluster,
 which can involve a lot of I/O.  Since the node is shortly going to be
-restarted, this I/O is unnecessary. You can avoid racing the clock by disabling
-allocation before shutting down the node:
+restarted, this I/O is unnecessary. You can avoid racing the clock by 
+<<shards-allocation, disabling allocation>> of replicas before shutting down
+the node:
 
 [source,js]
 --------------------------------------------------
 PUT _cluster/settings
 {
   "persistent": {
-    "cluster.routing.allocation.enable": "none"
+    "cluster.routing.allocation.enable": "primaries"
   }
 }
 --------------------------------------------------


### PR DESCRIPTION
The current documentation recommends disabling allocations of all shards. This prevents from shards of new indices to be allocated as well. That means that during a rolling upgrade, operations like roll over and index shrinking will operate correctly. This, in turn, can cause issues for data ingestion and ILM
