### PR TITLE
Show SSL usage when security is not disabled

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
@@ -107,6 +107,10 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
             builder.field(AUDIT_XFIELD, auditUsage);
             builder.field(IP_FILTER_XFIELD, ipFilterUsage);
             builder.field(ANONYMOUS_XFIELD, anonymousUsage);
+        } else if (sslUsage.isEmpty() == false) {
+            // A trial (or basic) license can have SSL without security.
+            // This is because security defaults to disabled on that license, but that dynamic-default does not disable SSL.
+            builder.field(SSL_XFIELD, sslUsage);
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatureSet.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatureSet.java
@@ -152,7 +152,7 @@ public class SecurityFeatureSet implements XPackFeatureSet {
     static Map<String, Object> sslUsage(Settings settings) {
         // If security has been explicitly disabled in the settings, then SSL is also explicitly disabled, and we don't want to report
         //  these http/transport settings as they would be misleading (they could report `true` even though they were ignored)
-        // But, if security has not been explicitly configure, but has defaulted to off due to the current license type,
+        // But, if security has not been explicitly configured, but has defaulted to off due to the current license type,
         // then these SSL settings are still respected (that is SSL might be enabled, while the rest of security is disabled).
         if (XPackSettings.SECURITY_ENABLED.get(settings)) {
             Map<String, Object> map = new HashMap<>(2);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatureSet.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatureSet.java
@@ -150,10 +150,18 @@ public class SecurityFeatureSet implements XPackFeatureSet {
     }
 
     static Map<String, Object> sslUsage(Settings settings) {
-        Map<String, Object> map = new HashMap<>(2);
-        map.put("http", singletonMap("enabled", HTTP_SSL_ENABLED.get(settings)));
-        map.put("transport", singletonMap("enabled", TRANSPORT_SSL_ENABLED.get(settings)));
-        return map;
+        // If security has been explicitly disabled in the settings, then SSL is also explicitly disabled, and we don't want to report
+        //  these http/transport settings as they would be misleading (they could report `true` even though they were ignored)
+        // But, if security has not been explicitly configure, but has defaulted to off due to the current license type,
+        // then these SSL settings are still respected (that is SSL might be enabled, while the rest of security is disabled).
+        if (XPackSettings.SECURITY_ENABLED.get(settings)) {
+            Map<String, Object> map = new HashMap<>(2);
+            map.put("http", singletonMap("enabled", HTTP_SSL_ENABLED.get(settings)));
+            map.put("transport", singletonMap("enabled", TRANSPORT_SSL_ENABLED.get(settings)));
+            return map;
+        } else {
+            return Collections.emptyMap();
+        }
     }
 
     static Map<String, Object> tokenServiceUsage(Settings settings) {


### PR DESCRIPTION
It is possible to have SSL enabled but security disabled if security
was dynamically disabled by the license type (e.g. trial license).

e.g. In the following configuration:

    xpack.license.self_generated.type: trial
    # xpack.security not set, default to disabled on trial
    xpack.security.transport.ssl.enabled: true

The security feature will be reported as

    available: true
    enabled: false

And in this case, SSL will be active even though security is not
enabled.

This commit causes the X-Pack feature usage to report the state of the
"ssl" features unless security was explicitly disabled in the
settings.

Relates: #37433