### PR TITLE
Rollup ignores time_zone on date histogram

### DIFF
--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupRequestTranslator.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupRequestTranslator.java
@@ -224,6 +224,9 @@ public class RollupRequestTranslator {
             filterConditions.add(new TermQueryBuilder(RollupField.formatFieldName(source,
                 DateHistogramGroupConfig.TIME_ZONE), timezone));
 
+            if (source.timeZone() != null) {
+                rolledDateHisto.timeZone(source.timeZone());
+            }
             rolledDateHisto.offset(source.offset());
             if (source.extendedBounds() != null) {
                 rolledDateHisto.extendedBounds(source.extendedBounds());


### PR DESCRIPTION
When translating the original aggregation for the rollup indices,
the timezone of the date histogram is validated against the rollup
job but the value is not copied in the newly created date_histogram.