### PR TITLE
Muting test for #40553

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/search/SearchResponseMergerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchResponseMergerTests.java
@@ -396,6 +396,7 @@ public class SearchResponseMergerTests extends ESTestCase {
         assertEquals(totalCount, bucket.getDocCount());
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/40553")
     public void testMergeSearchHits() throws InterruptedException {
         final long currentRelativeTime = randomLong();
         final SearchTimeProvider timeProvider = new SearchTimeProvider(randomLong(), 0, () -> currentRelativeTime);


### PR DESCRIPTION
Muting test org.elasticsearch.action.search.SearchResponseMergerTests.testMergeSearchHits

See #40553