### PR TITLE
[Monitoring] Add `usage` mapping for `monitoring-kibana` index

### DIFF
--- a/x-pack/plugin/core/src/main/resources/monitoring-kibana.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-kibana.json
@@ -50,6 +50,13 @@
         },
         "kibana_stats": {
           "properties": {
+            "usage": {
+              "properties": {
+                "index": {
+                  "type": "keyword"
+                }
+              }
+            },
             "kibana": {
               "properties": {
                 "uuid": {


### PR DESCRIPTION
Needed for this PR https://github.com/elastic/kibana/pull/34609, Since we will start filtering if this field `exists`.

Context: https://github.com/elastic/kibana/issues/32519

CC @chrisronline 