### PR TITLE
[DOCS] Add Quick Start page

### DIFF
--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -60,6 +60,8 @@ for its modifiers:
     "figures out" the path. This is especially useful for making sweeping
     assertions like "I made up all the numbers in this example, don't compare
     them" which looks like `// TESTRESPONSE[s/\d+/$body.$_path/]`.
+    * You can't use `// TESTRESPONSE` immediately after `// TESTSETUP`. Instead,
+    consider using `// TEST[continued]` or rearrange your snippets.
   * `// TESTRESPONSE[_cat]`: Add substitutions for testing `_cat` responses. Use
   this after all other substitutions so it doesn't make other substitutions
   difficult.

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -10,6 +10,8 @@
 
 include::../Versions.asciidoc[]
 
+include::quick-start.asciidoc[]
+
 include::getting-started.asciidoc[]
 
 include::setup.asciidoc[]

--- a/docs/reference/quick-start.asciidoc
+++ b/docs/reference/quick-start.asciidoc
@@ -64,7 +64,7 @@ To index a document with a specific ID, use the PUT method with the
 <<docs-index_, index API>>.
 
 This example command adds a document with an ID of `1` to the `customer` index.
-This command will also create the `customer` index if it doesn't already exist.
+This command also creates the `customer` index if it doesn't already exist.
 
 [source, js]
 --------------------------------------------------
@@ -105,11 +105,11 @@ Here's an example response, formatted to be more readable.
 ==== Autogenerate a document ID
 
 To add a document without providing an ID, use the POST method with the
-<<docs-index_, index API>>. {es} will automatically generate an ID for the
+<<docs-index_, index API>>. {es} automatically generates an ID for the
 document.
 
-This example command adds a document to `customer` index. This command will
-also create the `customer` index if it doesn't already exist.
+This example command adds a document to `customer` index. This command
+also creates the `customer` index if it doesn't already exist.
 
 [source, js]
 --------------------------------------------------
@@ -123,7 +123,7 @@ POST /customer/_doc
 --------------------------------------------------
 // CONSOLE
 
-{es} will provide the generated ID in `\_id` field of the response. Here's an
+{es} provides the generated ID in `\_id` field of the response. Here's an
 example response, formatted to be more readable.
 
 [source, js]

--- a/docs/reference/quick-start.asciidoc
+++ b/docs/reference/quick-start.asciidoc
@@ -66,7 +66,7 @@ To index a document with a specific ID, use the PUT method with the
 This example command adds a document with an ID of `1` to the `customer` index.
 This command will also create the `customer` index if it doesn't already exist.
 
-["source","sh",subs="attributes,callouts"]
+[source, js]
 --------------------------------------------------
 PUT /customer/_doc/1
 {
@@ -77,11 +77,12 @@ PUT /customer/_doc/1
 }
 --------------------------------------------------
 // CONSOLE
+// TESTSETUP
 
 You can confirm {es} used your ID by checking the `\_id` field of the response.
 Here's an example response, formatted to be more readable.
 
-["source","sh",subs="attributes,callouts"]
+[source, js]
 --------------------------------------------------
 {
   "_index" : "customer",
@@ -98,7 +99,7 @@ Here's an example response, formatted to be more readable.
   "_primary_term" : 1
 }
 --------------------------------------------------
-// NOTCONSOLE
+// TESTRESPONSE
 
 [float]
 ==== Autogenerate a document ID
@@ -110,7 +111,7 @@ document.
 This example command adds a document to `customer` index. This command will
 also create the `customer` index if it doesn't already exist.
 
-["source","sh",subs="attributes,callouts"]
+[source, js]
 --------------------------------------------------
 POST /customer/_doc
 {
@@ -125,12 +126,12 @@ POST /customer/_doc
 {es} will provide the generated ID in `\_id` field of the response. Here's an
 example response, formatted to be more readable.
 
-["source","sh",subs="attributes,callouts"]
+[source, js]
 --------------------------------------------------
 {
   "_index" : "customer",
   "_type" : "_doc",
-  "_id" : "yDWh7WkBJ8uiWiWqEEaF"",
+  "_id" : "yDWh7WkBJ8uiWiWqEEaF",
   "_version" : 2,
   "result" : "updated",
   "_shards" : {
@@ -142,7 +143,7 @@ example response, formatted to be more readable.
   "_primary_term" : 1
 }
 --------------------------------------------------
-// NOTCONSOLE
+// TESTRESPONSE[s/yDWh7WkBJ8uiWiWqEEaF/$body._id/]
 
 [float]
 === Run a search
@@ -158,7 +159,7 @@ To get a document based on its ID, use the <<docs-get, get API>>.
 This example returns the document with an ID of `1` in the
 `customer` index.
 
-["source","sh",subs="attributes,callouts"]
+[source, js]
 --------------------------------------------------
 GET /customer/_doc/1
 --------------------------------------------------
@@ -172,7 +173,7 @@ with query-string parameters. This is also called <<search-uri-request>>.
 This example performs a URI search for documents with an employer of
 `Geekfarm` in the `customer` index.
 
-["source","sh",subs="attributes,callouts"]
+[source, js]
 --------------------------------------------------
 GET /customer/_search?q=employer:Geekfarm
 --------------------------------------------------
@@ -191,7 +192,7 @@ following criteria in the `customer` index:
 * Last name of `Adams`
 * Age greater than `30`
 
-["source","sh",subs="attributes,callouts"]
+[source, js]
 --------------------------------------------------
 GET /customer/_search
 {
@@ -221,7 +222,7 @@ To update part of an existing document, use the <<docs-update, update API>>.
 This example updates the document with an ID of `1` in the
 `customer` index.
 
-["source","sh",subs="attributes,callouts"]
+[source, js]
 --------------------------------------------------
 POST /customer/_doc/1/_update
 {
@@ -241,7 +242,7 @@ method. Provide the ID of the document you'd like to replace.
 This example replaces the document with an ID of `1` in the
 `customer` index.
 
-["source","sh",subs="attributes,callouts"]
+[source, js]
 --------------------------------------------------
 PUT /customer/_doc/1
 {
@@ -261,12 +262,11 @@ To delete a document by ID, use the <<docs-delete, delete API>>.
 This example deletes the document with an ID of `1` in the `customer`
 index.
 
-["source","sh",subs="attributes,callouts"]
+[source, js]
 --------------------------------------------------
 DELETE /customer/_doc/1
 --------------------------------------------------
 // CONSOLE
-// TEST[setup:customer]
 
 
 [float]
@@ -277,9 +277,8 @@ When you delete an index, all documents in that index are also deleted.
 
 This example deletes the `customer` index. 
 
-["source","sh",subs="attributes,callouts"]
+[source, js]
 --------------------------------------------------
 DELETE /customer
 --------------------------------------------------
 // CONSOLE
-// TEST[setup:customer]

--- a/docs/reference/quick-start.asciidoc
+++ b/docs/reference/quick-start.asciidoc
@@ -78,7 +78,7 @@ PUT /customer/_doc/1
 --------------------------------------------------
 // CONSOLE
 
-You can confirm {es} used your ID by checking the `\_id` field of the response.
+You can confirm {es} used your ID by checking the `_id` field of the response.
 Here's an example response, formatted to be more readable.
 
 [source, js]
@@ -124,7 +124,7 @@ POST /customer/_doc
 // CONSOLE
 // TEST[continued]
 
-{es} provides the generated ID in `\_id` field of the response. Here's an
+{es} provides the generated ID in `_id` field of the response. Here's an
 example response, formatted to be more readable.
 
 [source, js]

--- a/docs/reference/quick-start.asciidoc
+++ b/docs/reference/quick-start.asciidoc
@@ -77,7 +77,6 @@ PUT /customer/_doc/1
 }
 --------------------------------------------------
 // CONSOLE
-// TESTSETUP
 
 You can confirm {es} used your ID by checking the `\_id` field of the response.
 Here's an example response, formatted to be more readable.
@@ -88,18 +87,19 @@ Here's an example response, formatted to be more readable.
   "_index" : "customer",
   "_type" : "_doc",
   "_id" : "1",
-  "_version" : 2,
-  "result" : "updated",
+  "_version" : 1,
+  "result" : "created",
   "_shards" : {
     "total" : 2,
     "successful" : 1,
     "failed" : 0
   },
-  "_seq_no" : 1,
+  "_seq_no" : 0,
   "_primary_term" : 1
 }
 --------------------------------------------------
-// TESTRESPONSE
+// TESTRESPONSE[s/yDWh7WkBJ8uiWiWqEEaF/$body._id/]
+// TESTRESPONSE[s/"_seq_no" : 0/"_seq_no" : $body._seq_no/]
 
 [float]
 ==== Autogenerate a document ID
@@ -122,6 +122,7 @@ POST /customer/_doc
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[continued]
 
 {es} provides the generated ID in `\_id` field of the response. Here's an
 example response, formatted to be more readable.
@@ -132,18 +133,19 @@ example response, formatted to be more readable.
   "_index" : "customer",
   "_type" : "_doc",
   "_id" : "yDWh7WkBJ8uiWiWqEEaF",
-  "_version" : 2,
-  "result" : "updated",
+  "_version" : 1,
+  "result" : "created",
   "_shards" : {
     "total" : 2,
     "successful" : 1,
     "failed" : 0
   },
-  "_seq_no" : 1,
+  "_seq_no" : 0,
   "_primary_term" : 1
 }
 --------------------------------------------------
 // TESTRESPONSE[s/yDWh7WkBJ8uiWiWqEEaF/$body._id/]
+// TESTRESPONSE[s/"_seq_no" : 0/"_seq_no" : $body._seq_no/]
 
 [float]
 === Run a search
@@ -164,6 +166,7 @@ This example returns the document with an ID of `1` in the
 GET /customer/_doc/1
 --------------------------------------------------
 // CONSOLE
+// TEST[continued]
 
 [float]
 ==== URI search
@@ -178,6 +181,7 @@ This example performs a URI search for documents with an employer of
 GET /customer/_search?q=employer:Geekfarm
 --------------------------------------------------
 // CONSOLE
+// TEST[continued]
 
 [float]
 ==== Fully-body search
@@ -213,6 +217,7 @@ GET /customer/_search
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[continued]
 
 [float]
 === Update a document
@@ -232,6 +237,7 @@ POST /customer/_doc/1/_update
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[continued]
 
 [float]
 === Replace a document
@@ -253,6 +259,7 @@ PUT /customer/_doc/1
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[continued]
 
 [float]
 === Delete a document
@@ -267,6 +274,7 @@ index.
 DELETE /customer/_doc/1
 --------------------------------------------------
 // CONSOLE
+// TEST[continued]
 
 
 [float]
@@ -282,3 +290,4 @@ This example deletes the `customer` index.
 DELETE /customer
 --------------------------------------------------
 // CONSOLE
+// TEST[continued]

--- a/docs/reference/quick-start.asciidoc
+++ b/docs/reference/quick-start.asciidoc
@@ -167,7 +167,7 @@ GET /customer/_doc/1
 
 [float]
 ==== URI search
-For simpler test searches, you can use {es}'s <<search-search, search API>>
+For simpler test searches, you can use the {es} <<search-search, search API>>
 with query-string parameters. This is also called <<search-uri-request>>.
 
 This example performs a URI search for documents with an employer of

--- a/docs/reference/quick-start.asciidoc
+++ b/docs/reference/quick-start.asciidoc
@@ -36,7 +36,7 @@ to open a new terminal window for the rest of these steps.
 [float]
 === How to talk to {es}
 While you can interact with {es} in many ways, the examples on this page
-use {es}'s REST API. The REST API offers a few advantages:
+use the {es} REST API. The REST API offers a few advantages:
 
 * You can talk to {es} using `curl` commands in your terminal.
 * You can use standard HTTP request methods, like `GET`, `POST`, `PUT`, and `DELETE`.
@@ -183,7 +183,7 @@ GET /customer/_search?q=employer:Geekfarm
 ==== Fully-body search
 For more complex queries or to run {es} in production, you'll want to use
 full-body search. With full-body search, you send search criteria to {es} as a
-JSON object in the body of your API requests. You can also use {es}'s
+JSON object in the body of your API requests. You can also use the {es}
 <<query-dsl>> to filter results or combine queries. It's flexible and powerful!
 
 This example performs a full-body search for documents that match the

--- a/docs/reference/quick-start.asciidoc
+++ b/docs/reference/quick-start.asciidoc
@@ -1,0 +1,285 @@
+[[quick-start]]
+== Quick Start
+
+One of the best ways to learn about Elasticsearch is to use it. This page walks
+you through steps for running {es} and doing common tasks. By the end, you
+should know how to:
+
+* Add your data to {es}
+* Run basic searches
+* Update or delete data in {es}
+
+Let's get started!
+
+[float]
+=== Install and run {es}
+
+. Visit https://www.elastic.co/downloads/elasticsearch and download the
+appropriate archive file for your operating system.
+
+. Extract the downloaded file.
++
+Once you've extracted the file, {es} is ready to run.
+
+. In your terminal, navigate to the newly extracted elasticsearch-{version}
+folder.
+
+. From the elasticsearch-{version} folder, run `bin/elasticsearch`. If using
+Windows, run `bin\elasticsearch.bat` instead.
+
+If all went well, you should see {es} logs in your terminal window.
+Congratulations, you've started {es}!
+
+To stop {es}, you can press `Ctrl + C` in this terminal window. You'll want
+to open a new terminal window for the rest of these steps.
+
+[float]
+=== How to talk to {es}
+While you can interact with {es} in many ways, the examples on this page
+use {es}'s REST API. The REST API offers a few advantages:
+
+* You can talk to {es} using `curl` commands in your terminal.
+* You can use standard HTTP request methods, like `GET`, `POST`, `PUT`, and `DELETE`.
+* Responses from the REST API provide standard HTTP status codes, like `200 OK`
+or `400 Bad Request`. These codes can be helpful when diagnosing a problem or
+figuring out if a request succeeded.
+
+[float]
+=== Index a document
+
+{es} stores data as JSON objects called documents. When adding a new document,
+you must assign it to a collection called an _index_. Usually an index contains
+documents of a similar type, like customer profiles or products in a catalog.
+
+The index not only stores your documents but makes them searchable. Indices are
+so important that adding new documents to {es} is called _indexing_.
+
+To keep your data organized, each document in an index requires a unique ID. You
+can provide this ID when you index a document or let {es} generate one for
+you.
+[float]
+==== Provide a document ID
+
+To index a document with a specific ID, use the PUT method with the
+<<docs-index_, index API>>.
+
+This example command adds a document with an ID of `1` to the `customer` index.
+This command will also create the `customer` index if it doesn't already exist.
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+PUT /customer/_doc/1
+{
+    "firstname": "Amber",
+    "lastname": "Duke",
+    "age": 32,
+    "employer": "Pyrami"
+}
+--------------------------------------------------
+// CONSOLE
+
+You can confirm {es} used your ID by checking the `\_id` field of the response.
+Here's an example response, formatted to be more readable.
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+{
+  "_index" : "customer",
+  "_type" : "_doc",
+  "_id" : "1",
+  "_version" : 2,
+  "result" : "updated",
+  "_shards" : {
+    "total" : 2,
+    "successful" : 1,
+    "failed" : 0
+  },
+  "_seq_no" : 1,
+  "_primary_term" : 1
+}
+--------------------------------------------------
+// NOTCONSOLE
+
+[float]
+==== Autogenerate a document ID
+
+To add a document without providing an ID, use the POST method with the
+<<docs-index_, index API>>. {es} will automatically generate an ID for the
+document.
+
+This example command adds a document to `customer` index. This command will
+also create the `customer` index if it doesn't already exist.
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+POST /customer/_doc
+{
+    "firstname": "Dale",
+    "lastname": "Adams",
+    "age": 48,
+    "employer": "Geekfarm"
+}
+--------------------------------------------------
+// CONSOLE
+
+{es} will provide the generated ID in `\_id` field of the response. Here's an
+example response, formatted to be more readable.
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+{
+  "_index" : "customer",
+  "_type" : "_doc",
+  "_id" : "yDWh7WkBJ8uiWiWqEEaF"",
+  "_version" : 2,
+  "result" : "updated",
+  "_shards" : {
+    "total" : 2,
+    "successful" : 1,
+    "failed" : 0
+  },
+  "_seq_no" : 1,
+  "_primary_term" : 1
+}
+--------------------------------------------------
+// NOTCONSOLE
+
+[float]
+=== Run a search
+
+Now that you have some documents stored in Elasticsearch, you can fetch
+and search your data.
+
+[float]
+==== Get a document by ID
+
+To get a document based on its ID, use the <<docs-get, get API>>.
+
+This example returns the document with an ID of `1` in the
+`customer` index.
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+GET /customer/_doc/1
+--------------------------------------------------
+// CONSOLE
+
+[float]
+==== URI search
+For simpler test searches, you can use {es}'s <<search-search, search API>>
+with query-string parameters. This is also called <<search-uri-request>>.
+
+This example performs a URI search for documents with an employer of
+`Geekfarm` in the `customer` index.
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+GET /customer/_search?q=employer:Geekfarm
+--------------------------------------------------
+// CONSOLE
+
+[float]
+==== Fully-body search
+For more complex queries or to run {es} in production, you'll want to use
+full-body search. With full-body search, you send search criteria to {es} as a
+JSON object in the body of your API requests. You can also use {es}'s
+<<query-dsl>> to filter results or combine queries. It's flexible and powerful!
+
+This example performs a full-body search for documents that match the
+following criteria in the `customer` index:
+
+* Last name of `Adams`
+* Age greater than `30`
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+GET /customer/_search
+{
+    "query" : {
+        "bool" : {
+            "must" : {
+                "match" : {
+                    "lastname" : "Adams"
+                }
+            },
+            "filter" : {
+                "range" : {
+                    "age" : { "gt" : 30 }
+                }
+            }
+        }
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+[float]
+=== Update a document
+
+To update part of an existing document, use the <<docs-update, update API>>.
+
+This example updates the document with an ID of `1` in the
+`customer` index.
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+POST /customer/_doc/1/_update
+{
+    "doc" : {
+        "employer" : "Geekfarm"
+   }
+}
+--------------------------------------------------
+// CONSOLE
+
+[float]
+=== Replace a document
+
+To replace an entire document, use the <<docs-index_, index API>> with the PUT
+method. Provide the ID of the document you'd like to replace.
+
+This example replaces the document with an ID of `1` in the
+`customer` index.
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+PUT /customer/_doc/1
+{
+    "firstname": "Nanette",
+    "lastname": "Bates",
+    "age": 43,
+    "employer": "Quility"
+}
+--------------------------------------------------
+// CONSOLE
+
+[float]
+=== Delete a document
+
+To delete a document by ID, use the <<docs-delete, delete API>>.
+
+This example deletes the document with an ID of `1` in the `customer`
+index.
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+DELETE /customer/_doc/1
+--------------------------------------------------
+// CONSOLE
+// TEST[setup:customer]
+
+
+[float]
+=== Delete an index
+
+To delete an entire index, use the <<indices-delete-index, delete index API>>.
+When you delete an index, all documents in that index are also deleted.
+
+This example deletes the `customer` index. 
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+DELETE /customer
+--------------------------------------------------
+// CONSOLE
+// TEST[setup:customer]


### PR DESCRIPTION
Creates a high-level, tutorial-based introduction to Elasticsearch and its basic features.
Resolves #40861.

Welcome any and all feedback.

### Firebase preview
https://es-demo-docs.firebaseapp.com/quick-start.html

### Notes
- I intentionally avoided more complex or architecture-related concepts, like nodes and clusters.
- I left out Java requirements. It looks like we'll be [bundling JDK](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/targz.html) with our distro in 7.0+.
- My examples used data from the Kibana [accounts sample set](https://download.elastic.co/demos/kibana/gettingstarted/accounts.zip). Happy to update this if we prefer to use the more common `twitter` examples.
- I'm not particularly happy with the instances of 'a document with an ID of `X`' throughout. I'd appreciate any suggestions for alternate wording.