### PR TITLE
SQL: Add JDBC trustore type to the docs

### DIFF
--- a/docs/reference/sql/endpoints/jdbc.asciidoc
+++ b/docs/reference/sql/endpoints/jdbc.asciidoc
@@ -113,6 +113,8 @@ Query timeout (in seconds). That is the maximum amount of time waiting for a que
 
 `ssl.truststore.pass`:: trust store password
 
+`ssl.truststore.type` (default `JKS`):: trust store type. `PKCS12` is a common, alternative format
+
 `ssl.protocol`(default `TLS`):: SSL protocol to be used
 
 [float]


### PR DESCRIPTION
`ssl.truststore.type` was missing from the documentation.
This is a PR mirroring the one from @tsouza (https://github.com/elastic/elasticsearch/pull/35544) which couldn't have its base branch changed to `master`.