### PR TITLE
Fix order of request body search parameter names

### DIFF
--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -188,46 +188,48 @@ to the client. This means it includes the time spent waiting in thread pools,
 executing a distributed search across the whole cluster and gathering all the
 results.
 
-include::request/query.asciidoc[]
-
-include::request/from-size.asciidoc[]
-
-include::request/sort.asciidoc[]
-
-include::request/track-total-hits.asciidoc[]
-
-include::request/source-filtering.asciidoc[]
-
-include::request/stored-fields.asciidoc[]
-
-include::request/script-fields.asciidoc[]
-
 include::request/docvalue-fields.asciidoc[]
-
-include::request/post-filter.asciidoc[]
-
-include::request/highlighting.asciidoc[]
-
-include::request/rescore.asciidoc[]
-
-include::request/search-type.asciidoc[]
-
-include::request/scroll.asciidoc[]
-
-include::request/preference.asciidoc[]
 
 include::request/explain.asciidoc[]
 
-include::request/version-and-seq-no.asciidoc[]
+include::request/collapse.asciidoc[]
+
+include::request/from-size.asciidoc[]
+
+include::request/highlighting.asciidoc[]
 
 include::request/index-boost.asciidoc[]
+
+include::request/inner-hits.asciidoc[]
 
 include::request/min-score.asciidoc[]
 
 include::request/named-queries-and-filters.asciidoc[]
 
-include::request/inner-hits.asciidoc[]
+include::request/post-filter.asciidoc[]
 
-include::request/collapse.asciidoc[]
+include::request/preference.asciidoc[]
+
+include::request/query.asciidoc[]
+
+include::request/rescore.asciidoc[]
+
+include::request/script-fields.asciidoc[]
+
+include::request/scroll.asciidoc[]
 
 include::request/search-after.asciidoc[]
+
+include::request/search-type.asciidoc[]
+
+include::request/seq-no.asciidoc[]
+
+include::request/sort.asciidoc[]
+
+include::request/source-filtering.asciidoc[]
+
+include::request/stored-fields.asciidoc[]
+
+include::request/track-total-hits.asciidoc[]
+
+include::request/version.asciidoc[]

--- a/docs/reference/search/request/seq-no.asciidoc
+++ b/docs/reference/search/request/seq-no.asciidoc
@@ -15,20 +15,3 @@ GET /_search
 }
 --------------------------------------------------
 // CONSOLE
-
-[[search-request-version]]
-=== Version
-
-Returns a version for each search hit.
-
-[source,js]
---------------------------------------------------
-GET /_search
-{
-    "version": true,
-    "query" : {
-        "term" : { "user" : "kimchy" }
-    }
-}
---------------------------------------------------
-// CONSOLE

--- a/docs/reference/search/request/stored-fields.asciidoc
+++ b/docs/reference/search/request/stored-fields.asciidoc
@@ -1,5 +1,5 @@
 [[search-request-stored-fields]]
-=== Fields
+=== Stored Fields
 
 WARNING: The `stored_fields` parameter is about fields that are explicitly marked as
 stored in the mapping, which is off by default and generally not recommended.

--- a/docs/reference/search/request/version.asciidoc
+++ b/docs/reference/search/request/version.asciidoc
@@ -1,0 +1,16 @@
+[[search-request-version]]
+=== Version
+
+Returns a version for each search hit.
+
+[source,js]
+--------------------------------------------------
+GET /_search
+{
+    "version": true,
+    "query" : {
+        "term" : { "user" : "kimchy" }
+    }
+}
+--------------------------------------------------
+// CONSOLE


### PR DESCRIPTION
The order was random, which made it super hard to find anything. This
changes the order to be alphabetically.

Current on the docs website:

![image](https://user-images.githubusercontent.com/667544/55478768-c83c9f80-561c-11e9-8064-1863b9b7b837.png)

With this

![image](https://user-images.githubusercontent.com/667544/55478795-d38fcb00-561c-11e9-84ff-6224dc64355c.png)
