### PR TITLE
[DOCS] [7.x] Fix command to save SMTP password for email account (#40444)

### DIFF
--- a/x-pack/docs/en/watcher/actions/email.asciidoc
+++ b/x-pack/docs/en/watcher/actions/email.asciidoc
@@ -443,7 +443,7 @@ In order to store the account SMTP password, use the keystore command
 
 [source,yaml]
 --------------------------------------------------
-bin/elasticsearch-keystore xpack.notification.email.account.exchange_account.smtp.secure_password
+bin/elasticsearch-keystore add xpack.notification.email.account.exchange_account.smtp.secure_password
 --------------------------------------------------
 
 [float]


### PR DESCRIPTION
Backport of  #40444

This PR fixes an error in the documentation about how to set the SMTP password for an email account that is configured in `elasticsearch.yml`.