### PR TITLE
Mention legacy discovery settings in migration doc

### DIFF
--- a/docs/reference/migration/migrate_7_0/discovery.asciidoc
+++ b/docs/reference/migration/migrate_7_0/discovery.asciidoc
@@ -38,6 +38,12 @@ file:
 - `discovery.seed_hosts`
 - `discovery.seed_providers`
 - `cluster.initial_master_nodes`
+- `discovery.zen.ping.unicast.hosts`
+- `discovery.zen.hosts_provider`
+
+The first three settings in this list are only available in versions 7.0 and
+above. If you are preparing to upgrade from an earlier version, you must set
+`discovery.zen.ping.unicast.hosts` or `discovery.zen.hosts_provider`.
 
 [float]
 ==== New name for `no_master_block` setting


### PR DESCRIPTION
Today the upgrade assistant identifies that discovery configuration is required
in production mode, but links to docs saying to add one of these settings:

- `discovery.seed_hosts`
- `discovery.seed_providers`
- `cluster.initial_master_nodes`

However these settings do not exist in 6.7 so this is unhelpful advice. This
commit adjusts the docs to give more useful advice to users arriving at this
page from the upgrade assistant.

Relates https://discuss.elastic.co/t/174102