### PR TITLE
[ML] fix test check as randomness allows for different hours (#40536)

### DIFF
--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFramePivotRestIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFramePivotRestIT.java
@@ -268,7 +268,6 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/40537")
     public void testPivotWithMaxOnDateField() throws Exception {
         String transformId = "simpleDateHistogramPivotWithMaxTime";
         String dataFrameIndex = "pivot_reviews_via_date_histogram_with_max_time";
@@ -312,7 +311,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
         Map<String, Object> searchResult = getAsMap(dataFrameIndex + "/_search?q=by_day:2017-01-15");
         String actual = (String) ((List<?>) XContentMapValues.extractValue("hits.hits._source.timestamp", searchResult)).get(0);
         // Do `containsString` as actual ending timestamp is indeterminate due to how data is generated
-        assertThat(actual, containsString("2017-01-15T20:"));
+        assertThat(actual, containsString("2017-01-15T"));
     }
 
     private void assertOnePivotValue(String query, double expected) throws IOException {


### PR DESCRIPTION
Fixes test as failures are possible due to different random seeds.
backport of: #40536
closes #40537