### PR TITLE
Cleanup JVM options after JDK 11 bump

### DIFF
--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -40,10 +40,10 @@
 ## G1GC Configuration
 # NOTE: G1GC is only supported on JDK version 10 or later.
 # To use G1GC uncomment the lines below.
-# 10-:-XX:-UseConcMarkSweepGC
-# 10-:-XX:-UseCMSInitiatingOccupancyOnly
-# 10-:-XX:+UseG1GC
-# 10-:-XX:InitiatingHeapOccupancyPercent=75
+# 11-:-XX:-UseConcMarkSweepGC
+# 11-:-XX:-UseCMSInitiatingOccupancyOnly
+# 11-:-XX:+UseG1GC
+# 11-:-XX:InitiatingHeapOccupancyPercent=75
 
 ## DNS cache policy
 # cache ttl in seconds for positive DNS lookups noting that this overrides the
@@ -101,19 +101,8 @@ ${heap.dump.path}
 # specify an alternative path for JVM fatal error logs
 ${error.file}
 
-## JDK 8 GC logging
-
-8:-XX:+PrintGCDetails
-8:-XX:+PrintGCDateStamps
-8:-XX:+PrintTenuringDistribution
-8:-XX:+PrintGCApplicationStoppedTime
-8:-Xloggc:${loggc}
-8:-XX:+UseGCLogFileRotation
-8:-XX:NumberOfGCLogFiles=32
-8:-XX:GCLogFileSize=64m
-
-# JDK 9+ GC logging
-9-:-Xlog:gc*,gc+age=trace,safepoint:file=${loggc}:utctime,pid,tags:filecount=32,filesize=64m
+# GC logging
+-Xlog:gc*,gc+age=trace,safepoint:file=${loggc}:utctime,pid,tags:filecount=32,filesize=64m
 # due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
 # time/date parsing will break in an incompatible way for some date patterns and locals
-9-:-Djava.locale.providers=COMPAT
+-Djava.locale.providers=COMPAT


### PR DESCRIPTION
This commit cleans up the default JVM options now that the minimum runtime is JDK 11.

Relates #40754
