### PR TITLE
Fix command line to run doc tests in docs/README.

### DIFF
--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -6,7 +6,7 @@ See: https://github.com/elastic/docs
 Snippets marked with `// CONSOLE` are automatically annotated with "VIEW IN
 CONSOLE" and "COPY AS CURL" in the documentation and are automatically tested
 by the command `gradle :docs:check`. To test just the docs from a single page,
-use e.g. `gradle :docs:check -Dtests.method="\*rollover*"`.
+use e.g. `./gradlew :docs:check -Dtests.method="*rollover*"`.
 
 NOTE: If you have an elasticsearch-extra folder alongside your elasticsearch
 folder, you must temporarily rename it when you are testing 6.3 or later branches.

--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -6,7 +6,7 @@ See: https://github.com/elastic/docs
 Snippets marked with `// CONSOLE` are automatically annotated with "VIEW IN
 CONSOLE" and "COPY AS CURL" in the documentation and are automatically tested
 by the command `gradle :docs:check`. To test just the docs from a single page,
-use e.g. `./gradlew :docs:check -Dtests.method="*rollover*"`.
+use e.g. `./gradlew :docs:integTestRunner --tests "*rollover*"`.
 
 NOTE: If you have an elasticsearch-extra folder alongside your elasticsearch
 folder, you must temporarily rename it when you are testing 6.3 or later branches.


### PR DESCRIPTION
It runs `gradle` instead of `gradlew` and has an extra `\`.
