### PR TITLE
Docs: Move id in the java-api

### DIFF
--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -1,8 +1,8 @@
-[[java-api]]
 = Java API
 
 include::../Versions.asciidoc[]
 
+[[java-api]]
 [preface]
 == Preface
 


### PR DESCRIPTION
Moves the id of the preface in the java-api so it is compatible with
both AsciiDoc and Asciidoctor. As it stands now we apply the id that we
want for the preface to the book itself which is strange and only works
with AsciiDoc.

This doesn't change how asciidoc renders the docs. It is a noop except
for the compatibility.