### PR TITLE
Reindex from remote deprecation of escaped index

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuilders.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuilders.java
@@ -21,12 +21,14 @@ package org.elasticsearch.index.reindex.remote;
 
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -53,6 +55,13 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
  * because the version constants have been removed.
  */
 final class RemoteRequestBuilders {
+    private static final DeprecationLogger DEPRECATION_LOGGER
+        = new DeprecationLogger(LogManager.getLogger(RemoteRequestBuilders.class));
+
+    static final String DEPRECATED_URL_ENCODED_INDEX_WARNING =
+        "Specifying index name using URL escaped index names for reindex from remote is deprecated. " +
+        "Instead specify index name without URL escaping.";
+
     private RemoteRequestBuilders() {}
 
     static Request initialSearch(SearchRequest searchRequest, BytesReference query, Version remoteVersion) {
@@ -173,6 +182,7 @@ final class RemoteRequestBuilders {
     private static String encodeIndex(String s) {
         if (s.contains("%")) { // already encoded, pass-through to allow this in mixed version clusters
             checkIndexOrType("Index", s);
+            DEPRECATION_LOGGER.deprecated(DEPRECATED_URL_ENCODED_INDEX_WARNING);
             return s;
         }
         try {

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuildersTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuildersTests.java
@@ -37,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
+import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.DEPRECATED_URL_ENCODED_INDEX_WARNING;
 import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.clearScroll;
 import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.initialSearch;
 import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.scroll;
@@ -82,6 +83,8 @@ public class RemoteRequestBuildersTests extends ESTestCase {
         // pass-through if already escaped.
         searchRequest.indices("%2f", "%3a");
         assertEquals("/%2f,%3a/c,d/_search", initialSearch(searchRequest, query, remoteVersion).getEndpoint());
+
+        assertWarnings(DEPRECATED_URL_ENCODED_INDEX_WARNING);
 
         // do not allow , and / if already escaped.
         searchRequest.indices("%2fcat,");


### PR DESCRIPTION
If a reindex from remote request contains an index name that is URL
escaped, we now issue a warning to be able to not support this in 8.0.

Follow-up to #40303.