### PR TITLE
Remove -Xlint exclusions in the ingest-common module.

### DIFF
--- a/modules/ingest-common/build.gradle
+++ b/modules/ingest-common/build.gradle
@@ -29,9 +29,6 @@ dependencies {
     compile project(':libs:dissect')
 }
 
-compileJava.options.compilerArgs << "-Xlint:-unchecked,-rawtypes"
-compileTestJava.options.compilerArgs << "-Xlint:-unchecked,-rawtypes"
-
 integTestCluster {
     module project(':modules:lang-painless')
 }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/AbstractStringProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/AbstractStringProcessor.java
@@ -29,8 +29,10 @@ import java.util.Map;
 /**
  * Base class for processors that manipulate source strings and require a single "fields" array config value, which
  * holds a list of field names in string format.
+ *
+ * @param <T> The resultant type for the target field
  */
-abstract class AbstractStringProcessor extends AbstractProcessor {
+abstract class AbstractStringProcessor<T> extends AbstractProcessor {
     private final String field;
     private final boolean ignoreMissing;
     private final String targetField;
@@ -68,7 +70,7 @@ abstract class AbstractStringProcessor extends AbstractProcessor {
         return document;
     }
 
-    protected abstract Object process(String value);
+    protected abstract T process(String value);
 
     abstract static class Factory implements Processor.Factory {
         final String processorType;
@@ -78,8 +80,8 @@ abstract class AbstractStringProcessor extends AbstractProcessor {
         }
 
         @Override
-        public AbstractStringProcessor create(Map<String, Processor.Factory> registry, String tag,
-                                              Map<String, Object> config) throws Exception {
+        public AbstractStringProcessor<?> create(Map<String, Processor.Factory> registry, String tag,
+                                                 Map<String, Object> config) throws Exception {
             String field = ConfigurationUtils.readStringProperty(processorType, tag, config, "field");
             boolean ignoreMissing = ConfigurationUtils.readBooleanProperty(processorType, tag, config, "ignore_missing", false);
             String targetField = ConfigurationUtils.readStringProperty(processorType, tag, config, "target_field", field);
@@ -87,7 +89,7 @@ abstract class AbstractStringProcessor extends AbstractProcessor {
             return newProcessor(tag, config, field, ignoreMissing, targetField);
         }
 
-        protected abstract AbstractStringProcessor newProcessor(String processorTag, Map<String, Object> config, String field,
-                                                                boolean ignoreMissing, String targetField);
+        protected abstract AbstractStringProcessor<?> newProcessor(String processorTag, Map<String, Object> config, String field,
+                                                                   boolean ignoreMissing, String targetField);
     }
 }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/AbstractStringProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/AbstractStringProcessor.java
@@ -29,10 +29,8 @@ import java.util.Map;
 /**
  * Base class for processors that manipulate source strings and require a single "fields" array config value, which
  * holds a list of field names in string format.
- *
- * @param <T> The resultant type for the target field
  */
-abstract class AbstractStringProcessor<T> extends AbstractProcessor {
+abstract class AbstractStringProcessor extends AbstractProcessor {
     private final String field;
     private final boolean ignoreMissing;
     private final String targetField;
@@ -70,7 +68,7 @@ abstract class AbstractStringProcessor<T> extends AbstractProcessor {
         return document;
     }
 
-    protected abstract T process(String value);
+    protected abstract Object process(String value);
 
     abstract static class Factory implements Processor.Factory {
         final String processorType;

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/BytesProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/BytesProcessor.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * Processor that converts the content of string fields to the byte value.
  * Throws exception is the field is not of type string or can not convert to the numeric byte value
  */
-public final class BytesProcessor extends AbstractStringProcessor {
+public final class BytesProcessor extends AbstractStringProcessor<Long> {
 
     public static final String TYPE = "bytes";
 

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GsubProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GsubProcessor.java
@@ -29,7 +29,7 @@ import static org.elasticsearch.ingest.ConfigurationUtils.readStringProperty;
  * Processor that allows to search for patterns in field content and replace them with corresponding string replacement.
  * Support fields of string type only, throws exception if a field is of a different type.
  */
-public final class GsubProcessor extends AbstractStringProcessor {
+public final class GsubProcessor extends AbstractStringProcessor<String> {
 
     public static final String TYPE = "gsub";
 
@@ -67,8 +67,8 @@ public final class GsubProcessor extends AbstractStringProcessor {
         }
 
         @Override
-        protected AbstractStringProcessor newProcessor(String processorTag, Map<String, Object> config, String field,
-                                                       boolean ignoreMissing, String targetField) {
+        protected GsubProcessor newProcessor(String processorTag, Map<String, Object> config, String field,
+                                             boolean ignoreMissing, String targetField) {
             String pattern = readStringProperty(TYPE, processorTag, config, "pattern");
             String replacement = readStringProperty(TYPE, processorTag, config, "replacement");
             Pattern searchPattern;

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/LowercaseProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/LowercaseProcessor.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * Throws exception is the field is not of type string.
  */
 
-public final class LowercaseProcessor extends AbstractStringProcessor {
+public final class LowercaseProcessor extends AbstractStringProcessor<String> {
 
     public static final String TYPE = "lowercase";
 

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/TrimProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/TrimProcessor.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * Processor that trims the content of string fields.
  * Throws exception is the field is not of type string.
  */
-public final class TrimProcessor extends AbstractStringProcessor {
+public final class TrimProcessor extends AbstractStringProcessor<String> {
 
     public static final String TYPE = "trim";
 

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/URLDecodeProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/URLDecodeProcessor.java
@@ -26,7 +26,7 @@ import java.util.Map;
 /**
  * Processor that URL-decodes a string
  */
-public final class URLDecodeProcessor extends AbstractStringProcessor {
+public final class URLDecodeProcessor extends AbstractStringProcessor<String> {
 
     public static final String TYPE = "urldecode";
 

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UppercaseProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UppercaseProcessor.java
@@ -26,7 +26,7 @@ import java.util.Map;
  * Processor that converts the content of string fields to uppercase.
  * Throws exception is the field is not of type string.
  */
-public final class UppercaseProcessor extends AbstractStringProcessor {
+public final class UppercaseProcessor extends AbstractStringProcessor<String> {
 
     public static final String TYPE = "uppercase";
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AbstractStringProcessorFactoryTestCase.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AbstractStringProcessorFactoryTestCase.java
@@ -37,7 +37,7 @@ public abstract class AbstractStringProcessorFactoryTestCase extends ESTestCase 
         return config;
     }
 
-    protected void assertProcessor(AbstractStringProcessor processor) {}
+    protected void assertProcessor(AbstractStringProcessor<?> processor) {}
 
     public void testCreate() throws Exception {
         AbstractStringProcessor.Factory factory = newFactory();
@@ -47,7 +47,7 @@ public abstract class AbstractStringProcessorFactoryTestCase extends ESTestCase 
         Map<String, Object> config = new HashMap<>();
         config.put("field", fieldName);
 
-        AbstractStringProcessor processor = factory.create(null, processorTag, modifyConfig(config));
+        AbstractStringProcessor<?> processor = factory.create(null, processorTag, modifyConfig(config));
         assertThat(processor.getTag(), equalTo(processorTag));
         assertThat(processor.getField(), equalTo(fieldName));
         assertThat(processor.isIgnoreMissing(), is(false));
@@ -64,7 +64,7 @@ public abstract class AbstractStringProcessorFactoryTestCase extends ESTestCase 
         config.put("field", fieldName);
         config.put("ignore_missing", true);
 
-        AbstractStringProcessor processor = factory.create(null, processorTag, modifyConfig(config));
+        AbstractStringProcessor<?> processor = factory.create(null, processorTag, modifyConfig(config));
         assertThat(processor.getTag(), equalTo(processorTag));
         assertThat(processor.getField(), equalTo(fieldName));
         assertThat(processor.isIgnoreMissing(), is(true));
@@ -82,7 +82,7 @@ public abstract class AbstractStringProcessorFactoryTestCase extends ESTestCase 
         config.put("field", fieldName);
         config.put("target_field", targetFieldName);
 
-        AbstractStringProcessor processor = factory.create(null, processorTag, modifyConfig(config));
+        AbstractStringProcessor<?> processor = factory.create(null, processorTag, modifyConfig(config));
         assertThat(processor.getTag(), equalTo(processorTag));
         assertThat(processor.getField(), equalTo(fieldName));
         assertThat(processor.isIgnoreMissing(), is(false));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AbstractStringProcessorTestCase.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AbstractStringProcessorTestCase.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.ingest.IngestDocumentMatcher.assertIngestDocumen
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
-public abstract class AbstractStringProcessorTestCase<T> extends ESTestCase {
+public abstract class AbstractStringProcessorTestCase extends ESTestCase {
 
     protected abstract AbstractStringProcessor newProcessor(String field, boolean ignoreMissing, String targetField);
 
@@ -39,10 +39,10 @@ public abstract class AbstractStringProcessorTestCase<T> extends ESTestCase {
         return input;
     }
 
-    protected abstract T expectedResult(String input);
+    protected abstract Object expectedResult(String input);
 
-    protected Class<T> expectedResultType(){
-        return (Class<T>) String.class;  // most results types are Strings
+    protected Class<?> expectedResultType(){
+        return String.class;  // most results types are Strings
     }
 
     public void testProcessor() throws Exception {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AbstractStringProcessorTestCase.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AbstractStringProcessorTestCase.java
@@ -31,15 +31,15 @@ import static org.elasticsearch.ingest.IngestDocumentMatcher.assertIngestDocumen
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
-public abstract class AbstractStringProcessorTestCase extends ESTestCase {
+public abstract class AbstractStringProcessorTestCase<T> extends ESTestCase {
 
-    protected abstract AbstractStringProcessor newProcessor(String field, boolean ignoreMissing, String targetField);
+    protected abstract AbstractStringProcessor<T> newProcessor(String field, boolean ignoreMissing, String targetField);
 
     protected String modifyInput(String input) {
         return input;
     }
 
-    protected abstract Object expectedResult(String input);
+    protected abstract T expectedResult(String input);
 
     protected Class<?> expectedResultType(){
         return String.class;  // most results types are Strings

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/BytesProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/BytesProcessorTests.java
@@ -29,12 +29,12 @@ import org.hamcrest.CoreMatchers;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class BytesProcessorTests extends AbstractStringProcessorTestCase {
+public class BytesProcessorTests extends AbstractStringProcessorTestCase<Long> {
 
     private String modifiedInput;
 
     @Override
-    protected AbstractStringProcessor newProcessor(String field, boolean ignoreMissing, String targetField) {
+    protected AbstractStringProcessor<Long> newProcessor(String field, boolean ignoreMissing, String targetField) {
         return new BytesProcessor(randomAlphaOfLength(10), field, ignoreMissing, targetField);
     }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GsubProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GsubProcessorFactoryTests.java
@@ -42,7 +42,7 @@ public class GsubProcessorFactoryTests extends AbstractStringProcessorFactoryTes
     }
 
     @Override
-    protected void assertProcessor(AbstractStringProcessor processor) {
+    protected void assertProcessor(AbstractStringProcessor<?> processor) {
         GsubProcessor gsubProcessor = (GsubProcessor) processor;
         assertThat(gsubProcessor.getPattern().toString(), equalTo("\\."));
         assertThat(gsubProcessor.getReplacement(), equalTo("-"));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GsubProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GsubProcessorTests.java
@@ -21,10 +21,10 @@ package org.elasticsearch.ingest.common;
 
 import java.util.regex.Pattern;
 
-public class GsubProcessorTests extends AbstractStringProcessorTestCase {
+public class GsubProcessorTests extends AbstractStringProcessorTestCase<String> {
 
     @Override
-    protected AbstractStringProcessor newProcessor(String field, boolean ignoreMissing, String targetField) {
+    protected AbstractStringProcessor<String> newProcessor(String field, boolean ignoreMissing, String targetField) {
         return new GsubProcessor(randomAlphaOfLength(10), field, Pattern.compile("\\."), "-", ignoreMissing, targetField);
     }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/LowercaseProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/LowercaseProcessorTests.java
@@ -21,9 +21,9 @@ package org.elasticsearch.ingest.common;
 
 import java.util.Locale;
 
-public class LowercaseProcessorTests extends AbstractStringProcessorTestCase {
+public class LowercaseProcessorTests extends AbstractStringProcessorTestCase<String> {
     @Override
-    protected AbstractStringProcessor newProcessor(String field, boolean ignoreMissing, String targetField) {
+    protected AbstractStringProcessor<String> newProcessor(String field, boolean ignoreMissing, String targetField) {
         return new LowercaseProcessor(randomAlphaOfLength(10), field, ignoreMissing, targetField);
     }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/TrimProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/TrimProcessorTests.java
@@ -19,10 +19,10 @@
 
 package org.elasticsearch.ingest.common;
 
-public class TrimProcessorTests extends AbstractStringProcessorTestCase {
+public class TrimProcessorTests extends AbstractStringProcessorTestCase<String> {
 
     @Override
-    protected AbstractStringProcessor newProcessor(String field, boolean ignoreMissing, String targetField) {
+    protected AbstractStringProcessor<String> newProcessor(String field, boolean ignoreMissing, String targetField) {
         return new TrimProcessor(randomAlphaOfLength(10), field, ignoreMissing, targetField);
     }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/URLDecodeProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/URLDecodeProcessorTests.java
@@ -22,14 +22,14 @@ package org.elasticsearch.ingest.common;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 
-public class URLDecodeProcessorTests extends AbstractStringProcessorTestCase {
+public class URLDecodeProcessorTests extends AbstractStringProcessorTestCase<String> {
     @Override
     protected String modifyInput(String input) {
         return "Hello%20G%C3%BCnter" + input;
     }
 
     @Override
-    protected AbstractStringProcessor newProcessor(String field, boolean ignoreMissing, String targetField) {
+    protected AbstractStringProcessor<String> newProcessor(String field, boolean ignoreMissing, String targetField) {
         return new URLDecodeProcessor(randomAlphaOfLength(10), field, ignoreMissing, targetField);
     }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UppercaseProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UppercaseProcessorTests.java
@@ -21,10 +21,10 @@ package org.elasticsearch.ingest.common;
 
 import java.util.Locale;
 
-public class UppercaseProcessorTests extends AbstractStringProcessorTestCase {
+public class UppercaseProcessorTests extends AbstractStringProcessorTestCase<String> {
 
     @Override
-    protected AbstractStringProcessor newProcessor(String field, boolean ignoreMissing, String targetField) {
+    protected AbstractStringProcessor<String> newProcessor(String field, boolean ignoreMissing, String targetField) {
         return new UppercaseProcessor(randomAlphaOfLength(10), field, ignoreMissing, targetField);
     }
 


### PR DESCRIPTION
The generics in AbstractStringProcessor is not needed
(IngestDocument#setFieldValue(...) invocation in 
AbstractStringProcessor accepts Object) and therefor it 
was removed. Otherwise the corresponding factory 
implementations would need typing too.

Relates to #40366