### PR TITLE
Add known ILM issue to release notes

### DIFF
--- a/docs/reference/release-notes/6.7.asciidoc
+++ b/docs/reference/release-notes/6.7.asciidoc
@@ -80,6 +80,13 @@ the new `build_type` value. For example, it cannot read main responses on `/`
 from a cluster that's running 6.7.0. Upgrade your client to 6.7.0 or later.
 (issue: {issue}/40511[#40511])
 
+Features/ILM::
+If an index is configured with an `index.lifecycle.name` that refers to a policy
+that does not exist, when <<start-stop-ilm, {ilm} is stopped>>, {ilm}'s status
+will remain as `STOPPING` until all policies that do not exist are removed from
+any indices by using the <<ilm-remove-policy,Remove Policy API>>.
+(issue: {issue}/40824[#40824])
+
 [[breaking-6.7.0]]
 [float]
 === Breaking changes


### PR DESCRIPTION
Adds a known issue with stopping ILM when some indices are configured to
use a policy that doesn't exist to the release notes.

Adding this to the release notes per discussion with @jasontedor.

Relates to https://github.com/elastic/elasticsearch/issues/40824