### PR TITLE
Remove dynamic objects from security index

### DIFF
--- a/x-pack/plugin/core/src/main/resources/security-index-template.json
+++ b/x-pack/plugin/core/src/main/resources/security-index-template.json
@@ -59,7 +59,7 @@
         },
         "metadata" : {
           "type" : "object",
-          "dynamic" : true
+          "dynamic" : false
         },
         "enabled": {
           "type": "boolean"
@@ -179,7 +179,7 @@
             },
             "metadata" : {
               "type" : "object",
-              "dynamic" : true
+              "dynamic" : false
             },
             "realm" : {
               "type" : "keyword"
@@ -188,7 +188,7 @@
         },
         "rules" : {
           "type" : "object",
-          "dynamic" : true
+          "dynamic" : false
         },
         "refresh_token" : {
           "type" : "object",
@@ -243,7 +243,7 @@
                 },
                 "metadata" : {
                   "type" : "object",
-                  "dynamic" : true
+                  "dynamic" : false
                 },
                 "authentication" : {
                   "type" : "binary"


### PR DESCRIPTION
The security index had a few "object" types with

    "dynamic": true

However, this automatically creates a mapping for each field that is
created within those objects. This means that types are dynamically
inferred and "locked in" for future updates.

Instead we want "dynamic": false which will allow us to store a range
of fields in these nested objects and retrieve them from the source,
without creating mapping types for those fields.

Closes: #35460