### PR TITLE
fix summary of phrase_prefix scoring

### DIFF
--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -85,11 +85,11 @@ parameter, which can be set to:
                     were one big field. Looks for each word in *any*
                     field. See <<type-cross-fields>>.
 
-`phrase`::          Runs a `match_phrase` query on each field and uses the  `_score` 
+`phrase`::          Runs a `match_phrase` query on each field and uses the `_score`
                     from the best field.  See <<type-phrase>>.
 
-`phrase_prefix`::   Runs a `match_phrase_prefix` query on each field and
-                    combines the `_score` from each field.  See <<type-phrase>>.
+`phrase_prefix`::   Runs a `match_phrase_prefix` query on each field and uses
+                    the `_score` from the best field.  See <<type-phrase>>.
 
 `bool_prefix`::     Creates a `match_bool_prefix` query on each field and
                     combines the `_score` from each field. See


### PR DESCRIPTION
The language here implies that `phrase_prefix` scoring works like `most_fields`, but it actually works like `best_fields`. It looks like this was addressed for `phrase` in #32672
