### PR TITLE
Mute RecoveryWithConcurrentIndexing test

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -122,6 +122,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
         return future;
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/40731")
     public void testRecoveryWithConcurrentIndexing() throws Exception {
         final String index = "recovery_with_concurrent_indexing";
         Response response = client().performRequest(new Request("GET", "_nodes"));


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/40733

Relates https://github.com/elastic/elasticsearch/issues/40731
