### PR TITLE
Always use IndexAnalyzers in analyze transport action

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
@@ -131,6 +131,24 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         idxMaxTokenCount = idxSettings.getMaxTokenCount();
     }
 
+    public void testPositionIncrementGap() throws IOException {
+        AnalyzeRequest request = new AnalyzeRequest();
+        request.text("a", "b");
+        request.analyzer("standard");
+
+        // check against no index
+        AnalyzeResponse response = TransportAnalyzeAction.analyze(request, "text", null, null, registry, environment, maxTokenCount);
+        assertEquals(2, response.getTokens().size());
+        assertEquals(0, response.getTokens().get(0).getPosition());
+        assertEquals(101, response.getTokens().get(1).getPosition());
+
+        // check against defined index
+        response = TransportAnalyzeAction.analyze(request, "text", null, indexAnalyzers, registry, environment, maxTokenCount);
+        assertEquals(2, response.getTokens().size());
+        assertEquals(0, response.getTokens().get(0).getPosition());
+        assertEquals(101, response.getTokens().get(1).getPosition());
+    }
+
     /**
      * Test behavior when the named analysis component isn't defined on the index. In that case we should build with defaults.
      */
@@ -267,7 +285,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
                     .analyzer("custom_analyzer")
                     .text("the qu1ck brown fox-dog"),
                 "text", null, null, registry, environment, maxTokenCount));
-        assertEquals(e.getMessage(), "failed to find global analyzer [custom_analyzer]");
+        assertEquals(e.getMessage(), "failed to find analyzer [custom_analyzer]");
     }
 
     public void testUnknown() throws IOException {


### PR DESCRIPTION
When no index is specified on an analyze request, the code that builds
the analysis chain for that request goes directly to the analysis registry
to check for pre-built analyzers.  This can cause inconsistencies due to
the fact that elasticsearch defaults for various analysis settings (eg
the position increment gap) are different to the lucene defaults.

To remove these inconsistencies, this commit builds a one-off IndexAnalyzers
object when none is provided.  This means that all analyzers accessed
through an analysis request will use elasticsearch defaults.

Fixes #29021