### PR TITLE
[DOCS] Document index.load_fixed_bitset_filters_eagerly

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -83,6 +83,11 @@ WARNING: Expert only. Checking shards may take a lot of time on large indices.
     than the `index.number_of_shards` unless the `index.number_of_shards` value is also 1.
     See <<routing-index-partition>> for more details about how this setting is used.
 
+[[load-fixed-bitset-filters-eagerly]] `index.load_fixed_bitset_filters_eagerly`::
+
+    Indicates where <<query-filter-context, cached filters>> are pre-loaded for
+    nested queries. Possible values are `true` (default) and `false`.
+
 [float]
 [[dynamic-index-settings]]
 === Dynamic index settings

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -85,7 +85,7 @@ WARNING: Expert only. Checking shards may take a lot of time on large indices.
 
 [[load-fixed-bitset-filters-eagerly]] `index.load_fixed_bitset_filters_eagerly`::
 
-    Indicates where <<query-filter-context, cached filters>> are pre-loaded for
+    Indicates whether <<query-filter-context, cached filters>> are pre-loaded for
     nested queries. Possible values are `true` (default) and `false`.
 
 [float]


### PR DESCRIPTION
Documents the `index.load_fixed_bitset_filters_eagerly` setting.

#### Context
Prior to 2.3, users would frequently set `index.load_fixed_bitset_filters_eagerly` to `false` to avoid memory errors for mappings containing a large number of nested fields.

The need for that workaround was largely reduced in 2.3+ with #15989. That PR introduced `index.mapping.nested_fields.limit` which limits the number of nested fields. For that reason, I avoided referencing the workaround or other heuristics in this definition.

#### Related Tickets
Resolves #14903 
