### PR TITLE
[Docs] Change example to show col headers

### DIFF
--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -108,7 +108,7 @@ You can check progress by submitting a <<cat-health,`_cat/health`>> request:
 
 [source,sh]
 --------------------------------------------------
-GET _cat/health
+GET _cat/health?v
 --------------------------------------------------
 // CONSOLE
 


### PR DESCRIPTION
Command needs `?v` so user can see the column headers. Otherwise the instructions in the note about checking the init and relo columns don't make sense
