### PR TITLE
[ML] generate unique doc ids for data frame

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameField.java
@@ -52,6 +52,9 @@ public final class DataFrameField {
      */
     public static final String FOR_INTERNAL_STORAGE = "for_internal_storage";
 
+    // internal document id
+    public static String DOCUMENT_ID_FIELD = "_id";
+
     private DataFrameField() {
     }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportPreviewDataFrameTransformAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportPreviewDataFrameTransformAction.java
@@ -82,7 +82,13 @@ public class TransportPreviewDataFrameTransformAction extends
                         r -> {
                             final CompositeAggregation agg = r.getAggregations().get(COMPOSITE_AGGREGATION_NAME);
                             DataFrameIndexerTransformStats stats = new DataFrameIndexerTransformStats();
-                            listener.onResponse(pivot.extractResults(agg, deducedMappings, stats).collect(Collectors.toList()));
+                            // remove all internal fields
+                            List<Map<String, Object>> results = pivot.extractResults(agg, deducedMappings, stats)
+                                    .map(record -> {
+                                        record.keySet().removeIf(k -> k.startsWith("_"));
+                                        return record;
+                                    }).collect(Collectors.toList());
+                            listener.onResponse(results);
                         },
                         listener::onFailure
                     ));

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
@@ -74,7 +74,7 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
         String indexName = transformConfig.getDestination().getIndex();
 
         return pivot.extractResults(agg, getFieldMappings(), getStats()).map(document -> {
-            String id = (String) document.remove(DataFrameField.DOCUMENT_ID_FIELD);
+            String id = (String) document.get(DataFrameField.DOCUMENT_ID_FIELD);
 
             if (id == null) {
                 throw new RuntimeException("Expected a document id but got null.");
@@ -83,7 +83,14 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
             XContentBuilder builder;
             try {
                 builder = jsonBuilder();
-                builder.map(document);
+                builder.startObject();
+                for (Map.Entry<String, ?> value : document.entrySet()) {
+                    // skip all internal fields
+                    if (value.getKey().startsWith("_") == false) {
+                        builder.field(value.getKey(), value.getValue());
+                    }
+                }
+                builder.endObject();
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.xpack.core.indexing.AsyncTwoPhaseIndexer;
@@ -73,6 +74,12 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
         String indexName = transformConfig.getDestination().getIndex();
 
         return pivot.extractResults(agg, getFieldMappings(), getStats()).map(document -> {
+            String id = (String) document.remove(DataFrameField.DOCUMENT_ID_FIELD);
+
+            if (id == null) {
+                throw new RuntimeException("Expected a document id but got null.");
+            }
+
             XContentBuilder builder;
             try {
                 builder = jsonBuilder();
@@ -81,7 +88,7 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
                 throw new UncheckedIOException(e);
             }
 
-            IndexRequest request = new IndexRequest(indexName).source(builder);
+            IndexRequest request = new IndexRequest(indexName).source(builder).id(id);
             return request;
         });
     }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/IDGenerator.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/IDGenerator.java
@@ -19,7 +19,7 @@ import java.util.Base64;
  *
  * uses MurmurHash with 128 bits
  */
-public class IDGenerator {
+public final class IDGenerator {
     private static final byte[] NULL_VALUE = "__NULL_VALUE__".getBytes(StandardCharsets.UTF_8);
     private static final BytesRef DELIM = new BytesRef("$");
     private static final long SEED = 19;

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/IDGenerator.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/IDGenerator.java
@@ -65,7 +65,7 @@ public class IDGenerator {
     }
 
     /**
-     * Turns objects into byte arrays, only supporting type that potentially come out of a composite agg.
+     * Turns objects into byte arrays, only supporting types returned groupBy
      *
      * @param value the value as object
      * @return a byte representation of the input object

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/IDGenerator.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/IDGenerator.java
@@ -23,6 +23,7 @@ public final class IDGenerator {
     private static final byte[] NULL_VALUE = "__NULL_VALUE__".getBytes(StandardCharsets.UTF_8);
     private static final BytesRef DELIM = new BytesRef("$");
     private static final long SEED = 19;
+    private static final int MAX_FIRST_BYTES = 5;
 
     private final BytesRefBuilder buffer = new BytesRefBuilder();
     private final BytesRefBuilder firstBytes =  new BytesRefBuilder();
@@ -41,7 +42,9 @@ public final class IDGenerator {
         buffer.append(DELIM);
 
         // keep the 1st byte of every object
-        firstBytes.append(v[0]);
+        if (firstBytes.length() <= MAX_FIRST_BYTES) {
+            firstBytes.append(v[0]);
+        }
     }
 
     /**

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/IDGenerator.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/IDGenerator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.dataframe.transforms;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.common.Numbers;
+import org.elasticsearch.common.hash.MurmurHash3;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * ID Generator for creating unique but deterministic document ids.
+ *
+ * uses MurmurHash with 128 bits
+ */
+public class IDGenerator {
+    private static final byte[] NULL_VALUE = "__NULL_VALUE__".getBytes(StandardCharsets.UTF_8);
+    private static final BytesRef DELIM = new BytesRef("$");
+    private static final long SEED = 19;
+
+    private final BytesRefBuilder buffer = new BytesRefBuilder();
+
+    public IDGenerator() {
+    }
+
+    /**
+     * Clear the internal buffer to reuse the generator
+     */
+    public void clear() {
+        buffer.clear();
+    }
+
+    /**
+     * Add a value to the generator
+     * @param value the value
+     */
+    public void add(Object value) {
+        byte[] v = getBytes(value);
+
+        buffer.append(v, 0, v.length);
+        buffer.append(DELIM);
+    }
+
+    /**
+     * Create a document id based on the input objects
+     *
+     * @return a document id as string
+     */
+    public String getID() {
+        if (buffer.length() == 0) {
+            throw new RuntimeException("Add at least 1 object before generating the ID");
+        }
+
+        MurmurHash3.Hash128 hasher = MurmurHash3.hash128(buffer.bytes(), 0, buffer.length(), SEED, new MurmurHash3.Hash128());
+        byte[] hashedBytes = new byte[16];
+        System.arraycopy(Numbers.longToBytes(hasher.h1), 0, hashedBytes, 0, 8);
+        System.arraycopy(Numbers.longToBytes(hasher.h2), 0, hashedBytes, 8, 8);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hashedBytes);
+    }
+
+    /**
+     * Turns objects into byte arrays, only supporting type that potentially come out of a composite agg.
+     *
+     * @param value the value as object
+     * @return a byte representation of the input object
+     */
+    private static byte[] getBytes(Object value) {
+        if (value == null) {
+            return NULL_VALUE;
+        } else if (value instanceof String) {
+            return ((String) value).getBytes(StandardCharsets.UTF_8);
+        } else if (value instanceof Long) {
+            return Numbers.longToBytes((Long) value);
+        } else if (value instanceof Double) {
+            return Numbers.doubleToBytes((Double) value);
+        } else if (value instanceof Integer) {
+            return Numbers.intToBytes((Integer) value);
+        }
+
+        throw new IllegalArgumentException("Value of type [" + value.getClass() + "] is not supported");
+    }
+}

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationResultUtils.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationResultUtils.java
@@ -27,6 +27,7 @@ import static org.elasticsearch.xpack.dataframe.transforms.pivot.SchemaUtil.isNu
 
 final class AggregationResultUtils {
     private static final Logger logger = LogManager.getLogger(AggregationResultUtils.class);
+
     /**
      * Extracts aggregation results from a composite aggregation and puts it into a map.
      *
@@ -51,8 +52,6 @@ final class AggregationResultUtils {
         return agg.getBuckets().stream().map(bucket -> {
             stats.incrementNumDocuments(bucket.getDocCount());
             idGen.clear();
-
-            dataFrameIndexerTransformStats.incrementNumDocuments(bucket.getDocCount());
             Map<String, Object> document = new HashMap<>();
 
             // important: the order is important for creating the document id, therefore we ensure order by sorting
@@ -60,6 +59,7 @@ final class AggregationResultUtils {
                 Object value = bucket.getKey().get(destinationFieldName);
                 idGen.add(value);
                 document.put(destinationFieldName, value);
+            });
 
             for (AggregationBuilder aggregationBuilder : aggregationBuilders) {
                 String aggName = aggregationBuilder.getName();

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationResultUtils.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationResultUtils.java
@@ -51,10 +51,9 @@ final class AggregationResultUtils {
             // - update documents
             IDGenerator idGen = new IDGenerator();
 
-            // important: the order is important for creating the document id, therefore we ensure order by sorting
-            groups.getGroups().keySet().stream().sorted().forEach(destinationFieldName -> {
+            groups.getGroups().keySet().forEach(destinationFieldName -> {
                 Object value = bucket.getKey().get(destinationFieldName);
-                idGen.add(value);
+                idGen.add(destinationFieldName, value);
                 document.put(destinationFieldName, value);
             });
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationResultUtils.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationResultUtils.java
@@ -43,16 +43,13 @@ final class AggregationResultUtils {
                                                                                  Collection<AggregationBuilder> aggregationBuilders,
                                                                                  Map<String, String> fieldTypeMap,
                                                                                  DataFrameIndexerTransformStats stats) {
-        // generator to create unique but deterministic document ids, so we
-        // - do not create duplicates if we re-run after failure
-        // - update documents
-        // re-use 1 generator per batch
-        IDGenerator idGen = new IDGenerator();
-
         return agg.getBuckets().stream().map(bucket -> {
             stats.incrementNumDocuments(bucket.getDocCount());
-            idGen.clear();
             Map<String, Object> document = new HashMap<>();
+            // generator to create unique but deterministic document ids, so we
+            // - do not create duplicates if we re-run after failure
+            // - update documents
+            IDGenerator idGen = new IDGenerator();
 
             // important: the order is important for creating the document id, therefore we ensure order by sorting
             groups.getGroups().keySet().stream().sorted().forEach(destinationFieldName -> {

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/IDGeneratorTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/IDGeneratorTests.java
@@ -33,33 +33,12 @@ public class IDGeneratorTests extends ESTestCase {
         idGen.add("key2");
         String id1 = idGen.getID();
 
-        idGen.clear();
+        idGen = new IDGenerator();
         idGen.add("key2");
         idGen.add("key1");
         String id2 = idGen.getID();
 
         assertNotEquals(id1, id2);
-    }
-
-    public void testReusage() {
-        IDGenerator idGen = new IDGenerator();
-        idGen.add("key1");
-        idGen.add("key2");
-        String id1 = idGen.getID();
-
-        idGen.clear();
-        idGen.add("key1");
-        idGen.add("key2");
-        String id2 = idGen.getID();
-
-        assertEquals(id1, id2);
-
-        IDGenerator idGen3 = new IDGenerator();
-        idGen3.add("key1");
-        idGen3.add("key2");
-        String id3 = idGen.getID();
-
-        assertEquals(id1, id3);
     }
 
     public void testEmptyThrows() {

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/IDGeneratorTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/IDGeneratorTests.java
@@ -12,33 +12,35 @@ public class IDGeneratorTests extends ESTestCase {
 
     public void testSupportedTypes() {
         IDGenerator idGen = new IDGenerator();
-        idGen.add("key1");
+        idGen.add("key1", "value1");
         String id = idGen.getID();
-        idGen.add(null);
+        idGen.add("key2", null);
         assertNotEquals(id, idGen.getID());
         id = idGen.getID();
-        idGen.add("key2");
+        idGen.add("key3", "value3");
         assertNotEquals(id, idGen.getID());
         id = idGen.getID();
-        idGen.add(12L);
+        idGen.add("key4", 12L);
         assertNotEquals(id, idGen.getID());
         id = idGen.getID();
-        idGen.add(44.444);
+        idGen.add("key5", 44.444);
+        assertNotEquals(id, idGen.getID());
+        idGen.add("key6", 13);
         assertNotEquals(id, idGen.getID());
     }
 
-    public void testOrderDependence() {
+    public void testOrderIndependence() {
         IDGenerator idGen = new IDGenerator();
-        idGen.add("key1");
-        idGen.add("key2");
+        idGen.add("key1", "value1");
+        idGen.add("key2", "value2");
         String id1 = idGen.getID();
 
         idGen = new IDGenerator();
-        idGen.add("key2");
-        idGen.add("key1");
+        idGen.add("key2", "value2");
+        idGen.add("key1", "value1");
         String id2 = idGen.getID();
 
-        assertNotEquals(id1, id2);
+        assertEquals(id1, id2);
     }
 
     public void testEmptyThrows() {
@@ -47,6 +49,15 @@ public class IDGeneratorTests extends ESTestCase {
         RuntimeException e = expectThrows(RuntimeException.class, () -> idGen.getID());
 
         assertEquals("Add at least 1 object before generating the ID", e.getMessage());
+    }
+
+    public void testDuplicatedKeyThrows() {
+        IDGenerator idGen = new IDGenerator();
+        idGen.add("key1", "value1");
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> idGen.add("key1", "some_other_value"));
+
+        assertEquals("Keys must be unique", e.getMessage());
     }
 
 }

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/IDGeneratorTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/IDGeneratorTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.dataframe.transforms;
+
+import org.elasticsearch.test.ESTestCase;
+
+public class IDGeneratorTests extends ESTestCase {
+
+    public void testSupportedTypes() {
+        IDGenerator idGen = new IDGenerator();
+        idGen.add("key1");
+        String id = idGen.getID();
+        idGen.add(null);
+        assertNotEquals(id, idGen.getID());
+        id = idGen.getID();
+        idGen.add("key2");
+        assertNotEquals(id, idGen.getID());
+        id = idGen.getID();
+        idGen.add(12L);
+        assertNotEquals(id, idGen.getID());
+        id = idGen.getID();
+        idGen.add(44.444);
+        assertNotEquals(id, idGen.getID());
+    }
+
+    public void testOrderDependence() {
+        IDGenerator idGen = new IDGenerator();
+        idGen.add("key1");
+        idGen.add("key2");
+        String id1 = idGen.getID();
+
+        idGen.clear();
+        idGen.add("key2");
+        idGen.add("key1");
+        String id2 = idGen.getID();
+
+        assertNotEquals(id1, id2);
+    }
+
+    public void testReusage() {
+        IDGenerator idGen = new IDGenerator();
+        idGen.add("key1");
+        idGen.add("key2");
+        String id1 = idGen.getID();
+
+        idGen.clear();
+        idGen.add("key1");
+        idGen.add("key2");
+        String id2 = idGen.getID();
+
+        assertEquals(id1, id2);
+
+        IDGenerator idGen3 = new IDGenerator();
+        idGen3.add("key1");
+        idGen3.add("key2");
+        String id3 = idGen.getID();
+
+        assertEquals(id1, id3);
+    }
+
+    public void testEmptyThrows() {
+        IDGenerator idGen = new IDGenerator();
+
+        RuntimeException e = expectThrows(RuntimeException.class, () -> idGen.getID());
+
+        assertEquals("Add at least 1 object before generating the ID", e.getMessage());
+    }
+
+}

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationResultUtilsTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationResultUtilsTests.java
@@ -503,8 +503,14 @@ public class AggregationResultUtilsTests extends ESTestCase {
                     ));
         DataFrameIndexerTransformStats stats = new DataFrameIndexerTransformStats();
 
-        List<Map<String, Object>> resultFirstRun = runExtraction(groupBy, aggregationBuilders, inputFirstRun, stats);
-        List<Map<String, Object>> resultSecondRun = runExtraction(groupBy, aggregationBuilders, inputSecondRun, stats);
+        Map<String, String> fieldTypeMap = asStringMap(
+                aggName, "double",
+                targetField, "keyword",
+                targetField2, "keyword"
+            );
+
+        List<Map<String, Object>> resultFirstRun = runExtraction(groupBy, aggregationBuilders, inputFirstRun, fieldTypeMap, stats);
+        List<Map<String, Object>> resultSecondRun = runExtraction(groupBy, aggregationBuilders, inputSecondRun, fieldTypeMap, stats);
 
         assertNotEquals(resultFirstRun, resultSecondRun);
 
@@ -532,8 +538,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
         XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
         builder.map(input);
 
-        List<Map<String, Object>> result = runExtraction(groups, aggregationBuilders, input, stats);
-                    .extractCompositeAggregationResults(agg, groups, aggregationBuilders, fieldTypeMap, stats).collect(Collectors.toList());
+        List<Map<String, Object>> result = runExtraction(groups, aggregationBuilders, input, fieldTypeMap, stats);
 
         // remove the document ids and test uniqueness
         Set<String> documentIds = new HashSet<>();
@@ -548,14 +553,14 @@ public class AggregationResultUtilsTests extends ESTestCase {
     }
 
     private List<Map<String, Object>> runExtraction(GroupConfig groups, Collection<AggregationBuilder> aggregationBuilders,
-            Map<String, Object> input, DataFrameIndexerTransformStats stats) throws IOException {
+            Map<String, Object> input, Map<String, String> fieldTypeMap, DataFrameIndexerTransformStats stats) throws IOException {
 
         XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
         builder.map(input);
 
         try (XContentParser parser = createParser(builder)) {
             CompositeAggregation agg = ParsedComposite.fromXContent(parser, "my_feature");
-            return AggregationResultUtils.extractCompositeAggregationResults(agg, groups, aggregationBuilders, stats)
+            return AggregationResultUtils.extractCompositeAggregationResults(agg, groups, aggregationBuilders, fieldTypeMap, stats)
                     .collect(Collectors.toList());
         }
     }

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationResultUtilsTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationResultUtilsTests.java
@@ -150,7 +150,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
         executeTest(groupBy, aggregationBuilders, input, fieldTypeMap, expected, 20);
     }
 
-    public void testExtractCompositeAggregationResultsMultiSources() throws IOException {
+    public void testExtractCompositeAggregationResultsMultipleGroups() throws IOException {
         String targetField = randomAlphaOfLengthBetween(5, 10);
         String targetField2 = randomAlphaOfLengthBetween(5, 10) + "_2";
 
@@ -409,26 +409,154 @@ public class AggregationResultUtilsTests extends ESTestCase {
         executeTest(groupBy, aggregationBuilders, input, fieldTypeMap, expected, 10);
     }
 
+    public void testExtractCompositeAggregationResultsDocIDs() throws IOException {
+        String targetField = randomAlphaOfLengthBetween(5, 10);
+        String targetField2 = randomAlphaOfLengthBetween(5, 10) + "_2";
+
+        GroupConfig groupBy = parseGroupConfig("{"
+                + "\"" + targetField + "\" : {"
+                + "  \"terms\" : {"
+                + "     \"field\" : \"doesn't_matter_for_this_test\""
+                + "  } },"
+                + "\"" + targetField2 + "\" : {"
+                + "  \"terms\" : {"
+                + "     \"field\" : \"doesn't_matter_for_this_test\""
+                + "  } }"
+                + "}");
+
+        String aggName = randomAlphaOfLengthBetween(5, 10);
+        String aggTypedName = "avg#" + aggName;
+        Collection<AggregationBuilder> aggregationBuilders = Collections.singletonList(AggregationBuilders.avg(aggName));
+
+        Map<String, Object> inputFirstRun = asMap(
+                "buckets",
+                    asList(
+                            asMap(
+                                  KEY, asMap(
+                                          targetField, "ID1",
+                                          targetField2, "ID1_2"
+                                          ),
+                                  aggTypedName, asMap(
+                                          "value", 42.33),
+                                  DOC_COUNT, 1),
+                            asMap(
+                                    KEY, asMap(
+                                            targetField, "ID1",
+                                            targetField2, "ID2_2"
+                                            ),
+                                    aggTypedName, asMap(
+                                            "value", 8.4),
+                                    DOC_COUNT, 2),
+                            asMap(
+                                  KEY, asMap(
+                                          targetField, "ID2",
+                                          targetField2, "ID1_2"
+                                          ),
+                                  aggTypedName, asMap(
+                                          "value", 28.99),
+                                  DOC_COUNT, 3),
+                            asMap(
+                                  KEY, asMap(
+                                          targetField, "ID3",
+                                          targetField2, "ID2_2"
+                                          ),
+                                  aggTypedName, asMap(
+                                          "value", 12.55),
+                                  DOC_COUNT, 4)
+                    ));
+
+        Map<String, Object> inputSecondRun = asMap(
+                "buckets",
+                    asList(
+                            asMap(
+                                  KEY, asMap(
+                                          targetField, "ID1",
+                                          targetField2, "ID1_2"
+                                          ),
+                                  aggTypedName, asMap(
+                                          "value", 433.33),
+                                  DOC_COUNT, 12),
+                            asMap(
+                                    KEY, asMap(
+                                            targetField, "ID1",
+                                            targetField2, "ID2_2"
+                                            ),
+                                    aggTypedName, asMap(
+                                            "value", 83.4),
+                                    DOC_COUNT, 32),
+                            asMap(
+                                  KEY, asMap(
+                                          targetField, "ID2",
+                                          targetField2, "ID1_2"
+                                          ),
+                                  aggTypedName, asMap(
+                                          "value", 21.99),
+                                  DOC_COUNT, 2),
+                            asMap(
+                                  KEY, asMap(
+                                          targetField, "ID3",
+                                          targetField2, "ID2_2"
+                                          ),
+                                  aggTypedName, asMap(
+                                          "value", 122.55),
+                                  DOC_COUNT, 44)
+                    ));
+        DataFrameIndexerTransformStats stats = new DataFrameIndexerTransformStats();
+
+        List<Map<String, Object>> resultFirstRun = runExtraction(groupBy, aggregationBuilders, inputFirstRun, stats);
+        List<Map<String, Object>> resultSecondRun = runExtraction(groupBy, aggregationBuilders, inputSecondRun, stats);
+
+        assertNotEquals(resultFirstRun, resultSecondRun);
+
+        Set<String> documentIdsFirstRun = new HashSet<>();
+        resultFirstRun.forEach(m -> {
+            documentIdsFirstRun.add((String) m.get(DataFrameField.DOCUMENT_ID_FIELD));
+        });
+
+        assertEquals(4, documentIdsFirstRun.size());
+
+        Set<String> documentIdsSecondRun = new HashSet<>();
+        resultSecondRun.forEach(m -> {
+            documentIdsSecondRun.add((String) m.get(DataFrameField.DOCUMENT_ID_FIELD));
+        });
+
+        assertEquals(4, documentIdsSecondRun.size());
+        assertEquals(documentIdsFirstRun, documentIdsSecondRun);
+    }
+
+
+
     private void executeTest(GroupConfig groups, Collection<AggregationBuilder> aggregationBuilders, Map<String, Object> input,
             Map<String, String> fieldTypeMap, List<Map<String, Object>> expected, long expectedDocCounts) throws IOException {
         DataFrameIndexerTransformStats stats = new DataFrameIndexerTransformStats();
         XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
         builder.map(input);
 
-        try (XContentParser parser = createParser(builder)) {
-            CompositeAggregation agg = ParsedComposite.fromXContent(parser, "my_feature");
-            List<Map<String, Object>> result = AggregationResultUtils
+        List<Map<String, Object>> result = runExtraction(groups, aggregationBuilders, input, stats);
                     .extractCompositeAggregationResults(agg, groups, aggregationBuilders, fieldTypeMap, stats).collect(Collectors.toList());
 
-            // remove the document ids and test uniqueness
-            Set<String> documentIds = new HashSet<>();
-            result.forEach(m -> {
-                documentIds.add((String) m.remove(DataFrameField.DOCUMENT_ID_FIELD));
-            });
+        // remove the document ids and test uniqueness
+        Set<String> documentIds = new HashSet<>();
+        result.forEach(m -> {
+            documentIds.add((String) m.remove(DataFrameField.DOCUMENT_ID_FIELD));
+        });
 
-            assertEquals(result.size(), documentIds.size());
-            assertEquals(expected, result);
-            assertEquals(expectedDocCounts, stats.getNumDocuments());
+        assertEquals(result.size(), documentIds.size());
+        assertEquals(expected, result);
+        assertEquals(expectedDocCounts, stats.getNumDocuments());
+
+    }
+
+    private List<Map<String, Object>> runExtraction(GroupConfig groups, Collection<AggregationBuilder> aggregationBuilders,
+            Map<String, Object> input, DataFrameIndexerTransformStats stats) throws IOException {
+
+        XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
+        builder.map(input);
+
+        try (XContentParser parser = createParser(builder)) {
+            CompositeAggregation agg = ParsedComposite.fromXContent(parser, "my_feature");
+            return AggregationResultUtils.extractCompositeAggregationResults(agg, groups, aggregationBuilders, stats)
+                    .collect(Collectors.toList());
         }
     }
 

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationResultUtilsTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationResultUtilsTests.java
@@ -44,6 +44,7 @@ import org.elasticsearch.search.aggregations.metrics.ValueCountAggregationBuilde
 import org.elasticsearch.search.aggregations.pipeline.ParsedStatsBucket;
 import org.elasticsearch.search.aggregations.pipeline.StatsBucketPipelineAggregationBuilder;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.pivot.GroupConfig;
 
@@ -51,8 +52,10 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
@@ -417,6 +420,13 @@ public class AggregationResultUtilsTests extends ESTestCase {
             List<Map<String, Object>> result = AggregationResultUtils
                     .extractCompositeAggregationResults(agg, groups, aggregationBuilders, fieldTypeMap, stats).collect(Collectors.toList());
 
+            // remove the document ids and test uniqueness
+            Set<String> documentIds = new HashSet<>();
+            result.forEach(m -> {
+                documentIds.add((String) m.remove(DataFrameField.DOCUMENT_ID_FIELD));
+            });
+
+            assertEquals(result.size(), documentIds.size());
             assertEquals(expected, result);
             assertEquals(expectedDocCounts, stats.getNumDocuments());
         }


### PR DESCRIPTION
create and use unique, deterministic document ids based on the grouping values.

This is a pre-requisite for updating documents as well as preventing duplicates after a hard failure during indexing.