### PR TITLE
[DOCS] Remind users to include @ symbol when applying license file

### DIFF
--- a/docs/reference/licensing/update-license.asciidoc
+++ b/docs/reference/licensing/update-license.asciidoc
@@ -79,16 +79,16 @@ POST /_license
 NOTE: These values are invalid; you must substitute the appropriate content
 from your license file.
 
-You can alternatively use a `curl` command, for example:
+You can also install your license file using a `curl` command. Be sure to add
+`@` before the license path.
 
-[source,js]
 [source,shell]
 ------------------------------------------------------------
 curl -XPUT -u <user> 'http://<host>:<port>/_license' -H "Content-Type: application/json" -d @license.json
 ------------------------------------------------------------
 // NOTCONSOLE
 
-On Windows machine, use the following command:
+On Windows, use the following command:
 
 [source,shell]
 ------------------------------------------------------------

--- a/docs/reference/licensing/update-license.asciidoc
+++ b/docs/reference/licensing/update-license.asciidoc
@@ -80,7 +80,7 @@ NOTE: These values are invalid; you must substitute the appropriate content
 from your license file.
 
 You can also install your license file using a `curl` command. Be sure to add
-`@` before the license path.
+`@` before the license file path to instruct curl to treat it as an input file.
 
 [source,shell]
 ------------------------------------------------------------


### PR DESCRIPTION
When using a curl command to install an x-pack license, some users leave out `@` before the license file path.

This adds a sentence to remind users to include the `@` symbol.

Closes #29778.