### PR TITLE
Wrap Dockerfile yum operations in retries

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -41,9 +41,10 @@ FROM centos:7
 
 ENV ELASTIC_CONTAINER true
 
-RUN yum update -y && \
+RUN for iter in {1..10}; do yum update -y && \
     yum install -y nc unzip wget which && \
-    yum clean all
+    yum clean all && exit_code=0 && break || exit_code=$? && echo "yum error: retry $iter in 10s" && sleep 10; done; \
+    (exit $exit_code)
 
 RUN groupadd -g 1000 elasticsearch && \
     adduser -u 1000 -g 1000 -G 0 -d /usr/share/elasticsearch elasticsearch && \


### PR DESCRIPTION
While yum does retry retrieving files 10 times by default [1], slow
network fetches, governed by `minrate` cause immediate aborts without
getting retried.

Wrap yum commands in a 10 iteration retry loop.

[1] http://man7.org/linux/man-pages/man5/yum.conf.5.html

Backport of #40349 