### PR TITLE
Clarify using time_zone and date math in range query

### DIFF
--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -139,7 +139,7 @@ GET _search
 // CONSOLE
 <1> This date will be converted to `2014-12-31T23:00:00 UTC`.
 <2> `now` is not affected by the `time_zone` parameter, its always the current system time (in UTC).
-However, when using <<date-math,date math rounding>> (e.g. to to the nearest day using `now/d`),
+However, when using <<date-math,date math rounding>> (e.g. down to the nearest day using `now/d`),
 the provided `time_zone` will be considered.
 
 

--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -138,7 +138,10 @@ GET _search
 --------------------------------------------------
 // CONSOLE
 <1> This date will be converted to `2014-12-31T23:00:00 UTC`.
-<2> `now` is not affected by the `time_zone` parameter (dates must be stored as UTC).
+<2> `now` is not affected by the `time_zone` parameter, its always the current system time (in UTC).
+However, when using <<date-math,date math rounding>> (e.g. to to the nearest day using `now/d`),
+the provided `time_zone` will be considered.
+
 
 [[querying-range-fields]]
 ==== Querying range fields


### PR DESCRIPTION
Currently, the docs correctly state that using `now` in range queries will not
be affected by the `time_zone` parameter. However, using date math roundings
like e.g. `now\d` will be affected by the `time_zone`. Adding this example
because it seems to be a frequently asked question and source of confusion.

Relates to #40581