### PR TITLE
[DOCS] Rewrite 'query' definition in glossary

### DIFF
--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -139,13 +139,12 @@ See also <<glossary-routing,routing>>
 
 [[glossary-query]] query ::
 
-A query is the basic component of a search. A search can be defined by one or more queries 
-which can be mixed and matched in endless combinations. While <<glossary-filter,filters>> are
-queries that only determine if a document matches, those queries that also calculate how well
-the document matches are known as "scoring queries". Those queries assign it a score, which is 
-later used to sort matched documents. Scoring queries take more resources than <<glossary-filter,non scoring queries>> 
-and their query results are not cacheable. As a general rule, use query clauses for full-text 
-search or for any condition that requires scoring, and use filters for everything else.
+A request for information from {es}. You can think of a query as a question,
+written in a way {es} understands. A search consists of one or more queries
+combined.
++
+There are two types of queries: _scoring queries_ and _filters_. For more
+information about query types, see <<query-filter-context>>.
 
 [[glossary-recovery]] recovery ::
 The process of syncing a shard copy from a source shard. Upon completion, the recovery process makes the shard copy available for queries.


### PR DESCRIPTION
Condenses and simplifies the `query` definition in the [Elasticsearch glossary](https://www.elastic.co/guide/en/elasticsearch/reference/current/glossary.html).

It's possible I oversimplified so any feedback is welcome!

After this PR is merged, I'll open a separate PR to sync the `query` definition in the [Stack Docs glossary](https://github.com/elastic/stack-docs/blob/master/docs/en/glossary/glossary.asciidoc).

Relates to elastic/stack-docs#261

Resolves #40643