### PR TITLE
Fix alpha build error message when generate version object from version string

### DIFF
--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -269,7 +269,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
                 if (buildStr.startsWith("alpha")) {
                     assert rawMajor >= 5 : "major must be >= 5 but was " + major;
                     build = Integer.parseInt(buildStr.substring(5));
-                    assert build < 25 : "expected a beta build but " + build + " >= 25";
+                    assert build < 25 : "expected a alpha build but " + build + " >= 25";
                 } else if (buildStr.startsWith("Beta") || buildStr.startsWith("beta")) {
                     build = betaOffset + Integer.parseInt(buildStr.substring(4));
                     assert build < 50 : "expected a beta build but " + build + " >= 50";


### PR DESCRIPTION
Class org.elasticsearch.Version provides the method ``` public static Version fromString(String version){...} ``` to generate version object from version string . In this method, alpha build requires a build number below 25. So in assertion
 ```
assert build < 25 : "expected a beta build but " + build + " >= 25";
```  
at line 328,  what really exceped is alpha build not beta build.