### PR TITLE
[DOCS] Adds notable highlights tags

### DIFF
--- a/docs/reference/release-notes/highlights-8.0.0.asciidoc
+++ b/docs/reference/release-notes/highlights-8.0.0.asciidoc
@@ -7,3 +7,12 @@
 coming[8.0.0]
 
 See also <<breaking-changes-8.0>> and <<release-notes-8.0.0-alpha1>>.
+
+////
+The following section is re-used in the Installation and Upgrade Guide
+[[notable-highlights-8.0.0]]
+=== Notable breaking changes
+////
+// tag::notable-highlights[]
+
+// end::notable-highlights[]


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/252

This PR drafts the addition of tags in the Elasticsearch Release Highlights that facilitate content re-use.