### PR TITLE
Docs: Move id of overview

### DIFF
--- a/docs/java-rest/index.asciidoc
+++ b/docs/java-rest/index.asciidoc
@@ -1,4 +1,3 @@
-[[java-rest]]
 = Java REST Client
 
 include::../Versions.asciidoc[]

--- a/docs/java-rest/overview.asciidoc
+++ b/docs/java-rest/overview.asciidoc
@@ -1,3 +1,4 @@
+[[java-rest]]
 == Overview
 
 Official low-level client for Elasticsearch. Allows to communicate with an


### PR DESCRIPTION
We accidentally setting the id of the overview in the java-rest
client to `java-rest` from 5.0 to 5.5. Asciidoctor doesn't play along
with this weird thing and we should just "fix" the id in those branches
so we can use asciidoctor there. This moves the id from the top level
rest client book to the overview which is a noop for AsciiDoc and make
Asciidoctor produce overview with the right id.
