### PR TITLE
Fixed synchronizing inflight breaker with internal variable

### DIFF
--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -13,6 +13,7 @@ coming[8.0.0]
 
 * <<breaking_80_analysis_changes>>
 * <<breaking_80_allocation_changes>>
+* <<breaking_80_breaker_changes>>
 * <<breaking_80_discovery_changes>>
 * <<breaking_80_mappings_changes>>
 * <<breaking_80_packaging_changes>>
@@ -53,6 +54,7 @@ Elasticsearch 7.x in order to be readable by Elasticsearch 8.x.
 
 include::migrate_8_0/analysis.asciidoc[]
 include::migrate_8_0/allocation.asciidoc[]
+include::migrate_8_0/breaker.asciidoc[]
 include::migrate_8_0/discovery.asciidoc[]
 include::migrate_8_0/mappings.asciidoc[]
 include::migrate_8_0/packaging.asciidoc[]

--- a/docs/reference/migration/migrate_8_0/breaker.asciidoc
+++ b/docs/reference/migration/migrate_8_0/breaker.asciidoc
@@ -1,0 +1,11 @@
+[float]
+[[breaking_80_breaker_changes]]
+=== Packaging changes
+
+//tag::notable-breaking-changes[]
+[float]
+==== In Flight Request Circuit Breaker
+
+The name of the in flight requests circuit breaker in log output and diagnostic APIs (such as the node stats API) changes from `in_flight_requests` to `inflight_requests` to align it with the name of the corresponding settings.
+
+//end::notable-breaking-changes[]

--- a/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
@@ -53,7 +53,7 @@ public interface CircuitBreaker {
      * The in-flight request breaker tracks bytes allocated for reading and
      * writing requests on the network layer.
      */
-    String IN_FLIGHT_REQUESTS = "in_flight_requests";
+    String IN_FLIGHT_REQUESTS = "inflight_requests";
     /**
      * The accounting breaker tracks things held in memory that is independent
      * of the request lifecycle. This includes memory used by Lucene for

--- a/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -201,7 +201,7 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
             assertThat(exception.getMessage(), containsString("[parent] Data too large, data for [should break] would be"));
             assertThat(exception.getMessage(), containsString("which is larger than the limit of [209715200/200mb]"));
             assertThat(exception.getMessage(),
-                containsString("usages [request=157286400/150mb, fielddata=54001664/51.5mb, in_flight_requests=0/0b, accounting=0/0b]"));
+                containsString("usages [request=157286400/150mb, fielddata=54001664/51.5mb, accounting=0/0b, inflight_requests=0/0b]"));
             assertThat(exception.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));
         }
     }
@@ -249,7 +249,7 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
         final long requestCircuitBreakerUsed = (requestBreaker.getUsed() + reservationInBytes) * 2;
         assertThat(exception.getMessage(),
             containsString("usages [request=" + requestCircuitBreakerUsed + "/" + new ByteSizeValue(requestCircuitBreakerUsed) +
-                ", fielddata=0/0b, in_flight_requests=0/0b, accounting=0/0b]"));
+                ", fielddata=0/0b, accounting=0/0b, inflight_requests=0/0b]"));
         assertThat(exception.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));
         assertEquals(0, requestBreaker.getTrippedCount());
         assertEquals(1, service.stats().getStats(CircuitBreaker.PARENT).getTrippedCount());


### PR DESCRIPTION
Tested http://localhost:9200/_nodes/stats/breaker
and found out that the in flight requests are divided with underscores.
This is wrong some versions already.
This is a replacement of pull request https://github.com/elastic/elasticsearch/pull/40755 and corrects the printed value in elasticsearch.