### PR TITLE
More details about the default shards number update

### DIFF
--- a/docs/reference/migration/migrate_7_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_7_0/indices.asciidoc
@@ -6,7 +6,8 @@
 [float]
 ==== Index creation no longer defaults to five shards
 Previous versions of Elasticsearch defaulted to creating five shards per index.
-Starting with 7.0.0, the default is now one shard per index.
+Starting with 7.0.0, the default is now one shard per index to avoid to overload the cluster when its size doesn't require it.
+Using the Split API is the recommanded solution to scale up your indices.
 //end::notable-breaking-changes[]
 
 [float]


### PR DESCRIPTION
It was a best practice to use 5 in the past but it's overloading the clusters sometimes for nothing and the spit API is now the best option to handle the indices growth.

It's a followup of a conversation I had with @dadoonet 

https://twitter.com/aheritier/status/1114980647020445698

Fill free, to rewrite, improve, but I think it makes sense to give more details when you change what was known as a best practice used by default by many.