### PR TITLE
Suppress lease background sync failures if stopping

### DIFF
--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.transport.TransportException;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -191,6 +192,14 @@ public final class ExceptionsHelper {
             } while ((t = t.getCause()) != null);
         }
         return null;
+    }
+
+    public static boolean isTransportStoppedForAction(final Throwable t, final String action) {
+        final TransportException maybeTransport =
+                (TransportException) ExceptionsHelper.unwrap(t, TransportException.class);
+        return maybeTransport != null
+                && (maybeTransport.getMessage().equals("TransportService is closed stopped can't send request")
+                || maybeTransport.getMessage().equals("transport stopped, action: " + action));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -205,10 +205,9 @@ public class ReplicationOperation<
 
     private void onNoLongerPrimary(Exception failure) {
         final Throwable cause = ExceptionsHelper.unwrapCause(failure);
-        final boolean nodeIsClosing = cause instanceof NodeClosedException
-            || (cause instanceof TransportException &&
-                ("TransportService is closed stopped can't send request".equals(cause.getMessage())
-                || "transport stopped, action: internal:cluster/shard/failure".equals(cause.getMessage())));
+        final boolean nodeIsClosing =
+                cause instanceof NodeClosedException
+                        || ExceptionsHelper.isTransportStoppedForAction(cause, "internal:cluster/shard/failure");
         final String message;
         if (nodeIsClosing) {
             message = String.format(Locale.ROOT,

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -38,7 +38,6 @@ import org.elasticsearch.index.shard.ReplicationGroup;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.transport.TransportException;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -964,7 +964,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     public static final Setting<TimeValue> RETENTION_LEASE_SYNC_INTERVAL_SETTING =
             Setting.timeSetting(
                     "index.soft_deletes.retention_lease.sync_interval",
-                    new TimeValue(30, TimeUnit.SECONDS),
+                    new TimeValue(25, TimeUnit.MILLISECONDS),
                     new TimeValue(0, TimeUnit.MILLISECONDS),
                     Property.Dynamic,
                     Property.IndexScope);

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -964,7 +964,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     public static final Setting<TimeValue> RETENTION_LEASE_SYNC_INTERVAL_SETTING =
             Setting.timeSetting(
                     "index.soft_deletes.retention_lease.sync_interval",
-                    new TimeValue(25, TimeUnit.MILLISECONDS),
+                    new TimeValue(30, TimeUnit.SECONDS),
                     new TimeValue(0, TimeUnit.MILLISECONDS),
                     Property.Dynamic,
                     Property.IndexScope);

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
@@ -44,7 +44,6 @@ import org.elasticsearch.index.shard.IndexShardClosedException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
@@ -114,11 +114,7 @@ public class RetentionLeaseBackgroundSyncAction extends TransportReplicationActi
                     ActionListener.wrap(
                             r -> {},
                             e -> {
-                                final TransportException maybeTransport =
-                                        (TransportException) ExceptionsHelper.unwrap(e, TransportException.class);
-                                if (maybeTransport != null
-                                        && (maybeTransport.getMessage().equals("TransportService is closed stopped can't send request")
-                                        || maybeTransport.getMessage().equals("transport stopped, action: " + ACTION_NAME + "[p]"))) {
+                                if (ExceptionsHelper.isTransportStoppedForAction(e, ACTION_NAME + "[p]")) {
                                     // we are likely shutting down
                                     return;
                                 }

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -274,6 +274,7 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
                     }
                     @Override
                     public void doRun() {
+                        // cf. ExceptionsHelper#isTransportStoppedForAction
                         TransportException ex = new TransportException("transport stopped, action: " + holderToNotify.action());
                         holderToNotify.handler().handleException(ex);
                     }
@@ -632,7 +633,7 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
                  *
                  * Do not edit this exception message, it is currently relied upon in production code!
                  */
-                // TODO: make a dedicated exception for a stopped transport service?
+                // TODO: make a dedicated exception for a stopped transport service? cf. ExceptionsHelper#isTransportStoppedForAction
                 throw new TransportException("TransportService is closed stopped can't send request");
             }
             if (timeoutHandler != null) {

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -626,8 +626,13 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         }
         try {
             if (lifecycle.stoppedOrClosed()) {
-                // if we are not started the exception handling will remove the RequestHolder again and calls the handler to notify
-                // the caller. It will only notify if the toStop code hasn't done the work yet.
+                /*
+                 * If we are not started the exception handling will remove the request holder again and calls the handler to notify the
+                 * caller. It will only notify if toStop hasn't done the work yet.
+                 *
+                 * Do not edit this exception message, it is currently relied upon in production code!
+                 */
+                // TODO: make a dedicated exception for a stopped transport service?
                 throw new TransportException("TransportService is closed stopped can't send request");
             }
             if (timeoutHandler != null) {

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncActionTests.java
@@ -208,12 +208,10 @@ public class RetentionLeaseBackgroundSyncActionTests extends ESTestCase {
                             new TransportException(randomFrom(
                                     "failed",
                                     "TransportService is closed stopped can't send request",
-                                    "transport stopped, action: indices:admin/seq_no/retention_lease_background_sync[p]"
-                            )),
+                                    "transport stopped, action: indices:admin/seq_no/retention_lease_background_sync[p]")),
                             new RuntimeException("failed"));
                     listener.onFailure(e);
-                    if (e instanceof AlreadyClosedException == false && e instanceof IndexShardClosedException == false &&
-                            (e instanceof TransportException && e.getMessage().equals("failed"))) {
+                    if (e.getMessage().equals("failed")) {
                         final ArgumentCaptor<ParameterizedMessage> captor = ArgumentCaptor.forClass(ParameterizedMessage.class);
                         verify(retentionLeaseSyncActionLogger).warn(captor.capture(), same(e));
                         final ParameterizedMessage message = captor.getValue();

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncActionTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportService;
 import org.mockito.ArgumentCaptor;
 
@@ -204,9 +205,15 @@ public class RetentionLeaseBackgroundSyncActionTests extends ESTestCase {
                     final Exception e = randomFrom(
                             new AlreadyClosedException("closed"),
                             new IndexShardClosedException(indexShard.shardId()),
+                            new TransportException(randomFrom(
+                                    "failed",
+                                    "TransportService is closed stopped can't send request",
+                                    "transport stopped, action: indices:admin/seq_no/retention_lease_background_sync[p]"
+                            )),
                             new RuntimeException("failed"));
                     listener.onFailure(e);
-                    if (e instanceof AlreadyClosedException == false && e instanceof IndexShardClosedException == false) {
+                    if (e instanceof AlreadyClosedException == false && e instanceof IndexShardClosedException == false &&
+                            (e instanceof TransportException && e.getMessage().equals("failed"))) {
                         final ArgumentCaptor<ParameterizedMessage> captor = ArgumentCaptor.forClass(ParameterizedMessage.class);
                         verify(retentionLeaseSyncActionLogger).warn(captor.capture(), same(e));
                         final ParameterizedMessage message = captor.getValue();


### PR DESCRIPTION
If the transport service is stopped, likely because we are shutting down, and a retention lease background sync fires the logs will display a warn message and stacktrace. Yet, this situaton is harmless and can happen as a normal course of business when shutting down. This commit suppresses the log messages in this case.
