### PR TITLE
docs: remove coming[6.7.0] tag

### DIFF
--- a/docs/reference/release-notes/6.7.asciidoc
+++ b/docs/reference/release-notes/6.7.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-6.7.0]]
 == {es} version 6.7.0
 
-coming[6.7.0]
-
 Also see <<breaking-changes-6.7,Breaking changes in 6.7>>.
 
 [[breaking-6.7.0]]


### PR DESCRIPTION
Removes the `coming[6.7.0]` tag in preparation for release. 