### PR TITLE
Hook SLM into ILM's start and stop APIs

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecycleMetadata.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.XPackPlugin.XPackMetaDataCustom;
+import org.elasticsearch.xpack.core.indexlifecycle.OperationMode;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -26,6 +27,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -37,13 +39,17 @@ import java.util.stream.Collectors;
 public class SnapshotLifecycleMetadata implements XPackMetaDataCustom {
 
     public static final String TYPE = "snapshot_lifecycle";
+    public static final ParseField OPERATION_MODE_FIELD = new ParseField("operation_mode");
     public static final ParseField POLICIES_FIELD = new ParseField("policies");
+
+    public static final SnapshotLifecycleMetadata EMPTY = new SnapshotLifecycleMetadata(Collections.emptyMap(), OperationMode.RUNNING);
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<SnapshotLifecycleMetadata, Void> PARSER = new ConstructingObjectParser<>(TYPE,
         a -> new SnapshotLifecycleMetadata(
             ((List<SnapshotLifecyclePolicyMetadata>) a[0]).stream()
-                .collect(Collectors.toMap(m -> m.getPolicy().getId(), Function.identity()))));
+                .collect(Collectors.toMap(m -> m.getPolicy().getId(), Function.identity())),
+            OperationMode.valueOf((String) a[1])));
 
     static {
         PARSER.declareNamedObjects(ConstructingObjectParser.constructorArg(), (p, c, n) -> SnapshotLifecyclePolicyMetadata.parse(p, n),
@@ -53,18 +59,24 @@ public class SnapshotLifecycleMetadata implements XPackMetaDataCustom {
     }
 
     private final Map<String, SnapshotLifecyclePolicyMetadata> snapshotConfigurations;
+    private final OperationMode operationMode;
 
-    public SnapshotLifecycleMetadata(Map<String, SnapshotLifecyclePolicyMetadata> snapshotConfigurations) {
+    public SnapshotLifecycleMetadata(Map<String, SnapshotLifecyclePolicyMetadata> snapshotConfigurations, OperationMode operationMode) {
         this.snapshotConfigurations = new HashMap<>(snapshotConfigurations);
-        // TODO: maybe operation mode here so it can be disabled/re-enabled separately like ILM is
+        this.operationMode = operationMode;
     }
 
     public SnapshotLifecycleMetadata(StreamInput in) throws IOException {
         this.snapshotConfigurations = in.readMap(StreamInput::readString, SnapshotLifecyclePolicyMetadata::new);
+        this.operationMode = in.readEnum(OperationMode.class);
     }
 
     public Map<String, SnapshotLifecyclePolicyMetadata> getSnapshotConfigurations() {
         return Collections.unmodifiableMap(this.snapshotConfigurations);
+    }
+
+    public OperationMode getOperationMode() {
+        return operationMode;
     }
 
     @Override
@@ -90,11 +102,13 @@ public class SnapshotLifecycleMetadata implements XPackMetaDataCustom {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeMap(this.snapshotConfigurations, StreamOutput::writeString, (out1, value) -> value.writeTo(out1));
+        out.writeEnum(this.operationMode);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.field(POLICIES_FIELD.getPreferredName(), this.snapshotConfigurations);
+        builder.field(OPERATION_MODE_FIELD.getPreferredName(), operationMode);
         return builder;
     }
 
@@ -103,26 +117,47 @@ public class SnapshotLifecycleMetadata implements XPackMetaDataCustom {
         return Strings.toString(this);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.snapshotConfigurations, this.operationMode);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        SnapshotLifecycleMetadata other = (SnapshotLifecycleMetadata) obj;
+        return this.snapshotConfigurations.equals(other.snapshotConfigurations) &&
+            this.operationMode.equals(other.operationMode);
+    }
+
     public static class SnapshotLifecycleMetadataDiff implements NamedDiff<MetaData.Custom> {
 
         final Diff<Map<String, SnapshotLifecyclePolicyMetadata>> lifecycles;
+        final OperationMode operationMode;
 
         SnapshotLifecycleMetadataDiff(SnapshotLifecycleMetadata before, SnapshotLifecycleMetadata after) {
             this.lifecycles = DiffableUtils.diff(before.snapshotConfigurations, after.snapshotConfigurations,
                 DiffableUtils.getStringKeySerializer());
+            this.operationMode = after.operationMode;
         }
 
         public SnapshotLifecycleMetadataDiff(StreamInput in) throws IOException {
             this.lifecycles = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getStringKeySerializer(),
                 SnapshotLifecyclePolicyMetadata::new,
                 SnapshotLifecycleMetadataDiff::readLifecyclePolicyDiffFrom);
+            this.operationMode = in.readEnum(OperationMode.class);
         }
 
         @Override
         public MetaData.Custom apply(MetaData.Custom part) {
             TreeMap<String, SnapshotLifecyclePolicyMetadata> newLifecycles = new TreeMap<>(
                 lifecycles.apply(((SnapshotLifecycleMetadata) part).snapshotConfigurations));
-            return new SnapshotLifecycleMetadata(newLifecycles);
+            return new SnapshotLifecycleMetadata(newLifecycles, this.operationMode);
         }
 
         @Override
@@ -133,6 +168,7 @@ public class SnapshotLifecycleMetadata implements XPackMetaDataCustom {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             lifecycles.writeTo(out);
+            out.writeEnum(this.operationMode);
         }
 
         static Diff<SnapshotLifecyclePolicyMetadata> readLifecyclePolicyDiffFrom(StreamInput in) throws IOException {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/snapshotlifecycle/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/snapshotlifecycle/SnapshotLifecycleTask.java
@@ -163,7 +163,7 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
             }
 
             snapLifecycles.put(policyName, newPolicyMetadata.build());
-            SnapshotLifecycleMetadata lifecycleMetadata = new SnapshotLifecycleMetadata(snapLifecycles);
+            SnapshotLifecycleMetadata lifecycleMetadata = new SnapshotLifecycleMetadata(snapLifecycles, snapMeta.getOperationMode());
             MetaData currentMeta = currentState.metaData();
             return ClusterState.builder(currentState)
                 .metaData(MetaData.builder(currentMeta)

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/snapshotlifecycle/action/TransportDeleteSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/snapshotlifecycle/action/TransportDeleteSnapshotLifecycleAction.java
@@ -79,7 +79,7 @@ public class TransportDeleteSnapshotLifecycleAction extends
                     return ClusterState.builder(currentState)
                         .metaData(MetaData.builder(metaData)
                             .putCustom(SnapshotLifecycleMetadata.TYPE,
-                                new SnapshotLifecycleMetadata(newConfigs)))
+                                new SnapshotLifecycleMetadata(newConfigs, snapMeta.getOperationMode())))
                         .build();
                 }
             });

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/OperationModeUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/indexlifecycle/OperationModeUpdateTaskTests.java
@@ -10,9 +10,10 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
-import org.elasticsearch.xpack.core.indexlifecycle.OperationMode;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.indexlifecycle.IndexLifecycleMetadata;
+import org.elasticsearch.xpack.core.indexlifecycle.OperationMode;
+import org.elasticsearch.xpack.core.snapshotlifecycle.SnapshotLifecycleMetadata;
 
 import java.util.Collections;
 
@@ -57,11 +58,15 @@ public class OperationModeUpdateTaskTests extends ESTestCase {
     private OperationMode executeUpdate(boolean metadataInstalled, OperationMode currentMode, OperationMode requestMode,
                                         boolean assertSameClusterState) {
         IndexLifecycleMetadata indexLifecycleMetadata = new IndexLifecycleMetadata(Collections.emptyMap(), currentMode);
+        SnapshotLifecycleMetadata snapshotLifecycleMetadata = new SnapshotLifecycleMetadata(Collections.emptyMap(), currentMode);
         ImmutableOpenMap.Builder<String, MetaData.Custom> customsMapBuilder = ImmutableOpenMap.builder();
         MetaData.Builder metaData = MetaData.builder()
             .persistentSettings(settings(Version.CURRENT).build());
         if (metadataInstalled) {
-            metaData.customs(customsMapBuilder.fPut(IndexLifecycleMetadata.TYPE, indexLifecycleMetadata).build());
+            metaData.customs(customsMapBuilder
+                .fPut(IndexLifecycleMetadata.TYPE, indexLifecycleMetadata)
+                .fPut(SnapshotLifecycleMetadata.TYPE, snapshotLifecycleMetadata)
+                .build());
         }
         ClusterState state = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).build();
         OperationModeUpdateTask task = new OperationModeUpdateTask(requestMode);

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/snapshotlifecycle/SnapshotLifecycleServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/snapshotlifecycle/SnapshotLifecycleServiceTests.java
@@ -116,7 +116,7 @@ public class SnapshotLifecycleServiceTests extends ESTestCase {
             state = createState(new SnapshotLifecycleMetadata(policies, OperationMode.STOPPED));
             sls.clusterChanged(new ClusterChangedEvent("3", state, emptyState));
 
-            // Since the service is stopping, jobs should have been cancelled
+            // Since the service is stopped, jobs should have been cancelled
             assertThat(sls.getScheduler().scheduledJobIds(), equalTo(Collections.emptySet()));
 
             threadPool.shutdownNow();

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/snapshotlifecycle/SnapshotLifecycleTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/snapshotlifecycle/SnapshotLifecycleTaskTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.indexlifecycle.OperationMode;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.core.snapshotlifecycle.SnapshotLifecycleMetadata;
 import org.elasticsearch.xpack.core.snapshotlifecycle.SnapshotLifecyclePolicy;
@@ -47,7 +48,7 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
     public void testGetSnapMetadata() {
         final String id = randomAlphaOfLength(4);
         final SnapshotLifecyclePolicyMetadata slpm = makePolicyMeta(id);
-        final SnapshotLifecycleMetadata meta = new SnapshotLifecycleMetadata(Collections.singletonMap(id, slpm));
+        final SnapshotLifecycleMetadata meta = new SnapshotLifecycleMetadata(Collections.singletonMap(id, slpm), OperationMode.RUNNING);
 
         final ClusterState state = ClusterState.builder(new ClusterName("test"))
             .metaData(MetaData.builder()
@@ -67,7 +68,7 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
     public void testSkipCreatingSnapshotWhenJobDoesNotMatch() {
         final String id = randomAlphaOfLength(4);
         final SnapshotLifecyclePolicyMetadata slpm = makePolicyMeta(id);
-        final SnapshotLifecycleMetadata meta = new SnapshotLifecycleMetadata(Collections.singletonMap(id, slpm));
+        final SnapshotLifecycleMetadata meta = new SnapshotLifecycleMetadata(Collections.singletonMap(id, slpm), OperationMode.RUNNING);
 
         final ClusterState state = ClusterState.builder(new ClusterName("test"))
             .metaData(MetaData.builder()
@@ -95,7 +96,7 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
     public void testCreateSnapshotOnTrigger() {
         final String id = randomAlphaOfLength(4);
         final SnapshotLifecyclePolicyMetadata slpm = makePolicyMeta(id);
-        final SnapshotLifecycleMetadata meta = new SnapshotLifecycleMetadata(Collections.singletonMap(id, slpm));
+        final SnapshotLifecycleMetadata meta = new SnapshotLifecycleMetadata(Collections.singletonMap(id, slpm), OperationMode.RUNNING);
 
         final ClusterState state = ClusterState.builder(new ClusterName("test"))
             .metaData(MetaData.builder()


### PR DESCRIPTION
(This pull request is for the `snapshot-lifecycle-management` branch)

This change allows the existing `/_ilm/stop` and `/_ilm/start` APIs to also
manage snapshot lifecycle scheduling. When ILM is stopped all scheduled jobs are
cancelled.

Relates to #38461
