### PR TITLE
Fix Race in AsyncTwoPhaseIndexerTests.testStateMachine

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
@@ -39,7 +39,7 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
 
         private final CountDownLatch latch;
         // test the execution order
-        private int step;
+        private volatile int step;
 
         protected MockIndexer(Executor executor, AtomicReference<IndexerState> initialState, Integer initialPosition,
                               CountDownLatch latch) {
@@ -113,8 +113,8 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
         protected void onFinish(ActionListener<Void> listener) {
             assertThat(step, equalTo(4));
             ++step;
-            isFinished.set(true);
             listener.onResponse(null);
+            isFinished.set(true);
         }
 
         @Override
@@ -206,8 +206,7 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix( bugUrl = "https://github.com/elastic/elasticsearch/issues/40946")
-    public void testStateMachine() throws InterruptedException {
+    public void testStateMachine() throws Exception {
         AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
         final ExecutorService executor = Executors.newFixedThreadPool(1);
         isFinished.set(false);


### PR DESCRIPTION
* The step is incremented by the listner in `org.elasticsearch.xpack.core.indexing.AsyncTwoPhaseIndexerTests.MockIndexer#onFinish` after isFinished is set to true, but the test only waited for `isFinished`,
fixed by calling `isFinished` last
* Also made `step` volatile since we are reading it from different thread from the one incrementing it
* Closes #40946

------

randomly ran into this and fixed it real quick
