### PR TITLE
Correct indention in synonym docs

### DIFF
--- a/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
@@ -69,10 +69,10 @@ PUT /test_index
                     }
                 },
                 "filter" : {
-                	"my_stop": {
-                		"type" : "stop",
-                		"stopwords": ["bar"]
-                	},
+                    "my_stop": {
+                        "type" : "stop",
+                        "stopwords": ["bar"]
+                    },
                     "synonym_graph" : {
                         "type" : "synonym_graph",
                         "lenient": true,

--- a/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
@@ -58,10 +58,10 @@ PUT /test_index
                     }
                 },
                 "filter" : {
-                	"my_stop": {
-                		"type" : "stop",
-                		"stopwords": ["bar"]
-                	},
+                    "my_stop": {
+                        "type" : "stop",
+                        "stopwords": ["bar"]
+                    },
                     "synonym" : {
                         "type" : "synonym",
                         "lenient": true,


### PR DESCRIPTION
The stopword filter should be on the same level as the synonym filter in the
example request. Correcting this for better readability.