### PR TITLE
[DOCS] Add notable-breaking-changes tags

### DIFF
--- a/docs/reference/migration/migrate_8_0/analysis.asciidoc
+++ b/docs/reference/migration/migrate_8_0/analysis.asciidoc
@@ -2,6 +2,13 @@
 [[breaking_80_analysis_changes]]
 === Analysis changes
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+// end::notable-breaking-changes[]
+
 [float]
 ==== The `nGram` and `edgeNGram` token filter names have been removed
 

--- a/docs/reference/migration/migrate_8_0/discovery.asciidoc
+++ b/docs/reference/migration/migrate_8_0/discovery.asciidoc
@@ -2,6 +2,13 @@
 [[breaking_80_discovery_changes]]
 === Discovery changes
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+// end::notable-breaking-changes[]
+
 [float]
 ==== Removal of old discovery settings
 

--- a/docs/reference/migration/migrate_8_0/java.asciidoc
+++ b/docs/reference/migration/migrate_8_0/java.asciidoc
@@ -2,6 +2,13 @@
 [[breaking_80_java_changes]]
 === Java API changes
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+// end::notable-breaking-changes[]
+
 [float]
 ==== Changes to Fuzziness
 

--- a/docs/reference/migration/migrate_8_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/mappings.asciidoc
@@ -2,6 +2,13 @@
 [[breaking_80_mappings_changes]]
 === Mapping changes
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+// end::notable-breaking-changes[]
+
 [float]
 ==== Limiting the number of completion contexts
 

--- a/docs/reference/migration/migrate_8_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_8_0/packaging.asciidoc
@@ -2,8 +2,8 @@
 [[breaking_80_packaging_changes]]
 === Packaging changes
 
-[float]
 //tag::notable-breaking-changes[]
+[float]
 ==== Java 11 is required
 
 Java 11 or higher is now required to run Elasticsearch and any of its command

--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -2,6 +2,13 @@
 [[breaking_80_security_changes]]
 === Security changes
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+// end::notable-breaking-changes[]
+
 [float]
 ==== The `accept_default_password` setting has been removed
 

--- a/docs/reference/migration/migrate_8_0/snapshots.asciidoc
+++ b/docs/reference/migration/migrate_8_0/snapshots.asciidoc
@@ -2,6 +2,13 @@
 [[breaking_80_snapshots_changes]]
 === Snapshot and Restore changes
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+// end::notable-breaking-changes[]
+
 [float]
 ==== Deprecated node level compress setting removed
 


### PR DESCRIPTION
This PR adds notable-breaking-changes tags to the files in the migration/migrate_8_0_0 folder, so that content in those files can be re-used in the Install and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/master/elasticsearch-breaking-changes.html)