### PR TITLE
Delete jdk extract dir before extracting

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -248,8 +248,12 @@ for (String platform : ['linux', 'darwin', 'windows']) {
     }
     it.includeEmptyDirs false
   }
-  project.task("extract${platform.capitalize()}Jdk", type: Sync) {
-    into "${buildDir}/jdks/openjdk-${jdkVersion}_${platform}"
+  String extractDir = "${buildDir}/jdks/openjdk-${jdkVersion}_${platform}"
+  project.task("extract${platform.capitalize()}Jdk", type: Copy) {
+    doFirst {
+      project.delete(extractDir)
+    }
+    into extractDir
     if (extension.equals('zip')) {
       from({ zipTree(jdkConfig.singleFile) }, removeRootDir)
     } else {

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -248,7 +248,7 @@ for (String platform : ['linux', 'darwin', 'windows']) {
     }
     it.includeEmptyDirs false
   }
-  project.task("extract${platform.capitalize()}Jdk", type: Copy) {
+  project.task("extract${platform.capitalize()}Jdk", type: Sync) {
     into "${buildDir}/jdks/openjdk-${jdkVersion}_${platform}"
     if (extension.equals('zip')) {
       from({ zipTree(jdkConfig.singleFile) }, removeRootDir)


### PR DESCRIPTION
This commit first deletes the directory we extract the bundled jdk into in order to make gradle's copy task happy.

