### PR TITLE
SQL: Upgrade H2GIS library to 1.5.0

### DIFF
--- a/x-pack/plugin/sql/qa/build.gradle
+++ b/x-pack/plugin/sql/qa/build.gradle
@@ -16,8 +16,12 @@ dependencies {
 
   // CLI testing dependencies
   compile project(path: xpackModule('sql:sql-cli'), configuration: 'nodeps')
-  compile "org.orbisgis:h2gis-ext:1.3.2"
- 
+  
+  // H2GIS testing dependencies
+  compile ("org.orbisgis:h2gis:1.5.0") {
+    exclude group: "org.locationtech.jts"
+  }
+
   // select just the parts of JLine that are needed
   compile("org.jline:jline-terminal-jna:${jlineVersion}") {
     exclude group: "net.java.dev.jna"
@@ -41,12 +45,8 @@ forbiddenApisMain {
   replaceSignatureFiles 'es-all-signatures', 'es-test-signatures'
 }
 
-
-thirdPartyAudit.ignoreMissingClasses (
-    // TODO: Temporary solution until core removes JTS as a dependency
-    'org.h2gis.functions.factory.H2GISFunctions',
-    'org.h2gis.network.functions.NetworkFunctions',
-)
+// just a test fixture: we aren't using this jars in releases and H2GIS requires disabling a lot of checks
+thirdPartyAudit.enabled = false
 
 subprojects {
   apply plugin: 'elasticsearch.standalone-rest-test'
@@ -63,8 +63,13 @@ subprojects {
 
     // JDBC testing dependencies
     testRuntime "net.sourceforge.csvjdbc:csvjdbc:1.0.34"
-    testRuntime "com.h2database:h2:1.4.196"
-    testRuntime "org.orbisgis:h2gis-ext:1.3.2"
+    testRuntime "com.h2database:h2:1.4.197"
+    
+    // H2GIS testing dependencies
+    testRuntime ("org.orbisgis:h2gis:1.5.0") {
+      exclude group: "org.locationtech.jts"
+    }
+    
     testRuntime project(path: xpackModule('sql:jdbc'), configuration: 'nodeps')
     testRuntime xpackProject('plugin:sql:sql-client')
 
@@ -87,16 +92,6 @@ subprojects {
     testRuntime "org.jline:jline-style:${jlineVersion}"
 
     testRuntime "org.elasticsearch:jna:${versions.jna}"
-  }
-
-  // TODO: Temporary solution until core removes JTS as a dependency
-  configurations {
-    testRuntime {
-      exclude group: 'org.locationtech.jts', module: 'jts-core'
-    }
-    testCompile {
-      exclude group: 'org.locationtech.jts', module: 'jts-core'
-    }
   }
 
   if (project.name != 'security') {

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/geo/GeoSqlSpecTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/geo/GeoSqlSpecTestCase.java
@@ -10,7 +10,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.xpack.sql.qa.jdbc.LocalH2;
 import org.elasticsearch.xpack.sql.qa.jdbc.SpecBaseIntegrationTestCase;
 import org.elasticsearch.xpack.sql.jdbc.JdbcConfiguration;
-import org.h2gis.ext.H2GISExtension;
+import org.h2gis.functions.factory.H2GISFunctions;
 import org.junit.Before;
 import org.junit.ClassRule;
 
@@ -32,7 +32,7 @@ public abstract class GeoSqlSpecTestCase extends SpecBaseIntegrationTestCase {
     @ClassRule
     public static LocalH2 H2 = new LocalH2((c) -> {
         // Load GIS extensions
-        H2GISExtension.load(c);
+        H2GISFunctions.load(c);
         c.createStatement().execute("RUNSCRIPT FROM 'classpath:/ogc/sqltsch.sql'");
         c.createStatement().execute("RUNSCRIPT FROM 'classpath:/geo/setup_test_geo.sql'");
     });

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcAssert.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcAssert.java
@@ -257,14 +257,7 @@ public class JdbcAssert {
                     }
                     // then timestamp
                     else if (type == Types.TIMESTAMP || type == Types.TIMESTAMP_WITH_TIMEZONE) {
-                        if (expected.getClass().getName().equals("org.h2.jdbc.JdbcResultSet")) {
-                            // TODO: This is a hack to work around no support for getTimestamp in H2 v1.4.196
-                            // I will remove it before merging when I can upgrade the branch to 1.4.197
-                            assertEquals(msg, expected.getTime(column, UTC_CALENDAR).getTime(),
-                                actual.getTime(column, UTC_CALENDAR).getTime());
-                        } else {
-                            assertEquals(msg, expected.getTimestamp(column), actual.getTimestamp(column));
-                        }
+                        assertEquals(msg, expected.getTimestamp(column), actual.getTimestamp(column));
                     }
                     // and floats/doubles
                     else if (type == Types.DOUBLE) {


### PR DESCRIPTION
Upgrades H2GIS to 1.5.0, restores H2 version to 1.4.197 and removes
work-around for bugs in H2 1.4.196 and jar conflicts in H2GIS 1.3.2.

