### PR TITLE
[ML] DataFrameAuditorIT::testAuditorWritesAudits refresh audit index before searching

### DIFF
--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameAuditorIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameAuditorIT.java
@@ -62,6 +62,7 @@ public class DataFrameAuditorIT extends DataFrameRestTestCase {
 
         // Make sure we wrote to the audit
         assertTrue(indexExists(DataFrameInternalIndex.AUDIT_INDEX));
+        refreshIndex(DataFrameInternalIndex.AUDIT_INDEX);
         Request request = new Request("GET", DataFrameInternalIndex.AUDIT_INDEX + "/_search");
         request.setJsonEntity("{\"query\":{\"term\":{\"transform_id\":\"simplePivotForAudit\"}}}");
         Map<String, Object> response = entityAsMap(client().performRequest(request));


### PR DESCRIPTION
refresh the audit index before searching.

Note: Fails locally, not yet reported as CI failure