### PR TITLE
[DOCS] Document 200 http code response for partial results

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -283,3 +283,8 @@ POST _bulk
 === Security
 
 See <<url-access-control>>.
+
+[float]
+[[bulk-partial-responses]]
+=== Partial responses
+To ensure fast responses, the multi search API will respond with partial results if one or more shards fail. See <<shard-failures, Shard failures>> for more information.

--- a/docs/reference/docs/data-replication.asciidoc
+++ b/docs/reference/docs/data-replication.asciidoc
@@ -102,12 +102,23 @@ is as follows:
 . Combine the results and respond. Note that in the case of get by ID look up, only one shard is relevant and this step can be skipped.
 
 [float]
-==== Failure handling
+==== Shard failures
 
-When a shard fails to respond to a read request, the coordinating node will select another copy from the same replication group
-and send the shard level search request to that copy instead. Repetitive failures can result in no shard copies being available.
-In some cases, such as `_search`, Elasticsearch will prefer to respond fast, albeit with partial results, instead of waiting 
-for the issue to be resolved (partial results are indicated in the `_shards` header of the response).
+When a shard fails to respond to a read request, the coordinating node sends the
+request to another shard copy in the same replication group. Repeated failures
+can result in no available shard copies.
+
+To ensure fast responses, the following APIs will
+respond with partial results if one or more shards fail:
+
+* <<search-search, Search>>
+* <<search-multi-search, Multi Search>>
+* <<docs-bulk, Bulk>>
+* <<docs-multi-get, Multi Get>>
+
+Responses containing partial results still provide a `200 OK` HTTP status code.
+Shard failures are indicated by the `timed_out` and `_shards` fields of
+the response header.
 
 [float]
 === A few simple implications

--- a/docs/reference/docs/data-replication.asciidoc
+++ b/docs/reference/docs/data-replication.asciidoc
@@ -102,6 +102,7 @@ is as follows:
 . Combine the results and respond. Note that in the case of get by ID look up, only one shard is relevant and this step can be skipped.
 
 [float]
+[[shard-failures]]
 ==== Shard failures
 
 When a shard fails to respond to a read request, the coordinating node sends the

--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -1,7 +1,7 @@
 [[docs-multi-get]]
 == Multi Get API
 
-Multi Get API allows to get multiple documents based on an index, type,
+The Multi get API returns multiple documents based on an index, type,
 (optional) and id (and possibly routing). The response includes a `docs` array
 with all the fetched documents in order corresponding to the original multi-get
 request (if there was a failure for a specific get, an object containing this
@@ -212,3 +212,8 @@ document `test/_doc/1` will be fetched from the shard corresponding to routing k
 === Security
 
 See <<url-access-control>>.
+
+[float]
+[[multi-get-partial-responses]]
+=== Partial responses
+To ensure fast responses, the multi get API will respond with partial results if one or more shards fail. See <<shard-failures, Shard failures>> for more information.

--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -173,3 +173,8 @@ GET _msearch/template
 -----------------------------------------------
 // CONSOLE
 // TEST[continued]
+
+[float]
+[[multi-search-partial-responses]]
+=== Partial responses
+To ensure fast responses, the multi search API will respond with partial results if one or more shards fail. See <<shard-failures, Shard failures>> for more information.

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -38,3 +38,8 @@ GET /_all/_search?q=tag:wow
 ---------------------------------------------------
 // CONSOLE
 // TEST[setup:twitter]
+
+[float]
+[[search-partial-responses]]
+=== Partial responses
+To ensure fast responses, the search API will respond with partial results if one or more shards fail. See <<shard-failures, Shard failures>> for more information.


### PR DESCRIPTION
Documents that API responses with partial results will provide a `200 OK` HTTP status code.

Makes a few other supporting changes:
- Wraps lines to ~80 characters
- Renames heading to `Shard failures` (page has another `Failure handling` heading).
- Notes Document APIs that can return partial results.
- Notes that shard failure is indicated by the `timed_out` and `_shards` response header fields

Closes #23059