### PR TITLE
Muting test related to #40537

### DIFF
--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFramePivotRestIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFramePivotRestIT.java
@@ -268,6 +268,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
         });
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/40537")
     public void testPivotWithMaxOnDateField() throws Exception {
         String transformId = "simpleDateHistogramPivotWithMaxTime";
         String dataFrameIndex = "pivot_reviews_via_date_histogram_with_max_time";


### PR DESCRIPTION
https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+multijob-darwin-compatibility/313/consoleFull

Reproduce line:

./gradlew :x-pack:plugin:data-frame:qa:single-node-tests:integTestRunner -Dtests.seed=33CD822722A48729 -Dtests.class=org.elasticsearch.xpack.dataframe.integration.DataFramePivotRestIT -Dtests.method="testPivotWithMaxOnDateField" -Dtests.security.manager=true -Dtests.locale=vi-VN -Dtests.timezone=America/Merida -Dcompiler.java=12 -Druntime.java=8

Looks like this random seed causes the max hour to be 19 and not the expected 20