### PR TITLE
Bat scripts to work with JAVA_HOME with parentheses backport(#39712)

### DIFF
--- a/distribution/src/bin/elasticsearch-env.bat
+++ b/distribution/src/bin/elasticsearch-env.bat
@@ -58,5 +58,5 @@ set ES_DISTRIBUTION_FLAVOR=${es.distribution.flavor}
 set ES_DISTRIBUTION_TYPE=${es.distribution.type}
 
 if not defined ES_TMPDIR (
-  for /f "tokens=* usebackq" %%a in (`"%JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.TempDirectory""`) do set ES_TMPDIR=%%a
+  for /f "tokens=* usebackq" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.TempDirectory"`) do set  ES_TMPDIR=%%a
 )

--- a/distribution/src/bin/elasticsearch.bat
+++ b/distribution/src/bin/elasticsearch.bat
@@ -41,9 +41,9 @@ IF ERRORLEVEL 1 (
 	EXIT /B %ERRORLEVEL%
 )
 
-set "ES_JVM_OPTIONS=%ES_PATH_CONF%\jvm.options"
+set ES_JVM_OPTIONS=%ES_PATH_CONF%\jvm.options
 @setlocal
-for /F "usebackq delims=" %%a in (`"%JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.JvmOptionsParser" "!ES_JVM_OPTIONS!" || echo jvm_options_parser_failed"`) do set JVM_OPTIONS=%%a
+for /F "usebackq delims=" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.JvmOptionsParser" "!ES_JVM_OPTIONS!" ^|^| echo jvm_options_parser_failed`) do set JVM_OPTIONS=%%a
 @endlocal & set "MAYBE_JVM_OPTIONS_PARSER_FAILED=%JVM_OPTIONS%" & set ES_JAVA_OPTS=%JVM_OPTIONS:${ES_TMPDIR}=!ES_TMPDIR!% %ES_JAVA_OPTS%
 
 if "%MAYBE_JVM_OPTIONS_PARSER_FAILED%" == "jvm_options_parser_failed" (

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
@@ -33,23 +33,18 @@ import org.elasticsearch.packaging.util.Shell.Result;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
-import org.elasticsearch.packaging.util.Distribution;
-import org.elasticsearch.packaging.util.Installation;
-
-import java.nio.charset.StandardCharsets;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.joining;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.getRandom;
+import static java.util.stream.Collectors.joining;
 import static org.elasticsearch.packaging.util.Archives.ARCHIVE_OWNER;
-import static org.elasticsearch.packaging.util.Cleanup.cleanEverything;
 import static org.elasticsearch.packaging.util.Archives.installArchive;
 import static org.elasticsearch.packaging.util.Archives.verifyArchiveInstallation;
+import static org.elasticsearch.packaging.util.Cleanup.cleanEverything;
 import static org.elasticsearch.packaging.util.FileMatcher.Fileness.File;
 import static org.elasticsearch.packaging.util.FileMatcher.file;
 import static org.elasticsearch.packaging.util.FileMatcher.p660;
@@ -84,7 +79,7 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
     protected abstract Distribution distribution();
 
     @BeforeClass
-    public static void cleanup() {
+    public static void cleanup() throws Exception {
         installation = null;
         cleanEverything();
     }
@@ -256,7 +251,7 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
         });
     }
 
-    public void test60AutoCreateKeystore() {
+    public void test60AutoCreateKeystore() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         assertThat(installation.config("elasticsearch.keystore"), file(File, ARCHIVE_OWNER, ARCHIVE_OWNER, p660));

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
@@ -20,8 +20,12 @@
 package org.elasticsearch.packaging.test;
 
 import com.carrotsearch.randomizedtesting.annotations.TestCaseOrdering;
+import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import org.apache.http.client.fluent.Request;
 import org.elasticsearch.packaging.util.Archives;
+import org.elasticsearch.packaging.util.Distribution;
+import org.elasticsearch.packaging.util.FileUtils;
+import org.elasticsearch.packaging.util.Installation;
 import org.elasticsearch.packaging.util.Platforms;
 import org.elasticsearch.packaging.util.ServerUtils;
 import org.elasticsearch.packaging.util.Shell;
@@ -32,13 +36,16 @@ import org.junit.BeforeClass;
 import org.elasticsearch.packaging.util.Distribution;
 import org.elasticsearch.packaging.util.Installation;
 
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.getRandom;
 import static org.elasticsearch.packaging.util.Archives.ARCHIVE_OWNER;
 import static org.elasticsearch.packaging.util.Cleanup.cleanEverything;
 import static org.elasticsearch.packaging.util.Archives.installArchive;
@@ -53,6 +60,7 @@ import static org.elasticsearch.packaging.util.FileUtils.mkdir;
 import static org.elasticsearch.packaging.util.FileUtils.rm;
 import static org.elasticsearch.packaging.util.ServerUtils.makeRequest;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -86,12 +94,12 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
         assumeTrue("only compatible distributions", distribution().packaging.compatible);
     }
 
-    public void test10Install() {
+    public void test10Install() throws Exception {
         installation = installArchive(distribution());
         verifyArchiveInstallation(installation, distribution());
     }
 
-    public void test20PluginsListWithNoPlugins() {
+    public void test20PluginsListWithNoPlugins() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         final Installation.Executables bin = installation.executables();
@@ -101,7 +109,7 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
         assertThat(r.stdout, isEmptyString());
     }
 
-    public void test30AbortWhenJavaMissing() {
+    public void test30AbortWhenJavaMissing() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         final Installation.Executables bin = installation.executables();
@@ -143,7 +151,7 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
         });
     }
 
-    public void test40CreateKeystoreManually() {
+    public void test40CreateKeystoreManually() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         final Installation.Executables bin = installation.executables();
@@ -176,7 +184,7 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
         });
     }
 
-    public void test50StartAndStop() throws IOException {
+    public void test50StartAndStop() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         // cleanup from previous test
@@ -191,6 +199,61 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
         ServerUtils.runElasticsearchTests();
 
         Archives.stopElasticsearch(installation);
+    }
+    public void test51JavaHomeWithSpecialCharacters() throws Exception {
+        assumeThat(installation, is(notNullValue()));
+
+        Platforms.onWindows(() -> {
+            final Shell sh = new Shell();
+            try {
+                // once windows 2012 is no longer supported and powershell 5.0 is always available we can change this command
+                sh.run("cmd /c mklink /D 'C:\\Program Files (x86)\\java' $Env:JAVA_HOME");
+
+                sh.getEnv().put("JAVA_HOME", "C:\\Program Files (x86)\\java");
+
+                //verify ES can start, stop and run plugin list
+                Archives.runElasticsearch(installation, sh);
+
+                Archives.stopElasticsearch(installation);
+
+                String pluginListCommand = installation.bin + "/elasticsearch-plugin list";
+                Result result = sh.run(pluginListCommand);
+                assertThat(result.exitCode, equalTo(0));
+
+            } finally {
+                //clean up sym link
+                sh.run("cmd /c del /F /Q 'C:\\Program Files (x86)\\java' ");
+            }
+        });
+
+        Platforms.onLinux(() -> {
+            final Shell sh = new Shell();
+            // Create temporary directory with a space and link to java binary.
+            // Use it as java_home
+            String nameWithSpace = RandomStrings.randomAsciiAlphanumOfLength(getRandom(), 10) + "java home";
+            String test_java_home = FileUtils.mkdir(Paths.get("/home",ARCHIVE_OWNER, nameWithSpace)).toAbsolutePath().toString();
+            try {
+                final String systemJavaHome = sh.run("echo $SYSTEM_JAVA_HOME").stdout.trim();
+                final String java = systemJavaHome + "/bin/java";
+
+                sh.run("mkdir -p \"" + test_java_home + "/bin\"");
+                sh.run("ln -s \"" + java + "\" \"" + test_java_home + "/bin/java\"");
+                sh.run("chown -R " + ARCHIVE_OWNER + ":" + ARCHIVE_OWNER + " \"" + test_java_home + "\"");
+
+                sh.getEnv().put("JAVA_HOME", test_java_home);
+
+                //verify ES can start, stop and run plugin list
+                Archives.runElasticsearch(installation, sh);
+
+                Archives.stopElasticsearch(installation);
+
+                String pluginListCommand = installation.bin + "/elasticsearch-plugin list";
+                Result result = sh.run(pluginListCommand);
+                assertThat(result.exitCode, equalTo(0));
+            } finally {
+                FileUtils.rm(Paths.get("\"" + test_java_home + "\""));
+            }
+        });
     }
 
     public void test60AutoCreateKeystore() {
@@ -212,7 +275,7 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
         });
     }
 
-    public void test70CustomPathConfAndJvmOptions() throws IOException {
+    public void test70CustomPathConfAndJvmOptions() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         final Path tempConf = getTempDir().resolve("esconf-alternate");
@@ -261,7 +324,7 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
         }
     }
 
-    public void test80RelativePathConf() throws IOException {
+    public void test80RelativePathConf() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         final Path temp = getTempDir().resolve("esconf-alternate");
@@ -304,7 +367,7 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
         }
     }
 
-    public void test90SecurityCliPackaging() {
+    public void test90SecurityCliPackaging() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         final Installation.Executables bin = installation.executables();
@@ -328,7 +391,7 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
         }
     }
 
-    public void test100RepairIndexCliPackaging() {
+    public void test91ElasticsearchShardCliPackaging() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         final Installation.Executables bin = installation.executables();
@@ -344,5 +407,4 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
             Platforms.onWindows(action);
         }
     }
-
 }

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
@@ -386,7 +386,7 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
         }
     }
 
-    public void test91ElasticsearchShardCliPackaging() throws Exception {
+    public void test100RepairIndexCliPackaging() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         final Installation.Executables bin = installation.executables();

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
@@ -202,7 +202,7 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
             final Shell sh = new Shell();
             try {
                 // once windows 2012 is no longer supported and powershell 5.0 is always available we can change this command
-                sh.run("cmd /c mklink /D 'C:\\Program Files (x86)\\java' $Env:JAVA_HOME");
+                sh.run("cmd /c mklink /D 'C:\\Program Files (x86)\\java' $Env:SYSTEM_JAVA_HOME");
 
                 sh.getEnv().put("JAVA_HOME", "C:\\Program Files (x86)\\java");
 
@@ -217,7 +217,7 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
 
             } finally {
                 //clean up sym link
-                sh.run("cmd /c del /F /Q 'C:\\Program Files (x86)\\java' ");
+                sh.run("cmd /c rmdir 'C:\\Program Files (x86)\\java' ");
             }
         });
 

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
@@ -202,7 +202,7 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
             final Shell sh = new Shell();
             try {
                 // once windows 2012 is no longer supported and powershell 5.0 is always available we can change this command
-                sh.run("cmd /c mklink /D 'C:\\Program Files (x86)\\java' $Env:SYSTEM_JAVA_HOME");
+                sh.run("cmd /c mklink /D 'C:\\Program Files (x86)\\java' $Env:JAVA_HOME");
 
                 sh.getEnv().put("JAVA_HOME", "C:\\Program Files (x86)\\java");
 
@@ -228,7 +228,7 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
             String nameWithSpace = RandomStrings.randomAsciiAlphanumOfLength(getRandom(), 10) + "java home";
             String test_java_home = FileUtils.mkdir(Paths.get("/home",ARCHIVE_OWNER, nameWithSpace)).toAbsolutePath().toString();
             try {
-                final String systemJavaHome = sh.run("echo $SYSTEM_JAVA_HOME").stdout.trim();
+                final String systemJavaHome = sh.run("echo $JAVA_HOME").stdout.trim();
                 final String java = systemJavaHome + "/bin/java";
 
                 sh.run("mkdir -p \"" + test_java_home + "/bin\"");

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/DebPreservationTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/DebPreservationTestCase.java
@@ -55,7 +55,7 @@ public abstract class DebPreservationTestCase extends PackagingTestCase {
     protected abstract Distribution distribution();
 
     @BeforeClass
-    public static void cleanup() {
+    public static void cleanup() throws Exception {
         installation = null;
         cleanEverything();
     }
@@ -66,14 +66,14 @@ public abstract class DebPreservationTestCase extends PackagingTestCase {
         assumeTrue("only compatible distributions", distribution().packaging.compatible);
     }
 
-    public void test10Install() {
+    public void test10Install() throws Exception {
         assertRemoved(distribution());
         installation = install(distribution());
         assertInstalled(distribution());
         verifyPackageInstallation(installation, distribution());
     }
 
-    public void test20Remove() {
+    public void test20Remove() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         remove(distribution());
@@ -118,7 +118,7 @@ public abstract class DebPreservationTestCase extends PackagingTestCase {
         assertTrue(Files.exists(installation.envFile));
     }
 
-    public void test30Purge() {
+    public void test30Purge() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         final Shell sh = new Shell();

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/PackageTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/PackageTestCase.java
@@ -20,6 +20,9 @@
 package org.elasticsearch.packaging.test;
 
 import com.carrotsearch.randomizedtesting.annotations.TestCaseOrdering;
+import com.carrotsearch.randomizedtesting.generators.RandomStrings;
+import org.apache.http.client.fluent.Request;
+import org.elasticsearch.packaging.util.FileUtils;
 import org.elasticsearch.packaging.util.Distribution;
 import org.elasticsearch.packaging.util.Installation;
 import org.elasticsearch.packaging.util.Platforms;
@@ -29,6 +32,7 @@ import org.elasticsearch.packaging.util.Shell.Result;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -39,6 +43,8 @@ import java.util.regex.Pattern;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.elasticsearch.packaging.util.Cleanup.cleanEverything;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.getRandom;
+import static org.elasticsearch.packaging.util.FileUtils.append;
 import static org.elasticsearch.packaging.util.FileUtils.assertPathsDontExist;
 import static org.elasticsearch.packaging.util.FileUtils.mv;
 import static org.elasticsearch.packaging.util.Packages.SYSTEMD_SERVICE;
@@ -77,7 +83,7 @@ public abstract class PackageTestCase extends PackagingTestCase {
     }
 
     @Before
-    public void onlyCompatibleDistributions() {
+    public void onlyCompatibleDistributions() throws Exception {
         assumeTrue("only compatible distributions", distribution().packaging.compatible);
     }
 
@@ -98,14 +104,14 @@ public abstract class PackageTestCase extends PackagingTestCase {
         }
     }
 
-    public void test10InstallPackage() {
+    public void test10InstallPackage() throws Exception {
         assertRemoved(distribution());
         installation = install(distribution());
         assertInstalled(distribution());
         verifyPackageInstallation(installation, distribution());
     }
 
-    public void test20PluginsCommandWhenNoPlugins() {
+    public void test20PluginsCommandWhenNoPlugins() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         final Shell sh = new Shell();
@@ -127,7 +133,7 @@ public abstract class PackageTestCase extends PackagingTestCase {
         verifyPackageInstallation(installation, distribution()); // check startup script didn't change permissions
     }
 
-    public void test50Remove() {
+    public void test50Remove() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         remove(distribution());
@@ -185,7 +191,7 @@ public abstract class PackageTestCase extends PackagingTestCase {
         Platforms.onRPM(() -> assertFalse(Files.exists(SYSTEMD_SERVICE)));
     }
 
-    public void test60Reinstall() {
+    public void test60Reinstall() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         installation = install(distribution());

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/PackageTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/PackageTestCase.java
@@ -20,19 +20,14 @@
 package org.elasticsearch.packaging.test;
 
 import com.carrotsearch.randomizedtesting.annotations.TestCaseOrdering;
-import com.carrotsearch.randomizedtesting.generators.RandomStrings;
-import org.apache.http.client.fluent.Request;
-import org.elasticsearch.packaging.util.FileUtils;
 import org.elasticsearch.packaging.util.Distribution;
 import org.elasticsearch.packaging.util.Installation;
 import org.elasticsearch.packaging.util.Platforms;
 import org.elasticsearch.packaging.util.Shell;
-
 import org.elasticsearch.packaging.util.Shell.Result;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
-import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -43,8 +38,6 @@ import java.util.regex.Pattern;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.elasticsearch.packaging.util.Cleanup.cleanEverything;
-import static com.carrotsearch.randomizedtesting.RandomizedTest.getRandom;
-import static org.elasticsearch.packaging.util.FileUtils.append;
 import static org.elasticsearch.packaging.util.FileUtils.assertPathsDontExist;
 import static org.elasticsearch.packaging.util.FileUtils.mv;
 import static org.elasticsearch.packaging.util.Packages.SYSTEMD_SERVICE;
@@ -58,13 +51,11 @@ import static org.elasticsearch.packaging.util.Packages.verifyPackageInstallatio
 import static org.elasticsearch.packaging.util.Platforms.getOsRelease;
 import static org.elasticsearch.packaging.util.Platforms.isSystemd;
 import static org.elasticsearch.packaging.util.ServerUtils.runElasticsearchTests;
-
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.isEmptyString;
-
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
@@ -77,7 +68,7 @@ public abstract class PackageTestCase extends PackagingTestCase {
     protected abstract Distribution distribution();
 
     @BeforeClass
-    public static void cleanup() {
+    public static void cleanup() throws Exception {
         installation = null;
         cleanEverything();
     }

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/RpmPreservationTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/RpmPreservationTestCase.java
@@ -58,7 +58,7 @@ public abstract class RpmPreservationTestCase extends PackagingTestCase {
     protected abstract Distribution distribution();
 
     @BeforeClass
-    public static void cleanup() {
+    public static void cleanup() throws Exception {
         installation = null;
         cleanEverything();
     }
@@ -69,14 +69,14 @@ public abstract class RpmPreservationTestCase extends PackagingTestCase {
         assumeTrue("only compatible distributions", distribution().packaging.compatible);
     }
 
-    public void test10Install() {
+    public void test10Install() throws Exception {
         assertRemoved(distribution());
         installation = install(distribution());
         assertInstalled(distribution());
         verifyPackageInstallation(installation, distribution());
     }
 
-    public void test20Remove() {
+    public void test20Remove() throws Exception {
         assumeThat(installation, is(notNullValue()));
 
         remove(distribution());
@@ -91,7 +91,7 @@ public abstract class RpmPreservationTestCase extends PackagingTestCase {
         assertFalse(Files.exists(installation.envFile));
     }
 
-    public void test30PreserveConfig() {
+    public void test30PreserveConfig() throws Exception {
         final Shell sh = new Shell();
 
         installation = install(distribution());

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/Archives.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/Archives.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.packaging.util;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -37,15 +36,14 @@ import static org.elasticsearch.packaging.util.FileUtils.getCurrentVersion;
 import static org.elasticsearch.packaging.util.FileUtils.getDefaultArchiveInstallPath;
 import static org.elasticsearch.packaging.util.FileUtils.getDistributionFile;
 import static org.elasticsearch.packaging.util.FileUtils.lsGlob;
-
 import static org.elasticsearch.packaging.util.FileUtils.mv;
 import static org.elasticsearch.packaging.util.FileUtils.slurp;
 import static org.elasticsearch.packaging.util.Platforms.isDPKG;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertTrue;
 
@@ -59,11 +57,11 @@ public class Archives {
         ? "vagrant"
         : "elasticsearch";
 
-    public static Installation installArchive(Distribution distribution) {
+    public static Installation installArchive(Distribution distribution) throws Exception {
         return installArchive(distribution, getDefaultArchiveInstallPath(), getCurrentVersion());
     }
 
-    public static Installation installArchive(Distribution distribution, Path fullInstallPath, String version) {
+    public static Installation installArchive(Distribution distribution, Path fullInstallPath, String version) throws Exception {
         final Shell sh = new Shell();
 
         final Path distributionFile = getDistributionFile(distribution);
@@ -255,11 +253,7 @@ public class Archives {
         ).forEach(configFile -> assertThat(es.config(configFile), file(File, owner, owner, p660)));
     }
 
-    public static void runElasticsearch(Installation installation) throws IOException {
-        runElasticsearch(installation, new Shell());
-    }
-
-    public static void runElasticsearch(Installation installation, Shell sh) throws IOException {
+    public static void runElasticsearch(Installation installation, Shell sh) throws Exception {
         final Path pidFile = installation.home.resolve("elasticsearch.pid");
 
         final Installation.Executables bin = installation.executables();
@@ -309,7 +303,7 @@ public class Archives {
         Platforms.onWindows(() -> sh.run("Get-Process -Id " + pid));
     }
 
-    public static void stopElasticsearch(Installation installation) {
+    public static void stopElasticsearch(Installation installation) throws Exception {
         Path pidFile = installation.home.resolve("elasticsearch.pid");
         assertTrue(Files.exists(pidFile));
         String pid = slurp(pidFile).trim();

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/Archives.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/Archives.java
@@ -253,6 +253,10 @@ public class Archives {
         ).forEach(configFile -> assertThat(es.config(configFile), file(File, owner, owner, p660)));
     }
 
+    public static void runElasticsearch(Installation installation) throws Exception {
+        runElasticsearch(installation, new Shell());
+    }
+
     public static void runElasticsearch(Installation installation, Shell sh) throws Exception {
         final Path pidFile = installation.home.resolve("elasticsearch.pid");
 

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/Cleanup.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/Cleanup.java
@@ -50,7 +50,7 @@ public class Cleanup {
     // todo
     private static final List<String> ELASTICSEARCH_FILES_WINDOWS = Collections.emptyList();
 
-    public static void cleanEverything() {
+    public static void cleanEverything() throws Exception {
         final Shell sh = new Shell();
 
         // kill elasticsearch processes

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/Packages.java
@@ -52,14 +52,14 @@ public class Packages {
     public static final Path SYSVINIT_SCRIPT = Paths.get("/etc/init.d/elasticsearch");
     public static final Path SYSTEMD_SERVICE = Paths.get("/usr/lib/systemd/system/elasticsearch.service");
 
-    public static void assertInstalled(Distribution distribution) {
+    public static void assertInstalled(Distribution distribution) throws Exception {
         final Result status = packageStatus(distribution);
         assertThat(status.exitCode, is(0));
 
         Platforms.onDPKG(() -> assertFalse(Pattern.compile("(?m)^Status:.+deinstall ok").matcher(status.stdout).find()));
     }
 
-    public static void assertRemoved(Distribution distribution) {
+    public static void assertRemoved(Distribution distribution) throws Exception {
         final Result status = packageStatus(distribution);
 
         Platforms.onRPM(() -> assertThat(status.exitCode, is(1)));
@@ -125,7 +125,7 @@ public class Packages {
         }
     }
 
-    public static void remove(Distribution distribution) {
+    public static void remove(Distribution distribution) throws Exception {
         final Shell sh = new Shell();
 
         Platforms.onRPM(() -> {

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/Platforms.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/Platforms.java
@@ -64,25 +64,25 @@ public class Platforms {
         return new Shell().runIgnoreExitCode("which service").isSuccess();
     }
 
-    public static void onWindows(PlatformAction action) {
+    public static void onWindows(PlatformAction action) throws Exception {
         if (WINDOWS) {
             action.run();
         }
     }
 
-    public static void onLinux(PlatformAction action) {
+    public static void onLinux(PlatformAction action) throws Exception {
         if (LINUX) {
             action.run();
         }
     }
 
-    public static void onRPM(PlatformAction action) {
+    public static void onRPM(PlatformAction action) throws Exception {
         if (isRPM()) {
             action.run();
         }
     }
 
-    public static void onDPKG(PlatformAction action) {
+    public static void onDPKG(PlatformAction action) throws Exception {
         if (isDPKG()) {
             action.run();
         }
@@ -93,6 +93,6 @@ public class Platforms {
      */
     @FunctionalInterface
     public interface PlatformAction {
-        void run();
+        void run() throws Exception;
     }
 }


### PR DESCRIPTION
the elasticsearch.bat and elasticsearch-env.bat won't work if JAVA
contains parentheses. This seems to be the limitation of FOR /F IN
(command) DO syntax.
The JAVA variable present in a command contains a path to a binary to
start elasticsearch (with spaces & parens). We can workaround the
problem of spaces and parentheses in this path by referring this
variable with a CALL command.
Note that executing binaries with CALL is an undocumented behaviour (but works)
closes #38578
closes #38624
closes #33405
closes #30606

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
