### PR TITLE
Resolve JAVA_HOME at windows service install time (#39714)

### DIFF
--- a/distribution/src/bin/elasticsearch-env.bat
+++ b/distribution/src/bin/elasticsearch-env.bat
@@ -16,7 +16,25 @@ for %%I in ("%ES_HOME%..") do set ES_HOME=%%~dpfI
 rem now set the classpath
 set ES_CLASSPATH=!ES_HOME!\lib\*
 
-rem now set the path to java
+set HOSTNAME=%COMPUTERNAME%
+
+if not defined ES_PATH_CONF (
+  set ES_PATH_CONF=!ES_HOME!\config
+)
+
+rem now make ES_PATH_CONF absolute
+for %%I in ("%ES_PATH_CONF%..") do set ES_PATH_CONF=%%~dpfI
+
+set ES_DISTRIBUTION_FLAVOR=${es.distribution.flavor}
+set ES_DISTRIBUTION_TYPE=${es.distribution.type}
+
+cd /d "%ES_HOME%"
+
+rem now set the path to java, pass "nojava" arg to skip setting JAVA_HOME and JAVA
+if "%1" == "nojava" (
+   exit /b
+)
+
 if defined JAVA_HOME (
   set JAVA="%JAVA_HOME%\bin\java.exe"
 ) else (
@@ -45,20 +63,6 @@ if defined JAVA_OPTS (
 rem check the Java version
 %JAVA% -cp "%ES_CLASSPATH%" "org.elasticsearch.tools.java_version_checker.JavaVersionChecker" || exit /b 1
 
-set HOSTNAME=%COMPUTERNAME%
-
-if not defined ES_PATH_CONF (
-  set ES_PATH_CONF=!ES_HOME!\config
-)
-
-rem now make ES_PATH_CONF absolute
-for %%I in ("%ES_PATH_CONF%..") do set ES_PATH_CONF=%%~dpfI
-
-set ES_DISTRIBUTION_FLAVOR=${es.distribution.flavor}
-set ES_DISTRIBUTION_TYPE=${es.distribution.type}
-
 if not defined ES_TMPDIR (
   for /f "tokens=* usebackq" %%a in (`"%JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.TempDirectory""`) do set ES_TMPDIR=%%a
 )
-
-cd /d "%ES_HOME%"

--- a/distribution/src/bin/elasticsearch-service.bat
+++ b/distribution/src/bin/elasticsearch-service.bat
@@ -3,7 +3,10 @@
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
-call "%~dp0elasticsearch-env.bat" || exit /b 1
+set NOJAVA=nojava
+if /i "%1" == "install" set NOJAVA=
+
+call "%~dp0elasticsearch-env.bat" %NOJAVA% || exit /b 1
 
 set EXECUTABLE=%ES_HOME%\bin\elasticsearch-service-x64.exe
 if "%SERVICE_ID%" == "" set SERVICE_ID=elasticsearch-service-x64
@@ -177,8 +180,7 @@ if not "%SERVICE_USERNAME%" == "" (
 		set SERVICE_PARAMS=%SERVICE_PARAMS% --ServiceUser "%SERVICE_USERNAME%" --ServicePassword "%SERVICE_PASSWORD%"
 	)
 )
-
-"%EXECUTABLE%" //IS//%SERVICE_ID% --Startup %ES_START_TYPE% --StopTimeout %ES_STOP_TIMEOUT% --StartClass org.elasticsearch.bootstrap.Elasticsearch --StartMethod main ++StartParams --quiet --StopClass org.elasticsearch.bootstrap.Elasticsearch --StopMethod close --Classpath "%ES_CLASSPATH%" --JvmMs %JVM_MS% --JvmMx %JVM_MX% --JvmSs %JVM_SS% --JvmOptions %ES_JAVA_OPTS% ++JvmOptions %ES_PARAMS% %LOG_OPTS% --PidFile "%SERVICE_ID%.pid" --DisplayName "%SERVICE_DISPLAY_NAME%" --Description "%SERVICE_DESCRIPTION%" --Jvm "%%JAVA_HOME%%%JVM_DLL%" --StartMode jvm --StopMode jvm --StartPath "%ES_HOME%" %SERVICE_PARAMS% ++Environment HOSTNAME="%%COMPUTERNAME%%"
+"%EXECUTABLE%" //IS//%SERVICE_ID% --Startup %ES_START_TYPE% --StopTimeout %ES_STOP_TIMEOUT% --StartClass org.elasticsearch.bootstrap.Elasticsearch --StartMethod main ++StartParams --quiet --StopClass org.elasticsearch.bootstrap.Elasticsearch --StopMethod close --Classpath "%ES_CLASSPATH%" --JvmMs %JVM_MS% --JvmMx %JVM_MX% --JvmSs %JVM_SS% --JvmOptions %ES_JAVA_OPTS% ++JvmOptions %ES_PARAMS% %LOG_OPTS% --PidFile "%SERVICE_ID%.pid" --DisplayName "%SERVICE_DISPLAY_NAME%" --Description "%SERVICE_DESCRIPTION%" --Jvm "%JAVA_HOME%%JVM_DLL%" --StartMode jvm --StopMode jvm --StartPath "%ES_HOME%" %SERVICE_PARAMS% ++Environment HOSTNAME="%%COMPUTERNAME%%"
 
 if not errorlevel 1 goto installed
 echo Failed installing '%SERVICE_ID%' service

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/WindowsServiceTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/WindowsServiceTestCase.java
@@ -39,7 +39,7 @@ import static org.elasticsearch.packaging.util.Archives.installArchive;
 import static org.elasticsearch.packaging.util.Archives.verifyArchiveInstallation;
 import static org.elasticsearch.packaging.util.FileUtils.mv;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 public abstract class WindowsServiceTestCase extends PackagingTestCase {
 
@@ -64,18 +64,6 @@ public abstract class WindowsServiceTestCase extends PackagingTestCase {
         sh.runIgnoreExitCode(serviceScript + " remove");
     }
 
-    private Result runWithoutJava(String script) {
-        final Path relocatedJdk = installation.bundledJdk.getParent().resolve("jdk.relocated");
-
-        try {
-            mv(installation.bundledJdk, relocatedJdk);
-            // ask for elasticsearch version to quickly exit if java is actually found (ie test failure)
-            return sh.runIgnoreExitCode(script);
-        } finally {
-            mv(relocatedJdk, installation.bundledJdk);
-        }
-    }
-
     private void assertService(String id, String status, String displayName) {
         Result result = sh.run("Get-Service " + id + " | Format-List -Property Name, Status, DisplayName");
         assertThat(result.stdout, containsString("Name        : " + id));
@@ -84,16 +72,27 @@ public abstract class WindowsServiceTestCase extends PackagingTestCase {
     }
 
     // runs the service command, dumping all log files on failure
-    private void assertCommand(String script) {
+    private Result assertCommand(String script) {
         Result result = sh.runIgnoreExitCode(script);
-        if (result.exitCode != 0) {
-            logger.error("---- Failed to run script: " + script);
+        assertExit(result, script, 0);
+        return result;
+    }
+
+    private Result assertFailure(String script, int exitCode) {
+        Result result = sh.runIgnoreExitCode(script);
+        assertExit(result, script, exitCode);
+        return result;
+    }
+
+    private void assertExit(Result result, String script, int exitCode) {
+        if (result.exitCode != exitCode) {
+            logger.error("---- Unexpected exit code (expected " + exitCode + ", got " + result.exitCode + ") for script: " + script);
             logger.error(result);
             logger.error("Dumping log files\n");
             Result logs = sh.run("$files = Get-ChildItem \"" + installation.logs + "\\elasticsearch.log\"; " +
                 "Write-Output $files; " +
                 "foreach ($file in $files) {" +
-                    "Write-Output \"$file\"; " +
+                    "Write-Output \"$file\"; " +    
                     "Get-Content \"$file\" " +
                 "}");
             logger.error(logs.stdout);
@@ -126,14 +125,20 @@ public abstract class WindowsServiceTestCase extends PackagingTestCase {
     }
 
     public void test13InstallMissingJava() throws IOException {
-        Result result = runWithoutJava(serviceScript + " install");
-        assertThat(result.exitCode, equalTo(1));
-        assertThat(result.stderr, containsString("could not find java in JAVA_HOME or bundled"));
+        final Path relocatedJdk = installation.bundledJdk.getParent().resolve("jdk.relocated");
+
+        try {
+            mv(installation.bundledJdk, relocatedJdk);
+            Result result = sh.runIgnoreExitCode(serviceScript + " install");
+            assertThat(result.exitCode, equalTo(1));
+            assertThat(result.stderr, containsString("could not find java in JAVA_HOME or bundled"));
+        } finally {
+            mv(relocatedJdk, installation.bundledJdk);
+        }
     }
 
     public void test14RemoveNotInstalled() {
-        Result result = sh.runIgnoreExitCode(serviceScript + " remove");
-        assertThat(result.stdout, result.exitCode, equalTo(1));
+        Result result = assertFailure(serviceScript + " remove", 1);
         assertThat(result.stdout, containsString("Failed removing '" + DEFAULT_ID + "' service"));
     }
 
@@ -155,10 +160,7 @@ public abstract class WindowsServiceTestCase extends PackagingTestCase {
     }
 
     // NOTE: service description is not attainable through any powershell api, so checking it is not possible...
-
-    public void test30StartStop() throws IOException {
-        sh.run(serviceScript + " install");
-        assertCommand(serviceScript + " start");
+    public void assertStartedAndStop() throws IOException {
         ServerUtils.waitForElasticsearch();
         ServerUtils.runElasticsearchTests();
 
@@ -189,6 +191,12 @@ public abstract class WindowsServiceTestCase extends PackagingTestCase {
             "}");
     }
 
+    public void test30StartStop() throws IOException {
+        sh.run(serviceScript + " install");
+        assertCommand(serviceScript + " start");
+        assertStartedAndStop();
+    }
+
     public void test31StartNotInstalled() throws IOException {
         Result result = sh.runIgnoreExitCode(serviceScript + " start");
         assertThat(result.stdout, result.exitCode, equalTo(1));
@@ -201,17 +209,20 @@ public abstract class WindowsServiceTestCase extends PackagingTestCase {
         assertThat(result.stdout, containsString("The service '" + DEFAULT_ID + "' has been stopped"));
     }
 
-    /*
-    // TODO: need to make JAVA_HOME resolve at install time for this to work
-    // see https://github.com/elastic/elasticsearch/issues/23097
     public void test33JavaChanged() throws IOException {
-        sh.run(serviceScript + " install");
-        runWithoutJava(serviceScript + "start");
-        ServerUtils.waitForElasticsearch();
-        sh.run(serviceScript + " stop");
-        sh.runIgnoreExitCode("Wait-Process -Name \"elasticsearch-service-x64\" -Timeout 10");
-        sh.run(serviceScript + " remove");
-    }*/
+        final Path relocatedJdk = installation.bundledJdk.getParent().resolve("jdk.relocated");
+
+        try {
+            mv(installation.bundledJdk, relocatedJdk);
+            sh.getEnv().put("JAVA_HOME", relocatedJdk.toString());
+            assertCommand(serviceScript + " install");
+            sh.getEnv().remove("JAVA_HOME");
+            assertCommand(serviceScript + " start");
+            assertStartedAndStop();
+        } finally {
+            mv(relocatedJdk, installation.bundledJdk);
+        }
+    }
 
     public void test60Manager() throws IOException {
         Path serviceMgr = installation.bin("elasticsearch-service-mgr.exe");


### PR DESCRIPTION
On windows, JAVA_HOME is currently resolved when the windows service is started. However, this is contrary to what our documentation states. This commit moves resolution to service install. This has the side effect of making java existence checking optional in elasticsearch-env.bat, since the rest of the service commands do not require java.

closes #30720