### PR TITLE
[DOCS] Add missing backtick

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -206,7 +206,7 @@ information, see {stack-ov}/setting-up-authentication.html[Setting up authentica
 ===== Settings valid for all realms
 
 `type`::
-The type of the realm: `native, `ldap`, `active_directory`, `pki`, or `file`. Required.
+The type of the realm: `native`, `ldap`, `active_directory`, `pki`, or `file`. Required.
 
 `order`::
 The priority of the realm within the realm chain. Realms with a lower order are


### PR DESCRIPTION
This PR adds a missing back tick in the docs
