### PR TITLE
SQL: Centralize SQL test dependencies version handling

### DIFF
--- a/x-pack/plugin/sql/build.gradle
+++ b/x-pack/plugin/sql/build.gradle
@@ -14,6 +14,10 @@ ext {
     // SQL dependency versions
     jlineVersion="3.10.0"
     antlrVersion="4.5.3"
+    
+    // SQL test dependency versions
+    csvjdbcVersion="1.0.34"
+    h2Version="1.4.197"
 }
 
 configurations {

--- a/x-pack/plugin/sql/qa/build.gradle
+++ b/x-pack/plugin/sql/qa/build.gradle
@@ -12,7 +12,7 @@ dependencies {
   compile project(path: xpackModule('sql:jdbc'), configuration: 'nodeps')
 
   compile project(path: xpackModule('sql:sql-action'))
-  compile "net.sourceforge.csvjdbc:csvjdbc:1.0.34"
+  compile "net.sourceforge.csvjdbc:csvjdbc:${csvjdbcVersion}"
 
   // CLI testing dependencies
   compile project(path: xpackModule('sql:sql-cli'), configuration: 'nodeps')
@@ -54,8 +54,8 @@ subprojects {
     testCompile "org.elasticsearch.test:framework:${version}"
 
     // JDBC testing dependencies
-    testRuntime "net.sourceforge.csvjdbc:csvjdbc:1.0.34"
-    testRuntime "com.h2database:h2:1.4.197"
+    testRuntime "net.sourceforge.csvjdbc:csvjdbc:${csvjdbcVersion}"
+    testRuntime "com.h2database:h2:${h2Version}"
     testRuntime project(path: xpackModule('sql:jdbc'), configuration: 'nodeps')
     testRuntime xpackProject('plugin:sql:sql-client')
 


### PR DESCRIPTION
Moves definitions of versions for csvjdbc and h2 libraries to the
central build.gradle file.

Follow up for #40461