### PR TITLE
[TEST] Mute DateTimeUnitTests.testConversion (#40086)

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/rounding/DateTimeUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/common/rounding/DateTimeUnitTests.java
@@ -66,6 +66,7 @@ public class DateTimeUnitTests extends ESTestCase {
         assertEquals(SECOND_OF_MINUTE, DateTimeUnit.resolve((byte) 8));
     }
 
+    @AwaitsFix( bugUrl = "https://github.com/elastic/elasticsearch/issues/39617")
     public void testConversion() {
         long millis = randomLongBetween(0, Instant.now().toEpochMilli());
         DateTimeZone zone = randomDateTimeZone();


### PR DESCRIPTION
Due to https://github.com/elastic/elasticsearch/issues/39617

Backport of https://github.com/elastic/elasticsearch/pull/40086