### PR TITLE
Fix building bwc versions

### DIFF
--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -169,8 +169,9 @@ bwcVersions.forPreviousUnreleased { BwcVersions.UnreleasedVersionInfo unreleased
                         'JAVA_HOME',
                         getJavaHome(it, Integer.parseInt(
                                 lines
-                                        .findAll({ it.startsWith("ES_BUILD_JAVA=java") })
+                                        .findAll({ it.startsWith("ES_BUILD_JAVA=")})
                                         .collect({ it.replace("ES_BUILD_JAVA=java", "").trim() })
+                                        .collect({ it.replace("ES_BUILD_JAVA=openjdk", "").trim() })
                                         .join("!!")
                         ))
                 )


### PR DESCRIPTION
we have to account for openjdk when figuring out what java version to
use for building bwc versions.

