### PR TITLE
Don't replace forbidden pattern failures when found

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ForbiddenPatternsTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ForbiddenPatternsTask.java
@@ -27,6 +27,7 @@ import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
@@ -84,13 +85,13 @@ public class ForbiddenPatternsTask extends DefaultTask {
     }
 
     @InputFiles
+    @SkipWhenEmpty
     public FileCollection files() {
-        FileCollection collection = getProject().getConvention().getPlugin(JavaPluginConvention.class).getSourceSets()
+        return getProject().getConvention().getPlugin(JavaPluginConvention.class).getSourceSets()
             .stream()
             .map(sourceSet -> sourceSet.getAllSource().matching(filesFilter))
             .reduce(FileTree::plus)
             .orElse(getProject().files().getAsFileTree());
-        return collection;
     }
 
     @TaskAction


### PR DESCRIPTION
This commit fixes a bug in forbidden patterns where the failures for a
file replace the failures from the previous files instead of extending
them.