### PR TITLE
[DOCS] Adds anchors and x-pack icons for frozen indices

### DIFF
--- a/docs/reference/frozen-indices.asciidoc
+++ b/docs/reference/frozen-indices.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="basic"]
 [[frozen-indices]]
-= Frozen Indices
+= Frozen indices
 
 [partintro]
 --
@@ -47,7 +47,10 @@ To make a frozen index writable again, use the <<unfreeze-index-api, Unfreeze In
 
 --
 
-== Best Practices
+[role="xpack"]
+[testenv="basic"]
+[[best_practices]]
+== Best practices
 
 Since frozen indices provide a much higher disk to heap ratio at the expense of search latency, it is advisable to allocate frozen indices to
 dedicated nodes to prevent searches on frozen indices influencing traffic on low latency nodes. There is significant overhead in loading
@@ -66,10 +69,13 @@ POST /twitter/_forcemerge?max_num_segments=1
 // CONSOLE
 // TEST[setup:twitter]
 
+[role="xpack"]
+[testenv="basic"]
+[[searching_a_frozen_index]]
 == Searching a frozen index
 
 Frozen indices are throttled in order to limit memory consumptions per node. The number of concurrently loaded frozen indices per node is
-limited by the number of threads in the <<search-throttled>> threadpool,  which is `1` by default. 
+limited by the number of threads in the <<search-throttled,search_throttled>> threadpool,  which is `1` by default. 
 Search requests will not be executed against frozen indices by default, even if a frozen index is named explicitly. This is 
 to prevent accidental slowdowns by targeting a frozen index by mistake. To include frozen indices a search request must be executed with
 the query parameter `ignore_throttled=false`.


### PR DESCRIPTION
The following pages about frozen indices do not have anchors defined so they're using automatically-generated ID:
https://www.elastic.co/guide/en/elasticsearch/reference/master/_best_practices.html
https://www.elastic.co/guide/en/elasticsearch/reference/master/_searching_a_frozen_index.html

This PR defines anchors explicitly instead.  This will enable us to link directly to these pages and will avoid some potential problems when we migrate to Asciidoctor, which sometimes generates different automatic IDs than our current builds.

It also adds the "role=xpack" attribute, which was missing from these pages.  

Finally, it fixes the sentence case of the titles and fixes an inline link that looked problematic.
