### PR TITLE
Deprecate versions of Java prior to Java 11

### DIFF
--- a/distribution/tools/java-version-checker/src/main/java/org/elasticsearch/tools/java_version_checker/JavaVersion.java
+++ b/distribution/tools/java-version-checker/src/main/java/org/elasticsearch/tools/java_version_checker/JavaVersion.java
@@ -27,6 +27,7 @@ public class JavaVersion {
 
     public static final List<Integer> CURRENT = parse(System.getProperty("java.specification.version"));
     public static final List<Integer> JAVA_8 = parse("1.8");
+    public static final List<Integer> JAVA_11 = parse("11");
 
     static List<Integer> parse(final String value) {
         if (!value.matches("^0*[0-9]+(\\.[0-9]+)*$")) {
@@ -65,6 +66,5 @@ public class JavaVersion {
         }
         return 0;
     }
-
 
 }

--- a/distribution/tools/java-version-checker/src/main/java/org/elasticsearch/tools/java_version_checker/JavaVersionChecker.java
+++ b/distribution/tools/java-version-checker/src/main/java/org/elasticsearch/tools/java_version_checker/JavaVersionChecker.java
@@ -48,6 +48,13 @@ final class JavaVersionChecker {
             errPrintln(message);
             exit(1);
         }
+        if (JavaVersion.compare(JavaVersion.CURRENT, JavaVersion.JAVA_11) < 0) {
+            final String message = String.format(
+                    Locale.ROOT,
+                    "future versions of Elasticsearch will require Java 11; your Java version from [%s] does not meet this requirement",
+                    System.getProperty("java.home"));
+            errPrintln(message);
+        }
         exit(0);
     }
 

--- a/qa/vagrant/src/test/resources/packaging/tests/60_systemd.bats
+++ b/qa/vagrant/src/test/resources/packaging/tests/60_systemd.bats
@@ -106,7 +106,7 @@ setup() {
 
     # Verifies that no new entries in journald have been added
     # since the last start
-    result="$(journalctl _SYSTEMD_UNIT=elasticsearch.service --since "$since" --output cat | wc -l)"
+    result="$(journalctl _SYSTEMD_UNIT=elasticsearch.service --since "$since" --output cat | grep -v "future versions of Elasticsearch will require Java 11" | wc -l)"
     [ "$result" -eq "0" ] || {
             echo "Expected no entries in journalctl for the Elasticsearch service but found:"
             journalctl _SYSTEMD_UNIT=elasticsearch.service --since "$since"


### PR DESCRIPTION
This commit deprecates versions of Java prior to Java 11. This commit will cause a warning to be printed to standard error when any command line tool is invoked, or when Elasticsearch is started. Additionally, we log a deprecation message when Elasticsearch is started.

Relates #40754
