### PR TITLE
Add more Java 12 distributions to testing

### DIFF
--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -9,6 +9,8 @@ ES_RUNTIME_JAVA:
   - java8
   - java8fips
   - java11
+  - java12
   - openjdk12
   - zulu8
   - zulu11
+  - zulu12


### PR DESCRIPTION
This commit adds the Oracle JDK 12 and the Zulu JDK 12 distributions to testing.
