### PR TITLE
Add a configuration property to ban ClusterFormationTasks

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -55,6 +55,9 @@ class ClusterFormationTasks {
      * Returns a list of NodeInfo objects for each node in the cluster.
      */
     static List<NodeInfo> setup(Project project, String prefix, Task runner, ClusterConfiguration config) {
+        if ("false".equals(System.getProperty("tests.allow.ClusterFormationTasks", "true"))) {
+            throw new IllegalStateException("Using cluster formation tasks but these are not allowed in this build");
+        }
         File sharedDir = new File(project.buildDir, "cluster/shared")
         Object startDependencies = config.dependencies
         /* First, if we want a clean environment, we remove everything in the


### PR DESCRIPTION
The intent is tofold:

- first, make sure what we think is converted actually is
- second, lather on, make sure that some checks in CI don't these tasks,
  so that once everything is converted we can be sure no new tests are
  added that follow the old ways
