### PR TITLE
SQL: Polish behavior of SYS TABLES command

### DIFF
--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcDatabaseMetaData.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcDatabaseMetaData.java
@@ -257,8 +257,7 @@ class JdbcDatabaseMetaData implements DatabaseMetaData, JdbcWrapper {
 
     @Override
     public boolean supportsConvert() throws SQLException {
-        //TODO: add Convert
-        return false;
+        return true;
     }
 
     @Override
@@ -774,14 +773,14 @@ class JdbcDatabaseMetaData implements DatabaseMetaData, JdbcWrapper {
     @Override
     public ResultSet getCatalogs() throws SQLException {
         // TABLE_CAT is the first column
-        Object[][] data = queryColumn(con, "SYS TABLES CATALOG LIKE '%'", 1);
+        Object[][] data = queryColumn(con, "SYS TABLES CATALOG LIKE '%' LIKE ''", 1);
         return memorySet(con.cfg, columnInfo("", "TABLE_CAT"), data);
     }
 
     @Override
     public ResultSet getTableTypes() throws SQLException {
         // TABLE_TYPE (4)
-        Object[][] data = queryColumn(con, "SYS TABLES TYPE '%'", 4);
+        Object[][] data = queryColumn(con, "SYS TABLES CATALOG LIKE '' LIKE '' TYPE '%'", 4);
         return memorySet(con.cfg, columnInfo("", "TABLE_TYPE"), data);
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/CommandBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/CommandBuilder.java
@@ -149,9 +149,8 @@ abstract class CommandBuilder extends LogicalPlanBuilder {
             if (value != null) {
                 // check special ODBC wildcard case
                 if (value.equals(StringUtils.SQL_WILDCARD) && ctx.string().size() == 1) {
-                    // convert % to enumeration
-                    // https://docs.microsoft.com/en-us/sql/odbc/reference/develop-app/value-list-arguments?view=ssdt-18vs2017
-                    types.addAll(IndexType.VALID);
+                    // treat % as null
+                    // https://docs.microsoft.com/en-us/sql/odbc/reference/develop-app/value-list-arguments
                 }
                 // special case for legacy apps (like msquery) that always asks for 'TABLE'
                 // which we manually map to all concrete tables supported

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
@@ -11,7 +11,6 @@ import org.elasticsearch.xpack.sql.analysis.index.IndexResolver.IndexType;
 import org.elasticsearch.xpack.sql.expression.Attribute;
 import org.elasticsearch.xpack.sql.expression.predicate.regex.LikePattern;
 import org.elasticsearch.xpack.sql.plan.logical.command.Command;
-import org.elasticsearch.xpack.sql.proto.StringUtils;
 import org.elasticsearch.xpack.sql.session.Rows;
 import org.elasticsearch.xpack.sql.session.SchemaRowSet;
 import org.elasticsearch.xpack.sql.session.SqlSession;
@@ -78,9 +77,9 @@ public class SysTables extends Command {
         // https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqltables-function?view=ssdt-18vs2017#comments
 
         // catalog enumeration
-        if (clusterPattern == null || (clusterPattern != null && clusterPattern.pattern().equals(SQL_WILDCARD))) {
+        if (clusterPattern == null || clusterPattern.pattern().equals(SQL_WILDCARD)) {
             // enumerate only if pattern is "" and no types are null
-            if (pattern != null && StringUtils.EMPTY.equals(pattern.pattern()) && index == null
+            if (pattern != null && pattern.pattern().isEmpty() && index == null
                     && types == null) {
                 Object[] enumeration = new Object[10];
                 // send only the cluster, everything else null
@@ -93,10 +92,10 @@ public class SysTables extends Command {
         // enumerate types
         // if no types were specified (the parser takes care of the % case)
         if (types == null) {
-            // empty string for catalog 
-            if (clusterPattern != null && StringUtils.EMPTY.equals(clusterPattern.pattern())
+            // empty string for catalog
+            if (clusterPattern != null && clusterPattern.pattern().isEmpty()
                     // empty string for table like and no index specified
-                    && pattern != null && StringUtils.EMPTY.equals(pattern.pattern()) && index == null) {
+                    && pattern != null && pattern.pattern().isEmpty() && index == null) {
                 List<List<?>> values = new ArrayList<>();
                 // send only the types, everything else is made of empty strings
                 for (IndexType type : IndexType.VALID) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
@@ -78,7 +78,7 @@ public class SysTables extends Command {
 
         // catalog enumeration
         if (clusterPattern == null || clusterPattern.pattern().equals(SQL_WILDCARD)) {
-            // enumerate only if pattern is "" and no types are null
+            // enumerate only if pattern is "" and no types are specified (types is null)
             if (pattern != null && pattern.pattern().isEmpty() && index == null
                     && types == null) {
                 Object[] enumeration = new Object[10];
@@ -90,7 +90,7 @@ public class SysTables extends Command {
         }
         
         // enumerate types
-        // if no types were specified (the parser takes care of the % case)
+        // if no types are specified (the parser takes care of the % case)
         if (types == null) {
             // empty string for catalog
             if (clusterPattern != null && clusterPattern.pattern().isEmpty()

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
@@ -54,13 +54,6 @@ public class SysTablesTests extends ESTestCase {
     //
     // catalog enumeration
     //
-    public void testSysTablesEnumerateCatalog() throws Exception {
-        executeCommand("SYS TABLES CATALOG LIKE '%' LIKE ''", r -> {
-            assertEquals(1, r.size());
-            assertEquals(CLUSTER_NAME, r.column(0));
-        });
-    }
-
     public void testSysTablesCatalogEnumeration() throws Exception {
         executeCommand("SYS TABLES CATALOG LIKE '%' LIKE ''", r -> {
             assertEquals(1, r.size());

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
@@ -51,20 +51,67 @@ public class SysTablesTests extends ESTestCase {
     private final IndexInfo index = new IndexInfo("test", IndexType.INDEX);
     private final IndexInfo alias = new IndexInfo("alias", IndexType.ALIAS);
 
+    //
+    // catalog enumeration
+    //
     public void testSysTablesEnumerateCatalog() throws Exception {
-        executeCommand("SYS TABLES CATALOG LIKE '%'", r -> {
+        executeCommand("SYS TABLES CATALOG LIKE '%' LIKE ''", r -> {
             assertEquals(1, r.size());
             assertEquals(CLUSTER_NAME, r.column(0));
         });
     }
 
-    public void testSysTablesEnumerateTypes() throws Exception {
-        executeCommand("SYS TABLES TYPE '%'", r -> {
+    public void testSysTablesCatalogEnumeration() throws Exception {
+        executeCommand("SYS TABLES CATALOG LIKE '%' LIKE ''", r -> {
+            assertEquals(1, r.size());
+            assertEquals(CLUSTER_NAME, r.column(0));
+            // everything else should be null
+            for (int i = 1; i < 10; i++) {
+                assertNull(r.column(i));
+            }
+        }, index);
+    }
+
+    //
+    // table types enumeration
+    //
+    public void testSysTablesTypesEnumerationWoString() throws Exception {
+        executeCommand("SYS TABLES CATALOG LIKE '' LIKE '' ", r -> {
             assertEquals(2, r.size());
             assertEquals("BASE TABLE", r.column(3));
             assertTrue(r.advanceRow());
             assertEquals("VIEW", r.column(3));
-        });
+        }, new IndexInfo[0]);
+    }
+
+    public void testSysTablesEnumerateTypes() throws Exception {
+        executeCommand("SYS TABLES CATALOG LIKE '' LIKE '' TYPE '%'", r -> {
+            assertEquals(2, r.size());
+            assertEquals("BASE TABLE", r.column(3));
+            assertTrue(r.advanceRow());
+            assertEquals("VIEW", r.column(3));
+        }, alias, index);
+    }
+
+    public void testSysTablesTypesEnumeration() throws Exception {
+        executeCommand("SYS TABLES CATALOG LIKE '' LIKE '' TYPE '%'", r -> {
+            assertEquals(2, r.size());
+
+            Iterator<IndexType> it = IndexType.VALID.stream().sorted(Comparator.comparing(IndexType::toSql)).iterator();
+
+            for (int t = 0; t < r.size(); t++) {
+                assertEquals(it.next().toSql(), r.column(3));
+
+                // everything else should be null
+                for (int i = 0; i < 10; i++) {
+                    if (i != 3) {
+                        assertNull(r.column(i));
+                    }
+                }
+
+                r.advanceRow();
+            }
+        }, new IndexInfo[0]);
     }
 
     public void testSysTablesDifferentCatalog() throws Exception {
@@ -77,17 +124,42 @@ public class SysTablesTests extends ESTestCase {
     public void testSysTablesNoTypes() throws Exception {
         executeCommand("SYS TABLES", r -> {
             assertEquals(2, r.size());
+            assertEquals("test", r.column(2));
             assertEquals("BASE TABLE", r.column(3));
             assertTrue(r.advanceRow());
+            assertEquals("alias", r.column(2));
+            assertEquals("VIEW", r.column(3));
+        }, index, alias);
+    }
+
+    public void testSysTablesWithLegacyTypes() throws Exception {
+        executeCommand("SYS TABLES TYPE 'TABLE', 'ALIAS'", r -> {
+            assertEquals(2, r.size());
+            assertEquals("test", r.column(2));
+            assertEquals("TABLE", r.column(3));
+            assertTrue(r.advanceRow());
+            assertEquals("alias", r.column(2));
+            assertEquals("VIEW", r.column(3));
+        }, index, alias);
+    }
+
+    public void testSysTablesWithProperTypes() throws Exception {
+        executeCommand("SYS TABLES TYPE 'BASE TABLE', 'ALIAS'", r -> {
+            assertEquals(2, r.size());
+            assertEquals("test", r.column(2));
+            assertEquals("BASE TABLE", r.column(3));
+            assertTrue(r.advanceRow());
+            assertEquals("alias", r.column(2));
             assertEquals("VIEW", r.column(3));
         }, index, alias);
     }
 
     public void testSysTablesPattern() throws Exception {
         executeCommand("SYS TABLES LIKE '%'", r -> {
-            assertEquals("test", r.column(2));
-            assertTrue(r.advanceRow());
             assertEquals(2, r.size());
+            assertEquals("test", r.column(2));
+            assertEquals("BASE TABLE", r.column(3));
+            assertTrue(r.advanceRow());
             assertEquals("alias", r.column(2));
         }, index, alias);
     }
@@ -130,7 +202,18 @@ public class SysTablesTests extends ESTestCase {
             assertEquals("test", r.column(2));
             assertEquals("TABLE", r.column(3));
         }, index);
+    }
 
+    public void testSysTablesNoPatternWithTypesSpecifiedInLegacyMode() throws Exception {
+        executeCommand("SYS TABLES TYPE 'TABLE','VIEW'", r -> {
+            assertEquals(2, r.size());
+            assertEquals("test", r.column(2));
+            assertEquals("TABLE", r.column(3));
+            assertTrue(r.advanceRow());
+            assertEquals("alias", r.column(2));
+            assertEquals("VIEW", r.column(3));
+
+        }, index, alias);
     }
 
     public void testSysTablesOnlyIndicesLegacyModeParameterized() throws Exception {
@@ -192,43 +275,6 @@ public class SysTablesTests extends ESTestCase {
         }, new IndexInfo[0]);
     }
 
-    public void testSysTablesCatalogEnumeration() throws Exception {
-        executeCommand("SYS TABLES CATALOG LIKE '%' LIKE ''", r -> {
-            assertEquals(1, r.size());
-            assertEquals(CLUSTER_NAME, r.column(0));
-            // everything else should be null
-            for (int i = 1; i < 10; i++) {
-                assertNull(r.column(i));
-            }
-        }, new IndexInfo[0]);
-    }
-
-    public void testSysTablesTypesEnumeration() throws Exception {
-        executeCommand("SYS TABLES CATALOG LIKE '' LIKE '' TYPE '%'", r -> {
-            assertEquals(2, r.size());
-
-            Iterator<IndexType> it = IndexType.VALID.stream().sorted(Comparator.comparing(IndexType::toSql)).iterator();
-
-            for (int t = 0; t < r.size(); t++) {
-                assertEquals(it.next().toSql(), r.column(3));
-
-                // everything else should be null
-                for (int i = 0; i < 10; i++) {
-                    if (i != 3) {
-                        assertNull(r.column(i));
-                    }
-                }
-
-                r.advanceRow();
-            }
-        }, new IndexInfo[0]);
-    }
-
-    public void testSysTablesTypesEnumerationWoString() throws Exception {
-        executeCommand("SYS TABLES CATALOG LIKE '' LIKE '' ", r -> {
-            assertEquals(0, r.size());
-        }, new IndexInfo[0]);
-    }
 
     private SqlTypedParamValue param(Object value) {
         return new SqlTypedParamValue(DataTypes.fromJava(value).typeName, value);


### PR DESCRIPTION
SYS TABLES meta command has been improved to better adhere to the ODBC
spec in particular with regards to the handling of enumerations (and
the differences between '%', null and ''(empty string))

Fix #40348