### PR TITLE
Remove Gradle deprecation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ plugins {
     id 'com.gradle.build-scan' version '2.0.2'
     id 'base'
 }
-if (properties.get("org.elasticsearch.acceptScanTOS", "false") == "true") {
+if (project.properties.get("org.elasticsearch.acceptScanTOS", "false") == "true") {
     buildScan {
         termsOfServiceUrl = 'https://gradle.com/terms-of-service'
         termsOfServiceAgree = 'yes'

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ plugins {
     id 'com.gradle.build-scan' version '2.0.2'
     id 'base'
 }
-if (project.properties.get("org.elasticsearch.acceptScanTOS", "false") == "true") {
+if (Boolean.valueOf(project.findProperty('org.elasticsearch.acceptScanTOS') ?: "false")) {
     buildScan {
         termsOfServiceUrl = 'https://gradle.com/terms-of-service'
         termsOfServiceAgree = 'yes'


### PR DESCRIPTION
Turns out that without the explicit project, some how the deprecated
properties were being red.
With this change we have no Gradle deprecation warnings.
