### PR TITLE
Mute RecoveryWithConcurrentIndexing test

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -121,6 +121,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
         return future;
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/40731")
     public void testRecoveryWithConcurrentIndexing() throws Exception {
         final String index = "recovery_with_concurrent_indexing";
         Response response = client().performRequest(new Request("GET", "_nodes"));


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/issues/40731
