### PR TITLE
Update eager-global-ordinals.asciidoc

### DIFF
--- a/docs/reference/mapping/params/eager-global-ordinals.asciidoc
+++ b/docs/reference/mapping/params/eager-global-ordinals.asciidoc
@@ -28,7 +28,7 @@ but in general it is low, since it source field data has already been loaded.
 The memory overhead of global ordinals is a small because it is very
 efficiently compressed.
 
-By default, global ordinals are loaded at search-time, which is the right
+By default, global ordinals are loaded as-needed as opposed to up-front, which is the right
 trade-off if you are optimizing for indexing speed. However, if you are more
 interested in search speed, it could be interesting to set
 `eager_global_ordinals: true` on fields that you plan to use in terms


### PR DESCRIPTION
Adding clarification on global ordinals.
Global ordinals are loaded as-needed by default as opposed to up-front. setting `eager_global_ordinals: true` will load them up-front and keep them up-to-date, as opposed to lazy loading when needed.
eager_global_ordinals is false by default, just trying to clarify that bit.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
