### PR TITLE
[DOCS] [7.0] Update Windows command to support prettified JSON licenses

### DIFF
--- a/docs/reference/licensing/update-license.asciidoc
+++ b/docs/reference/licensing/update-license.asciidoc
@@ -92,7 +92,7 @@ On Windows machine, use the following command:
 
 [source,shell]
 ------------------------------------------------------------
-gc .\license.json |  Invoke-WebRequest -uri http://<host>:<port>/_license -Credential elastic -Method Put -ContentType "application/json"
+Invoke-WebRequest -uri http://<host>:<port>/_xpack/license -Credential elastic -Method Put -ContentType "application/json" -InFile .\license.json
 ------------------------------------------------------------
 
 In these examples,


### PR DESCRIPTION
Without extra parameters, `gc` does not support licenses in prettified JSON.

Per @eskibars' s suggestion, this updates the command to use the `-InFile` parameter of PowerShell's `Invoke-WebRequest`. This removes the need for `gc` entirely.

Resolves #40139