### PR TITLE
Deprecate types in `_graph/explore` calls.

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/graph/GraphExploreRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/graph/GraphExploreRequest.java
@@ -115,6 +115,7 @@ public class GraphExploreRequest implements IndicesRequest.Replaceable, ToXConte
      * @deprecated Types are in the process of being removed. Instead of using a type, prefer to
      * filter on a field on the document.
      */
+    @Deprecated
     public String[] types() {
         return this.types;
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/graph/GraphExploreRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/graph/GraphExploreRequest.java
@@ -108,10 +108,25 @@ public class GraphExploreRequest implements IndicesRequest.Replaceable, ToXConte
         return this;
     }
 
+    /**
+     * The document types to execute the explore against. Defaults to be executed against
+     * all types.
+     *
+     * @deprecated Types are in the process of being removed. Instead of using a type, prefer to
+     * filter on a field on the document.
+     */
     public String[] types() {
         return this.types;
     }
 
+    /**
+     * The document types to execute the explore request against. Defaults to be executed against
+     * all types.
+     *
+     * @deprecated Types are in the process of being removed. Instead of using a type, prefer to
+     * filter on a field on the document.
+     */
+    @Deprecated
     public GraphExploreRequest types(String... types) {
         this.types = types;
         return this;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/GraphExploreRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/GraphExploreRequest.java
@@ -96,10 +96,26 @@ public class GraphExploreRequest extends ActionRequest implements IndicesRequest
         return this;
     }
 
+    /**
+     * The document types to execute the explore against. Defaults to be executed against
+     * all types.
+     *
+     * @deprecated Types are in the process of being removed. Instead of using a type, prefer to
+     * filter on a field on the document.
+     */
+    @Deprecated
     public String[] types() {
         return this.types;
     }
 
+    /**
+     * The document types to execute the explore request against. Defaults to be executed against
+     * all types.
+     *
+     * @deprecated Types are in the process of being removed. Instead of using a type, prefer to
+     * filter on a field on the document.
+     */
+    @Deprecated
     public GraphExploreRequest types(String... types) {
         this.types = types;
         return this;

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
@@ -114,7 +114,7 @@ public class RestGraphAction extends XPackRestHandler {
         }
 
         if (request.hasParam("type")) {
-            deprecationLogger.deprecatedAndMaybeLog("search_with_types", TYPES_DEPRECATION_MESSAGE);
+            deprecationLogger.deprecatedAndMaybeLog("graph_with_types", TYPES_DEPRECATION_MESSAGE);
             graphRequest.types(Strings.splitStringByCommaToArray(request.param("type")));
         }
         return channel -> client.es().execute(INSTANCE, graphRequest, new RestToXContentListener<>(channel));

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/rest/action/RestGraphAction.java
@@ -41,6 +41,8 @@ import static org.elasticsearch.xpack.core.graph.action.GraphExploreAction.INSTA
 public class RestGraphAction extends XPackRestHandler {
 
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestGraphAction.class));
+    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal]" +
+            " Specifying types in graph requests is deprecated.";
 
     public static final ParseField TIMEOUT_FIELD = new ParseField("timeout");
     public static final ParseField SIGNIFICANCE_FIELD = new ParseField("use_significance");
@@ -111,7 +113,10 @@ public class RestGraphAction extends XPackRestHandler {
             parseHop(parser, currentHop, graphRequest);
         }
 
-        graphRequest.types(Strings.splitStringByCommaToArray(request.param("type")));
+        if (request.hasParam("type")) {
+            deprecationLogger.deprecatedAndMaybeLog("search_with_types", TYPES_DEPRECATION_MESSAGE);
+            graphRequest.types(Strings.splitStringByCommaToArray(request.param("type")));
+        }
         return channel -> client.es().execute(INSTANCE, graphRequest, new RestToXContentListener<>(channel));
     }
 

--- a/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/action/RestGraphActionTests.java
+++ b/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/action/RestGraphActionTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.graph.action;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.test.rest.RestActionTestCase;
+import org.elasticsearch.xpack.graph.rest.action.RestGraphAction;
+import org.junit.Before;
+
+public class RestGraphActionTests extends RestActionTestCase {
+
+    @Before
+    public void setUpAction() {
+        new RestGraphAction(Settings.EMPTY, controller());
+    }
+
+    public void testTypeInPath() {
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.GET)
+            .withPath("/some_index/some_type/_graph/explore")
+            .withContent(new BytesArray("{}"), XContentType.JSON)
+            .build();
+
+        dispatchRequest(request);
+        assertWarnings(RestGraphAction.TYPES_DEPRECATION_MESSAGE);
+    }
+
+}

--- a/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/rest/action/RestGraphActionTests.java
+++ b/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/rest/action/RestGraphActionTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-package org.elasticsearch.xpack.graph.action;
+package org.elasticsearch.xpack.graph.rest.action;
 
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
@@ -12,7 +12,6 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.rest.RestActionTestCase;
-import org.elasticsearch.xpack.graph.rest.action.RestGraphAction;
 import org.junit.Before;
 
 public class RestGraphActionTests extends RestActionTestCase {


### PR DESCRIPTION
Any call that uses a path that sets a type will trigger a deprecation warning.
