### PR TITLE
Fix dense/sparse vector limit documentation

### DIFF
--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -5,7 +5,7 @@ experimental[]
 
 A `dense_vector` field stores dense vectors of float values.
 The maximum number of dimensions that can be in a vector should
-not exceed 500. The number of dimensions can be
+not exceed 1024. The number of dimensions can be
 different across documents. A `dense_vector` field is
 a single-valued field.
 

--- a/docs/reference/mapping/types/sparse-vector.asciidoc
+++ b/docs/reference/mapping/types/sparse-vector.asciidoc
@@ -5,7 +5,7 @@ experimental[]
 
 A `sparse_vector` field stores sparse vectors of float values.
 The maximum number of dimensions that can be in a vector should
-not exceed 500. The number of dimensions can be
+not exceed 1024. The number of dimensions can be
 different across documents. A `sparse_vector` field is
 a single-valued field.
 


### PR DESCRIPTION
The documentation stated a wrong limit of dense/sparse vector sizes.
This was changed in #40597 but the documentation was not fixed.

