### PR TITLE
Help Eclipse infering lambda parameter types

### DIFF
--- a/server/src/test/java/org/elasticsearch/BuildTests.java
+++ b/server/src/test/java/org/elasticsearch/BuildTests.java
@@ -162,8 +162,8 @@ public class BuildTests extends ESTestCase {
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(new WriteableBuild(new Build(
                 randomFrom(Build.Flavor.values()), randomFrom(Build.Type.values()),
                 randomAlphaOfLength(6), randomAlphaOfLength(6), randomBoolean(), randomAlphaOfLength(6))),
-            b -> copyWriteable(b, writableRegistry(), WriteableBuild::new, Version.CURRENT),
-            b -> {
+            (WriteableBuild b) -> copyWriteable(b, writableRegistry(), WriteableBuild::new, Version.CURRENT),
+            (WriteableBuild b) -> {
                 switch (randomIntBetween(1, 6)) {
                     case 1:
                         return new WriteableBuild(new Build(

--- a/server/src/test/java/org/elasticsearch/BuildTests.java
+++ b/server/src/test/java/org/elasticsearch/BuildTests.java
@@ -162,6 +162,7 @@ public class BuildTests extends ESTestCase {
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(new WriteableBuild(new Build(
                 randomFrom(Build.Flavor.values()), randomFrom(Build.Type.values()),
                 randomAlphaOfLength(6), randomAlphaOfLength(6), randomBoolean(), randomAlphaOfLength(6))),
+            // Note: the cast of the Copy- and MutateFunction is needed for some IDE (specifically Eclipse 4.10.0) to infer the right type
             (WriteableBuild b) -> copyWriteable(b, writableRegistry(), WriteableBuild::new, Version.CURRENT),
             (WriteableBuild b) -> {
                 switch (randomIntBetween(1, 6)) {


### PR DESCRIPTION
The Eclipse compiler (4.10, Photon) cannot build this test because it cannot
correctly infer the type arguments of the functions. Explicitely adding them
helps in this case.