### PR TITLE
[DOCS] Removes 'coming' tag for 6.7.1

### DIFF
--- a/docs/reference/release-notes/6.7.asciidoc
+++ b/docs/reference/release-notes/6.7.asciidoc
@@ -1,7 +1,6 @@
 [[release-notes-6.7.1]]
 == {es} version 6.7.1
 
-coming[6.7.1]
 
 Also see <<breaking-changes-6.7,Breaking changes in 6.7>>.
 


### PR DESCRIPTION
This PR removes the 'coming' tag for 6.7.1 release notes. 