### PR TITLE
[DOCS] Update release state for 6.7 'Elasticsearch Reference'

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -11,7 +11,7 @@
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:   unreleased
+:release-state:   released
 
 :issue:           https://github.com/elastic/elasticsearch/issues/
 :ml-issue:        https://github.com/elastic/ml-cpp/issues/


### PR DESCRIPTION
Updates the release state for the [6.7 Elasticsearch Reference](https://www.elastic.co/guide/en/elasticsearch/reference/6.7/index.html).