### PR TITLE
[BACKPORT 7.0] Improve certutil --pass documentation about empty password

### DIFF
--- a/docs/reference/commands/certutil.asciidoc
+++ b/docs/reference/commands/certutil.asciidoc
@@ -177,14 +177,17 @@ with the `ca` parameter.
 
 `--pass <password>`:: Specifies the password for the generated private keys.
 +
-Keys stored in PKCS#12 format are always password protected.
+Keys stored in PKCS#12 format are always password protected, however,
+this password may be _blank_. If you want to specify a blank password
+without a prompt, use `--pass ""` (with no `=`) on the command line.
 +
 Keys stored in PEM format are password protected only if the
 `--pass` parameter is specified. If you do not supply an argument for the
 `--pass` parameter, you are prompted for a password.
-+
-If you want to specify a _blank_ password (without prompting), use 
-`--pass ""` (with no `=`).
+Encrypted PEM files do not support blank passwords (if you do not
+wish to password-protect your PEM keys, then do not specify
+`--pass`).
+
 
 `--pem`:: Generates certificates and keys in PEM format instead of PKCS#12. This
 parameter cannot be used with the `csr` parameter.


### PR DESCRIPTION
Improve the documentation of parameter --pass of elasticsearch-certutil

Backport of: #40137

Co-Authored-By: Diego Cardozo Sandrim <diegocsandrim@users.noreply.github.com>
Co-Authored-By: Vigneash Sundar <vikene@users.noreply.github.com>