### PR TITLE
[7.x][ML] Scrolling datafeed should clear scroll contexts on error

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
@@ -87,12 +87,22 @@ class ScrollDataExtractor implements DataExtractor {
         if (!hasNext()) {
             throw new NoSuchElementException();
         }
-        Optional<InputStream> stream = scrollId == null ?
-                Optional.ofNullable(initScroll(context.start)) : Optional.ofNullable(continueScroll());
+        Optional<InputStream> stream = tryNextStream();
         if (!stream.isPresent()) {
             hasNext = false;
         }
         return stream;
+    }
+
+    private Optional<InputStream> tryNextStream() throws IOException {
+        try {
+            return scrollId == null ?
+                Optional.ofNullable(initScroll(context.start)) : Optional.ofNullable(continueScroll());
+        } catch (Exception e) {
+            // In case of error make sure we clear the scroll context
+            clearScroll();
+            throw e;
+        }
     }
 
     protected InputStream initScroll(long startTimestamp) throws IOException {
@@ -131,6 +141,8 @@ class ScrollDataExtractor implements DataExtractor {
 
     private InputStream processSearchResponse(SearchResponse searchResponse) throws IOException {
 
+        scrollId = searchResponse.getScrollId();
+
         if (searchResponse.getFailedShards() > 0 && searchHasShardFailure == false) {
             LOGGER.debug("[{}] Resetting scroll search after shard failure", context.jobId);
             markScrollAsErrored();
@@ -138,10 +150,9 @@ class ScrollDataExtractor implements DataExtractor {
         }
 
         ExtractorUtils.checkSearchWasSuccessful(context.jobId, searchResponse);
-        scrollId = searchResponse.getScrollId();
         if (searchResponse.getHits().getHits().length == 0) {
             hasNext = false;
-            clearScroll(scrollId);
+            clearScroll();
             return null;
         }
 
@@ -155,7 +166,7 @@ class ScrollDataExtractor implements DataExtractor {
                             timestampOnCancel = timestamp;
                         } else if (timestamp.equals(timestampOnCancel) == false) {
                             hasNext = false;
-                            clearScroll(scrollId);
+                            clearScroll();
                             break;
                         }
                     }
@@ -189,7 +200,7 @@ class ScrollDataExtractor implements DataExtractor {
     private void markScrollAsErrored() {
         // This could be a transient error with the scroll Id.
         // Reinitialise the scroll and try again but only once.
-        resetScroll();
+        clearScroll();
         if (lastTimestamp != null) {
             lastTimestamp++;
         }
@@ -204,17 +215,13 @@ class ScrollDataExtractor implements DataExtractor {
                 .get());
     }
 
-    private void resetScroll() {
-        clearScroll(scrollId);
-        scrollId = null;
-    }
-
-    private void clearScroll(String scrollId) {
+    private void clearScroll() {
         if (scrollId != null) {
             ClearScrollRequest request = new ClearScrollRequest();
             request.addScrollId(scrollId);
             ClientHelper.executeWithHeaders(context.headers, ClientHelper.ML_ORIGIN, client,
                     () -> client.execute(ClearScrollAction.INSTANCE, request).actionGet());
+            scrollId = null;
         }
     }
 }


### PR DESCRIPTION
(#40773)

Closes #40772
