### PR TITLE
SQL: Convert ST_Distance into query when possible

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/geo/GeoShape.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/geo/GeoShape.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.geo.geometry.Geometry;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 
 import java.io.IOException;
@@ -56,6 +57,10 @@ public class GeoShape implements ToXContentFragment, NamedWriteable {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         return builder.value(shapeBuilder.toWKT());
+    }
+
+    public Geometry toGeometry() {
+        return shapeBuilder.buildGeometry();
     }
 
     public static double distance(GeoShape shape1, GeoShape shape2) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/geo/StDistance.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/geo/StDistance.java
@@ -12,7 +12,6 @@ import org.elasticsearch.xpack.sql.expression.FieldAttribute;
 import org.elasticsearch.xpack.sql.expression.gen.pipeline.Pipe;
 import org.elasticsearch.xpack.sql.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.sql.expression.predicate.BinaryOperator;
-import org.elasticsearch.xpack.sql.expression.predicate.PredicateBiFunction;
 import org.elasticsearch.xpack.sql.tree.NodeInfo;
 import org.elasticsearch.xpack.sql.tree.Source;
 import org.elasticsearch.xpack.sql.type.DataType;
@@ -23,7 +22,7 @@ import static org.elasticsearch.xpack.sql.expression.gen.script.ParamsBuilder.pa
 /**
  * Calculates the distance between two points
  */
-public class StDistance extends BinaryOperator<Object, Object, Double, StDistance.StDistanceFunction> {
+public class StDistance extends BinaryOperator<Object, Object, Double, StDistanceFunction> {
 
     private static final StDistanceFunction FUNCTION = new StDistanceFunction();
 
@@ -71,23 +70,5 @@ public class StDistance extends BinaryOperator<Object, Object, Double, StDistanc
     @Override
     protected String scriptMethodName() {
         return "stDistance";
-    }
-
-    public static class StDistanceFunction implements PredicateBiFunction<Object, Object, Double> {
-
-        @Override
-        public String name() {
-            return "ST_DISTANCE";
-        }
-
-        @Override
-        public String symbol() {
-            return "ST_DISTANCE";
-        }
-
-        @Override
-        public Double doApply(Object s1, Object s2) {
-            return StDistanceProcessor.process(s1, s2);
-        }
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/geo/StDistance.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/geo/StDistance.java
@@ -65,6 +65,10 @@ public class StDistance extends BinaryScalarFunction {
             dataType());
     }
 
+    public StDistance swapLeftAndRight() {
+        return new StDistance(source(), right(), left());
+    }
+
     @Override
     public Object fold() {
         return process(left().fold(), right().fold());

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/geo/StDistanceFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/geo/StDistanceFunction.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.expression.function.scalar.geo;
+
+import org.elasticsearch.xpack.sql.expression.predicate.PredicateBiFunction;
+
+class StDistanceFunction  implements PredicateBiFunction<Object, Object, Double> {
+
+    @Override
+    public String name() {
+        return "ST_DISTANCE";
+    }
+
+    @Override
+    public String symbol() {
+        return "ST_DISTANCE";
+    }
+
+    @Override
+    public Double doApply(Object s1, Object s2) {
+        return StDistanceProcessor.process(s1, s2);
+    }
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
@@ -42,7 +42,6 @@ import org.elasticsearch.xpack.sql.expression.function.aggregate.TopHits;
 import org.elasticsearch.xpack.sql.expression.function.scalar.Cast;
 import org.elasticsearch.xpack.sql.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.sql.expression.function.scalar.ScalarFunctionAttribute;
-import org.elasticsearch.xpack.sql.expression.function.scalar.geo.StDistance;
 import org.elasticsearch.xpack.sql.expression.predicate.BinaryOperator;
 import org.elasticsearch.xpack.sql.expression.predicate.BinaryPredicate;
 import org.elasticsearch.xpack.sql.expression.predicate.Negatable;
@@ -135,8 +134,6 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                 // needs to occur before BinaryComparison combinations (see class)
                 new PropagateEquals(),
                 new CombineBinaryComparisons(),
-                // Geo
-                new StDistanceLiteralsOnTheRight(),
                 // prune/elimination
                 new PruneFilters(),
                 new PruneOrderBy(),
@@ -1410,22 +1407,6 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
         }
     }
 
-
-    static class StDistanceLiteralsOnTheRight extends OptimizerExpressionRule {
-
-        StDistanceLiteralsOnTheRight() {
-            super(TransformDirection.UP);
-        }
-
-        @Override
-        protected Expression rule(Expression e) {
-            return e instanceof StDistance ? literalToTheRight((StDistance) e) : e;
-        }
-
-        private Expression literalToTheRight(StDistance sd) {
-            return sd.left() instanceof Literal && !(sd.right() instanceof Literal) ? sd.swapLeftAndRight() : sd;
-        }
-    }
     /**
      * Propagate Equals to eliminate conjuncted Ranges.
      * When encountering a different Equals or non-containing {@link Range}, the conjunction becomes false.

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
@@ -673,14 +673,9 @@ final class QueryTranslator {
             Object value = valueOf(bc.right());
             String format = dateFormat(bc.left());
 
-            if (bc instanceof GreaterThan) {
-                return new RangeQuery(source, name, value, false, null, false, format);
-            }
-            if (bc instanceof GreaterThanOrEqual) {
-                return new RangeQuery(source, name, value, true, null, false, format);
-            }
-            if (bc instanceof LessThan) {
-                if (bc.left() instanceof StDistance && value instanceof Number) {
+            // Possible geo optimization
+            if (bc.left() instanceof StDistance && value instanceof Number) {
+                 if (bc instanceof LessThan || bc instanceof LessThanOrEqual) {
                     // Special case for ST_Distance translatable into geo_distance query
                     StDistance stDistance = (StDistance) bc.left();
                     if (stDistance.left() instanceof FieldAttribute && stDistance.right().foldable()) {
@@ -695,6 +690,14 @@ final class QueryTranslator {
                         }
                     }
                 }
+            }
+            if (bc instanceof GreaterThan) {
+                return new RangeQuery(source, name, value, false, null, false, format);
+            }
+            if (bc instanceof GreaterThanOrEqual) {
+                return new RangeQuery(source, name, value, true, null, false, format);
+            }
+            if (bc instanceof LessThan) {
                 return new RangeQuery(source, name, null, false, value, false, format);
             }
             if (bc instanceof LessThanOrEqual) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/query/GeoDistanceQuery.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/query/GeoDistanceQuery.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.sql.querydsl.query;
+
+import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.xpack.sql.tree.Source;
+
+import java.util.Objects;
+
+public class GeoDistanceQuery extends LeafQuery {
+
+    private final String field;
+    private final double lat;
+    private final double lon;
+    private final double distance;
+
+    public GeoDistanceQuery(Source source, String field, double distance, double lat, double lon) {
+        super(source);
+        this.field = field;
+        this.distance = distance;
+        this.lat = lat;
+        this.lon = lon;
+    }
+
+    public String field() {
+        return field;
+    }
+
+    public double lat() {
+        return lat;
+    }
+
+    public double lon() {
+        return lon;
+    }
+
+    public double distance() {
+        return distance;
+    }
+
+    @Override
+    public QueryBuilder asBuilder() {
+        return QueryBuilders.geoDistanceQuery(field).distance(distance, DistanceUnit.METERS).point(lat, lon);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field, distance, lat, lon);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        GeoDistanceQuery other = (GeoDistanceQuery) obj;
+        return Objects.equals(field, other.field) &&
+            Objects.equals(distance, other.distance) &&
+            Objects.equals(lat, other.lat) &&
+            Objects.equals(lon, other.lon);
+    }
+
+    @Override
+    protected String innerToString() {
+        return field + ":" + "(" + distance + "," + "(" + lat + ", " +  lon + "))";
+    }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DayOfYear
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.IsoWeekOfYear;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.MonthOfYear;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.Year;
+import org.elasticsearch.xpack.sql.expression.function.scalar.geo.StDistance;
 import org.elasticsearch.xpack.sql.expression.function.scalar.math.ACos;
 import org.elasticsearch.xpack.sql.expression.function.scalar.math.ASin;
 import org.elasticsearch.xpack.sql.expression.function.scalar.math.ATan;
@@ -81,6 +82,7 @@ import org.elasticsearch.xpack.sql.optimizer.Optimizer.PruneDuplicateFunctions;
 import org.elasticsearch.xpack.sql.optimizer.Optimizer.ReplaceFoldableAttributes;
 import org.elasticsearch.xpack.sql.optimizer.Optimizer.ReplaceMinMaxWithTopHits;
 import org.elasticsearch.xpack.sql.optimizer.Optimizer.SimplifyConditional;
+import org.elasticsearch.xpack.sql.optimizer.Optimizer.StDistanceLiteralsOnTheRight;
 import org.elasticsearch.xpack.sql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.sql.plan.logical.Filter;
 import org.elasticsearch.xpack.sql.plan.logical.LocalRelation;
@@ -620,6 +622,15 @@ public class OptimizerTests extends ESTestCase {
         NullEquals nullEquals= (NullEquals) result;
         assertEquals(a, nullEquals.left());
         assertEquals(FIVE, nullEquals.right());
+    }
+
+    public void testLiteralsOnTheRightInStDistance() {
+        Alias a = new Alias(EMPTY, "a", L(10));
+        Expression result = new StDistanceLiteralsOnTheRight().rule(new StDistance(EMPTY, FIVE, a));
+        assertTrue(result instanceof StDistance);
+        StDistance sd = (StDistance) result;
+        assertEquals(a, sd.left());
+        assertEquals(FIVE, sd.right());
     }
 
     public void testBoolSimplifyNotIsNullAndNotIsNotNull() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
@@ -82,7 +82,6 @@ import org.elasticsearch.xpack.sql.optimizer.Optimizer.PruneDuplicateFunctions;
 import org.elasticsearch.xpack.sql.optimizer.Optimizer.ReplaceFoldableAttributes;
 import org.elasticsearch.xpack.sql.optimizer.Optimizer.ReplaceMinMaxWithTopHits;
 import org.elasticsearch.xpack.sql.optimizer.Optimizer.SimplifyConditional;
-import org.elasticsearch.xpack.sql.optimizer.Optimizer.StDistanceLiteralsOnTheRight;
 import org.elasticsearch.xpack.sql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.sql.plan.logical.Filter;
 import org.elasticsearch.xpack.sql.plan.logical.LocalRelation;
@@ -626,7 +625,7 @@ public class OptimizerTests extends ESTestCase {
 
     public void testLiteralsOnTheRightInStDistance() {
         Alias a = new Alias(EMPTY, "a", L(10));
-        Expression result = new StDistanceLiteralsOnTheRight().rule(new StDistance(EMPTY, FIVE, a));
+        Expression result = new BooleanLiteralsOnTheRight().rule(new StDistance(EMPTY, FIVE, a));
         assertTrue(result instanceof StDistance);
         StDistance sd = (StDistance) result;
         assertEquals(a, sd.left());

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.xpack.sql.querydsl.agg.AggFilter;
 import org.elasticsearch.xpack.sql.querydsl.agg.GroupByDateHistogram;
 import org.elasticsearch.xpack.sql.querydsl.query.BoolQuery;
 import org.elasticsearch.xpack.sql.querydsl.query.ExistsQuery;
+import org.elasticsearch.xpack.sql.querydsl.query.GeoDistanceQuery;
 import org.elasticsearch.xpack.sql.querydsl.query.NotQuery;
 import org.elasticsearch.xpack.sql.querydsl.query.Query;
 import org.elasticsearch.xpack.sql.querydsl.query.QueryStringQuery;
@@ -596,22 +597,53 @@ public class QueryTranslatorTests extends ESTestCase {
         assertEquals("[{v=keyword}, {v=point (10.0 20.0)}]", aggFilter.scriptTemplate().params().toString());
     }
 
-    public void testTranslateStDistance() {
-        LogicalPlan p = plan("SELECT shape FROM test WHERE ST_Distance(shape, ST_WKTToSQL('point (10 20)')) > 20");
+    public void testTranslateStDistanceToScript() {
+        String operator = randomFrom(">", ">=", "<=");
+        String operatorFunction = null;
+        switch (operator) {
+            case ">":
+                operatorFunction = "gt";
+                break;
+            case ">=":
+                operatorFunction = "gte";
+                break;
+            case "<=":
+                operatorFunction = "lte";
+                break;
+            default:
+                fail("Unexpected operator [" + operator + "]");
+        }
+        LogicalPlan p = plan("SELECT shape FROM test WHERE ST_Distance(shape, ST_WKTToSQL('point (10 20)')) " + operator + " 20");
         assertThat(p, instanceOf(Project.class));
         assertThat(p.children().get(0), instanceOf(Filter.class));
         Expression condition = ((Filter) p.children().get(0)).condition();
         assertFalse(condition.foldable());
-        QueryTranslation translation = QueryTranslator.toQuery(condition, true);
-        assertNull(translation.query);
-        AggFilter aggFilter = translation.aggFilter;
-
+        QueryTranslation translation = QueryTranslator.toQuery(condition, false);
+        assertNull(translation.aggFilter);
+        assertTrue(translation.query instanceof ScriptQuery);
+        ScriptQuery sc = (ScriptQuery) translation.query;
         assertEquals("InternalSqlScriptUtils.nullSafeFilter(" +
-                "InternalSqlScriptUtils.gt(" +
+                "InternalSqlScriptUtils." + operatorFunction + "(" +
                 "InternalSqlScriptUtils.stDistance(" +
                 "InternalSqlScriptUtils.geoDocValue(doc,params.v0),InternalSqlScriptUtils.stWktToSql(params.v1)),params.v2))",
-            aggFilter.scriptTemplate().toString());
-        assertEquals("[{v=shape}, {v=point (10.0 20.0)}, {v=20}]", aggFilter.scriptTemplate().params().toString());
+            sc.script().toString());
+        assertEquals("[{v=shape}, {v=point (10.0 20.0)}, {v=20}]", sc.script().params().toString());
+    }
+
+    public void testTranslateStDistanceToQuery() {
+        LogicalPlan p = plan("SELECT shape FROM test WHERE ST_Distance(shape, ST_WKTToSQL('point (10 20)')) < 25");
+        assertThat(p, instanceOf(Project.class));
+        assertThat(p.children().get(0), instanceOf(Filter.class));
+        Expression condition = ((Filter) p.children().get(0)).condition();
+        assertFalse(condition.foldable());
+        QueryTranslation translation = QueryTranslator.toQuery(condition, false);
+        assertNull(translation.aggFilter);
+        assertTrue(translation.query instanceof GeoDistanceQuery);
+        GeoDistanceQuery gq = (GeoDistanceQuery) translation.query;
+        assertEquals("shape", gq.field());
+        assertEquals(20.0, gq.lat(), 0.00001);
+        assertEquals(10.0, gq.lon(), 0.00001);
+        assertEquals(25.0, gq.distance(), 0.00001);
     }
 
     public void testTranslateCoalesce_GroupBy_Painless() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -598,21 +598,8 @@ public class QueryTranslatorTests extends ESTestCase {
     }
 
     public void testTranslateStDistanceToScript() {
-        String operator = randomFrom(">", ">=", "<=");
-        String operatorFunction = null;
-        switch (operator) {
-            case ">":
-                operatorFunction = "gt";
-                break;
-            case ">=":
-                operatorFunction = "gte";
-                break;
-            case "<=":
-                operatorFunction = "lte";
-                break;
-            default:
-                fail("Unexpected operator [" + operator + "]");
-        }
+        String operator = randomFrom(">", ">=");
+        String operatorFunction = operator.equalsIgnoreCase(">") ? "gt" : "gte";
         LogicalPlan p = plan("SELECT shape FROM test WHERE ST_Distance(shape, ST_WKTToSQL('point (10 20)')) " + operator + " 20");
         assertThat(p, instanceOf(Project.class));
         assertThat(p.children().get(0), instanceOf(Filter.class));
@@ -631,7 +618,8 @@ public class QueryTranslatorTests extends ESTestCase {
     }
 
     public void testTranslateStDistanceToQuery() {
-        LogicalPlan p = plan("SELECT shape FROM test WHERE ST_Distance(shape, ST_WKTToSQL('point (10 20)')) < 25");
+        String operator = randomFrom("<", "<=");
+        LogicalPlan p = plan("SELECT shape FROM test WHERE ST_Distance(shape, ST_WKTToSQL('point (10 20)')) " + operator + " 25");
         assertThat(p, instanceOf(Project.class));
         assertThat(p.children().get(0), instanceOf(Filter.class));
         Expression condition = ((Filter) p.children().get(0)).condition();


### PR DESCRIPTION
Adds additional optimization logic to convert ST_Distance function
calls into geo_distance query when it is called in WHERE clauses.

