### PR TITLE
Source additional files correctly in elasticsearch-cli

### DIFF
--- a/distribution/src/bin/elasticsearch-cli
+++ b/distribution/src/bin/elasticsearch-cli
@@ -7,7 +7,7 @@ source "`dirname "$0"`"/elasticsearch-env
 IFS=';' read -r -a additional_sources <<< "$ES_ADDITIONAL_SOURCES"
 for additional_source in "${additional_sources[@]}"
 do
-  source "$ES_HOME/bin"/$additional_source
+  source "$ES_HOME"/bin/$additional_source
 done
 
 IFS=';' read -r -a additional_classpath_directories <<< "$ES_ADDITIONAL_CLASSPATH_DIRECTORIES"

--- a/distribution/src/bin/elasticsearch-cli
+++ b/distribution/src/bin/elasticsearch-cli
@@ -7,7 +7,7 @@ source "`dirname "$0"`"/elasticsearch-env
 IFS=';' read -r -a additional_sources <<< "$ES_ADDITIONAL_SOURCES"
 for additional_source in "${additional_sources[@]}"
 do
-  source $ES_HOME/bin/$additional_source
+  source "$ES_HOME/bin"/$additional_source
 done
 
 IFS=';' read -r -a additional_classpath_directories <<< "$ES_ADDITIONAL_CLASSPATH_DIRECTORIES"

--- a/distribution/src/bin/elasticsearch-cli
+++ b/distribution/src/bin/elasticsearch-cli
@@ -7,7 +7,7 @@ source "`dirname "$0"`"/elasticsearch-env
 IFS=';' read -r -a additional_sources <<< "$ES_ADDITIONAL_SOURCES"
 for additional_source in "${additional_sources[@]}"
 do
-  source "`dirname "$0"`"/$additional_source
+  source $ES_HOME/bin/$additional_source
 done
 
 IFS=';' read -r -a additional_classpath_directories <<< "$ES_ADDITIONAL_CLASSPATH_DIRECTORIES"

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
@@ -439,4 +439,33 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
         assertThat(result.stdout, containsString("Master node was successfully bootstrapped"));
     }
 
+    public void test94ElasticsearchNodeExecuteCliNotEsHomeWorkDir() throws Exception {
+        assumeThat(installation, is(notNullValue()));
+
+        final Installation.Executables bin = installation.executables();
+        final Shell sh = newShell();
+        // Run the cli tools from the tmp dir
+        sh.setWorkingDirectory(getTempDir());
+
+        Platforms.PlatformAction action = () -> {
+            Result result = sh.run(bin.elasticsearchCertutil+ " -h");
+            assertThat(result.stdout,
+                containsString("Simplifies certificate creation for use with the Elastic Stack"));
+            result = sh.run(bin.elasticsearchSyskeygen+ " -h");
+            assertThat(result.stdout,
+                containsString("system key tool"));
+            result = sh.run(bin.elasticsearchSetupPasswords+ " -h");
+            assertThat(result.stdout,
+                containsString("Sets the passwords for reserved users"));
+            result = sh.run(bin.elasticsearchUsers+ " -h");
+            assertThat(result.stdout,
+                containsString("Manages elasticsearch file users"));
+        };
+
+        if (distribution().equals(Distribution.DEFAULT_LINUX) || distribution().equals(Distribution.DEFAULT_WINDOWS)) {
+            Platforms.onLinux(action);
+            Platforms.onWindows(action);
+        }
+    }
+
 }

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/Installation.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/Installation.java
@@ -104,6 +104,9 @@ public class Installation {
         public final Path elasticsearchCertutil = platformExecutable("elasticsearch-certutil");
         public final Path elasticsearchShard = platformExecutable("elasticsearch-shard");
         public final Path elasticsearchNode = platformExecutable("elasticsearch-node");
+        public final Path elasticsearchSetupPasswords = platformExecutable("elasticsearch-setup-passwords");
+        public final Path elasticsearchSyskeygen = platformExecutable("elasticsearch-syskeygen");
+        public final Path elasticsearchUsers = platformExecutable("elasticsearch-users");
 
         private Path platformExecutable(String name) {
             final String platformExecutableName = Platforms.WINDOWS


### PR DESCRIPTION
Since we only source additional sources from the same dir as our
cli scripts, resolve the path relevant to $ES_HOME

Resolves: #40889