### PR TITLE
Properly handle all Monitoring exporters being disabled

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/ExportBulk.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/ExportBulk.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.monitoring.exporter;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -14,7 +15,6 @@ import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringDoc;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
 /**
@@ -25,7 +25,10 @@ public abstract class ExportBulk {
 
     protected final String name;
     protected final ThreadContext threadContext;
-    private final AtomicReference<State> state = new AtomicReference<>(State.INITIALIZING);
+    /**
+     * {@code closed} being {@code false} means that it can still be added onto.
+     */
+    private final AtomicBoolean closed = new AtomicBoolean();
 
     public ExportBulk(String name, ThreadContext threadContext) {
         this.name = Objects.requireNonNull(name);
@@ -45,7 +48,7 @@ public abstract class ExportBulk {
      * Add documents to the exporting bulk
      */
     public void add(Collection<MonitoringDoc> docs) throws ExportException {
-        if (state.get() == State.INITIALIZING) {
+        if (closed.get() == false) {
             doAdd(docs);
         }
     }
@@ -56,7 +59,7 @@ public abstract class ExportBulk {
      * Flush the exporting bulk
      */
     public void flush(ActionListener<Void> listener) {
-        if (state.compareAndSet(State.INITIALIZING, State.FLUSHING)) {
+        if (closed.compareAndSet(false, true)) {
             doFlush(listener);
         } else {
             listener.onResponse(null);
@@ -64,56 +67,6 @@ public abstract class ExportBulk {
     }
 
     protected abstract void doFlush(ActionListener<Void> listener);
-
-    /**
-     * Close the exporting bulk
-     */
-    public void close(boolean flush, ActionListener<Void> listener) {
-        if (state.getAndSet(State.CLOSED) != State.CLOSED) {
-            if (flush) {
-                flushAndClose(listener);
-            } else {
-                doClose(listener);
-            }
-        } else {
-            listener.onResponse(null);
-        }
-    }
-
-    private void flushAndClose(ActionListener<Void> listener) {
-        doFlush(new ActionListener<Void>() {
-            @Override
-            public void onResponse(Void aVoid) {
-                doClose(listener);
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                // we need to close in spite of the failure, but we will return the failure
-                doClose(new ActionListener<Void>() {
-
-                    private final ExportException exportException = new ExportException("Exception when closing export bulk", e);
-
-                    @Override
-                    public void onResponse(Void aVoid) {
-                        listener.onFailure(exportException);
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        exportException.addSuppressed(e);
-                        listener.onFailure(exportException);
-                    }
-                });
-            }
-        });
-    }
-
-    protected abstract void doClose(ActionListener<Void> listener);
-
-    protected boolean isClosed() {
-        return state.get() == State.CLOSED;
-    }
 
     /**
      * This class holds multiple export bulks exposed as a single compound bulk.
@@ -170,54 +123,16 @@ public abstract class ExportBulk {
             iteratingActionListener.run();
         }
 
-        @Override
-        protected void doClose(ActionListener<Void> listener) {
-            final SetOnce<ExportException> exceptionRef = new SetOnce<>();
-            final BiConsumer<ExportBulk, ActionListener<Void>> bulkBiConsumer = (exportBulk, iteratingListener) -> {
-                // for every export bulk we close and pass back the response, which should always be
-                // null. When we have an exception, we wrap the first and then add suppressed exceptions
-                exportBulk.doClose(ActionListener.wrap(iteratingListener::onResponse, e -> {
-                    if (exceptionRef.get() == null) {
-                        exceptionRef.set(new ExportException("failed to close export bulks", e));
-                    } else if (e instanceof ExportException) {
-                        exceptionRef.get().addExportException((ExportException) e);
-                    } else {
-                        exceptionRef.get().addSuppressed(e);
-                    }
-                    // this is tricky to understand but basically we suppress the exception for use
-                    // later on and call the passed in listener so that iteration continues
-                    iteratingListener.onResponse(null);
-                }));
-            };
-            IteratingActionListener<Void, ExportBulk> iteratingActionListener =
-                    new IteratingActionListener<>(newExceptionHandlingListener(exceptionRef, listener), bulkBiConsumer, bulks,
-                            threadContext);
-            iteratingActionListener.run();
-        }
-
         private static ActionListener<Void> newExceptionHandlingListener(SetOnce<ExportException> exceptionRef,
                                                                          ActionListener<Void> listener) {
-            return new ActionListener<Void>() {
-                @Override
-                public void onResponse(Void aVoid) {
-                    if (exceptionRef.get() == null) {
-                        listener.onResponse(null);
-                    } else {
-                        listener.onFailure(exceptionRef.get());
-                    }
+            return ActionListener.wrap(r -> {
+                if (exceptionRef.get() == null) {
+                    listener.onResponse(null);
+                } else {
+                    listener.onFailure(exceptionRef.get());
                 }
-
-                @Override
-                public void onFailure(Exception e) {
-                    listener.onFailure(e);
-                }
-            };
+            }, listener::onFailure);
         }
     }
 
-    private enum State {
-        INITIALIZING,
-        FLUSHING,
-        CLOSED
-    }
 }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporters.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporters.java
@@ -179,6 +179,14 @@ public class Exporters extends AbstractLifecycleComponent {
         }
 
         final Map<String, Exporter> exporterMap = exporters.get();
+
+        // if no exporters are defined (which is only possible if all are defined explicitly disabled),
+        // then ignore the request immediately
+        if (exporterMap.isEmpty()) {
+            listener.onResponse(null);
+            return;
+        }
+
         final AtomicArray<ExportBulk> accumulatedBulks = new AtomicArray<>(exporterMap.size());
         final CountDown countDown = new CountDown(exporterMap.size());
 
@@ -225,7 +233,7 @@ public class Exporters extends AbstractLifecycleComponent {
         } catch (ExportException e) {
             exceptionRef.set(e);
         } finally {
-            bulk.close(lifecycleState() == Lifecycle.State.STARTED, ActionListener.wrap(r -> {
+            bulk.flush(ActionListener.wrap(r -> {
                 if (exceptionRef.get() == null) {
                     listener.onResponse(null);
                 } else {

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExportBulk.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExportBulk.java
@@ -123,11 +123,6 @@ class HttpExportBulk extends ExportBulk {
         }
     }
 
-    @Override
-    protected void doClose(ActionListener<Void> listener) {
-        listener.onResponse(null);
-    }
-
     private byte[] toBulkBytes(final MonitoringDoc doc) throws IOException {
         final XContentType xContentType = XContentType.JSON;
         final XContent xContent = xContentType.xContent();

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalBulk.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalBulk.java
@@ -30,8 +30,8 @@ import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
 /**
  * LocalBulk exports monitoring data in the local cluster using bulk requests. Its usage is not thread safe since the
- * {@link LocalBulk#add(Collection)}, {@link LocalBulk#flush(org.elasticsearch.action.ActionListener)} and
- * {@link LocalBulk#doClose(ActionListener)} methods are not synchronized.
+ * {@link LocalBulk#add(Collection)} and {@link LocalBulk#flush(org.elasticsearch.action.ActionListener)}
+ * methods are not synchronized.
  */
 public class LocalBulk extends ExportBulk {
 
@@ -52,13 +52,10 @@ public class LocalBulk extends ExportBulk {
     }
 
     @Override
-    public void doAdd(Collection<MonitoringDoc> docs) throws ExportException {
+    protected void doAdd(Collection<MonitoringDoc> docs) throws ExportException {
         ExportException exception = null;
 
         for (MonitoringDoc doc : docs) {
-            if (isClosed()) {
-                return;
-            }
             if (requestBuilder == null) {
                 requestBuilder = client.prepareBulk();
             }
@@ -99,8 +96,8 @@ public class LocalBulk extends ExportBulk {
     }
 
     @Override
-    public void doFlush(ActionListener<Void> listener) {
-        if (requestBuilder == null || requestBuilder.numberOfActions() == 0 || isClosed()) {
+    protected void doFlush(ActionListener<Void> listener) {
+        if (requestBuilder == null || requestBuilder.numberOfActions() == 0) {
             listener.onResponse(null);
         } else {
             try {
@@ -138,11 +135,4 @@ public class LocalBulk extends ExportBulk {
         }
     }
 
-    @Override
-    protected void doClose(ActionListener<Void> listener) {
-        if (isClosed() == false) {
-            requestBuilder = null;
-        }
-        listener.onResponse(null);
-    }
 }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ExportersTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ExportersTests.java
@@ -266,10 +266,8 @@ public class ExportersTests extends ESTestCase {
     public void testNoExporters() throws Exception {
         Settings.Builder settings =
             Settings.builder()
-                    .put("xpack.monitoring.exporters.explicitly_disabled.type", "record")
+                    .put("xpack.monitoring.exporters.explicitly_disabled.type", "local")
                     .put("xpack.monitoring.exporters.explicitly_disabled.enabled", false);
-
-        factories.put("record", (s) -> new CountingExporter(s, threadContext));
 
         Exporters exporters = new Exporters(settings.build(), factories, clusterService, licenseState, threadContext);
         exporters.start();

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ExportersTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ExportersTests.java
@@ -52,6 +52,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -260,6 +261,27 @@ public class ExportersTests extends ESTestCase {
     }
 
     /**
+     * Verifies that, when no exporters are enabled, the {@code Exporters} will still return as expected.
+     */
+    public void testNoExporters() throws Exception {
+        Settings.Builder settings =
+            Settings.builder()
+                    .put("xpack.monitoring.exporters.explicitly_disabled.type", "record")
+                    .put("xpack.monitoring.exporters.explicitly_disabled.enabled", false);
+
+        factories.put("record", (s) -> new CountingExporter(s, threadContext));
+
+        Exporters exporters = new Exporters(settings.build(), factories, clusterService, licenseState, threadContext);
+        exporters.start();
+
+        assertThat(exporters.getEnabledExporters(), empty());
+
+        assertExporters(exporters);
+
+        exporters.close();
+    }
+
+    /**
      * This test creates N threads that export a random number of document
      * using a {@link Exporters} instance.
      */
@@ -276,18 +298,37 @@ public class ExportersTests extends ESTestCase {
         Exporters exporters = new Exporters(settings.build(), factories, clusterService, licenseState, threadContext);
         exporters.start();
 
+        assertThat(exporters.getEnabledExporters(), hasSize(nbExporters));
+
+        final int total = assertExporters(exporters);
+
+        for (Exporter exporter : exporters.getEnabledExporters()) {
+            assertThat(exporter, instanceOf(CountingExporter.class));
+            assertThat(((CountingExporter) exporter).getExportedCount(), equalTo(total));
+        }
+
+        exporters.close();
+    }
+
+    /**
+     * Attempt to export a random number of documents via {@code exporters} from multiple threads.
+     *
+     * @param exporters The setup / started exporters instance to use.
+     * @return The total number of documents sent to the {@code exporters}.
+     */
+    private int assertExporters(final Exporters exporters) throws InterruptedException {
         final Thread[] threads = new Thread[3 + randomInt(7)];
         final CyclicBarrier barrier = new CyclicBarrier(threads.length);
         final List<Throwable> exceptions = new CopyOnWriteArrayList<>();
+        final AtomicInteger counter = new AtomicInteger(threads.length);
 
         int total = 0;
 
         for (int i = 0; i < threads.length; i++) {
-            int nbDocs = randomIntBetween(10, 50);
-            total += nbDocs;
-
+            final int threadDocs = randomIntBetween(10, 50);
             final int threadNum = i;
-            final int threadDocs = nbDocs;
+
+            total += threadDocs;
 
             threads[i] = new Thread(new AbstractRunnable() {
                 @Override
@@ -297,18 +338,25 @@ public class ExportersTests extends ESTestCase {
 
                 @Override
                 protected void doRun() throws Exception {
-                    List<MonitoringDoc> docs = new ArrayList<>();
+                    final List<MonitoringDoc> docs = new ArrayList<>();
                     for (int n = 0; n < threadDocs; n++) {
                         docs.add(new TestMonitoringDoc(randomAlphaOfLength(5), randomNonNegativeLong(), randomNonNegativeLong(),
                                                        null, MonitoredSystem.ES, randomAlphaOfLength(5), null, String.valueOf(n)));
                     }
-                    barrier.await(10, TimeUnit.SECONDS);
                     exporters.export(docs, ActionListener.wrap(
-                            r -> logger.debug("--> thread [{}] successfully exported {} documents", threadNum, threadDocs),
-                            e -> logger.debug("--> thread [{}] failed to export {} documents", threadNum, threadDocs)));
-
+                        r -> {
+                            counter.decrementAndGet();
+                            logger.debug("--> thread [{}] successfully exported {} documents", threadNum, threadDocs);
+                        },
+                        e -> {
+                            exceptions.add(e);
+                            logger.debug("--> thread [{}] failed to export {} documents", threadNum, threadDocs);
+                        })
+                    );
+                    barrier.await(10, TimeUnit.SECONDS);
                 }
             }, "export_thread_" + i);
+
             threads[i].start();
         }
 
@@ -317,12 +365,9 @@ public class ExportersTests extends ESTestCase {
         }
 
         assertThat(exceptions, empty());
-        for (Exporter exporter : exporters.getEnabledExporters()) {
-            assertThat(exporter, instanceOf(CountingExporter.class));
-            assertThat(((CountingExporter) exporter).getExportedCount(), equalTo(total));
-        }
+        assertThat(counter.get(), is(0));
 
-        exporters.close();
+        return total;
     }
 
     static class TestExporter extends Exporter {
@@ -398,11 +443,6 @@ public class ExportersTests extends ESTestCase {
 
         @Override
         protected void doFlush(ActionListener<Void> listener) {
-            listener.onResponse(null);
-        }
-
-        @Override
-        protected void doClose(ActionListener<Void> listener) {
             listener.onResponse(null);
         }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
@@ -608,7 +608,7 @@ public class HttpExporterIT extends MonitoringIntegTestCase {
         assertBusy(() -> assertThat(clusterService().state().version(), not(ClusterState.UNKNOWN_VERSION)));
 
         try (HttpExporter exporter = createHttpExporter(settings)) {
-            final CountDownLatch awaitResponseAndClose = new CountDownLatch(2);
+            final CountDownLatch awaitResponseAndClose = new CountDownLatch(1);
 
             exporter.openBulk(ActionListener.wrap(exportBulk -> {
                 final HttpExportBulk bulk = (HttpExportBulk)exportBulk;
@@ -620,9 +620,8 @@ public class HttpExporterIT extends MonitoringIntegTestCase {
                     e -> fail(e.getMessage())
                 );
 
-                bulk.doAdd(docs);
-                bulk.doFlush(listener);
-                bulk.doClose(listener); // reusing the same listener, which is why we expect countDown x2
+                bulk.add(docs);
+                bulk.flush(listener);
             }, e -> fail("Failed to create HttpExportBulk")));
 
             // block until the bulk responds


### PR DESCRIPTION
When monitoring exporters are all disabled, which must be done explicitly, _and_ monitoring collection is enabled, then any call to `_xpack/monitoring/_bulk` will create a task that never closes _and_ ES collection will stop happening because a semaphore is never marked as completed.

This also simplifies the async `ExportBulk` code by removing the third step (second async step, `close`) entirely because it was entirely unnecessary by both implementations.

Closes #40919