### PR TITLE
Upgrade to latest build scan plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ import org.gradle.util.DistributionLocator
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 
 plugins {
-    id 'com.gradle.build-scan' version '2.0.2'
+    id 'com.gradle.build-scan' version '2.2.1'
     id 'base'
 }
 if (Boolean.valueOf(project.findProperty('org.elasticsearch.acceptScanTOS') ?: "false")) {


### PR DESCRIPTION
There are some fixes and perf improvement in the latest plugin, as well as support for more accurately tracking collection callback (e.g. `withType() { }` or `all { }`) configuration time cost.