### PR TITLE
Simplify BlobStoreRepository Constructor

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -157,8 +157,6 @@ class S3Repository extends BlobStoreRepository {
 
     private final String cannedACL;
 
-    private final RepositoryMetaData repositoryMetaData;
-
     /**
      * Constructs an s3 backed repository
      */
@@ -168,8 +166,6 @@ class S3Repository extends BlobStoreRepository {
                  final S3Service service) {
         super(metadata, settings, namedXContentRegistry);
         this.service = service;
-
-        this.repositoryMetaData = metadata;
 
         // Parse and validate the user's S3 Storage Class setting
         this.bucket = BUCKET_SETTING.get(metadata.settings());
@@ -216,7 +212,7 @@ class S3Repository extends BlobStoreRepository {
 
     @Override
     protected S3BlobStore createBlobStore() {
-        return new S3BlobStore(service, bucket, serverSideEncryption, bufferSize, cannedACL, storageClass, repositoryMetaData);
+        return new S3BlobStore(service, bucket, serverSideEncryption, bufferSize, cannedACL, storageClass, metadata);
     }
 
     // only use for testing

--- a/server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
@@ -63,7 +63,7 @@ public class FsRepository extends BlobStoreRepository {
         new ByteSizeValue(Long.MAX_VALUE), new ByteSizeValue(5), new ByteSizeValue(Long.MAX_VALUE), Property.NodeScope);
     private final Environment environment;
 
-    private ByteSizeValue chunkSize;
+    private final ByteSizeValue chunkSize;
 
     private final BlobPath basePath;
 


### PR DESCRIPTION
* Thanks to #39346 we can simplify the logic here some more, now that compress is a `final` field
