### PR TITLE
[DOCS] Small typo in the doc

### DIFF
--- a/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
@@ -132,7 +132,7 @@ See <<ref-ldap-settings>>.
 . Map LDAP groups to roles. 
 +
 --
-The `ldap` realm enables you to map LDAP users to to roles via their LDAP
+The `ldap` realm enables you to map LDAP users to roles via their LDAP
 groups, or other metadata. This role mapping can be configured via the
 {ref}/security-api-put-role-mapping.html[add role mapping API] or by using a file stored
 on each node. When a user authenticates with LDAP, the privileges


### PR DESCRIPTION
Note: There's the same typo here: https://www.elastic.co/guide/en/elastic-stack-overview/current/ldap-realm.html but I didn't find the place fix it.