### PR TITLE
Support Geo Distance Query with 0-distance

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
@@ -156,8 +156,8 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
             throw new IllegalArgumentException("distance unit must not be null");
         }
         double newDistance = DistanceUnit.parse(distance, unit, DistanceUnit.DEFAULT);
-        if (newDistance <= 0.0) {
-            throw new IllegalArgumentException("distance must be greater than zero");
+        if (newDistance < 0.0) {
+            throw new IllegalArgumentException("distance must be greater than or equal to zero");
         }
         this.distance = newDistance;
         return this;

--- a/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -103,8 +103,8 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
         assertEquals("distance unit must not be null", e.getMessage());
 
         e = expectThrows(IllegalArgumentException.class, () -> query.distance(
-                randomIntBetween(Integer.MIN_VALUE, 0), DistanceUnit.DEFAULT));
-        assertEquals("distance must be greater than zero", e.getMessage());
+                randomIntBetween(Integer.MIN_VALUE, -1), DistanceUnit.DEFAULT));
+        assertEquals("distance must be greater than or equal to zero", e.getMessage());
 
         e = expectThrows(IllegalArgumentException.class, () -> query.geohash(null));
         assertEquals("geohash must not be null or empty", e.getMessage());


### PR DESCRIPTION
Hope it is OK that I haven't opened an issue for this first as the code change was pretty simple.
I would expect a 0-distance to be supported in the Geo Distance Query, basically as an exact match. I tried removing the validation and this seems to actually result in the behavior I was expecting.

If you want to proceed with this change, it would probably be a good idea to add a test case that verifies that a 0-distance query will match exact coordinates but I wasn't sure where to add this?

From a UI perspective I could see the distance in the Geo Distance Query following the value from a slider. If the slider value becomes 0 it seems IMO unexpected that the ES query will fail, especially considering that the 0-distance case seems like a valid case for exact match.