### PR TITLE
Unrevert: Change HLRC CCR response tests to use AbstractResponseTestCase base class 

### DIFF
--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -64,6 +64,9 @@ dependencies {
   testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
   //this is needed to make RestHighLevelClientTests#testApiNamingConventions work from IDEs
   testCompile "org.elasticsearch:rest-api-spec:${version}"
+  // Needed for serialization tests: 
+  // (In order to serialize a server side class to a client side class or the other way around)
+  testCompile "org.elasticsearch.plugin:x-pack-core:${version}"
 
   restSpec "org.elasticsearch:rest-api-spec:${version}"
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/CcrStatsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/CcrStatsResponseTests.java
@@ -20,50 +20,110 @@
 package org.elasticsearch.client.ccr;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.client.ccr.AutoFollowStats.AutoFollowedCluster;
+import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.client.ccr.IndicesFollowStats.ShardFollowStats;
 import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ccr.ShardFollowNodeTaskStatus;
+import org.elasticsearch.xpack.core.ccr.action.CcrStatsAction;
+import org.elasticsearch.xpack.core.ccr.action.FollowStatsAction;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
-import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
-public class CcrStatsResponseTests extends ESTestCase {
+public class CcrStatsResponseTests extends AbstractResponseTestCase<CcrStatsAction.Response, CcrStatsResponse> {
 
-    public void testFromXContent() throws IOException {
-        xContentTester(this::createParser,
-            CcrStatsResponseTests::createTestInstance,
-            CcrStatsResponseTests::toXContent,
-            CcrStatsResponse::fromXContent)
-            .supportsUnknownFields(true)
-            .assertEqualsConsumer(CcrStatsResponseTests::assertEqualInstances)
-            .assertToXContentEquivalence(false)
-            .test();
+    @Override
+    protected CcrStatsAction.Response createServerTestInstance() {
+        org.elasticsearch.xpack.core.ccr.AutoFollowStats autoFollowStats = new org.elasticsearch.xpack.core.ccr.AutoFollowStats(
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomReadExceptions(),
+            randomTrackingClusters()
+        );
+        FollowStatsAction.StatsResponses statsResponse = createStatsResponse();
+        return new CcrStatsAction.Response(autoFollowStats, statsResponse);
     }
 
-    // Needed, because exceptions in IndicesFollowStats and AutoFollowStats cannot be compared
-    private static void assertEqualInstances(CcrStatsResponse expectedInstance, CcrStatsResponse newInstance) {
-        assertNotSame(expectedInstance, newInstance);
+    static NavigableMap<String, Tuple<Long, ElasticsearchException>> randomReadExceptions() {
+        final int count = randomIntBetween(0, 16);
+        final NavigableMap<String, Tuple<Long, ElasticsearchException>> readExceptions = new TreeMap<>();
+        for (int i = 0; i < count; i++) {
+            readExceptions.put("" + i, Tuple.tuple(randomNonNegativeLong(),
+                new ElasticsearchException(new IllegalStateException("index [" + i + "]"))));
+        }
+        return readExceptions;
+    }
 
+    static NavigableMap<String, org.elasticsearch.xpack.core.ccr.AutoFollowStats.AutoFollowedCluster> randomTrackingClusters() {
+        final int count = randomIntBetween(0, 16);
+        final NavigableMap<String, org.elasticsearch.xpack.core.ccr.AutoFollowStats.AutoFollowedCluster> readExceptions = new TreeMap<>();
+        for (int i = 0; i < count; i++) {
+            readExceptions.put("" + i,
+                new org.elasticsearch.xpack.core.ccr.AutoFollowStats.AutoFollowedCluster(randomLong(), randomNonNegativeLong()));
+        }
+        return readExceptions;
+    }
+
+    static FollowStatsAction.StatsResponses createStatsResponse() {
+        int numResponses = randomIntBetween(0, 8);
+        List<FollowStatsAction.StatsResponse> responses = new ArrayList<>(numResponses);
+        for (int i = 0; i < numResponses; i++) {
+            ShardFollowNodeTaskStatus status = new ShardFollowNodeTaskStatus(
+                randomAlphaOfLength(4),
+                randomAlphaOfLength(4),
+                randomAlphaOfLength(4),
+                randomInt(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomIntBetween(0, Integer.MAX_VALUE),
+                randomIntBetween(0, Integer.MAX_VALUE),
+                randomIntBetween(0, Integer.MAX_VALUE),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                Collections.emptyNavigableMap(),
+                randomLong(),
+                randomBoolean() ? new ElasticsearchException("fatal error") : null);
+            responses.add(new FollowStatsAction.StatsResponse(status));
+        }
+        return new FollowStatsAction.StatsResponses(Collections.emptyList(), Collections.emptyList(), responses);
+    }
+
+    @Override
+    protected CcrStatsResponse doParseToClientInstance(XContentParser parser) throws IOException {
+        return CcrStatsResponse.fromXContent(parser);
+    }
+
+    @Override
+    protected void assertInstances(CcrStatsAction.Response serverTestInstance, CcrStatsResponse clientInstance) {
         {
-            AutoFollowStats newAutoFollowStats = newInstance.getAutoFollowStats();
-            AutoFollowStats expectedAutoFollowStats = expectedInstance.getAutoFollowStats();
+            AutoFollowStats newAutoFollowStats = clientInstance.getAutoFollowStats();
+            org.elasticsearch.xpack.core.ccr.AutoFollowStats expectedAutoFollowStats = serverTestInstance.getAutoFollowStats();
             assertThat(newAutoFollowStats.getNumberOfSuccessfulFollowIndices(),
                 equalTo(expectedAutoFollowStats.getNumberOfSuccessfulFollowIndices()));
             assertThat(newAutoFollowStats.getNumberOfFailedRemoteClusterStateRequests(),
@@ -89,62 +149,69 @@ public class CcrStatsResponseTests extends ESTestCase {
             }
         }
         {
-            IndicesFollowStats newIndicesFollowStats = newInstance.getIndicesFollowStats();
-            IndicesFollowStats expectedIndicesFollowStats = expectedInstance.getIndicesFollowStats();
+            IndicesFollowStats newIndicesFollowStats = clientInstance.getIndicesFollowStats();
+
+            // sort by index name, then shard ID
+            final Map<String, Map<Integer, FollowStatsAction.StatsResponse>> expectedIndicesFollowStats = new TreeMap<>();
+            for (final FollowStatsAction.StatsResponse statsResponse : serverTestInstance.getFollowStats().getStatsResponses()) {
+                expectedIndicesFollowStats.computeIfAbsent(
+                    statsResponse.status().followerIndex(),
+                    k -> new TreeMap<>()).put(statsResponse.status().getShardId(), statsResponse);
+            }
             assertThat(newIndicesFollowStats.getShardFollowStats().size(),
-                equalTo(expectedIndicesFollowStats.getShardFollowStats().size()));
+                equalTo(expectedIndicesFollowStats.size()));
             assertThat(newIndicesFollowStats.getShardFollowStats().keySet(),
-                equalTo(expectedIndicesFollowStats.getShardFollowStats().keySet()));
+                equalTo(expectedIndicesFollowStats.keySet()));
             for (Map.Entry<String, List<ShardFollowStats>> indexEntry : newIndicesFollowStats.getShardFollowStats().entrySet()) {
                 List<ShardFollowStats> newStats = indexEntry.getValue();
-                List<ShardFollowStats> expectedStats = expectedIndicesFollowStats.getShardFollowStats(indexEntry.getKey());
+                Map<Integer, FollowStatsAction.StatsResponse> expectedStats = expectedIndicesFollowStats.get(indexEntry.getKey());
                 assertThat(newStats.size(), equalTo(expectedStats.size()));
                 for (int i = 0; i < newStats.size(); i++) {
                     ShardFollowStats actualShardFollowStats = newStats.get(i);
-                    ShardFollowStats expectedShardFollowStats = expectedStats.get(i);
+                    ShardFollowNodeTaskStatus expectedShardFollowStats = expectedStats.get(actualShardFollowStats.getShardId()).status();
 
                     assertThat(actualShardFollowStats.getRemoteCluster(), equalTo(expectedShardFollowStats.getRemoteCluster()));
-                    assertThat(actualShardFollowStats.getLeaderIndex(), equalTo(expectedShardFollowStats.getLeaderIndex()));
-                    assertThat(actualShardFollowStats.getFollowerIndex(), equalTo(expectedShardFollowStats.getFollowerIndex()));
+                    assertThat(actualShardFollowStats.getLeaderIndex(), equalTo(expectedShardFollowStats.leaderIndex()));
+                    assertThat(actualShardFollowStats.getFollowerIndex(), equalTo(expectedShardFollowStats.followerIndex()));
                     assertThat(actualShardFollowStats.getShardId(), equalTo(expectedShardFollowStats.getShardId()));
                     assertThat(actualShardFollowStats.getLeaderGlobalCheckpoint(),
-                        equalTo(expectedShardFollowStats.getLeaderGlobalCheckpoint()));
-                    assertThat(actualShardFollowStats.getLeaderMaxSeqNo(), equalTo(expectedShardFollowStats.getLeaderMaxSeqNo()));
+                        equalTo(expectedShardFollowStats.leaderGlobalCheckpoint()));
+                    assertThat(actualShardFollowStats.getLeaderMaxSeqNo(), equalTo(expectedShardFollowStats.leaderMaxSeqNo()));
                     assertThat(actualShardFollowStats.getFollowerGlobalCheckpoint(),
-                        equalTo(expectedShardFollowStats.getFollowerGlobalCheckpoint()));
-                    assertThat(actualShardFollowStats.getLastRequestedSeqNo(), equalTo(expectedShardFollowStats.getLastRequestedSeqNo()));
+                        equalTo(expectedShardFollowStats.followerGlobalCheckpoint()));
+                    assertThat(actualShardFollowStats.getLastRequestedSeqNo(), equalTo(expectedShardFollowStats.lastRequestedSeqNo()));
                     assertThat(actualShardFollowStats.getOutstandingReadRequests(),
-                        equalTo(expectedShardFollowStats.getOutstandingReadRequests()));
+                        equalTo(expectedShardFollowStats.outstandingReadRequests()));
                     assertThat(actualShardFollowStats.getOutstandingWriteRequests(),
-                        equalTo(expectedShardFollowStats.getOutstandingWriteRequests()));
+                        equalTo(expectedShardFollowStats.outstandingWriteRequests()));
                     assertThat(actualShardFollowStats.getWriteBufferOperationCount(),
-                        equalTo(expectedShardFollowStats.getWriteBufferOperationCount()));
+                        equalTo(expectedShardFollowStats.writeBufferOperationCount()));
                     assertThat(actualShardFollowStats.getFollowerMappingVersion(),
-                        equalTo(expectedShardFollowStats.getFollowerMappingVersion()));
+                        equalTo(expectedShardFollowStats.followerMappingVersion()));
                     assertThat(actualShardFollowStats.getFollowerSettingsVersion(),
-                        equalTo(expectedShardFollowStats.getFollowerSettingsVersion()));
+                        equalTo(expectedShardFollowStats.followerSettingsVersion()));
                     assertThat(actualShardFollowStats.getTotalReadTimeMillis(),
-                        equalTo(expectedShardFollowStats.getTotalReadTimeMillis()));
+                        equalTo(expectedShardFollowStats.totalReadTimeMillis()));
                     assertThat(actualShardFollowStats.getSuccessfulReadRequests(),
-                        equalTo(expectedShardFollowStats.getSuccessfulReadRequests()));
-                    assertThat(actualShardFollowStats.getFailedReadRequests(), equalTo(expectedShardFollowStats.getFailedReadRequests()));
-                    assertThat(actualShardFollowStats.getOperationsReads(), equalTo(expectedShardFollowStats.getOperationsReads()));
-                    assertThat(actualShardFollowStats.getBytesRead(), equalTo(expectedShardFollowStats.getBytesRead()));
+                        equalTo(expectedShardFollowStats.successfulReadRequests()));
+                    assertThat(actualShardFollowStats.getFailedReadRequests(), equalTo(expectedShardFollowStats.failedReadRequests()));
+                    assertThat(actualShardFollowStats.getOperationsReads(), equalTo(expectedShardFollowStats.operationsReads()));
+                    assertThat(actualShardFollowStats.getBytesRead(), equalTo(expectedShardFollowStats.bytesRead()));
                     assertThat(actualShardFollowStats.getTotalWriteTimeMillis(),
-                        equalTo(expectedShardFollowStats.getTotalWriteTimeMillis()));
+                        equalTo(expectedShardFollowStats.totalWriteTimeMillis()));
                     assertThat(actualShardFollowStats.getSuccessfulWriteRequests(),
-                        equalTo(expectedShardFollowStats.getSuccessfulWriteRequests()));
+                        equalTo(expectedShardFollowStats.successfulWriteRequests()));
                     assertThat(actualShardFollowStats.getFailedWriteRequests(),
-                        equalTo(expectedShardFollowStats.getFailedWriteRequests()));
-                    assertThat(actualShardFollowStats.getOperationWritten(), equalTo(expectedShardFollowStats.getOperationWritten()));
+                        equalTo(expectedShardFollowStats.failedWriteRequests()));
+                    assertThat(actualShardFollowStats.getOperationWritten(), equalTo(expectedShardFollowStats.operationWritten()));
                     assertThat(actualShardFollowStats.getReadExceptions().size(),
-                        equalTo(expectedShardFollowStats.getReadExceptions().size()));
+                        equalTo(expectedShardFollowStats.readExceptions().size()));
                     assertThat(actualShardFollowStats.getReadExceptions().keySet(),
-                        equalTo(expectedShardFollowStats.getReadExceptions().keySet()));
+                        equalTo(expectedShardFollowStats.readExceptions().keySet()));
                     for (final Map.Entry<Long, Tuple<Integer, ElasticsearchException>> entry :
                         actualShardFollowStats.getReadExceptions().entrySet()) {
                         final Tuple<Integer, ElasticsearchException> expectedTuple =
-                            expectedShardFollowStats.getReadExceptions().get(entry.getKey());
+                            expectedShardFollowStats.readExceptions().get(entry.getKey());
                         assertThat(entry.getValue().v1(), equalTo(expectedTuple.v1()));
                         // x-content loses the exception
                         final ElasticsearchException expected = expectedTuple.v2();
@@ -156,246 +223,10 @@ public class CcrStatsResponseTests extends ESTestCase {
                         assertThat(entry.getValue().v2().getCause().getMessage(), containsString(expected.getCause().getMessage()));
                     }
                     assertThat(actualShardFollowStats.getTimeSinceLastReadMillis(),
-                        equalTo(expectedShardFollowStats.getTimeSinceLastReadMillis()));
+                        equalTo(expectedShardFollowStats.timeSinceLastReadMillis()));
                 }
             }
         }
-    }
-
-    private static void toXContent(CcrStatsResponse response, XContentBuilder builder) throws IOException {
-        builder.startObject();
-        {
-            AutoFollowStats autoFollowStats = response.getAutoFollowStats();
-            builder.startObject(CcrStatsResponse.AUTO_FOLLOW_STATS_FIELD.getPreferredName());
-            {
-                builder.field(AutoFollowStats.NUMBER_OF_SUCCESSFUL_INDICES_AUTO_FOLLOWED.getPreferredName(),
-                    autoFollowStats.getNumberOfSuccessfulFollowIndices());
-                builder.field(AutoFollowStats.NUMBER_OF_FAILED_REMOTE_CLUSTER_STATE_REQUESTS.getPreferredName(),
-                    autoFollowStats.getNumberOfFailedRemoteClusterStateRequests());
-                builder.field(AutoFollowStats.NUMBER_OF_FAILED_INDICES_AUTO_FOLLOWED.getPreferredName(),
-                    autoFollowStats.getNumberOfFailedFollowIndices());
-                builder.startArray(AutoFollowStats.RECENT_AUTO_FOLLOW_ERRORS.getPreferredName());
-                for (Map.Entry<String, Tuple<Long, ElasticsearchException>> entry :
-                    autoFollowStats.getRecentAutoFollowErrors().entrySet()) {
-                    builder.startObject();
-                    {
-                        builder.field(AutoFollowStats.LEADER_INDEX.getPreferredName(), entry.getKey());
-                        builder.field(AutoFollowStats.TIMESTAMP.getPreferredName(), entry.getValue().v1());
-                        builder.field(AutoFollowStats.AUTO_FOLLOW_EXCEPTION.getPreferredName());
-                        builder.startObject();
-                        {
-                            ElasticsearchException.generateThrowableXContent(builder, ToXContent.EMPTY_PARAMS, entry.getValue().v2());
-                        }
-                        builder.endObject();
-                    }
-                    builder.endObject();
-                }
-                builder.endArray();
-                builder.startArray(AutoFollowStats.AUTO_FOLLOWED_CLUSTERS.getPreferredName());
-                for (Map.Entry<String, AutoFollowedCluster> entry : autoFollowStats.getAutoFollowedClusters().entrySet()) {
-                    builder.startObject();
-                    {
-                        builder.field(AutoFollowStats.CLUSTER_NAME.getPreferredName(), entry.getKey());
-                        builder.field(AutoFollowStats.TIME_SINCE_LAST_CHECK_MILLIS.getPreferredName(),
-                            entry.getValue().getTimeSinceLastCheckMillis());
-                        builder.field(AutoFollowStats.LAST_SEEN_METADATA_VERSION.getPreferredName(),
-                            entry.getValue().getLastSeenMetadataVersion());
-                    }
-                    builder.endObject();
-                }
-                builder.endArray();
-            }
-            builder.endObject();
-
-            IndicesFollowStats indicesFollowStats = response.getIndicesFollowStats();
-            builder.startObject(CcrStatsResponse.FOLLOW_STATS_FIELD.getPreferredName());
-            {
-                builder.startArray(IndicesFollowStats.INDICES_FIELD.getPreferredName());
-                for (Map.Entry<String, List<ShardFollowStats>> indexEntry :
-                    indicesFollowStats.getShardFollowStats().entrySet()) {
-                    builder.startObject();
-                    {
-                        builder.field(IndicesFollowStats.INDEX_FIELD.getPreferredName(), indexEntry.getKey());
-                        builder.startArray(IndicesFollowStats.SHARDS_FIELD.getPreferredName());
-                        {
-                            for (ShardFollowStats stats : indexEntry.getValue()) {
-                                builder.startObject();
-                                {
-                                    builder.field(ShardFollowStats.LEADER_CLUSTER.getPreferredName(), stats.getRemoteCluster());
-                                    builder.field(ShardFollowStats.LEADER_INDEX.getPreferredName(), stats.getLeaderIndex());
-                                    builder.field(ShardFollowStats.FOLLOWER_INDEX.getPreferredName(), stats.getFollowerIndex());
-                                    builder.field(ShardFollowStats.SHARD_ID.getPreferredName(), stats.getShardId());
-                                    builder.field(ShardFollowStats.LEADER_GLOBAL_CHECKPOINT_FIELD.getPreferredName(),
-                                        stats.getLeaderGlobalCheckpoint());
-                                    builder.field(ShardFollowStats.LEADER_MAX_SEQ_NO_FIELD.getPreferredName(), stats.getLeaderMaxSeqNo());
-                                    builder.field(ShardFollowStats.FOLLOWER_GLOBAL_CHECKPOINT_FIELD.getPreferredName(),
-                                        stats.getFollowerGlobalCheckpoint());
-                                    builder.field(ShardFollowStats.FOLLOWER_MAX_SEQ_NO_FIELD.getPreferredName(),
-                                        stats.getFollowerMaxSeqNo());
-                                    builder.field(ShardFollowStats.LAST_REQUESTED_SEQ_NO_FIELD.getPreferredName(),
-                                        stats.getLastRequestedSeqNo());
-                                    builder.field(ShardFollowStats.OUTSTANDING_READ_REQUESTS.getPreferredName(),
-                                        stats.getOutstandingReadRequests());
-                                    builder.field(ShardFollowStats.OUTSTANDING_WRITE_REQUESTS.getPreferredName(),
-                                        stats.getOutstandingWriteRequests());
-                                    builder.field(ShardFollowStats.WRITE_BUFFER_OPERATION_COUNT_FIELD.getPreferredName(),
-                                        stats.getWriteBufferOperationCount());
-                                    builder.humanReadableField(
-                                        ShardFollowStats.WRITE_BUFFER_SIZE_IN_BYTES_FIELD.getPreferredName(),
-                                        "write_buffer_size",
-                                        new ByteSizeValue(stats.getWriteBufferSizeInBytes()));
-                                    builder.field(ShardFollowStats.FOLLOWER_MAPPING_VERSION_FIELD.getPreferredName(),
-                                        stats.getFollowerMappingVersion());
-                                    builder.field(ShardFollowStats.FOLLOWER_SETTINGS_VERSION_FIELD.getPreferredName(),
-                                        stats.getFollowerSettingsVersion());
-                                    builder.humanReadableField(
-                                        ShardFollowStats.TOTAL_READ_TIME_MILLIS_FIELD.getPreferredName(),
-                                        "total_read_time",
-                                        new TimeValue(stats.getTotalReadTimeMillis(), TimeUnit.MILLISECONDS));
-                                    builder.humanReadableField(
-                                        ShardFollowStats.TOTAL_READ_REMOTE_EXEC_TIME_MILLIS_FIELD.getPreferredName(),
-                                        "total_read_remote_exec_time",
-                                        new TimeValue(stats.getTotalReadRemoteExecTimeMillis(), TimeUnit.MILLISECONDS));
-                                    builder.field(ShardFollowStats.SUCCESSFUL_READ_REQUESTS_FIELD.getPreferredName(),
-                                        stats.getSuccessfulReadRequests());
-                                    builder.field(ShardFollowStats.FAILED_READ_REQUESTS_FIELD.getPreferredName(),
-                                        stats.getFailedReadRequests());
-                                    builder.field(ShardFollowStats.OPERATIONS_READ_FIELD.getPreferredName(), stats.getOperationsReads());
-                                    builder.humanReadableField(
-                                        ShardFollowStats.BYTES_READ.getPreferredName(),
-                                        "total_read",
-                                        new ByteSizeValue(stats.getBytesRead(), ByteSizeUnit.BYTES));
-                                    builder.humanReadableField(
-                                        ShardFollowStats.TOTAL_WRITE_TIME_MILLIS_FIELD.getPreferredName(),
-                                        "total_write_time",
-                                        new TimeValue(stats.getTotalWriteTimeMillis(), TimeUnit.MILLISECONDS));
-                                    builder.field(ShardFollowStats.SUCCESSFUL_WRITE_REQUESTS_FIELD.getPreferredName(),
-                                        stats.getSuccessfulWriteRequests());
-                                    builder.field(ShardFollowStats.FAILED_WRITE_REQUEST_FIELD.getPreferredName(),
-                                        stats.getFailedWriteRequests());
-                                    builder.field(ShardFollowStats.OPERATIONS_WRITTEN.getPreferredName(), stats.getOperationWritten());
-                                    builder.startArray(ShardFollowStats.READ_EXCEPTIONS.getPreferredName());
-                                    {
-                                        for (final Map.Entry<Long, Tuple<Integer, ElasticsearchException>> entry :
-                                            stats.getReadExceptions().entrySet()) {
-                                            builder.startObject();
-                                            {
-                                                builder.field(ShardFollowStats.READ_EXCEPTIONS_ENTRY_FROM_SEQ_NO.getPreferredName(),
-                                                    entry.getKey());
-                                                builder.field(ShardFollowStats.READ_EXCEPTIONS_RETRIES.getPreferredName(),
-                                                    entry.getValue().v1());
-                                                builder.field(ShardFollowStats.READ_EXCEPTIONS_ENTRY_EXCEPTION.getPreferredName());
-                                                builder.startObject();
-                                                {
-                                                    ElasticsearchException.generateThrowableXContent(builder, ToXContent.EMPTY_PARAMS,
-                                                        entry.getValue().v2());
-                                                }
-                                                builder.endObject();
-                                            }
-                                            builder.endObject();
-                                        }
-                                    }
-                                    builder.endArray();
-                                    builder.humanReadableField(
-                                        ShardFollowStats.TIME_SINCE_LAST_READ_MILLIS_FIELD.getPreferredName(),
-                                        "time_since_last_read",
-                                        new TimeValue(stats.getTimeSinceLastReadMillis(), TimeUnit.MILLISECONDS));
-                                    if (stats.getFatalException() != null) {
-                                        builder.field(ShardFollowStats.FATAL_EXCEPTION.getPreferredName());
-                                        builder.startObject();
-                                        {
-                                            ElasticsearchException.generateThrowableXContent(builder, ToXContent.EMPTY_PARAMS,
-                                                stats.getFatalException());
-                                        }
-                                        builder.endObject();
-                                    }
-                                }
-                                builder.endObject();
-                            }
-                        }
-                        builder.endArray();
-                    }
-                    builder.endObject();
-                }
-                builder.endArray();
-            }
-            builder.endObject();
-        }
-        builder.endObject();
-    }
-
-    private static CcrStatsResponse createTestInstance() {
-        return new CcrStatsResponse(randomAutoFollowStats(), randomIndicesFollowStats());
-    }
-
-    private static AutoFollowStats randomAutoFollowStats() {
-        final int count = randomIntBetween(0, 16);
-        final NavigableMap<String, Tuple<Long, ElasticsearchException>> readExceptions = new TreeMap<>();
-        for (int i = 0; i < count; i++) {
-            readExceptions.put("" + i, Tuple.tuple(randomNonNegativeLong(),
-                new ElasticsearchException(new IllegalStateException("index [" + i + "]"))));
-        }
-        final NavigableMap<String, AutoFollowedCluster> autoFollowClusters = new TreeMap<>();
-        for (int i = 0; i < count; i++) {
-            autoFollowClusters.put("" + i, new AutoFollowedCluster(randomLong(), randomNonNegativeLong()));
-        }
-        return new AutoFollowStats(
-            randomNonNegativeLong(),
-            randomNonNegativeLong(),
-            randomNonNegativeLong(),
-            readExceptions,
-            autoFollowClusters
-        );
-    }
-
-    static IndicesFollowStats randomIndicesFollowStats() {
-        int numIndices = randomIntBetween(0, 16);
-        NavigableMap<String, List<ShardFollowStats>> shardFollowStats = new TreeMap<>();
-        for (int i = 0; i < numIndices; i++) {
-            String index = randomAlphaOfLength(4);
-            int numShards = randomIntBetween(0, 5);
-            List<ShardFollowStats> stats = new ArrayList<>(numShards);
-            shardFollowStats.put(index, stats);
-            for (int j = 0; j < numShards; j++) {
-                final int count = randomIntBetween(0, 16);
-                final NavigableMap<Long, Tuple<Integer, ElasticsearchException>> readExceptions = new TreeMap<>();
-                for (long k = 0; k < count; k++) {
-                    readExceptions.put(k, new Tuple<>(randomIntBetween(0, Integer.MAX_VALUE),
-                        new ElasticsearchException(new IllegalStateException("index [" + k + "]"))));
-                }
-
-                stats.add(new ShardFollowStats(
-                    randomAlphaOfLength(4),
-                    randomAlphaOfLength(4),
-                    randomAlphaOfLength(4),
-                    randomInt(),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomIntBetween(0, Integer.MAX_VALUE),
-                    randomIntBetween(0, Integer.MAX_VALUE),
-                    randomIntBetween(0, Integer.MAX_VALUE),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomNonNegativeLong(),
-                    randomLong(),
-                    readExceptions,
-                    randomBoolean() ? new ElasticsearchException("fatal error") : null));
-            }
-        }
-        return new IndicesFollowStats(shardFollowStats);
     }
 
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/FollowInfoResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/FollowInfoResponseTests.java
@@ -19,59 +19,89 @@
 
 package org.elasticsearch.client.ccr;
 
-import org.elasticsearch.client.ccr.FollowInfoResponse.FollowerInfo;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.client.AbstractResponseTestCase;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ccr.action.FollowInfoAction;
+import org.elasticsearch.xpack.core.ccr.action.FollowParameters;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
-import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
-public class FollowInfoResponseTests extends ESTestCase {
+public class FollowInfoResponseTests extends AbstractResponseTestCase<FollowInfoAction.Response, FollowInfoResponse> {
 
-    public void testFromXContent() throws IOException {
-        xContentTester(this::createParser,
-            FollowInfoResponseTests::createTestInstance,
-            FollowInfoResponseTests::toXContent,
-            FollowInfoResponse::fromXContent)
-            .supportsUnknownFields(true)
-            .test();
-    }
-
-    private static void toXContent(FollowInfoResponse response, XContentBuilder builder) throws IOException {
-        builder.startObject();
-        builder.startArray(FollowInfoResponse.FOLLOWER_INDICES_FIELD.getPreferredName());
-        for (FollowerInfo info : response.getInfos()) {
-            builder.startObject();
-            builder.field(FollowerInfo.FOLLOWER_INDEX_FIELD.getPreferredName(), info.getFollowerIndex());
-            builder.field(FollowerInfo.REMOTE_CLUSTER_FIELD.getPreferredName(), info.getRemoteCluster());
-            builder.field(FollowerInfo.LEADER_INDEX_FIELD.getPreferredName(), info.getLeaderIndex());
-            builder.field(FollowerInfo.STATUS_FIELD.getPreferredName(), info.getStatus().getName());
-            if (info.getParameters() != null) {
-                builder.startObject(FollowerInfo.PARAMETERS_FIELD.getPreferredName());
-                {
-                    info.getParameters().toXContentFragment(builder, ToXContent.EMPTY_PARAMS);
-                }
-                builder.endObject();
-            }
-            builder.endObject();
-        }
-        builder.endArray();
-        builder.endObject();
-    }
-
-    private static FollowInfoResponse createTestInstance() {
-        int numInfos = randomIntBetween(0, 64);
-        List<FollowerInfo> infos = new ArrayList<>(numInfos);
+    @Override
+    protected FollowInfoAction.Response createServerTestInstance() {
+        int numInfos = randomIntBetween(0, 32);
+        List<FollowInfoAction.Response.FollowerInfo> infos = new ArrayList<>(numInfos);
         for (int i = 0; i < numInfos; i++) {
-            FollowInfoResponse.Status status = randomFrom(FollowInfoResponse.Status.values());
-            FollowConfig followConfig = randomBoolean() ? FollowConfigTests.createTestInstance() : null;
-            infos.add(new FollowerInfo(randomAlphaOfLength(4), randomAlphaOfLength(4), randomAlphaOfLength(4), status, followConfig));
+            FollowParameters followParameters = null;
+            if (randomBoolean()) {
+                followParameters = randomFollowParameters();
+            }
+
+            infos.add(new FollowInfoAction.Response.FollowerInfo(randomAlphaOfLength(4), randomAlphaOfLength(4), randomAlphaOfLength(4),
+                randomFrom(FollowInfoAction.Response.Status.values()), followParameters));
         }
-        return new FollowInfoResponse(infos);
+        return new FollowInfoAction.Response(infos);
+    }
+
+    static FollowParameters randomFollowParameters() {
+        FollowParameters followParameters = new FollowParameters();
+        followParameters.setMaxOutstandingReadRequests(randomIntBetween(0, Integer.MAX_VALUE));
+        followParameters.setMaxOutstandingWriteRequests(randomIntBetween(0, Integer.MAX_VALUE));
+        followParameters.setMaxReadRequestOperationCount(randomIntBetween(0, Integer.MAX_VALUE));
+        followParameters.setMaxWriteRequestOperationCount(randomIntBetween(0, Integer.MAX_VALUE));
+        followParameters.setMaxReadRequestSize(new ByteSizeValue(randomNonNegativeLong()));
+        followParameters.setMaxWriteRequestSize(new ByteSizeValue(randomNonNegativeLong()));
+        followParameters.setMaxWriteBufferCount(randomIntBetween(0, Integer.MAX_VALUE));
+        followParameters.setMaxWriteBufferSize(new ByteSizeValue(randomNonNegativeLong()));
+        followParameters.setMaxRetryDelay(new TimeValue(randomNonNegativeLong()));
+        followParameters.setReadPollTimeout(new TimeValue(randomNonNegativeLong()));
+        return followParameters;
+    }
+
+    @Override
+    protected FollowInfoResponse doParseToClientInstance(XContentParser parser) throws IOException {
+        return FollowInfoResponse.fromXContent(parser);
+    }
+
+    @Override
+    protected void assertInstances(FollowInfoAction.Response serverTestInstance, FollowInfoResponse clientInstance) {
+        assertThat(serverTestInstance.getFollowInfos().size(), equalTo(clientInstance.getInfos().size()));
+        for (int i = 0; i < serverTestInstance.getFollowInfos().size(); i++) {
+            FollowInfoAction.Response.FollowerInfo serverFollowInfo = serverTestInstance.getFollowInfos().get(i);
+            FollowInfoResponse.FollowerInfo clientFollowerInfo = clientInstance.getInfos().get(i);
+
+            assertThat(serverFollowInfo.getRemoteCluster(), equalTo(clientFollowerInfo.getRemoteCluster()));
+            assertThat(serverFollowInfo.getLeaderIndex(), equalTo(clientFollowerInfo.getLeaderIndex()));
+            assertThat(serverFollowInfo.getFollowerIndex(), equalTo(clientFollowerInfo.getFollowerIndex()));
+            assertThat(serverFollowInfo.getStatus().toString().toLowerCase(Locale.ROOT),
+                equalTo(clientFollowerInfo.getStatus().getName().toLowerCase(Locale.ROOT)));
+
+            FollowParameters serverParams = serverFollowInfo.getParameters();
+            FollowConfig clientParams = clientFollowerInfo.getParameters();
+            if (serverParams != null) {
+                assertThat(serverParams.getMaxReadRequestOperationCount(), equalTo(clientParams.getMaxReadRequestOperationCount()));
+                assertThat(serverParams.getMaxWriteRequestOperationCount(), equalTo(clientParams.getMaxWriteRequestOperationCount()));
+                assertThat(serverParams.getMaxOutstandingReadRequests(), equalTo(clientParams.getMaxOutstandingReadRequests()));
+                assertThat(serverParams.getMaxOutstandingWriteRequests(), equalTo(clientParams.getMaxOutstandingWriteRequests()));
+                assertThat(serverParams.getMaxReadRequestSize(), equalTo(clientParams.getMaxReadRequestSize()));
+                assertThat(serverParams.getMaxWriteRequestSize(), equalTo(clientParams.getMaxWriteRequestSize()));
+                assertThat(serverParams.getMaxWriteBufferCount(), equalTo(clientParams.getMaxWriteBufferCount()));
+                assertThat(serverParams.getMaxWriteBufferSize(), equalTo(clientParams.getMaxWriteBufferSize()));
+                assertThat(serverParams.getMaxRetryDelay(), equalTo(clientParams.getMaxRetryDelay()));
+                assertThat(serverParams.getReadPollTimeout(), equalTo(clientParams.getReadPollTimeout()));
+            } else {
+                assertThat(clientParams, nullValue());
+            }
+        }
     }
 
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/FollowStatsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/FollowStatsResponseTests.java
@@ -20,234 +20,115 @@
 package org.elasticsearch.client.ccr;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.client.ccr.IndicesFollowStats.ShardFollowStats;
 import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ccr.ShardFollowNodeTaskStatus;
+import org.elasticsearch.xpack.core.ccr.action.FollowStatsAction;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
+import java.util.TreeMap;
 
-import static org.elasticsearch.client.ccr.CcrStatsResponseTests.randomIndicesFollowStats;
-import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
+import static org.elasticsearch.client.ccr.CcrStatsResponseTests.createStatsResponse;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
-public class FollowStatsResponseTests extends ESTestCase {
+public class FollowStatsResponseTests extends AbstractResponseTestCase<FollowStatsAction.StatsResponses, FollowStatsResponse> {
 
-    public void testFromXContent() throws IOException {
-        xContentTester(this::createParser,
-            FollowStatsResponseTests::createTestInstance,
-            FollowStatsResponseTests::toXContent,
-            FollowStatsResponse::fromXContent)
-            .supportsUnknownFields(true)
-            .assertEqualsConsumer(FollowStatsResponseTests::assertEqualInstances)
-            .assertToXContentEquivalence(false)
-            .test();
+    @Override
+    protected FollowStatsAction.StatsResponses createServerTestInstance() {
+        return createStatsResponse();
     }
 
-    // Needed, because exceptions in IndicesFollowStats cannot be compared
-    private static void assertEqualInstances(FollowStatsResponse expectedInstance, FollowStatsResponse newInstance) {
-        assertNotSame(expectedInstance, newInstance);
-        {
-            IndicesFollowStats newIndicesFollowStats = newInstance.getIndicesFollowStats();
-            IndicesFollowStats expectedIndicesFollowStats = expectedInstance.getIndicesFollowStats();
-            assertThat(newIndicesFollowStats.getShardFollowStats().size(),
-                equalTo(expectedIndicesFollowStats.getShardFollowStats().size()));
-            assertThat(newIndicesFollowStats.getShardFollowStats().keySet(),
-                equalTo(expectedIndicesFollowStats.getShardFollowStats().keySet()));
-            for (Map.Entry<String, List<ShardFollowStats>> indexEntry : newIndicesFollowStats.getShardFollowStats().entrySet()) {
-                List<ShardFollowStats> newStats = indexEntry.getValue();
-                List<ShardFollowStats> expectedStats = expectedIndicesFollowStats.getShardFollowStats(indexEntry.getKey());
-                assertThat(newStats.size(), equalTo(expectedStats.size()));
-                for (int i = 0; i < newStats.size(); i++) {
-                    ShardFollowStats actualShardFollowStats = newStats.get(i);
-                    ShardFollowStats expectedShardFollowStats = expectedStats.get(i);
+    @Override
+    protected FollowStatsResponse doParseToClientInstance(XContentParser parser) throws IOException {
+        return FollowStatsResponse.fromXContent(parser);
+    }
 
-                    assertThat(actualShardFollowStats.getRemoteCluster(), equalTo(expectedShardFollowStats.getRemoteCluster()));
-                    assertThat(actualShardFollowStats.getLeaderIndex(), equalTo(expectedShardFollowStats.getLeaderIndex()));
-                    assertThat(actualShardFollowStats.getFollowerIndex(), equalTo(expectedShardFollowStats.getFollowerIndex()));
-                    assertThat(actualShardFollowStats.getShardId(), equalTo(expectedShardFollowStats.getShardId()));
-                    assertThat(actualShardFollowStats.getLeaderGlobalCheckpoint(),
-                        equalTo(expectedShardFollowStats.getLeaderGlobalCheckpoint()));
-                    assertThat(actualShardFollowStats.getLeaderMaxSeqNo(), equalTo(expectedShardFollowStats.getLeaderMaxSeqNo()));
-                    assertThat(actualShardFollowStats.getFollowerGlobalCheckpoint(),
-                        equalTo(expectedShardFollowStats.getFollowerGlobalCheckpoint()));
-                    assertThat(actualShardFollowStats.getLastRequestedSeqNo(), equalTo(expectedShardFollowStats.getLastRequestedSeqNo()));
-                    assertThat(actualShardFollowStats.getOutstandingReadRequests(),
-                        equalTo(expectedShardFollowStats.getOutstandingReadRequests()));
-                    assertThat(actualShardFollowStats.getOutstandingWriteRequests(),
-                        equalTo(expectedShardFollowStats.getOutstandingWriteRequests()));
-                    assertThat(actualShardFollowStats.getWriteBufferOperationCount(),
-                        equalTo(expectedShardFollowStats.getWriteBufferOperationCount()));
-                    assertThat(actualShardFollowStats.getFollowerMappingVersion(),
-                        equalTo(expectedShardFollowStats.getFollowerMappingVersion()));
-                    assertThat(actualShardFollowStats.getFollowerSettingsVersion(),
-                        equalTo(expectedShardFollowStats.getFollowerSettingsVersion()));
-                    assertThat(actualShardFollowStats.getTotalReadTimeMillis(),
-                        equalTo(expectedShardFollowStats.getTotalReadTimeMillis()));
-                    assertThat(actualShardFollowStats.getSuccessfulReadRequests(),
-                        equalTo(expectedShardFollowStats.getSuccessfulReadRequests()));
-                    assertThat(actualShardFollowStats.getFailedReadRequests(), equalTo(expectedShardFollowStats.getFailedReadRequests()));
-                    assertThat(actualShardFollowStats.getOperationsReads(), equalTo(expectedShardFollowStats.getOperationsReads()));
-                    assertThat(actualShardFollowStats.getBytesRead(), equalTo(expectedShardFollowStats.getBytesRead()));
-                    assertThat(actualShardFollowStats.getTotalWriteTimeMillis(),
-                        equalTo(expectedShardFollowStats.getTotalWriteTimeMillis()));
-                    assertThat(actualShardFollowStats.getSuccessfulWriteRequests(),
-                        equalTo(expectedShardFollowStats.getSuccessfulWriteRequests()));
-                    assertThat(actualShardFollowStats.getFailedWriteRequests(),
-                        equalTo(expectedShardFollowStats.getFailedWriteRequests()));
-                    assertThat(actualShardFollowStats.getOperationWritten(), equalTo(expectedShardFollowStats.getOperationWritten()));
-                    assertThat(actualShardFollowStats.getReadExceptions().size(),
-                        equalTo(expectedShardFollowStats.getReadExceptions().size()));
-                    assertThat(actualShardFollowStats.getReadExceptions().keySet(),
-                        equalTo(expectedShardFollowStats.getReadExceptions().keySet()));
-                    for (final Map.Entry<Long, Tuple<Integer, ElasticsearchException>> entry :
-                        actualShardFollowStats.getReadExceptions().entrySet()) {
-                        final Tuple<Integer, ElasticsearchException> expectedTuple =
-                            expectedShardFollowStats.getReadExceptions().get(entry.getKey());
-                        assertThat(entry.getValue().v1(), equalTo(expectedTuple.v1()));
-                        // x-content loses the exception
-                        final ElasticsearchException expected = expectedTuple.v2();
-                        assertThat(entry.getValue().v2().getMessage(), containsString(expected.getMessage()));
-                        assertNotNull(entry.getValue().v2().getCause());
-                        assertThat(
-                            entry.getValue().v2().getCause(),
-                            anyOf(instanceOf(ElasticsearchException.class), instanceOf(IllegalStateException.class)));
-                        assertThat(entry.getValue().v2().getCause().getMessage(), containsString(expected.getCause().getMessage()));
-                    }
-                    assertThat(actualShardFollowStats.getTimeSinceLastReadMillis(),
-                        equalTo(expectedShardFollowStats.getTimeSinceLastReadMillis()));
+    @Override
+    protected void assertInstances(FollowStatsAction.StatsResponses serverTestInstance, FollowStatsResponse clientInstance) {
+        IndicesFollowStats newIndicesFollowStats = clientInstance.getIndicesFollowStats();
+
+        // sort by index name, then shard ID
+        final Map<String, Map<Integer, FollowStatsAction.StatsResponse>> expectedIndicesFollowStats = new TreeMap<>();
+        for (final FollowStatsAction.StatsResponse statsResponse : serverTestInstance.getStatsResponses()) {
+            expectedIndicesFollowStats.computeIfAbsent(
+                statsResponse.status().followerIndex(),
+                k -> new TreeMap<>()).put(statsResponse.status().getShardId(), statsResponse);
+        }
+        assertThat(newIndicesFollowStats.getShardFollowStats().size(),
+            equalTo(expectedIndicesFollowStats.size()));
+        assertThat(newIndicesFollowStats.getShardFollowStats().keySet(),
+            equalTo(expectedIndicesFollowStats.keySet()));
+        for (Map.Entry<String, List<ShardFollowStats>> indexEntry : newIndicesFollowStats.getShardFollowStats().entrySet()) {
+            List<ShardFollowStats> newStats = indexEntry.getValue();
+            Map<Integer, FollowStatsAction.StatsResponse> expectedStats = expectedIndicesFollowStats.get(indexEntry.getKey());
+            assertThat(newStats.size(), equalTo(expectedStats.size()));
+            for (int i = 0; i < newStats.size(); i++) {
+                ShardFollowStats actualShardFollowStats = newStats.get(i);
+                ShardFollowNodeTaskStatus expectedShardFollowStats = expectedStats.get(actualShardFollowStats.getShardId()).status();
+
+                assertThat(actualShardFollowStats.getRemoteCluster(), equalTo(expectedShardFollowStats.getRemoteCluster()));
+                assertThat(actualShardFollowStats.getLeaderIndex(), equalTo(expectedShardFollowStats.leaderIndex()));
+                assertThat(actualShardFollowStats.getFollowerIndex(), equalTo(expectedShardFollowStats.followerIndex()));
+                assertThat(actualShardFollowStats.getShardId(), equalTo(expectedShardFollowStats.getShardId()));
+                assertThat(actualShardFollowStats.getLeaderGlobalCheckpoint(),
+                    equalTo(expectedShardFollowStats.leaderGlobalCheckpoint()));
+                assertThat(actualShardFollowStats.getLeaderMaxSeqNo(), equalTo(expectedShardFollowStats.leaderMaxSeqNo()));
+                assertThat(actualShardFollowStats.getFollowerGlobalCheckpoint(),
+                    equalTo(expectedShardFollowStats.followerGlobalCheckpoint()));
+                assertThat(actualShardFollowStats.getLastRequestedSeqNo(), equalTo(expectedShardFollowStats.lastRequestedSeqNo()));
+                assertThat(actualShardFollowStats.getOutstandingReadRequests(),
+                    equalTo(expectedShardFollowStats.outstandingReadRequests()));
+                assertThat(actualShardFollowStats.getOutstandingWriteRequests(),
+                    equalTo(expectedShardFollowStats.outstandingWriteRequests()));
+                assertThat(actualShardFollowStats.getWriteBufferOperationCount(),
+                    equalTo(expectedShardFollowStats.writeBufferOperationCount()));
+                assertThat(actualShardFollowStats.getFollowerMappingVersion(),
+                    equalTo(expectedShardFollowStats.followerMappingVersion()));
+                assertThat(actualShardFollowStats.getFollowerSettingsVersion(),
+                    equalTo(expectedShardFollowStats.followerSettingsVersion()));
+                assertThat(actualShardFollowStats.getTotalReadTimeMillis(),
+                    equalTo(expectedShardFollowStats.totalReadTimeMillis()));
+                assertThat(actualShardFollowStats.getSuccessfulReadRequests(),
+                    equalTo(expectedShardFollowStats.successfulReadRequests()));
+                assertThat(actualShardFollowStats.getFailedReadRequests(), equalTo(expectedShardFollowStats.failedReadRequests()));
+                assertThat(actualShardFollowStats.getOperationsReads(), equalTo(expectedShardFollowStats.operationsReads()));
+                assertThat(actualShardFollowStats.getBytesRead(), equalTo(expectedShardFollowStats.bytesRead()));
+                assertThat(actualShardFollowStats.getTotalWriteTimeMillis(),
+                    equalTo(expectedShardFollowStats.totalWriteTimeMillis()));
+                assertThat(actualShardFollowStats.getSuccessfulWriteRequests(),
+                    equalTo(expectedShardFollowStats.successfulWriteRequests()));
+                assertThat(actualShardFollowStats.getFailedWriteRequests(),
+                    equalTo(expectedShardFollowStats.failedWriteRequests()));
+                assertThat(actualShardFollowStats.getOperationWritten(), equalTo(expectedShardFollowStats.operationWritten()));
+                assertThat(actualShardFollowStats.getReadExceptions().size(),
+                    equalTo(expectedShardFollowStats.readExceptions().size()));
+                assertThat(actualShardFollowStats.getReadExceptions().keySet(),
+                    equalTo(expectedShardFollowStats.readExceptions().keySet()));
+                for (final Map.Entry<Long, Tuple<Integer, ElasticsearchException>> entry :
+                    actualShardFollowStats.getReadExceptions().entrySet()) {
+                    final Tuple<Integer, ElasticsearchException> expectedTuple =
+                        expectedShardFollowStats.readExceptions().get(entry.getKey());
+                    assertThat(entry.getValue().v1(), equalTo(expectedTuple.v1()));
+                    // x-content loses the exception
+                    final ElasticsearchException expected = expectedTuple.v2();
+                    assertThat(entry.getValue().v2().getMessage(), containsString(expected.getMessage()));
+                    assertNotNull(entry.getValue().v2().getCause());
+                    assertThat(
+                        entry.getValue().v2().getCause(),
+                        anyOf(instanceOf(ElasticsearchException.class), instanceOf(IllegalStateException.class)));
+                    assertThat(entry.getValue().v2().getCause().getMessage(), containsString(expected.getCause().getMessage()));
                 }
+                assertThat(actualShardFollowStats.getTimeSinceLastReadMillis(),
+                    equalTo(expectedShardFollowStats.timeSinceLastReadMillis()));
             }
         }
-    }
-
-    private static void toXContent(FollowStatsResponse response, XContentBuilder builder) throws IOException {
-        builder.startObject();
-        {
-            builder.startArray(IndicesFollowStats.INDICES_FIELD.getPreferredName());
-            for (Map.Entry<String, List<ShardFollowStats>> indexEntry :
-                response.getIndicesFollowStats().getShardFollowStats().entrySet()) {
-                builder.startObject();
-                {
-                    builder.field(IndicesFollowStats.INDEX_FIELD.getPreferredName(), indexEntry.getKey());
-                    builder.startArray(IndicesFollowStats.SHARDS_FIELD.getPreferredName());
-                    {
-                        for (ShardFollowStats stats : indexEntry.getValue()) {
-                            builder.startObject();
-                            {
-                                builder.field(ShardFollowStats.LEADER_CLUSTER.getPreferredName(), stats.getRemoteCluster());
-                                builder.field(ShardFollowStats.LEADER_INDEX.getPreferredName(), stats.getLeaderIndex());
-                                builder.field(ShardFollowStats.FOLLOWER_INDEX.getPreferredName(), stats.getFollowerIndex());
-                                builder.field(ShardFollowStats.SHARD_ID.getPreferredName(), stats.getShardId());
-                                builder.field(ShardFollowStats.LEADER_GLOBAL_CHECKPOINT_FIELD.getPreferredName(),
-                                    stats.getLeaderGlobalCheckpoint());
-                                builder.field(ShardFollowStats.LEADER_MAX_SEQ_NO_FIELD.getPreferredName(), stats.getLeaderMaxSeqNo());
-                                builder.field(ShardFollowStats.FOLLOWER_GLOBAL_CHECKPOINT_FIELD.getPreferredName(),
-                                    stats.getFollowerGlobalCheckpoint());
-                                builder.field(ShardFollowStats.FOLLOWER_MAX_SEQ_NO_FIELD.getPreferredName(),
-                                    stats.getFollowerMaxSeqNo());
-                                builder.field(ShardFollowStats.LAST_REQUESTED_SEQ_NO_FIELD.getPreferredName(),
-                                    stats.getLastRequestedSeqNo());
-                                builder.field(ShardFollowStats.OUTSTANDING_READ_REQUESTS.getPreferredName(),
-                                    stats.getOutstandingReadRequests());
-                                builder.field(ShardFollowStats.OUTSTANDING_WRITE_REQUESTS.getPreferredName(),
-                                    stats.getOutstandingWriteRequests());
-                                builder.field(ShardFollowStats.WRITE_BUFFER_OPERATION_COUNT_FIELD.getPreferredName(),
-                                    stats.getWriteBufferOperationCount());
-                                builder.humanReadableField(
-                                    ShardFollowStats.WRITE_BUFFER_SIZE_IN_BYTES_FIELD.getPreferredName(),
-                                    "write_buffer_size",
-                                    new ByteSizeValue(stats.getWriteBufferSizeInBytes()));
-                                builder.field(ShardFollowStats.FOLLOWER_MAPPING_VERSION_FIELD.getPreferredName(),
-                                    stats.getFollowerMappingVersion());
-                                builder.field(ShardFollowStats.FOLLOWER_SETTINGS_VERSION_FIELD.getPreferredName(),
-                                    stats.getFollowerSettingsVersion());
-                                builder.humanReadableField(
-                                    ShardFollowStats.TOTAL_READ_TIME_MILLIS_FIELD.getPreferredName(),
-                                    "total_read_time",
-                                    new TimeValue(stats.getTotalReadTimeMillis(), TimeUnit.MILLISECONDS));
-                                builder.humanReadableField(
-                                    ShardFollowStats.TOTAL_READ_REMOTE_EXEC_TIME_MILLIS_FIELD.getPreferredName(),
-                                    "total_read_remote_exec_time",
-                                    new TimeValue(stats.getTotalReadRemoteExecTimeMillis(), TimeUnit.MILLISECONDS));
-                                builder.field(ShardFollowStats.SUCCESSFUL_READ_REQUESTS_FIELD.getPreferredName(),
-                                    stats.getSuccessfulReadRequests());
-                                builder.field(ShardFollowStats.FAILED_READ_REQUESTS_FIELD.getPreferredName(),
-                                    stats.getFailedReadRequests());
-                                builder.field(ShardFollowStats.OPERATIONS_READ_FIELD.getPreferredName(), stats.getOperationsReads());
-                                builder.humanReadableField(
-                                    ShardFollowStats.BYTES_READ.getPreferredName(),
-                                    "total_read",
-                                    new ByteSizeValue(stats.getBytesRead(), ByteSizeUnit.BYTES));
-                                builder.humanReadableField(
-                                    ShardFollowStats.TOTAL_WRITE_TIME_MILLIS_FIELD.getPreferredName(),
-                                    "total_write_time",
-                                    new TimeValue(stats.getTotalWriteTimeMillis(), TimeUnit.MILLISECONDS));
-                                builder.field(ShardFollowStats.SUCCESSFUL_WRITE_REQUESTS_FIELD.getPreferredName(),
-                                    stats.getSuccessfulWriteRequests());
-                                builder.field(ShardFollowStats.FAILED_WRITE_REQUEST_FIELD.getPreferredName(),
-                                    stats.getFailedWriteRequests());
-                                builder.field(ShardFollowStats.OPERATIONS_WRITTEN.getPreferredName(), stats.getOperationWritten());
-                                builder.startArray(ShardFollowStats.READ_EXCEPTIONS.getPreferredName());
-                                {
-                                    for (final Map.Entry<Long, Tuple<Integer, ElasticsearchException>> entry :
-                                        stats.getReadExceptions().entrySet()) {
-                                        builder.startObject();
-                                        {
-                                            builder.field(ShardFollowStats.READ_EXCEPTIONS_ENTRY_FROM_SEQ_NO.getPreferredName(),
-                                                entry.getKey());
-                                            builder.field(ShardFollowStats.READ_EXCEPTIONS_RETRIES.getPreferredName(),
-                                                entry.getValue().v1());
-                                            builder.field(ShardFollowStats.READ_EXCEPTIONS_ENTRY_EXCEPTION.getPreferredName());
-                                            builder.startObject();
-                                            {
-                                                ElasticsearchException.generateThrowableXContent(builder, ToXContent.EMPTY_PARAMS,
-                                                    entry.getValue().v2());
-                                            }
-                                            builder.endObject();
-                                        }
-                                        builder.endObject();
-                                    }
-                                }
-                                builder.endArray();
-                                builder.humanReadableField(
-                                    ShardFollowStats.TIME_SINCE_LAST_READ_MILLIS_FIELD.getPreferredName(),
-                                    "time_since_last_read",
-                                    new TimeValue(stats.getTimeSinceLastReadMillis(), TimeUnit.MILLISECONDS));
-                                if (stats.getFatalException() != null) {
-                                    builder.field(ShardFollowStats.FATAL_EXCEPTION.getPreferredName());
-                                    builder.startObject();
-                                    {
-                                        ElasticsearchException.generateThrowableXContent(builder, ToXContent.EMPTY_PARAMS,
-                                            stats.getFatalException());
-                                    }
-                                    builder.endObject();
-                                }
-                            }
-                            builder.endObject();
-                        }
-                    }
-                    builder.endArray();
-                }
-                builder.endObject();
-            }
-            builder.endArray();
-        }
-        builder.endObject();
-    }
-
-    private static FollowStatsResponse createTestInstance() {
-        return new FollowStatsResponse(randomIndicesFollowStats());
     }
 
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/GetAutoFollowPatternResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/GetAutoFollowPatternResponseTests.java
@@ -19,99 +19,111 @@
 
 package org.elasticsearch.client.ccr;
 
+import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ccr.AutoFollowMetadata;
+import org.elasticsearch.xpack.core.ccr.action.GetAutoFollowPatternAction;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 
-import static org.elasticsearch.client.ccr.PutAutoFollowPatternRequest.FOLLOW_PATTERN_FIELD;
-import static org.elasticsearch.client.ccr.PutAutoFollowPatternRequest.LEADER_PATTERNS_FIELD;
-import static org.elasticsearch.client.ccr.PutFollowRequest.REMOTE_CLUSTER_FIELD;
-import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
-public class GetAutoFollowPatternResponseTests extends ESTestCase {
+public class GetAutoFollowPatternResponseTests extends AbstractResponseTestCase<
+    GetAutoFollowPatternAction.Response,
+    GetAutoFollowPatternResponse> {
 
-    public void testFromXContent() throws IOException {
-        xContentTester(this::createParser,
-            this::createTestInstance,
-            GetAutoFollowPatternResponseTests::toXContent,
-            GetAutoFollowPatternResponse::fromXContent)
-            .supportsUnknownFields(true)
-            .test();
-    }
-
-    private GetAutoFollowPatternResponse createTestInstance() {
+    @Override
+    protected GetAutoFollowPatternAction.Response createServerTestInstance() {
         int numPatterns = randomIntBetween(0, 16);
-        NavigableMap<String, GetAutoFollowPatternResponse.Pattern> patterns = new TreeMap<>();
+        NavigableMap<String, AutoFollowMetadata.AutoFollowPattern> patterns = new TreeMap<>();
         for (int i = 0; i < numPatterns; i++) {
-            GetAutoFollowPatternResponse.Pattern pattern = new GetAutoFollowPatternResponse.Pattern(
-                randomAlphaOfLength(4), Collections.singletonList(randomAlphaOfLength(4)), randomAlphaOfLength(4));
+            String remoteCluster = randomAlphaOfLength(4);
+            List<String> leaderIndexPatters = Collections.singletonList(randomAlphaOfLength(4));
+            String followIndexNamePattern = randomAlphaOfLength(4);
+
+            Integer maxOutstandingReadRequests = null;
             if (randomBoolean()) {
-                pattern.setMaxOutstandingReadRequests(randomIntBetween(0, Integer.MAX_VALUE));
+                maxOutstandingReadRequests = randomIntBetween(0, Integer.MAX_VALUE);
             }
+            Integer maxOutstandingWriteRequests = null;
             if (randomBoolean()) {
-                pattern.setMaxOutstandingWriteRequests(randomIntBetween(0, Integer.MAX_VALUE));
+                maxOutstandingWriteRequests = randomIntBetween(0, Integer.MAX_VALUE);
             }
+            Integer maxReadRequestOperationCount = null;
             if (randomBoolean()) {
-                pattern.setMaxReadRequestOperationCount(randomIntBetween(0, Integer.MAX_VALUE));
+                maxReadRequestOperationCount = randomIntBetween(0, Integer.MAX_VALUE);
             }
+            ByteSizeValue maxReadRequestSize = null;
             if (randomBoolean()) {
-                pattern.setMaxReadRequestSize(new ByteSizeValue(randomNonNegativeLong()));
+                maxReadRequestSize = new ByteSizeValue(randomNonNegativeLong());
             }
+            Integer maxWriteBufferCount = null;
             if (randomBoolean()) {
-                pattern.setMaxWriteBufferCount(randomIntBetween(0, Integer.MAX_VALUE));
+                maxWriteBufferCount = randomIntBetween(0, Integer.MAX_VALUE);
             }
+            ByteSizeValue maxWriteBufferSize = null;
             if (randomBoolean()) {
-                pattern.setMaxWriteBufferSize(new ByteSizeValue(randomNonNegativeLong()));
+                maxWriteBufferSize = new ByteSizeValue(randomNonNegativeLong());
             }
+            Integer maxWriteRequestOperationCount = null;
             if (randomBoolean()) {
-                pattern.setMaxWriteRequestOperationCount(randomIntBetween(0, Integer.MAX_VALUE));
+                maxWriteRequestOperationCount = randomIntBetween(0, Integer.MAX_VALUE);
             }
+            ByteSizeValue maxWriteRequestSize = null;
             if (randomBoolean()) {
-                pattern.setMaxWriteRequestSize(new ByteSizeValue(randomNonNegativeLong()));
+                maxWriteRequestSize = new ByteSizeValue(randomNonNegativeLong());
             }
+            TimeValue maxRetryDelay =  null;
             if (randomBoolean()) {
-                pattern.setMaxRetryDelay(new TimeValue(randomNonNegativeLong()));
+                maxRetryDelay = new TimeValue(randomNonNegativeLong());
             }
+            TimeValue readPollTimeout = null;
             if (randomBoolean()) {
-                pattern.setReadPollTimeout(new TimeValue(randomNonNegativeLong()));
+                readPollTimeout = new TimeValue(randomNonNegativeLong());
             }
-            patterns.put(randomAlphaOfLength(4), pattern);
+            patterns.put(randomAlphaOfLength(4), new AutoFollowMetadata.AutoFollowPattern(remoteCluster, leaderIndexPatters,
+                followIndexNamePattern, maxReadRequestOperationCount, maxWriteRequestOperationCount, maxOutstandingReadRequests,
+                maxOutstandingWriteRequests, maxReadRequestSize, maxWriteRequestSize, maxWriteBufferCount, maxWriteBufferSize,
+                maxRetryDelay, readPollTimeout));
         }
-        return new GetAutoFollowPatternResponse(patterns);
+        return new GetAutoFollowPatternAction.Response(patterns);
     }
 
-    public static void toXContent(GetAutoFollowPatternResponse response, XContentBuilder builder) throws IOException {
-        builder.startObject();
-        {
-            builder.startArray(GetAutoFollowPatternResponse.PATTERNS_FIELD.getPreferredName());
-            for (Map.Entry<String, GetAutoFollowPatternResponse.Pattern> entry : response.getPatterns().entrySet()) {
-                builder.startObject();
-                {
-                    builder.field(GetAutoFollowPatternResponse.NAME_FIELD.getPreferredName(), entry.getKey());
-                    builder.startObject(GetAutoFollowPatternResponse.PATTERN_FIELD.getPreferredName());
-                    {
-                        GetAutoFollowPatternResponse.Pattern pattern = entry.getValue();
-                        builder.field(REMOTE_CLUSTER_FIELD.getPreferredName(), pattern.getRemoteCluster());
-                        builder.field(LEADER_PATTERNS_FIELD.getPreferredName(), pattern.getLeaderIndexPatterns());
-                        if (pattern.getFollowIndexNamePattern()!= null) {
-                            builder.field(FOLLOW_PATTERN_FIELD.getPreferredName(), pattern.getFollowIndexNamePattern());
-                        }
-                        entry.getValue().toXContentFragment(builder, ToXContent.EMPTY_PARAMS);
-                    }
-                    builder.endObject();
-                }
-                builder.endObject();
-            }
-            builder.endArray();
-        }
-        builder.endObject();
+    @Override
+    protected GetAutoFollowPatternResponse doParseToClientInstance(XContentParser parser) throws IOException {
+        return GetAutoFollowPatternResponse.fromXContent(parser);
     }
+
+    @Override
+    protected void assertInstances(GetAutoFollowPatternAction.Response serverTestInstance, GetAutoFollowPatternResponse clientInstance) {
+        assertThat(serverTestInstance.getAutoFollowPatterns().size(), equalTo(clientInstance.getPatterns().size()));
+        for (Map.Entry<String, AutoFollowMetadata.AutoFollowPattern> entry : serverTestInstance.getAutoFollowPatterns().entrySet()) {
+            AutoFollowMetadata.AutoFollowPattern serverPattern = entry.getValue();
+            GetAutoFollowPatternResponse.Pattern clientPattern = clientInstance.getPatterns().get(entry.getKey());
+            assertThat(clientPattern, notNullValue());
+
+            assertThat(serverPattern.getRemoteCluster(), equalTo(clientPattern.getRemoteCluster()));
+            assertThat(serverPattern.getLeaderIndexPatterns(), equalTo(clientPattern.getLeaderIndexPatterns()));
+            assertThat(serverPattern.getFollowIndexPattern(), equalTo(clientPattern.getFollowIndexNamePattern()));
+            assertThat(serverPattern.getMaxOutstandingReadRequests(), equalTo(clientPattern.getMaxOutstandingReadRequests()));
+            assertThat(serverPattern.getMaxOutstandingWriteRequests(), equalTo(clientPattern.getMaxOutstandingWriteRequests()));
+            assertThat(serverPattern.getMaxReadRequestOperationCount(), equalTo(clientPattern.getMaxReadRequestOperationCount()));
+            assertThat(serverPattern.getMaxWriteRequestOperationCount(), equalTo(clientPattern.getMaxWriteRequestOperationCount()));
+            assertThat(serverPattern.getMaxReadRequestSize(), equalTo(clientPattern.getMaxReadRequestSize()));
+            assertThat(serverPattern.getMaxWriteRequestSize(), equalTo(clientPattern.getMaxWriteRequestSize()));
+            assertThat(serverPattern.getMaxWriteBufferCount(), equalTo(clientPattern.getMaxWriteBufferCount()));
+            assertThat(serverPattern.getMaxWriteBufferSize(), equalTo(clientPattern.getMaxWriteBufferSize()));
+            assertThat(serverPattern.getMaxRetryDelay(), equalTo(clientPattern.getMaxRetryDelay()));
+            assertThat(serverPattern.getReadPollTimeout(), equalTo(clientPattern.getReadPollTimeout()));
+        }
+    }
+
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/PutFollowResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/PutFollowResponseTests.java
@@ -19,35 +19,30 @@
 
 package org.elasticsearch.client.ccr;
 
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.client.AbstractResponseTestCase;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ccr.action.PutFollowAction;
 
 import java.io.IOException;
 
-import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
+import static org.hamcrest.Matchers.is;
 
-public class PutFollowResponseTests extends ESTestCase {
+public class PutFollowResponseTests extends AbstractResponseTestCase<PutFollowAction.Response, PutFollowResponse> {
 
-    public void testFromXContent() throws IOException {
-        xContentTester(this::createParser,
-            this::createTestInstance,
-            PutFollowResponseTests::toXContent,
-            PutFollowResponse::fromXContent)
-            .supportsUnknownFields(true)
-            .test();
+    @Override
+    protected PutFollowAction.Response createServerTestInstance() {
+        return new PutFollowAction.Response(randomBoolean(), randomBoolean(), randomBoolean());
     }
 
-    private PutFollowResponse createTestInstance() {
-        return new PutFollowResponse(randomBoolean(), randomBoolean(), randomBoolean());
+    @Override
+    protected PutFollowResponse doParseToClientInstance(XContentParser parser) throws IOException {
+        return PutFollowResponse.fromXContent(parser);
     }
 
-    public static void toXContent(PutFollowResponse response, XContentBuilder builder) throws IOException {
-        builder.startObject();
-        {
-            builder.field(PutFollowResponse.FOLLOW_INDEX_CREATED.getPreferredName(), response.isFollowIndexCreated());
-            builder.field(PutFollowResponse.FOLLOW_INDEX_SHARDS_ACKED.getPreferredName(), response.isFollowIndexShardsAcked());
-            builder.field(PutFollowResponse.INDEX_FOLLOWING_STARTED.getPreferredName(), response.isIndexFollowingStarted());
-        }
-        builder.endObject();
+    @Override
+    protected void assertInstances(PutFollowAction.Response serverTestInstance, PutFollowResponse clientInstance) {
+        assertThat(serverTestInstance.isFollowIndexCreated(), is(clientInstance.isFollowIndexCreated()));
+        assertThat(serverTestInstance.isFollowIndexShardsAcked(), is(clientInstance.isFollowIndexShardsAcked()));
+        assertThat(serverTestInstance.isIndexFollowingStarted(), is(clientInstance.isIndexFollowingStarted()));
     }
 }


### PR DESCRIPTION
Now that #40877 is in, the [commit](df91237a94fd3d3ae954eb1845c434dda692d087) that reverted #40257 can now be un-reverted.