### PR TITLE
Remove -Xlint exclusions in all plugins.

### DIFF
--- a/plugins/ingest-attachment/build.gradle
+++ b/plugins/ingest-attachment/build.gradle
@@ -68,10 +68,6 @@ dependencies {
   compile "org.apache.james:apache-mime4j-dom:${versions.mime4j}"
 }
 
-// TODO: stop using LanguageIdentifier...
-compileJava.options.compilerArgs << "-Xlint:-deprecation"
-
-
 dependencyLicenses {
   mapping from: /apache-mime4j-.*/, to: 'apache-mime4j'
 }

--- a/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/AttachmentProcessor.java
+++ b/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/AttachmentProcessor.java
@@ -112,6 +112,7 @@ public final class AttachmentProcessor extends AbstractProcessor {
         }
 
         if (properties.contains(Property.LANGUAGE) && Strings.hasLength(parsedContent)) {
+            // TODO: stop using LanguageIdentifier...
             LanguageIdentifier identifier = new LanguageIdentifier(parsedContent);
             String language = identifier.getLanguage();
             additionalFields.put(Property.LANGUAGE.toLowerCase(), language);

--- a/plugins/mapper-size/build.gradle
+++ b/plugins/mapper-size/build.gradle
@@ -21,7 +21,3 @@ esplugin {
   description 'The Mapper Size plugin allows document to record their uncompressed size at index time.'
   classname 'org.elasticsearch.plugin.mapper.MapperSizePlugin'
 }
-
-// TODO: migrate to points
-compileJava.options.compilerArgs << "-Xlint:-deprecation"
-compileTestJava.options.compilerArgs << "-Xlint:-deprecation"

--- a/plugins/transport-nio/build.gradle
+++ b/plugins/transport-nio/build.gradle
@@ -24,9 +24,6 @@ esplugin {
     hasClientJar = true
 }
 
-compileJava.options.compilerArgs << "-Xlint:-try"
-compileTestJava.options.compilerArgs << "-Xlint:-rawtypes,-unchecked"
-
 dependencies {
     compile "org.elasticsearch:elasticsearch-nio:${version}"
 

--- a/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/NettyAdaptor.java
+++ b/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/NettyAdaptor.java
@@ -36,7 +36,7 @@ import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.function.BiConsumer;
 
-public class NettyAdaptor implements AutoCloseable {
+class NettyAdaptor {
 
     private final EmbeddedChannel nettyChannel;
     private final LinkedList<FlushOperation> flushOperations = new LinkedList<>();
@@ -64,7 +64,6 @@ public class NettyAdaptor implements AutoCloseable {
         nettyChannel.pipeline().addLast(handlers);
     }
 
-    @Override
     public void close() throws Exception {
         assert flushOperations.isEmpty() : "Should close outbound operations before calling close";
 


### PR DESCRIPTION
The xlint exclusions of the following plugins were removed:
* ingest-attachment.
* mapper-size.
* transport-nio. Removing the -try exclusion required some work, because
  the NettyAdaptor implements AutoCloseable and NettyAdaptor#close() method
  could throw an InterruptedException (from ChannelFuture#await() and a generic
  Exception is re-thrown, which maybe an InterruptedException). The easiest way
  around this to me seemed that NettyAdaptor should not implement AutoCloseable,
  because it is not directly used in a try-with-resources statement. @tbrooks8 wdyt?

Relates to #40366