### PR TITLE
refactor onStart and onFinish to take runnables and executed them guarded by state

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
@@ -319,7 +319,7 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
                 // execute finishing tasks
                 onFinish(ActionListener.wrap(
                         r -> doSaveState(finishAndSetState(), position.get(), () -> {}),
-                        e -> doSaveState(finishAndSetState(), position.get(), () -> onFailure(e))));
+                        e -> doSaveState(finishAndSetState(), position.get(), () -> {})));
 
                 return;
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * An abstract class that builds an index incrementally. A background job can be launched using {@link #maybeTriggerAsyncJob(long)},
  * it will create the index from the source index up to the last complete bucket that is allowed to be built (based on job position).
- * Only one background job can run simultaneously and {@link #onFinish()} is called when the job
+ * Only one background job can run simultaneously and {@link #onFinish(Runnable)} is called when the job
  * finishes. {@link #onFailure(Exception)} is called if the job fails with an exception and {@link #onAbort()} is called if the indexer is
  * aborted while a job is running. The indexer must be started ({@link #start()} to allow a background job to run when
  * {@link #maybeTriggerAsyncJob(long)} is called. {@link #stop()} can be used to stop the background job without aborting the indexer.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
@@ -152,7 +152,10 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
                     onStart(now, ActionListener.wrap(r -> {
                         stats.markStartSearch();
                         doNextSearch(buildSearchRequest(), ActionListener.wrap(this::onSearchResponse, this::finishWithSearchFailure));
-                    }, e -> doSaveState(finishAndSetState(), position.get(), () -> onFailure(e))));
+                    }, e -> {
+                        finishAndSetState();
+                        onFailure(e);
+                    }));
                 });
                 logger.debug("Beginning to index [" + getJobId() + "], state: [" + currentState + "]");
                 return true;
@@ -316,7 +319,7 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
                 // execute finishing tasks
                 onFinish(ActionListener.wrap(
                         r -> doSaveState(finishAndSetState(), position.get(), () -> {}),
-                        e -> doSaveState(finishAndSetState(), position.get(), () -> {})));
+                        e -> doSaveState(finishAndSetState(), position.get(), () -> onFailure(e))));
 
                 return;
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * An abstract class that builds an index incrementally. A background job can be launched using {@link #maybeTriggerAsyncJob(long)},
  * it will create the index from the source index up to the last complete bucket that is allowed to be built (based on job position).
- * Only one background job can run simultaneously and {@link #onFinish(Runnable)} is called when the job
+ * Only one background job can run simultaneously and {@link #onFinish} is called when the job
  * finishes. {@link #onFailure(Exception)} is called if the job fails with an exception and {@link #onAbort()} is called if the indexer is
  * aborted while a job is running. The indexer must be started ({@link #start()} to allow a background job to run when
  * {@link #maybeTriggerAsyncJob(long)} is called. {@link #stop()} can be used to stop the background job without aborting the indexer.
@@ -149,15 +149,10 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
             if (state.compareAndSet(IndexerState.STARTED, IndexerState.INDEXING)) {
                 // fire off the search. Note this is async, the method will return from here
                 executor.execute(() -> {
-                    try {
-                        onStart(now, () -> {
-                            stats.markStartSearch();
-                            doNextSearch(buildSearchRequest(), ActionListener.wrap(this::onSearchResponse, this::finishWithSearchFailure));
-                        });
-                    } catch (Exception e) {
-                        logger.error("Indexer failed on start", e);
-                        doSaveState(finishAndSetState(), position.get(), () -> onFailure(e));
-                    }
+                    onStart(now, ActionListener.wrap(r -> {
+                        stats.markStartSearch();
+                        doNextSearch(buildSearchRequest(), ActionListener.wrap(this::onSearchResponse, this::finishWithSearchFailure));
+                    }, e -> doSaveState(finishAndSetState(), position.get(), () -> onFailure(e))));
                 });
                 logger.debug("Beginning to index [" + getJobId() + "], state: [" + currentState + "]");
                 return true;
@@ -198,12 +193,10 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
      * Called at startup after job has been triggered using {@link #maybeTriggerAsyncJob(long)} and the
      * internal state is {@link IndexerState#STARTED}.
      *
-     * Implementors MUST ensure that next.run() gets called.
-     *
      * @param now The current time in milliseconds passed through from {@link #maybeTriggerAsyncJob(long)}
-     * @param next Runnable for the next phase
+     * @param listener listener to call after done
      */
-    protected abstract void onStart(long now, Runnable next);
+    protected abstract void onStart(long now, ActionListener<Void> listener);
 
     /**
      * Executes the {@link SearchRequest} and calls <code>nextPhase</code> with the
@@ -251,12 +244,11 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
 
     /**
      * Called when a background job finishes before the internal state changes from {@link IndexerState#INDEXING} back to
-     * {@link IndexerState#STARTED}. The passed runnable trigger persisting and changing the state and can be wrapped to
-     * execute code after the state has changed.
+     * {@link IndexerState#STARTED}.
      *
-     * @param finishAndSetState Runnable for finishing and setting state
+     * @param listener listener to call after done
      */
-    protected abstract void onFinish(Runnable finishAndSetState);
+    protected abstract void onFinish(ActionListener<Void> listener);
 
     /**
      * Called when a background job detects that the indexer is aborted causing the
@@ -322,17 +314,9 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
                 logger.debug("Finished indexing for job [" + getJobId() + "], saving state and shutting down.");
 
                 // execute finishing tasks
-                try {
-                    onFinish(() -> {
-                        // Change state first, then try to persist. This prevents in-progress
-                        // STOPPING/ABORTING from
-                        // being persisted as STARTED but then stop the job
-                        doSaveState(finishAndSetState(), position.get(), () -> {});
-                    });
-                } catch (Exception e) {
-                    logger.error("Indexer failed on finish", e);
-                    doSaveState(finishAndSetState(), position.get(), () -> onFailure(e));
-                }
+                onFinish(ActionListener.wrap(
+                        r -> doSaveState(finishAndSetState(), position.get(), () -> {}),
+                        e -> doSaveState(finishAndSetState(), position.get(), () -> {})));
 
                 return;
             }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
@@ -76,10 +76,10 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
         }
 
         @Override
-        protected void onStart(long now, Runnable next) {
+        protected void onStart(long now, ActionListener<Void> listener) {
             assertThat(step, equalTo(0));
             ++step;
-            next.run();
+            listener.onResponse(null);
         }
 
         @Override
@@ -110,11 +110,11 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
         }
 
         @Override
-        protected void onFinish(Runnable finishAndSetState) {
+        protected void onFinish(ActionListener<Void> listener) {
             assertThat(step, equalTo(4));
             ++step;
             isFinished.set(true);
-            finishAndSetState.run();
+            listener.onResponse(null);
         }
 
         @Override
@@ -155,10 +155,10 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
         }
 
         @Override
-        protected void onStart(long now, Runnable next) {
+        protected void onStart(long now, ActionListener<Void> listener) {
             assertThat(step, equalTo(0));
             ++step;
-            next.run();
+            listener.onResponse(null);
         }
 
         @Override
@@ -186,7 +186,7 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
         }
 
         @Override
-        protected void onFinish(Runnable finishAndSetState) {
+        protected void onFinish(ActionListener<Void> listener) {
             fail("should not be called");
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
@@ -76,9 +76,10 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
         }
 
         @Override
-        protected void onStartJob(long now) {
+        protected void onStart(long now, Runnable next) {
             assertThat(step, equalTo(0));
             ++step;
+            next.run();
         }
 
         @Override
@@ -109,10 +110,11 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
         }
 
         @Override
-        protected void beforeFinish() {
+        protected void onFinish(Runnable finishAndSetState) {
             assertThat(step, equalTo(4));
             ++step;
             isFinished.set(true);
+            finishAndSetState.run();
         }
 
         @Override
@@ -153,9 +155,10 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
         }
 
         @Override
-        protected void onStartJob(long now) {
+        protected void onStart(long now, Runnable next) {
             assertThat(step, equalTo(0));
             ++step;
+            next.run();
         }
 
         @Override
@@ -183,7 +186,7 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
         }
 
         @Override
-        protected void beforeFinish() {
+        protected void onFinish(Runnable finishAndSetState) {
             fail("should not be called");
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
@@ -173,14 +173,12 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
 
         @Override
         protected void doSaveState(IndexerState state, Integer position, Runnable next) {
-            assertThat(step, equalTo(2));
-            ++step;
-            next.run();
+            fail("should not be called");
         }
 
         @Override
         protected void onFailure(Exception exc) {
-            assertThat(step, equalTo(3));
+            assertThat(step, equalTo(2));
             ++step;
             isFinished.set(true);
         }
@@ -243,8 +241,8 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
             indexer.start();
             assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
             assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
-            assertTrue(ESTestCase.awaitBusy(() -> isFinished.get()));
-            assertThat(indexer.getStep(), equalTo(4));
+            assertTrue(ESTestCase.awaitBusy(() -> isFinished.get(), 10000, TimeUnit.SECONDS));
+            assertThat(indexer.getStep(), equalTo(3));
 
         } finally {
             executor.shutdownNow();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
@@ -98,7 +98,7 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
 
         @Override
         protected void doSaveState(IndexerState state, Integer position, Runnable next) {
-            assertThat(step, equalTo(4));
+            assertThat(step, equalTo(5));
             ++step;
             next.run();
         }
@@ -109,8 +109,8 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
         }
 
         @Override
-        protected void onFinish() {
-            assertThat(step, equalTo(5));
+        protected void beforeFinish() {
+            assertThat(step, equalTo(4));
             ++step;
             isFinished.set(true);
         }
@@ -183,7 +183,7 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
         }
 
         @Override
-        protected void onFinish() {
+        protected void beforeFinish() {
             fail("should not be called");
         }
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.dataframe.transforms;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -51,11 +52,14 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
     protected abstract Map<String, String> getFieldMappings();
 
     @Override
-    protected void onStart(long now, Runnable next) {
-        QueryBuilder queryBuilder = getConfig().getSource().getQueryConfig().getQuery();
-
-        pivot = new Pivot(getConfig().getSource().getIndex(), queryBuilder, getConfig().getPivotConfig());
-        next.run();
+    protected void onStart(long now, ActionListener<Void> listener) {
+        try {
+            QueryBuilder queryBuilder = getConfig().getSource().getQueryConfig().getQuery();
+            pivot = new Pivot(getConfig().getSource().getIndex(), queryBuilder, getConfig().getPivotConfig());
+            listener.onResponse(null);
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
     }
 
     @Override

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
@@ -51,10 +51,11 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
     protected abstract Map<String, String> getFieldMappings();
 
     @Override
-    protected void onStartJob(long now) {
+    protected void onStart(long now, Runnable next) {
         QueryBuilder queryBuilder = getConfig().getSource().getQueryConfig().getQuery();
 
         pivot = new Pivot(getConfig().getSource().getIndex(), queryBuilder, getConfig().getPivotConfig());
+        next.run();
     }
 
     @Override

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -478,10 +478,14 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
         }
 
         @Override
-        protected void onFinish(Runnable finishAndSetState) {
-            auditor.info(transform.getId(), "Finished indexing for data frame transform");
-            logger.info("Finished indexing for data frame transform [" + transform.getId() + "]");
-            finishAndSetState.run();
+        protected void onFinish(ActionListener<Void> listener) {
+            try {
+                auditor.info(transform.getId(), "Finished indexing for data frame transform");
+                logger.info("Finished indexing for data frame transform [" + transform.getId() + "]");
+                listener.onResponse(null);
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
         }
 
         @Override

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -478,7 +478,7 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
         }
 
         @Override
-        protected void onFinish() {
+        protected void beforeFinish() {
             auditor.info(transform.getId(), "Finished indexing for data frame transform");
             logger.info("Finished indexing for data frame transform [" + transform.getId() + "]");
         }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -27,12 +27,12 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.common.notifications.Auditor;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.dataframe.DataFrameMessages;
-import org.elasticsearch.xpack.core.dataframe.notifications.DataFrameAuditMessage;
-import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransform;
 import org.elasticsearch.xpack.core.dataframe.action.StartDataFrameTransformTaskAction;
 import org.elasticsearch.xpack.core.dataframe.action.StartDataFrameTransformTaskAction.Response;
 import org.elasticsearch.xpack.core.dataframe.action.StopDataFrameTransformAction;
+import org.elasticsearch.xpack.core.dataframe.notifications.DataFrameAuditMessage;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransform;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformState;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformTaskState;
@@ -478,9 +478,10 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
         }
 
         @Override
-        protected void beforeFinish() {
+        protected void onFinish(Runnable finishAndSetState) {
             auditor.info(transform.getId(), "Finished indexing for data frame transform");
             logger.info("Finished indexing for data frame transform [" + transform.getId() + "]");
+            finishAndSetState.run();
         }
 
         @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupJobTask.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupJobTask.java
@@ -138,9 +138,9 @@ public class RollupJobTask extends AllocatedPersistentTask implements SchedulerE
         }
 
         @Override
-        protected void onFinish(Runnable finishAndSetState) {
+        protected void onFinish(ActionListener<Void> listener) {
             logger.debug("Finished indexing for job [" + job.getConfig().getId() + "]");
-            finishAndSetState.run();
+            listener.onResponse(null);
         }
 
         @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupJobTask.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupJobTask.java
@@ -138,8 +138,9 @@ public class RollupJobTask extends AllocatedPersistentTask implements SchedulerE
         }
 
         @Override
-        protected void beforeFinish() {
+        protected void onFinish(Runnable finishAndSetState) {
             logger.debug("Finished indexing for job [" + job.getConfig().getId() + "]");
+            finishAndSetState.run();
         }
 
         @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupJobTask.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupJobTask.java
@@ -138,7 +138,7 @@ public class RollupJobTask extends AllocatedPersistentTask implements SchedulerE
         }
 
         @Override
-        protected void onFinish() {
+        protected void beforeFinish() {
             logger.debug("Finished indexing for job [" + job.getConfig().getId() + "]");
         }
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -581,8 +581,9 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
         }
 
         @Override
-        protected void beforeFinish() {
+        protected void onFinish(Runnable finishAndSetState) {
             latch.countDown();
+            finishAndSetState.run();
         }
 
         @Override

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -581,9 +581,9 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
         }
 
         @Override
-        protected void onFinish(Runnable finishAndSetState) {
+        protected void onFinish(ActionListener<Void> listener) {
             latch.countDown();
-            finishAndSetState.run();
+            listener.onResponse(null);
         }
 
         @Override

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -581,7 +581,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
         }
 
         @Override
-        protected void onFinish() {
+        protected void beforeFinish() {
             latch.countDown();
         }
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
@@ -24,7 +24,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.rollup.ConfigTestHelpers;
 import org.elasticsearch.xpack.core.rollup.RollupField;
-import org.elasticsearch.xpack.core.rollup.job.GroupConfig;
+import org.elasticsearch.xpack.core.rollup.job.RollupIndexerJobStats;
 import org.elasticsearch.xpack.core.rollup.job.RollupJob;
 import org.elasticsearch.xpack.core.rollup.job.RollupJobConfig;
 import org.mockito.stubbing.Answer;
@@ -44,11 +44,18 @@ import java.util.function.Function;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.spy;
+
 
 public class RollupIndexerStateTests extends ESTestCase {
     private static class EmptyRollupIndexer extends RollupIndexer {
+        EmptyRollupIndexer(Executor executor, RollupJob job, AtomicReference<IndexerState> initialState,
+                Map<String, Object> initialPosition, boolean upgraded, RollupIndexerJobStats stats) {
+            super(executor, job, initialState, initialPosition, new AtomicBoolean(upgraded), stats);
+        }
+
         EmptyRollupIndexer(Executor executor, RollupJob job, AtomicReference<IndexerState> initialState,
                            Map<String, Object> initialPosition, boolean upgraded) {
             super(executor, job, initialState, initialPosition, new AtomicBoolean(upgraded));
@@ -124,7 +131,9 @@ public class RollupIndexerStateTests extends ESTestCase {
         }
 
         @Override
-        protected void beforeFinish() {}
+        protected void onFinish(Runnable finishAndSetState) {
+            finishAndSetState.run();
+        }
     }
 
     private static class DelayedEmptyRollupIndexer extends EmptyRollupIndexer {
@@ -138,6 +147,11 @@ public class RollupIndexerStateTests extends ESTestCase {
         DelayedEmptyRollupIndexer(Executor executor, RollupJob job, AtomicReference<IndexerState> initialState,
                                   Map<String, Object> initialPosition) {
             super(executor, job, initialState, initialPosition, randomBoolean());
+        }
+
+        DelayedEmptyRollupIndexer(Executor executor, RollupJob job, AtomicReference<IndexerState> initialState,
+                Map<String, Object> initialPosition, RollupIndexerJobStats stats) {
+            super(executor, job, initialState, initialPosition, randomBoolean(), stats);
         }
 
         private CountDownLatch newLatch() {
@@ -214,7 +228,9 @@ public class RollupIndexerStateTests extends ESTestCase {
         }
 
         @Override
-        protected void beforeFinish() {}
+        protected void onFinish(Runnable finishAndSetState) {
+            finishAndSetState.run();
+        }
     }
 
     public void testStarted() throws Exception {
@@ -248,8 +264,8 @@ public class RollupIndexerStateTests extends ESTestCase {
             AtomicBoolean isFinished = new AtomicBoolean(false);
             DelayedEmptyRollupIndexer indexer = new DelayedEmptyRollupIndexer(executor, job, state, null) {
                 @Override
-                protected void beforeFinish() {
-                    super.beforeFinish();
+                protected void onFinish(Runnable finishAndSetState) {
+                    super.onFinish(finishAndSetState);
                     isFinished.set(true);
                 }
             };
@@ -274,23 +290,29 @@ public class RollupIndexerStateTests extends ESTestCase {
 
     public void testStateChangeMidTrigger() throws Exception {
         AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
+
+        RollupIndexerJobStats stats = new RollupIndexerJobStats();
+        RollupIndexerJobStats spyStats = spy(stats);
         RollupJobConfig config = mock(RollupJobConfig.class);
 
-        // We pull the config before a final state check, so this allows us to flip the state
+        // We call stats before a final state check, so this allows us to flip the state
         // and make sure the appropriate error is thrown
-        when(config.getGroupConfig()).then((Answer<GroupConfig>) invocationOnMock -> {
+        Answer<?> forwardAndChangeState = invocation -> {
+            invocation.callRealMethod();
             state.set(IndexerState.STOPPED);
-            return ConfigTestHelpers.randomGroupConfig(random());
-        });
+            return null;
+        };
+
+        doAnswer(forwardAndChangeState).when(spyStats).incrementNumInvocations(1L);
         RollupJob job = new RollupJob(config, Collections.emptyMap());
 
         final ExecutorService executor = Executors.newFixedThreadPool(1);
         try {
             AtomicBoolean isFinished = new AtomicBoolean(false);
-            DelayedEmptyRollupIndexer indexer = new DelayedEmptyRollupIndexer(executor, job, state, null) {
+            DelayedEmptyRollupIndexer indexer = new DelayedEmptyRollupIndexer(executor, job, state, null, spyStats) {
                 @Override
-                protected void beforeFinish() {
-                    super.beforeFinish();
+                protected void onFinish(Runnable finishAndSetState) {
+                    super.onFinish(finishAndSetState);
                     isFinished.set(true);
                 }
             };
@@ -318,7 +340,7 @@ public class RollupIndexerStateTests extends ESTestCase {
         try {
             EmptyRollupIndexer indexer = new EmptyRollupIndexer(executor, job, state, null) {
                 @Override
-                protected void beforeFinish() {
+                protected void onFinish(Runnable finishAndSetState) {
                     fail("Should not have called onFinish");
                 }
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
@@ -131,8 +131,8 @@ public class RollupIndexerStateTests extends ESTestCase {
         }
 
         @Override
-        protected void onFinish(Runnable finishAndSetState) {
-            finishAndSetState.run();
+        protected void onFinish(ActionListener<Void> listener) {
+            listener.onResponse(null);
         }
     }
 
@@ -228,8 +228,8 @@ public class RollupIndexerStateTests extends ESTestCase {
         }
 
         @Override
-        protected void onFinish(Runnable finishAndSetState) {
-            finishAndSetState.run();
+        protected void onFinish(ActionListener<Void> listener) {
+            listener.onResponse(null);
         }
     }
 
@@ -264,9 +264,11 @@ public class RollupIndexerStateTests extends ESTestCase {
             AtomicBoolean isFinished = new AtomicBoolean(false);
             DelayedEmptyRollupIndexer indexer = new DelayedEmptyRollupIndexer(executor, job, state, null) {
                 @Override
-                protected void onFinish(Runnable finishAndSetState) {
-                    super.onFinish(finishAndSetState);
-                    isFinished.set(true);
+                protected void onFinish(ActionListener<Void> listener) {
+                    super.onFinish(ActionListener.wrap(r -> {
+                        isFinished.set(true);
+                        listener.onResponse(r);
+                    }, listener::onFailure));
                 }
             };
             final CountDownLatch latch = indexer.newLatch();
@@ -311,9 +313,11 @@ public class RollupIndexerStateTests extends ESTestCase {
             AtomicBoolean isFinished = new AtomicBoolean(false);
             DelayedEmptyRollupIndexer indexer = new DelayedEmptyRollupIndexer(executor, job, state, null, spyStats) {
                 @Override
-                protected void onFinish(Runnable finishAndSetState) {
-                    super.onFinish(finishAndSetState);
-                    isFinished.set(true);
+                protected void onFinish(ActionListener<Void> listener) {
+                    super.onFinish(ActionListener.wrap(r -> {
+                        isFinished.set(true);
+                        listener.onResponse(r);
+                    }, listener::onFailure));
                 }
             };
             final CountDownLatch latch = indexer.newLatch();
@@ -340,7 +344,7 @@ public class RollupIndexerStateTests extends ESTestCase {
         try {
             EmptyRollupIndexer indexer = new EmptyRollupIndexer(executor, job, state, null) {
                 @Override
-                protected void onFinish(Runnable finishAndSetState) {
+                protected void onFinish(ActionListener<Void> listener) {
                     fail("Should not have called onFinish");
                 }
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
@@ -124,7 +124,7 @@ public class RollupIndexerStateTests extends ESTestCase {
         }
 
         @Override
-        protected void onFinish() {}
+        protected void beforeFinish() {}
     }
 
     private static class DelayedEmptyRollupIndexer extends EmptyRollupIndexer {
@@ -214,7 +214,7 @@ public class RollupIndexerStateTests extends ESTestCase {
         }
 
         @Override
-        protected void onFinish() {}
+        protected void beforeFinish() {}
     }
 
     public void testStarted() throws Exception {
@@ -248,8 +248,8 @@ public class RollupIndexerStateTests extends ESTestCase {
             AtomicBoolean isFinished = new AtomicBoolean(false);
             DelayedEmptyRollupIndexer indexer = new DelayedEmptyRollupIndexer(executor, job, state, null) {
                 @Override
-                protected void onFinish() {
-                    super.onFinish();
+                protected void beforeFinish() {
+                    super.beforeFinish();
                     isFinished.set(true);
                 }
             };
@@ -289,8 +289,8 @@ public class RollupIndexerStateTests extends ESTestCase {
             AtomicBoolean isFinished = new AtomicBoolean(false);
             DelayedEmptyRollupIndexer indexer = new DelayedEmptyRollupIndexer(executor, job, state, null) {
                 @Override
-                protected void onFinish() {
-                    super.onFinish();
+                protected void beforeFinish() {
+                    super.beforeFinish();
                     isFinished.set(true);
                 }
             };
@@ -318,7 +318,7 @@ public class RollupIndexerStateTests extends ESTestCase {
         try {
             EmptyRollupIndexer indexer = new EmptyRollupIndexer(executor, job, state, null) {
                 @Override
-                protected void onFinish() {
+                protected void beforeFinish() {
                     fail("Should not have called onFinish");
                 }
 


### PR DESCRIPTION
refactor onStart and onFinish to take action listeners and execute them when indexer is in indexing state.

Motivation of this change: DataFrameTransforms requires a hooks to prepare inner state before the 1st search request and to change inner state before the indexer finishes.

Rollup used the hooks mostly for logging purposes ans should be unaffected by this change.