### PR TITLE
[DOCS] Document common settings for snapshot repository plugins (#40475) (7.0)

### DIFF
--- a/docs/plugins/repository-azure.asciidoc
+++ b/docs/plugins/repository-azure.asciidoc
@@ -126,9 +126,7 @@ The Azure repository supports following settings:
     setting doesn't affect index files that are already compressed by default.
     Defaults to `false`.
 
-`readonly`::
-
-    Makes repository read-only. Defaults to `false`.
+include::repository-shared-settings.asciidoc[]
 
 `location_mode`::
 

--- a/docs/plugins/repository-gcs.asciidoc
+++ b/docs/plugins/repository-gcs.asciidoc
@@ -240,6 +240,8 @@ The following settings are supported:
     setting doesn't affect index files that are already compressed by default.
     Defaults to `false`.
 
+include::repository-shared-settings.asciidoc[]
+
 `application_name`::
 
     deprecated[7.0.0, This setting is now defined in the <<repository-gcs-client, client settings>>]

--- a/docs/plugins/repository-hdfs.asciidoc
+++ b/docs/plugins/repository-hdfs.asciidoc
@@ -64,6 +64,8 @@ The following settings are supported:
 
     Whether to compress the metadata or not. (Disabled by default)
 
+include::repository-shared-settings.asciidoc[]
+
 `chunk_size`::
 
     Override the chunk size. (Disabled by default)

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -213,6 +213,8 @@ The following settings are supported:
     setting doesn't affect index files that are already compressed by default.
     Defaults to `false`.
 
+include::repository-shared-settings.asciidoc[]
+
 `server_side_encryption`::
 
     When set to `true` files are encrypted on server side using AES256

--- a/docs/plugins/repository-shared-settings.asciidoc
+++ b/docs/plugins/repository-shared-settings.asciidoc
@@ -1,0 +1,11 @@
+`max_restore_bytes_per_sec`::
+
+    Throttles per node restore rate. Defaults to `40mb` per second.
+
+`max_snapshot_bytes_per_sec`::
+
+    Throttles per node snapshot rate. Defaults to `40mb` per second.
+
+`readonly`::
+
+    Makes repository read-only.  Defaults to `false`.


### PR DESCRIPTION
Adds documentation for the `max_snapshot_bytes_per_sec`, `max_restore_bytes_per_sec`, and `readonly` settings to the following plugins:

- [Azure](https://www.elastic.co/guide/en/elasticsearch/plugins/7.x/repository-azure.html)
- [S3](https://www.elastic.co/guide/en/elasticsearch/plugins/7.x/repository-s3-repository.html)
- [Hadoop HDFS](https://www.elastic.co/guide/en/elasticsearch/plugins/7.x/repository-hdfs.html)
- [Google Cloud](https://www.elastic.co/guide/en/elasticsearch/plugins/7.x/repository-gcs.html)

Reuses definitions from the [Snapshot and Restore docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-snapshots.html#_shared_file_system_repository).

Backport of #40475