### PR TITLE
Specify from and size as querystring parameters

### DIFF
--- a/docs/reference/ml/apis/get-filter.asciidoc
+++ b/docs/reference/ml/apis/get-filter.asciidoc
@@ -28,7 +28,7 @@ You can get a single filter or all filters. For more information, see
   (string) Identifier for the filter.
 
 
-==== Request Body
+==== Querystring Parameters
 
 `from`:::
     (integer) Skips the specified number of filters.


### PR DESCRIPTION
This PR updates the header for from and size to indicate
that they can be specified as querystring parameters.

