### PR TITLE
Correct bug in ScriptDocValues

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -186,19 +186,8 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
             return this.in;
         }
 
-        public long getValue() {
-            if (count == 0) {
-                if (ScriptDocValues.EXCEPTION_FOR_MISSING_VALUE) {
-                    throw new IllegalStateException("A document doesn't have a value for a field! " +
-                        "Use doc[<field>].size()==0 to check if a document is missing a field!");
-                }
-                deprecated("scripting_missing_value_deprecation",
-                    "returning default values for missing document values is deprecated. " +
-                    "Set system property '-Des.scripting.exception_for_missing_value=true' "  +
-                    "to make behaviour compatible with future major versions!");
-                return 0L;
-            }
-            return values[0];
+        public long getValue() {          
+            return get(0);
         }
 
         @Deprecated
@@ -223,6 +212,17 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
 
         @Override
         public Long get(int index) {
+            if (count == 0) {
+                if (ScriptDocValues.EXCEPTION_FOR_MISSING_VALUE) {
+                    throw new IllegalStateException("A document doesn't have a value for a field! " +
+                        "Use doc[<field>].size()==0 to check if a document is missing a field!");
+                }
+                deprecated("scripting_missing_value_deprecation",
+                    "returning default values for missing document values is deprecated. " +
+                    "Set system property '-Des.scripting.exception_for_missing_value=true' "  +
+                    "to make behaviour compatible with future major versions!");
+                return 0L;
+            }
             return values[index];
         }
 
@@ -266,17 +266,6 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
          * in.
          */
         public JodaCompatibleZonedDateTime getValue() {
-            if (count == 0) {
-                if (ScriptDocValues.EXCEPTION_FOR_MISSING_VALUE) {
-                    throw new IllegalStateException("A document doesn't have a value for a field! " +
-                        "Use doc[<field>].size()==0 to check if a document is missing a field!");
-                }
-                deprecated("scripting_missing_value_deprecation",
-                    "returning default values for missing document values is deprecated. " +
-                    "Set system property '-Des.scripting.exception_for_missing_value=true' "  +
-                    "to make behaviour compatible with future major versions!");
-                return EPOCH;
-            }
             return get(0);
         }
 
@@ -299,7 +288,18 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
 
         @Override
-        public JodaCompatibleZonedDateTime get(int index) {
+        public JodaCompatibleZonedDateTime get(int index) {   
+            if (count == 0) {
+                if (ScriptDocValues.EXCEPTION_FOR_MISSING_VALUE) {
+                    throw new IllegalStateException("A document doesn't have a value for a field! " +
+                        "Use doc[<field>].size()==0 to check if a document is missing a field!");
+                }
+                deprecated("scripting_missing_value_deprecation",
+                    "returning default values for missing document values is deprecated. " +
+                    "Set system property '-Des.scripting.exception_for_missing_value=true' "  +
+                    "to make behaviour compatible with future major versions!");
+                return EPOCH;
+            }
             if (index >= count) {
                 throw new IndexOutOfBoundsException(
                         "attempted to fetch the [" + index + "] date when there are only ["
@@ -382,8 +382,13 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
             return this.in;
         }
 
-        public double getValue() {
-            if (count == 0) {
+        public double getValue() {      
+            return get(0);
+        }
+
+        @Override
+        public Double get(int index) {
+             if (count == 0) {
                 if (ScriptDocValues.EXCEPTION_FOR_MISSING_VALUE) {
                     throw new IllegalStateException("A document doesn't have a value for a field! " +
                         "Use doc[<field>].size()==0 to check if a document is missing a field!");
@@ -394,11 +399,6 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
                     "to make behaviour compatible with future major versions!");
                 return 0d;
             }
-            return values[0];
-        }
-
-        @Override
-        public Double get(int index) {
             return values[index];
         }
 
@@ -457,18 +457,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
 
         public GeoPoint getValue() {
-            if (count == 0) {
-                if (ScriptDocValues.EXCEPTION_FOR_MISSING_VALUE) {
-                    throw new IllegalStateException("A document doesn't have a value for a field! " +
-                        "Use doc[<field>].size()==0 to check if a document is missing a field!");
-                }
-                deprecated("scripting_missing_value_deprecation",
-                    "returning default values for missing document values is deprecated. " +
-                    "Set system property '-Des.scripting.exception_for_missing_value=true' "  +
-                    "to make behaviour compatible with future major versions!");
-                return null;
-            }
-            return values[0];
+            return get(0);
         }
 
         public double getLat() {
@@ -499,6 +488,17 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
 
         @Override
         public GeoPoint get(int index) {
+            if (count == 0) {
+                if (ScriptDocValues.EXCEPTION_FOR_MISSING_VALUE) {
+                    throw new IllegalStateException("A document doesn't have a value for a field! " +
+                        "Use doc[<field>].size()==0 to check if a document is missing a field!");
+                }
+                deprecated("scripting_missing_value_deprecation",
+                    "returning default values for missing document values is deprecated. " +
+                    "Set system property '-Des.scripting.exception_for_missing_value=true' "  +
+                    "to make behaviour compatible with future major versions!");
+                return null;
+            }
             final GeoPoint point = values[index];
             return new GeoPoint(point.lat(), point.lon());
         }
@@ -585,6 +585,11 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
 
         public boolean getValue() {
+            return get(0);
+        }
+
+        @Override
+        public Boolean get(int index) {
             if (count == 0) {
                 if (ScriptDocValues.EXCEPTION_FOR_MISSING_VALUE) {
                     throw new IllegalStateException("A document doesn't have a value for a field! " +
@@ -596,11 +601,6 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
                     "to make behaviour compatible with future major versions!");
                 return false;
             }
-            return values[0];
-        }
-
-        @Override
-        public Boolean get(int index) {
             return values[index];
         }
 
@@ -681,10 +681,6 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
 
         @Override
         public String get(int index) {
-            return values[index].get().utf8ToString();
-        }
-
-        public String getValue() {
             if (count == 0) {
                 if (ScriptDocValues.EXCEPTION_FOR_MISSING_VALUE) {
                     throw new IllegalStateException("A document doesn't have a value for a field! " +
@@ -696,6 +692,10 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
                     "to make behaviour compatible with future major versions!");
                 return null;
             }
+            return values[index].get().utf8ToString();
+        }
+
+        public String getValue() {
             return get(0);
         }
     }
@@ -714,15 +714,6 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
 
         @Override
         public BytesRef get(int index) {
-            /**
-             * We need to make a copy here because {@link BinaryScriptDocValues} might reuse the
-             * returned value and the same instance might be used to
-             * return values from multiple documents.
-             **/
-            return values[index].toBytesRef();
-        }
-
-        public BytesRef getValue() {
             if (count == 0) {
                 if (ScriptDocValues.EXCEPTION_FOR_MISSING_VALUE) {
                     throw new IllegalStateException("A document doesn't have a value for a field! " +
@@ -734,6 +725,15 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
                     "to make behaviour compatible with future major versions!");
                 return new BytesRef();
             }
+            /**
+             * We need to make a copy here because {@link BinaryScriptDocValues} might reuse the
+             * returned value and the same instance might be used to
+             * return values from multiple documents.
+             **/
+            return values[index].toBytesRef();
+        }
+
+        public BytesRef getValue() {
             return get(0);
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesLongsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesLongsTests.java
@@ -65,6 +65,7 @@ public class ScriptDocValuesLongsTests extends ESTestCase {
             int d = between(0, values.length - 1);
             longs.setNextDocId(d);
             assertEquals(values[d].length > 0 ? values[d][0] : 0, longs.getValue());
+            assertEquals(values[d].length > 0 ? values[d][0] : 0, (long) longs.get(0));
             assertEquals(values[d].length, longs.size());
             assertEquals(values[d].length, longs.getValues().size());
             for (int i = 0; i < values[d].length; i++) {

--- a/server/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesMissingV7BehaviourTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesMissingV7BehaviourTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.fielddata;
 
 import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.index.fielddata.ScriptDocValues.GeoPoints;
 import org.elasticsearch.index.fielddata.ScriptDocValues.Booleans;
 import org.elasticsearch.index.fielddata.ScriptDocValues.Dates;
 import org.elasticsearch.index.fielddata.ScriptDocValues.Longs;
@@ -78,13 +79,40 @@ public class ScriptDocValuesMissingV7BehaviourTests extends ESTestCase {
         }
     }
 
-    public void testNullForMissingValueGeo() throws IOException{
-        final MultiGeoPointValues values = wrap(new GeoPoint[0]);
-        final ScriptDocValues.GeoPoints script = new ScriptDocValues.GeoPoints(values);
-        script.setNextDocId(0);
-        Exception e = expectThrows(IllegalStateException.class, () -> script.getValue());
-        assertEquals("A document doesn't have a value for a field! " +
-            "Use doc[<field>].size()==0 to check if a document is missing a field!", e.getMessage());
+    public void testMissingValuesGeo() throws IOException {
+        GeoPoint[][] points = new GeoPoint[between(3, 10)][];
+        for (int d = 0; d < points.length; d++) {
+            points[d] = new GeoPoint[randomBoolean() ? 0 : between(1, 10)];
+            for (int i = 0; i< points[d].length; i++) {
+                points[d][i] =  new GeoPoint(randomLat(), randomLon());
+            }
+        }
+        final ScriptDocValues.GeoPoints geoPoints = new GeoPoints(wrap(points));
+        for (int d = 0; d < points.length; d++) {
+            geoPoints.setNextDocId(d);
+            if (points[d].length > 0) {
+                assertEquals(points[d][0], geoPoints.getValue());
+            } else {
+                Exception e = expectThrows(IllegalStateException.class, () -> geoPoints.getValue());
+                assertEquals("A document doesn't have a value for a field! " +
+                    "Use doc[<field>].size()==0 to check if a document is missing a field!", e.getMessage());
+                e = expectThrows(IllegalStateException.class, () -> geoPoints.get(0));
+                assertEquals("A document doesn't have a value for a field! " +
+                    "Use doc[<field>].size()==0 to check if a document is missing a field!", e.getMessage());
+            }
+            assertEquals(points[d].length, geoPoints.size());
+            for (int i = 0; i < points[d].length; i++) {
+                assertEquals(points[d][i], geoPoints.get(i));
+            }
+        }
+    }
+
+    private static double randomLat() {
+        return randomDouble() * 180 - 90;
+    }
+
+    private static double randomLon() {
+        return randomDouble() * 360 - 180;
     }
 
 
@@ -152,28 +180,30 @@ public class ScriptDocValuesMissingV7BehaviourTests extends ESTestCase {
     }
 
 
-   private static MultiGeoPointValues wrap(final GeoPoint... points) {
+    private static MultiGeoPointValues wrap(GeoPoint[][] points) {
         return new MultiGeoPointValues() {
-            int docID = -1;
+            GeoPoint[] current;
             int i;
+
             @Override
             public GeoPoint nextValue() {
-                if (docID != 0) {
-                    fail();
-                }
-                return points[i++];
+                return current[i++];
             }
+
             @Override
             public boolean advanceExact(int docId) {
-                docID = docId;
-                return points.length > 0;
+                if (docId < points.length) {
+                    current = points[docId];
+                } else {
+                    current = new GeoPoint[0];
+                }
+                i = 0;
+                return current.length > 0;
             }
+
             @Override
             public int docValueCount() {
-                if (docID != 0) {
-                    return 0;
-                }
-                return points.length;
+                return current.length;
             }
         };
     }


### PR DESCRIPTION
If a field field_name was missing in a document,
doc['field_name'].get(0) incorrectly retrieved
a value of the previously accessed document.
This happened because get(int index) function
was just accessing values[index] without
checking the number of values:count.

backport for #40488