### PR TITLE
[DOCS] Fix broken link to Elasticsearch Docker source code

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -5,9 +5,9 @@
 The images use https://hub.docker.com/_/centos/[centos:7] as the base image.
 
 A list of all published Docker images and tags is available at
-https://www.docker.elastic.co[www.docker.elastic.co]. The source Dockerfile is
-in
-https://github.com/elastic/elasticsearch/blob/{branch}/distribution/docker/src/docker/Dockerfile[Github].
+https://www.docker.elastic.co[www.docker.elastic.co]. The source files
+are in
+https://github.com/elastic/elasticsearch/blob/{branch}/distribution/docker[Github].
 
 These images are free to use under the Elastic license. They contain open source 
 and free commercial features and access to paid commercial features.  

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -5,8 +5,9 @@
 The images use https://hub.docker.com/_/centos/[centos:7] as the base image.
 
 A list of all published Docker images and tags is available at
-https://www.docker.elastic.co[www.docker.elastic.co]. The source code is in
-https://github.com/elastic/elasticsearch-docker/tree/master[GitHub].
+https://www.docker.elastic.co[www.docker.elastic.co]. The source Dockerfile is
+in
+https://github.com/elastic/elasticsearch/blob/{branch}/distribution/docker/src/docker/Dockerfile[Github].
 
 These images are free to use under the Elastic license. They contain open source 
 and free commercial features and access to paid commercial features.  

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -6,7 +6,7 @@ The images use https://hub.docker.com/_/centos/[centos:7] as the base image.
 
 A list of all published Docker images and tags is available at
 https://www.docker.elastic.co[www.docker.elastic.co]. The source code is in
-https://github.com/elastic/elasticsearch-docker/tree/{branch}[GitHub].
+https://github.com/elastic/elasticsearch-docker/tree/master[GitHub].
 
 These images are free to use under the Elastic license. They contain open source 
 and free commercial features and access to paid commercial features.  


### PR DESCRIPTION
In our [Docker installation instructions](https://www.elastic.co/guide/en/elasticsearch/reference/master/docker.html), we link to the source code for the official Elasticsearch Docker image in the elastic/elasticsearch-docker repo.

With 6.6, we relocated the Docker files to the elastic/elasticsearch repo at https://github.com/elastic/elasticsearch/tree/master/distribution/docker. This points the link to that new location.

Resolves #40813.