### PR TITLE
Fix Failing to Handle Ex. in TransportShardBulkAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -194,7 +194,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                         null, context.getPrimary(), logger));
             }
 
-        }.doRun();
+        }.run();
     }
 
     /**


### PR DESCRIPTION
* Fixing minor mistake from #39793 here, we should be using `run` so that the `onFailure` path is executed if the first invocation of this `Runnable` fails for an unexpected reason
