### PR TITLE
Describing the latest version

### DIFF
--- a/docs/python/index.asciidoc
+++ b/docs/python/index.asciidoc
@@ -58,8 +58,8 @@ The recommended way to set your requirements in your `setup.py` or
 
 [source,txt]
 ------------------------------------
-    # Elasticsearch 5.x
-    elasticsearch>=5.0.0,<6.0.0
+    # Elasticsearch 6.x
+    elasticsearch>=6.0.0,<7.0.0
 
     # Elasticsearch 2.x
     elasticsearch2


### PR DESCRIPTION
The doc maintain examples by giving two examples for each procedure, one example for the older version (2.x) and the other for the latest version. Making the correction as now the latest major version is 6.