### PR TITLE
[ML] Changes default destination index field mapping and adds scripted_metric agg (#40750)

### DIFF
--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFramePivotRestIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFramePivotRestIT.java
@@ -314,6 +314,59 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
         assertThat(actual, containsString("2017-01-15T"));
     }
 
+    public void testPivotWithScriptedMetricAgg() throws Exception {
+        String transformId = "scriptedMetricPivot";
+        String dataFrameIndex = "scripted_metric_pivot_reviews";
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
+
+        final Request createDataframeTransformRequest = createRequestWithAuth("PUT", DATAFRAME_ENDPOINT + transformId,
+            BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
+
+        String config = "{"
+            + " \"source\": {\"index\":\"" + REVIEWS_INDEX_NAME + "\"},"
+            + " \"dest\": {\"index\":\"" + dataFrameIndex + "\"},";
+
+        config += " \"pivot\": {"
+            + "   \"group_by\": {"
+            + "     \"reviewer\": {"
+            + "       \"terms\": {"
+            + "         \"field\": \"user_id\""
+            + " } } },"
+            + "   \"aggregations\": {"
+            + "     \"avg_rating\": {"
+            + "       \"avg\": {"
+            + "         \"field\": \"stars\""
+            + " } },"
+            + "     \"squared_sum\": {"
+            + "       \"scripted_metric\": {"
+            + "         \"init_script\": \"state.reviews_sqrd = []\","
+            + "         \"map_script\": \"state.reviews_sqrd.add(doc.stars.value * doc.stars.value)\","
+            + "         \"combine_script\": \"state.reviews_sqrd\","
+            + "         \"reduce_script\": \"def sum = 0.0; for(l in states){ for(a in l) { sum += a}} return sum\""
+            + " } }"
+            + " } }"
+            + "}";
+
+        createDataframeTransformRequest.setJsonEntity(config);
+        Map<String, Object> createDataframeTransformResponse = entityAsMap(client().performRequest(createDataframeTransformRequest));
+        assertThat(createDataframeTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
+        assertTrue(indexExists(dataFrameIndex));
+
+        startAndWaitForTransform(transformId, dataFrameIndex, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN_WITH_SOME_DATA_ACCESS);
+
+        // we expect 27 documents as there shall be 27 user_id's
+        Map<String, Object> indexStats = getAsMap(dataFrameIndex + "/_stats");
+        assertEquals(27, XContentMapValues.extractValue("_all.total.docs.count", indexStats));
+
+        // get and check some users
+        Map<String, Object> searchResult = getAsMap(dataFrameIndex + "/_search?q=reviewer:user_4");
+        assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
+        Number actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.avg_rating", searchResult)).get(0);
+        assertEquals(3.878048780, actual.doubleValue(), 0.000001);
+        actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.squared_sum", searchResult)).get(0);
+        assertEquals(711.0, actual.doubleValue(), 0.000001);
+    }
+
     private void assertOnePivotValue(String query, double expected) throws IOException {
         Map<String, Object> searchResult = getAsMap(query);
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportPreviewDataFrameTransformAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportPreviewDataFrameTransformAction.java
@@ -95,6 +95,5 @@ public class TransportPreviewDataFrameTransformAction extends
             },
             listener::onFailure
         ));
-
     }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationResultUtils.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationResultUtils.java
@@ -13,6 +13,7 @@ import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation.SingleValue;
+import org.elasticsearch.search.aggregations.metrics.ScriptedMetric;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.pivot.GroupConfig;
@@ -73,6 +74,8 @@ final class AggregationResultUtils {
                     } else {
                         document.put(aggName, aggResultSingleValue.getValueAsString());
                     }
+                } else if (aggResult instanceof ScriptedMetric) {
+                    document.put(aggName, ((ScriptedMetric) aggResult).aggregation());
                 } else {
                     // Execution should never reach this point!
                     // Creating transforms with unsupported aggregations shall not be possible

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/Aggregations.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/Aggregations.java
@@ -12,6 +12,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public final class Aggregations {
+
+    // the field mapping should not explicitly be set and allow ES to dynamically determine mapping via the data.
+    private static final String DYNAMIC = "_dynamic";
+    // the field mapping should be determined explicitly from the source field mapping if possible.
+    private static final String SOURCE = "_source";
     private Aggregations() {}
 
     /**
@@ -27,9 +32,10 @@ public final class Aggregations {
         AVG("avg", "double"),
         CARDINALITY("cardinality", "long"),
         VALUE_COUNT("value_count", "long"),
-        MAX("max", null),
-        MIN("min", null),
-        SUM("sum", null);
+        MAX("max", SOURCE),
+        MIN("min", SOURCE),
+        SUM("sum", SOURCE),
+        SCRIPTED_METRIC("scripted_metric", DYNAMIC);
 
         private final String aggregationType;
         private final String targetMapping;
@@ -55,8 +61,12 @@ public final class Aggregations {
         return aggregationSupported.contains(aggregationType.toUpperCase(Locale.ROOT));
     }
 
+    public static boolean isDynamicMapping(String targetMapping) {
+        return DYNAMIC.equals(targetMapping);
+    }
+
     public static String resolveTargetMapping(String aggregationType, String sourceType) {
         AggregationType agg = AggregationType.valueOf(aggregationType.toUpperCase(Locale.ROOT));
-        return agg.getTargetMapping() == null ? sourceType : agg.getTargetMapping();
+        return agg.getTargetMapping().equals(SOURCE) ? sourceType : agg.getTargetMapping();
     }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/SchemaUtil.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/SchemaUtil.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRespon
 import org.elasticsearch.client.Client;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.ScriptedMetricAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.dataframe.transforms.pivot.PivotConfig;
@@ -75,6 +76,8 @@ public final class SchemaUtil {
                 ValuesSourceAggregationBuilder<?, ?> valueSourceAggregation = (ValuesSourceAggregationBuilder<?, ?>) agg;
                 aggregationSourceFieldNames.put(valueSourceAggregation.getName(), valueSourceAggregation.field());
                 aggregationTypes.put(valueSourceAggregation.getName(), valueSourceAggregation.getType());
+            } else if(agg instanceof ScriptedMetricAggregationBuilder) {
+                aggregationTypes.put(agg.getName(), agg.getType());
             } else {
                 // execution should not reach this point
                 listener.onFailure(new RuntimeException("Unsupported aggregation type [" + agg.getType() + "]"));
@@ -127,15 +130,17 @@ public final class SchemaUtil {
 
         aggregationTypes.forEach((targetFieldName, aggregationName) -> {
             String sourceFieldName = aggregationSourceFieldNames.get(targetFieldName);
-            String destinationMapping = Aggregations.resolveTargetMapping(aggregationName, sourceMappings.get(sourceFieldName));
+            String sourceMapping = sourceFieldName == null ? null : sourceMappings.get(sourceFieldName);
+            String destinationMapping = Aggregations.resolveTargetMapping(aggregationName, sourceMapping);
 
             logger.debug(
                     "Deduced mapping for: [" + targetFieldName + "], agg type [" + aggregationName + "] to [" + destinationMapping + "]");
-            if (destinationMapping != null) {
+            if (Aggregations.isDynamicMapping(destinationMapping)) {
+                logger.info("Dynamic target mapping set for field ["+ targetFieldName +"] and aggregation [" + aggregationName +"]");
+            } else if (destinationMapping != null) {
                 targetMapping.put(targetFieldName, destinationMapping);
             } else {
-                logger.warn("Failed to deduce mapping for [" + targetFieldName + "], fall back to double.");
-                targetMapping.put(targetFieldName, "double");
+                logger.warn("Failed to deduce mapping for [" + targetFieldName + "], fall back to dynamic mapping.");
             }
         });
 

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationsTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationsTests.java
@@ -15,9 +15,31 @@ public class AggregationsTests extends ESTestCase {
         assertEquals("double", Aggregations.resolveTargetMapping("avg", "int"));
         assertEquals("double", Aggregations.resolveTargetMapping("avg", "double"));
 
+        // cardinality
+        assertEquals("long", Aggregations.resolveTargetMapping("cardinality", "int"));
+        assertEquals("long", Aggregations.resolveTargetMapping("cardinality", "double"));
+
+        // value_count
+        assertEquals("long", Aggregations.resolveTargetMapping("value_count", "int"));
+        assertEquals("long", Aggregations.resolveTargetMapping("value_count", "double"));
+
         // max
         assertEquals("int", Aggregations.resolveTargetMapping("max", "int"));
         assertEquals("double", Aggregations.resolveTargetMapping("max", "double"));
         assertEquals("half_float", Aggregations.resolveTargetMapping("max", "half_float"));
+
+        // min
+        assertEquals("int", Aggregations.resolveTargetMapping("min", "int"));
+        assertEquals("double", Aggregations.resolveTargetMapping("min", "double"));
+        assertEquals("half_float", Aggregations.resolveTargetMapping("min", "half_float"));
+
+        // sum
+        assertEquals("int", Aggregations.resolveTargetMapping("sum", "int"));
+        assertEquals("double", Aggregations.resolveTargetMapping("sum", "double"));
+        assertEquals("half_float", Aggregations.resolveTargetMapping("sum", "half_float"));
+
+        // scripted_metric
+        assertEquals("_dynamic", Aggregations.resolveTargetMapping("scripted_metric", null));
+        assertEquals("_dynamic", Aggregations.resolveTargetMapping("scripted_metric", "int"));
     }
 }


### PR DESCRIPTION


This PR adjusts the default behavior for aggregations whose destination mapping cannot be accurately determined either through agg type or source field mapping. Previously, setting the field mapping to double was the default behavior. This will not work for more complex scenarios. So, instead of enforcing an explicit mapping for indeterminable fields, I allow the mapping to dynamically determine the appropriate type.

The reason for adding scripted_metric in this PR as well, is so we have an aggregation that will exercise the new default behavior code path.

I did NOT attempt to determine the explicit mapping for scripted_metric and simply let it always be dynamic. The reasoning for this is that we would simply be doing what the ES mapping system already does for us. It would add complexity with little benefit.

Also, this simply adds the support for the aggregation. This PR does NOT include any new abstractions, interfaces, fields, etc. in the API. If we want to obfuscate the complexities in the scripted_metric aggregation, that will have to be future work.

Backport of:  #40750
