### PR TITLE
SQL: Increase the interval filtering for current_date tests

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/date.csv-spec
@@ -35,21 +35,21 @@ SELECT TRUNCATE(YEAR(TODAY() - INTERVAL 50 YEARS) / 1000) AS result;
 ;
 
 
-currentDateFilter-Ignore
-SELECT first_name FROM test_emp WHERE hire_date > CURRENT_DATE() - INTERVAL 25 YEARS ORDER BY first_name ASC LIMIT 10;
+currentDateFilter
+SELECT first_name FROM test_emp WHERE hire_date > CURRENT_DATE() - INTERVAL 35 YEARS ORDER BY first_name ASC LIMIT 10;
 
     first_name
 -----------------
-Kazuhito
-Kenroku
-Lillian
-Mayumi
-Mingsen
-Sailaja
-Saniya
-Shahaf
-Suzette
-Tuval
+Alejandro      
+Amabile        
+Anneke         
+Anoosh         
+Arumugam       
+Basil          
+Berhard        
+Berni          
+Bezalel        
+Bojan          
 ;
 
 currentDateFilterScript

--- a/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
@@ -2400,17 +2400,17 @@ SELECT TODAY() AS result;
 // end::todayFunction
 ;
 
-filterToday-Ignore
+filterToday
 // tag::filterToday
-SELECT first_name FROM emp WHERE hire_date > TODAY() - INTERVAL 25 YEARS ORDER BY first_name ASC LIMIT 5;
+SELECT first_name FROM emp WHERE hire_date > TODAY() - INTERVAL 35 YEARS ORDER BY first_name ASC LIMIT 5;
 
  first_name
 ------------
-Kazuhito
-Kenroku
-Lillian
-Mayumi
-Mingsen
+Alejandro
+Amabile
+Anneke
+Anoosh
+Arumugam
 // end::filterToday
 ;
 


### PR DESCRIPTION
These two tests fail because the `hire_date` field used in the filtering is 1994 and for the document missing from the results the `hire_date` is 1994-04-09 (exactly 25 years from now :-) ). And the filters now don't match anymore on that specific day.

I've increased the filtering to 35 years interval.