### PR TITLE
Restricts naming for repositories

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -35,6 +35,7 @@ import org.elasticsearch.cluster.metadata.RepositoriesMetaData;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
@@ -94,6 +95,7 @@ public class RepositoriesService implements ClusterStateApplier {
      */
     public void registerRepository(final PutRepositoryRequest request, final ActionListener<ClusterStateUpdateResponse> listener) {
         final RepositoryMetaData newRepositoryMetaData = new RepositoryMetaData(request.name(), request.type(), request.settings());
+        validate(request.name());
 
         final ActionListener<ClusterStateUpdateResponse> registrationListener;
         if (request.verify()) {
@@ -417,6 +419,20 @@ public class RepositoriesService implements ClusterStateApplier {
             throw new RepositoryException(repositoryMetaData.name(), "failed to create repository", e);
         }
     }
+
+    private static void validate(final String repositoryName) {
+        if (Strings.hasLength(repositoryName) == false) {
+            throw new RepositoryException(repositoryName, "cannot be empty");
+        }
+        if (repositoryName.contains("#")) {
+            throw new RepositoryException(repositoryName, "must not contain '#'");
+        }
+        if (Strings.validFileName(repositoryName) == false) {
+            throw new RepositoryException(repositoryName,
+                "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
+        }
+    }
+
 
     private void ensureRepositoryNotInUse(ClusterState clusterState, String repository) {
         if (SnapshotsService.isRepositoryInUse(clusterState, repository) || RestoreService.isRepositoryInUse(clusterState, repository)) {

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
@@ -104,18 +104,14 @@ public class RepositoriesServiceTests extends ESTestCase {
     }
 
     public void testRegisterRejectsInvalidRepositoryNames() {
-        List<String> invalidRepoNames = new ArrayList<>();
-        invalidRepoNames.add("");
-        invalidRepoNames.add("contains#InvalidCharacter");
+        assertThrowsOnRegister("");
+        assertThrowsOnRegister("contains#InvalidCharacter");
         for (char c : Strings.INVALID_FILENAME_CHARS) {
-            invalidRepoNames.add("contains" + c + "InvalidCharacters");
-        }
-        for (String repoName : invalidRepoNames) {
-            doTestRegisterRejectsInvalidRepositoryNames(repoName);
+            assertThrowsOnRegister("contains" + c + "InvalidCharacters");
         }
     }
 
-    private void doTestRegisterRejectsInvalidRepositoryNames(String repoName) {
+    private void assertThrowsOnRegister(String repoName) {
         PutRepositoryRequest request = new PutRepositoryRequest(repoName);
         expectThrows(RepositoryException.class, () -> repositoriesService.registerRepository(request, null));
     }

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
@@ -47,7 +47,6 @@ import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 


### PR DESCRIPTION
Applies the same naming restrictions to repositories as to snapshots except that leading underscores and uppercase characters are permitted.

Fixes #40817.
