### PR TITLE
Fix MLT like text with custom frequencies, closes#40125

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/search/XMoreLikeThis.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/XMoreLikeThis.java
@@ -37,6 +37,7 @@ package org.elasticsearch.common.lucene.search;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.TermFrequencyAttribute;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.Fields;
@@ -893,6 +894,7 @@ public final class XMoreLikeThis {
             int tokenCount = 0;
             // for every token
             CharTermAttribute termAtt = ts.addAttribute(CharTermAttribute.class);
+            TermFrequencyAttribute tfAtt = ts.addAttribute(TermFrequencyAttribute.class);
             ts.reset();
             while (ts.incrementToken()) {
                 String word = termAtt.toString();
@@ -910,9 +912,9 @@ public final class XMoreLikeThis {
                 // increment frequency
                 Int cnt = termFreqMap.get(word);
                 if (cnt == null) {
-                    termFreqMap.put(word, new Int());
+                    termFreqMap.put(word, new Int(tfAtt.getTermFrequency()));
                 } else {
-                    cnt.x++;
+                    cnt.x += tfAtt.getTermFrequency();
                 }
             }
             ts.end();
@@ -1052,6 +1054,10 @@ public final class XMoreLikeThis {
 
         Int() {
             x = 1;
+        }
+
+        Int(int initialValue) {
+            x = initialValue;
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/lucene/search/morelikethis/MoreLikeThisQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/search/morelikethis/MoreLikeThisQueryTests.java
@@ -19,21 +19,39 @@
 
 package org.elasticsearch.common.lucene.search.morelikethis;
 
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.core.WhitespaceTokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.TermFrequencyAttribute;
+import org.apache.lucene.analysis.util.TokenFilterFactory;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.MoreLikeThisQuery;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.BiFunction;
+
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 
 public class MoreLikeThisQueryTests extends ESTestCase {
     public void testSimple() throws Exception {
@@ -63,5 +81,125 @@ public class MoreLikeThisQueryTests extends ESTestCase {
 
         reader.close();
         indexWriter.close();
+    }
+
+    public void testCustomFrequency() throws Exception {
+        Analyzer analyzer = new CustomFrequencyAnalyzer();
+
+        FieldType fieldType = new FieldType();
+        fieldType.setIndexOptions(IndexOptions.DOCS_AND_FREQS); // cannot index positions while using custom TermFrequencyAttribute
+        fieldType.setTokenized(true);
+        fieldType.setStored(true);
+        fieldType.freeze();
+
+        Directory dir = new RAMDirectory();
+        IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(analyzer));
+        indexWriter.commit();
+
+        Document document = new Document();
+        document.add(new TextField("_id", "1", Field.Store.YES));
+        document.add(new Field("text", "foo|1 bar|2", fieldType));
+        indexWriter.addDocument(document);
+
+        document = new Document();
+        document.add(new TextField("_id", "2", Field.Store.YES));
+        document.add(new Field("text", "foo|2 bar|1", fieldType));
+        indexWriter.addDocument(document);
+
+        IndexReader reader = DirectoryReader.open(indexWriter);
+        IndexSearcher searcher = new IndexSearcher(reader);
+
+        BiFunction<String, Integer, Query> makeQuery = (like, minTermFrequency) -> {
+            MoreLikeThisQuery mltQuery = new MoreLikeThisQuery(like, new String[]{"text"}, analyzer);
+            mltQuery.setMinTermFrequency(minTermFrequency);
+            mltQuery.setMinDocFreq(1);
+            mltQuery.setBoostTerms(true);
+            return mltQuery;
+        };
+
+        // expect to get results as frequency of 'foo' >= 2
+        TopDocs topDocs = searcher.search(makeQuery.apply("foo|2 bar|1", 2), 1);
+        assertEquals(1, topDocs.scoreDocs.length);
+        assertEquals(1L, topDocs.scoreDocs[0].doc);
+
+        // Doc 1 should get higher score than doc 0 as 'foo' has higher
+        // frequency in the 'like' text
+        topDocs = searcher.search(makeQuery.apply("foo|2 bar|1", 1), 2);
+        assertEquals(2, topDocs.scoreDocs.length);
+        assertEquals(1L, topDocs.scoreDocs[0].doc);
+        assertEquals(0L, topDocs.scoreDocs[1].doc);
+        assertThat(topDocs.scoreDocs[0].score, greaterThan(topDocs.scoreDocs[1].score));
+
+        // Doc 0 should get higher score than doc 1 as 'bar' has higher
+        // frequency in the 'like' text
+        topDocs = searcher.search(makeQuery.apply("foo|1 bar|2", 1), 2);
+        assertEquals(2, topDocs.scoreDocs.length);
+        assertEquals(0L, topDocs.scoreDocs[0].doc);
+        assertEquals(1L, topDocs.scoreDocs[1].doc);
+        assertThat(topDocs.scoreDocs[0].score, greaterThan(topDocs.scoreDocs[1].score));
+
+        reader.close();
+        indexWriter.close();
+    }
+
+    /**
+     * A token filter that uses pipe '|' to denote term frequency, for example 'foo|3'
+     * would be parsed as term 'foo' with frequency of 3.
+     */
+    private static class CustomFrequencyTokenFilterFactory extends TokenFilterFactory {
+        CustomFrequencyTokenFilterFactory(Map<String, String> args) {
+            super(args);
+        }
+
+        @Override
+        public TokenStream create(TokenStream input) {
+            return new TokenFilter(input) {
+
+                @Override
+                public boolean incrementToken() throws IOException {
+                    final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+                    final TermFrequencyAttribute tfAtt = addAttribute(TermFrequencyAttribute.class);
+
+                    if (input.incrementToken()) {
+                        final char[] buffer = termAtt.buffer();
+                        final int length = termAtt.length();
+                        for (int i = 0; i < length; i++) {
+                            if (buffer[i] == '|') {
+                                termAtt.setLength(i);
+                                i++;
+                                tfAtt.setTermFrequency(ArrayUtil.parseInt(buffer, i, length - i));
+                                return true;
+                            }
+                        }
+                        return true;
+                    }
+                    return false;
+                }
+            };
+        }
+    }
+
+    /**
+     * An analyzer that tokenizes by whitespace and uses pipe '|' to denote term frequency.
+     * For example 'foo|2 bar|3' would be first tokenized as 'foo|2', 'bar|3' and then
+     * custom frequencies interpreted as 'foo': 2, 'bar': 3
+     */
+    private static class CustomFrequencyAnalyzer extends Analyzer {
+        private final TokenFilterFactory factory;
+
+        CustomFrequencyAnalyzer() {
+            this.factory = new CustomFrequencyTokenFilterFactory(Collections.emptyMap());
+        }
+
+        @Override
+        protected TokenStreamComponents createComponents(String fieldName) {
+            WhitespaceTokenizer tokenizer = new WhitespaceTokenizer();
+            return new TokenStreamComponents(tokenizer, factory.create(tokenizer));
+        }
+
+        @Override
+        protected TokenStream normalize(String fieldName, TokenStream in) {
+            return factory.create(in);
+        }
     }
 }


### PR DESCRIPTION
When an analyzer with custom term frequencies is used with MLT like
texts, the custom term frequencies are incorrectly omitted and a fixed
frequency of 1 is used instead. This has the following implications:
(1) Hit scoring and thus ordering might be incorrect.
(2) Parameter `min_term_freq` may work unexpectedly resulting to
missing hits.

This commit fixes the issue by using `TermFrequencyAttribute` to get
the term frequencies instead of using fixed 1. Also adds test cases
for them mentioned issues.
