### PR TITLE
Add tests for SnapshotLifecyclePolicyItem

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecyclePolicyItem.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecyclePolicyItem.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.snapshotlifecycle;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * The {@code SnapshotLifecyclePolicyItem} class is a special wrapper almost exactly like the
+ * {@link SnapshotLifecyclePolicyMetadata}, however, it elides the headers to ensure that they
+ * are not leaked to the user since they may contain sensitive information.
+ */
+public class SnapshotLifecyclePolicyItem implements ToXContentFragment, Writeable {
+
+    private final SnapshotLifecyclePolicy policy;
+    private final long version;
+    private final long modifiedDate;
+
+    @Nullable
+    private final SnapshotInvocationRecord lastSuccess;
+
+    @Nullable
+    private final SnapshotInvocationRecord lastFailure;
+    public SnapshotLifecyclePolicyItem(SnapshotLifecyclePolicyMetadata policyMetadata) {
+        this.policy = policyMetadata.getPolicy();
+        this.version = policyMetadata.getVersion();
+        this.modifiedDate = policyMetadata.getModifiedDate();
+        this.lastSuccess = policyMetadata.getLastSuccess();
+        this.lastFailure = policyMetadata.getLastFailure();
+    }
+
+    public SnapshotLifecyclePolicyItem(StreamInput in) throws IOException {
+        this.policy = new SnapshotLifecyclePolicy(in);
+        this.version = in.readVLong();
+        this.modifiedDate = in.readVLong();
+        this.lastSuccess = in.readOptionalWriteable(SnapshotInvocationRecord::new);
+        this.lastFailure = in.readOptionalWriteable(SnapshotInvocationRecord::new);
+    }
+
+    // For testing
+
+    SnapshotLifecyclePolicyItem(SnapshotLifecyclePolicy policy, long version, long modifiedDate,
+                                SnapshotInvocationRecord lastSuccess, SnapshotInvocationRecord lastFailure) {
+        this.policy = policy;
+        this.version = version;
+        this.modifiedDate = modifiedDate;
+        this.lastSuccess = lastSuccess;
+        this.lastFailure = lastFailure;
+    }
+    public SnapshotLifecyclePolicy getPolicy() {
+        return policy;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public long getModifiedDate() {
+        return modifiedDate;
+    }
+
+    public SnapshotInvocationRecord getLastSuccess() {
+        return lastSuccess;
+    }
+
+    public SnapshotInvocationRecord getLastFailure() {
+        return lastFailure;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        policy.writeTo(out);
+        out.writeVLong(version);
+        out.writeVLong(modifiedDate);
+        out.writeOptionalWriteable(lastSuccess);
+        out.writeOptionalWriteable(lastFailure);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(policy, version, modifiedDate, lastSuccess, lastFailure);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        SnapshotLifecyclePolicyItem other = (SnapshotLifecyclePolicyItem) obj;
+        return policy.equals(other.policy) &&
+            version == other.version &&
+            modifiedDate == other.modifiedDate &&
+            Objects.equals(lastSuccess, other.lastSuccess) &&
+            Objects.equals(lastFailure, other.lastFailure);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(policy.getId());
+        builder.field("version", version);
+        builder.field("modified_date", modifiedDate);
+        builder.field("policy", policy);
+        if (lastSuccess != null) {
+            builder.field("last_success", lastSuccess);
+        }
+        if (lastFailure != null) {
+            builder.field("last_failure", lastFailure);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/action/GetSnapshotLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/action/GetSnapshotLifecycleAction.java
@@ -10,17 +10,13 @@ import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.core.snapshotlifecycle.SnapshotInvocationRecord;
-import org.elasticsearch.xpack.core.snapshotlifecycle.SnapshotLifecyclePolicy;
-import org.elasticsearch.xpack.core.snapshotlifecycle.SnapshotLifecyclePolicyMetadata;
+import org.elasticsearch.xpack.core.snapshotlifecycle.SnapshotLifecyclePolicyItem;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -148,91 +144,4 @@ public class GetSnapshotLifecycleAction extends Action<GetSnapshotLifecycleActio
         }
     }
 
-    /**
-     * The {@code SnapshotLifecyclePolicyItem} class is a special wrapper almost exactly like the
-     * {@link SnapshotLifecyclePolicyMetadata}, however, it elides the headers to ensure that they
-     * are not leaked to the user since they may contain sensitive information.
-     */
-    public static class SnapshotLifecyclePolicyItem implements ToXContentFragment, Writeable {
-
-        private final SnapshotLifecyclePolicy policy;
-        private final long version;
-        private final long modifiedDate;
-        @Nullable
-        private final SnapshotInvocationRecord lastSuccess;
-        @Nullable
-        private final SnapshotInvocationRecord lastFailure;
-
-        public SnapshotLifecyclePolicyItem(SnapshotLifecyclePolicyMetadata policyMetadata) {
-            this.policy = policyMetadata.getPolicy();
-            this.version = policyMetadata.getVersion();
-            this.modifiedDate = policyMetadata.getModifiedDate();
-            this.lastSuccess = policyMetadata.getLastSuccess();
-            this.lastFailure = policyMetadata.getLastFailure();
-        }
-
-        public SnapshotLifecyclePolicyItem(StreamInput in) throws IOException {
-            this.policy = new SnapshotLifecyclePolicy(in);
-            this.version = in.readVLong();
-            this.modifiedDate = in.readVLong();
-            this.lastSuccess = in.readOptionalWriteable(SnapshotInvocationRecord::new);
-            this.lastFailure = in.readOptionalWriteable(SnapshotInvocationRecord::new);
-        }
-
-        public SnapshotLifecyclePolicy getPolicy() {
-            return policy;
-        }
-
-        public long getVersion() {
-            return version;
-        }
-
-        public long getModifiedDate() {
-            return modifiedDate;
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            policy.writeTo(out);
-            out.writeVLong(version);
-            out.writeVLong(modifiedDate);
-            out.writeOptionalWriteable(lastSuccess);
-            out.writeOptionalWriteable(lastFailure);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(policy, version, modifiedDate);
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == null) {
-                return false;
-            }
-            if (obj.getClass() != getClass()) {
-                return false;
-            }
-            SnapshotLifecyclePolicyItem other = (SnapshotLifecyclePolicyItem) obj;
-            return policy.equals(other.policy) &&
-                version == other.version &&
-                modifiedDate == other.modifiedDate;
-        }
-
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.startObject(policy.getId());
-            builder.field("version", version);
-            builder.field("modified_date", modifiedDate);
-            builder.field("policy", policy);
-            if (lastSuccess != null) {
-                builder.field("last_success", lastSuccess);
-            }
-            if (lastFailure != null) {
-                builder.field("last_failure", lastFailure);
-            }
-            builder.endObject();
-            return builder;
-        }
-    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecyclePolicyItemTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecyclePolicyItemTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.snapshotlifecycle;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.elasticsearch.xpack.core.snapshotlifecycle.SnapshotLifecyclePolicyMetadataTests.createRandomPolicy;
+import static org.elasticsearch.xpack.core.snapshotlifecycle.SnapshotLifecyclePolicyMetadataTests.createRandomPolicyMetadata;
+
+public class SnapshotLifecyclePolicyItemTests extends AbstractWireSerializingTestCase<SnapshotLifecyclePolicyItem> {
+
+    @Override
+    protected SnapshotLifecyclePolicyItem createTestInstance() {
+        return new SnapshotLifecyclePolicyItem(createRandomPolicyMetadata(randomAlphaOfLengthBetween(5, 10)));
+    }
+
+    @Override
+    protected SnapshotLifecyclePolicyItem mutateInstance(SnapshotLifecyclePolicyItem instance) {
+        switch (between(0, 4)) {
+            case 0:
+                String newPolicyId = randomValueOtherThan(instance.getPolicy().getId(), () -> randomAlphaOfLengthBetween(5, 10));
+                return new SnapshotLifecyclePolicyItem(createRandomPolicy(newPolicyId),
+                    instance.getVersion(),
+                    instance.getModifiedDate(),
+                    instance.getLastSuccess(),
+                    instance.getLastFailure());
+            case 1:
+                return new SnapshotLifecyclePolicyItem(instance.getPolicy(),
+                    randomValueOtherThan(instance.getVersion(), ESTestCase::randomNonNegativeLong),
+                    instance.getModifiedDate(),
+                    instance.getLastSuccess(),
+                    instance.getLastFailure());
+            case 2:
+                return new SnapshotLifecyclePolicyItem(instance.getPolicy(),
+                    instance.getVersion(),
+                    randomValueOtherThan(instance.getModifiedDate(), ESTestCase::randomNonNegativeLong),
+                    instance.getLastSuccess(),
+                    instance.getLastFailure());
+            case 3:
+                return new SnapshotLifecyclePolicyItem(instance.getPolicy(),
+                    instance.getVersion(),
+                    instance.getModifiedDate(),
+                    randomValueOtherThan(instance.getLastSuccess(),
+                        SnapshotInvocationRecordTests::randomSnapshotInvocationRecord),
+                    instance.getLastFailure());
+            case 4:
+                return new SnapshotLifecyclePolicyItem(instance.getPolicy(),
+                    instance.getVersion(),
+                    instance.getModifiedDate(),
+                    instance.getLastSuccess(),
+                    randomValueOtherThan(instance.getLastFailure(),
+                        SnapshotInvocationRecordTests::randomSnapshotInvocationRecord));
+            default:
+                throw new AssertionError("failure, got illegal switch case");
+        }
+    }
+
+    @Override
+    protected Writeable.Reader<SnapshotLifecyclePolicyItem> instanceReader() {
+        return SnapshotLifecyclePolicyItem::new;
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecyclePolicyMetadataTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecyclePolicyMetadataTests.java
@@ -28,23 +28,10 @@ public class SnapshotLifecyclePolicyMetadataTests extends AbstractSerializingTes
     @Override
     protected SnapshotLifecyclePolicyMetadata createTestInstance() {
         policyId = randomAlphaOfLength(5);
-        SnapshotLifecyclePolicyMetadata.Builder builder = SnapshotLifecyclePolicyMetadata.builder()
-            .setPolicy(createRandomPolicy(policyId))
-            .setVersion(randomNonNegativeLong())
-            .setModifiedDate(randomNonNegativeLong());
-        if (randomBoolean()) {
-            builder.setHeaders(randomHeaders());
-        }
-        if (randomBoolean()) {
-            builder.setLastSuccess(randomSnapshotInvocationRecord());
-        }
-        if (randomBoolean()) {
-            builder.setLastFailure(randomSnapshotInvocationRecord());
-        }
-        return builder.build();
+        return createRandomPolicyMetadata(policyId);
     }
 
-    private Map<String, String> randomHeaders() {
+    private static Map<String, String> randomHeaders() {
         Map<String, String> headers = new HashMap<>();
         int headerCount = randomIntBetween(1,10);
         for (int i = 0; i < headerCount; i++) {
@@ -71,7 +58,7 @@ public class SnapshotLifecyclePolicyMetadataTests extends AbstractSerializingTes
                     .build();
             case 2:
                 return SnapshotLifecyclePolicyMetadata.builder(instance)
-                    .setHeaders(randomValueOtherThan(instance.getHeaders(), this::randomHeaders))
+                    .setHeaders(randomValueOtherThan(instance.getHeaders(), SnapshotLifecyclePolicyMetadataTests::randomHeaders))
                     .build();
             case 3:
                 return SnapshotLifecyclePolicyMetadata.builder(instance)
@@ -86,6 +73,23 @@ public class SnapshotLifecyclePolicyMetadataTests extends AbstractSerializingTes
             default:
                 throw new AssertionError("failure, got illegal switch case");
         }
+    }
+
+    public static SnapshotLifecyclePolicyMetadata createRandomPolicyMetadata(String policyId) {
+        SnapshotLifecyclePolicyMetadata.Builder builder = SnapshotLifecyclePolicyMetadata.builder()
+            .setPolicy(createRandomPolicy(policyId))
+            .setVersion(randomNonNegativeLong())
+            .setModifiedDate(randomNonNegativeLong());
+        if (randomBoolean()) {
+            builder.setHeaders(randomHeaders());
+        }
+        if (randomBoolean()) {
+            builder.setLastSuccess(randomSnapshotInvocationRecord());
+        }
+        if (randomBoolean()) {
+            builder.setLastFailure(randomSnapshotInvocationRecord());
+        }
+        return builder.build();
     }
 
     public static SnapshotLifecyclePolicy createRandomPolicy(String policyId) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/snapshotlifecycle/action/TransportGetSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/snapshotlifecycle/action/TransportGetSnapshotLifecycleAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.snapshotlifecycle.SnapshotLifecycleMetadata;
+import org.elasticsearch.xpack.core.snapshotlifecycle.SnapshotLifecyclePolicyItem;
 import org.elasticsearch.xpack.core.snapshotlifecycle.action.GetSnapshotLifecycleAction;
 
 import java.io.IOException;
@@ -66,7 +67,7 @@ public class TransportGetSnapshotLifecycleAction extends
             listener.onResponse(new GetSnapshotLifecycleAction.Response(Collections.emptyList()));
         } else {
             final Set<String> ids = new HashSet<>(Arrays.asList(request.getLifecycleIds()));
-            List<GetSnapshotLifecycleAction.SnapshotLifecyclePolicyItem> lifecycles = snapMeta.getSnapshotConfigurations()
+            List<SnapshotLifecyclePolicyItem> lifecycles = snapMeta.getSnapshotConfigurations()
                 .values()
                 .stream()
                 .filter(meta -> {
@@ -76,7 +77,7 @@ public class TransportGetSnapshotLifecycleAction extends
                         return ids.contains(meta.getPolicy().getId());
                     }
                 })
-                .map(GetSnapshotLifecycleAction.SnapshotLifecyclePolicyItem::new)
+                .map(SnapshotLifecyclePolicyItem::new)
                 .collect(Collectors.toList());
             listener.onResponse(new GetSnapshotLifecycleAction.Response(lifecycles));
         }


### PR DESCRIPTION
Adds serialization tests for SnapshotLifecyclePolicyItem.

Follow-up to discussion in https://github.com/elastic/elasticsearch/pull/40619
Relates to https://github.com/elastic/elasticsearch/issues/38461