### PR TITLE
Update feature aware check ASM to 7.1

### DIFF
--- a/x-pack/test/feature-aware/build.gradle
+++ b/x-pack/test/feature-aware/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'elasticsearch.build'
 
 dependencies {
-  compile 'org.ow2.asm:asm:7.0'
+  compile 'org.ow2.asm:asm:7.1'
   compile "org.elasticsearch:elasticsearch:${version}"
   compile "org.elasticsearch.plugin:x-pack-core:${version}"
   testCompile "org.elasticsearch.test:framework:${version}"


### PR DESCRIPTION
This commit updates the feature aware check ASM dependency to ASM
7.1. This gives us JDK 13 compatibility.
