### PR TITLE
SQL: unwrap the first value in an array in case of array leniency

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractor.java
@@ -173,9 +173,10 @@ public class FieldHitExtractor implements HitExtractor {
                 
                 if (node instanceof List) {
                     List listOfValues = (List) node;
-                    if (listOfValues.size() == 1) {
+                    if (listOfValues.size() == 1 || arrayLeniency) {
                         // this is a List with a size of 1 e.g.: {"a" : [{"b" : "value"}]} meaning the JSON is a list with one element
                         // or a list of values with one element e.g.: {"a": {"b" : ["value"]}}
+                        // in case of being lenient about arrays, just extract the first value in the array
                         node = listOfValues.get(0);
                     } else {
                         // a List of elements with more than one value. Break early and let unwrapMultiValue deal with the list

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractorTests.java
@@ -295,7 +295,8 @@ public class FieldHitExtractorTests extends AbstractWireSerializingTestCase<Fiel
             path[i] = randomAlphaOfLength(randomIntBetween(1, 10));
             sj.add(path[i]);
         }
-        FieldHitExtractor fe = getFieldHitExtractor(sj.toString(), false);
+        boolean arrayLeniency = randomBoolean();
+        FieldHitExtractor fe = new FieldHitExtractor(sj.toString(), null, UTC, false, arrayLeniency);
 
         List<String> paths = new ArrayList<>(path.length);
         int start = 0;
@@ -336,7 +337,7 @@ public class FieldHitExtractorTests extends AbstractWireSerializingTestCase<Fiel
             expected.insert(0, paths.get(i) + ".");
         }
 
-        if (valuesCount == 1) {
+        if (valuesCount == 1 || arrayLeniency) {
             // if the number of generated values is 1, just check we return the correct value
             assertEquals(value instanceof List ? ((List) value).get(0) : value, fe.extractFromSource(map));
         } else {


### PR DESCRIPTION
This bug fix covers an edge case for array leniency option where the array of values is actually an array of objects.

Fixes https://github.com/elastic/elasticsearch/issues/40296.