### PR TITLE
Adjust BWC candidates in retention lease BWC tests

### DIFF
--- a/qa/retention-lease-bwc/build.gradle
+++ b/qa/retention-lease-bwc/build.gradle
@@ -30,13 +30,17 @@ esplugin {
 integTest.enabled = false
 
 task bwcTest {
-  description = 'runs retention lease backwards compatability tests'
+  description = 'runs retention lease backwards compatibility tests'
   group = 'verification'
 }
 
 for (Version version : bwcVersions.wireCompatible) {
   if (version.before("6.5.0")) {
     // versions before 6.5.0 do not support soft deletes
+    continue
+  }
+  if (version.onOrAfter("6.7.0")) {
+    // we are known to be compatible with these versions
     continue
   }
 


### PR DESCRIPTION
We test BWC with nodes older than 6.7.0 since such nodes would not understand retention lease sync requests. However, we do not need to test compatibility with nodes on or after 6.7.0 since we know these nodes understand retention lease sync requests, which are already exercised in other tests. Therefore, we can skip these versions when running the BWC tests and only test against versions that do not understand retention lease sync requests.

Closes #40559
Relates #40561
