### PR TITLE
[DOCS] Document limits for JSON objects with `ignore_malformed` mapping setting

### DIFF
--- a/docs/reference/mapping/params/ignore-malformed.asciidoc
+++ b/docs/reference/mapping/params/ignore-malformed.asciidoc
@@ -91,3 +91,13 @@ become meaningless. Elasticsearch makes it easy to check how many documents
 have malformed fields by using `exist` or `term` queries on the special
 <<mapping-ignored-field,`_ignored`>> field.
 
+==== Limits for JSON Objects
+
+You can't use `ignore_malformed` to index JSON objects into field datatypes used
+for other data formats, like `text` or `integer`.
+
+Similarly, `ignore_malformed` does not support datatypes used for JSON objects, including:
+
+* <<nested, Nested datatype>>
+* <<object, Object datatype>>
+* <<range, Range datatypes>>

--- a/docs/reference/mapping/params/ignore-malformed.asciidoc
+++ b/docs/reference/mapping/params/ignore-malformed.asciidoc
@@ -92,12 +92,15 @@ have malformed fields by using `exist` or `term` queries on the special
 <<mapping-ignored-field,`_ignored`>> field.
 
 ==== Limits for JSON Objects
-
-You can't use `ignore_malformed` to index JSON objects into field datatypes used
-for other data formats, like `text` or `integer`.
-
-Similarly, `ignore_malformed` does not support datatypes used for JSON objects, including:
+You can't use `ignore_malformed` with the following datatypes:
 
 * <<nested, Nested datatype>>
 * <<object, Object datatype>>
 * <<range, Range datatypes>>
+
+You also can't use `ignore_malformed` to ignore JSON objects submitted to fields
+of the wrong datatype. A JSON object is any data surrounded by curly brackets
+`"{}"` and includes data mapped to the nested, object, and range datatypes.
+
+If you submit a JSON object to an unsupported field, {es} will return an error
+and reject the entire document regardless of the `ignore_malformed` setting.


### PR DESCRIPTION
As of this writing,`ignore_malformed` has two undocumented limits for JSON objects:

- `ignore_malformed` does not support datatypes intended for JSON objects, like `range` or `object`
- Other field types support `ignore_malformed` for any JSON data format _except_ JSON objects

This documents those limits. As #12366 notes, support for JSON objects may be added later. We can remove this section then.

Resolves #36464.